### PR TITLE
Allow empty params to `where` method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -736,7 +736,7 @@ module ActiveRecord
     def where(*args)
       if args.empty?
         WhereChain.new(spawn)
-      elsif args.length == 1 && args.first.blank?
+      elsif args.first.blank?
         self
       else
         spawn.where!(*args)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -437,5 +437,12 @@ module ActiveRecord
 
       assert_equal 1, posts.invert_where.first.id
     end
+
+    def test_where_with_empty_arguments
+      expected = Post.where("")
+      actual   = Post.where("").where("", {})
+
+      assert_equal expected.to_sql, actual.to_sql
+    end
   end
 end


### PR DESCRIPTION
### Summary

I faced on the problem about `where` method (ActiveRecord::QueryMethods).

After updating rails to 6.1 version, If `where` method's params is set "" as first and {} as second args,
a generated sql has syntax error that only `WHERE` claus is putted on last of sentence.
(e.g.) `SELECT "users".* FROM "users" WHERE`

The environment of main branch also has same problem.
About rails 6.0.5 version, this problem is not happened.

The following logs is each version's results.

rails : 6.0.5
ruby  : 2.7.6

```ruby
puts User.where("", {}).to_sql
# => SELECT "users".* FROM "users"
```

rails : 6.1.4.1
ruby  : 2.7.6
```ruby
puts User.where("", {}).to_sql
# => SELECT "users".* FROM "users" WHERE
# 'WHERE' is unnecessary!
```

I fixed it on this issue.


### Other Information

I referred to the following info.

https://github.com/rails/rails/pull/39784
