### PR TITLE
Add validity for PostgreSQL indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add validity for PostgreSQL indexes.
+
+    ```ruby
+    connection.index_exists?(:users, :email, valid: true)
+    connection.indexes(:users).select(&:valid?)
+    ```
+
+    *fatkodima*
+
 *   Fix eager loading for models without primary keys.
 
     *Anmol Chopra*, *Matt Lawrence*, and *Jonathan Hefner*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment, :valid
 
       def initialize(
         table, name,
@@ -18,7 +18,8 @@ module ActiveRecord
         where: nil,
         type: nil,
         using: nil,
-        comment: nil
+        comment: nil,
+        valid: true
       )
         @table = table
         @name = name
@@ -31,6 +32,11 @@ module ActiveRecord
         @type = type
         @using = using
         @comment = comment
+        @valid = valid
+      end
+
+      def valid?
+        @valid
       end
 
       def column_options
@@ -39,6 +45,13 @@ module ActiveRecord
           order: orders,
           opclass: opclasses,
         }
+      end
+
+      def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, **options)
+        (columns.nil? || Array(self.columns) == Array(columns).map(&:to_s)) &&
+          (name.nil? || self.name == name.to_s) &&
+          (unique.nil? || self.unique == unique) &&
+          (valid.nil? || self.valid == valid)
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -96,18 +96,11 @@ module ActiveRecord
       #   # Check an index with a custom name exists
       #   index_exists?(:suppliers, :company_id, name: "idx_company_id")
       #
+      #   # Check a valid index exists (PostgreSQL only)
+      #   index_exists?(:suppliers, :company_id, valid: true)
+      #
       def index_exists?(table_name, column_name, **options)
-        checks = []
-
-        if column_name.present?
-          column_names = Array(column_name).map(&:to_s)
-          checks << lambda { |i| Array(i.columns) == column_names }
-        end
-
-        checks << lambda { |i| i.unique } if options[:unique]
-        checks << lambda { |i| i.name == options[:name].to_s } if options[:name]
-
-        indexes(table_name).any? { |i| checks.all? { |check| check[i] } }
+        indexes(table_name).any? { |i| i.defined_for?(column_name, **options) }
       end
 
       # Returns an array of +Column+ objects for the table specified by +table_name+.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -88,7 +88,7 @@ module ActiveRecord
 
           result = query(<<~SQL, "SCHEMA")
             SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,
-                            pg_catalog.obj_description(i.oid, 'pg_class') AS comment
+                            pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid
             FROM pg_class t
             INNER JOIN pg_index d ON t.oid = d.indrelid
             INNER JOIN pg_class i ON d.indexrelid = i.oid
@@ -107,6 +107,7 @@ module ActiveRecord
             inddef = row[3]
             oid = row[4]
             comment = row[5]
+            valid = row[6]
 
             using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
 
@@ -144,7 +145,8 @@ module ActiveRecord
               opclasses: opclasses,
               where: where,
               using: using.to_sym,
-              comment: comment.presence
+              comment: comment.presence,
+              valid: valid
             )
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -322,6 +322,20 @@ module ActiveRecord
         end
       end
 
+      def test_invalid_index
+        with_example_table do
+          @connection.exec_query("INSERT INTO ex (number) VALUES (1), (1)")
+          error = assert_raises(ActiveRecord::RecordNotUnique) do
+            @connection.add_index(:ex, :number, unique: true, algorithm: :concurrently, name: :invalid_index)
+          end
+          assert_match(/could not create unique index/, error.message)
+
+          assert @connection.index_exists?(:ex, :number, name: :invalid_index)
+          assert_not @connection.index_exists?(:ex, :number, name: :invalid_index, valid: true)
+          assert @connection.index_exists?(:ex, :number, name: :invalid_index, valid: false)
+        end
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
Reopening reverted https://github.com/rails/rails/pull/45151.

> To me it's confusing if `index_exists?` returns false, but `add_index` raises because the index exists.
> (I think a new kwarg - `index_exists ..., valid: true` - could be an option here?)

Should `indexes(table_name)` and `index_name_exists?` accept the same kwarg? 
I'm not very happy that PostgreSQL internal terminology of "invalid" indexes will bubble up to other adapters. People from MySQL may be wondering "oh, what are invalid indexes?".

Maybe we can do the same way as with `validate` for PostgreSQL? Each `IndexDefinition` will have a `valid` field. And `index_exists?` and `index_name_exists?` will accept `:valid` through its existing `**options` parameter, as you suggested, and will do the filtering.

cc @byroot @ghiculescu 