### PR TITLE
Load Tree Setup

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -50,6 +50,7 @@ module ActiveRecord
   autoload :Inheritance
   autoload :Integration
   autoload :InternalMetadata
+  autoload :LoadTree
   autoload :Migration
   autoload :Migrator, "active_record/migration"
   autoload :ModelSchema
@@ -352,6 +353,9 @@ module ActiveRecord
 
   singleton_class.attr_accessor :query_transformers
   self.query_transformers = []
+
+  singleton_class.attr_accessor :load_tree_enabled
+  self.load_tree_enabled = false
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -244,10 +244,8 @@ module ActiveRecord
 
         def setup_load_trees(records)
           records.each do |record|
-            record._create_association_load_tree_node(
-              siblings: records,
-              parent: owner,
-              child_name: reflection.name)
+            record._create_load_tree_node(siblings: records)
+            record._load_tree_node.add_parent(owner, reflection.name, :association)
           end
         end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -245,7 +245,7 @@ module ActiveRecord
         def setup_load_trees(records)
           records.each do |record|
             record._create_load_tree_node(
-              siblings: [],
+              siblings: records,
               parents: [{
                 instance: owner,
                 child_name: reflection.name,

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -229,13 +229,25 @@ module ActiveRecord
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, klass.connection) do |record|
+          records = sc.execute(binds, klass.connection) do |record|
             set_inverse_instance(record)
             if owner.strict_loading_n_plus_one_only? && reflection.macro == :has_many
               record.strict_loading!
             else
               record.strict_loading!(false, mode: owner.strict_loading_mode)
             end
+          end
+
+          setup_load_trees(records)
+          records
+        end
+
+        def setup_load_trees(records)
+          records.each do |record|
+            record._create_association_load_tree_node(
+              siblings: records,
+              parent: owner,
+              child_name: reflection.name)
           end
         end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -244,8 +244,14 @@ module ActiveRecord
 
         def setup_load_trees(records)
           records.each do |record|
-            record._create_load_tree_node(siblings: records)
-            record._load_tree_node.add_parent(owner, reflection.name, :association)
+            record._create_load_tree_node(
+              siblings: [],
+              parents: [{
+                instance: owner,
+                child_name: reflection.name,
+                child_type: :association
+              }]
+            ).set_records
           end
         end
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -201,7 +201,7 @@ module ActiveRecord
                     child_name: reflection.name,
                     child_type: association
                   }]
-                  ).set_records
+                ).set_records
               else
                 record._load_tree_node.add_parent(owner, reflection.name, :association)
               end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -191,7 +191,7 @@ module ActiveRecord
               entries = (@records_by_owner[owner] ||= [])
               association_owner = preloaded_split_owner_association[owner.class.name] ||= {}
               association_of_records = association_owner[reflection.name] ||= []
-              association_of_records << record
+              association_of_records << record if association_of_records.exclude?(record)
 
               if record._load_tree_node.nil?
                 record._create_load_tree_node(

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -187,16 +187,17 @@ module ActiveRecord
           @preloaded_records = raw_records.select do |record|
             assignments = false
 
+            if record._load_tree_node.nil?
+              record._create_load_tree_node(
+                siblings: [])
+            end
             owners_by_key[convert_key(record[association_key_name])]&.each do |owner|
               entries = (@records_by_owner[owner] ||= [])
               association_owner = preloaded_split_owner_association[owner.class.name] ||= {}
               association_of_records = association_owner[reflection.name] ||= []
               association_of_records << record
 
-              record._create_association_load_tree_node(
-                siblings: [],
-                parent: owner,
-                child_name: reflection.name)
+              record._load_tree_node.add_parent(owner, reflection.name, :association)
 
               if reflection.collection? || entries.empty?
                 entries << record

--- a/activerecord/lib/active_record/load_tree.rb
+++ b/activerecord/lib/active_record/load_tree.rb
@@ -3,9 +3,15 @@
 module ActiveRecord
   module LoadTree
     def _create_load_tree_node(creator: self, parents: [], siblings: [])
+      parent_objects = parents.map do |parent_hash|
+        Parent.new(parent: parent_hash[:instance],
+                   child_name: parent_hash[:child_name],
+                   child_type: parent_hash[:child_type])
+      end
+
       @_load_tree_node = ActiveRecord::LoadTree::Node.new(
         creator: creator,
-        parents: parents,
+        parents: parent_objects,
         siblings: siblings
       ).set_records
     end

--- a/activerecord/lib/active_record/load_tree.rb
+++ b/activerecord/lib/active_record/load_tree.rb
@@ -2,13 +2,11 @@
 
 module ActiveRecord
   module LoadTree
-    def _create_load_tree_node(creator: self, parent: nil, siblings: [], child_name: nil, child_type: nil)
+    def _create_load_tree_node(creator: self, parents: [], siblings: [])
       @_load_tree_node = ActiveRecord::LoadTree::Node.new(
         creator: creator,
-        parent: parent,
-        siblings: siblings,
-        child_name: child_name,
-        child_type: child_type,
+        parents: parents,
+        siblings: siblings
       ).set_records
     end
 
@@ -21,65 +19,49 @@ module ActiveRecord
       _create_load_tree_node(creator: self, siblings: siblings).set_records
     end
 
-    def _create_association_load_tree_node(parent:, siblings:, child_name:)
-      return unless ActiveRecord.load_tree_enabled
-      _create_load_tree_node(creator: self, parent: parent, siblings: siblings, child_name: child_name, child_type: :association).set_records
-    end
-
     class Node
       # SiblingSizeLimit is the maximum number of siblings we will track. This
       # Is limited because preloading can blow up if we have a lot of siblings.
       attr_reader :model_class_name
-      attr_accessor :siblings, :parent, :children, :child_type, :child_name
+      attr_accessor :siblings, :parents, :children
 
       # Create a Load Tree instance representing the loaded record and its place in the overall
       # hierarchy of the object tree. Any passed parents or sibilings should also include the load_tree
       # instance on themselves.
       #
       # creator: The record that owns the tree
-      # parent: Instance that is the parent of the loaded record.
+      # parents: Instances that are the parents of the loaded record.
       # siblings: Instances that were loaded at the same time as the loaded model.
-      # child_name: The name of the child that was loaded as referred to by the parent.
-      # child_type: Type of child loading method, for example associations from active record.
-      def initialize(creator:, parent: nil, siblings: [], child_name: nil, child_type: nil)
-        @parent = parent
+      def initialize(creator:, parents: [], siblings: [])
+        @parents = parents
         @model_class_name = creator.class.name
-        @child_name = child_name
         @children = []
         @siblings = siblings
-        @child_type = child_type unless root?
       end
 
       def set_records
         select_allowed_siblings
-        parent._load_tree_node.add_loaded_child(child_name) unless parent.nil? || child_name.nil?
+        parents.each do |parent|
+          parent.parent._load_tree_node.add_loaded_child(parent.child_name) unless parent.child_name.nil?
+        end
         self
       end
 
       # Does this load tree belong to a parent?
       def root?
-        parent.nil?
-      end
-
-      # The full call path to the parent of this load tree. Traverses up the load tree
-      # checking if the current load tree is the the root, if it is then it returns
-      # the class name of the record for the root element, if not it returns the child
-      # name that was used to instantiate the current load tree's record. This will put together
-      # a full method chain.
-      #
-      # parent = Person.find(1)
-      # child = parent.children.first
-      # child._load_tree.full_load_call_path # => "Person.children"
-      #
-      def full_load_path
-        return model_class_name if root?
-        parent._load_tree_node.full_load_path + "." + child_name.to_s
+        parents.empty?
       end
 
       # Add an child name to the list of loaded children.
       def add_loaded_child(child_name)
         return if child_name.nil? || @children.include?(child_name)
         @children << child_name
+      end
+
+      def add_parent(parent, child_name, child_type)
+        return if parent.nil? || @parents.include?(parent)
+        @parents << Parent.new(parent: parent, child_name: child_name, child_type: child_type)
+        set_records
       end
 
       private
@@ -89,6 +71,20 @@ module ActiveRecord
         def select_allowed_siblings
           @siblings = siblings.select { |s| s.class.name == model_class_name }.compact
         end
+    end
+
+    class Parent
+      attr_accessor :parent, :child_name, :child_type
+
+      def initialize(parent:, child_name:, child_type:)
+        @parent = parent
+        @child_name = child_name
+        @child_type = child_type
+      end
+
+      def ==(o)
+        o.class == self.class && o.parent == parent && o.child_name == child_name && o.child_type == child_type
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/load_tree.rb
+++ b/activerecord/lib/active_record/load_tree.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module LoadTree
+    def _create_load_tree_node(creator: self, parent: nil, siblings: [], child_name: nil, child_type: nil)
+      @_load_tree_node = ActiveRecord::LoadTree::Node.new(
+        creator: creator,
+        parent: parent,
+        siblings: siblings,
+        child_name: child_name,
+        child_type: child_type,
+      ).set_records
+    end
+
+    def _load_tree_node
+      @_load_tree_node || ActiveRecord::LoadTree::Node.new(creator: self, siblings: [])
+    end
+
+    def _create_root_load_tree_node(siblings:)
+      return unless ActiveRecord.load_tree_enabled
+      _create_load_tree_node(creator: self, siblings: siblings).set_records
+    end
+
+    def _create_association_load_tree_node(parent:, siblings:, child_name:)
+      return unless ActiveRecord.load_tree_enabled
+      _create_load_tree_node(creator: self, parent: parent, siblings: siblings, child_name: child_name, child_type: :association).set_records
+    end
+
+    class Node
+      # SiblingSizeLimit is the maximum number of siblings we will track. This
+      # Is limited because preloading can blow up if we have a lot of siblings.
+      attr_reader :model_class_name
+      attr_accessor :siblings, :parent, :children, :child_type, :child_name
+
+      # Create a Load Tree instance representing the loaded record and its place in the overall
+      # hierarchy of the object tree. Any passed parents or sibilings should also include the load_tree
+      # instance on themselves.
+      #
+      # creator: The record that owns the tree
+      # parent: Instance that is the parent of the loaded record.
+      # siblings: Instances that were loaded at the same time as the loaded model.
+      # child_name: The name of the child that was loaded as referred to by the parent.
+      # child_type: Type of child loading method, for example associations from active record.
+      def initialize(creator:, parent: nil, siblings: [], child_name: nil, child_type: nil)
+        @parent = parent
+        @model_class_name = creator.class.name
+        @child_name = child_name
+        @children = []
+        @siblings = siblings
+        @child_type = child_type unless root?
+      end
+
+      def set_records
+        select_allowed_siblings
+        parent._load_tree_node.add_loaded_child(child_name) unless parent.nil? || child_name.nil?
+        self
+      end
+
+      # Does this load tree belong to a parent?
+      def root?
+        parent.nil?
+      end
+
+      # The full call path to the parent of this load tree. Traverses up the load tree
+      # checking if the current load tree is the the root, if it is then it returns
+      # the class name of the record for the root element, if not it returns the child
+      # name that was used to instantiate the current load tree's record. This will put together
+      # a full method chain.
+      #
+      # parent = Person.find(1)
+      # child = parent.children.first
+      # child._load_tree.full_load_call_path # => "Person.children"
+      #
+      def full_load_path
+        return model_class_name if root?
+        parent._load_tree_node.full_load_path + "." + child_name.to_s
+      end
+
+      # Add an child name to the list of loaded children.
+      def add_loaded_child(child_name)
+        return if child_name.nil? || @children.include?(child_name)
+        @children << child_name
+      end
+
+      private
+        # We only want to keep sibling of the same class type as the creator
+        # This ensures we will not try to preload any children that may not
+        # exist on some of the sibling which were loaded because of STI.
+        def select_allowed_siblings
+          @siblings = siblings.select { |s| s.class.name == model_class_name }.compact
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -927,8 +927,10 @@ module ActiveRecord
             if null_relation? || !instance_variable_defined?("@association")
               record._create_root_load_tree_node(siblings: records)
             else
-              record._create_load_tree_node(siblings: records)
-              record._load_tree_node.add_parent(@association.owner, @association.reflection.name, :association)
+              record._create_load_tree_node(
+                siblings: records,
+                parents: [{ instance: @association.owner, child_name: @association.reflection.name, child_type: :association }]
+              ).set_records
             end
             record.readonly! if readonly_value
             record.strict_loading!(strict_loading_value) unless strict_loading_value.nil?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -927,10 +927,8 @@ module ActiveRecord
             if null_relation? || !instance_variable_defined?("@association")
               record._create_root_load_tree_node(siblings: records)
             else
-              record._create_association_load_tree_node(
-                siblings: records,
-                parent: @association.owner,
-                child_name: @association.reflection.name)
+              record._create_load_tree_node(siblings: records)
+              record._load_tree_node.add_parent(@association.owner, @association.reflection.name, :association)
             end
             record.readonly! if readonly_value
             record.strict_loading!(strict_loading_value) unless strict_loading_value.nil?

--- a/activerecord/test/cases/load_tree_test.rb
+++ b/activerecord/test/cases/load_tree_test.rb
@@ -209,7 +209,7 @@ class LoadTreeTest < ActiveRecord::TestCase
     end
   end
 
-   def test_preload_when_an_association_is_shared
+  def test_preload_when_an_association_is_shared
     book = books(:awdr)
     book.author = authors(:david)
     book.save
@@ -229,7 +229,7 @@ class LoadTreeTest < ActiveRecord::TestCase
     author_parents = [create_parent(books.first, :author), create_parent(books.second, :author)]
     assert_equal books.first.author._load_tree_node.siblings, [books.first.author]
     assert_equal books.first.author._load_tree_node.parents, author_parents
-  end
+ end
 
   test "preload sets a load tree" do
     ship = Ship.first

--- a/activerecord/test/cases/load_tree_test.rb
+++ b/activerecord/test/cases/load_tree_test.rb
@@ -1,0 +1,392 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+require "models/contract"
+require "models/company"
+require "models/computer"
+require "models/mentor"
+require "models/project"
+require "models/ship"
+require "models/ship_part"
+require "models/strict_zine"
+require "models/post"
+require "models/pirate"
+require "models/treasure"
+require "models/book"
+
+class LoadTreeTest < ActiveRecord::TestCase
+  fixtures :developers, :developers_projects, :projects, :ships, :books, :posts, :authors
+
+  def setup
+    ActiveRecord.load_tree_enabled = true
+  end
+
+  def teardown
+    ActiveRecord.load_tree_enabled = false
+  end
+
+  test "an association is able to find its siblings" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    ship_parts_array = [stern1, bow1]
+    trinket_for_parents = [
+      stern1.trinkets.create!(name: "Stern Trinket"),
+      stern1.trinkets.create!(name: "Stern Trinket 2"),
+      bow1.trinkets.create!(name: "Bow Trinket")
+    ].sort
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.includes(:projects, ship: [parts: [:trinkets]]).find(developer.id)
+
+    developer.projects.each do |project|
+      assert_equal developer.projects.to_a.sort, project._load_tree_node.siblings.sort
+    end
+    assert_equal developer.ship._load_tree_node.siblings, [developer.ship]
+
+    developer.ship.parts.each do |part|
+      assert_equal ship_parts_array, part._load_tree_node.siblings
+      part.trinkets.each do |trinket|
+        assert_equal trinket_for_parents, trinket._load_tree_node.siblings
+      end
+    end
+
+    developer.ship.parts.first.trinkets.first._load_tree_node.siblings.each do |trinket|
+      assert_equal trinket_for_parents, trinket._load_tree_node.siblings
+    end
+  end
+
+  test "when a where at the top level is requested, it should have a load tree" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    records.each do |record|
+      assert_equal record._load_tree_node.siblings, records
+    end
+  end
+
+
+  test "when a record is duplicated it does not inherit the load tree" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    dup_records = records.map(&:dup)
+    dup_records.each do |record|
+      assert_equal record._load_tree_node.siblings, [record]
+    end
+  end
+
+  test "when a record is at the top level it should be a root node and not have a parent" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    records.each do |record|
+      assert record._load_tree_node.root?
+      assert record._load_tree_node.parent.nil?
+      assert_nil record._load_tree_node.child_name
+    end
+  end
+
+  test "when a record is not at the top level it should have a parent and the association name that loaded it" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+    bow1.trinkets.create!(name: "Bow Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    assert developer._load_tree_node.root?
+    assert_equal developer._load_tree_node.siblings, [developer]
+
+    developer.projects.each do |project|
+      assert_not project._load_tree_node.root?
+      assert_equal developer, project._load_tree_node.parent
+      assert_equal :projects, project._load_tree_node.child_name
+    end
+    assert_equal developer.ship._load_tree_node.parent, developer
+    assert_equal :ship, developer.ship._load_tree_node.child_name
+
+    developer.ship.parts.each do |part|
+      assert_equal developer.ship, part._load_tree_node.parent
+      assert_not part._load_tree_node.root?
+      assert_equal :parts, part._load_tree_node.child_name
+      part.trinkets.each do |trinket|
+        assert_equal part, trinket._load_tree_node.parent
+        assert_not trinket._load_tree_node.root?
+        assert_equal :trinkets, trinket._load_tree_node.child_name
+        assert_equal ship, trinket._load_tree_node.parent._load_tree_node.parent
+      end
+    end
+  end
+
+  test "when an association is loaded, it lets the parent know that it is loaded to assist with tree crawling" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+    bow1.trinkets.create!(name: "Bow Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    developer.projects.each do |project|
+      assert developer._load_tree_node.children.include?(:projects), "Loaded association should include :project #{developer._load_tree_node.children}"
+    end
+    developer.ship
+    assert developer._load_tree_node.children.include?(:ship), "Loaded association should include :ship #{developer._load_tree_node.children}"
+
+    developer.ship.parts.each do |part|
+      assert developer.ship._load_tree_node.children.include?(:parts), "Loaded association should include :parts #{developer.ship._load_tree_node.children}"
+      part.trinkets.each do |trinket|
+        assert part._load_tree_node.children.include?(:trinkets), "Loaded association should include :trinkets #{part._load_tree_node.children}"
+      end
+    end
+
+    developer._load_tree_node.children.each do |assoc|
+      child = developer.send(assoc)
+      if child.is_a?(Array) || child.is_a?(ActiveRecord::Associations::CollectionProxy)
+        child.each do |c|
+          assert_equal c._load_tree_node.parent, developer
+        end
+        last_child = child.last
+      else
+        assert_equal child._load_tree_node.parent, developer
+        last_child = child
+      end
+      last_child._load_tree_node.children.each do |assoc2|
+        grandchild = last_child.send(assoc2).first
+        assert_equal grandchild._load_tree_node.parent, last_child
+      end
+    end
+  end
+
+  test "load tree can get the full method path from the tree for a particular object" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects.destroy_all
+    developer.projects << project
+
+    developer = Developer.find(developer.id)
+
+    assert_equal "Developer.projects.firm", developer.projects.first.firm._load_tree_node.full_load_path
+    assert_equal "Developer.ship.parts.trinkets", developer.ship.parts.first.trinkets.first._load_tree_node.full_load_path
+  end
+
+  def test_preload_groups_queries_with_same_scope_but_different_sti_classes_separates_the_siblings_by_sti_class
+    book = books(:awdr)
+    book.author = authors(:david)
+    book.save
+    book2 = books(:rfr)
+    book2.author = authors(:mary)
+    book2.save
+    post = posts(:welcome)
+    post.author = authors(:mary)
+    post.save
+
+
+    book = Book.find(book.id)
+    book2 = Book.find(book2.id)
+    post = Post.find(post.id)
+    assert_queries(1) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: [book, book2, post], associations: :author)
+      preloader.call
+
+      assert_equal book.author._load_tree_node.siblings, [book.author, book2.author]
+      assert_equal book.author._load_tree_node.parent, book
+      post.author
+      assert_equal post.author._load_tree_node.siblings, [post.author]
+      assert_equal post.author._load_tree_node.parent, post
+    end
+  end
+
+  test "preload sets a load tree" do
+    ship = Ship.first
+    ship2 = Ship.last
+    10.times do |i|
+      ShipPart.create!(name: "Stern#{i}", ship: ship)
+      ShipPart.create!(name: "Stern#{i}", ship: ship2)
+    end
+    ships = Ship.preload(:parts).where(id: [ship.id, ship2.id]).to_a
+    ship = ships.first
+    tree = ship.parts.to_a.first._load_tree_node
+
+    (ship.parts + ship2.parts).each do |part|
+      assert tree.siblings.include?(part), "Siblings should include #{part.inspect}"
+    end
+    assert_equal [:parts], ship._load_tree_node.children
+    assert_equal ship, tree.parent
+    assert_equal :association, tree.child_type
+    assert_equal :parts, tree.child_name
+  end
+
+  test "eager load sets a load tree" do
+    ship = Ship.first
+    ship2 = Ship.last
+    10.times do |i|
+      ShipPart.create!(name: "Stern#{i}", ship: ship)
+      ShipPart.create!(name: "Stern#{i}", ship: ship2)
+    end
+    ships = Ship.preload(:parts).where(id: [ship.id, ship2.id]).to_a
+    ship = ships.first
+    tree = ship.parts.to_a.first._load_tree_node
+    (ship.parts + ship2.parts).each do |part|
+      assert tree.siblings.include?(part), "Siblings should include #{part.inspect}"
+    end
+    assert_equal [:parts], ship._load_tree_node.children
+    assert_equal ship, tree.parent
+    assert_equal :association, tree.child_type
+    assert_equal :parts, tree.child_name
+  end
+end
+
+
+class BookNonAR
+  attr_accessor :author, :reviews
+  include ActiveRecord::LoadTree
+
+  def initialize(author)
+    @author = author
+    @reviews = []
+  end
+end
+
+class ReviewNonAR
+  attr_accessor :book, :author
+  include ActiveRecord::LoadTree
+
+  def initialize(book, author)
+    @book = book
+    book.reviews << self
+    @author = author
+    author.reviews << self
+  end
+end
+
+
+class AuthorNonAR
+  attr_accessor :reviews, :books, :author_bio
+  include ActiveRecord::LoadTree
+
+  def initialize(author_bio)
+    @author_bio = author_bio
+    author_bio.author = self
+    @reviews = []
+  end
+end
+
+class AuthorBioNonAR
+  attr_accessor :author
+  include ActiveRecord::LoadTree
+end
+
+class LoadTreeNodeTest < ActiveRecord::TestCase
+  def setup
+    @review_author_bio = AuthorBioNonAR.new
+    @author_bio = AuthorBioNonAR.new
+    @review_author = AuthorNonAR.new(@review_author_bio)
+    @author = AuthorNonAR.new(@author_bio)
+
+    @book1 = BookNonAR.new(@author)
+    @book2 = BookNonAR.new(@author)
+    @review = ReviewNonAR.new(@book1, @review_author)
+
+
+    @book1._create_load_tree_node(siblings: [@book1, @book2]).set_records
+    @book2._create_load_tree_node(siblings: [@book1, @book2]).set_records
+    @review._create_load_tree_node(siblings: [@review], parent: @book1, child_name: :reviews, child_type: :association).set_records
+    @author._create_load_tree_node(siblings: [@author], parent: @book1, child_name: :author, child_type: :association).set_records
+    @author_bio._create_load_tree_node(siblings: [@author_bio], parent: @author, child_name: :author_bio, child_type: :association).set_records
+    @review_author._create_load_tree_node(siblings: [@review_author], parent: @review, child_name: :author, child_type: :association).set_records
+    @review_author_bio._create_load_tree_node(siblings: [@review_author_bio], parent: @review_author, child_name: :author_bio, child_type: :association).set_records
+  end
+
+
+  test "if a load tree gets a sibling that is not of the same class it ignores it" do
+    tree = ActiveRecord::LoadTree::Node.new(creator: @book1, siblings: [@book1, @book2, @post]).set_records
+    assert_equal [@book1, @book2], tree.siblings
+  end
+
+  test "attributes properly set" do
+    tree = @review._load_tree_node
+    assert_equal @review.class.name, tree.model_class_name
+    assert_equal @book1, tree.parent
+    assert_equal :reviews, tree.child_name
+    assert_equal :association, tree.child_type
+    assert_not tree.root?
+  end
+
+  test "parent/child associations setup up" do
+    review_tree = @review._load_tree_node
+    book_tree = review_tree.parent._load_tree_node
+    assert book_tree.root?
+    assert_not review_tree.root?
+    assert_equal [:reviews, :author], book_tree.children
+    assert_equal [:author], review_tree.children
+    assert_equal :association, review_tree.child_type
+    assert_nil book_tree.child_type
+  end
+
+  test "full load path recurses up the tree" do
+    tree = @review_author_bio._load_tree_node
+    assert_equal tree.full_load_path, "BookNonAR.reviews.author.author_bio"
+    assert_equal @book1._load_tree_node.full_load_path, "BookNonAR"
+  end
+
+  test "load trees can be traversed up" do
+    tree = @review_author_bio._load_tree_node
+    assert_equal tree.parent, @review_author
+    assert_equal tree.parent._load_tree_node.parent, @review
+    assert_equal tree.parent._load_tree_node.parent._load_tree_node.parent, @book1
+  end
+
+  test "load trees can be traversed down" do
+    child_recurse(@book1)
+  end
+
+  def child_recurse(parent)
+    tree = parent._load_tree_node
+    tree.children.each do |child_method|
+      children_helper(parent, child_method)
+    end
+  end
+
+  def children_helper(parent, child_method)
+    child = parent.send(child_method)
+    if child.is_a?(Array)
+      child.each do |sub_child|
+        assert_equal sub_child._load_tree_node.parent, parent
+        child_recurse(sub_child)
+      end
+    else
+      assert_equal child._load_tree_node.parent, parent
+      child_recurse(child)
+    end
+  end
+end

--- a/activerecord/test/cases/load_tree_test.rb
+++ b/activerecord/test/cases/load_tree_test.rb
@@ -19,6 +19,10 @@ def create_parent(parent, name)
   ActiveRecord::LoadTree::Parent.new(parent: parent, child_name: name, child_type: :association)
 end
 
+def create_parent_hash(parent, name)
+  { instance: parent, child_name: name, child_type: :association }
+end
+
 class LoadTreeTest < ActiveRecord::TestCase
   fixtures :developers, :developers_projects, :projects, :ships, :books, :posts, :authors
 
@@ -299,11 +303,11 @@ class LoadTreeNodeTest < ActiveRecord::TestCase
 
     @book1._create_load_tree_node(siblings: [@book1, @book2]).set_records
     @book2._create_load_tree_node(siblings: [@book1, @book2]).set_records
-    @review._create_load_tree_node(siblings: [@review], parents: [create_parent(@book1, :reviews)]).set_records
-    @author._create_load_tree_node(siblings: [@author], parents: [create_parent(@book1, :author)]).set_records
-    @author_bio._create_load_tree_node(siblings: [@author_bio], parents: [create_parent(@author, :author_bio)]).set_records
-    @review_author._create_load_tree_node(siblings: [@review_author], parents: [create_parent(@review, :author)]).set_records
-    @review_author_bio._create_load_tree_node(siblings: [@review_author_bio], parents: [create_parent(@review_author, :author_bio)]).set_records
+    @review._create_load_tree_node(siblings: [@review], parents: [create_parent_hash(@book1, :reviews)]).set_records
+    @author._create_load_tree_node(siblings: [@author], parents: [create_parent_hash(@book1, :author)]).set_records
+    @author_bio._create_load_tree_node(siblings: [@author_bio], parents: [create_parent_hash(@author, :author_bio)]).set_records
+    @review_author._create_load_tree_node(siblings: [@review_author], parents: [create_parent_hash(@review, :author)]).set_records
+    @review_author_bio._create_load_tree_node(siblings: [@review_author_bio], parents: [create_parent_hash(@review_author, :author_bio)]).set_records
   end
 
 


### PR DESCRIPTION
### Summary
As the first step in splitting up ActiveRecord dynamic includes and the new load tree debug view as proposed in #45071 we need the load tree to be available.

The load tree being part of ActiveModel allows for its use in both the context of ActiveRecord and x other external service. This is desirable as it allows consumers to build automatic includes across any data fetching service where preventing an n+1 query is performant.

The load tree also will provide data to the associated debugging view which is also being split out of #45071. 

There will be 2 follow up PR's to this, one re-introducing auto loading, or dynamic loading of associations. The second will be to add a debug view of the load tree.

### Other Information

I considered adding a setting for this, maybe something in ActiveRecord to only setup the load trees if it is on? @matthewd and @jhawthorn have both suggested alternate implementations of how to hold the siblings, should they be weakrefs or not is an open question.

cc @eileencodes 
