### PR TITLE
Deprecate plural association names on singular associations

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -23,7 +23,7 @@ module ActiveRecord
     end
 
     def associated_with?(table_name)
-      klass&._reflect_on_association(table_name) || klass&._reflect_on_association(table_name.singularize)
+      klass&._reflect_on_association(table_name)
     end
 
     def associated_table(table_name)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -437,5 +437,11 @@ module ActiveRecord
 
       assert_equal 1, posts.invert_where.first.id
     end
+
+    def test_nested_conditional_on_enum
+      post = Post.first
+      Comment.create!(label: :default, post: post, body: "Nice weather today")
+      assert_equal [post], Post.joins(:comments).where(comments: { label: :default, body: "Nice weather today" }).to_a
+    end
   end
 end


### PR DESCRIPTION
Before this change associations could be called by their plural or singular name,

i.e.

	  class Post < ActiveRecord::Base
	    has_many :comments
	  end

	  class Comment < ActiveRecord::Base
	    belongs_to :post
	  end

	  # this works with `post` as the key:
	  Comment.where(post: Post.first)
	  # this also works with `:posts` as the key (after this change this will warn):
	  Comment.where(posts: Post.first)

This PR deprecates using the plural association name when the association was not defined as plural.

Motivated by https://github.com/rails/rails/pull/45020 which found that singularize call is slow and happens very often when you are querying a column name which is not a relation, so it must try both paths. After this deprecation cycle we can save that time in the `where(column_name: "value")` case and `where(association: "value")` case.

After this deprecation cycle, we can also avoid a potentially annoying edge case where you are unable to query a column with a singular name the same as your association's name.

It seems this singularize was added 2 years ago here: https://github.com/rails/rails/pull/39465 , however inheritance and calculation tests still pass with this change removed. I also added a test for the enum case that is referenced in the the issue associated with the above PR to be extra safe.

for extra clarity, here is a test case that will pass after this deprecation that doesn't today,

<details>

```
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.string :posts
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_association_stuff
    comment = Comment.create!(posts: "hi there")

    assert_equal 1, Comment.where(posts: "hi there").count
  end
end
```

</details>