### PR TITLE
Cache the where clause extract_from_hash method

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/build_method.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/build_method.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class BuildMethod # :nodoc:
+      def initialize(klass)
+        @lookups = {}
+        klass&.aggregate_reflections&.keys&.each do |aggregate|
+          @lookups[aggregate] = :aggregate
+        end
+
+        # TODO: can I check `reflection.is_a?(ThroughReflection) instead?
+        klass&._reflections&.each do |reflection, reflection_obj|
+          @lookups[reflection] = :reflection
+        end
+      end
+
+      def build_query(predicate_builder, table, key, value, attributes)
+        self.send(@lookups[key] || :column, predicate_builder, table, key, value, attributes)
+      end
+
+      protected
+        def column(predicate_builder, table, key, value, attributes)
+          predicate_builder[key, value]
+        end
+
+        def reflection(predicate_builder, table, key, value, attributes)
+          # Find the foreign key when using queries such as:
+          # Post.where(author: author)
+          #
+          # For polymorphic relationships, find the foreign key and type:
+          # PriceEstimate.where(estimate_of: treasure)
+          associated_table = table.associated_table(key)
+          if associated_table.polymorphic_association?
+            value = [value] unless value.is_a?(Array)
+            klass = PredicateBuilder::PolymorphicArrayValue
+          elsif associated_table.through_association?
+            return associated_table.predicate_builder.expand_from_hash(associated_table.primary_key => value)
+          end
+
+          klass ||= PredicateBuilder::AssociationQueryValue
+          queries = klass.new(associated_table, value).queries.map! do |query|
+            # If the query produced is identical to attributes don't go any deeper.
+            # Prevents stack level too deep errors when association and foreign_key are identical.
+            query == attributes ? predicate_builder[key, value] : predicate_builder.expand_from_hash(query)
+          end
+
+          predicate_builder.grouping_queries(queries)
+        end
+
+        def aggregate(predicate_builder, table, key, value, attributes)
+          mapping = table.reflect_on_aggregation(key).mapping
+          values = value.nil? ? [nil] : Array.wrap(value)
+          if mapping.length == 1 || values.empty?
+            column_name, aggr_attr = mapping.first
+            values = values.map do |object|
+              object.respond_to?(aggr_attr) ? object.public_send(aggr_attr) : object
+            end
+            predicate_builder[column_name, values]
+          else
+            queries = values.map do |object|
+              mapping.map do |field_attr, aggregate_attr|
+                predicate_builder[field_attr, object.try!(aggregate_attr)]
+              end
+            end
+
+            predicate_builder.grouping_queries(queries)
+          end
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -8,6 +8,7 @@ module ActiveRecord
       @klass = klass
       @arel_table = arel_table
       @reflection = reflection
+      @build_method = PredicateBuilder::BuildMethod.new(klass)
     end
 
     def primary_key
@@ -16,6 +17,10 @@ module ActiveRecord
 
     def type(column_name)
       arel_table.type_for_attribute(column_name)
+    end
+
+    def build_query(predicate_builder, table, key, value, attributes)
+      @build_method.build_query(predicate_builder, table, key, value, attributes)
     end
 
     def has_column?(column_name)


### PR DESCRIPTION
We know as soon as the associations are loaded if it s a column, reflection or aggregate, we we can check once and never again.
this way we only have to check what type a key is once. This avoid a reasonably large amount of work at runtime.

before:

```
-- create_table(:posts, {:force=>true})
   -> 0.0147s
-- create_table(:comments, {:force=>true})
   -> 0.0004s
Warming up --------------------------------------
Comment.where with 2 columns
                         1.631k i/100ms
Comment.where 1 association
                       614.000  i/100ms
Calculating -------------------------------------
Comment.where with 2 columns
                         16.215k (± 1.9%) i/s -     81.550k in   5.031218s
Comment.where 1 association
                          6.060k (± 2.1%) i/s -     30.700k in   5.068333s
```

after:

```
-- create_table(:posts, {:force=>true})
   -> 0.0150s
-- create_table(:comments, {:force=>true})
   -> 0.0004s
Warming up --------------------------------------
Comment.where with 2 columns
                         4.554k i/100ms
Comment.where 1 association
                       706.000  i/100ms
Calculating -------------------------------------
Comment.where with 2 columns
                         45.166k (± 2.3%) i/s -    227.700k in   5.044079s
Comment.where 1 association
                         6.964k (± 2.5%) i/s -     35.300k in   5.072544s
```

benchmark script:

<details>

```ruby
require "active_record"
require "logger"
require "stackprof"
require "benchmark/ips"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
  create_table :comments, force: true do |t|
    t.belongs_to :post
    t.string :title
    t.text :body
    t.integer :likes
    t.datetime :posted_at
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

# puts "BEFORE WHERE"

# first case:
# Comment.where(post: { title: "hi" })
# # second case:
# puts "AFTER FIRST WHERE"

# Comment.where(post: Post.first(0))
# third case:
# Comment.group_by(:like_count).where(like_count: 10)
# fourth case:
# Comment.where(title: "best post ever!")

# binding.irb

Benchmark.ips do |x|
  x.report "Comment.where with 2 columns" do
    Comment.where(title: "best post ever!", post_id: 3)
  end

  x.report "Comment.where 1 association" do
    Comment.where(post: Post.first)
  end
end
```

</details