### PR TITLE
Bypass CGI escaping in `Hash#to_param`

### DIFF
--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -94,6 +94,12 @@ module AbstractController
         )
       end
 
+      def test_anchor_with_hash_should_escape_unsafe_pchar_only_once
+        assert_equal("/c/a#subject=Only%20Once&tag=%23yolo",
+          W.new.url_for(only_path: true, controller: "c", action: "a", anchor: { subject: "Only Once", tag: "#yolo" })
+        )
+      end
+
       def test_default_host
         add_host!
         assert_equal("http://www.basecamphq.com/c/a/i",

--- a/activesupport/test/core_ext/object/to_param_test.rb
+++ b/activesupport/test/core_ext/object/to_param_test.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/object/to_param"
 class ToParamTest < ActiveSupport::TestCase
   class CustomString < String
     def to_param
-      "custom-#{ self }"
+      "custom:#{ self }"
     end
   end
 
@@ -33,7 +33,14 @@ class ToParamTest < ActiveSupport::TestCase
     assert_equal "1/2/3/4", array.to_param
 
     # Array of different objects
-    array = [1, "3", { a: 1, b: 2 }, nil, true, false, CustomString.new("object")]
-    assert_equal "1/3/a=1&b=2//true/false/custom-object", array.to_param
+    array = [1, "next one", { a: 1, b: 2 }, nil, true, false, CustomString.new("object")]
+    assert_equal "1/next one/a=1&b=2//true/false/custom:object", array.to_param
+  end
+
+  def test_hash
+    assert_equal "", {}.to_param
+
+    hash = { a: 1, b: "next one", c: [3, 2, 1], d: nil, e: true, f: false, g: CustomString.new("object") }
+    assert_equal "a=1&b=next one&c[]=3&c[]=2&c[]=1&d=&e=true&f=false&g=custom:object", hash.to_param
   end
 end


### PR DESCRIPTION
Prior to this commit, `Hash#to_param` was an alias for `Hash#to_query`, which meant `Hash#to_param` CGI-escaped query string keys and values, like other `to_query` methods, but *unlike* other `to_param` methods.  This caused double escaping in some cases, such as when passing a `Hash` as an `anchor` argument to `url_for`.

This commit adds an internal-use-only optional `escape` block to `to_query` methods, and `Hash#to_param` now uses this block to bypass escaping, while still being implemented in terms of `Hash#to_query`.

Fixes #43289.
Closes #43293.

---

@intrip I've added you as a co-author, due to your work on #43293.  What do you think of this approach?

This is a potentially breaking change, but I feel like it's more of a "fix" to make `Hash#to_param` behave the same as other `to_param` methods.
