### PR TITLE
Forward `drop_join_table` options to `drop_table`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -396,14 +396,14 @@ module ActiveRecord
       end
 
       # Drops the join table specified by the given arguments.
-      # See #create_join_table for details.
+      # See #create_join_table and #drop_table for details.
       #
       # Although this command ignores the block if one is given, it can be helpful
       # to provide one in a migration's +change+ method so it can be reverted.
       # In that case, the block will be used by #create_join_table.
       def drop_join_table(table_1, table_2, **options)
         join_table_name = find_join_table_name(table_1, table_2, options)
-        drop_table(join_table_name)
+        drop_table(join_table_name, **options)
       end
 
       # A block for changing columns in +table+.

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -126,6 +126,13 @@ module ActiveRecord
         assert_not connection.table_exists?("catalog")
       end
 
+      def test_drop_join_table_with_drop_table_options
+        assert_not connection.table_exists?("artists_musics")
+        assert_nothing_raised do
+          connection.drop_join_table :artists, :musics, if_exists: true
+        end
+      end
+
       def test_drop_join_table_with_column_options
         connection.create_join_table :artists, :musics, column_options: { null: true }
         connection.drop_join_table :artists, :musics, column_options: { null: true }


### PR DESCRIPTION
[`drop_table`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/AbstractMysqlAdapter.html#method-i-drop_table) supports options like `force` and `if_not_exists`. 
This PR extends `drop_join_table` to support these options by forwarding them to the `drop_table` method.