### PR TITLE
Allow all available locales for template lookups

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -17,9 +17,11 @@ module ActionView
       ParsedPath = Struct.new(:path, :details)
 
       def build_path_regex
-        handlers = Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
-        formats = Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
-        locales = "[a-z]{2}(?:[-_][A-Z]{2})?"
+        handlers = Regexp.union(Template::Handlers.extensions.map(&:to_s))
+        formats = Regexp.union(Template::Types.symbols.map(&:to_s))
+        available_locales = I18n.available_locales.map(&:to_s)
+        regular_locales = [/[a-z]{2}(?:[-_][A-Z]{2})?/]
+        locales = Regexp.union(available_locales + regular_locales)
         variants = "[^.]*"
 
         %r{

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -242,4 +242,16 @@ module ResolverSharedTests
 
     assert_equal "Texto simple!", es_ar[0].source
   end
+
+  def test_finds_template_with_arbitrarily_formatted_locale
+    I18n.backend.store_translations(:en_customer1, { hello: "hello" })
+    with_file "test/hello_world.en_customer1.text.erb", "Good day, world."
+
+    templates = context.find_all("hello_world", "test", false, [], locale: [:en_customer1])
+
+    assert_equal 1, templates.size
+    assert_equal "Good day, world.", templates[0].source
+  ensure
+    I18n.reload!
+  end
 end


### PR DESCRIPTION
### Summary

This is a follow up to #44154 and especially the discussion here: https://github.com/rails/rails/pull/44174/files#r785160819

This PR tries to implement the idea from that discussion, to just use `I18n.available_locales` to build a list of allowed locales in a template file name.

### Other Information

Background: The `i18n` gem is relatively lax when it comes to naming locales. It does not enforce any standard. Using non-standard locale names also worked fine with translated templates up until (and including) rails 6.1.

Rails 7 changed the template lookup and enforced a naming scheme for locales. This poses a problem for legacy apps that use non-standard locale names.

In my case, I am currently trying to upgrade an app to rails 7 that is big on multitenancy and uses i18n to allow for per-tenant text changes and layout differences. Thus the tenant name is sometimes part of the locale. I worked on another app (not yet on rails 7) that used non-standard locale names to provide an alternative version of the site in "simple language", something that was required by law in this case.

Stemming from the discussion in the ticket mentioned above, the naming rules have already been relaxed a little. But as the discussion in the PR shows, this is not enough for all apps.

This PR is only a suggestion. I would be glad to have any solution that would let me keep the locale names in the aformentioned apps. And of course I am happy to help in any way I can.