### PR TITLE
Explicitly states that the return value is seconds [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -337,9 +337,8 @@ module ActiveSupport
     alias_method :in, :+
 
     # Subtracts an interval of time and returns a new TimeWithZone object unless
-    # the other value +acts_like?+ time. Then it will return a Float of the difference
-    # between the two times that represents the difference between the current
-    # object's time and the +other+ time.
+    # the other value +acts_like?+ time. In which case, it will subtract the
+    # other time and return the difference in seconds as a Float.
     #
     #   Time.zone = 'Eastern Time (US & Canada)' # => 'Eastern Time (US & Canada)'
     #   now = Time.zone.now # => Mon, 03 Nov 2014 00:26:28.725182881 EST -05:00


### PR DESCRIPTION
### Summary

Documentation change only.

The previous documentation _hints_ that the Time unit return value is "seconds" with the example, but it doesn't explicitly say "seconds" anywhere.  Just trying to make it more obvious that the value is seconds, and not something like milliseconds or nanoseconds, etc.
