### PR TITLE
Change `DeveloperWithDefaultNilableMentorScopeAllQueries` name

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -112,7 +112,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_create
-    create_sql = capture_sql { DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita") }.first
+    create_sql = capture_sql { DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita") }.first
 
     assert_no_match(/AND$/, create_sql)
   end
@@ -134,8 +134,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_select
-    DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
-    select_sql = capture_sql { DeveloperWithDefaultNilableMentorScopeAllQueries.find_by(name: "Nikita") }.first
+    DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
+    select_sql = capture_sql { DeveloperWithDefaultNilableFirmScopeAllQueries.find_by(name: "Nikita") }.first
 
     assert_no_match(/AND$/, select_sql)
   end
@@ -157,7 +157,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_update
-    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     update_sql = capture_sql { dev.update!(name: "Not Nikita") }.first
 
     assert_no_match(/AND$/, update_sql)
@@ -180,7 +180,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_update_columns
-    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     update_sql = capture_sql { dev.update_columns(name: "Not Nikita") }.first
 
     assert_no_match(/AND$/, update_sql)
@@ -203,7 +203,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_destroy
-    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     destroy_sql = capture_sql { dev.destroy }.first
 
     assert_no_match(/AND$/, destroy_sql)
@@ -226,7 +226,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_reload
-    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     reload_sql = capture_sql { dev.reload }.first
 
     assert_no_match(/AND$/, reload_sql)

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -162,7 +162,7 @@ class DeveloperWithDefaultMentorScopeAllQueries < ActiveRecord::Base
   default_scope -> { where(mentor_id: 1) }, all_queries: true
 end
 
-class DeveloperWithDefaultNilableMentorScopeAllQueries < ActiveRecord::Base
+class DeveloperWithDefaultNilableFirmScopeAllQueries < ActiveRecord::Base
   self.table_name = "developers"
   firm_id = nil # Could be something like Current.firm_id
   default_scope -> { where(firm_id: firm_id) if firm_id }, all_queries: true


### PR DESCRIPTION
### Summary

I'm sorry for a cosmetic change but the misleading class name I created a while ago in https://github.com/rails/rails/commit/43d83b4423353b7b13182ae5a0892b0ad48c363b is really bothering me
I imagine anyone who uses this class is going to be confused by the `Mentor` part in the name even though no mentor reference is being used and it's the `firm_id` column that is being nilable

I guess I made this mistake because initially wanted to use `mentor_id` column as nilable value in the query but end up using `firm_id` because a `Firm` sounds better as a "tenant" to be stored in `Current.firm_id`  
