### PR TITLE
Add `force:` support to `ActiveSupport::Cache::Store#fetch_multi`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `force:` support to `ActiveSupport::Cache::Store#fetch_multi`.
+
+    *fatkodima*
+
 *   Deprecated `:pool_size` and `:pool_timeout` options for configuring connection pooling in cache stores.
 
     Use `pool: true` to enable pooling with default settings:

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -480,7 +480,8 @@ module ActiveSupport
       #   # => { "bim" => "bam",
       #   #      "unknown_key" => "Fallback value for key: unknown_key" }
       #
-      # Options are passed to the underlying cache implementation. For example:
+      # You may also specify additional options via the +options+ argument. See #fetch for details.
+      # Other options are passed to the underlying cache implementation. For example:
       #
       #   cache.fetch_multi("fizz", expires_in: 5.seconds) do |key|
       #     "buzz"
@@ -498,7 +499,12 @@ module ActiveSupport
         options = merged_options(options)
 
         instrument :read_multi, names, options do |payload|
-          reads   = read_multi_entries(names, **options)
+          if options[:force]
+            reads = {}
+          else
+            reads = read_multi_entries(names, **options)
+          end
+
           writes  = {}
           ordered = names.index_with do |name|
             reads.fetch(name) { writes[name] = yield(name) }

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -434,9 +434,9 @@ module ActiveSupport
         end
 
         # Nonstandard store provider API to write multiple values at once.
-        def write_multi_entries(entries, expires_in: nil, **options)
+        def write_multi_entries(entries, expires_in: nil, race_condition_ttl: nil, **options)
           if entries.any?
-            if mset_capable? && expires_in.nil?
+            if mset_capable? && expires_in.nil? && race_condition_ttl.nil?
               failsafe :write_multi_entries do
                 payload = serialize_entries(entries, **options)
                 redis.with do |c|

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -194,6 +194,18 @@ module CacheStoreBehavior
     end
   end
 
+  def test_fetch_multi_with_forced_cache_miss
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "bar")
+
+    values = @cache.fetch_multi(key, other_key, force: true) { |value| value * 2 }
+
+    assert_equal({ key => (key * 2), other_key => (other_key * 2) }, values)
+    assert_equal(key * 2, @cache.read(key))
+    assert_equal(other_key * 2, @cache.read(other_key))
+  end
+
   # Use strings that are guaranteed to compress well, so we can easily tell if
   # the compression kicked in or not.
   SMALL_STRING = "0" * 100
@@ -600,6 +612,22 @@ module CacheStoreBehavior
         "baz"
       end
       assert_equal "baz", result
+    end
+  end
+
+  def test_fetch_multi_race_condition_protection
+    time = Time.now
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "foo", expires_in: 60)
+    @cache.write(other_key, "bar", expires_in: 100)
+    Time.stub(:now, time + 71) do
+      result = @cache.fetch_multi(key, other_key, race_condition_ttl: 10) do
+        assert_nil @cache.read(key)
+        assert_equal "bar", @cache.read(other_key)
+        "baz"
+      end
+      assert_equal({ key => "baz", other_key => "bar" }, result)
     end
   end
 


### PR DESCRIPTION
Now `#fetch_multi` supports all of the `#fetch` options. 
I fixed support of `race_condition_ttl` by `RedisCacheStore`, added support for `force` and updated the docs.