### PR TITLE
Ensure Rails is green with Rack-Test main branch

### DIFF
--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -44,6 +44,10 @@ module RenderStreaming
   end
 
   class StreamingTest < Rack::TestCase
+    def get(path, headers: { "SERVER_PROTOCOL" => "HTTP/1.1", "HTTP_VERSION" => "HTTP/1.1" })
+      super
+    end
+
     test "rendering with streaming enabled at the class level" do
       get "/render_streaming/basic/hello_world"
       assert_body "b\r\nHello world\r\nb\r\n, I'm here!\r\n0\r\n\r\n"

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -59,7 +59,7 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       get "/set_session_value"
       assert_response :success
       assert cookies["_session_id"]
-      session_cookie = cookies.send(:hash_for)["_session_id"]
+      session_cookie = cookies.get_cookie("_session_id")
 
       get "/call_reset_session"
       assert_response :success


### PR DESCRIPTION
This commit just ensures we're green with the main branch of rack test.
The changes are things we should have done anyway, and are backwards
compatible with older versions of rack test