### PR TITLE
Allow setting db with use_postgresql tests

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -703,20 +703,6 @@ module ApplicationTests
         end
       end
 
-      test "db:prepare setup the database even if schema does not exist" do
-        Dir.chdir(app_path) do
-          use_postgresql(multi_db: true) # bug doesn't exist with sqlite3
-          output = rails("db:drop")
-          assert_match(/Dropped database/, output)
-
-          rails "generate", "model", "recipe", "title:string"
-          output = rails("db:prepare")
-          assert_match(/CreateRecipes: migrated/, output)
-        end
-      ensure
-        rails "db:drop" rescue nil
-      end
-
       test "db:prepare does not touch schema when dumping is disabled" do
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
@@ -735,13 +721,15 @@ module ApplicationTests
 
       test "db:prepare creates test database if it does not exist" do
         Dir.chdir(app_path) do
-          use_postgresql
+          use_postgresql(database_name: "railties_db")
           rails "db:drop", "db:create"
-          rails "runner", "ActiveRecord::Base.connection.drop_database(:railties_test)"
+          rails "runner", "ActiveRecord::Base.connection.drop_database(:railties_db_test)"
 
           output = rails("db:prepare")
-          assert_match(%r{Created database 'railties_test'}, output)
+          assert_match(%r{Created database 'railties_db_test'}, output)
         end
+      ensure
+        rails "db:drop" rescue nil
       end
 
       test "lazily loaded schema cache isn't read when reading the schema migrations table" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -753,6 +753,20 @@ module ApplicationTests
         db_migrate_and_schema_cache_dump
       end
 
+      test "db:prepare setup the database even if schema does not exist" do
+        Dir.chdir(app_path) do
+          use_postgresql(multi_db: true) # bug doesn't exist with sqlite3
+          output = rails("db:drop")
+          assert_match(/Dropped database/, output)
+
+          rails "generate", "model", "recipe", "title:string"
+          output = rails("db:prepare")
+          assert_match(/CreateRecipes: migrated/, output)
+        end
+      ensure
+        rails "db:drop" rescue nil
+      end
+
       # Note that schema cache loader depends on the connection and
       # does not work for all connections.
       test "schema_cache is loaded on primary db in multi-db app" do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -464,7 +464,7 @@ module TestHelpers
       $:.reject! { |path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
 
-    def use_postgresql(multi_db: false)
+    def use_postgresql(multi_db: false, database_name: "railties_#{Process.pid}")
       if multi_db
         File.open("#{app_path}/config/database.yml", "w") do |f|
           f.puts <<-YAML
@@ -474,10 +474,10 @@ module TestHelpers
           development:
             primary:
               <<: *default
-              database: railties_test
+              database: #{database_name}_test
             animals:
               <<: *default
-              database: railties_animals_test
+              database: #{database_name}_animals_test
               migrations_paths: db/animals_migrate
           YAML
         end
@@ -489,10 +489,10 @@ module TestHelpers
             pool: 5
           development:
             <<: *default
-            database: railties_development
+            database: #{database_name}_development
           test:
             <<: *default
-            database: railties_test
+            database: #{database_name}_test
           YAML
         end
       end


### PR DESCRIPTION
If more than one test is using `use_postgresql` for it's tests and both
need to create `db:create` those tests will fail often due to them
running in parallel. I tried turning off parallelization for these tests
and they still ran in separate processes. Ultimately though, turning off
parallelization means we don't get to test parallelization. Instead I've
added the ability to set a `database_name` so that in files that require
dropping/creating the same db, we can set up a new db for those.

Fixes #45114
Fixes #45158