### PR TITLE
Bump `timeout` gem to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,7 +519,7 @@ GEM
       rack (>= 1, < 3)
     thor (1.2.1)
     tilt (2.0.10)
-    timeout (0.2.0)
+    timeout (0.3.0)
     trailblazer-option (0.1.2)
     turbo-rails (1.0.0)
       actionpack (>= 6.0.0)


### PR DESCRIPTION
This fixes the build for `guides/bug_report_templates/*_gem.rb` files.

Example failure: https://buildkite.com/rails/rails/builds/86750#0180fae4-9e78-4f61-9d12-630c7e1519f9/1158-1267

This is similar to #45052.  Eventually, this should be fixed permanently by either https://github.com/rubygems/rubygems/pull/5529 or https://github.com/rubygems/rubygems/pull/5535.
