### PR TITLE
Deprecate behaviour constant

### DIFF
--- a/actioncable/lib/action_cable/connection/stream.rb
+++ b/actioncable/lib/action_cable/connection/stream.rb
@@ -98,7 +98,7 @@ module ActionCable
 
         # This should return the underlying io according to the SPEC:
         @rack_hijack_io = @socket_object.env["rack.hijack"].call
-        # Retain existing behaviour if required:
+        # Retain existing behavior if required:
         @rack_hijack_io ||= @socket_object.env["rack.hijack_io"]
 
         @event_loop.attach(@rack_hijack_io, self)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -28,7 +28,7 @@
 *   Add the ability to use custom logic for storing and retrieving CSRF tokens.
 
     By default, the token will be stored in the session.  Custom classes can be
-    defined to specify arbitrary behaviour, but the ability to store them in
+    defined to specify arbitrary behavior, but the ability to store them in
     encrypted cookies is built in.
 
     *Andrew Kowpak*

--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -80,7 +80,7 @@ module ActionController
       # Provides a proxy to access helper methods from outside the view.
       #
       # Note that the proxy is rendered under a different view context.
-      # This may cause incorrect behaviour with capture methods. Consider
+      # This may cause incorrect behavior with capture methods. Consider
       # using {helper}[rdoc-ref:AbstractController::Helpers::ClassMethods#helper]
       # instead when using +capture+.
       def helpers

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -139,7 +139,7 @@ module ActionController # :nodoc:
       #      end
       #
       #      def handle_unverified_request
-      #        # Custom behaviour for unverfied request
+      #        # Custom behavior for unverfied request
       #      end
       #    end
       #

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -275,7 +275,7 @@ module ActionController
             comparisons between instances of `ActionController::Parameters`. If
             you need to compare to a hash, first convert it using
             `ActionController::Parameters#new`.
-            To disable the deprecated behaviour set
+            To disable the deprecated behavior set
             `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false`.
           WARNING
           @parameters == other

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -595,7 +595,7 @@ module ActionView
         # We ignore any extra parameters in the request_uri if the
         # submitted URL doesn't have any either. This lets the function
         # work with things like ?order=asc
-        # the behaviour can be disabled with check_parameters: true
+        # the behavior can be disabled with check_parameters: true
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
         request_uri = URI::DEFAULT_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -24,7 +24,7 @@
     was called before calling `perform_now`. When a record no longer exists
     and is serialized using GlobalID this led to raising
     an `ActiveJob::DeserializationError` before reaching `perform_now` call.
-    This behaviour makes difficult testing the job `discard_on/retry_on` logic.
+    This behavior makes difficult testing the job `discard_on/retry_on` logic.
 
     Now `deserialize_arguments_if_needed` call is postponed to when `perform_now`
     is called.

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -116,7 +116,7 @@ module ActiveRecord
       # true.
       # +ApplicationRecord+, for example, is generated as an abstract class.
       #
-      # Consider the following default behaviour:
+      # Consider the following default behavior:
       #
       #   Shape = Class.new(ActiveRecord::Base)
       #   Polygon = Class.new(Shape)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -326,7 +326,7 @@ module ActiveRecord
         assert_not_predicate @pool, :active_connection?
       end
 
-      def test_checkout_behaviour
+      def test_checkout_behavior
         pool = ConnectionPool.new(@pool_config)
         main_connection = pool.connection
         assert_not_nil main_connection

--- a/activerecord/test/cases/finder_respond_to_test.rb
+++ b/activerecord/test/cases/finder_respond_to_test.rb
@@ -6,19 +6,19 @@ require "models/topic"
 class FinderRespondToTest < ActiveRecord::TestCase
   fixtures :topics
 
-  def test_should_preserve_normal_respond_to_behaviour_on_base
+  def test_should_preserve_normal_respond_to_behavior_on_base
     assert_respond_to ActiveRecord::Base, :new
     assert_not_respond_to ActiveRecord::Base, :find_by_something
   end
 
-  def test_should_preserve_normal_respond_to_behaviour_and_respond_to_newly_added_method
+  def test_should_preserve_normal_respond_to_behavior_and_respond_to_newly_added_method
     Topic.singleton_class.define_method(:method_added_for_finder_respond_to_test) { }
     assert_respond_to Topic, :method_added_for_finder_respond_to_test
   ensure
     Topic.singleton_class.remove_method :method_added_for_finder_respond_to_test
   end
 
-  def test_should_preserve_normal_respond_to_behaviour_and_respond_to_standard_object_method
+  def test_should_preserve_normal_respond_to_behavior_and_respond_to_standard_object_method
     assert_respond_to Topic, :to_s
   end
 

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -114,7 +114,7 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     if 123.455.to_d(5) == BigDecimal("123.46")
       # BigDecimal's to_d behavior changed in BigDecimal 3.0.1, see https://github.com/ruby/bigdecimal/issues/70
       # TODO: replace this with a check against BigDecimal::VERSION, currently
-      # we just check the behaviour because both versions of BigDecimal report "3.0.0"
+      # we just check the behavior because both versions of BigDecimal report "3.0.0"
       assert_not_predicate subject, :valid?
     else
       assert_predicate subject, :valid?

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -287,7 +287,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
   end
 
-  class ConnectionPoolBehaviourTest < StoreTest
+  class ConnectionPoolBehaviorTest < StoreTest
     include ConnectionPoolBehavior
 
     def test_deprecated_connection_pool_works
@@ -316,7 +316,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
   end
 
-  class RedisDistributedConnectionPoolBehaviourTest < ConnectionPoolBehaviourTest
+  class RedisDistributedConnectionPoolBehaviorTest < ConnectionPoolBehaviorTest
     private
       def store_options
         { url: REDIS_URLS }

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -754,7 +754,7 @@ class StringConversionsTest < ActiveSupport::TestCase
   end
 end
 
-class StringBehaviourTest < ActiveSupport::TestCase
+class StringBehaviorTest < ActiveSupport::TestCase
   def test_acts_like_string
     assert_predicate "Bambi", :acts_like_string?
   end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -136,7 +136,7 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_equal 4, @c.size
   end
 
-  def test_raise_behaviour
+  def test_raise_behavior
     ActiveSupport::Deprecation.behavior = :raise
 
     message   = "Revise this deprecated stuff now!"

--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -93,7 +93,7 @@ class MultibyteCharsTest < ActiveSupport::TestCase
   end
 end
 
-class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
+class MultibyteCharsUTF8BehaviorTest < ActiveSupport::TestCase
   include MultibyteTestHelpers
 
   def setup

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -64,7 +64,7 @@ class SubscriberTest < ActiveSupport::TestCase
     PartySubscriber.detach_from :doodle
   end
 
-  def test_attaches_subscribers_with_inherit_all_option_replaces_original_behaviour
+  def test_attaches_subscribers_with_inherit_all_option_replaces_original_behavior
     PartySubscriber.attach_to :doodle, inherit_all: true
 
     ActiveSupport::Notifications.instrument("another_open_party.doodle")

--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -792,7 +792,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
     `ActiveSupport::TimeZone::MAPPING`.
     ([Pull Request](https://github.com/rails/rails/pull/31176))
 
-*   Changed default behaviour of `ActiveSupport::SecurityUtils.secure_compare`,
+*   Changed default behavior of `ActiveSupport::SecurityUtils.secure_compare`,
     to make it not leak length information even for variable length string.
     Renamed old `ActiveSupport::SecurityUtils.secure_compare` to
     `fixed_length_secure_compare`, and started raising `ArgumentError` in

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -418,7 +418,7 @@ end
 as long as they have no ordering, since the method needs to force an order
 internally to iterate.
 
-If an order is present in the receiver the behaviour depends on the flag
+If an order is present in the receiver the behavior depends on the flag
 [`config.active_record.error_on_ignored_order`][]. If true, `ArgumentError` is
 raised, otherwise the order is ignored and a warning issued, which is the
 default. This can be overridden with the option `:error_on_ignore`, explained

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -606,7 +606,7 @@ rails_blob_path(user.avatar, disposition: "attachment")
 ```
 
 WARNING: To prevent XSS attacks, Active Storage forces the Content-Disposition header
-to "attachment" for some kind of files. To change this behaviour see the
+to "attachment" for some kind of files. To change this behavior see the
 available configuration options in [Configuring Rails Applications](configuring.html#configuring-active-storage).
 
 If you need to create a link from outside of controller/view context (Background

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1165,7 +1165,7 @@ the top level, or on individual controllers.
 
 #### `config.action_controller.allow_deprecated_parameters_hash_equality`
 
-Controls behaviour of `ActionController::Parameters#==` with `Hash` arguments.
+Controls behavior of `ActionController::Parameters#==` with `Hash` arguments.
 Value of the setting determines whether an `ActionController::Parameters` instance is equal to an equivalent `Hash`.
 
 The default value depends on the `config.load_defaults` target version:

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -639,10 +639,10 @@ end
 get('my_action.csv')
 ```
 
-Previous behaviour was returning a `text/csv` response's Content-Type which is inaccurate since a JSON response is being rendered.
-Current behaviour correctly returns a `application/json` response's Content-Type.
+Previous behavior was returning a `text/csv` response's Content-Type which is inaccurate since a JSON response is being rendered.
+Current behavior correctly returns a `application/json` response's Content-Type.
 
-If your application relies on the previous incorrect behaviour, you are encouraged to specify
+If your application relies on the previous incorrect behavior, you are encouraged to specify
 which formats your action accepts, i.e.
 
 ```ruby

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Rails::Generators::Testing::Behaviour` in favor of `Rails::Generators::Testing::Behavior`.
+
+    *Gannon McGibbon*
+
 *   Allow configuration of logger size for local and test environments
 
     `config.log_file_size`

--- a/railties/lib/rails/generators/test_case.rb
+++ b/railties/lib/rails/generators/test_case.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators"
-require "rails/generators/testing/behaviour"
+require "rails/generators/testing/behavior"
 require "rails/generators/testing/setup_and_teardown"
 require "rails/generators/testing/assertions"
 require "fileutils"
@@ -28,7 +28,7 @@ module Rails
     #     setup :prepare_destination
     #   end
     class TestCase < ActiveSupport::TestCase
-      include Rails::Generators::Testing::Behaviour
+      include Rails::Generators::Testing::Behavior
       include Rails::Generators::Testing::SetupAndTeardown
       include Rails::Generators::Testing::Assertions
       include FileUtils

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -11,7 +11,7 @@ require "rails/generators"
 module Rails
   module Generators
     module Testing
-      module Behaviour
+      module Behavior
         extend ActiveSupport::Concern
         include ActiveSupport::Testing::Stream
 
@@ -107,6 +107,8 @@ module Rails
             Dir.glob("#{dirname}/[0-9]*_*.rb").grep(/\d+_#{file_name}.rb$/).first
           end
       end
+
+      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Behaviour", "Behavior")
     end
   end
 end

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -108,7 +108,7 @@ module Rails
           end
       end
 
-      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Behaviour", "Behavior")
+      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("behavior", "Behavior")
     end
   end
 end


### PR DESCRIPTION
### Summary

I noticed this constant was misspelled compared to other behavior modules. I also updated test cases and documentation to use the american english spelling (which seems to be the majority of usages).

