### PR TITLE
remove unused rendered_format from LookupContext

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -13,7 +13,7 @@ module ActionView
   # view paths, used in the resolver cache lookup. Since this key is generated
   # only once during the request, it speeds up all cache accesses.
   class LookupContext # :nodoc:
-    attr_accessor :prefixes, :rendered_format
+    attr_accessor :prefixes
 
     singleton_class.attr_accessor :registered_details
     self.registered_details = []


### PR DESCRIPTION
### Summary

This accessor is unused since https://github.com/rails/rails/pull/35331, and it was deprecated at the time. 

It was intended to be removed in https://github.com/rails/rails/commit/b57e227f6d6a1e410cca2d0d1b60fdf46bd3a186 but the removal of the actual accessor was missed, and only the deprecation warnings were removed.

From the comment at https://github.com/rails/rails/pull/35331#discussion_r258528415 - this method shouldn't have needed a deprecation because it was private. 