### PR TITLE
Dup options in `validates_with`

### DIFF
--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -83,7 +83,7 @@ module ActiveModel
         options[:class] = self
 
         args.each do |klass|
-          validator = klass.new(options, &block)
+          validator = klass.new(options.dup, &block)
 
           if validator.respond_to?(:attributes) && !validator.attributes.empty?
             validator.attributes.each do |attribute|
@@ -139,7 +139,7 @@ module ActiveModel
       options[:class] = self.class
 
       args.each do |klass|
-        validator = klass.new(options, &block)
+        validator = klass.new(options.dup, &block)
         validator.validate(self)
       end
     end


### PR DESCRIPTION
Some validators, such as validators that inherit from `EachValidator`, mutate the options they receive.  This can cause problems when passing multiple validators and options to `validates_with`.  This can also be a problem if a validator deletes standard options such as `:if` and `:on`, because the validation callback would then not receive them.

This commit modifies `validates_with` to `dup` options before passing them to validators, thus preventing these issues.

Fixes #44460.
Closes #44476.

---

@dspaeth-lp I've tried to add you as a co-author due to your work on #44476, but GitHub doesn't seem to like the "ä" in your name -- see `=?UTF-8?q?Dieter=20Sp=C3=A4th?=` at https://patch-diff.githubusercontent.com/raw/rails/rails/pull/44476.patch.
