### PR TITLE
Add include_seconds option to datetime_local_field.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `include_seconds` option for `datetime_local_field`
+
+    This allows to omit seconds part in the input field, by passing `include_seconds: false`
+
+    *Wojciech Wnętrzak*
+
 *   Guard against `ActionView::Helpers::FormTagHelper#field_name` calls with nil
     `object_name` arguments. For example:
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1496,6 +1496,12 @@ module ActionView
       #   datetime_field("user", "born_on", min: "2014-05-20T00:00:00")
       #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000" />
       #
+      # By default, provided datetimes will be formatted including seconds. You can render just the date, hour,
+      # and minute by passing <tt>include_seconds: false</tt>.
+      #
+      #   @user.born_on = Time.current
+      #   datetime_field("user", "born_on", include_seconds: false)
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="2014-05-20T14:35" />
       def datetime_field(object_name, method, options = {})
         Tags::DatetimeLocalField.new(object_name, method, self, options).render
       end

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -757,6 +757,7 @@ module ActionView
       # * <tt>:min</tt> - The minimum acceptable value.
       # * <tt>:max</tt> - The maximum acceptable value.
       # * <tt>:step</tt> - The acceptable value granularity.
+      # * <tt>:include_seconds</tt> - Include seconds in the output timestamp format (true by default).
       # * Otherwise accepts the same options as text_field_tag.
       def datetime_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: "datetime-local"))

--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -4,6 +4,11 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class DatetimeLocalField < DatetimeField # :nodoc:
+        def initialize(object_name, method_name, template_object, options = {})
+          @include_seconds = options.delete(:include_seconds) { true }
+          super
+        end
+
         class << self
           def field_type
             @field_type ||= "datetime-local"
@@ -12,7 +17,11 @@ module ActionView
 
         private
           def format_date(value)
-            value&.strftime("%Y-%m-%dT%T")
+            if @include_seconds
+              value&.strftime("%Y-%m-%dT%T")
+            else
+              value&.strftime("%Y-%m-%dT%H:%M")
+            end
           end
       end
     end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1254,6 +1254,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, datetime_local_field("post", "written_on"))
   end
 
+  def test_datetime_local_field_without_seconds
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00" />}
+    assert_dom_equal(expected, datetime_local_field("post", "written_on", include_seconds: false))
+  end
+
   def test_month_field
     expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
     assert_dom_equal(expected, month_field("post", "written_on"))


### PR DESCRIPTION
This allows to omit seconds part in the input field, by passing `include_seconds: false`

It's a follow up to https://github.com/rails/rails/pull/41728 /cc @ghiculescu

The difference on the UI (Firefox):

Before:
![image](https://user-images.githubusercontent.com/10766/170643991-fd414fa6-868d-4b08-97a5-122c6500d949.png)
After:
![image](https://user-images.githubusercontent.com/10766/170644042-47b98307-598c-4a3c-a318-7f4f0a4bca5e.png)
