### PR TITLE
Fixes #44879 Getting started

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1472,6 +1472,7 @@ So first, we'll wire up the Article show template
                     turbo_method: :delete,
                     turbo_confirm: "Are you sure?"
                   } %></li>
+                  <%= turbo_include_tags %>
 </ul>
 
 <h2>Add a comment:</h2>


### PR DESCRIPTION
Getting started - 7.5 deleting an article add reference to turbo_include_tags
Adding 
`<%= turbo_include_tags %>`
on line 1475

Ensures dialog opens to ask user if they would like to delete.

Without this, nothing further happens and blog post will not delete.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
