### PR TITLE
Make `find_nth_from_last` more performant when using custom order

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -559,10 +559,10 @@ module ActiveRecord
         else
           relation = ordered_relation
 
-          if equal?(relation) || has_limit_or_offset?
+          if relation.order_values.empty? || relation.has_limit_or_offset?
             relation.records[-index]
           else
-            relation.last(index)[-index]
+            relation.reverse_order.offset(index - 1).first
           end
         end
       end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -872,6 +872,17 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_nth_to_last_with_order_uses_limit
+    c = Topic.connection
+    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) do
+      Topic.second_to_last
+    end
+
+    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.updated_at"))} DESC LIMIT/i) do
+      Topic.order(:updated_at).second_to_last
+    end
+  end
+
   def test_last_bang_present
     assert_nothing_raised do
       assert_equal topics(:second), Topic.where("title = 'The Second Topic of the day'").last!


### PR DESCRIPTION
Before this PR, when using custom order with `find_nth_from_last`, like `User.order(:updated_at).second_to_last`, AR will load all the records.

### Before
```
> User.order(:updated_at).second_to_last
User Load (0.6ms)  SELECT "users".* FROM "users" ORDER BY "users"."updated_at" ASC
```

### After
```
> User.order(:updated_at).second_to_last
User Load (1.1ms)  SELECT "users".* FROM "users" ORDER BY "users"."updated_at" DESC LIMIT $1  [["LIMIT", 2]]
```

Follow up of https://github.com/rails/rails/commit/f5328d9379da473bfc5420996693a14c6e0d2556