### PR TITLE
Application-specific `rails routes` option

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Set `application_set: true` when building routes
+
+    When drawing routes that are defined from within the application, set `application_set` 
+    to true.
+
+    *Paul Hendrick*
+
 *   Allow using `helper_method`s in `content_security_policy` and `permissions_policy`
 
     Previously you could access basic helpers (defined in helper modules), but not

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,10 +1,3 @@
-*   Set `application_set: true` when building routes
-
-    When drawing routes that are defined from within the application, set `application_set` 
-    to true.
-
-    *Paul Hendrick*
-
 *   Allow using `helper_method`s in `content_security_policy` and `permissions_policy`
 
     Previously you could access basic helpers (defined in helper modules), but not

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -5,7 +5,7 @@ module ActionDispatch
   module Journey
     class Route
       attr_reader :app, :path, :defaults, :name, :precedence, :constraints,
-                  :internal, :scope_options, :ast
+                  :internal, :scope_options, :ast, :application_set
 
       alias :conditions :constraints
 
@@ -53,7 +53,7 @@ module ActionDispatch
       ##
       # +path+ is a path constraint.
       # +constraints+ is a hash of constraints to be applied to this route.
-      def initialize(name:, app: nil, path:, constraints: {}, required_defaults: [], defaults: {}, request_method_match: nil, precedence: 0, scope_options: {}, internal: false)
+      def initialize(name:, app: nil, path:, constraints: {}, required_defaults: [], defaults: {}, request_method_match: nil, precedence: 0, scope_options: {}, internal: false, application_set: false)
         @name        = name
         @app         = app
         @path        = path
@@ -69,6 +69,7 @@ module ActionDispatch
         @path_formatter    = @path.build_formatter
         @scope_options     = scope_options
         @internal          = internal
+        @application_set   = application_set
 
         @ast = @path.ast.root
         @path.ast.route = self

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       end
 
       def format(formatter, filter = {})
-        routes_to_display = filter_routes(normalize_filter(filter))
+        routes_to_display = filter_routes(normalize_filter(filter), application_routes: filter[:application] == "application")
         routes = collect_routes(routes_to_display)
         if routes.none?
           formatter.no_routes(collect_routes(@routes), filter)
@@ -97,7 +97,9 @@ module ActionDispatch
           end
         end
 
-        def filter_routes(filter)
+        def filter_routes(filter, application_routes: false)
+          @routes = @routes.select { |route| route.application_set } if application_routes
+
           if filter
             @routes.select do |route|
               route_wrapper = RouteWrapper.new(route)

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -69,7 +69,7 @@ module ActionDispatch
       end
 
       def format(formatter, filter = {})
-        routes_to_display = filter_routes(normalize_filter(filter), application_routes: filter[:application] == "application")
+        routes_to_display = filter_routes(normalize_filter(filter), application_routes: filter[:application])
         routes = collect_routes(routes_to_display)
         if routes.none?
           formatter.no_routes(collect_routes(@routes), filter)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -170,7 +170,8 @@ module ActionDispatch
           Journey::Route.new(name: name, app: application, path: path, constraints: conditions,
                              required_defaults: required_defaults, defaults: defaults,
                              request_method_match: request_method, precedence: precedence,
-                             scope_options: scope_options, internal: @internal)
+                             scope_options: scope_options, internal: @internal,
+                             application_set: @set.config.application_set)
         end
 
         def application

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -406,7 +406,7 @@ module ActionDispatch
       private :make_request
 
       def draw(&block)
-        if Rails.root.present? && block_given?
+        if defined?(Rails.root) && block_given?
           config.application_set = /^#{Rails.root}/.match?(block.source_location.first)
         end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -336,7 +336,7 @@ module ActionDispatch
       attr_accessor :formatter, :set, :named_routes, :default_scope, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names
       attr_accessor :default_url_options, :draw_paths
-      attr_reader :env_key, :polymorphic_mappings
+      attr_reader :env_key, :polymorphic_mappings, :config
 
       alias :routes :set
 
@@ -359,7 +359,7 @@ module ActionDispatch
         new route_set_config
       end
 
-      Config = Struct.new :relative_url_root, :api_only
+      Config = Struct.new :relative_url_root, :api_only, :application_set
 
       DEFAULT_CONFIG = Config.new(nil, false)
 
@@ -406,6 +406,10 @@ module ActionDispatch
       private :make_request
 
       def draw(&block)
+        if Rails.root.present? && block_given?
+          config.application_set = /^#{Rails.root}/.match?(block.source_location.first)
+        end
+
         clear! unless @disable_clear_and_finalize
         eval_block(block)
         finalize! unless @disable_clear_and_finalize

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Adds an `--application` option to the routes command to enable only 
+    showing routes defined in routes.rb
+
+    *Paul Hendrick*
+    
 *   Avoid booting in development then test for test tasks.
 
     Running one of the rails test subtasks (e.g. test:system, test:models) would

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -8,6 +8,7 @@ module Rails
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
+      class_option :application, aliases: "-a", desc: "Only print routes defined in routes.rb"
 
       def perform(*)
         require_application_and_environment!
@@ -30,7 +31,7 @@ module Rails
         end
 
         def routes_filter
-          options.symbolize_keys.slice(:controller, :grep)
+          options.symbolize_keys.slice(:controller, :grep, :application)
         end
     end
   end

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -8,7 +8,7 @@ module Rails
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
-      class_option :application, aliases: "-a", desc: "Only print routes defined in routes.rb"
+      class_option :application, aliases: "-a", type: :boolean, desc: "Only print routes defined in routes.rb"
 
       def perform(*)
         require_application_and_environment!

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -197,6 +197,25 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     MESSAGE
   end
 
+  test "rails application routes only" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resource :post
+      end
+    RUBY
+
+    assert_equal <<~OUTPUT, run_routes_command([ "--application" ])
+                             Prefix Verb   URI Pattern          Controller#Action
+                           new_post GET    /post/new(.:format)  posts#new
+                          edit_post GET    /post/edit(.:format) posts#edit
+                               post GET    /post(.:format)      posts#show
+                                    PATCH  /post(.:format)      posts#update
+                                    PUT    /post(.:format)      posts#update
+                                    DELETE /post(.:format)      posts#destroy
+                                    POST   /post(.:format)      posts#create
+    OUTPUT
+  end
+
   test "rails routes with expanded option" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do


### PR DESCRIPTION
This PR allows users to view just the routes defined in their application's routes.rb with: `rails routes --application`

When printing the routes an additonal class_option (`--application`) includes an additional key in the routes_filter hash, which is passed into `RoutesInspector#format`. 

Each `Route` instance in @routes is initialized with `application_set: ` which is true when the corresponding `RouteSet` is generated by routes drawn in a routes.rb file within the application root folder. 