### PR TITLE
Allow GCS service update_metadata method to set cache_control header

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow GCS service update_metadata method to set cache_control header
+
+    Previously, the update_metadata method in `ActiveStorage::Service::GCSService`
+    did not allow for updating the `"Cache-Control"` header on the service.
+    Now, update_metadata takes an argument `cache_control` that correctly
+    updates the `"Cache-Control"` header for the file on Google Cloud Storage.
+
+    *Texas Delaney*
+
 *   Fixes proxy downloads of files over 5mb 
 
     Previously, trying to view and/or download files larger than 5mb stored in

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -43,11 +43,12 @@ module ActiveStorage
       end
     end
 
-    def update_metadata(key, content_type:, disposition: nil, filename: nil, custom_metadata: {})
+    def update_metadata(key, content_type:, disposition: nil, filename: nil, cache_control: nil, custom_metadata: {})
       instrument :update_metadata, key: key, content_type: content_type, disposition: disposition do
         file_for(key).update do |file|
           file.content_type = content_type
           file.content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
+          file.cache_control = cache_control if cache_control
           file.metadata = custom_metadata
         end
       end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -132,6 +132,22 @@ if SERVICE_CONFIGURATIONS[:gcs]
       service.delete key
     end
 
+    test "update cache_control" do
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html", custom_metadata: { "foo" => "baz" })
+
+      @service.update_metadata(key, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain", cache_control: "public, max-age=2200", custom_metadata: { "foo" => "bar" })
+      url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "text/plain", response.content_type
+      assert_match(/inline;.*test.txt/, response["Content-Disposition"])
+      assert_equal("public, max-age=2200", response["Cache-Control"])
+    ensure
+      @service.delete key
+    end
+
     test "upload with custom_metadata" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"


### PR DESCRIPTION
Previously, the update_metadata method in `ActiveStorage::Service::GCSService` did not allow for updating the `"Cache-Control"` header on the service. Now, update_metadata takes an argument `cache_control` that correctly updates the `"Cache-Control"` header for the file on Google Cloud Storage.
