### PR TITLE
Improve ActiveStorage::Analyzer::ImageAnalyzer#metadata

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -32,8 +32,10 @@ module ActiveStorage
         {}
       end
 
+      ROTATIONS = Set.new(%w[RightTop LeftBottom TopRight BottomLeft]).freeze
+
       def rotated_image?(image)
-        %w[ RightTop LeftBottom TopRight BottomLeft ].include?(image["%[orientation]"])
+        ROTATIONS.include?(image["%[orientation]"])
       end
   end
 end

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -33,8 +33,9 @@ module ActiveStorage
       end
 
       ROTATIONS = /Right-top|Left-bottom|Top-right|Bottom-left/
+
       def rotated_image?(image)
-        ROTATIONS === image.get("exif-ifd0-Orientation")
+        ROTATIONS.match? image.get("exif-ifd0-Orientation")
       rescue ::Vips::Error
         false
       end


### PR DESCRIPTION
### Summary

Fixing both implementations having each a different problem related to the assertion of the rotation of the images soon to be analyzed:

- VIPS: is too slow
- Imagemagick: creates a new array on every call (using more memory)

### Other Information

VIPS
----

The implementation using ruby-vips is using `Regexp#===` to compare the results of the EXIF data using `Vips::Image#get`, which turns out is not that fast compared with `Regexp#match?` when using the following micro-benchmark:

```ruby
require 'benchmark/ips'

cases = [
 "1 (Top-left, Short, 1 components, 2 bytes)",
 "0 (Top-right, Short, 1 components, 2 bytes)",
 "3 (Bottom-right, Short, 1 components, 2 bytes)",
 "4 (Bottom-left, Short, 1 components, 2 bytes)",
 "5 (Left-top, Short, 1 components, 2 bytes)",
 "6 (Right-top, Short, 1 components, 2 bytes)",
 "7 (Right-bottom, Short, 1 components, 2 bytes)",
 "8 (Left-bottom, Short, 1 components, 2 bytes)"
].freeze

ROTATIONS = /Right-top|Left-bottom|Top-right|Bottom-left/

Benchmark.ips do |x|
  x.report('Regexp.match?') { ROTATIONS.match?(cases.sample) }
  x.report('Regexp ===') { ROTATIONS === cases.sample }
  x.compare!
end
```
Results - using the minimal improvement since the maximal goes up to 3.x faster:

```
Warming up --------------------------------------
       Regexp.match?   482.481k i/100ms
          Regexp ===   205.449k i/100ms
Calculating -------------------------------------
       Regexp.match?      3.075M (± 3.0%) i/s - 15.439M in   5.025161s
          Regexp ===      1.987M (± 2.7%) i/s - 10.067M in   5.070618s

Comparison:
       Regexp.match?:  3075191.3 i/s
          Regexp ===:  1986792.5 i/s - 1.55x (± 0.00) slower
```
I've checked the compatibility of both methods, and both looks like yielding the same results:

```ruby
cases = [
 "1 (Top-left, Short, 1 components, 2 bytes)",
 "2 (Top-right, Short, 1 components, 2 bytes)",
 "3 (Bottom-right, Short, 1 components, 2 bytes)",
 "4 (Bottom-left, Short, 1 components, 2 bytes)",
 "5 (Left-top, Short, 1 components, 2 bytes)",
 "6 (Right-top, Short, 1 components, 2 bytes)",
 "7 (Right-bottom, Short, 1 components, 2 bytes)",
 "8 (Left-bottom, Short, 1 components, 2 bytes)"
]

cases.each_with_object({}) do |orientation, hash|
  hash[orientation] = {
    '==='    => ROTATIONS === orientation,
    'match?' => ROTATIONS.match?(orientation)
  }
end

{"1 (Top-left, Short, 1 components, 2 bytes)"
   => {"===" => false, "match?" => false},
 "2 (Top-right, Short, 1 components, 2 bytes)"
   => {"===" => true, "match?" => true},
 "3 (Bottom-right, Short, 1 components, 2 bytes)"
   => {"===" => false, "match?" => false},
 "4 (Bottom-left, Short, 1 components, 2 bytes)"
   => {"===" => true, "match?" => true},
 "5 (Left-top, Short, 1 components, 2 bytes)"
   => {"===" => false, "match?" => false},
 "6 (Right-top, Short, 1 components, 2 bytes)"
   => {"===" => true, "match?" => true},
 "7 (Right-bottom, Short, 1 components, 2 bytes)"
   => {"=== "=> false, "match?" => false},
 "8 (Left-bottom, Short, 1 components, 2 bytes)"
   => {"===" => true, "match?" => true}
   }
```

Image Magick
---

In this case, the method was creating an array on every execution of `rotated_image?`, extracting the array into a constant and changing to be a `Set` will bring two benefit at once: don't use more memory and also be slightly fast since the Set are a O(1) operation and the array search is O(n).

A last benefit of this change is to have symmetric implementations when using `ROTATIONS` constant for both.
