### PR TITLE
Fix with_options bug when first argument is a Proc

### DIFF
--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -15,8 +15,8 @@ module ActiveSupport
     private
       def method_missing(method, *arguments, &block)
         options = nil
-        if arguments.first.is_a?(Proc)
-          proc = arguments.pop
+        if arguments.size == 1 && arguments.first.is_a?(Proc)
+          proc = arguments.shift
           arguments << lambda { |*args| @options.deep_merge(proc.call(*args)) }
         elsif arguments.last.respond_to?(:to_hash)
           options = @options.deep_merge(arguments.pop)

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -84,10 +84,19 @@ class OptionMergerTest < ActiveSupport::TestCase
     end
   end
 
-  def test_nested_method_with_options_using_lambda
+  def test_nested_method_with_options_using_lambda_as_only_argument
     local_lambda = lambda { { lambda: true } }
     with_options(@options) do |o|
       assert_equal @options.merge(local_lambda.call), o.method_with_options(local_lambda).call
+    end
+  end
+
+  def test_proc_as_first_argument_with_other_options_should_still_merge_options
+    local_proc = proc { }
+    local_options = { "cool" => true }
+
+    with_options(@options) do |o|
+      assert_equal [local_proc, @options.merge(local_options)], o.method_with_args(local_proc, local_options)
     end
   end
 
@@ -114,6 +123,10 @@ class OptionMergerTest < ActiveSupport::TestCase
   end
 
   private
+    def method_with_args(*args)
+      args
+    end
+
     def method_with_options(options = {})
       options
     end


### PR DESCRIPTION
An ArgumentError was being raised when methods were called with (proc, options) inside a `with_options` block:

```ruby
def my_method(arg1, **kwargs)
  [arg1, kwargs]
end

# this would raise instead of merging options
with_options(hello: "world") do
  my_method(proc {}, {fizz: "buzz"})
end
```

Fixes #45183