### PR TITLE
Pass additional connection options to `psql` when running `rails dbconsole`

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -52,6 +52,11 @@ module Rails
         ENV["PGSSLCERT"]      = config[:sslcert].to_s if config[:sslcert]
         ENV["PGSSLKEY"]       = config[:sslkey].to_s if config[:sslkey]
         ENV["PGSSLROOTCERT"]  = config[:sslrootcert].to_s if config[:sslrootcert]
+        if config[:variables]
+          ENV["PGOPTIONS"] = config[:variables].filter_map do |name, value|
+            "-c #{name}=#{value.to_s.gsub(/[ \\]/, '\\\\\0')}" unless value == ":default" || value == :default
+          end.join(" ")
+        end
         find_cmd_and_exec("psql", db_config.database)
 
       when "sqlite3"

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -158,6 +158,12 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_equal "q1w2e3", ENV["PGPASSWORD"]
   end
 
+  def test_postgresql_include_variables
+    start(adapter: "postgresql", database: "db", variables: { search_path: "my_schema, default, \\my_schema", statement_timeout: 5000, lock_timeout: ":default" })
+    assert_not aborted
+    assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema -c statement_timeout=5000", ENV["PGOPTIONS"]
+  end
+
   def test_sqlite3
     start(adapter: "sqlite3", database: "db.sqlite3")
     assert_not aborted


### PR DESCRIPTION
Previously, when we have a `database.yml` with something like
```yml
development:
  adapter: postgresql
  database: app_development
  variables:
    statement_timeout: 5s
```

then when running `rails dbconsole`, the `statement_timeout` will not be correctly set.

The logic for `:default` and `":default"` is based on https://github.com/rails/rails/blob/ea9d914cbabe747ea268cdd7442974f3d8682ccf/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L878-L881

and parameters are quoted accordingly to the rules from [pg docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS).