### PR TITLE
Adds ability to get the combined bytes_size of all attached blobs

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add a helper to get the combined byte size of blobs attached via `has_many_attached`.
+
+    ```ruby
+    document.images.byte_size # => 2048
+    ```
+
+    *Sandip Mane*, *fatkodima*
+
 *   Implement `attach!` as a bang counterpart to `attach`.
 
     This method raises an exception if the attachment was not saved, similar

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -77,6 +77,13 @@ module ActiveStorage
       attachments.any?
     end
 
+    # Returns the combined size in bytes of all attached blobs.
+    #
+    #   document.images.byte_size # => 2048
+    def byte_size
+      blobs.pluck(:byte_size).sum
+    end
+
     def as_json(options = nil)
       attachments.as_json(options)
     end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -955,6 +955,20 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
   end
 
+  test "getting the combined byte size of persisted attachments" do
+    blobs = [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ]
+    @user.highlights.attach(blobs)
+
+    assert_equal blobs.sum(&:byte_size), @user.highlights.byte_size
+  end
+
+  test "getting the combined byte size of non persisted attachments" do
+    blobs = [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ]
+    @user.highlights = blobs
+
+    assert_equal blobs.sum(&:byte_size), @user.highlights.byte_size
+  end
+
   test "as_json returns an empty array when no attachments are present" do
     assert_equal [], @user.highlights.as_json
   end


### PR DESCRIPTION
Adds ability to get the combined bytes_size of all attached blobs.

Example:
```ruby
class Gallery < ApplicationRecord
  has_many_attached :photos
end

Gallery.new.photos.byte_size
```