### PR TITLE
small error/typo in first example of pluck section

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2064,7 +2064,7 @@ irb> Customer.connection.select_all("SELECT first_name, created_at FROM customer
 
 ```irb
 irb> Book.where(out_of_print: true).pluck(:id)
-SELECT id FROM books WHERE out_of_print = false
+SELECT id FROM books WHERE out_of_print = true
 => [1, 2, 3]
 
 irb> Order.distinct.pluck(:status)


### PR DESCRIPTION
### Summary

In section "20.2 pluck" of the Active Record Query Interface Guide, the comment of the first query example says `WHERE out_of_print = false` while the query sets `out_of_print: true` actually.
