### PR TITLE
Use `no-skip` flags to restore components `minimal` skips

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow `--no-skip-*` flags with `rails new` to restore individual components
+    in a `--minimal` build.
+
+    For example, `rails new cool_app --minimal --no-skip-action-cable` will
+    create a standard minimal app with Action Cable functionality also included.
+
+    *Brad Trick*
+
 *   Deprecate `Rails::Generators::Testing::Behaviour` in favor of `Rails::Generators::Testing::Behavior`.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -84,6 +84,9 @@ module Rails
         class_option :skip_bootsnap,       type: :boolean, default: false,
                                            desc: "Skip bootsnap gem"
 
+        class_option :skip_dev_gems,       type: :boolean, default: false,
+                                           desc: "Skip development gems (e.g., web-console)"
+
         class_option :dev,                 type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -232,10 +235,6 @@ module Rails
 
       def skip_action_text? # :doc:
         options[:skip_action_text] || skip_active_storage?
-      end
-
-      def skip_dev_gems? # :doc:
-        options[:skip_dev_gems]
       end
 
       def skip_sprockets?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -268,7 +268,24 @@ module Rails
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
       class_option :skip_decrypted_diffs, type: :boolean, default: false, desc: "Don't configure git to show decrypted diffs of encrypted credentials"
 
-      def initialize(*args)
+      def initialize(positional_argv, option_argv, *)
+        if option_argv.include?("--minimal")
+          option_argv.insert(0, *%w[
+            --skip-action-cable
+            --skip-action-mailer
+            --skip-action-mailbox
+            --skip-action-text
+            --skip-active-job
+            --skip-active-storage
+            --skip-bootsnap
+            --skip-dev-gems
+            --skip-javascript
+            --skip-jbuilder
+            --skip-system-test
+            --skip-hotwire
+          ])
+        end
+
         super
 
         if !options[:skip_active_record] && !DATABASES.include?(options[:database])
@@ -279,22 +296,6 @@ module Rails
         # Can't modify options hash as it's frozen by default.
         if options[:api]
           self.options = options.merge(skip_asset_pipeline: true, skip_javascript: true).freeze
-        end
-
-        if options[:minimal]
-          self.options = options.merge(
-            skip_action_cable: true,
-            skip_action_mailer: true,
-            skip_action_mailbox: true,
-            skip_action_text: true,
-            skip_active_job: true,
-            skip_active_storage: true,
-            skip_bootsnap: true,
-            skip_dev_gems: true,
-            skip_javascript: true,
-            skip_jbuilder: true,
-            skip_system_test: true,
-            skip_hotwire: true).freeze
         end
 
         @after_bundle_callbacks = []

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1063,6 +1063,74 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "web-console"
   end
 
+  def test_minimal_rails_app_plus_action_cable
+    run_generator [destination_root, "--minimal", "--no-skip-action-cable"]
+    assert_file "config/cable.yml"
+  end
+
+  def test_minimal_rails_app_plus_action_mailer
+    run_generator [destination_root, "--minimal", "--no-skip-action-mailer"]
+    assert_file "app/views/layouts/mailer.html.erb"
+  end
+
+  def test_minimal_rails_app_plus_action_mailbox
+    run_generator [destination_root, "--minimal", "--no-skip-action-mailbox", "--no-skip-active-storage"]
+    assert_file "config/application.rb" do |content|
+      assert_match %r/^require\s+["']action_mailbox\/engine["']/, content
+    end
+  end
+
+  def test_minimal_rails_app_plus_action_text
+    run_generator [destination_root, "--minimal", "--no-skip-action-text", "--no-skip-active-storage"]
+    assert_file "config/application.rb" do |content|
+      assert_match %r/^require\s+["']action_text\/engine["']/, content
+    end
+  end
+
+  def test_minimal_rails_app_plus_active_job
+    run_generator [destination_root, "--minimal", "--no-skip-active-job"]
+    assert_file "app/jobs/application_job.rb"
+  end
+
+  def test_minimal_rails_app_plus_active_storage
+    run_generator [destination_root, "--minimal", "--no-skip-active-storage"]
+    assert_file "config/storage.yml"
+  end
+
+  def test_minimal_rails_app_plus_bootsnap
+    run_generator [destination_root, "--minimal", "--no-skip-bootsnap"]
+    unless defined?(JRUBY_VERSION)
+      assert_gem "bootsnap"
+    else
+      assert_no_gem "bootsnap"
+    end
+  end
+
+  def test_minimal_rails_app_plus_dev_gems
+    run_generator [destination_root, "--minimal", "--no-skip-dev-gems"]
+    assert_gem "web-console"
+  end
+
+  def test_minimal_rails_app_plus_javascript
+    run_generator [destination_root, "--minimal", "--no-skip-javascript"]
+    assert_gem "importmap-rails"
+  end
+
+  def test_minimal_rails_app_plus_jbuilder
+    run_generator [destination_root, "--minimal", "--no-skip-jbuilder"]
+    assert_gem "jbuilder"
+  end
+
+  def test_minimal_rails_app_plus_system_test
+    run_generator [destination_root, "--minimal", "--no-skip-system-test"]
+    assert_gem "capybara"
+  end
+
+  def test_minimal_rails_app_plus_hotwire
+    run_generator [destination_root, "--minimal", "--no-skip-javascript", "--no-skip-hotwire"]
+    assert_gem "turbo-rails"
+  end
+
   def test_name_option
     run_generator [destination_root, "--name=my-app"]
     assert_file "config/application.rb", /^module MyApp$/


### PR DESCRIPTION
Allow `--no-skip-*` flags with `rails new` to restore individual components
in a `--minimal` build.

For example, `rails new cool_app --minimal --no-skip-action-cable` will
create a standard minimal app with Action Cable functionality also included.

Allowed flags are:

    --no-skip-action-cable
    --no-skip-action-mailer
    --no-skip-action-mailbox
    --no-skip-action-text
    --no-skip-active-job
    --no-skip-active-storage
    --no-skip-bootsnap
    --no-skip-dev-gems
    --no-skip-javascript
    --no-skip-jbuilder
    --no-skip-system-test
    --no-skip-hotwire

Commit also makes `:skip_dev_gems` a `class_option` for `AppBase`
and includes tests for each flag.
<!-- ### Summary -->

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
