### PR TITLE
Omit `workers` and `preload_app!` from Puma config

### DIFF
--- a/actionmailbox/test/dummy/config/puma.rb
+++ b/actionmailbox/test/dummy/config/puma.rb
@@ -15,20 +15,5 @@ port        Integer(ENV.fetch("PORT", "3000"))
 #
 environment ENV.fetch("RAILS_ENV", "development")
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers Integer(ENV.fetch("WEB_CONCURRENCY", "2"))
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
-
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/actiontext/test/dummy/config/puma.rb
+++ b/actiontext/test/dummy/config/puma.rb
@@ -15,20 +15,5 @@ port        ENV.fetch("PORT") { 3000 }
 #
 environment ENV.fetch("RAILS_ENV") { "development" }
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
-
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -1,3 +1,7 @@
+# This configuration file will be evaluated by Puma. The top-level methods that
+# are invoked here are part of Puma's configuration DSL. For more information
+# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -23,21 +27,6 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
-
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Since Puma 5.0 (puma/puma@05936689c832e33a915a052b10a20b5bbd173e1a), Puma will automatically set `workers` to `ENV["WEB_CONCURRENCY"] || 0`.  Additionally, if `ENV["WEB_CONCURRENCY"]` > 1, Puma will automatically set `preload_app`.

This can lead to confusing scenarios for users who are unaware of this behavior and have customized `config/puma.rb`.  For example, if a user uncomments the `workers` and `preload_app!` directives, it is clear that Puma will preload the app, and the number of workers can be configured by setting `ENV["WEB_CONCURRENCY"]`.  If the user sets `ENV["WEB_CONCURRENCY"]` > 1, but then changes their mind and removes the `workers` or `preload_app!` directives *without* clearing `ENV["WEB_CONCURRENCY"]`, Puma will still preload the app and launch `ENV["WEB_CONCURRENCY"]` number of workers.  Similarly, if a user uncomments *only* the `workers` directive and sets `ENV["WEB_CONCURRENCY"]` > 1, Puma will preload the app even though the `preload_app!` directive is still commented out.

To avoid such scenarios, this commit removes the commented-out `workers` and `preload_app!` directives from the default `config/puma.rb`.

Also, to improve discoverability of available configuration options, this commit adds a link to the Puma DSL documentation at the top of the file.
