### PR TITLE
Temporarily remove platforms from tzinfo-data gem

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -16,7 +16,9 @@ ruby <%= "\"#{RUBY_VERSION}\"" -%>
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+<%# TODO: use platforms again after rubygems/rubygems#5269 is fixed -%>
+<%# gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ] -%>
+gem "tzinfo-data"
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb


### PR DESCRIPTION
### Summary

The current platforms string will not match for Ruby 3.1+ on Windows,
causing tzdata-info to not be installed and loading the environment
during `rails new` to fail.

For now, we should remove the platforms restriction so that all new
application Gemfiles will include tzdata-info by default. This provides
a better experience for those running Ruby 3.1 on Windows, and if the
user knows they will not be running on Windows then they can remove the
gem or apply the platforms optimization themselves.

This change should be reverted (or updated) after rubygems/rubygems#5269
is resolved.

### Other Information

Closes #44952
Closes #44879 
Closes #45190 