### PR TITLE
Support adding and removing `CHECK` constraints in bulk `change_table`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support adding and removing `CHECK` constraints in bulk `change_table`.
+
+    Previously, each operation generated their own `ALTER TABLE` statement.
+
+    *fatkodima*
+
 *   Fix eager loading for models without primary keys.
 
     *Anmol Chopra*, *Matt Lawrence*, and *Jonathan Hefner*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -24,8 +24,8 @@ module ActiveRecord
           sql << o.adds.map { |col| accept col }.join(" ")
           sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
           sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
-          sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
-          sql << o.check_constraint_drops.map { |con| visit_DropCheckConstraint con }.join(" ")
+          sql << o.check_constraint_adds.map { |con| accept con }.join(" ")
+          sql << o.check_constraint_drops.map { |con| accept con }.join(" ")
         end
 
         def visit_ColumnDefinition(o)
@@ -110,11 +110,11 @@ module ActiveRecord
         end
 
         def visit_AddCheckConstraint(o)
-          "ADD #{accept(o)}"
+          "ADD #{accept(o.check_constraint_definition)}"
         end
 
-        def visit_DropCheckConstraint(name)
-          "DROP CONSTRAINT #{quote_column_name(name)}"
+        def visit_DropCheckConstraint(o)
+          "DROP CONSTRAINT #{quote_column_name(o.name)}"
         end
 
         def quoted_columns(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -150,6 +150,9 @@ module ActiveRecord
       end
     end
 
+    AddCheckConstraint = Struct.new(:check_constraint_definition)
+    DropCheckConstraint = Struct.new(:name)
+
     class ReferenceDefinition # :nodoc:
       def initialize(
         name,
@@ -570,11 +573,11 @@ module ActiveRecord
       end
 
       def add_check_constraint(expression, options)
-        @check_constraint_adds << @td.new_check_constraint_definition(expression, options)
+        @check_constraint_adds << AddCheckConstraint.new(@td.new_check_constraint_definition(expression, options))
       end
 
       def drop_check_constraint(constraint_name)
-        @check_constraint_drops << constraint_name
+        @check_constraint_drops << DropCheckConstraint.new(constraint_name)
       end
 
       def add_column(name, type, **options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -11,8 +11,8 @@ module ActiveRecord
             "DROP FOREIGN KEY #{name}"
           end
 
-          def visit_DropCheckConstraint(name)
-            "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{name}"
+          def visit_DropCheckConstraint(o)
+            "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{o.name}"
           end
 
           def visit_AddColumnDefinition(o)


### PR DESCRIPTION
```ruby
change_table :users, bulk: true do |t|
  t.integer :age
  t.check_constraint "age >= 0"
end
```

### Before
```
(0.5ms)  ALTER TABLE "users" ADD "age" integer
(0.4ms)  ALTER TABLE "users" ADD CONSTRAINT chk_rails_124019740c CHECK (age >= 0)
```

### After
```
(0.8ms)  ALTER TABLE "users" ADD "age" integer, ADD CONSTRAINT chk_rails_124019740c CHECK (age >= 0)
```