### PR TITLE
Fix incorrect paths in generator tests

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -545,7 +545,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_if_skip_active_job_is_given
     run_generator [destination_root, "--skip-active-job"]
-    assert_no_file "app/jobs/application.rb"
+    assert_no_file "app/jobs/application_job.rb"
     assert_file "config/environments/production.rb" do |content|
       assert_no_match(/config\.active_job/, content)
     end
@@ -1036,8 +1036,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "config/storage.yml"
     assert_no_file "config/cable.yml"
-    assert_no_file "views/layouts/mailer.html.erb"
-    assert_no_file "app/jobs/application.rb"
+    assert_no_file "app/views/layouts/mailer.html.erb"
+    assert_no_file "app/jobs/application_job.rb"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_no_match(/data-turbo-track/, content)
     end


### PR DESCRIPTION
### Summary

This commit fixes three `assert_no_file` tests with incorrect paths.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
