### PR TITLE
Event.delete_all after `UniquenessValidationWithIndexTest#test_uniqueness_on_relation`

### DIFF
--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -763,6 +763,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
     end
   ensure
     TopicWithEvent.clear_validators!
+    Event.delete_all
   end
 
   def test_index_of_sublist_of_columns


### PR DESCRIPTION
This pull request fixes this failure.
https://buildkite.com/rails/rails/builds/86845#018111de-9342-4b33-a792-cb06c07721e2

```ruby
$ ARCONN=sqlite3 bin/test test/cases/validations/uniqueness_validation_test.rb test/cases/adapter_test.rb -n "/^(?:UniquenessValidationWithIndexTest#(?:test_uniqueness_on_relation)|ActiveRecord::AdapterTest#(?:test_select_all_insert_update_delete_with_binds|test_select_all_insert_update_delete_with_casted_binds))$/" --seed 65047
Using sqlite3
Run options: -n "/^(?:UniquenessValidationWithIndexTest#(?:test_uniqueness_on_relation)|ActiveRecord::AdapterTest#(?:test_select_all_insert_update_delete_with_binds|test_select_all_insert_update_delete_with_casted_binds))$/" --seed 65047

.E

Error:
ActiveRecord::AdapterTest#test_select_all_insert_update_delete_with_binds:
ActiveRecord::RecordNotUnique: SQLite3::ConstraintException: UNIQUE constraint failed: events.id
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:108:in `step'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:108:in `block in each'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:107:in `loop'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:107:in `each'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:56:in `to_a'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:56:in `block (2 levels) in exec_query'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/dependencies/interlock.rb:41:in `permit_concurrent_loads'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:47:in `block in exec_query'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:830:in `block in log'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:821:in `log'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:46:in `exec_query'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:132:in `exec_insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:167:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapter_test.rb:264:in `test_select_all_insert_update_delete_with_binds'

bin/test test/cases/adapter_test.rb:260

E

Error:
ActiveRecord::AdapterTest#test_select_all_insert_update_delete_with_casted_binds:
ActiveRecord::RecordNotUnique: SQLite3::ConstraintException: UNIQUE constraint failed: events.id
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:108:in `step'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:108:in `block in each'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:107:in `loop'
    /home/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sqlite3-1.4.2/lib/sqlite3/statement.rb:107:in `each'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:56:in `to_a'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:56:in `block (2 levels) in exec_query'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/dependencies/interlock.rb:41:in `permit_concurrent_loads'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:47:in `block in exec_query'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:830:in `block in log'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:821:in `log'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:46:in `exec_query'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:132:in `exec_insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:167:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapter_test.rb:244:in `test_select_all_insert_update_delete_with_casted_binds'

bin/test test/cases/adapter_test.rb:240

Finished in 0.041846s, 71.6915 runs/s, 95.5887 assertions/s.
3 runs, 4 assertions, 0 failures, 2 errors, 0 skips
$
```

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
