### PR TITLE
Drop test databases if exist for PG ActiveRecord test setup

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -246,8 +246,8 @@ namespace :db do
     desc "Drop the PostgreSQL test databases"
     task :drop do
       config = ARTest.config["connections"]["postgresql"]
-      %x( dropdb #{config["arunit"]["database"]} )
-      %x( dropdb #{config["arunit2"]["database"]} )
+      %x( dropdb --if-exists #{config["arunit"]["database"]} )
+      %x( dropdb --if-exists #{config["arunit2"]["database"]} )
     end
 
     desc "Rebuild the PostgreSQL test databases"


### PR DESCRIPTION
### Summary

I saw from the [job log](https://buildkite.com/rails/rails/builds/86854#01811390-431d-4c70-944a-b40e121fdf8e) has these error notices:

![CleanShot 2022-05-30 at 20 14 19@2x](https://user-images.githubusercontent.com/1000669/170981054-e6ec76e7-84af-47d4-96c6-fcafc194198e.png)

I think we can pass a if exists flag to avoid these error notices.

