### PR TITLE
Do not run tests that have `ensure` instead of `skip`

### DIFF
--- a/railties/test/console_helpers.rb
+++ b/railties/test/console_helpers.rb
@@ -18,8 +18,8 @@ module ConsoleHelpers
 
     assert_includes output, expected, "#{expected.inspect} expected, but got:\n\n#{output}"
   end
+end
 
-  def available_pty?
-    defined?(PTY) && PTY.respond_to?(:open)
-  end
+def available_pty?
+  defined?(PTY) && PTY.respond_to?(:open)
 end

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -30,35 +30,31 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
     assert_equal "test", output.strip
   end
 
-  def test_console_command_work_inside_engine
-    skip "PTY unavailable" unless available_pty?
+  if available_pty?
+    def test_console_command_work_inside_engine
+      primary, replica = PTY.open
+      cmd = "console --singleline"
+      spawn_command(cmd, replica)
+      assert_output(">", primary)
+    ensure
+      primary.puts "quit"
+    end
 
-    primary, replica = PTY.open
-    cmd = "console --singleline"
-    spawn_command(cmd, replica)
-    assert_output(">", primary)
-  ensure
-    primary.puts "quit"
-  end
+    def test_dbconsole_command_work_inside_engine
+      primary, replica = PTY.open
+      spawn_command("dbconsole", replica)
+      assert_output("sqlite>", primary)
+    ensure
+      primary.puts ".exit"
+    end
 
-  def test_dbconsole_command_work_inside_engine
-    skip "PTY unavailable" unless available_pty?
-
-    primary, replica = PTY.open
-    spawn_command("dbconsole", replica)
-    assert_output("sqlite>", primary)
-  ensure
-    primary.puts ".exit"
-  end
-
-  def test_server_command_work_inside_engine
-    skip "PTY unavailable" unless available_pty?
-
-    primary, replica = PTY.open
-    pid = spawn_command("server", replica)
-    assert_output("Listening on", primary)
-  ensure
-    kill(pid)
+    def test_server_command_work_inside_engine
+      primary, replica = PTY.open
+      pid = spawn_command("server", replica)
+      assert_output("Listening on", primary)
+    ensure
+      kill(pid)
+    end
   end
 
   private


### PR DESCRIPTION
### Summary

This commit enables `Minitest/SkipEnsure` available since RuboCop Minitest 0.20
via https://github.com/rubocop/rubocop-minitest/pull/171

This cop does not support auto-correction, these offenses are fixed
manually.

- Add `begin` .. `end` not to call `ensure` when it is skipped.

- Removed `if file` at ensure in `test_pool_from_any_process_for_uses_most_recent_spec`
because the `file` should have been created inside the test code when
it is not skipped.

### Other Information

This cop idea was based on https://github.com/rails/rails/pull/42691.
One of the tests had raised `ActiveRecord::StatementInvalid` exception
because it attempted to drop a column that was added inside the test code.
Adding column inside the test was skipped but drop column inside the ensure was called.

https://buildkite.com/rails/rails/builds/78986#ccd268e5-7a1f-4c4f-9631-9cb4bb61ff4e/1086-1122



<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
