### PR TITLE
Strings returned from `strip_tags` are correctly tagged `html_safe?`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Strings returned from `strip_tags` are correctly tagged `html_safe?`
+
+    Because these strings contain no HTML elements and the basic entities are escaped, they are safe
+    to be included as-is as PCDATA in HTML content. Tagging them as html-safe avoids double-escaping
+    entities when being concatenated to a SafeBuffer during rendering.
+
+    Fixes [rails/rails-html-sanitizer#124](https://github.com/rails/rails-html-sanitizer/issues/124)
+
+    *Mike Dalessio*
+
 *   Move `convert_to_model` call from `form_for` into `form_with`
 
     Now that `form_for` is implemented in terms of `form_with`, remove the

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -101,7 +101,7 @@ module ActionView
       #   strip_tags("> A quote from Smith & Wesson")
       #   # => &gt; A quote from Smith &amp; Wesson
       def strip_tags(html)
-        self.class.full_sanitizer.sanitize(html)
+        self.class.full_sanitizer.sanitize(html)&.html_safe
       end
 
       # Strips all link tags from +html+ leaving just the link text.

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -37,6 +37,12 @@ class SanitizeHelperTest < ActionView::TestCase
     assert_equal "test\r\n\r\ntest", strip_tags("test\r\n\r\ntest")
   end
 
+  def test_strip_tags_is_marked_safe
+    frag = "<div>&lt;<span>script</span>&gt;xss();&lt;<span>/script</span>&gt;</div>"
+    assert_equal("&lt;script&gt;xss();&lt;/script&gt;", strip_tags(frag)) # this string is safe for use as pcdata in html
+    assert_predicate(strip_tags(frag), :html_safe?)
+  end
+
   def test_sanitize_is_marked_safe
     assert_predicate sanitize("<html><script></script></html>"), :html_safe?
   end

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -25,7 +25,8 @@ class SafeBufferTest < ActiveSupport::TestCase
 
   test "Should NOT escape a safe value passed to it" do
     @buffer << "<script>".html_safe
-    assert_equal "<script>", @buffer
+    @buffer << "hello &amp; goodbye".html_safe
+    assert_equal("<script>hello &amp; goodbye", @buffer)
   end
 
   test "Should not mess with an innocuous string" do


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails-html-sanitizer/issues/124

Because the strings returned from `strip_tags` contain no HTML elements and the basic entities are escaped, they are safe to be included as-is as PCDATA in HTML content. Tagging them as html-safe avoids double-escaping entities when being concatenated to a SafeBuffer during rendering.


### Other Information

The added tests contain some explanatory context, but I'll explain here as well. The bug at https://github.com/rails/rails-html-sanitizer/issues/124 describes this behavior and asks if it is incorrect:

```ruby
    buffer = ActiveSupport::SafeBuffer.new
    buffer << helper.strip_tags("<div>hello & goodbye</div>")
    buffer # => "hello &amp;amp; goodbye"
```

The things to note in this example:

- `strip_tags` escapes the `&` character, transforming it into the HTML entity `&amp;`
- `SafeBuffer#<<` sees that the string is not `html_safe?` and escapes it again, resulting in the double-escaped `&amp;amp;`

This appears to be unexpected and incorrect behavior. In fact, any string returned from `strip_tags` is "HTML safe" in the sense that it can be safely parsed by a browser as PCDATA. We can demonstrate this with an example of an attempted XSS attack:

```ruby
    frag = "<div>&lt;<span>script</span>&gt;xss();&lt;<span>/script</span>&gt;</div>"
    strip_tags(frag) # => "&lt;script&gt;xss();&lt;/script&gt;"
```

By marking the returned string as `html_safe?`, double-escaping is avoided and the string correctly represents itself as "HTML safe" to any other code in Rails (besides `SafeBuffer`) that might attempt escaping or manipulating HTML content.