### PR TITLE
Delegate `empty?` query method to relation

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
-      :exists?, :any?, :many?, :none?, :one?,
+      :exists?, :any?, :many?, :none?, :empty?, :one?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
         method.end_with?("=", "!", "?", "value", "values", "clause")
       } - [:reverse_order, :arel, :extensions, :construct_join_dependency] + [
-        :any?, :many?, :none?, :one?,
+        :any?, :many?, :none?, :empty?, :one?,
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,


### PR DESCRIPTION
```ruby
User.empty? # => false
```

There is already `none?`, but `empty?` seems more natural to me personally and associated with `exists?`. 
But `none?` associated with the need to iterate the whole collection and I always have to double check, if that is true or not.