### PR TITLE
Fix eql? of AC::Parameters to match hash

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -284,10 +284,15 @@ module ActionController
         end
       end
     end
-    alias eql? ==
+
+    def eql?(other)
+      self.class == other.class &&
+        permitted? == other.permitted? &&
+        parameters.eql?(other.parameters)
+    end
 
     def hash
-      [@parameters.hash, @permitted].hash
+      [self.class, @parameters, @permitted].hash
     end
 
     # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -97,22 +97,6 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_equal @params, ActionController::Parameters.new(@params.each_pair.to_h)
   end
 
-  test "deprecated comparison works" do
-    assert_kind_of Enumerator, @params.each_pair
-    assert_deprecated do
-      assert_equal @params, @params.each_pair.to_h
-    end
-  end
-
-  test "deprecated comparison disabled" do
-    without_deprecated_params_hash_equality do
-      assert_kind_of Enumerator, @params.each_pair
-      assert_not_deprecated do
-        assert_not_equal @params, @params.each_pair.to_h
-      end
-    end
-  end
-
   test "each_value carries permitted status" do
     @params.permit!
     @params.each_value do |value|
@@ -418,28 +402,4 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     @params.dig(:person, :addresses)[0] = { city: "Boston", state: "Massachusetts" }
     assert_equal "Boston", @params.dig(:person, :addresses, 0, :city)
   end
-
-  test "has_value? converts hashes to parameters" do
-    assert_not_deprecated do
-      params = ActionController::Parameters.new(foo: { bar: "baz" })
-      assert params.has_value?("bar" => "baz")
-      params[:foo] # converts value to AC::Params
-      assert params.has_value?("bar" => "baz")
-    end
-  end
-
-  test "has_value? works with parameters" do
-    without_deprecated_params_hash_equality do
-      params = ActionController::Parameters.new(foo: { bar: "baz" })
-      assert params.has_value?(ActionController::Parameters.new("bar" => "baz"))
-    end
-  end
-
-  private
-    def without_deprecated_params_hash_equality
-      ActionController::Parameters.allow_deprecated_parameters_hash_equality = false
-      yield
-    ensure
-      ActionController::Parameters.allow_deprecated_parameters_hash_equality = true
-    end
 end

--- a/actionpack/test/controller/parameters/equality_test.rb
+++ b/actionpack/test/controller/parameters/equality_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_controller/metal/strong_parameters"
+
+class ParametersAccessorsTest < ActiveSupport::TestCase
+  setup do
+    ActionController::Parameters.permit_all_parameters = false
+
+    @params = ActionController::Parameters.new(
+      person: {
+        age: "32",
+        name: {
+          first: "David",
+          last: "Heinemeier Hansson"
+        },
+        addresses: [{ city: "Chicago", state: "Illinois" }]
+      }
+    )
+  end
+
+  test "deprecated comparison works" do
+    assert_kind_of Enumerator, @params.each_pair
+    assert_deprecated do
+      assert_equal @params, @params.each_pair.to_h
+    end
+  end
+
+  test "deprecated comparison disabled" do
+    without_deprecated_params_hash_equality do
+      assert_kind_of Enumerator, @params.each_pair
+      assert_not_deprecated do
+        assert_not_equal @params, @params.each_pair.to_h
+      end
+    end
+  end
+
+  test "has_value? converts hashes to parameters" do
+    assert_not_deprecated do
+      params = ActionController::Parameters.new(foo: { bar: "baz" })
+      assert params.has_value?("bar" => "baz")
+      params[:foo] # converts value to AC::Params
+      assert params.has_value?("bar" => "baz")
+    end
+  end
+
+  test "has_value? works with parameters" do
+    without_deprecated_params_hash_equality do
+      params = ActionController::Parameters.new(foo: { bar: "baz" })
+      assert params.has_value?(ActionController::Parameters.new("bar" => "baz"))
+    end
+  end
+
+  private
+    def without_deprecated_params_hash_equality
+      ActionController::Parameters.allow_deprecated_parameters_hash_equality = false
+      yield
+    ensure
+      ActionController::Parameters.allow_deprecated_parameters_hash_equality = true
+    end
+end

--- a/actionpack/test/controller/parameters_integration_test.rb
+++ b/actionpack/test/controller/parameters_integration_test.rb
@@ -6,6 +6,14 @@ class IntegrationController < ActionController::Base
   def yaml_params
     render plain: params.to_yaml
   end
+
+  def permit_params
+    params.permit(
+      key1: {}
+    )
+
+    render plain: "Home"
+  end
 end
 
 class ActionControllerParametersIntegrationTest < ActionController::TestCase
@@ -23,5 +31,21 @@ parameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
 permitted: false
     YAML
     assert_equal expected, response.body
+  end
+
+  # Ensure no deprecation warning from comparing AC::Parameters against Hash
+  # See https://github.com/rails/rails/issues/44940
+  test "identical arrays can be permitted" do
+    params = {
+      key1: {
+        a: [{ same_key: { c: 1 } }],
+        b: [{ same_key: { c: 1 } }]
+      }
+    }
+
+    assert_not_deprecated do
+      post :permit_params, params: params
+    end
+    assert_response :ok
   end
 end


### PR DESCRIPTION
Previously, as of https://github.com/rails/rails/commit/80aaa111884247e6aa17b7bbab268c7719847521, ActionController::Parameters has defined `#hash` as:

``` ruby
[@parameters.hash, @permitted].hash
```

Defining hash means that `eql?` must be defined, and `eql?` must be at least as strict as the `hash` value generated. That is, for any two objects which return a different hash value, `a.eql?(b)` should return false. Otherwise, because hash values have a random seed added, and in some cases have only some of their bits compared, their behaviour in a
hash becomes undefined. Previously we were breaking this expectation by allowing a deprecated comparison between Parameters and a plain hash.

This commit fixes `eql?` to match `hash`, only returning true when the class matches as well as the permitted? and parameters values (ie. `eql?` never allows the deprecated relaxed equality branch).

This also adds the class to the `hash` and `eql?` check, which previously wasn't there, which isn't strictly necessary to fix this but I think is a best practice.

I believe this should fix the issues reported in #45220 and #44940. Thank you @olefriis and @nvasilevski for the clear reproductions 🙇‍♂️. IMO this has been a bug since #36672 (as that introduced the undefined behaviour when hashing `AC::Parameters`), but wasn't noticed until we began deprecating using `==` with a Hash (https://github.com/rails/rails/pull/44812, https://github.com/rails/rails/pull/23733).

This doesn't change the implementation of `==`, just `eql?`.