### PR TITLE
Fix Hstore deserialize regression

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix Hstore deserialize regression.
+
+    *edsharp*
+
 *   Add validity for PostgreSQL indexes.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/hstore.rb
@@ -26,7 +26,7 @@ module ActiveRecord
                 raise(ArgumentError, ERROR % scanner.string.inspect)
               end
 
-              unless key = scanner.scan_until(/(?<!\\)(?=")/)
+              unless key = scanner.scan(/^(\\[\\"]|[^\\"])*?(?=")/)
                 raise(ArgumentError, ERROR % scanner.string.inspect)
               end
 
@@ -41,7 +41,7 @@ module ActiveRecord
                   raise(ArgumentError, ERROR % scanner.string.inspect)
                 end
 
-                unless value = scanner.scan_until(/(?<!\\)(?=")/)
+                unless value = scanner.scan(/^(\\[\\"]|[^\\"])*?(?=")/)
                   raise(ArgumentError, ERROR % scanner.string.inspect)
                 end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -293,6 +293,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
   def test_backslash
     assert_cycle('a\\b' => 'b\\ar', '1"foo' => "2")
     assert_cycle('a\\"' => 'b\\ar', '1"foo' => "2")
+    assert_cycle("a\\" => "bar\\", '1"foo' => "2")
   end
 
   def test_comma


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/commit/98bf64bcb9648f88bff4cb59a7ae4db2b6410241 (which landed in [v7.0.0.alpha1](https://github.com/rails/rails/releases/tag/v7.0.0.alpha1))
introduced a StringScanner to ensure that value is a valid hstore
document.

However, the negative lookbehind in the regex used to find the final
double-quote of both the key and the value (`/(?<!\\)(?=")/`) doesn't
differentiate between a backslash-escaped double-quote and a
backslash-escaped backslash followed by an unescaped double-quote.

In other words a valid hstore document such as:

```
    postgres=# select '"\\"=>"\\"'::hstore;
       hstore
    ------------
     "\\"=>"\\"
```

will be incorrectly deemed invalid.

This commit aims to rectify that by switching from `scan_until` to `scan`
and lazily matching zero or more of either:

- an escaped pair (either `\\` or `\"`); or

- a character that doesn't need escaping

until the positive lookahead matches a double-quote.

The tests have been updated to include both a key and value that end in
a backslash.

This is my first rails PR. @pixeltrix as the original author, I'd appreciate your thoughts. Looking at https://www.postgresql.org/docs/current/hstore.html I see:

> The order of the pairs is not significant (and may not be reproduced on output). Whitespace between pairs or around the => sign is ignored. Double-quote keys and values that include whitespace, commas, =s or >s. To include a double quote or a backslash in a key or value, escape it with a backslash.

I note that keys and values don't necessarily need to be quoted, although I assume `deserialize` has been based around what postgres returns rather than what it accepts. In the following example, we can see an unquoted key gets returned as quoted in any case; and also that a backslash-escaped `a` is returned without the backslash escape:

```
postgres=# select '\a=>"\\"'::hstore;
  hstore
-----------
 "a"=>"\\"
(1 row)

postgres=# select '"\a"=>"\\"'::hstore;
  hstore
-----------
 "a"=>"\\"
(1 row)
```

In particular, the fact that a backslash-escaped `a` is returned as `a` led me to choose `\\[\\"]` rather than `\\.` when matching valid escaped pairs.

You can play with the regex (and see the unit tests) at: https://regex101.com/r/GdaUrc/1

### Other Information

I made the following benchmark:

```ruby
require 'benchmark/ips'
require "strscan"

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  value = %q{123\"456\\7890asdfghjkl"=>"some_value"}

  x.report("init StringScanner") do
    scanner = StringScanner.new(value)
  end

  x.report("original") do
    scanner = StringScanner.new(value)
    scanner.scan_until(/(?<!\\)(?=")/)
  end

  x.report("patched") do
    scanner = StringScanner.new(value)
    scanner.scan(/^(\\[\\"]|[^\\"])*?(?=")/)
  end

  x.compare!
end
```

I chose `value` to reflect a valid hstore after the scanner would have skipped the first double-quote.

Given the scanner is stateful, I compared just the creation of a scanner against the original and patched version.

```
Warming up --------------------------------------
  init StringScanner   304.809k i/100ms
            original   150.793k i/100ms
             patched   148.973k i/100ms
Calculating -------------------------------------
  init StringScanner      3.130M (± 2.3%) i/s -     15.850M in   5.066893s
            original      1.513M (± 2.3%) i/s -      7.690M in   5.086272s
             patched      1.521M (± 2.3%) i/s -      7.747M in   5.097384s

Comparison:
  init StringScanner:  3129842.8 i/s
             patched:  1520528.0 i/s - 2.06x  (± 0.00) slower
            original:  1512859.8 i/s - 2.07x  (± 0.00) slower
```

I made a few variations of `value` and in all cases `patched` and `original` were very similar in performance.