### PR TITLE
Fix store dirty tracking documentation [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -59,7 +59,7 @@ module ActiveRecord
   #   u.color = 'green'
   #   u.color_changed? # => true
   #   u.color_was # => 'black'
-  #   u.color_change # => ['black', 'red']
+  #   u.color_change # => ['black', 'green']
   #
   #   # Add additional accessors to an existing store through store_accessor
   #   class SuperUser < User


### PR DESCRIPTION
### Summary

Fixes an error in the code example for dirty tracking in ActiveRecord::Store.
