### PR TITLE
Parse `application/csp-report` by default

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -44,7 +44,8 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 # https://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
 # https://www.ietf.org/rfc/rfc7807.txt
-Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
+# https://www.w3.org/TR/CSP3/
+Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json application/csp-report )
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -46,6 +46,22 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json params for application/csp-report" do
+    assert_parses(
+{
+        "csp-report" => {
+          "document-uri" => "http://example.com/index.html",
+          "referrer" => "",
+          "blocked-uri" => "http://otherdomain.com/css/style.css",
+          "violated-directive" => "default-src 'self'",
+          "original-policy" => "default-src 'self'; report-uri /csp-incident-reports"
+        }
+      },
+      "{\"csp-report\": {\"document-uri\": \"http://example.com/index.html\", \"referrer\": \"\", \"blocked-uri\": \"http://otherdomain.com/css/style.css\", \"violated-directive\": \"default-src 'self'\", \"original-policy\": \"default-src 'self'; report-uri /csp-incident-reports\"}}",
+      "CONTENT_TYPE" =>  "application/csp-report"
+)
+  end
+
   test "does not parse unregistered media types such as application/vnd.api+json" do
     assert_parses(
       {},
@@ -177,7 +193,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   ensure
     Mime::Type.unregister :json
-    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json application/csp-report )
   end
 
   test "parses json params after custom json mime type registered with synonym" do
@@ -189,7 +205,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   ensure
     Mime::Type.unregister :json
-    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json application/csp-report )
   end
 
   private


### PR DESCRIPTION
### Summary

If `report-uri` is provided in `Content-Security-Policy:  ...` header (e.g. When `Rails.application.config.content_security_policy.report_uri` is configured), browsers will report CSP violations to `report-uri` as a JSON object ([schema](https://w3c.github.io/webappsec-csp/#deprecated-serialize-violation)) with a `Content-Type: application/csp-report` header.

For a Rails user, If he configured `config.report_uri` pointing to a Rails `controller#action`, he would also have to do either one of the following:
1. Write `body = JSON.parse(request.body.read)` in the corresponding controller action
2. Add `Mime::Type.register('application/csp-report', :json)` in `config/intializers/mime_type.rb`

Since Rails [supports `Content Security Policy`](https://edgeguides.rubyonrails.org/security.html#content-security-policy-header) out of the box, I think it would be nice if `application/csp-report` is also supported by default.

### Other Information

This PR may be similar to #44608
