### PR TITLE
`change_column_null` should raise if a non-boolean 3rd argument is provided

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `change_column_null` raises if a non-boolean argument is provided
+
+    Previously if you provided a non-boolean argument, `change_column_null` would
+    treat it as truthy and make your column nullable. This could be surprising, so now
+    the input must be either `true` or `false`.
+
+    ```ruby
+    change_column_null :table, :column, true # good
+    change_column_null :table, :column, false # good
+    change_column_null :table, :column, from: true, to: false # raises (previously this made the column nullable)
+    ```
+
+    *Alex Ghiculescu*
+
 *   Enforce limit on table names length.
 
     Fixes #45130.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1395,6 +1395,12 @@ module ActiveRecord
       end
 
       private
+        def validate_change_column_null_argument!(value)
+          unless value == true || value == false
+            raise ArgumentError, "change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: #{value.inspect}"
+          end
+        end
+
         def column_options_keys
           [:limit, :precision, :scale, :default, :null, :collation, :comment]
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -353,6 +353,8 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
+        validate_change_column_null_argument!(null)
+
         unless null || default.nil?
           execute("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote(default)} WHERE #{quote_column_name(column_name)} IS NULL")
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -415,6 +415,8 @@ module ActiveRecord
         end
 
         def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
+          validate_change_column_null_argument!(null)
+
           clear_cache!
           unless null || default.nil?
             column = column_for(table_name, column_name)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -287,6 +287,8 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
+        validate_change_column_null_argument!(null)
+
         unless null || default.nil?
           exec_query("UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote(default)} WHERE #{quote_column_name(column_name)} IS NULL")
         end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -61,6 +61,10 @@ module ActiveRecord
           super
         end
 
+        def change_column_null(table_name, column_name, null, default = nil)
+          super(table_name, column_name, !!null, default)
+        end
+
         private
           def compatible_table_definition(t)
             class << t

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -273,6 +273,7 @@ module ActiveRecord
       def test_change_column_default_to_null
         add_column "test_models", "first_name", :string
         connection.change_column_default "test_models", "first_name", nil
+
         assert_nil TestModel.new.first_name
       end
 
@@ -281,6 +282,32 @@ module ActiveRecord
         connection.change_column_default "test_models", "first_name", from: nil, to: "Tester"
 
         assert_equal "Tester", TestModel.new.first_name
+      end
+
+      def test_change_column_null_false
+        add_column "test_models", "first_name", :string
+        connection.change_column_null "test_models", "first_name", false
+
+        assert_raise(ActiveRecord::NotNullViolation) do
+          TestModel.create!(first_name: nil)
+        end
+      end
+
+      def test_change_column_null_true
+        add_column "test_models", "first_name", :string
+        connection.change_column_null "test_models", "first_name", true
+
+        assert_difference("TestModel.count" => 1) do
+          TestModel.create!(first_name: nil)
+        end
+      end
+
+      def test_change_column_null_with_non_boolean_arguments_raises
+        add_column "test_models", "first_name", :string
+        e = assert_raise(ArgumentError) do
+          connection.change_column_null "test_models", "first_name", from: true, to: false
+        end
+        assert_equal "change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: {:from=>true, :to=>false}", e.message
       end
 
       def test_remove_column_no_second_parameter_raises_exception


### PR DESCRIPTION
Currently if you provide a non-boolean argument, `change_column_null` will treat it as truthy and make your column nullable. This might not be what you want. For example, I've noticed this happen a few times, where someone assumes that `change_column_null` and `change_column_default` have the same signature:

```ruby
change_column_default(:posts, :state, from: nil, to: "draft")
change_column_null(:posts, :state, from: true, to: false)
```

Reading the migration you would expect that the default is now "draft" and the column doesn't accept nulls. But actually, the "null" argument is `{ from: true, to: false }` which is truthy, so now the column accepts nulls. If you aren't paying close attention to the migration output you might miss this.

I think we can protect users here by having `change_column_null` require the 3rd argument to be `true` or `false` and raising an error otherwise. This PR implements that, for migrations created on Rails 7.1 onward.
