### PR TITLE
Allows associations to be automatically preloadable.

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -281,6 +281,7 @@ module ActiveRecord
       autoload :HasOneThroughAssociation
 
       autoload :Preloader
+      autoload :AutomaticPreloader
       autoload :JoinDependency
       autoload :AssociationScope
       autoload :DisableJoinsAssociationScope

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -172,6 +172,8 @@ module ActiveRecord
       # ActiveRecord::RecordNotFound is rescued within the method, and it is
       # not reraised. The proxy is \reset and +nil+ is the return value.
       def load_target
+        automatically_preload! if automatic_preload?
+
         @target = find_target if (@stale_state && stale_target?) || find_target?
 
         loaded! unless loaded?
@@ -211,6 +213,16 @@ module ActiveRecord
       end
 
       private
+        def automatically_preload!
+          owner.automatic_preloader.automatically_preload(reflection.name)
+        end
+
+        def automatic_preload?
+          return false unless reflection.scope.nil? || reflection.scope.arity == 0
+
+          !loaded? && owner.persisted? && owner.automatic_preloading?
+        end
+
         # Reader and writer methods call this so that consistent errors are presented
         # when the association target class does not exist.
         def ensure_klass_exists!

--- a/activerecord/lib/active_record/associations/automatic_preloader.rb
+++ b/activerecord/lib/active_record/associations/automatic_preloader.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Associations
+    class AutomaticPreloader < Preloader
+      def self.attach(records)
+        new(records: records.dup, associations: nil).tap do |automatic_preloader|
+          records.each do |record|
+            record.automatic_preloader = automatic_preloader
+          end
+        end
+      end
+
+      def automatically_preload(associations)
+        # It is possible that the records array has multiple different classes (think single table inheritance).
+        # Thus, it is possible that some of the records don't have an association.
+        records_with_association = records.reject do |record|
+          record.class.reflect_on_association(associations).nil?
+        end
+        self.class.new(records: records_with_association, associations: associations).call
+      end
+
+      # We do not want the automatic preloader to be dumpable
+      # If you dump a ActiveRecord::Base object that has an automatic_preloader instance variable
+      # you will also end up dumping all of the records the preloader has reference to.
+      # Imagine getting N objects from a query and dumping each one of those into a cache
+      # each object would dump N+1 objects which means you'll end up storing O(N^2) memory. That's no good.
+      # So instead, we will just nullify the automatic preloader on load
+      def _dump(level)
+        ""
+      end
+
+      def self._load(args)
+        nil
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -260,6 +260,8 @@ module ActiveRecord
       end
 
       def load_target
+        automatically_preload! if automatic_preload?
+
         if find_target?
           @target = merge_target_lists(find_target, target)
         end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -130,8 +130,12 @@ module ActiveRecord
             associate_records_to_owner(owner, records[owner] || [])
           end if @associate
 
+          Associations::AutomaticPreloader.attach(@preloaded_records) if mark_records_as_automatically_preloadable?
+
           self
         end
+
+
 
         def records_by_owner
           load_records unless defined?(@records_by_owner)
@@ -224,6 +228,13 @@ module ActiveRecord
 
         private
           attr_reader :owners, :reflection, :preload_scope, :model
+
+          def mark_records_as_automatically_preloadable?
+            return false unless defined?(@preloaded_records)
+            return false unless reflection.scope.nil? || reflection.scope.arity == 0
+
+            klass.automatic_preloading_by_default || owners.any?(&:automatic_preloading?)
+          end
 
           # The name of the key on the model which declares the association
           def owner_key_name

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -89,6 +89,8 @@ module ActiveRecord
 
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false
 
+      class_attribute :automatic_preloading_by_default, instance_accessor: false, default: false
+
       class_attribute :has_many_inversing, instance_accessor: false, default: false
 
       class_attribute :run_commit_callbacks_on_first_saved_instances_in_transaction, instance_accessor: false, default: true
@@ -630,6 +632,13 @@ module ActiveRecord
     def strict_loading?
       @strict_loading
     end
+
+    # Returns +true+ if the record is in automatic_preloading mode.
+    def automatic_preloading?
+      !automatic_preloader.nil?
+    end
+
+    attr_accessor :automatic_preloader
 
     # Sets the record to strict_loading mode. This will raise an error
     # if the record tries to lazily load an association.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with,
+      :pluck, :pick, :ids, :async_ids, :strict_loading, :automatic_preloading, :excluding, :without, :with,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -9,7 +9,7 @@ module ActiveRecord
                             :with]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering, :strict_loading,
-                            :reverse_order, :distinct, :create_with, :skip_query_cache]
+                            :automatic_preloading, :reverse_order, :distinct, :create_with, :skip_query_cache]
 
     CLAUSE_METHODS = [:where, :having, :from]
     INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :with]
@@ -802,7 +802,7 @@ module ActiveRecord
     end
 
     def values_for_queries # :nodoc:
-      @values.except(:extending, :skip_query_cache, :strict_loading)
+      @values.except(:extending, :skip_query_cache, :strict_loading, :automatic_preloading)
     end
 
     def inspect
@@ -933,6 +933,7 @@ module ActiveRecord
 
           records.each(&:readonly!) if readonly_value
           records.each { |record| record.strict_loading!(strict_loading_value) } unless strict_loading_value.nil?
+          Associations::AutomaticPreloader.attach(records) if automatic_preloading_value || klass.automatic_preloading_by_default
 
           records
         end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1193,6 +1193,22 @@ module ActiveRecord
       self
     end
 
+    # Sets the returned relation to automatic_preloading mode. This will automatically
+    # preload associations on records.
+    #
+    #    users = User.automatic_preloading.where(id: 1, 3)
+    #    users.each { |user| user.comments.to_a }
+    # SELECT `comments`.* FROM `comments` WHERE user_id IN (1, 3)
+    def automatic_preloading(value = true)
+      spawn.automatic_preloading!(value)
+    end
+
+    def automatic_preloading!(value = true) # :nodoc:
+      self.automatic_preloading_value = value
+      self
+    end
+
+
     # Sets attributes to be used when creating new records from a
     # relation object.
     #

--- a/activerecord/test/cases/automatic_preloading_test.rb
+++ b/activerecord/test/cases/automatic_preloading_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+require "models/company"
+require "models/computer"
+require "models/comment"
+require "models/contract"
+require "models/mentor"
+require "models/post"
+
+class AutomaticPreloadingTest < ActiveRecord::TestCase
+  fixtures :developers, :companies, :posts
+
+  def test_models_are_marked_as_automatically_preloading
+    developers = Developer.order(:id).limit(2).automatic_preloading.to_a
+    developers.each do |developer|
+      assert developer.automatic_preloading?
+    end
+  end
+
+  def test_automatic_preloading_by_default
+    with_automatic_preloading_by_default(ActiveRecord::Base) do
+      developers = Developer.order(:id).limit(2).to_a
+      developers.each do |developer|
+        assert developer.automatic_preloading?
+      end
+    end
+  end
+
+  def test_collection_associations_are_automatically_loaded
+    Developer.order(:id).limit(2).all.each do |developer|
+      Contract.create!(developer_id: developer.id)
+    end
+
+    developers = Developer.order(:id).limit(2).automatic_preloading.to_a
+
+    developers.each do |developer|
+      assert_not developer.association(:contracts).loaded?
+    end
+
+    assert_queries(1) do
+      developers.each do |developer|
+        developer.contracts.load
+      end
+    end
+
+    developers.each do |developer|
+      assert developer.association(:contracts).loaded?
+    end
+  end
+
+  def test_has_one_association_is_automatically_loaded
+    Developer.order(:id).limit(2).each do |developer|
+      developer.update!(mentor: Mentor.create!)
+    end
+
+    developers = Developer.order(:id).limit(2).automatic_preloading.to_a
+
+    developers.each do |developer|
+      assert_not developer.association(:mentor).loaded?
+    end
+
+    assert_queries(1) do
+      developers.each do |developer|
+        developer.mentor
+      end
+    end
+
+    developers.each do |developer|
+      assert developer.association(:mentor).loaded?
+    end
+  end
+
+  def test_chained_associations_are_automatically_loaded
+    companies = [companies(:first_client), companies(:first_firm)]
+    Developer.order(:id).limit(2).all.each_with_index do |developer, i|
+      Contract.create!(developer_id: developer.id, company: companies[i])
+    end
+
+    developers = Developer.order(:id).limit(2).automatic_preloading.to_a
+
+    developers.first.contracts.to_a
+    developers.each do |developer|
+      assert_not developer.contracts.first.association(:company).loaded?
+    end
+
+    assert_queries(1) do
+      developers.each do |developer|
+        developer.contracts.first.company
+      end
+    end
+
+    developers.each do |developer|
+      assert developer.contracts.first.association(:company).loaded?
+    end
+  end
+
+  def test_cannot_automatically_load_scoped_associations
+    Developer.order(:id).limit(2).all.each do |developer|
+      Comment.create!(developer_id: developer.id, body: "I'm #{developer.name}", post: posts(:welcome))
+    end
+
+    developers = Developer.limit(2).automatic_preloading.to_a
+
+    developers.each do |developer|
+      assert_not developer.association(:comments).loaded?
+    end
+
+    assert_queries(2) do
+      developers.each do |developer|
+        developer.comments.load
+      end
+    end
+
+    developers.each do |developer|
+      assert developer.association(:comments).loaded?
+    end
+  end
+
+  private
+    def with_automatic_preloading_by_default(model)
+      previous_automatic_preloading_by_default = model.automatic_preloading_by_default
+
+      model.automatic_preloading_by_default = true
+
+      yield
+    ensure
+      model.automatic_preloading_by_default = previous_automatic_preloading_by_default
+    end
+end


### PR DESCRIPTION
### Summary

Before we load an association for the first time, we can preload
the association. This will eliminate most standard N+1 queries in Rails
apps.

We do this by capturing the group of records returned by a query in an
AutomaticPreloader and having each record have a reference to it.

Once a record has been flagged to allow automatic preloading, subsequent
associations are also flagged the same so this will allow deeply nested
associations to all be dynamically preloaded

This is off by default and can be opted in with each relation. There
is also a global option to enable it by default

For example: 
This code snippet:
```ruby
developers = Developer.order(:id).limit(2).to_a
developers.each do |developer|
  developer.contracts.to_a.first.company
end
```
would typically result in a few N+1 queries.  The queries would look something like:
```sql
SELECT "developers".* FROM "developers" ORDER BY "developers"."id" ASC LIMIT 2
SELECT "contracts".* FROM "contracts" WHERE "contracts"."developer_id" = 1 
SELECT "companies".* FROM "companies" WHERE "companies"."id" = 1 LIMIT 1
SELECT "contracts".* FROM "contracts" WHERE "contracts"."developer_id" = 2 
SELECT "companies".* FROM "companies" WHERE "companies"."id" = 2 LIMIT 1
```

With `automatic_preloading` added (`Developer.order(:id).automatic_preloading.limit(2).to_a`), the same code would generate queries like:
```sql
SELECT "developers".* FROM "developers" ORDER BY "developers"."id" ASC LIMIT 2
SELECT "contracts".* FROM "contracts" WHERE "contracts"."developer_id" IN (1, 2)
SELECT "companies".* FROM "companies" WHERE "companies"."id" IN (1, 2)
```

