### PR TITLE
Use const_get to get validator classes

### DIFF
--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -116,7 +116,7 @@ module ActiveModel
           key = "#{key.to_s.camelize}Validator"
 
           begin
-            validator = key.include?("::") ? key.constantize : const_get(key)
+            validator = const_get(key)
           rescue NameError
             raise ArgumentError, "Unknown validator: '#{key}'"
           end


### PR DESCRIPTION
Though we needed to use constantize for ruby < 2.0, ruby >= 2.0
const_get can handle namespace.

> https://docs.ruby-lang.org/en/2.0.0/NEWS.html
> Module#const_get accepts a qualified constant string, e.g. Object.const_get(“Foo::Bar::Baz”)