### PR TITLE
Fix regression in XSS filtering of HTML characters

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -33,6 +33,10 @@ module ActionText
       options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
       editor_tag = content_tag("trix-editor", "", options)
+                     .gsub("<trixeditor ", "<trix-editor ") # Fix non-compliant HTML tag.
+                     .gsub("</trixeditor>", "</trix-editor>")
+                     .html_safe
+
       input_tag = hidden_field_tag(name, value.try(:to_trix_html) || value, id: options[:input], form: form)
 
       input_tag + editor_tag

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix regression for HTML character filtering in protections for XSS in
+    `ActionView::Helpers` and `ERB::Util`. This is a complete fix for that
+    regression, related to #45027 , which was incomplete.
+
+    We would need to support XHTML, HTML4 and HTML5. But since XHTML and HTML4
+    have had a note for future deprecation in the documentation for more than
+    5 years, simplify the filtering by removing support for XHTML and HTML4.
+
+    *Álvaro Martín Fraguas*
+
 *   Guard against `ActionView::Helpers::FormTagHelper#field_name` calls with nil
     `object_name` arguments. For example:
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -773,7 +773,7 @@ module ActionView
           options[:multipart] ||= builder.multipart?
 
           html_options = html_options_for_form_with(url, model, **options)
-          form_tag_with_body(html_options, output)
+          form_tag_html(html_options, output)
         else
           html_options = html_options_for_form_with(url, model, **options)
           form_tag_html(html_options)

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -800,7 +800,7 @@ module ActionView
               end
             tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
           else
-            ""
+            "".html_safe
           end
         end
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -319,9 +319,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi"></video>),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov"></video>),
     %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov"></video>),
-    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
+    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>)
   }
 
   AudioPathToTag = {
@@ -357,9 +357,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav"></audio>),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
-    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>)
   }
 
   FontPathToTag = {
@@ -773,11 +773,11 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_image_tag_interpreting_email_cid_correctly
     # An inline image has no need for an alt tag to be automatically generated from the cid:
-    assert_equal '<img src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid")
+    assert_equal '<img src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid")
   end
 
   def test_image_tag_interpreting_email_adding_optional_alt_tag
-    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
+    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
   end
 
   def test_should_not_modify_source_string

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -14,11 +14,11 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   end
 
   def test_csp_meta_tag
-    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag
   end
 
   def test_csp_meta_tag_with_options
-    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag(property: "csp-nonce")
   end
 end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -68,7 +68,7 @@ class FormTagHelperTest < ActionView::TestCase
     end
   end
 
-  VALID_HTML_ID = /^[A-Za-z][-_:.A-Za-z0-9]*$/ # see http://www.w3.org/TR/html4/types.html#type-name
+  VALID_HTML_ID = /[^\t\n\f\r ]/ # see https://html.spec.whatwg.org/#the-id-attribute
 
   def test_check_box_tag
     actual = check_box_tag "admin"
@@ -91,6 +91,11 @@ class FormTagHelperTest < ActionView::TestCase
   def test_check_box_tag_id_sanitized
     label_elem = root_elem(check_box_tag("project[2][admin]"))
     assert_match VALID_HTML_ID, label_elem["id"]
+  end
+
+  def test_id_sanitized_for_html5
+    label_elem = root_elem(check_box_tag("project[2][a(dmin]"))
+    assert_equal "project_2_a(dmin", label_elem["id"]
   end
 
   def test_form_tag
@@ -689,14 +694,14 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_submit_tag_doesnt_have_data_disable_with_twice
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing...">),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice_with_hash
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing...">),
       submit_tag("Save", data: { disable_with: "Processing..." })
     )
   end

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -80,7 +80,7 @@ class OutputSafetyHelperTest < ActionView::TestCase
       safe_join(["<marquee>shady stuff</marquee>", tag("br")])
     end
     url = "https://example.com"
-    expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
+    expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br></p>)
     actual = to_sentence([link_to(url, url), ptag])
     assert_predicate actual, :html_safe?
     assert_equal(expected, actual)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix regression for HTML character filtering in protections for XSS in
+    `ActionView::Helpers` and `ERB::Util`. This is a complete fix for that
+    regression, related to #45027 , which was incomplete.
+
+    We would need to support XHTML, HTML4 and HTML5. But since XHTML and HTML4
+    have had a note for future deprecation in the documentation for more than
+    5 years, simplify the filtering by removing support for XHTML and HTML4.
+
+    *Álvaro Martín Fraguas*
+
 *   Enable connection pooling by default for `MemCacheStore` and `RedisCacheStore`.
 
     If you want to disable connection pooling, set `:pool` option to `false` when configuring the cache store:

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -77,12 +77,12 @@ module ApplicationTests
         javascript_path:        %r{/javascripts/#{contents}},
         stylesheet_path:        %r{/stylesheets/#{contents}},
         image_tag:              %r{<img src="/images/#{contents}"},
-        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}" />},
-        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css" />},
+        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}">},
+        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css">},
         javascript_include_tag: %r{<script src="/javascripts/#{contents}.js">},
         audio_tag:              %r{<audio src="/audios/#{contents}"></audio>},
         video_tag:              %r{<video src="/videos/#{contents}"></video>},
-        image_submit_tag:       %r{<input type="image" src="/images/#{contents}" />}
+        image_submit_tag:       %r{<input type="image" src="/images/#{contents}">}
       }
 
       class ::PostsController < ActionController::Base

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2786,7 +2786,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["Link"]
     end
 
@@ -2812,7 +2812,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_nil last_response.headers["Link"]
     end
 


### PR DESCRIPTION
A previous fix of mine for protections for XSS in `ActionView::Helpers` and `ERB::Util` introduced a regression by not filtering HTML characters properly. This is a complete fix for that regression, related to #45027 , which was incomplete.

We would need to support XHTML, HTML4 and HTML5. But since XHTML and HTML4 have had a note for future deprecation in the documentation for more than 5 years ( https://github.com/rails/rails/blame/main/actionview/lib/action_view/helpers/tag_helper.rb#L263 ), these changes simplify the filtering by removing support for XHTML and HTML4.

### Summary

The regression was caused by filtering according to the XML standard. Instead of that, there are now two different sets of characters for the filtering: one for the names of HTML tags and one for the names of attributes in HTML tags.

We could deprecate the legacy syntax fully, but that may add too many changes to this pull request. Still, I have updated many internal uses of the legacy syntax, especially in the tests.

### Other Information

This is a change in the API, so the minor version of Rails should be increased. Since browsers may not support the HTML standard completely, it may be a good idea to have these changes merged in main for a while before releasing them. That way, there will be some time for possible regressions to be noticed and fixed.

These changes probably won't have a big impact on security. However, they seem like an improvement by following the HTML standard closely and reducing the complexity of supporting old standards. The part that looks more risky are the changes in the form tag and the fieldset tag, since there is manual string concatenation, please review those changes carefully.