### PR TITLE
Simplify regex detecting comments in sql query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -36,7 +36,7 @@ module ActiveRecord
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
-      COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}m
+      COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}
 
       attr_accessor :pool
       attr_reader :visitor, :owner, :logger, :lock

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -127,6 +127,16 @@ module ActiveRecord
       end
     end
 
+    def test_errors_when_an_insert_query_prefixed_by_a_multiline_double_dash_comment_is_called_while_preventing_writes
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          Timeout.timeout(0.1) do # should be fast to parse the query
+            @connection.insert("#{"-- comment\n" * 50}INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          end
+        end
+      end
+    end
+
     def test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_containing_read_command_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do


### PR DESCRIPTION
`/m` is redundant in the regexp (`.` is only used in the single line comment pattern of the regexp, but this patern already ends with `\n`).

Follow up to #45012.
Fixes https://github.com/rails/rails/issues/45234.