### PR TITLE
Add extension for ActionView::Helpers::TagHelper to ActionView::Base

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -139,6 +139,7 @@ module ActionView # :nodoc:
   # For more information on Builder please consult the {source
   # code}[https://github.com/jimweirich/builder].
   class Base
+    extend ActionView::Helpers::TagHelper
     include Helpers, ::ERB::Util, Context
 
     # Specify the proc used to decorate input tags that refer to attributes with errors.


### PR DESCRIPTION
Issue [#45165](https://github.com/rails/rails/issues/45165 ) describes a no_method error in ActionView::Base when calling ActionView::Helpers::TagHelper.content_tag. The TagHelper Module is included in base, therefore content_tag is only available as an instance method. 

The desired behavior is for content_tag to be available to ActionView::Base as a class method. To achieve this I simply extended ActionView::Helpers::TagHelper into ActionView::Base. This effectively allows ActionView::Base access to ActionView::Helpers::TagHelper as both instance and class methods.

PS. This is my first Rails pull request ! Any advice, comments and or corrections would be appreciated. 

