### PR TITLE
Add Colorized, a new routes formatter

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -236,7 +236,7 @@ module ActionDispatch
         private
           def draw_section(routes)
             routes.map do |route|
-              verb = "     #{route[:verb]} "
+              verb = "     #{route[:verb]}"
               path = "#{route[:path]} ".rjust(10 - route[:verb].size + route[:path].size)
               name_and_reqs = " #{name_and_reqs(route)}     ".rjust(@width - verb.size - path.size, ".")
 

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -264,7 +264,7 @@ module ActionDispatch
           end
 
           def colorize_path(path)
-            path.gsub(/\/(:[a-z]*)/, "/#{YELLOW}\\1#{CLEAR}")
+            path.gsub(/\/(:[\w\d]*)/, "/#{YELLOW}\\1#{CLEAR}")
           end
 
           def name_and_reqs(route)

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -206,6 +206,78 @@ module ActionDispatch
           end
       end
 
+      class Colorized < Base
+        CLEAR   = "\e[0m"
+
+        # Colors
+        BLACK   = "\e[1;90m"
+        BLUE    = "\e[1;94m"
+        RED     = "\e[1;91m"
+        YELLOW  = "\e[1;93m"
+        WHITE   = "\e[1;97m"
+
+        def initialize(width: IO.console_size[1])
+          @width = width
+          super()
+        end
+
+        def section_title(title)
+          @buffer << "\n#{title}:"
+        end
+
+        def section(routes)
+          @buffer << draw_section(routes)
+        end
+
+        def header(routes)
+          @buffer << draw_header(routes)
+        end
+
+        private
+          def draw_section(routes)
+            routes.map do |route|
+              verb = "     #{route[:verb]} "
+              path = "#{route[:path]} ".rjust(10 - route[:verb].size + route[:path].size)
+              name_and_reqs = " #{name_and_reqs(route)}     ".rjust(@width - verb.size - path.size, ".")
+
+              verb = colorize_verb(verb)
+              path = colorize_path(path)
+              name_and_reqs = "#{BLACK}#{name_and_reqs}#{CLEAR}"
+
+              "#{verb}#{path}#{name_and_reqs}"
+            end
+          end
+
+          def colorize_verb(verb)
+            case verb
+            when %r{GET}
+              "#{BLUE}#{verb}#{CLEAR}"
+            when %r{HEAD}
+              "#{BLACK}#{verb}#{CLEAR}"
+            when %r{PUT|POST|PATCH}
+              "#{YELLOW}#{verb}#{CLEAR}"
+            when %r{DELETE}
+              "#{RED}#{verb}#{CLEAR}"
+            else
+              verb
+            end
+          end
+
+          def colorize_path(path)
+            path.gsub(/\/(:[a-z]*)/, "/#{YELLOW}\\1#{CLEAR}")
+          end
+
+          def name_and_reqs(route)
+            return route[:reqs] if route[:name].blank?
+
+            "#{route[:name]}_path > #{route[:reqs]}"
+          end
+
+          def draw_header(routes)
+            ""
+          end
+      end
+
       class Expanded < Base
         def initialize(width: IO.console_size[1])
           @width = width

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -396,12 +396,12 @@ module ActionDispatch
         end
 
         assert_equal ["",
-                      "\e[1;94m     GET \e[0m      /custom/assets(.:format) \e[1;90m................custom_assets_path > custom_assets#show     \e[0m",
-                      "\e[1;94m     GET \e[0m      /custom/furnitures(.:format) \e[1;90m....custom_furnitures_path > custom_furnitures#show     \e[0m",
-                      "               /blog \e[1;90m..................................................blog_path > Blog::Engine     \e[0m",
+                      "\e[1;94m     GET\e[0m      /custom/assets(.:format) \e[1;90m................ custom_assets_path > custom_assets#show     \e[0m",
+                      "\e[1;94m     GET\e[0m      /custom/furnitures(.:format) \e[1;90m.... custom_furnitures_path > custom_furnitures#show     \e[0m",
+                      "              /blog \e[1;90m.................................................. blog_path > Blog::Engine     \e[0m",
                       "",
                       "Routes for Blog::Engine:",
-                      "\e[1;94m     GET \e[0m      /cart(.:format) \e[1;90m...........................................cart_path > cart#show     \e[0m"], output
+                      "\e[1;94m     GET\e[0m      /cart(.:format) \e[1;90m........................................... cart_path > cart#show     \e[0m"], output
       end
 
       def test_no_routes_matched_filter_when_colorized
@@ -434,14 +434,14 @@ module ActionDispatch
         end
 
         assert_equal ["",
-                      "\e[1;94m     GET \e[0m      /posts(.:format) \e[1;90m.........posts_path > posts#index     \e[0m",
-                      "\e[1;93m     POST \e[0m     /posts(.:format) \e[1;90m.....................posts#create     \e[0m",
-                      "\e[1;94m     GET \e[0m      /posts/new(.:format) \e[1;90m....new_post_path > posts#new     \e[0m",
-                      "\e[1;94m     GET \e[0m      /posts/\e[1;93m:id\e[0m/edit(.:format) \e[1;90medit_post_path > posts#edit     \e[0m",
-                      "\e[1;94m     GET \e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.......post_path > posts#show     \e[0m",
-                      "\e[1;93m     PATCH \e[0m    /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.................posts#update     \e[0m",
-                      "\e[1;93m     PUT \e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.................posts#update     \e[0m",
-                      "\e[1;91m     DELETE \e[0m   /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m................posts#destroy     \e[0m"], output
+                      "\e[1;94m     GET\e[0m      /posts(.:format) \e[1;90m......... posts_path > posts#index     \e[0m",
+                      "\e[1;93m     POST\e[0m     /posts(.:format) \e[1;90m..................... posts#create     \e[0m",
+                      "\e[1;94m     GET\e[0m      /posts/new(.:format) \e[1;90m.... new_post_path > posts#new     \e[0m",
+                      "\e[1;94m     GET\e[0m      /posts/\e[1;93m:id\e[0m/edit(.:format) \e[1;90m edit_post_path > posts#edit     \e[0m",
+                      "\e[1;94m     GET\e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m....... post_path > posts#show     \e[0m",
+                      "\e[1;93m     PATCH\e[0m    /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m................. posts#update     \e[0m",
+                      "\e[1;93m     PUT\e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m................. posts#update     \e[0m",
+                      "\e[1;91m     DELETE\e[0m   /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m................ posts#destroy     \e[0m"], output
       end
 
       def test_routes_can_be_filtered_with_namespaced_controllers

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -379,6 +379,71 @@ module ActionDispatch
         ], output
       end
 
+      def test_routes_when_colorized
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new(width: 100)) do
+          get "/custom/assets", to: "custom_assets#show"
+          get "/custom/furnitures", to: "custom_furnitures#show"
+          mount engine => "/blog", :as => "blog"
+        end
+
+        assert_equal ["",
+                      "\e[1;94m     GET \e[0m      /custom/assets(.:format) \e[1;90m................custom_assets_path > custom_assets#show     \e[0m",
+                      "\e[1;94m     GET \e[0m      /custom/furnitures(.:format) \e[1;90m....custom_furnitures_path > custom_furnitures#show     \e[0m",
+                      "               /blog \e[1;90m..................................................blog_path > Blog::Engine     \e[0m",
+                      "",
+                      "Routes for Blog::Engine:",
+                      "\e[1;94m     GET \e[0m      /cart(.:format) \e[1;90m...........................................cart_path > cart#show     \e[0m"], output
+      end
+
+      def test_no_routes_matched_filter_when_colorized
+        output = draw(grep: "rails/dummy", formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new) do
+          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+        end
+
+        assert_equal [
+          "No routes were found for this grep pattern.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
+      def test_not_routes_when_colorized
+        output = draw(grep: "rails/dummy", formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new) { }
+
+        assert_equal [
+          "You don't have any routes defined!",
+          "",
+          "Please add some routes in config/routes.rb.",
+          "",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
+      def test_routes_can_be_filtered_when_colorize
+        output = draw(grep: "posts", formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new(width: 70)) do
+          resources :articles
+          resources :posts
+        end
+
+        assert_equal ["",
+                      "\e[1;94m     GET \e[0m      /posts(.:format) \e[1;90m.........posts_path > posts#index     \e[0m",
+                      "\e[1;93m     POST \e[0m     /posts(.:format) \e[1;90m.....................posts#create     \e[0m",
+                      "\e[1;94m     GET \e[0m      /posts/new(.:format) \e[1;90m....new_post_path > posts#new     \e[0m",
+                      "\e[1;94m     GET \e[0m      /posts/\e[1;93m:id\e[0m/edit(.:format) \e[1;90medit_post_path > posts#edit     \e[0m",
+                      "\e[1;94m     GET \e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.......post_path > posts#show     \e[0m",
+                      "\e[1;93m     PATCH \e[0m    /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.................posts#update     \e[0m",
+                      "\e[1;93m     PUT \e[0m      /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m.................posts#update     \e[0m",
+                      "\e[1;91m     DELETE \e[0m   /posts/\e[1;93m:id\e[0m(.:format) \e[1;90m................posts#destroy     \e[0m"], output
+      end
+
       def test_routes_can_be_filtered_with_namespaced_controllers
         output = draw(grep: "admin/posts") do
           resources :articles

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -392,12 +392,14 @@ module ActionDispatch
         output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new(width: 100)) do
           get "/custom/assets", to: "custom_assets#show"
           get "/custom/furnitures", to: "custom_furnitures#show"
+          get "/post/:post_id/comments/:comment_ID_2", to: "custom_furnitures#show"
           mount engine => "/blog", :as => "blog"
         end
 
         assert_equal ["",
                       "\e[1;94m     GET\e[0m      /custom/assets(.:format) \e[1;90m................ custom_assets_path > custom_assets#show     \e[0m",
                       "\e[1;94m     GET\e[0m      /custom/furnitures(.:format) \e[1;90m.... custom_furnitures_path > custom_furnitures#show     \e[0m",
+                      "\e[1;94m     GET\e[0m      /post/\e[1;93m:post_id\e[0m/comments/\e[1;93m:comment_ID_2\e[0m(.:format) \e[1;90m.......... custom_furnitures#show     \e[0m",
                       "              /blog \e[1;90m.................................................. blog_path > Blog::Engine     \e[0m",
                       "",
                       "Routes for Blog::Engine:",
@@ -427,7 +429,7 @@ module ActionDispatch
         ], output
       end
 
-      def test_routes_can_be_filtered_when_colorize
+      def test_routes_can_be_filtered_when_colorized
         output = draw(grep: "posts", formatter: ActionDispatch::Routing::ConsoleFormatter::Colorized.new(width: 70)) do
           resources :articles
           resources :posts

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -26,7 +26,7 @@ module Rails
           if options.key?("expanded")
             ActionDispatch::Routing::ConsoleFormatter::Expanded.new
           elsif options.key?("colorized")
-            ActionDispatch::Routing::ConsoleFormatter::Colorized.new
+            ActionDispatch::Routing::ConsoleFormatter::Colorized.new(width: 100)
           else
             ActionDispatch::Routing::ConsoleFormatter::Sheet.new
           end

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -8,6 +8,7 @@ module Rails
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
+      class_option :colorized, type: :boolean, aliases: "-C", desc: "Print routes with a colorized version"
 
       def perform(*)
         require_application_and_environment!
@@ -24,6 +25,8 @@ module Rails
         def formatter
           if options.key?("expanded")
             ActionDispatch::Routing::ConsoleFormatter::Expanded.new
+          elsif options.key?("colorized")
+            ActionDispatch::Routing::ConsoleFormatter::Colorized.new
           else
             ActionDispatch::Routing::ConsoleFormatter::Sheet.new
           end


### PR DESCRIPTION
### Summary

I added `ActionDispatch::Routing::ConsoleFormatter::Colorized` that is a new routes formatter.

**Why a new formatter?**

The intention of this one is to add a different structure and colors to the actual `rails route` command.
This formatter can be used by a new flag (`-C`) added on the `route` command.

### Before
![Screen Shot 2022-06-01 at 6 10 17 PM](https://user-images.githubusercontent.com/16840674/171506536-c60cec25-75b7-4271-8b5e-634f349cb13b.png)

### After
![Screen Shot 2022-06-01 at 6 10 02 PM](https://user-images.githubusercontent.com/16840674/171506525-ac1d414f-08e8-4f7a-8cce-ed0ced7c68cb.png)