### PR TITLE
Fix scoped associations with empty loaded records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -320,7 +320,6 @@ module ActiveRecord
         #   * Otherwise, attributes should have the value found in the database
         def merge_target_lists(persisted, memory)
           return persisted if memory.empty?
-          return memory    if persisted.empty?
 
           persisted.map! do |record|
             if mem_record = memory.delete(record)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -32,6 +32,8 @@ require "models/discount"
 require "models/line_item"
 require "models/shipping_line"
 require "models/essay"
+require "models/member"
+require "models/membership"
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -125,7 +127,7 @@ class AssociationsTest < ActiveRecord::TestCase
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects
+  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects, :members
 
   def test_push_does_not_load_target
     david = authors(:david)
@@ -298,6 +300,27 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     assert_equal 1, david.thinking_posts.size
     assert_equal 1, david.thinking_posts.to_a.size
+  end
+
+  def test_target_merging_ignores_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    assert_empty member.favorite_memberships.to_a
+  end
+
+  def test_target_merging_recognizes_updated_in_memory_records
+    member = members(:blarpy_winkup)
+    membership = member.create_membership!(favorite: false)
+
+    assert_empty member.favorite_memberships
+
+    membership.update!(favorite: true)
+
+    assert_not_empty member.favorite_memberships.to_a
   end
 end
 


### PR DESCRIPTION
This fix was originally part of https://github.com/rails/rails/pull/45019 but that PR was solving different issues at once, so I decided to break that up into separate PRs for each problem.

### Problem statement
This PR addresses a bug found while working in our Rails application. It impacts associations with a scope, like so:
```ruby
class Member < ActiveRecord::Base
  has_many :memberships, -> { where(favorite: true) }
end
```

### Steps to reproduce

Using the example above:
```ruby
member = Member.create!
membership = member.memberships.create!(favorite: true)
membership.update!(favorite: false)
assert_empty member.memberships.to_a

# This test fails with:
# Expected [#<Membership id: 1, member_id: 1, favorite: false>] to be empty.
```

<details>
<summary>Full reproduction script</summary>

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem 'rails', github: 'rails/rails', branch: 'main'
  gem 'sqlite3'
end

require 'active_record'
require 'minitest/autorun'
require 'logger'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :members, force: true do |t|
  end

  create_table :memberships, force: true do |t|
    t.integer :member_id
    t.boolean :favorite
  end
end

class Member < ActiveRecord::Base
  has_many :memberships, -> { where(favorite: true) }
end

class Membership < ActiveRecord::Base
  belongs_to :member
end

class BugTest < Minitest::Test
  def test_loading_associations
    member = Member.create!
    membership = member.memberships.create!(favorite: true)
    membership.update!(favorite: false)

    assert_empty member.memberships.to_a
  end
end
```
</details>

### Implementation details
The bug is in `CollectionAssociation#merge_target_lists`. 
* The purpose of that method is to join 2 lists:
  a. records persisted to the database
  b. records in memory
* That method is called right after loading records from the database (in `#find_target`) https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L264
* Previously, it assumed that if the list of database records was empty, it meant the list of records in memory hadn't been persisted yet https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L323
* That assumption is not valid if there's a scope as in the example above. We can have an empty list of persisted records while there are records in memory that get filtered out by the scope.
* The fix is to remove that early return and let execution continue so that it can filter out persisted records from the in-memory list here https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L338

### Other Information

1. I ran this fix against the GitHub monolith tests and got a green build
4. I spoke to `@tenderlove` at the Rails contribution office hours at RailsConf and he suggested I add a test proving that the opposite scenario also works - starting with an empty association due to `favorite: false` and updating it to `favorite: true` should show up. I added that here https://github.com/rails/rails/blob/822ed9f974e3007fa0968d37ebef49378189f8ff/activerecord/test/cases/associations_test.rb#L315-L324

