### PR TITLE
Clear out target when no new records

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -81,10 +81,13 @@ module ActiveRecord
             scope.count(:all)
           end
 
-          # If there's nothing in the database and @target has no new records
-          # we are certain the current target is an empty array. This is a
-          # documented side-effect of the method that may avoid an extra SELECT.
-          loaded! if count == 0
+          # If there's nothing in the database, @target should only contain new
+          # records or be an empty array. This is a documented side-effect of
+          # the method that may avoid an extra SELECT.
+          if count == 0
+            target.select!(&:new_record?)
+            loaded!
+          end
 
           [association_scope.limit_value, count].compact.min
         end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -322,6 +322,20 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     assert_not_empty member.favorite_memberships.to_a
   end
+
+  def test_size_differentiates_between_new_and_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    # CollectionAssociation#size has different behavior when loaded vs. non-loaded
+    # the first call will mark the association as loaded and the second call will
+    # take a different code path, so it's important to keep both assertions
+    assert_equal 0, member.favorite_memberships.size
+    assert_equal 0, member.favorite_memberships.size
+  end
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
This fix was originally part of https://github.com/rails/rails/pull/45019 but that PR was solving different issues at once, so I decided to break that up into separate PRs for each problem.

### Summary

Calling `#size` on a `CollectionAssociation` can yield the wrong results when the collection association's target value gets out of sync. This issue can happen for associations with a scope, like so:
```ruby
class Member < ActiveRecord::Base
  has_many :memberships, -> { where(favorite: true) }
end
```

### Steps to reproduce

Using the example above:
```ruby
member = Member.create!
membership = member.memberships.create!(favorite: true)
membership.update!(favorite: false)

assert_equal 0, member.memberships.size
assert_equal 0, member.memberships.size

# The first assertion passes and the second fails with:
# Expected: 0
#   Actual: 1
```

<details>
<summary>Full reproduction script</summary>

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem 'rails', github: 'rails/rails', branch: 'main'
  gem 'sqlite3'
end

require 'active_record'
require 'minitest/autorun'
require 'logger'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :members, force: true do |t|
  end

  create_table :memberships, force: true do |t|
    t.integer :member_id
    t.boolean :favorite
  end
end

class Member < ActiveRecord::Base
  has_many :memberships, -> { where(favorite: true) }
end

class Membership < ActiveRecord::Base
  belongs_to :member
end

class BugTest < Minitest::Test
  def test_associations_size
    member = Member.create!
    membership = member.memberships.create!(favorite: true)
    membership.update!(favorite: false)

    assert_equal 0, member.memberships.size
    assert_equal 0, member.memberships.size
  end
end
```
</details>

It's important to have both assertions because `CollectionAssociation#size` has a conditional with multiple branches and each time we call `#size` in the test above it takes a different code path. 
In the first call the association isn't loaded, so we end up on this branch of the conditional
https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L208-L210
Inside the `count_records` method called above we mark the association as loaded and assume the `target` is empty, but we never ensure that's the case. This assumption can be incorrect when you have a scope on the association as in the example above
https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/has_many_association.rb#L82-L85

In the second call to `#size`, the association is loaded so we end up on this branch. 
https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L202-L203
Now, the target should be empty, but it actually has 1 record, so we get the test failure.

The fix is to ensure `target` is empty inside `count_records` if `count` is 0

### Other Information

I ran this fix against the GitHub monolith tests and got a green build
