### PR TITLE
MemCacheStore shorten keys properly

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -74,6 +74,7 @@ module ActiveSupport
       end
       prepend DupLocalCache
 
+      KEY_MAX_SIZE = 250
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
       # Creates a new Dalli::Client instance with specified addresses and options.
@@ -306,7 +307,13 @@ module ActiveSupport
           if key
             key = key.dup.force_encoding(Encoding::ASCII_8BIT)
             key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-            key = "#{key[0, 212]}:hash:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
+
+            if key.size > KEY_MAX_SIZE
+              key_separator = ":hash:"
+              key_hash = ActiveSupport::Digest.hexdigest(key)
+              key_trim_size = KEY_MAX_SIZE - key_separator.size - key_hash.size
+              key = "#{key[0, key_trim_size]}#{key_separator}#{key_hash}"
+            end
           end
           key
         end


### PR DESCRIPTION
The logic for shortening long keys in MemCacheStore
is broken since the time it stopped using MD5 checksumming.

Memcached supports keys up to 250 chars length. The reason
things worked I believe is because the underlying Dalli
library is doing it's own key shortening. Which uses its own
hashing function and in fact limits keys to 249 chars, see
petergoldstein/dalli@74b2625f11ff56dd6f55c7316bc115bc5a29be5f

This patch in a similar way properly truncates keys to 250
characters and avoids double hashing on Dalli side. Also
makes key name more predictable and independent from the
underlying Dalli version.