### PR TITLE
Fix includes of deprecation proxy modules 

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -158,6 +158,21 @@ module ActiveSupport
         target.class
       end
 
+      def append_features(base)
+        @deprecator.warn(@message, caller_locations)
+        base.include(target)
+      end
+
+      def prepend_features(base)
+        @deprecator.warn(@message, caller_locations)
+        base.prepend(target)
+      end
+
+      def extended(base)
+        @deprecator.warn(@message, caller_locations)
+        base.extend(target)
+      end
+
       private
         def target
           ActiveSupport::Inflector.constantize(@new_const.to_s)

--- a/activesupport/test/deprecation/proxy_wrappers_test.rb
+++ b/activesupport/test/deprecation/proxy_wrappers_test.rb
@@ -7,6 +7,12 @@ class ProxyWrappersTest < ActiveSupport::TestCase
   Waffles     = false
   NewWaffles  = :hamburgers
 
+  module WaffleModule
+    def waffle?
+      true
+    end
+  end
+
   def test_deprecated_object_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(nil, "message")
     assert_not proxy
@@ -20,5 +26,36 @@ class ProxyWrappersTest < ActiveSupport::TestCase
   def test_deprecated_constant_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(Waffles, NewWaffles)
     assert_not proxy
+  end
+
+  def test_including_proxy_module
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    klass = Class.new
+    assert_deprecated do
+      klass.include proxy
+    end
+    assert klass.new.waffle?
+  end
+
+  def test_prepending_proxy_module
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    klass = Class.new do
+      def waffle?
+        false
+      end
+    end
+    assert_deprecated do
+      klass.prepend proxy
+    end
+    assert klass.new.waffle?
+  end
+
+  def test_extending_proxy_module
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    obj = Object.new
+    assert_deprecated do
+      obj.extend proxy
+    end
+    assert obj.waffle?
   end
 end

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -108,7 +108,7 @@ module Rails
           end
       end
 
-      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("behavior", "Behavior")
+      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Behaviour", "Behavior")
     end
   end
 end


### PR DESCRIPTION
Previously (at least since #36557), including/prepending/extending one of these deprecated constants would silently succeed, since the proxy is a module.

This adds a defintion for append_features/prepend_features/extended so that it can forward the inclusion onto the target module and issue the deprecation warning.

I noticed this due to the change in #45180