### PR TITLE
Revert "Delegate `empty?` query method to relation"

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
-      :exists?, :any?, :many?, :none?, :empty?, :one?,
+      :exists?, :any?, :many?, :none?, :one?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
         method.end_with?("=", "!", "?", "value", "values", "clause")
       } - [:reverse_order, :arel, :extensions, :construct_join_dependency] + [
-        :any?, :many?, :none?, :empty?, :one?,
+        :any?, :many?, :none?, :one?,
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,


### PR DESCRIPTION
Reverts rails/rails#45219

https://github.com/rails/rails/pull/45219#issuecomment-1145427837

Because `empty?` implies `blank?` which implies `!present?`, this is likely to cause surprising behaviour and extra queries for users.