### PR TITLE
Improve rails new documentation

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -14,6 +14,57 @@ After reading this guide, you will know:
 
 NOTE: This tutorial assumes you have basic Rails knowledge from reading the [Getting Started with Rails Guide](getting_started.html).
 
+Creating a Rails App
+--------------------
+
+First, let's create a simple Rails application using the `rails new` command.
+
+We will use this application to play and discover all the commands described in this guide.
+
+INFO: You can install the rails gem by typing `gem install rails`, if you don't have it already.
+
+### `rails new`
+
+The first argument we'll pass to the `rails new` command is the application name.
+
+```bash
+$ rails new commandsapp
+     create
+     create  README.md
+     create  Rakefile
+     create  config.ru
+     create  .gitignore
+     create  Gemfile
+     create  app
+     ...
+     create  tmp/cache
+     ...
+        run  bundle install
+```
+
+Rails will set you up with what seems like a huge amount of stuff for such a tiny command! You've got the entire Rails directory structure now with all the code you need to run our simple application right out of the box.
+
+If you wish to skip some files or components from being generated, you can append the following arguments to your `rails new` command:
+
+| Argument                | Description                                                 |
+| ----------------------- | ----------------------------------------------------------- |
+| `--skip-git`            | Skip .gitignore file                                        |
+| `--skip-keeps`          | Skip source control .keep files                             |
+| `--skip-action-mailer`  | Skip Action Mailer files                                    |
+| `--skip-action-mailbox` | Skip Action Mailbox gem                                     |
+| `--skip-action-text`    | Skip Action Text gem                                        |
+| `--skip-active-record`  | Skip Active Record files                                    |
+| `--skip-active-job`     | Skip Active Job                                             |
+| `--skip-active-storage` | Skip Active Storage files                                   |
+| `--skip-action-cable`   | Skip Action Cable files                                     |
+| `--skip-asset-pipeline` | Skip Asset Pipeline                                         |
+| `--skip-javascript`     | Skip JavaScript files                                       |
+| `--skip-hotwire`        | Skip Hotwire integration                                    |
+| `--skip-jbuilder`       | Skip jbuilder gem                                           |
+| `--skip-test`           | Skip test files                                             |
+| `--skip-system-test`    | Skip system test files                                      |
+| `--skip-bootsnap`       | Skip bootsnap gem                                           |
+
 Command Line Basics
 -------------------
 
@@ -64,52 +115,6 @@ In addition to those commands, there are:
  restart                             Restart app by touching ...
  tmp:create                          Creates tmp directories ...
 ```
-
-Let's create a simple Rails application to step through each of these commands in context.
-
-### `rails new`
-
-The first thing we'll want to do is create a new Rails application by running the `rails new` command after installing Rails.
-
-INFO: You can install the rails gem by typing `gem install rails`, if you don't have it already.
-
-```bash
-$ rails new commandsapp
-     create
-     create  README.md
-     create  Rakefile
-     create  config.ru
-     create  .gitignore
-     create  Gemfile
-     create  app
-     ...
-     create  tmp/cache
-     ...
-        run  bundle install
-```
-
-Rails will set you up with what seems like a huge amount of stuff for such a tiny command! You've got the entire Rails directory structure now with all the code you need to run our simple application right out of the box.
-
-If you wish to skip some files or components from being generated, you can append the following arguments to your `rails new` command:
-
-| Argument                | Description                                                 |
-| ----------------------- | ----------------------------------------------------------- |
-| `--skip-git`            | Skip .gitignore file                                        |
-| `--skip-keeps`          | Skip source control .keep files                             |
-| `--skip-action-mailer`  | Skip Action Mailer files                                    |
-| `--skip-action-mailbox` | Skip Action Mailbox gem                                     |
-| `--skip-action-text`    | Skip Action Text gem                                        |
-| `--skip-active-record`  | Skip Active Record files                                    |
-| `--skip-active-job`     | Skip Active Job                                             |
-| `--skip-active-storage` | Skip Active Storage files                                   |
-| `--skip-action-cable`   | Skip Action Cable files                                     |
-| `--skip-asset-pipeline` | Skip Asset Pipeline                                         |
-| `--skip-javascript`     | Skip JavaScript files                                       |
-| `--skip-hotwire`        | Skip Hotwire integration                                    |
-| `--skip-jbuilder`       | Skip jbuilder gem                                           |
-| `--skip-test`           | Skip test files                                             |
-| `--skip-system-test`    | Skip system test files                                      |
-| `--skip-bootsnap`       | Skip bootsnap gem                                           |
 
 ### `bin/rails server`
 


### PR DESCRIPTION
### Summary

This PR is a first step to update [the CLI Rails guide](https://guides.rubyonrails.org/command_line.html) as proposed in @p8 [comment](https://github.com/rails/rails/issues/44325#issuecomment-1140489948).

The main idea is to create a clear space for `rails new` docs. I moved the main text in it's own section and made some rewordings to fit the new context.