### PR TITLE
Fix ActiveSupport::MessageEncryptor run_rotations to return decryption for nil value

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -171,12 +171,18 @@ module ActiveSupport
       if digest_matches_data?(digest, data)
         begin
           message = Messages::Metadata.verify(decode(data), purpose)
-          @serializer.load(message) if message
+          if message
+            return @serializer.load(message)
+          else
+            return message
+          end
         rescue ArgumentError => argument_error
           return if argument_error.message.include?("invalid base64")
           raise
         end
       end
+
+      raise(InvalidSignature)
     end
 
     # Decodes the signed message using the +MessageVerifier+'s secret.
@@ -192,7 +198,7 @@ module ActiveSupport
     #   other_verifier = ActiveSupport::MessageVerifier.new("different_secret")
     #   other_verifier.verify(signed_message) # => ActiveSupport::MessageVerifier::InvalidSignature
     def verify(*args, **options)
-      verified(*args, **options) || raise(InvalidSignature)
+      verified(*args, **options)
     end
 
     # Generates a signed message for the provided value.

--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -56,7 +56,11 @@ module ActiveSupport
       end
 
       def verify(purpose)
-        @message if match?(purpose) && fresh?
+        if match?(purpose) && fresh?
+          @message
+        else
+          raise(ActiveSupport::MessageVerifier::InvalidSignature)
+        end
       end
 
       private

--- a/activesupport/lib/active_support/secure_compare_rotator.rb
+++ b/activesupport/lib/active_support/secure_compare_rotator.rb
@@ -39,8 +39,7 @@ module ActiveSupport
 
     def secure_compare!(other_value, on_rotation: @on_rotation)
       secure_compare(@value, other_value) ||
-        run_rotations(on_rotation) { |wrapper| wrapper.secure_compare!(other_value) } ||
-        raise(InvalidMatch)
+        run_rotations(on_rotation, InvalidMatch) { |wrapper| wrapper.secure_compare!(other_value) }
     end
 
     private

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -39,8 +39,10 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_equal @data, @verifier.verify(message)
   end
 
-  def test_verified_returns_false_on_invalid_message
-    assert_not @verifier.verified("purejunk")
+  def test_verified_returns_exception_on_invalid_message
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      @verifier.verified("purejunk")
+    end
   end
 
   def test_verify_exception_on_invalid_message

--- a/activesupport/test/metadata/shared_metadata_tests.rb
+++ b/activesupport/test/metadata/shared_metadata_tests.rb
@@ -20,10 +20,16 @@ module SharedMessageMetadataTests
     assert_equal data, parse(generate(data, purpose: :registration), purpose: :registration)
   end
 
-  def test_encryption_and_decryption_with_different_purposes_returns_nil
-    assert_nil parse(generate(data, purpose: "payment"), purpose: "sign up")
-    assert_nil parse(generate(data, purpose: "payment"))
-    assert_nil parse(generate(data), purpose: "sign up")
+  def test_encryption_and_decryption_with_different_purposes_returns_exception
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      parse(generate(data, purpose: "payment"), purpose: "sign up")
+    end
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      parse(generate(data, purpose: "payment"))
+    end
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      parse(generate(data), purpose: "sign up")
+    end
   end
 
   def test_purpose_using_symbols
@@ -39,7 +45,9 @@ module SharedMessageMetadataTests
     assert_equal data, parse(encrypted_message)
 
     travel 2.minutes
-    assert_nil parse(encrypted_message)
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      parse(encrypted_message)
+    end
   end
 
   def test_set_relative_expiration_date_by_passing_expires_in
@@ -49,7 +57,9 @@ module SharedMessageMetadataTests
     assert_equal data, parse(encrypted_message)
 
     travel 1.hour + 1.second
-    assert_nil parse(encrypted_message)
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      assert_nil parse(encrypted_message)
+    end
   end
 
   def test_passing_expires_in_less_than_a_second_is_not_expired
@@ -60,7 +70,9 @@ module SharedMessageMetadataTests
       assert_equal data, parse(encrypted_message)
 
       travel 1.second
-      assert_nil parse(encrypted_message)
+      assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+        parse(encrypted_message)
+      end
     end
   end
 
@@ -71,7 +83,9 @@ module SharedMessageMetadataTests
     assert_equal data, parse(payment_related_message, purpose: :payment)
 
     travel 1.year + 1.day
-    assert_nil parse(payment_related_message, purpose: "payment")
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      parse(payment_related_message, purpose: "payment")
+    end
   end
 
   def test_skip_expires_at_and_expires_in_to_disable_expiration_check


### PR DESCRIPTION
Fix ActiveSupport::MessageEncryptor run_rotations to return decryption for nil value