### PR TITLE
Fix typo in documentation examples

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -460,7 +460,7 @@ module ActionView
       # Active Storage blobs (videos that are uploaded by the users of your app):
       #
       #   video_tag(user.intro_video)
-      #   # => <img src="/rails/active_storage/blobs/.../intro_video.mp4" />
+      #   # => <video src="/rails/active_storage/blobs/.../intro_video.mp4"></video>
       def video_tag(*sources)
         options = sources.extract_options!.symbolize_keys
         public_poster_folder = options.delete(:poster_skip_pipeline)
@@ -492,7 +492,7 @@ module ActionView
       # Active Storage blobs (audios that are uploaded by the users of your app):
       #
       #   audio_tag(user.name_pronunciation_audio)
-      #   # => <img src="/rails/active_storage/blobs/.../name_pronunciation_audio.mp4" />
+      #   # => <audio src="/rails/active_storage/blobs/.../name_pronunciation_audio.mp3"></audio>
       def audio_tag(*sources)
         multiple_sources_tag_builder("audio", sources)
       end


### PR DESCRIPTION
Fix typo in documentation examples

Add audio & video tags respectively

### Summary

This fixes the typo for the recently added change in this PR https://github.com/rails/rails/pull/44085 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
