### PR TITLE
Show Guides Index as selected for `/` on small screens [ci-skip]

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -49,7 +49,7 @@
 
     var guidesIndexItem   = document.querySelector("select.guides-index-item");
     var currentGuidePath  = window.location.pathname;
-    guidesIndexItem.value = currentGuidePath.substring(currentGuidePath.lastIndexOf("/") + 1);
+    guidesIndexItem.value = currentGuidePath.substring(currentGuidePath.lastIndexOf("/") + 1) || 'index.html';
 
     guidesIndexItem.addEventListener("change", function(e) {
       if (Turbolinks.supported) {


### PR DESCRIPTION
### Summary

On small screens the guides index is shown as a select dropdown.
If the `window.location` matches the value of an option, it will be selected.

The first option in the `select` is "Guides Index" and has the value 'index.html'.
When visiting `https://guides.rubyonrails.org/index.html` this option is selected.
When visiting `https://guides.rubyonrails.org/` this option won't be
selected as the pathname doesn't include index.html.

Javascript treats empty strings as falsey, so for the root path we can
return `index.html` instead of an empty string.
This makes sure the "Guides Index" is selected as well. 

### Before

<img width="396" alt="image" src="https://user-images.githubusercontent.com/28561/172210313-e03301aa-21fc-4d7d-bded-23dfe027c756.png">

### After

<img width="393" alt="image" src="https://user-images.githubusercontent.com/28561/172210474-6fef3094-fb28-4d4d-b3a9-cce9e33eeb25.png">
