### PR TITLE
Add installation instructions for importmap-rails

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -32,6 +32,20 @@ manage your JavaScript dependencies, there is no need to install Node.js or Yarn
 When using import maps, no separate build process is required, just start your server with
 `bin/rails server` and you are good to go.
 
+### Installing importmap-rails
+
+Importmap for Rails is automatically included in Rails 7+ for new applications, but you can also install it manually in existing applications:
+
+```bash
+$ bin/bundle add importmap-rails
+```
+
+Run the install task:
+
+```bash
+$ bin/rails importmap:install
+```
+
 ### Adding NPM Packages with importmap-rails
 
 To add new packages to your import map-powered application, run the `bin/importmap pin` command


### PR DESCRIPTION
### Summary

Adds missing installation instructions for `importrails-gem` from https://github.com/rails/importmap-rails