### PR TITLE
Reflect PostgreSQL UUID functionality part of core since v13.0

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -325,8 +325,7 @@ SELECT n.nspname AS enum_schema,
 * [pgcrypto generator function](https://www.postgresql.org/docs/current/static/pgcrypto.html)
 * [uuid-ossp generator functions](https://www.postgresql.org/docs/current/static/uuid-ossp.html)
 
-NOTE: You need to enable the `pgcrypto` (only PostgreSQL >= 9.4) or `uuid-ossp`
-extension to use uuid.
+NOTE: If you're using PostgreSQL earlier than version 13.0 you may need to enable special extensions to use UUIDs. Enable the `pgcrypto` extension (PostgreSQL >= 9.4) or `uuid-ossp` extension (for even earlier releases).
 
 ```ruby
 # db/migrate/20131220144913_create_revisions.rb


### PR DESCRIPTION
### Summary

This change reflects that the SQL function used to generate UUIDs `gen_random_uuid ()` is part of PostgreSQL core beginning with version 13.0. Thus, no special extensions are needed to use UUIDs with PostgreSQL equal or greater version 13.0.

### Other Information

See https://www.postgresql.org/docs/current/functions-uuid.html, https://www.postgresql.org/docs/release/13.0/ (look for `gen_random_uuid()` in release notes) and https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb#L50 for further reference.
