### PR TITLE
Run transactional callbacks on instances most likely to match DB state

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Run transactional callbacks on the freshest instance to save a given 
+    record within a transaction.
+
+    When multiple Active Record instances change the same record within a 
+    transaction, Rails runs `after_commit` or `after_rollback` callbacks for 
+    only one of them. `config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction` 
+    was added to specify how Rails chooses which instance receives the 
+    callbacks. The framework defaults were changed to use the new logic.
+
+    When `config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction` 
+    is `true`, transactional callbacks are run on the first instance to save, 
+    even though its instance state may be stale.
+
+    When it is `false`, which is the new framework default starting with version 
+    7.1, transactional callbacks are run on the instances with the freshest 
+    instance state. Those instances are chosen as follows:
+
+    - In general, run transactional callbacks on the last instance to save a 
+      given record within the transaction.
+    - There are two exceptions:
+        - If the record is created within the transaction, then updated by 
+          another instance, `after_create_commit` callbacks will be run on the 
+          second instance. This is instead of the `after_update_commit` 
+          callbacks that would naively be run based on that instance’s state.
+        - If the record is destroyed within the transaction, then 
+          `after_destroy_commit` callbacks will be fired on the last destroyed 
+          instance, even if a stale instance subsequently performed an update 
+          (which will have affected 0 rows).
+
+    *Cameron Bothner and Mitch Vollebregt*
+
 *   Resolve issue where a relation cache_version could be left stale.
 
     Previously, when `reset` was called on a relation object it did not reset the cache_versions

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -81,6 +81,8 @@ module ActiveRecord
 
       class_attribute :has_many_inversing, instance_accessor: false, default: false
 
+      class_attribute :run_commit_callbacks_on_first_saved_instances_in_transaction, instance_accessor: false, default: true
+
       class_attribute :default_connection_handler, instance_writer: false
 
       class_attribute :default_role, instance_writer: false

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -13,6 +13,8 @@ module ActiveRecord
                        scope: [:kind, :name]
     end
 
+    attr_accessor :_new_record_before_last_commit # :nodoc:
+
     # = Active Record Transactions
     #
     # \Transactions are protective blocks where SQL statements are only permanent

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -937,6 +937,26 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 7.0                   | `true`               |
 
+#### `config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`
+
+When multiple Active Record instances change the same record within a transaction, Rails runs `after_commit` or `after_rollback` callbacks for only one of them. This option specifies how Rails chooses which instance receives the callbacks.
+
+When `true`, transactional callbacks are run on the first instance to save, even though its instance state may be stale.
+
+When `false`, transactional callbacks are run on the instances with the freshest instance state. Those instances are chosen as follows:
+
+- In general, run transactional callbacks on the last instance to save a given record within the transaction.
+- There are two exceptions:
+    - If the record is created within the transaction, then updated by another instance, `after_create_commit` callbacks will be run on the second instance. This is instead of the `after_update_commit` callbacks that would naively be run based on that instance’s state.
+    - If the record is destroyed within the transaction, then `after_destroy_commit` callbacks will be fired on the last destroyed instance, even if a stale instance subsequently performed an update (which will have affected 0 rows).
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 7.1                   | `false`              |
+
 #### `config.active_record.query_log_tags_enabled`
 
 Specifies whether or not to enable adapter-level query comments. Defaults to

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -262,6 +262,10 @@ module Rails
             self.log_file_size = (100 * 1024 * 1024)
           end
 
+          if respond_to?(:active_record)
+            active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+          end
+
           if respond_to?(:action_dispatch)
             action_dispatch.default_headers = {
               "X-Frame-Options" => "SAMEORIGIN",

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -28,3 +28,10 @@
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 # Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+
+# No longer run after_commit callbacks on the first of multiple Active Record
+# instances to save changes to the same database row within a transaction.
+# Instead, run these callbacks on the instance most likely to have internal
+# state which matches what was committed to the database, typically the last
+# instance to save.
+# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2382,6 +2382,32 @@ module ApplicationTests
       assert_equal true, ActiveRecord.verify_foreign_keys_for_fixtures
     end
 
+    test "ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction is false by default for new apps" do
+      app "development"
+
+      assert_equal false, ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction
+    end
+
+    test "ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction is true by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal true, ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction
+    end
+
+    test "ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction can be configured via config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction
+    end
+
     test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption is true by default for new apps" do
       app "development"
 


### PR DESCRIPTION
When multiple instances of the same ActiveRecord model are used to persist changes within a transaction, Rails always runs `after_commit` callbacks on the first to save. This results in very unintuitive behavior:

```ruby
Product.transaction do
  Product.find(id).update!(title: "T-Shirt")
  Product.find(id).update!(description: "A cool T-shirt")
end
# When the transaction commits, `after_update_commit` callbacks are fired
# on the first instance, which does not have the new description.

Product.transaction do
  Product.find(id).update!(title: "T-Shirt")
  Product.find(id).destroy!
end
# When the transaction commits, `after_update_commit` callbacks are fired,
# even though the product is destroyed.
```

This PR implements a change to instead fire transactional callbacks on instances with internal state most likely to match the committed database state. 

- In general, run transactional callbacks on the last instance to save a given record within the transaction.
- There are two exceptions:
    - If the record is created within the transaction, then updated by another instance, `after_create_commit` callbacks will be run on the second instance. This is instead of the `after_update_commit` callbacks that would naively be run based on that instance’s state.
    - If the record is destroyed within the transaction, then `after_destroy_commit` callbacks will be fired on the last destroyed instance, even if a stale instance subsequently performed an update (which will have affected 0 rows).

Please see the added test cases for a more detailed statement of behavior.
