### PR TITLE
Use AS::N build_handle API in Rails::Rack::Logger

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -30,17 +30,15 @@ module Rails
       private
         def call_app(request, env) # :doc:
           instrumenter = ActiveSupport::Notifications.instrumenter
-          instrumenter_state = instrumenter.start "request.action_dispatch", request: request
-          instrumenter_finish = -> () {
-            instrumenter.finish_with_state(instrumenter_state, "request.action_dispatch", request: request)
-          }
+          handle = instrumenter.build_handle("request.action_dispatch", { request: request })
+          handle.start
 
           logger.info { started_request_message(request) }
           status, headers, body = @app.call(env)
-          body = ::Rack::BodyProxy.new(body, &instrumenter_finish)
+          body = ::Rack::BodyProxy.new(body, &handle.method(:finish))
           [status, headers, body]
         rescue Exception
-          instrumenter_finish.call
+          handle.finish
           raise
         ensure
           ActiveSupport::LogSubscriber.flush_all!


### PR DESCRIPTION
Rails::Rack::Logger is one of the few (the only?) places where we aren't able to use the preferred `ActiveSupport::Notifications.instrument` API with a block. This is because we want to finish the event when the Rack body is closed, rather than when the status and headers are first returned.

This switches to using the low-level `build_handle` API, introduced in #44469, which allows safe interleaving of events and doesn't make use of thread or fiber locals.