### PR TITLE
Support descending order for `in_batches` without block.

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -203,12 +203,13 @@ module ActiveRecord
     # other processes are modifying the database.
     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc)
       relation = self
-      unless block_given?
-        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self)
-      end
 
       unless [:asc, :desc].include?(order)
         raise ArgumentError, ":order must be :asc or :desc, got #{order.inspect}"
+      end
+
+      unless block_given?
+        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, order: order)
       end
 
       if arel.orders.present?

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -5,11 +5,12 @@ module ActiveRecord
     class BatchEnumerator
       include Enumerable
 
-      def initialize(of: 1000, start: nil, finish: nil, relation:) # :nodoc:
+      def initialize(of: 1000, start: nil, finish: nil, relation:, order: :asc) # :nodoc:
         @of       = of
         @relation = relation
         @start = start
         @finish = finish
+        @order = order
       end
 
       # The primary key value from which the BatchEnumerator starts, inclusive of the value.
@@ -50,7 +51,7 @@ module ActiveRecord
       def each_record(&block)
         return to_enum(:each_record) unless block_given?
 
-        @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: true).each do |relation|
+        @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: true, order: @order).each do |relation|
           relation.records.each(&block)
         end
       end
@@ -90,7 +91,7 @@ module ActiveRecord
       #     relation.update_all(awesome: true)
       #   end
       def each(&block)
-        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false)
+        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false, order: @order)
         return enum.each(&block) if block_given?
         enum
       end


### PR DESCRIPTION
### Summary

Follow-up #30590.
In the feature of `descending order for batches` introduced in #30590 but the case of calling `in_batches` without a block was not supported.
Perhaps the reason it was not supported was a correction omission.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

### When calling `in_batches` with block. It works fine.

```
# Post Pluck (0.1ms)  SELECT "posts"."id" FROM "posts" ORDER BY "posts"."id" DESC LIMIT ?  [["LIMIT", 1000]]
Post.in_batches(order: :desc) {}
```

### When calling `in_batches` without block.

**before**: expected `DESC`, got `ASC`

```
# Post Pluck (0.1ms)  SELECT "posts"."id" FROM "posts" ORDER BY "posts"."id" ASC LIMIT ?  [["LIMIT", 1000]]
Post.in_batches(order: :desc).each {}
```

**after**

```
# Post Pluck (0.1ms)  SELECT "posts"."id" FROM "posts" ORDER BY "posts"."id" DESC LIMIT ?  [["LIMIT", 1000]]
Post.in_batches(order: :desc).each {}
```