### PR TITLE
Handle `Date` objects for PostgreSQL `timestamptz` columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
@@ -13,7 +13,7 @@ module ActiveRecord
             return if value.blank?
 
             time = super
-            return time if time.is_a?(ActiveSupport::TimeWithZone)
+            return time unless time.acts_like?(:time)
 
             # While in UTC mode, the PG gem may not return times back in "UTC" even if they were provided to Postgres in UTC.
             # We prefer times always in UTC, so here we convert back.

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -180,6 +180,15 @@ if supports_datetime_with_precision?
       assert_nil Foo.create!(happened_at: "").happened_at
     end
 
+    def test_writing_a_date_attribute
+      @connection.create_table(:foos, force: true) do |t|
+        t.datetime :happened_at
+      end
+
+      date = ::Date.new(2001, 2, 3)
+      assert_equal date, Foo.create!(happened_at: date).happened_at
+    end
+
     if current_adapter?(:PostgreSQLAdapter)
       def test_writing_a_blank_attribute_timestamptz
         with_postgresql_datetime_type(:timestamptz) do
@@ -189,6 +198,17 @@ if supports_datetime_with_precision?
 
           assert_nil Foo.create!(happened_at: nil).happened_at
           assert_nil Foo.create!(happened_at: "").happened_at
+        end
+      end
+
+      def test_writing_a_date_attribute_timestamptz
+        with_postgresql_datetime_type(:timestamptz) do
+          @connection.create_table(:foos, force: true) do |t|
+            t.datetime :happened_at
+          end
+
+          date = ::Date.new(2001, 2, 3)
+          assert_equal date, Foo.create!(happened_at: date).happened_at
         end
       end
     end


### PR DESCRIPTION
Fixes #45283.

cc @ghiculescu 