### PR TITLE
Correctly read the `cache_format_version` setting on boot

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -873,7 +873,7 @@ module ActiveSupport
           when 7.0
             Rails70Coder
           else
-            raise ArgumentError, "Unknown ActiveSupport::Cache.format_version #{Cache.format_version.inspect}"
+            raise ArgumentError, "Unknown ActiveSupport::Cache.format_version: #{Cache.format_version.inspect}"
           end
         end
       end

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -63,6 +63,9 @@ module Rails
 
       # Initialize cache early in the stack so railties can make use of it.
       initializer :initialize_cache, group: :all do
+        cache_format_version = config.active_support.delete(:cache_format_version)
+        ActiveSupport.cache_format_version = cache_format_version if cache_format_version
+
         unless Rails.cache
           Rails.cache = ActiveSupport::Cache.lookup_store(*config.cache_store)
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/45289

### Other Information

I'm not sure if it's an antipattern to read from the config of specific modules in `railties/lib/rails/application/bootstrap.rb`. But we know for sure Active Support has loaded by then (I think), and this seems like the only way to ensure that this config is used correctly.