### PR TITLE
Introduce ActiveSupport::ConfigurationOptions

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -9,7 +9,7 @@ require "action_view/railtie"
 
 module ActionController
   class Railtie < Rails::Railtie # :nodoc:
-    config.action_controller = ActiveSupport::ConfigurationOptions.new
+    config.action_controller = ActiveSupport::ConfigurationOptions.new("config.action_controller")
     config.action_controller.raise_on_open_redirects = false
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -32,6 +32,10 @@ module ActiveSupport
     alias_method :_get, :[] # preserve the original #[] method
     protected :_get # make it protected
 
+    def delete(key)
+      super(key.to_sym)
+    end
+
     def []=(key, value)
       super(key.to_sym, value)
     end
@@ -95,5 +99,65 @@ module ActiveSupport
     def inheritable_copy
       self.class.new(self)
     end
+  end
+
+  class ConfigurationOptions
+    DEPRECATED_HASH_METHODS = [
+      :clear, :compact!, :compact_blank!, :deep_merge!, :deconstruct_keys,
+      :deep_merge, :deep_stringify_keys, :deep_stringify_keys!,
+      :deep_symbolize_keys, :deep_symbolize_keys!, :deep_transform_keys!,
+      :default=, :default_proc=, :delete, :delete_if, :except!, :extract!,
+      :filter!, :merge!,:reject!, :replace, :select!, :slice!,
+      :stringify_keys!, :symbolize_keys!, :to_options!, :transform_keys!,
+      :transform_values!,
+    ].to_set
+
+    def initialize
+      @options = OrderedOptions.new
+      @consumed_keys = Set.new
+    end
+
+    def consume(key)
+      key = key.to_sym
+      @consumed_keys << key
+      self[key]
+    end
+
+    def []=(key, value)
+      key = key.to_sym
+      if @consumed_keys.include?(key)
+        raise "#{key} was already used"
+      else
+        @options[key] = value
+      end
+    end
+
+    def remaining
+      except(*@consumed_keys)
+    end
+
+    def inspect
+      "#<#{self.class.name} #{@options.to_h.inspect}>"
+    end
+
+    private
+
+    def respond_to_missing?(name, include_private)
+      name.end_with?("=") || !Hash.method_defined?(name)
+    end
+
+    def method_missing(name, *args, &block)
+      if DEPRECATED_HASH_METHODS.include?(name)
+        ActiveSuppport::Deprecation.warn(<<~MSG.squish)
+          #{self.class.name}##{name} is deprecated and wil be removed. TODO: What shall we say?
+        MSG
+        @options.public_send(name, *args, &block)
+      elsif name.end_with?("=")
+        self[name.to_s.chomp!("=")] = args.first
+      else
+        @options.public_send(name, *args, &block)
+      end
+    end
+    ruby2_keywords :method_missing
   end
 end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -112,7 +112,8 @@ module ActiveSupport
       :transform_values!,
     ].to_set
 
-    def initialize
+    def initialize(path)
+      @path = path
       @options = OrderedOptions.new
       @consumed_keys = Set.new
     end
@@ -126,7 +127,7 @@ module ActiveSupport
     def []=(key, value)
       key = key.to_sym
       if @consumed_keys.include?(key)
-        raise "#{key} was already used"
+        raise KeyError, "#{@path}.#{key} was already used. Changing it now would have no effect."
       else
         @options[key] = value
       end

--- a/activesupport/test/configuration_options_test.rb
+++ b/activesupport/test/configuration_options_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/ordered_options"
+
+class ConfigurationOptionsTest < ActiveSupport::TestCase
+  def test_usage
+    a = ActiveSupport::ConfigurationOptions.new
+
+    assert_nil a[:not_set]
+
+    a[:allow_concurrency] = true
+    assert_equal 1, a.size
+    assert a[:allow_concurrency]
+
+    a[:allow_concurrency] = false
+    assert_equal 1, a.size
+    assert_not a[:allow_concurrency]
+
+    a["else_where"] = 56
+    assert_equal 2, a.size
+    assert_equal 56, a[:else_where]
+  end
+
+  def test_looping
+    a = ActiveSupport::ConfigurationOptions.new
+
+    a[:allow_concurrency] = true
+    a["else_where"] = 56
+
+    test = [[:allow_concurrency, true], [:else_where, 56]]
+
+    a.each_with_index do |(key, value), index|
+      assert_equal test[index].first, key
+      assert_equal test[index].last, value
+    end
+  end
+
+  def test_string_dig
+    a = ActiveSupport::ConfigurationOptions.new
+
+    a[:test_key] = 56
+    assert_equal 56, a.test_key
+    assert_equal 56, a["test_key"]
+    assert_equal 56, a.dig(:test_key)
+    assert_equal 56, a.dig("test_key")
+  end
+
+  def test_method_access
+    a = ActiveSupport::ConfigurationOptions.new
+
+    assert_nil a.not_set
+
+    a.allow_concurrency = true
+    assert_equal 1, a.size
+    assert a.allow_concurrency
+
+    a.allow_concurrency = false
+    assert_equal 1, a.size
+    assert_not a.allow_concurrency
+
+    a.else_where = 56
+    assert_equal 2, a.size
+    assert_equal 56, a.else_where
+  end
+
+  def test_inheritable_options_continues_lookup_in_parent
+    parent = ActiveSupport::ConfigurationOptions.new
+    parent[:foo] = true
+
+    child = ActiveSupport::InheritableOptions.new(parent)
+    assert child.foo
+  end
+
+  def test_inheritable_options_can_override_parent
+    parent = ActiveSupport::ConfigurationOptions.new
+    parent[:foo] = :bar
+
+    child = ActiveSupport::InheritableOptions.new(parent)
+    child[:foo] = :baz
+
+    assert_equal :baz, child.foo
+  end
+
+  def test_inheritable_options_inheritable_copy
+    original = ActiveSupport::InheritableOptions.new
+    copy     = original.inheritable_copy
+
+    assert copy.kind_of?(original.class)
+    assert_not_equal copy.object_id, original.object_id
+  end
+
+  def test_introspection
+    a = ActiveSupport::ConfigurationOptions.new
+    assert_respond_to a, :blah
+    assert_respond_to a, :blah=
+    assert_equal 42, a.method(:blah=).call(42)
+    assert_equal 42, a.method(:blah).call
+  end
+
+  def test_raises_with_bang
+    a = ActiveSupport::ConfigurationOptions.new
+    a[:foo] = :bar
+    assert_respond_to a, :foo!
+
+    assert_nothing_raised { a.foo! }
+    assert_equal a.foo, a.foo!
+
+    assert_raises(KeyError) do
+      a.foo = nil
+      a.foo!
+    end
+    assert_raises(KeyError) { a.non_existing_key! }
+  end
+
+  def test_inheritable_options_with_bang
+    a = ActiveSupport::InheritableOptions.new(foo: :bar)
+
+    assert_nothing_raised { a.foo! }
+    assert_equal a.foo, a.foo!
+
+    assert_raises(KeyError) do
+      a.foo = nil
+      a.foo!
+    end
+    assert_raises(KeyError) { a.non_existing_key! }
+  end
+
+  def test_inspect
+    a = ActiveSupport::ConfigurationOptions.new
+    assert_equal "#<ActiveSupport::ConfigurationOptions {}>", a.inspect
+
+    a.foo   = :bar
+    a[:baz] = :quz
+
+    assert_equal "#<ActiveSupport::ConfigurationOptions {:foo=>:bar, :baz=>:quz}>", a.inspect
+  end
+
+  def test_consume_values
+    a = ActiveSupport::ConfigurationOptions.new
+    a.foo = :bar
+    a.foo = :plop
+    assert_equal :plop, a.consume(:foo)
+    assert_equal :plop, a.consume(:foo)
+
+    assert_raises do
+      a.foo = :bar
+    end
+
+    assert_raises do
+      a[:foo] = :bar
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/44980
Ref: https://github.com/rails/rails/pull/44996

A very common problem we're running into are configurations that are set after they are applied. It's particularly bad because it silently have no effect.

If initializers are explicit when they consume a configuration value, it would allow use to raise when a user changes it later.

Instead of just accessing the config, we call `consume(:my_config)` and any later attempt at changing it will fail.

Of course this requires to rewrite most initializers, and 3rd party railties will likely lag behind for a while, but even then we can effectively solve the problem for all 1st party configurations.
