### PR TITLE
Fix: Inconsistent Polymorphic Association Autosave

### DIFF
--- a/activerecord/test/fixtures/cake_designers.yml
+++ b/activerecord/test/fixtures/cake_designers.yml
@@ -1,0 +1,5 @@
+flora:
+  id: 1
+
+frosty:
+  id: 2

--- a/activerecord/test/fixtures/chefs.yml
+++ b/activerecord/test/fixtures/chefs.yml
@@ -1,0 +1,5 @@
+gordon_ramsay:
+  id: 1
+
+marco_pierre_white:
+  id: 2

--- a/activerecord/test/fixtures/drink_designers.yml
+++ b/activerecord/test/fixtures/drink_designers.yml
@@ -1,0 +1,5 @@
+turner:
+  id: 1
+
+sparrow:
+  id: 3


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Issue: https://github.com/rails/rails/issues/44986.
This PR fixes a bug with autosave on polymorphic associations with the same IDs.
The autosave for `has_one` associations simply compares the record's foreign key with the inverse polymorphic association's ID when checking for changes.
This fix ensures that a change in the inverse polymorphic assocation's type is checked as well so this case is recognised as a change.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
