### PR TITLE
Add adapter option disallowing foreign keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add adapter option disallowing foreign keys
+
+    This adds a new option to be added to `database.yml` which enables skipping
+    foreign key constraints usage even if the underlying database supports them.
+
+    Usage:
+    ```yaml
+    development:
+        <<: *default
+        database: db/development.sqlite3
+        foreign_keys: false
+    ```
+
+    *Paulo Barros*
+
 *   Add configurable deprecation warning for singular associations
 
     This adds a deprecation warning when using the plural name of a singular associations in `where`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -14,9 +14,9 @@ module ActiveRecord
       end
 
       delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
-        :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys?,
-        :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?, :supports_exclusion_constraints?,
-        to: :@conn, private: true
+        :options_include_default?, :supports_indexes_in_create?, :use_foreign_keys?,
+        :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?,
+        :supports_exclusion_constraints?, to: :@conn, private: true
 
       private
         def visit_AlterTable(o)
@@ -51,7 +51,7 @@ module ActiveRecord
             statements.concat(o.indexes.map { |column_name, options| index_in_create(o.name, column_name, options) })
           end
 
-          if supports_foreign_keys?
+          if use_foreign_keys?
             statements.concat(o.foreign_keys.map { |fk| accept fk })
           end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -116,7 +116,7 @@ module ActiveRecord
         end
 
         # dump foreign keys at the end to make sure all dependent tables exist.
-        if @connection.supports_foreign_keys?
+        if @connection.use_foreign_keys?
           sorted_tables.each do |tbl|
             foreign_keys(tbl, stream) unless ignored?(tbl)
           end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -554,6 +554,34 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           end
         end
 
+        def test_does_not_create_foreign_keys_when_bypassed_by_config
+          connection = ActiveRecord::Base.establish_connection(
+            {
+              adapter: "sqlite3",
+              database: "test/db/test.sqlite3",
+              foreign_keys: false,
+            }
+          ).connection
+
+          connection.create_table "rockets", force: true do |t|
+            t.string :name
+          end
+          connection.create_table "astronauts", force: true do |t|
+            t.string :name
+            t.references :rocket
+          end
+
+          connection.add_foreign_key :astronauts, :rockets
+
+          foreign_keys = connection.foreign_keys("astronauts")
+          assert_equal 0, foreign_keys.size
+        ensure
+          connection.drop_table "astronauts", if_exists: true rescue nil
+          connection.drop_table "rockets", if_exists: true rescue nil
+
+          ActiveRecord::Base.establish_connection(:arunit)
+        end
+
         def test_schema_dumping
           @connection.add_foreign_key :astronauts, :rockets
           output = dump_table_schema "astronauts"

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -416,6 +416,21 @@ class SchemaDumperTest < ActiveRecord::TestCase
       output = dump_table_schema "authors"
       assert_equal ["authors"], output.scan(/^\s*add_foreign_key "([^"]+)".+$/).flatten
     end
+
+    def test_do_not_dump_foreign_keys_when_bypassed_by_config
+      ActiveRecord::Base.establish_connection(
+        {
+          adapter: "sqlite3",
+          database: "test/db/test.sqlite3",
+          foreign_keys: false,
+        }
+      )
+
+      output = perform_schema_dump
+      assert_no_match(/^\s+add_foreign_key "fk_test_has_fk"[^\n]+\n\s+add_foreign_key "lessons_students"/, output)
+    ensure
+      ActiveRecord::Base.establish_connection(:arunit)
+    end
   end
 
   class CreateDogMigration < ActiveRecord::Migration::Current


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Sometimes, apps can choose not to make use of foreign keys even though the underlying database supports it. One reason, for example, could be having trouble migrating big tables online due to the way [some tools](https://github.com/soundcloud/lhm/issues/34) handle foreign key constraints.

Regardless of the motivation for not wanting to use foreign key constraints, the most likely way of doing that would be to patch `ActiveRecord::ConnectionAdapters::AbstractAdapter#support_foreign_keys` to return `false` and override the concrete adapters' implementation, which will depend on individual database systems.

This PR introduces a new adapter config option in Active Record which allows apps to override the connection adapters' implementation if they need/want to. It can be added to `database.yml` like the following:

```yaml
development:
  <<: *default
  database: db/development.sqlite3
  foreign_keys: false
```

Thanks for the feedback!
