### PR TITLE
Add a note about connection pooling by default to the Upgrade Guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -248,6 +248,20 @@ Alternatively, you could load defaults for 7.1
 config.load_defaults 7.1
 ```
 
+### `MemCacheStore` and `RedisCacheStore` now use connection pooling by default
+
+The `connection_pool` gem has been added as a dependency of the `activesupport` gem,
+and the `MemCacheStore` and `RedisCacheStore` now use connection pooling by default.
+
+If you don't want to use connection pooling, set `:pool` option to `false` when
+configuring your cache store:
+
+```ruby
+config.cache_store = :mem_cache_store, "cache.example.com", pool: false
+```
+
+See the [caching with Rails](https://guides.rubyonrails.org/caching_with_rails.html#connection-pool-options) guide for more information.
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/45235 is a new default, and while it is a better default I think it is still worth alerting users to it. If we aren't adding a new config for it then I think we should note it in the upgrade guide so it doesn't get lost in the changelog.

cc @byroot @fatkodima 