### PR TITLE
Remove `cache_format_version` from `new_framework_defaults` file

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -34,13 +34,6 @@
 # implementation.
 # Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
 
-# Change the format of the cache entry.
-# Changing this default means that all new cache entries added to the cache
-# will have a different format that is not supported by Rails 6.1 applications.
-# Only change this value after your application is fully deployed to Rails 7.0
-# and you have no plans to rollback.
-# Rails.application.config.active_support.cache_format_version = 7.0
-
 # Calls `Rails.application.executor.wrap` around test cases.
 # This makes test cases behave closer to an actual request or job.
 # Several features that are normally disabled in test, such as Active Record query cache
@@ -103,6 +96,17 @@
 #   "X-Permitted-Cross-Domain-Policies" => "none",
 #   "Referrer-Policy" => "strict-origin-when-cross-origin"
 # }
+
+
+# ** Please read carefully, this must be configured in config/application.rb **
+# Change the format of the cache entry.
+# Changing this default means that all new cache entries added to the cache
+# will have a different format that is not supported by Rails 6.1 applications.
+# Only change this value after your application is fully deployed to Rails 7.0
+# and you have no plans to rollback.
+# When you're ready to change format, add this to `config/application.rb` (NOT this file):
+#  config.active_support.cache_format_version = 7.0
+
 
 # Cookie serializer: 2 options
 # 


### PR DESCRIPTION
As noted in https://github.com/rails/rails/pull/45293 this setting doesn't work in initializers, nor in `config/application.rb`, in Rails 7. Anyone who has set `Rails.application.config.active_support.cache_format_version = 7.0` is still using the Rails 6.1 coder.

This PR removes it from new framework defaults on `7-0-stable`, so that users don't set it and expect it to do something.

In a future PR I will be making this the new default in 7.1 as discussed [here](https://github.com/rails/rails/pull/45293#issuecomment-1149177039).
