### PR TITLE
Add foreign key in the same statement as adding a column for PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Add foreign key in the same statement as adding a column for PostgreSQL.
+
+    ```ruby
+    add_reference :pictures, :users, foreign_key: true
+    ```
+
+    ```sql
+    -- Before
+    ALTER TABLE "pictures" ADD "users_id" bigint
+    ALTER TABLE "pictures" ADD CONSTRAINT "fk_rails_fc5f872279" FOREIGN KEY ("users_id") REFERENCES "users" ("id")
+
+    -- After
+    ALTER TABLE "pictures" ADD "users_id" bigint CONSTRAINT "fk_rails_fc5f872279" REFERENCES "users" ("id")
+    ```
+
+    This completely skips the foreign key validation and performs orders of magnitude faster on large tables.
+
+    *fatkodima*, *Cody Cutrer*
+
 *   Add ActiveRecord::Encryption::MessagePackMessageSerializer
 
     Serialize data to the MessagePack format, for efficient storage in binary columns.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -22,6 +22,7 @@ module ActiveRecord
 
       private
         def visit_AlterTable(o)
+          set_current_table(o.name)
           sql = +"ALTER TABLE #{quote_table_name(o.name)} "
           sql << o.adds.map { |col| accept col }.join(" ")
           sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
@@ -42,6 +43,7 @@ module ActiveRecord
         end
 
         def visit_TableDefinition(o)
+          set_current_table(o.name)
           create_sql = +"CREATE#{table_modifier_in_create(o)} TABLE "
           create_sql << "IF NOT EXISTS " if o.if_not_exists
           create_sql << "#{quote_table_name(o.name)} "
@@ -129,6 +131,10 @@ module ActiveRecord
 
         def visit_DropCheckConstraint(name)
           "DROP CONSTRAINT #{quote_column_name(name)}"
+        end
+
+        def set_current_table(table_name)
+          @table_name = table_name
         end
 
         def quoted_columns(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -86,6 +86,7 @@ module ActiveRecord
         :collation,
         :comment,
         :primary_key,
+        :foreign_key,
         :if_exists,
         :if_not_exists
       ]

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -562,6 +562,9 @@ module ActiveRecord
       #   <tt>:datetime</tt>, and <tt>:time</tt> columns.
       # * <tt>:scale</tt> -
       #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
+      # [<tt>:foreign_key</tt>]
+      #   (PostgreSQL only) Add a foreign key to the specified table. This setting allows to add
+      #   the foreign key in the same SQL statement as adding a column and avoids costly foreign key validation.
       # * <tt>:if_not_exists</tt> -
       #   Specifies if the column already exists to not try to re-add it. This will avoid
       #   duplicate column errors.
@@ -614,6 +617,12 @@ module ActiveRecord
       #  # Defines a column with a database-specific type.
       #  add_column(:shapes, :triangle, 'polygon')
       #  # ALTER TABLE "shapes" ADD "triangle" polygon
+      #
+      #  # Defines a column and a foreign key.
+      #  add_column(:pictures, :user_id, :bigint, foreign_key: { to_table: :users })
+      #  # ALTER TABLE "pictures" ADD "user_id" bigint CONSTRAINT "fk_rails_3268570edc" REFERENCES "users" ("id")
+      #
+      #  Note: only supported by PostgreSQL.
       #
       #  # Ignores the method call if the column exists
       #  add_column(:shapes, :triangle, 'polygon', if_not_exists: true)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -235,6 +235,21 @@ module ActiveRecord
         end
       end
 
+      class ReferenceDefinition < ActiveRecord::ConnectionAdapters::ReferenceDefinition
+        def add(table_name, connection)
+          columns.each do |name, type, options|
+            if foreign_key
+              options = options.merge(foreign_key: foreign_key_options.merge(to_table: foreign_table_name))
+            end
+            connection.add_column(table_name, name, type, **options)
+          end
+
+          if index
+            connection.add_index(table_name, column_names, **index_options(table_name))
+          end
+        end
+      end
+
       # = Active Record PostgreSQL Adapter \Table Definition
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include ColumnMethods

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -535,6 +535,10 @@ module ActiveRecord
           super
         end
 
+        def add_reference(table_name, ref_name, **options)
+          PostgreSQL::ReferenceDefinition.new(ref_name, **options).add(table_name, self)
+        end
+
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
           fk_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -421,6 +421,26 @@ module ActiveRecord
       ensure
         connection.drop_table :my_table, if_exists: true
       end
+
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_add_column_with_foreign_key
+          assert_queries_count(1) do
+            add_column :test_models, :user_id, :integer, foreign_key: { to_table: :users }
+          end
+
+          assert connection.foreign_key_exists?(:test_models, :users)
+        end
+
+        def test_column_with_foreign_key
+          connection.create_table :my_table, force: true do |t|
+            t.integer :user_id, foreign_key: { to_table: :users }
+          end
+
+          assert connection.foreign_key_exists?(:my_table, :users)
+        ensure
+          connection.drop_table(:my_table, if_exists: true)
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       include ActiveRecord::Migration::TestHelper
 
       def invalid_add_column_option_exception_message(key)
-        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":if_exists", ":if_not_exists"]
+        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":foreign_key", ":if_exists", ":if_not_exists"]
 
         if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           default_keys.concat([":auto_increment", ":charset", ":as", ":size", ":unsigned", ":first", ":after", ":type", ":stored"])

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -289,6 +289,17 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           fk_definitions = fks.map { |fk| [fk.from_table, fk.to_table, fk.column] }
           assert_equal([["testings", "testing_parents", "parent2_id"]], fk_definitions)
         end
+
+        if current_adapter?(:PostgreSQLAdapter)
+          test "add_reference combines adding column and foreign key" do
+            @connection.create_table :testings
+            assert_queries_count(1) do
+              @connection.add_reference :testings, :parent1, foreign_key: { to_table: :testing_parents }, index: false
+            end
+
+            assert @connection.foreign_key_exists?(:testings, :testing_parents)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When using `add_reference`, PostgreSQL adds a new column and a foreign key separately. For large tables, adding a foreign key leads to problems, because the dbms needs to validate all the rows which takes a lot of time while holding exclusive locks on both tables.
 
There are 2 approaches to solve this:
1. add invalid foreign key and validate separately - safe approach, but cumbersome and takes the same long time
2. add foreign key in the same statement as a new column, which is blazingly fast. This approach is implemented in this PR; before is was possible only via raw sql.

Example:
```
\timing on
create table foos (id integer primary key);
create table bars (id integer primary key);
INSERT INTO bars (id) SELECT i FROM generate_series(1, 50000000) AS i;

-- Separately
ALTER TABLE "bars" ADD "foo_id" bigint, ADD CONSTRAINT "fk_rails_9e5a99443d" FOREIGN KEY ("foo_id") REFERENCES "foos" ("id");
ALTER TABLE
Time: 23305.494 ms (00:23.305)

alter table bars drop column foo_id;

-- Combined
ALTER TABLE "bars" ADD "foo_id" bigint CONSTRAINT "fk_rails_9e5a99443d" REFERENCES "foos" ("id");
ALTER TABLE
Time: 2.362 ms
```

`23s` vs `2ms`.

I added support only for PostgreSQL, because for other dbms' this will not add any benefits.

Based on https://github.com/rails/rails/pull/41863, added @ccutrer as a co-author.