### PR TITLE
Enable testing of binary data in request specs

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add the ability to test requests with binary data
+
+    Previously it was not possible to test a POST request with an empty Content-Type.
+    The request would default to a Content-Type of `application/x-www-form-urlencoded`,
+    which could cause errors with request parameter decoding. Now you can supply an
+    `input` parameter that can be a String or an IO-like object:
+
+    ```ruby
+    post "/test_upload", input: ActiveSupport::Gzip.compress("hello world")
+    ```
+
+    *Stan Hu*
+
 *   Allow using `helper_method`s in `content_security_policy` and `permissions_policy`
 
     Previously you could access basic helpers (defined in helper modules), but not

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -205,6 +205,8 @@ module ActionDispatch
       # - +as+: Used for encoding the request with different content type.
       #   Supports +:json+ by default and will set the appropriate request headers.
       #   The headers will be merged into the Rack env hash.
+      # - +input+: The input data to pass as the body. This may be +nil+, a String, or
+      #   an IO-like object.
       #
       # This method is rarely used directly. Use +#get+, +#post+, or other standard
       # HTTP methods in integration tests. +#process+ is only required when using a
@@ -217,7 +219,7 @@ module ActionDispatch
       #
       # Example:
       #   process :get, '/author', params: { since: 201501011400 }
-      def process(method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil)
+      def process(method, path, params: nil, headers: nil, env: nil, xhr: false, as: nil, input: nil)
         request_encoder = RequestEncoder.encoder(as)
         headers ||= {}
 
@@ -256,6 +258,7 @@ module ActionDispatch
           "HTTP_ACCEPT"    => request_encoder.accept_header || accept
         }
 
+        request_env[:input] = input if input
         wrapped_headers = Http::Headers.from_hash({})
         wrapped_headers.merge!(headers) if headers
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1258,3 +1258,33 @@ class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
     assert_equal "45142", @response.body
   end
 end
+
+class IntegrationNoContentTypeTest < ActionDispatch::IntegrationTest
+  class IntegrationController < ActionController::Base
+    def test_upload
+      render json: { action: request.params[:action], body: ActiveSupport::Gzip.decompress(request.body.read) }
+    end
+  end
+
+  def self.routes
+    @routes ||= ActionDispatch::Routing::RouteSet.new
+  end
+
+  def self.call(env)
+    routes.call(env)
+  end
+
+  def app
+    self.class
+  end
+
+  routes.draw do
+    post "test_upload", to: "integration_no_content_type_test/integration#test_upload"
+  end
+
+  def test_gzip_upload
+    post "/test_upload", input: ActiveSupport::Gzip.compress("hello world")
+
+    assert_equal({ "action" => "test_upload", "body" => "hello world" }, @response.parsed_body)
+  end
+end


### PR DESCRIPTION
### Summary

Previously it was not possible to test POST requests with binary data
with no `Content-Type` header. rack-test will default to a
`Content-Type` of `application/x-www-form-urlencoded`, which causes
encoding errors if binary data is passed in the request parameters.

If an `:input` parameter is passed to `Rack::Test::Session`, then
`Rack::Test::Session` will not attempt to set the `Content-Type`, and
the raw data will be passed to the body of the POST request. We can
use this to test binary data with no `Content-Type`.

This came up in https://github.com/rack/rack-test/issues/247.
