### PR TITLE
Fix deprecated minitest assertion.

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1758,7 +1758,7 @@ module ApplicationTests
     test "config.log_file_size returns no limit in production" do
       app "production"
 
-      assert_equal nil, app.config.log_file_size
+      assert_nil app.config.log_file_size
     end
 
     test "rake_tasks block works at instance level" do


### PR DESCRIPTION
Fixes the deprecation from minitest regarding calling assert_equal on
nil.

```
DEPRECATED: Use assert_nil if expecting nil from
test/application/configuration_test.rb:1761. This will fail in
Minitest 6.
```