### PR TITLE
Fix shared config feature in 3-tier config

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -387,8 +387,14 @@ module Rails
         config = if yaml&.exist?
           loaded_yaml = ActiveSupport::ConfigurationFile.parse(yaml)
           if (shared = loaded_yaml.delete("shared"))
-            loaded_yaml.each do |_k, values|
-              values.reverse_merge!(shared)
+            loaded_yaml.each do |env, config|
+              if config.is_a?(Hash) && config.values.all?(Hash)
+                config.map do |name, sub_config|
+                  sub_config.reverse_merge!(shared)
+                end
+              else
+                config.reverse_merge!(shared)
+              end
             end
           end
           Hash.new(shared).merge(loaded_yaml)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1985,6 +1985,25 @@ module ApplicationTests
       assert_equal "dev_db",  ar_config["development"]["database"]
     end
 
+    test "loads database.yml using shared keys with a 3-tier config" do
+      app_file "config/database.yml", <<-YAML
+        shared:
+          username: bobby
+          adapter: sqlite3
+
+        development:
+          primary:
+            database: 'dev_db'
+      YAML
+
+      app "development"
+
+      ar_config = Rails.application.config.database_configuration
+      assert_equal "sqlite3", ar_config["development"]["primary"]["adapter"]
+      assert_equal "bobby",   ar_config["development"]["primary"]["username"]
+      assert_equal "dev_db",  ar_config["development"]["primary"]["database"]
+    end
+
     test "config.action_mailer.show_previews defaults to true in development" do
       app "development"
 


### PR DESCRIPTION
Rails allows you to use a `shared` entry in the database yaml which gets
merged into other entries. This was broken when using a 3-tier config.

The change here ensures we're looping through all the configs. We know
we have a 3-tier config if the config is a hash and all the values
inside that config are a hash. If so we need to keep looping, otherwise
we have a standard 2-tier config.

Fixes #45299