### PR TITLE
Fix build: Use Sidekiq Explicit Configuration

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -53,10 +53,12 @@ module SidekiqJobsManager
 
       require "sidekiq/cli"
       require "sidekiq/launcher"
-      sidekiq = Sidekiq::Launcher.new(queues: ["integration_tests"],
-                                       environment: "test",
-                                       concurrency: 1,
-                                       timeout: 1)
+      config = Sidekiq
+      config[:queues] = ["integration_tests"]
+      config[:environment] = "test"
+      config[:concurrency] = 1
+      config[:timeout] = 1
+      sidekiq = Sidekiq::Launcher.new(config)
       Sidekiq.average_scheduled_poll_interval = 0.5
       Sidekiq.options[:poll_interval_average] = 1
       begin

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -53,11 +53,20 @@ module SidekiqJobsManager
 
       require "sidekiq/cli"
       require "sidekiq/launcher"
-      config = Sidekiq
-      config[:queues] = ["integration_tests"]
-      config[:environment] = "test"
-      config[:concurrency] = 1
-      config[:timeout] = 1
+      if Sidekiq.respond_to?(:[]=)
+        config = Sidekiq
+        config[:queues] = ["integration_tests"]
+        config[:environment] = "test"
+        config[:concurrency] = 1
+        config[:timeout] = 1
+      else
+        config = {
+          queues: ["integration_tests"],
+          environment: "test",
+          concurrency: 1,
+          timeout: 1
+        }
+      end
       sidekiq = Sidekiq::Launcher.new(config)
       Sidekiq.average_scheduled_poll_interval = 0.5
       Sidekiq.options[:poll_interval_average] = 1


### PR DESCRIPTION
Active Job tests for Sidekiq [starts to fail](https://buildkite.com/rails/rails/builds/87116#01814886-3d51-4867-baa9-0c9db9c7e7ec) since [buildkite rails/rails/#87116](https://buildkite.com/rails/rails/builds/87116) because Sidekiq 6.5.0 has API changes on how to configure Sidekiq. The new API does not accept hash anymore, so This Pull Request changes to how it is supposed to be configured (see [here](https://github.com/mperham/sidekiq/blob/67daa7a408b214d593100f782271ed108686c147/lib/sidekiq/cli.rb#L25) that a `config` is actually the `Sidekiq` module).

After https://github.com/mperham/sidekiq/issues/5225 / https://github.com/mperham/sidekiq/issues/5329 is implemented, use the new `Sidekiq::Config` API.

<details>
<summary>View Active Job Integration Test Failure</summary>

![CleanShot 2022-06-09 at 23 31 16@2x](https://user-images.githubusercontent.com/1000669/172872390-b3351e01-234b-4365-b176-69fa5893ce18.png)

</details>


### Summary

Fixes ActiveJob integration tests that failed to start Sidekiq worker due to Sidekiq API changes.
