### PR TITLE
Fix generated index names for tables within schemas in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -482,6 +482,11 @@ module ActiveRecord
           execute "ALTER INDEX #{quote_column_name(old_name)} RENAME TO #{quote_table_name(new_name)}"
         end
 
+        def index_name(table_name, options) # :nodoc:
+          table_name = Utils.extract_schema_qualified_name(table_name.to_s).identifier
+          super
+        end
+
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
           fk_info = exec_query(<<~SQL, "SCHEMA")

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1164,6 +1164,26 @@ class ExplicitlyNamedIndexMigrationTest < ActiveRecord::TestCase
   end
 end
 
+if current_adapter?(:PostgreSQLAdapter)
+  class IndexForTableWithSchemaMigrationTest < ActiveRecord::TestCase
+    def test_add_and_remove_index
+      connection = Person.connection
+      connection.create_schema("my_schema")
+      connection.create_table("my_schema.values", force: true) do |t|
+        t.integer :value
+      end
+
+      connection.add_index("my_schema.values", :value)
+      assert connection.index_exists?("my_schema.values", :value)
+
+      connection.remove_index("my_schema.values", :value)
+      assert_not connection.index_exists?("my_schema.values", :value)
+    ensure
+      connection.drop_schema("my_schema")
+    end
+  end
+end
+
 if ActiveRecord::Base.connection.supports_bulk_alter?
   class BulkAlterTableMigrationsTest < ActiveRecord::TestCase
     def setup


### PR DESCRIPTION
Creation of indexes for tables with schemas generates incorrect index names:

```
connection.add_index "ci.my_table", "my_column"
(1.7ms)  CREATE INDEX "index_ci.my_table_on_my_column" ON "ci"."my_table" ("my_column")
```

And it is impossible then to delete this index:
```
connection.remove_index "ci.my_table", "my_column"
(0.4ms)  DROP INDEX  "ci"."index_ci"
PG::UndefinedObject: ERROR:  index "index_ci" does not exist (ActiveRecord::StatementInvalid)
```

And the same when explicitly specifying an index name:
```
connection.remove_index "ci.my_table", "my_column", name: "index_ci.my_table_on_my_column"
/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb:466:in `remove_index': Index schema 'index_ci' does not match table schema 'ci' (ArgumentError)
```
 
Fixes #40821.