### PR TITLE
Make retrieval of cached entry scope to be public. Fixes #45311

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -613,6 +613,12 @@ module ActiveSupport
         raise NotImplementedError.new("#{self.class.name} does not support clear")
       end
 
+      # Reads an entry from the cache implementation. Subclasses must implement
+      # this method.
+      def read_entry(key, **options)
+        raise NotImplementedError.new
+      end
+
       private
         def default_coder
           Coders[Cache.format_version]
@@ -635,12 +641,6 @@ module ActiveSupport
           else
             pattern
           end
-        end
-
-        # Reads an entry from the cache implementation. Subclasses must implement
-        # this method.
-        def read_entry(key, **options)
-          raise NotImplementedError.new
         end
 
         # Writes an entry to the cache implementation. Subclasses must implement

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -85,14 +85,14 @@ module ActiveSupport
         end
       end
 
-      private
-        def read_entry(key, **options)
-          if payload = read_serialized_entry(key, **options)
-            entry = deserialize_entry(payload)
-            entry if entry.is_a?(Cache::Entry)
-          end
+      def read_entry(key, **options)
+        if payload = read_serialized_entry(key, **options)
+          entry = deserialize_entry(payload)
+          entry if entry.is_a?(Cache::Entry)
         end
+      end
 
+      private
         def read_serialized_entry(key, **)
           File.binread(key) if File.exist?(key)
         rescue => error

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -189,6 +189,11 @@ module ActiveSupport
         @data.with { |c| c.stats }
       end
 
+      # Read an entry from the cache.
+      def read_entry(key, **options)
+        deserialize_entry(read_serialized_entry(key, **options), **options)
+      end
+
       private
         module Coders # :nodoc:
           class << self
@@ -236,11 +241,6 @@ module ActiveSupport
 
         def default_coder
           Coders[Cache.format_version]
-        end
-
-        # Read an entry from the cache.
-        def read_entry(key, **options)
-          deserialize_entry(read_serialized_entry(key, **options), **options)
         end
 
         def read_serialized_entry(key, **options)

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -161,6 +161,18 @@ module ActiveSupport
         @monitor.synchronize(&block)
       end
 
+      def read_entry(key, **options)
+        entry = nil
+        synchronize do
+          payload = @data.delete(key)
+          if payload
+            @data[key] = payload
+            entry = deserialize_entry(payload)
+          end
+        end
+        entry
+      end
+
       private
         PER_ENTRY_OVERHEAD = 240
 
@@ -170,18 +182,6 @@ module ActiveSupport
 
         def cached_size(key, payload)
           key.to_s.bytesize + payload.bytesize + PER_ENTRY_OVERHEAD
-        end
-
-        def read_entry(key, **options)
-          entry = nil
-          synchronize do
-            payload = @data.delete(key)
-            if payload
-              @data[key] = payload
-              entry = deserialize_entry(payload)
-            end
-          end
-          entry
         end
 
         def write_entry(key, entry, **options)

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -32,11 +32,11 @@ module ActiveSupport
       def delete_matched(matcher, options = nil)
       end
 
-      private
-        def read_entry(key, **s)
-          deserialize_entry(read_serialized_entry(key))
-        end
+      def read_entry(key, **s)
+        deserialize_entry(read_serialized_entry(key))
+      end
 
+      private
         def read_serialized_entry(_key, **)
         end
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -335,6 +335,12 @@ module ActiveSupport
         @mset_capable
       end
 
+      # Store provider interface:
+      # Read an entry from the cache.
+      def read_entry(key, **options)
+        deserialize_entry(read_serialized_entry(key, **options), **options)
+      end
+
       private
         def set_redis_capabilities
           case redis
@@ -345,12 +351,6 @@ module ActiveSupport
             @mget_capable = true
             @mset_capable = true
           end
-        end
-
-        # Store provider interface:
-        # Read an entry from the cache.
-        def read_entry(key, **options)
-          deserialize_entry(read_serialized_entry(key, **options), **options)
         end
 
         def read_serialized_entry(key, raw: false, **options)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -341,6 +341,14 @@ module ActiveSupport
         deserialize_entry(read_serialized_entry(key, **options), **options)
       end
 
+      def read_multi_entries(names, **options)
+        if mget_capable?
+          read_multi_mget(*names, **options)
+        else
+          super
+        end
+      end
+
       private
         def set_redis_capabilities
           case redis
@@ -356,14 +364,6 @@ module ActiveSupport
         def read_serialized_entry(key, raw: false, **options)
           failsafe :read_entry do
             redis.with { |c| c.get(key) }
-          end
-        end
-
-        def read_multi_entries(names, **options)
-          if mget_capable?
-            read_multi_mget(*names, **options)
-          else
-            super
           end
         end
 


### PR DESCRIPTION
### Summary
Making the retrieval of `ActiveSupport::Cache::Entry` objects public to assist in consumers retrieving a value prior to its deletion if they so wish to perform a retry operation at some future period of time.

Fixes #45311 

### Other Information
n/a
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
