### PR TITLE
remove call to conditionally configure legacy_connection_handling

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -164,9 +164,6 @@ module Rails
 
           if respond_to?(:active_record)
             active_record.has_many_inversing = true
-            if respond_to?(:legacy_connection_handling)
-              active_record.legacy_connection_handling = false
-            end
           end
 
           if respond_to?(:active_job)


### PR DESCRIPTION
In #44827, support was removed for legacy_connection_handling. 

As part of this, the the setting of the configuration was changed to check on the existence of methods. These methods will never be defined - so the configuration would never be set - and even if it was - it would have no effect.

I believe that this check and setting of a value should be able to be removed.

