### PR TITLE
Fix Inconsistent ActiveRecord `insert_all!` Interfaces

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   `ActiveRecord::Persistence::ClassMethods#insert_all!` now supports `unique_by` option.
+
+    ```ruby
+    books = [
+      { name: 'A', author_id: 1, price: 100 },
+      { name: 'B', author_id: 1, price: 200 },
+      { name: 'A', author_id: 1, price: 300 },
+    ]
+
+    # Raises ActiveRecord::RecordNotUnique
+    Book.insert_all!(books, unique_by: [:name, :author_id])
+
+    # Returns ActiveRecord::Result
+    Book.insert_all(books, unique_by: [:name, :author_id])
+    ```
+
+    *Bernie Chiu*
+
 *   Update `db:prepare` task to load schema when an uninitialized database exists, and dump schema after migrations.
 
     *Ben Sheldon*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -209,8 +209,8 @@ module ActiveRecord
       #     { id: 1, title: "Rework", author: "David" },
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
-      def insert_all!(attributes, returning: nil, record_timestamps: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps).execute
+      def insert_all!(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
+        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps).execute
       end
 
       # Updates or inserts (upserts) a single record into the database in a

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -78,6 +78,16 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_raises_on_duplicate_records_when_unqiue_by_is_provided
+    assert_raise ActiveRecord::RecordNotUnique do
+      Cart.insert_all! [
+        { id: 1, shop_id: 1, title: "My cart" },
+        { id: 2, shop_id: 1, title: "My another cart" },
+        { id: 1, shop_id: 1, title: "My another cart" },
+      ], unique_by: [:shop_id, :id]
+    end
+  end
+
   def test_insert_all_returns_ActiveRecord_Result
     result = Book.insert_all! [{ name: "Rework", author_id: 1 }]
     assert_kind_of ActiveRecord::Result, result


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Currently the method `insert_all!` is missing the arguments to apply `unique_by` in cases when we need to use them, not sure why it has the inconsistent interface for calling with `!` besides raising error, they should share the same argument interface.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
