### PR TITLE
Document Rails 7 backward incompatibility with Date/Time #to_s

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -605,6 +605,13 @@ ActiveRecord::Schema[6.1].define(version: 2022_01_28_123512) do
 NOTE: The first time you dump the schema with Rails 7.0, you will see many changes to that file, including
 some column information. Make sure to review the new schema file content and commit it to your repository.
 
+### Date and Time `#to_s` no longer use the `:default` format
+
+When a Date or Time is converted to a string using `#to_s` (e.g. in an ERB
+template) the result will no longer use the `:default` format defined in
+`Date::DATE_FORMATS` and `Time::DATE_FORMATS`. To achieve the previous
+behavior, use the `#to_fs` method instead.
+
 Upgrading from Rails 6.0 to Rails 6.1
 -------------------------------------
 


### PR DESCRIPTION
After upgrading my project, several internal tests failed due to a
change in date and time formats generated by ERB templates. For example,
if a template contained:

    <p>Created at: <%= record.created_at %></p>

The rendered result changed from rendering the human friendly :default
format to "mimicking Ruby Time#to_s format".

It wasn't immediately clear to me why this changed and I didn't see the
intent documented anywhere, so adding it to the upgrade docs for future
unsuspecting users.