### PR TITLE
Fix did you mean tests for ruby-trunk (3.2)

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -177,7 +177,11 @@ class PerformActionTest < ActionController::TestCase
     exception = assert_raise AbstractController::ActionNotFound do
       get :ello
     end
-    assert_match "Did you mean?", exception.message
+    if exception.respond_to?(:detailed_message)
+      assert_match "Did you mean?", exception.detailed_message
+    else
+      assert_match "Did you mean?", exception.message
+    end
   end
 
   def test_action_missing_should_work

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -88,7 +88,11 @@ class HelpersTypoControllerTest < ActiveSupport::TestCase
   def test_helper_typo_error_message
     e = assert_raise(NameError) { HelpersTypoController.helper "admin/users" }
     assert_includes e.message, "uninitialized constant Admin::UsersHelper"
-    assert_includes e.message, "Did you mean?  Admin::UsersHelpeR"
+    if e.respond_to?(:detailed_message)
+      assert_includes e.detailed_message, "Did you mean?  Admin::UsersHelpeR"
+    else
+      assert_includes e.message, "Did you mean?  Admin::UsersHelpeR"
+    end
   end
 end
 

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -26,12 +26,20 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     error = assert_raise ActionController::ParameterMissing do
       post :create, params: { boko: { name: "Mjallo!" } }
     end
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
 
     error = assert_raise ActionController::ParameterMissing do
       post :create, params: { book: { naem: "Mjallo!" } }
     end
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
   end
 
   test "required parameters that are present will not raise" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4907,7 +4907,11 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
   test "exceptions have suggestions for fix" do
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
   end
 
   # FIXME: we should fix all locations that raise this exception to provide

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -642,32 +642,55 @@ module RenderTestCases
 
   def test_render_partial_provides_spellcheck
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partail") }
-    assert_match %r{Did you mean\?  test/partial\n *test/partialhtml}, e.message
+    if e.respond_to?(:detailed_message)
+      assert_match %r{Did you mean\?  test/partial\e\[m\n\e\[1m *test/partialhtml}, e.detailed_message
+    else
+      assert_match %r{Did you mean\?  test/partial\n *test/partialhtml}, e.message
+    end
   end
 
   def test_spellcheck_doesnt_list_directories
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/directory") }
-    assert_match %r{Did you mean\?}, e.message
-    assert_no_match %r{Did you mean\?  test/directory\n}, e.message # test/hello is a directory
+    if e.respond_to?(:detailed_message)
+      assert_match %r{Did you mean\?}, e.detailed_message
+      assert_no_match %r{Did you mean\?  test/directory\n}, e.detailed_message # test/hello is a directory
+    else
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/directory\n}, e.message # test/hello is a directory
+    end
   end
 
   def test_spellcheck_only_lists_templates
     e = assert_raises(ActionView::MissingTemplate) { @view.render(template: "test/partial") }
 
-    assert_match %r{Did you mean\?}, e.message
-    assert_no_match %r{Did you mean\?  test/partial\n}, e.message
+    if e.respond_to?(:detailed_message)
+      assert_match %r{Did you mean\?}, e.detailed_message
+      assert_no_match %r{Did you mean\?  test/partial\n}, e.detailed_message
+    else
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/partial\n}, e.message
+    end
   end
 
   def test_spellcheck_only_lists_partials
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/template") }
 
-    assert_match %r{Did you mean\?}, e.message
-    assert_no_match %r{Did you mean\?  test/template\n}, e.message
+    if e.respond_to?(:detailed_message)
+      assert_match %r{Did you mean\?}, e.detailed_message
+      assert_no_match %r{Did you mean\?  test/template\n}, e.detailed_message
+    else
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/template\n}, e.message
+    end
   end
 
   def test_render_partial_wrong_details_no_spellcheck
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partial_with_only_html_version", formats: [:xml]) }
-    assert_no_match %r{Did you mean\?}, e.message
+    if e.respond_to?(:detailed_message)
+      assert_no_match %r{Did you mean\?}, e.detailed_message
+    else
+      assert_no_match %r{Did you mean\?}, e.message
+    end
   end
 
   def test_render_with_nested_layout

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -877,7 +877,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     error = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: :taggingz).find(6)
     }
-    assert_match "Did you mean?  tagging\n", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?  tagging", error.detailed_message
+    else
+      assert_match "Did you mean?  tagging\n", error.message
+    end
   end
 
   def test_eager_has_many_through_with_order

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -390,7 +390,11 @@ class InverseHasOneTests < ActiveRecord::TestCase
       Human.first.confused_face
     }
 
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
     assert_equal "confused_human", error.corrections.first
   end
 end
@@ -851,7 +855,11 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       Face.first.confused_human
     }
 
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
     assert_equal "confused_face", error.corrections.first
   end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -345,7 +345,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     error = assert_raise(ActiveRecord::HasManyThroughAssociationNotFoundError) {
       authors(:david).nothings
     }
-    assert_match "Did you mean?", error.message
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
   end
 
   def test_has_many_through_join_model_with_conditions

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -272,8 +272,13 @@ module Rails
             MSG
           else
             error = CorrectableError.new("Could not find server '#{server}'.", server, RACK_SERVERS)
+            if error.respond_to?(:detailed_message)
+              formatted_message = error.detailed_message
+            else
+              formatted_message = error.message
+            end
             <<~MSG
-              #{error.message}
+              #{formatted_message}
               Run `bin/rails server --help` for more options.
             MSG
           end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -266,8 +266,14 @@ module Rails
           options = sorted_groups.flat_map(&:last)
           error   = Command::Base::CorrectableError.new("Could not find generator '#{namespace}'.", namespace, options)
 
+          if error.respond_to?(:detailed_message)
+            formatted_message = error.detailed_message
+          else
+            formatted_message = error.message
+          end
+
           puts <<~MSG
-            #{error.message}
+            #{formatted_message}
             Run `bin/rails generate --help` for more options.
           MSG
         end


### PR DESCRIPTION
In
https://github.com/ruby/ruby/commit/f075be3dcb4b82b89496d1820002bf3d80f653ef
did_you_mean and error_highlight now use `detailed_message` over
`message` to display errors.

For cases where we are testing `message`, in 3.2 and above we need to
test against `detailed_message` instead.

As far as I can tell in a Rails console when these errors are raised the
`detailed_message` is used so we shouldn't need to make other changes to
Rails. The only case where this isn't true is in the Railties changes -
we are explicitly formatting the did you mean message so we need to be
sure to call `detailed_message` here.

This fixes most of the failing tests for ruby-trunk.