### PR TITLE
Introduce "Execution Strategy" object for Migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce strategy pattern for executing migrations.
+
+    By default, migrations will use a strategy object that delegates the method
+    to the connection adapter. Consumers can implement custom strategy objects
+    to change how their migrations run.
+
+    *Adrianna Chang*
+
 *   Add adapter option disallowing foreign keys
 
     This adds a new option to be added to `database.yml` which enables skipping

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -304,6 +304,12 @@ module ActiveRecord
 
   ##
   # :singleton-method:
+  # Specify strategy to use for executing migrations.
+  singleton_class.attr_accessor :migration_strategy
+  self.migration_strategy = Migration::DefaultStrategy
+
+  ##
+  # :singleton-method:
   # Specify whether schema dump should happen at the end of the
   # bin/rails db:migrate command. This is true by default, which is useful for the
   # development environment. This should ideally be false in the production

--- a/activerecord/lib/active_record/migration/default_strategy.rb
+++ b/activerecord/lib/active_record/migration/default_strategy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class Migration
+    # The default strategy for executing migrations. Delegates method calls
+    # to the connection adapter.
+    class DefaultStrategy < ExecutionStrategy # :nodoc:
+      private
+        def method_missing(method, *arguments, &block)
+          connection.send(method, *arguments, &block)
+        end
+        ruby2_keywords(:method_missing)
+
+        def respond_to_missing?(method, *)
+          connection.respond_to?(method) || super
+        end
+
+        def connection
+          migration.connection
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/migration/execution_strategy.rb
+++ b/activerecord/lib/active_record/migration/execution_strategy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class Migration
+    # ExecutionStrategy is used by the migration to respond to any method calls
+    # that the migration class does not implement directly. This is the base strategy.
+    # All strategies should inherit from this class.
+    #
+    # The ExecutionStrategy receives the current +migration+ when initialized.
+    class ExecutionStrategy # :nodoc:
+      def initialize(migration)
+        @migration = migration
+      end
+
+      private
+        attr_reader :migration
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -767,6 +767,22 @@ Specifies if an error should be raised if the order of a query is ignored during
 
 Controls whether migrations are numbered with serial integers or with timestamps. The default is `true`, to use timestamps, which are preferred if there are multiple developers working on the same application.
 
+#### `config.active_record.migration_strategy`
+
+Controls the strategy class used to perform schema statement methods in a migration. The default class
+delegates to the connection adapter. Custom strategies should inherit from `ActiveRecord::Migration::ExecutionStrategy`,
+or may inherit from `DefaultStrategy`, which will preserve the default behaviour for methods that aren't implemented:
+
+```ruby
+class CustomMigrationStrategy < ActiveRecord::Migration::DefaultStrategy
+  def drop_table(*)
+    raise "Dropping tables is not supported!"
+  end
+end
+
+config.active_record.migration_strategy = CustomMigrationStrategy
+```
+
 #### `config.active_record.lock_optimistically`
 
 Controls whether Active Record will use optimistic locking and is `true` by default.


### PR DESCRIPTION
### Summary

This PR introduces a strategy pattern around executing migrations. Currently, a `Migration` object will use `method_missing` to delegate a schema statement command to the connection adapter. By introducing an intermediary strategy object and allowing applications to configure their own strategy objects, we give application authors a lot of flexibility in how they'd like to run their migrations. For example, users might want to:
- Add an additional kwarg to a schema statement method like `#create_table`
- Disallow certain operations; their strategy could raise if that method is called
- "Dry run" a migration, e.g. run a migration and have it spit out the operations being called or perform some checks on the operations and their arguments without actually making changes to the db schema

At Shopify, we have a particular use case: in production, we don't want to execute SQL right away when a migration is run. Instead, we want to translate a migration into a JSON DDL and then submit that to another service for execution across all of our db shards. If we can customize the strategy object to be used by the `Migration` class, we can write our own object that produces JSON commands and makes an API call to send the JSON to another service.

In this PR, I've introduced:
- A base `ExecutionStrategy` class that all strategies should inherit from.
- A `DefaultStrategy` that preserves the current behaviour of how migrations work by delegating the method to the connection.

### Other Information

I've added a config option and a note to the `configuring` docs, but this might be premature. Right now the strategy holds onto both the `migration` and the `connection` (which makes it easy for us to move things around in the interim), but this might change, and I suppose we want to be more explicit about what a strategy should look like in our documentation. I can hold off on adding anything to the guides for now, or we can leave this as a starting point for the docs.
