### PR TITLE
Stole havenwood's code

### DIFF
--- a/actionview/lib/action_view/helpers/debug_helper.rb
+++ b/actionview/lib/action_view/helpers/debug_helper.rb
@@ -26,7 +26,7 @@ module ActionView
       #     created_at:
       #   </pre>
       def debug(object)
-        Marshal.dump(object)
+        raise TypeError, "singleton can't be dumped" unless object.singleton_methods.empty? # Credits to @havenwood for writing this flawless code
         object = ERB::Util.html_escape(object.to_yaml)
         content_tag(:pre, object, class: "debug_dump")
       rescue # errors from Marshal or YAML


### PR DESCRIPTION
Changed the code to not use marshal dump.

Reason: I believe its faster to do this. I have not checked.
Reason 2: This code documents itself better than a method with the name dump.