### PR TITLE
Correct minimum MariaDB version for CHECK_CONSTRAINTS

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Adjust the minimum MariaDB version for check constraints support.
+
+    *Eddie Lebow*
+
 *   Fix Hstore deserialize regression.
 
     *edsharp*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -99,7 +99,7 @@ module ActiveRecord
 
       def supports_check_constraints?
         if mariadb?
-          database_version >= "10.2.1"
+          database_version >= "10.3.10" || (database_version < "10.3" && database_version >= "10.2.22")
         else
           database_version >= "8.0.16"
         end


### PR DESCRIPTION
### Summary

According to the MariaDB documentation, `CHECK_CONSTRAINTS` is not supported until `10.2.22`. https://mariadb.com/kb/en/information-schema-check_constraints-table/