### PR TITLE
Add more detailed description to job generator

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add more detailed description to job generator.
+
+    *Gannon McGibbon*
+
 *   `perform.active_job` notification payloads now include `:db_runtime`, which
     is the total time (in ms) taken by database queries while performing a job.
     This value can be used to better understand how a job's time is spent.

--- a/activejob/lib/rails/generators/job/USAGE
+++ b/activejob/lib/rails/generators/job/USAGE
@@ -1,0 +1,15 @@
+Description:
+    Generates a new job. Pass the job name, either CamelCased or
+    under_scored, with or without the job postfix.
+
+Examples:
+    `bin/rails generate job checkout`
+
+      Creates the the following files:
+
+        Job:   app/jobs/checkout_job.rb
+        Test:  test/jobs/checkout_job_test.rb
+
+    `bin/rails generate job send_sms --queue=sms`
+
+      Creates a job and test with a custom sms queue.

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -5,8 +5,6 @@ require "rails/generators/named_base"
 module Rails # :nodoc:
   module Generators # :nodoc:
     class JobGenerator < Rails::Generators::NamedBase # :nodoc:
-      desc "This generator creates an active job file at app/jobs"
-
       class_option :queue, type: :string, default: "default", desc: "The queue name for the generated job"
 
       check_class_collision suffix: "Job"


### PR DESCRIPTION
### Summary

Adds better description to job generator.

Before:
```
> bin/rails g job
Usage:
  rails generate job NAME [options]

Options:
      [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
      [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
      [--queue=QUEUE]                                        # The queue name for the generated job
                                                             # Default: default
  -t, [--test-framework=NAME]                                # Test framework to be invoked
                                                             # Default: test_unit

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

This generator creates an active job file at app/jobs
```

After:
```
> bin/rails g job
Usage:
  rails generate shopify:job NAME [options]

Options:
      [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
      [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
      [--queue=QUEUE]                                        # The queue name for the generated job
                                                             # Default: default
  -t, [--test-framework=NAME]                                # Test framework to be invoked
                                                             # Default: test_unit

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a new job. Pass the job name, either CamelCased or
    under_scored, with or without the job postfix.

Examples:
    `bin/rails generate job checkout`

      Creates the the following files:

        Job:   app/jobs/checkout_job.rb
        Test:  test/jobs/checkout_job_test.rb

    `bin/rails generate job send_sms --queue=sms`

      Creates a job and test with a custom sms queue.
```