### PR TITLE
Remove outdated comment of ActiveRecord's spawn method. [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -6,7 +6,6 @@ require "active_record/relation/merger"
 
 module ActiveRecord
   module SpawnMethods
-    # This is overridden by Associations::CollectionProxy
     def spawn # :nodoc:
       already_in_scope?(klass.scope_registry) ? klass.all : clone
     end


### PR DESCRIPTION
Per my findings, this method is not overridden anymore.