### PR TITLE
Update AR Relation method to reset cache_version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Resolve issue where a relation cache_version could be left stale.
+
+    Previously, when `reset` was called on a relation object it did not reset the cache_versions
+    ivar. This led to a confusing situation where despite having the correct data the relation
+    still reported a stale cache_version.
+
+    Usage:
+
+    ```ruby
+    developers = Developer.all
+    developers.cache_version
+
+    Developer.update_all(updated_at: Time.now.utc + 1.second)
+
+    developers.cache_version # Stale cache_version
+    developers.reset
+    developers.cache_version # Returns the current correct cache_version
+    ```
+
+    Fixes #45341.
+
+    *Austen Madden*
+
 *   Add support for exclusion constraints (PostgreSQL-only).
 
     ```ruby

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -713,6 +713,7 @@ module ActiveRecord
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
       @cache_keys = nil
+      @cache_versions = nil
       @records = nil
       self
     end

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -254,6 +254,19 @@ module ActiveRecord
       end
     end
 
+    test "reset will reset cache_version" do
+      with_collection_cache_versioning do
+        developers = Developer.all
+
+        assert_equal Developer.all.cache_version, developers.cache_version
+
+        Developer.update_all(updated_at: Time.now.utc + 1.second)
+        developers.reset
+
+        assert_equal Developer.all.cache_version, developers.cache_version
+      end
+    end
+
     test "cache_key_with_version contains key and version regardless of collection_cache_versioning setting" do
       key_with_version_1 = Developer.all.cache_key_with_version
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, key_with_version_1)


### PR DESCRIPTION
Resolves #45341 

### Summary

Currently, when #reset is called on a relation object it does not reset
the cache_versions ivar. This can lead to a confusing and buggy
situation where despite having the correct data the relation is still
reporting a stale cache_version. Resetting this ivar along with the
other relation state corrects this situation.

### Other Information
~There is a bit of a drive by fix in the tests of this change. I noticed there were a sequence of test using sleep to resolve a precision issue which appeared could be bypassed by using an explicit value rather than the implicit amount of time that has passed since the original data was inserted. Kept as a separate commit so can be omitted if need be.~

Saved for another day!

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
