### PR TITLE
Fix #45339 attachments for new record within transaction

### DIFF
--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -47,16 +47,9 @@ module ActiveStorage
     #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpeg")
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
-      if record.persisted? && !record.changed?
-        record.public_send("#{name}=", blobs + attachables.flatten)
-        if record.save
-          record.public_send("#{name}")
-        else
-          false
-        end
-      else
-        record.public_send("#{name}=", (change&.attachables || blobs) + attachables.flatten)
-      end
+      record.public_send("#{name}=", blobs + attachables.flatten)
+      return false if record.persisted? && !record.changed? && !record.save
+      record.public_send("#{name}")
     end
 
     # Returns true if any attachments have been made.


### PR DESCRIPTION
### Summary

First attempt to fix #45339 by not using the `change.attachables` on the `#attach` method.

That change was introduced in https://github.com/rails/rails/commit/836eb915b14f01eca8a5ea655e4f30b6a8a7ce38 when fixing #36806 however when reverting the change, the test that was introduced along with it, still passes (except when append on assign).

~We added a new failing test just in case but seems that the bug already existed even before #42300 . So it might be worth tackling it separately.~

cc @georgeclaghorn 