### PR TITLE
Fix references to RequestHelpers methods in docs [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -21,9 +21,8 @@ module ActionDispatch # :nodoc:
   # Nevertheless, integration tests may want to inspect controller responses in
   # more detail, and that's when \Response can be useful for application
   # developers. Integration test methods such as
-  # ActionDispatch::Integration::Session#get and
-  # ActionDispatch::Integration::Session#post return objects of type
-  # TestResponse (which are of course also of type \Response).
+  # Integration::RequestHelpers#get and Integration::RequestHelpers#post return
+  # objects of type TestResponse (which are of course also of type \Response).
   #
   # For example, the following demo integration test prints the body of the
   # controller response to the console:

--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -3,8 +3,8 @@
 require "action_dispatch/testing/request_encoder"
 
 module ActionDispatch
-  # Integration test methods such as ActionDispatch::Integration::Session#get
-  # and ActionDispatch::Integration::Session#post return objects of class
+  # Integration test methods such as Integration::RequestHelpers#get
+  # and Integration::RequestHelpers#post return objects of class
   # TestResponse, which represent the HTTP response results of the requested
   # controller actions.
   #


### PR DESCRIPTION
### Summary

These were extracted into the RequestHelpers module in 9bac470
