### PR TITLE
Fix supporting timezone awareness for `tsrange` array columns.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix supporting timezone awareness for `tsrange` and `tstzrange` array columns.
+
+    ```ruby
+    # In database migrations
+    add_column :shops, :open_hours, :tsrange, array: true
+    # In app config
+    ActiveRecord::Base.time_zone_aware_types += [:tsrange]
+    # In the code times are properly converted to app time zone
+    Shop.create!(open_hours: [Time.current..8.hour.from_now])
+    ```
+
+    *Wojciech Wnętrzak*
+
 *   Introduce strategy pattern for executing migrations.
 
     By default, migrations will use a strategy object that delegates the method

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -19,6 +19,8 @@ module ActiveRecord
 
           if value.is_a?(Hash)
             set_time_zone_without_conversion(super)
+          elsif value.is_a?(Range)
+            Range.new(user_input_in_time_zone(value.begin), user_input_in_time_zone(value.end), value.exclude_end?)
           elsif value.respond_to?(:in_time_zone)
             begin
               super(user_input_in_time_zone(value)) || super
@@ -40,6 +42,8 @@ module ActiveRecord
               value.in_time_zone
             elsif value.respond_to?(:infinite?) && value.infinite?
               value
+            elsif value.is_a?(Range)
+              Range.new(convert_time_to_time_zone(value.begin), convert_time_to_time_zone(value.end), value.exclude_end?)
             else
               map_avoiding_infinite_recursion(value) { |v| convert_time_to_time_zone(v) }
             end


### PR DESCRIPTION
Before the fix, the error was thrown "TypeError: can't iterate from ActiveSupport::TimeWithZone".