### PR TITLE
Correctly check if frameworks are disabled when running `app:update`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Correctly check if frameworks are disabled when running app:update.
+
+    *Étienne Barrié* and *Paulo Barros*
+
 *   Delegate model generator description to orm hooked generator.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -21,10 +21,14 @@ module Rails
       private
         def generator_options
           options = { api: !!Rails.application.config.api_only, update: true }
+          options[:skip_active_job]     = !defined?(ActiveJob::Railtie)
           options[:skip_active_record]  = !defined?(ActiveRecord::Railtie)
           options[:skip_active_storage] = !defined?(ActiveStorage::Engine) || !defined?(ActiveRecord::Railtie)
           options[:skip_action_mailer]  = !defined?(ActionMailer::Railtie)
+          options[:skip_action_mailbox] = !defined?(ActionMailbox::Engine)
+          options[:skip_action_text]    = !defined?(ActionText::Engine)
           options[:skip_action_cable]   = !defined?(ActionCable::Engine)
+          options[:skip_test]           = !defined?(Rails::TestUnitRailtie)
           options[:skip_asset_pipeline] = !defined?(Sprockets::Railtie) && !defined?(Propshaft::Railtie)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options[:updating]            = true

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -290,6 +290,54 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_skip_active_job
+    app_root = File.join(destination_root, "myapp")
+    run_generator [ app_root, "--skip-active-job", "--skip-active-storage", "--skip-action-mailer" ]
+
+    FileUtils.cd(app_root) do
+      config = "config/application.rb"
+      assert_no_changes -> { File.readlines(config).grep(/require /) } do
+        system("yes | TEST=hi bin/rails app:update")
+      end
+    end
+  end
+
+  def test_app_update_preserves_skip_action_mailbox
+    app_root = File.join(destination_root, "myapp")
+    run_generator [ app_root, "--skip-action-mailbox" ]
+
+    FileUtils.cd(app_root) do
+      config = "config/application.rb"
+      assert_no_changes -> { File.readlines(config).grep(/require /) } do
+        quietly { system("yes | bin/rails app:update") }
+      end
+    end
+  end
+
+  def test_app_update_preserves_skip_action_text
+    app_root = File.join(destination_root, "myapp")
+    run_generator [ app_root, "--skip-action-text" ]
+
+    FileUtils.cd(app_root) do
+      config = "config/application.rb"
+      assert_no_changes -> { File.readlines(config).grep(/require /) } do
+        quietly { system("yes | bin/rails app:update") }
+      end
+    end
+  end
+
+  def test_app_update_preserves_skip_test
+    app_root = File.join(destination_root, "myapp")
+    run_generator [ app_root, "--skip-test" ]
+
+    FileUtils.cd(app_root) do
+      config = "config/application.rb"
+      assert_no_changes -> { File.readlines(config).grep(/require /) } do
+        quietly { system("yes | bin/rails app:update") }
+      end
+    end
+  end
+
   def test_gem_for_active_storage
     run_generator
     assert_file "Gemfile", /^# gem "image_processing"/


### PR DESCRIPTION
### Summary

When you use `--skip-*` options to disable frameworks, and later run `bin/rails app:update`, sometimes the options are not preserved.

### Other Information

```sh-session
$ rails _7.0.3_ new --skip-test my-app && cd my-app
*snip*
$ grep "require " config/application.rb
require "rails"
require "active_model/railtie"
require "active_job/railtie"
require "active_record/railtie"
require "active_storage/engine"
require "action_controller/railtie"
require "action_mailer/railtie"
require "action_mailbox/engine"
require "action_text/engine"
require "action_view/railtie"
require "action_cable/engine"
# require "rails/test_unit/railtie"
```
The test_unit railtie is not required.
```sh-session
$ yes | bin/rails app:update
*snip*
$ grep "require " config/application.rb
require "rails/all"
```

You can see the test_unit railtie is now loaded, so `rails/all` is required.

With this PR it does:
```sh-session
$ BUNDLE_GEMFILE=~/src/github.com/rails/rails/Gemfile bundle exec rails new my-app --skip-test --dev && cd my-app
$ yes | bin/rails app:update
$ grep test_unit  config/application.rb
# require "rails/test_unit/railtie"
```