### PR TITLE
Redo multi-db initializers

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -24,13 +24,15 @@ module ActiveRecord
     #
     #   bin/rails g active_record:multi_db
     #
-    # This will create a file named +config/initializers/multi_db.rb+ with the
-    # following contents:
+    # This will create a file named +config/initializers/multi_db.rb+. Find the following
+    # code and uncomment it.
     #
     #   Rails.application.configure do
-    #     config.active_record.database_selector = { delay: 2.seconds }
-    #     config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    #     config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #     options = { delay: 2.seconds }
+    #     resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    #     context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #
+    #     config.middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, context, options
     #   end
     #
     # Alternatively you can set the options in your environment config or
@@ -39,9 +41,13 @@ module ActiveRecord
     # The default behavior can be changed by setting the config options to a
     # custom class:
     #
-    #   config.active_record.database_selector = { delay: 2.seconds }
-    #   config.active_record.database_resolver = MyResolver
-    #   config.active_record.database_resolver_context = MyResolver::MySession
+    #   Rails.application.configure do
+    #     options = { delay: 2.seconds }
+    #     resolver = MyResolver
+    #     context = MyResolver::MySession
+    #
+    #     config.middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, context, options
+    #   end
     #
     # Note: If you are using `rails new my_app --minimal` you will need to call
     # `require "active_support/core_ext/integer/time"` to load the libraries

--- a/activerecord/lib/active_record/middleware/shard_selector.rb
+++ b/activerecord/lib/active_record/middleware/shard_selector.rb
@@ -14,18 +14,33 @@ module ActiveRecord
     # For tenant based sharding, +lock+ should always be true to prevent application
     # code from mistakenly switching between tenants.
     #
-    # Options can be set in the config:
+    # To use the ShardSelector in your application with default settings,
+    # run the provided generator.
     #
-    #   config.active_record.shard_selector = { lock: true }
+    #   bin/rails g active_record:multi_db
+    #
+    # This will create a file named +config/initializers/multi_db.rb+. Find the following
+    # code and uncomment it.
+    #
+    #   Rails.application.configure do
+    #     options = { lock: true }
+    #     resolver = ->(request) { Tenant.find_by!(host: request.host).shard }
+    #
+    #     config.middleware.use ActiveRecord::Middleware::ShardSelector, resolver, options
+    #   end
     #
     # Applications must also provide the code for the resolver as it depends on application
     # specific models. An example resolver would look like this:
     #
-    #   config.active_record.shard_resolver = ->(request) {
-    #     subdomain = request.subdomain
-    #     tenant = Tenant.find_by_subdomain!(subdomain)
-    #     tenant.shard
-    #   }
+    #   Rails.application.configure do
+    #     resolver = ->(request) {
+    #       subdomain = request.subdomain
+    #       tenant = Tenant.find_by_subdomain!(subdomain)
+    #       tenant.shard
+    #     }
+    #
+    #     config.middleware.use ActiveRecord::Middleware::ShardSelector, resolver
+    #   end
     class ShardSelector
       def initialize(app, resolver, options = {})
         @app = app

--- a/activerecord/lib/rails/generators/active_record/multi_db/templates/multi_db.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/multi_db/templates/multi_db.rb.tt
@@ -23,9 +23,11 @@
 # these configuration options.
 #
 # Rails.application.configure do
-#   config.active_record.database_selector = { delay: 2.seconds }
-#   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-#   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+#   options = { delay: 2.seconds }
+#   resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+#   context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+#
+#   config.middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, context, options
 # end
 #
 # Enable Shard Selector
@@ -39,6 +41,8 @@
 # in a proc. See guides for an example.
 #
 # Rails.application.configure do
-#   config.active_record.shard_selector = { lock: true }
-#   config.active_record.shard_resolver = ->(request) { Tenant.find_by!(host: request.host).shard }
+#   options = { lock: true }
+#   resolver = ->(request) { Tenant.find_by!(host: request.host).shard }
+#
+#   config.middleware.use ActiveRecord::Middleware::ShardSelector, resolver, options
 # end

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -449,9 +449,11 @@ module ApplicationTests
         config.session_store :cookie_store, key: "_random_key"
         config.middleware.use ActionDispatch::Cookies
         config.middleware.use config.session_store, config.session_options
-        config.active_record.database_selector = { delay: 2.seconds }
-        config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-        config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+	config.middleware.use ActiveRecord::Middleware::DatabaseSelector,
+			      ActiveRecord::Middleware::DatabaseSelector::Resolver,
+			      ActiveRecord::Middleware::DatabaseSelector::Resolver::Session,
+			      { delay: 15.seconds }
       RUBY
 
       controller :test, <<-RUBY

--- a/railties/test/generators/multi_db_generator_test.rb
+++ b/railties/test/generators/multi_db_generator_test.rb
@@ -11,8 +11,8 @@ class MultiDbGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_file "config/initializers/multi_db.rb" do |record|
       assert_match(/Multi-db Configuration/, record)
-      assert_match(/config.active_record.database_resolver/, record)
-      assert_match(/config.active_record.shard_resolver/, record)
+      assert_match(/middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, context, options/, record)
+      assert_match(/middleware.use ActiveRecord::Middleware::ShardSelector, resolver, options/, record)
     end
   end
 end


### PR DESCRIPTION
I recently discovered in #45162 that the initializers for multiple
databases are not working as intended. The
`config.active_record.database_selector` and other selector config options
work fine if they are called from `config/application.rb` or from
`config/environments/production.rb`. However when called from config
initalizers, the initializer from acitve record is loaded _before_ the
multi-db initialzier. This means that options never gets set and the
middleware never gets installed.

While it's nice to have the `config.active_record` keys for setting this
configuration, it's not really necessary, so I've solved this by using
the initializer to install the middleware directly like this:

Database Selector Before:

```ruby
Rails.application.configure do
  config.active_record.database_selector = { delay: 2.seconds }
  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
end
```

Database Selector After:

```ruby
Rails.application.configure do
  options = { delay: 2.seconds }
  resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
  context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session

  config.middleware.use ActiveRecord::Middleware::DatabaseSelector, resolver, context, options
end
```

Shard Selector Before:

```ruby
Rails.application.configure do
  config.active_record.shard_selector = { lock: true }
  config.active_record.shard_resolver = ->(request) { Tenant.find_by!(host: request.host).shard }
end
```

Shard Selector After:

```ruby
Rails.application.configure do
  options = { lock: true }
  resolver = ->(request) { Tenant.find_by!(host: request.host).shard }

  config.middleware.use ActiveRecord::Middleware::ShardSelector, resolver, options
end
```

The changes here are:

1) Raise if anyone is using the old keys. I'd love to deprecate this
but it's straight up not working so it needs to be removed instead.
2) Update the multi_db generator file to use the new method.
3) Update the documentation to use the new method.

This is going to be the least fun for applications that are using these
keys in their `application.rb` or env configs already. But since I can't
distinguish between where these are loaded the best course of action is
to just remove them and raise an error pushing them in the right
direction. I don't love this especially since it will need to be
backported to a release, 7.0, but I don't see a better option. I tried a
bunch of different ways to get these configs to load on time but nothing
worked. I had hope `after_initialize` would work, but the middleware
still isn't installed on time.

Closes #45162