### PR TITLE
Skip Active Storage and Action Mailer if Active Job is skipped

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Skip Active Storage and Action Mailer if Active Job is skipped.
+
+    *Étienne Barrié*
+
 *   Correctly check if frameworks are disabled when running app:update.
 
     *Étienne Barrié* and *Paulo Barros*

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -23,7 +23,7 @@ module Rails
           options = { api: !!Rails.application.config.api_only, update: true }
           options[:skip_active_job]     = !defined?(ActiveJob::Railtie)
           options[:skip_active_record]  = !defined?(ActiveRecord::Railtie)
-          options[:skip_active_storage] = !defined?(ActiveStorage::Engine) || !defined?(ActiveRecord::Railtie)
+          options[:skip_active_storage] = !defined?(ActiveStorage::Engine)
           options[:skip_action_mailer]  = !defined?(ActionMailer::Railtie)
           options[:skip_action_mailbox] = !defined?(ActionMailbox::Engine)
           options[:skip_action_text]    = !defined?(ActionText::Engine)

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -190,12 +190,12 @@ module Rails
         [
           options.values_at(
             :skip_active_record,
-            :skip_action_mailer,
             :skip_test,
             :skip_action_cable,
             :skip_active_job
           ),
           skip_active_storage?,
+          skip_action_mailer?,
           skip_action_mailbox?,
           skip_action_text?
         ].flatten.none?
@@ -223,7 +223,11 @@ module Rails
       end
 
       def skip_active_storage? # :doc:
-        options[:skip_active_storage] || options[:skip_active_record]
+        options[:skip_active_storage] || options[:skip_active_record] || options[:skip_active_job]
+      end
+
+      def skip_action_mailer? # :doc:
+        options[:skip_action_mailer] || options[:skip_active_job]
       end
 
       def skip_action_mailbox? # :doc:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -292,12 +292,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_app_update_preserves_skip_active_job
     app_root = File.join(destination_root, "myapp")
-    run_generator [ app_root, "--skip-active-job", "--skip-active-storage", "--skip-action-mailer" ]
+    run_generator [ app_root, "--skip-active-job" ]
 
     FileUtils.cd(app_root) do
       config = "config/application.rb"
       assert_no_changes -> { File.readlines(config).grep(/require /) } do
-        system("yes | TEST=hi bin/rails app:update")
+        quietly { system("yes | bin/rails app:update") }
       end
     end
   end
@@ -599,6 +599,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file "config/application.rb" do |content|
       assert_match(/#\s+require\s+["']active_job\/railtie["']/, content)
+      assert_match(/#\s+require\s+["']active_storage\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_mailer\/railtie["']/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

If you use either of these frameworks, Active Job is used. That means that only skipping Active Job will not really skip it, and whenever `app:update` runs, Active Job will be added back.

### Other Information

As mentioned in https://github.com/rails/rails/pull/45351/files#r896994504, it's the same logic as https://github.com/rails/rails/issues/30102, but maybe it's a bit different: while Active Record is core to Active Storage, I think you can somewhat use it without Active Job (provided you don't use `purge_later` or any analyzers).

As it is right now, the dependency of Active Storage on Active Job [is not optional](https://github.com/etiennebarrie/rails/blob/957886532956020319673eb066d2737d768d0e44/activestorage/lib/active_storage/engine.rb#L5), so this makes sense. Let me know if instead we should try to disentangle Storage from Job, but I don't really think it's worth it. 

Similarly, Action Mailer depends on a job to `deliver_later`, I don't it's worth breaking the dependency, I think it runs pretty deep.