### PR TITLE
Skip association validation when the record is persisted, unchanged and invalid

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -329,7 +329,7 @@ module ActiveRecord
       # enabled records if they're marked_for_destruction? or destroyed.
       def association_valid?(reflection, record, index = nil)
         return true if record.destroyed? || (reflection.options[:autosave] && record.marked_for_destruction?)
-        return true if !custom_validation_context? && record.persisted? && !record.has_changes_to_save? && !record.valid?
+        return true if !custom_validation_context? && record.persisted? && !record.has_changes_to_save?
 
         context = validation_context if custom_validation_context?
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -329,6 +329,7 @@ module ActiveRecord
       # enabled records if they're marked_for_destruction? or destroyed.
       def association_valid?(reflection, record, index = nil)
         return true if record.destroyed? || (reflection.options[:autosave] && record.marked_for_destruction?)
+        return true if !custom_validation_context? && record.persisted? && !record.has_changes_to_save? && !record.valid?
 
         context = validation_context if custom_validation_context?
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1734,6 +1734,14 @@ module AutosaveAssociationOnACollectionAssociationTests
       @pirate.save!
     end
   end
+
+  def test_should_save_when_children_is_persisted_unchanged_and_invalid
+    parrot = Parrot.new(name: nil)
+    assert parrot.save(validate: false)
+
+    pirate = Pirate.new(parrots: [parrot], catchphrase: "Arrrr")
+    assert pirate.save
+  end
 end
 
 class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes [#45320](https://github.com/rails/rails/issues/45320)

This adds consistency to the behavior described in the issue. Basically, skips validation when the associated record is persisted, unchanged and invalid.
