### PR TITLE
Add documentation on check constraints in Active Record Migrations to Rails Guides

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -579,6 +579,33 @@ remove_foreign_key :accounts, :branches
 remove_foreign_key :accounts, column: :owner_id
 ```
 
+### Check Constraints
+
+While it's not required you might want to add check constraints to limit the
+value range that can be placed in a column.
+
+```ruby
+add_check_constraint :products, "price > 0", name: "price_check"
+```
+
+This [`add_check_constraint`][] call adds a new check constraint to the
+`products` table.
+The check constraint guarantees that a value in the `price` column in the
+`products` table falls within the value range set by the `expression`.
+
+`add_check_constraint` also supports options such as `name`, and `validate`
+(PostgreSQL only).
+
+Check constraints can also be removed:
+
+```ruby
+remove_check_constraint :products, name: "price_check"
+```
+
+The `expression` parameter will be ignored if present. It can be helpful to
+provide this in a migration's change method so it can be reverted. In that case,
+ expression will be used by `add_check_constraint`.
+
 ### When Helpers aren't Enough
 
 If the helpers provided by Active Record aren't enough you can use the [`execute`][]
@@ -606,6 +633,7 @@ The `change` method is the primary way of writing migrations. It works for the
 majority of cases in which Active Record knows how to reverse a migration's
 actions automatically. Below are some of the actions that `change` supports:
 
+* [`add_check_constraint`][]
 * [`add_column`][]
 * [`add_foreign_key`][]
 * [`add_index`][]
@@ -621,6 +649,7 @@ actions automatically. Below are some of the actions that `change` supports:
 * [`drop_join_table`][]
 * [`drop_table`][] (must supply a block)
 * `enable_extension`
+* [`remove_check_constraint`][]
 * [`remove_column`][] (must supply a type)
 * [`remove_foreign_key`][] (must supply a second table)
 * [`remove_index`][]
@@ -644,12 +673,14 @@ remove_column :posts, :slug, :string, null: false, default: ''
 If you're going to need to use any other methods, you should use `reversible`
 or write the `up` and `down` methods instead of using the `change` method.
 
+[`add_check_constraint`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_check_constraint
 [`add_foreign_key`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
 [`add_timestamps`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_timestamps
 [`change_column_comment`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_column_comment
 [`change_table_comment`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table_comment
 [`drop_join_table`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_join_table
 [`drop_table`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_table
+[`remove_check_constraint`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_check_constraint
 [`remove_foreign_key`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_foreign_key
 [`remove_index`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_index
 [`remove_reference`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_reference


### PR DESCRIPTION
### Summary

Edge Rails Guides don't have any information in the [Active Record Migrations](https://edgeguides.rubyonrails.org/active_record_migrations.html) about the feature added in Rails 6.1: https://github.com/rails/rails/pull/31323

We should inform Rails users that they can now use these helpers instead of writing raw SQL.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
