### PR TITLE
Update Command Line guide --database usage [ci-skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -67,6 +67,59 @@ If you wish to skip some files from being generated or skip some libraries, you 
 
 These are just some of the options you can append to `rails new`. For a comprehensive list of options, type `rails new --help`.
 
+### Preconfigure a Different Database
+
+When creating a new Rails application, you have the option to specify what kind
+of database your application is going to use. This will save you a few minutes,
+and certainly many keystrokes.
+
+Let's see what a `--database=postgresql` option will do for us:
+
+```bash
+$ rails new petstore --database=postgresql
+      create
+      create  app/controllers
+      create  app/helpers
+...
+```
+
+Let's see what it put in our database configuration:
+
+```bash
+$ cd petstore
+$ cat config/database.yml
+# PostgreSQL. Versions 9.3 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem "pg"
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+..development:
+  <<: *default
+  database: petstore_development.
+...
+```
+
+It generated some lines in our `database.yml` configuration corresponding
+to our choice of PostgreSQL for database.
+
 Command Line Basics
 -------------------
 
@@ -652,77 +705,3 @@ $ bin/rails db:nothing
 ```
 
 NOTE: If you need to interact with your application models, perform database queries, and so on, your task should depend on the `environment` task, which will load your application code.
-
-The Rails Advanced Command Line
--------------------------------
-
-More advanced use of the command line is focused around finding useful (even surprising at times) options in the utilities, and fitting those to your needs and specific work flow. Listed here are some tricks up Rails' sleeve.
-
-### Rails with Databases and SCM
-
-When creating a new Rails application, you have the option to specify what kind of database and what kind of source code management system your application is going to use. This will save you a few minutes, and certainly many keystrokes.
-
-Let's see what a `--git` option and a `--database=postgresql` option will do for us:
-
-```bash
-$ mkdir gitapp
-$ cd gitapp
-$ git init
-Initialized empty Git repository in .git/
-$ rails new . --git --database=postgresql
-      exists
-      create  app/controllers
-      create  app/helpers
-...
-...
-      create  tmp/cache
-      create  tmp/pids
-      create  Rakefile
-add 'Rakefile'
-      create  README.md
-add 'README.md'
-      create  app/controllers/application_controller.rb
-add 'app/controllers/application_controller.rb'
-      create  app/helpers/application_helper.rb
-...
-      create  log/test.log
-add 'log/test.log'
-```
-
-We had to create the **gitapp** directory and initialize an empty git repository before Rails would add files it created to our repository. Let's see what it put in our database configuration:
-
-```bash
-$ cat config/database.yml
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
-default: &default
-  adapter: postgresql
-  encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
-development:
-  <<: *default
-  database: gitapp_development
-...
-...
-```
-
-It also generated some lines in our `database.yml` configuration corresponding to our choice of PostgreSQL for database.
-
-NOTE. The only catch with using the SCM options is that you have to make your application's directory first, then initialize your SCM, then you can run the `rails new` command to generate the basis of your app.


### PR DESCRIPTION
### Summary

The current Command Line guide has an advanced section describing
specifying git as SCM and PostgreSQL as the database. This section is
easily overlooked: https://github.com/rails/rails/issues/44325

By moving whole "advanced" section under the `rails new` section, it's
easier to find. Also specifying the database is pretty common I guess
and not an "advanced" topic.

All mentions of the SCM option have been removed, as it seems to no
longer be an option and we always initialize with Git only.