### PR TITLE
Move `raise_on_missing_translations` config onto `ActionView::Base`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Moved `ActionView::Helpers::TranslationHelper.raise_on_missing_translations` to
+    `ActionView::Base.raise_on_missing_translations` to correctly execute the `on_load` hook in the `I18n::Railtie`.
+
+    *Kevin McPhillips* and *Gannon McGibbon*
+
 *   Strings returned from `strip_tags` are correctly tagged `html_safe?`
 
     Because these strings contain no HTML elements and the basic entities are escaped, they are safe

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -162,6 +162,9 @@ module ActionView # :nodoc:
     # Annotate rendered view with file names
     cattr_accessor :annotate_rendered_view_with_filenames, default: false
 
+    # Specify whether an error should be raised for missing translations
+    cattr_accessor :raise_on_missing_translations, default: false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -11,8 +11,23 @@ module ActionView
 
       include TagHelper
 
-      # Specify whether an error should be raised for missing translations
-      singleton_class.attr_accessor :raise_on_missing_translations
+      class << self
+        def raise_on_missing_translations
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+            `ActionView::Helpers::TranslationHelper.raise_on_missing_translations` is deprecated and will be removed in Rails 7.2.
+            Please use `ActionView::Base.raise_on_missing_translations`.
+          MESSAGE
+          ActionView::Base.raise_on_missing_translations
+        end
+
+        def raise_on_missing_translations=(value)
+          ActiveSupport::Deprecation.warn(<<-MESSAGE.squish)
+            `ActionView::Helpers::TranslationHelper.raise_on_missing_translations` is deprecated and will be removed in Rails 7.2.
+            Please use `ActionView::Base.raise_on_missing_translations`.
+          MESSAGE
+          ActionView::Base.raise_on_missing_translations = value
+        end
+      end
 
       included do
         mattr_accessor :debug_missing_translation, default: true
@@ -78,7 +93,7 @@ module ActionView
           options[:default].is_a?(Array) ? options.delete(:default).compact : [options.delete(:default)]
         end
 
-        options[:raise] = true if options[:raise].nil? && TranslationHelper.raise_on_missing_translations
+        options[:raise] = true if options[:raise].nil? && ActionView::Base.raise_on_missing_translations
         default = MISSING_TRANSLATION
 
         translation = while key || alternatives.present?

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -118,28 +118,48 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_raises_missing_translation_message_with_raise_config_option
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
+    ActionView::Base.raise_on_missing_translations = true
 
     assert_raise(I18n::MissingTranslationData) do
       translate("translations.missing")
     end
   ensure
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
+    ActionView::Base.raise_on_missing_translations = false
   end
 
   def test_raise_arg_overrides_raise_config_option
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
+    ActionView::Base.raise_on_missing_translations = true
 
     expected = "translation missing: en.translations.missing"
     assert_equal expected, translate(:"translations.missing", raise: false)
   ensure
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
+    ActionView::Base.raise_on_missing_translations = false
   end
 
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", raise: true)
     end
+  end
+
+  def test_raises_missing_translation_message_with_raise_config_option_with_deprecation
+    assert_deprecated do
+      ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
+    end
+
+    assert_deprecated do
+      assert ActionView::Helpers::TranslationHelper.raise_on_missing_translations
+    end
+
+    assert_raise(I18n::MissingTranslationData) do
+      translate("translations.missing")
+    end
+
+    assert_deprecated do
+      ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
+    end
+  ensure
+    ActionView::Base.raise_on_missing_translations = false
   end
 
   def test_uses_custom_exception_handler_when_specified

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -79,7 +79,7 @@ module I18n
 
     def self.forward_raise_on_missing_translations_config(app)
       ActiveSupport.on_load(:action_view) do
-        ActionView::Helpers::TranslationHelper.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
+        ActionView::Base.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
       end
 
       ActiveSupport.on_load(:action_controller) do


### PR DESCRIPTION
## Problem

The `raise_on_missing_translations` value is not correctly copied from Rails config into `ActionView` in all autoloading cases.

The value is copied here:
https://github.com/rails/rails/blob/962a1dd231de475130b78f4357b090a6bb28709d/activesupport/lib/active_support/i18n_railtie.rb#L81-L83

That sets the value here:
https://github.com/rails/rails/blob/962a1dd231de475130b78f4357b090a6bb28709d/actionview/lib/action_view/helpers/translation_helper.rb#L15

However, the `on_load(:action_view)` hook only fires when `ActionView::Base` is autoloaded. And if the `ActionView::Helpers::TranslationHelper` is used directly, the `raise_on_missing_translations` _may_ not correctly be set. And if it is not set, the translation missing behaviour will behave differently.


## Solution

We have moved the config variable to `ActionView::Base.raise_on_missing_translations`, then the value will always be copied in `on_load` before it is ever read.

The original location now delegates to the new location, and we added a deprecation notice for Rails 7.2.

We briefly considered adding a new `on_load` hook, but that seems unnecessary.

Paired on this with @gmcgibbon 


## Next steps

This config has the same problem, where the hook is not quite correct. I will refactor that one next.
https://github.com/rails/rails/blob/962a1dd231de475130b78f4357b090a6bb28709d/activesupport/lib/active_support/i18n_railtie.rb#L85-L87