### PR TITLE
Support calls to `#field_name` with nil `object_name`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Guard against `ActionView::Helpers::FormTagHelper#field_name` calls with nil
+    `object_name` arguments. For example:
+
+    ```erb
+    <%= fields do |f| %>
+      <%= f.field_name :body %>
+    <% end %>
+    ```
+
+    *Sean Doyle*
+
 *   Strings returned from `strip_tags` are correctly tagged `html_safe?`
 
     Because these strings contain no HTML elements and the basic entities are escaped, they are safe

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -131,7 +131,7 @@ module ActionView
 
         # a little duplication to construct fewer strings
         case
-        when object_name.empty?
+        when object_name.blank?
           "#{method_name}#{names}#{multiple ? "[]" : ""}"
         when index
           "#{object_name}[#{index}][#{method_name}]#{names}#{multiple ? "[]" : ""}"

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -225,7 +225,13 @@ class FormTagHelperTest < ActionView::TestCase
     assert_equal "post_author_name", value
   end
 
-  def test_field_name_without_object_name
+  def test_field_name_with_nil_object_name
+    value = field_name(nil, :title)
+
+    assert_equal "title", value
+  end
+
+  def test_field_name_with_blank_object_name
     value = field_name("", :title)
 
     assert_equal "title", value


### PR DESCRIPTION
### Summary

It's possible for `ActionView::Helpers::FormTagHelper#field_name` calls
made by instances constructed through `fields` and `fields_for` helpers
to have an `object_name` argument that's `nil`.  For example, the
following will raise an `undefined method `empty?' for nil:NilClass`
exception:

```erb
<%= fields do |f| %>
  <%= f.field_name :body %>
<% end %>
```

### Other Information

To guard against those calls, replace the method's call to
`String#empty?` with `Object#blank?`, since `NilClass#empty?` is not
defined.