### PR TITLE
Behaviour constant deprecation fix

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -104,7 +104,7 @@ module ActiveSupport
     end
 
     # DeprecatedConstantProxy transforms a constant into a deprecated one. It
-    # takes the names of an old (deprecated) constant and of a new constant
+    # takes the full names of an old (deprecated) constant and of a new constant
     # (both in string form) and optionally a deprecator. The deprecator defaults
     # to +ActiveSupport::Deprecator+ if none is specified. The deprecated constant
     # now returns the value of the new one.

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -108,7 +108,7 @@ module Rails
           end
       end
 
-      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Behaviour", "Behavior")
+      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Rails::Generators::Testing::Behaviour", "Rails::Generators::Testing::Behavior")
     end
   end
 end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -253,4 +253,10 @@ class GeneratorsTest < Rails::Generators::TestCase
     Rails::Generators.hide_namespace("special:namespace")
     assert_includes Rails::Generators.hidden_namespaces, "special:namespace"
   end
+
+  def test_behaviour_aliases_behavior
+    assert_deprecated do
+      assert_same Rails::Generators::Testing::Behavior, Rails::Generators::Testing::Behaviour.itself
+    end
+  end
 end


### PR DESCRIPTION
@jhawthorn's #45251 addressed a sed-gone-wild in the deprecation of `Rails::Generators::Testing::Behaviour` (now `…Behavior`):

https://github.com/rails/rails/blob/c81a9bca1131a2a0ca0c4b3fa780068641b4ed46/railties/lib/rails/generators/testing/behavior.rb#L111
… but this never worked to begin with. `DeprecatedConstantProxy` needs the full name, as it resolves from the root:

https://github.com/rails/rails/blob/c81a9bca1131a2a0ca0c4b3fa780068641b4ed46/activesupport/lib/active_support/deprecation/proxy_wrappers.rb#L177-L179

This PR adds a test that exposes the failing deprecation, fixes it, and adds a slight hint in the docs for `DeprecatedConstantProxy` that suggests full names might work better.