### PR TITLE
Fix tests for minitest 5.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "minitest", ">= 5.15.0", "< 5.16.0"
+if RUBY_VERSION < "3"
+  gem "minitest", ">= 5.15.0", "< 5.16"
+else
+  gem "minitest", ">= 5.15.0"
+end
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.1)
     minitest-bisect (1.5.1)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
@@ -586,7 +586,7 @@ DEPENDENCIES
   kindlerb (~> 1.2.0)
   libxml-ruby
   listen (~> 3.3)
-  minitest (>= 5.15.0, < 5.16.0)
+  minitest (>= 5.15.0)
   minitest-bisect
   minitest-ci
   minitest-retry

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -36,91 +36,91 @@ class SessionTest < ActiveSupport::TestCase
   def test_get
     path = "/index"; params = "blah"; headers = { location: "blah" }
 
-    assert_called_with @session, :process, [:get, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:get, path], params: params, headers: headers do
       @session.get(path, params: params, headers: headers)
     end
   end
 
   def test_get_with_env_and_headers
     path = "/index"; params = "blah"; headers = { location: "blah" }; env = { "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest" }
-    assert_called_with @session, :process, [:get, path, params: params, headers: headers, env: env] do
+    assert_called_with @session, :process, [:get, path], params: params, headers: headers, env: env do
       @session.get(path, params: params, headers: headers, env: env)
     end
   end
 
   def test_post
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:post, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:post, path], params: params, headers: headers do
       @session.post(path, params: params, headers: headers)
     end
   end
 
   def test_patch
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:patch, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:patch, path], params: params, headers: headers do
       @session.patch(path, params: params, headers: headers)
     end
   end
 
   def test_put
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:put, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:put, path], params: params, headers: headers do
       @session.put(path, params: params, headers: headers)
     end
   end
 
   def test_delete
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:delete, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:delete, path], params: params, headers: headers do
       @session.delete(path, params: params, headers: headers)
     end
   end
 
   def test_head
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:head, path, params: params, headers: headers] do
+    assert_called_with @session, :process, [:head, path], params: params, headers: headers do
       @session.head(path, params: params, headers: headers)
     end
   end
 
   def test_xml_http_request_get
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:get, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:get, path], params: params, headers: headers, xhr: true do
       @session.get(path, params: params, headers: headers, xhr: true)
     end
   end
 
   def test_xml_http_request_post
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:post, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:post, path], params: params, headers: headers, xhr: true do
       @session.post(path, params: params, headers: headers, xhr: true)
     end
   end
 
   def test_xml_http_request_patch
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:patch, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:patch, path], params: params, headers: headers, xhr: true do
       @session.patch(path, params: params, headers: headers, xhr: true)
     end
   end
 
   def test_xml_http_request_put
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:put, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:put, path], params: params, headers: headers, xhr: true do
       @session.put(path, params: params, headers: headers, xhr: true)
     end
   end
 
   def test_xml_http_request_delete
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:delete, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:delete, path], params: params, headers: headers, xhr: true do
       @session.delete(path, params: params, headers: headers, xhr: true)
     end
   end
 
   def test_xml_http_request_head
     path = "/index"; params = "blah"; headers = { location: "blah" }
-    assert_called_with @session, :process, [:head, path, params: params, headers: headers, xhr: true] do
+    assert_called_with @session, :process, [:head, path], params: params, headers: headers, xhr: true do
       @session.head(path, params: params, headers: headers, xhr: true)
     end
   end

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -49,7 +49,7 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
   end
 
   def test_time_ago_in_words_passes_locale
-    assert_called_with(I18n, :t, [:less_than_x_minutes, scope: :'datetime.distance_in_words', count: 1, locale: "ru"]) do
+    assert_called_with(I18n, :t, [:less_than_x_minutes], scope: :'datetime.distance_in_words', count: 1, locale: "ru") do
       time_ago_in_words(15.seconds.ago, locale: "ru")
     end
   end
@@ -84,7 +84,7 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
     options = { locale: "en", scope: :'datetime.distance_in_words' }.merge!(expected_options)
     options[:count] = count if count
 
-    assert_called_with(I18n, :t, [key, options]) do
+    assert_called_with(I18n, :t, [key], **options) do
       distance_of_time_in_words(@from, to, passed_options.merge(locale: "en"))
     end
   end
@@ -103,13 +103,13 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
   end
 
   def test_select_month_translates_monthnames
-    assert_called_with(I18n, :translate, [:'date.month_names', locale: "en"], returns: Date::MONTHNAMES) do
+    assert_called_with(I18n, :translate, [:'date.month_names'], returns: Date::MONTHNAMES, locale: "en") do
       select_month(8, locale: "en")
     end
   end
 
   def test_select_month_given_use_short_month_option_translates_abbr_monthnames
-    assert_called_with(I18n, :translate, [:'date.abbr_month_names', locale: "en"], returns: Date::ABBR_MONTHNAMES) do
+    assert_called_with(I18n, :translate, [:'date.abbr_month_names'], returns: Date::ABBR_MONTHNAMES, locale: "en") do
       select_month(8, locale: "en", use_short_month: true)
     end
   end
@@ -147,8 +147,8 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
 
   def test_date_or_time_select_given_no_order_options_translates_order
     mock = Minitest::Mock.new
-    mock.expect(:call, ["year", "month", "day"], [:'date.order', { locale: "en", default: [] }])
-    mock.expect(:call, [], [:'date.month_names', { locale: "en" }])
+    expect_called_with(mock, [:'date.order'], locale: "en", default: [], returns: ["year", "month", "day"])
+    expect_called_with(mock, [:'date.month_names'], locale: "en", returns: [])
 
     I18n.stub(:translate, mock) do
       datetime_select("post", "updated_at", locale: "en")
@@ -158,7 +158,7 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
   end
 
   def test_date_or_time_select_given_invalid_order
-    assert_called_with(I18n, :translate, [:'date.order', locale: "en", default: []], returns: %w(invalid month day)) do
+    assert_called_with(I18n, :translate, [:'date.order'], returns: %w(invalid month day), locale: "en", default: []) do
       assert_raise StandardError do
         datetime_select("post", "updated_at", locale: "en")
       end
@@ -167,8 +167,8 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
 
   def test_date_or_time_select_given_symbol_keys
     mock = Minitest::Mock.new
-    mock.expect(:call, [:year, :month, :day], [:'date.order', { locale: "en", default: [] }])
-    mock.expect(:call, [], [:'date.month_names', { locale: "en" }])
+    expect_called_with(mock, [:'date.order'], locale: "en", default: [], returns: [:year, :month, :day])
+    expect_called_with(mock, [:'date.month_names'], locale: "en", returns: [])
 
     I18n.stub(:translate, mock) do
       datetime_select("post", "updated_at", locale: "en")

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -1768,7 +1768,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     mock = Minitest::Mock.new
     @post.comments.each do
-      mock.expect(:call, "body", ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"])
+      expect_called_with(mock, ["post.comments.body"], default: [:"comment.body", ""], scope: "helpers.label", returns: "body")
     end
 
     I18n.stub(:t, mock) do

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3302,7 +3302,7 @@ class FormHelperTest < ActionView::TestCase
 
     mock = Minitest::Mock.new
     @post.comments.each do
-      mock.expect(:call, "body", ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"])
+      expect_called_with(mock, ["post.comments.body"], default: [:"comment.body", ""], scope: "helpers.label", returns: "body")
     end
 
     I18n.stub(:t, mock) do

--- a/actionview/test/template/form_options_helper_i18n_test.rb
+++ b/actionview/test/template/form_options_helper_i18n_test.rb
@@ -16,7 +16,7 @@ class FormOptionsHelperI18nTests < ActionView::TestCase
   end
 
   def test_select_with_prompt_true_translates_prompt_message
-    assert_called_with(I18n, :translate, ["helpers.select.prompt", { default: "Please select" }]) do
+    assert_called_with(I18n, :translate, ["helpers.select.prompt"], default: "Please select") do
       select("post", "category", [], prompt: true)
     end
   end

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -65,7 +65,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_delegates_localize_to_i18n
     @time = Time.utc(2008, 7, 8, 12, 18, 38)
-    assert_called_with(I18n, :localize, [@time, locale: "en"]) do
+    assert_called_with(I18n, :localize, [@time], locale: "en") do
       localize @time, locale: "en"
     end
     assert_equal "Tue, 08 Jul 2008 12:18:38 +0000", localize(@time, locale: "en")

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -995,7 +995,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def lock_thread=(lock_thread); end
     end.new
 
-    assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
+    assert_called_with(connection, :begin_transaction, [], joinable: false, _lazy: false) do
       fire_connection_notification(connection)
     end
   end
@@ -1035,14 +1035,14 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def lock_thread=(lock_thread); end
     end.new
 
-    assert_called_with(connection, :begin_transaction, [joinable: false, _lazy: false]) do
+    assert_called_with(connection, :begin_transaction, [], joinable: false, _lazy: false) do
       fire_connection_notification(connection, shard: :shard_two)
     end
   end
 
   private
     def fire_connection_notification(connection, shard: ActiveRecord::Base.default_shard)
-      assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book", { shard: shard }], returns: connection) do
+      assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book"], returns: connection, shard: shard) do
         message_bus = ActiveSupport::Notifications.instrumenter
         payload = {
           spec_name: "book",

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -17,117 +17,131 @@ module ActiveRecord
         yield ActiveRecord::Base.connection.update_table_definition(:delete_me, @connection)
       end
 
+      if Minitest::Mock.instance_method(:expect).parameters.map(&:first).include?(:keyrest)
+        def expect(method, returns, args, **kwargs)
+          @connection.expect(method, returns, args, **kwargs)
+        end
+      else
+        def expect(method, returns, args, **kwargs)
+          if !kwargs.empty?
+            @connection.expect(method, returns, [*args, kwargs])
+          else
+            @connection.expect(method, returns, args)
+          end
+        end
+      end
+
       def test_references_column_type_adds_id
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :customer]
+          expect :add_reference, nil, [:delete_me, :customer]
           t.references :customer
         end
       end
 
       def test_remove_references_column_type_removes_id
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :customer]
+          expect :remove_reference, nil, [:delete_me, :customer]
           t.remove_references :customer
         end
       end
 
       def test_add_belongs_to_works_like_add_references
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :customer]
+          expect :add_reference, nil, [:delete_me, :customer]
           t.belongs_to :customer
         end
       end
 
       def test_remove_belongs_to_works_like_remove_references
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :customer]
+          expect :remove_reference, nil, [:delete_me, :customer]
           t.remove_belongs_to :customer
         end
       end
 
       def test_references_column_type_with_polymorphic_adds_type
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true]
+          expect :add_reference, nil, [:delete_me, :taggable], polymorphic: true
           t.references :taggable, polymorphic: true
         end
       end
 
       def test_remove_references_column_type_with_polymorphic_removes_type
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true]
+          expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true
           t.remove_references :taggable, polymorphic: true
         end
       end
 
       def test_references_column_type_with_polymorphic_and_options_null_is_false_adds_table_flag
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true, null: false]
+          expect :add_reference, nil, [:delete_me, :taggable], polymorphic: true, null: false
           t.references :taggable, polymorphic: true, null: false
         end
       end
 
       def test_remove_references_column_type_with_polymorphic_and_options_null_is_false_removes_table_flag
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true, null: false]
+          expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true, null: false
           t.remove_references :taggable, polymorphic: true, null: false
         end
       end
 
       def test_references_column_type_with_polymorphic_and_type
         with_change_table do |t|
-          @connection.expect :add_reference, nil, [:delete_me, :taggable, polymorphic: true, type: :string]
+          expect :add_reference, nil, [:delete_me, :taggable], polymorphic: true, type: :string
           t.references :taggable, polymorphic: true, type: :string
         end
       end
 
       def test_remove_references_column_type_with_polymorphic_and_type
         with_change_table do |t|
-          @connection.expect :remove_reference, nil, [:delete_me, :taggable, polymorphic: true, type: :string]
+          expect :remove_reference, nil, [:delete_me, :taggable], polymorphic: true, type: :string
           t.remove_references :taggable, polymorphic: true, type: :string
         end
       end
 
       def test_timestamps_creates_updated_at_and_created_at
         with_change_table do |t|
-          @connection.expect :add_timestamps, nil, [:delete_me, null: true]
+          expect :add_timestamps, nil, [:delete_me], null: true
           t.timestamps null: true
         end
       end
 
       def test_remove_timestamps_creates_updated_at_and_created_at
         with_change_table do |t|
-          @connection.expect :remove_timestamps, nil, [:delete_me, { null: true }]
+          expect :remove_timestamps, nil, [:delete_me], null: true
           t.remove_timestamps(null: true)
         end
       end
 
       def test_primary_key_creates_primary_key_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :id, :primary_key, primary_key: true, first: true]
+          expect :add_column, nil, [:delete_me, :id, :primary_key], primary_key: true, first: true
           t.primary_key :id, first: true
         end
       end
 
       def test_integer_creates_integer_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :foo, :integer]
-          @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
+          expect :add_column, nil, [:delete_me, :foo, :integer]
+          expect :add_column, nil, [:delete_me, :bar, :integer]
           t.integer :foo, :bar
         end
       end
 
       def test_bigint_creates_bigint_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :foo, :bigint]
-          @connection.expect :add_column, nil, [:delete_me, :bar, :bigint]
+          expect :add_column, nil, [:delete_me, :foo, :bigint]
+          expect :add_column, nil, [:delete_me, :bar, :bigint]
           t.bigint :foo, :bar
         end
       end
 
       def test_string_creates_string_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :foo, :string]
-          @connection.expect :add_column, nil, [:delete_me, :bar, :string]
+          expect :add_column, nil, [:delete_me, :foo, :string]
+          expect :add_column, nil, [:delete_me, :bar, :string]
           t.string :foo, :bar
         end
       end
@@ -135,30 +149,30 @@ module ActiveRecord
       if current_adapter?(:PostgreSQLAdapter)
         def test_json_creates_json_column
           with_change_table do |t|
-            @connection.expect :add_column, nil, [:delete_me, :foo, :json]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :json]
+            expect :add_column, nil, [:delete_me, :foo, :json]
+            expect :add_column, nil, [:delete_me, :bar, :json]
             t.json :foo, :bar
           end
         end
 
         def test_xml_creates_xml_column
           with_change_table do |t|
-            @connection.expect :add_column, nil, [:delete_me, :foo, :xml]
-            @connection.expect :add_column, nil, [:delete_me, :bar, :xml]
+            expect :add_column, nil, [:delete_me, :foo, :xml]
+            expect :add_column, nil, [:delete_me, :bar, :xml]
             t.xml :foo, :bar
           end
         end
 
         def test_exclusion_constraint_creates_exclusion_constraint
           with_change_table do |t|
-            @connection.expect :add_exclusion_constraint, nil, [:delete_me, "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"]
+            expect :add_exclusion_constraint, nil, [:delete_me, "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"]
             t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"
           end
         end
 
         def test_remove_exclusion_constraint_removes_exclusion_constraint
           with_change_table do |t|
-            @connection.expect :remove_exclusion_constraint, nil, [:delete_me, name: "date_overlap"]
+            expect :remove_exclusion_constraint, nil, [:delete_me, name: "date_overlap"]
             t.remove_exclusion_constraint name: "date_overlap"
           end
         end
@@ -166,120 +180,120 @@ module ActiveRecord
 
       def test_column_creates_column
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
+          expect :add_column, nil, [:delete_me, :bar, :integer]
           t.column :bar, :integer
         end
       end
 
       def test_column_creates_column_with_options
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :bar, :integer, { null: false }]
+          expect :add_column, nil, [:delete_me, :bar, :integer], null: false
           t.column :bar, :integer, null: false
         end
       end
 
       def test_column_creates_column_with_index
         with_change_table do |t|
-          @connection.expect :add_column, nil, [:delete_me, :bar, :integer]
-          @connection.expect :add_index, nil, [:delete_me, :bar]
+          expect :add_column, nil, [:delete_me, :bar, :integer]
+          expect :add_index, nil, [:delete_me, :bar]
           t.column :bar, :integer, index: true
         end
       end
 
       def test_index_creates_index
         with_change_table do |t|
-          @connection.expect :add_index, nil, [:delete_me, :bar]
+          expect :add_index, nil, [:delete_me, :bar]
           t.index :bar
         end
       end
 
       def test_index_creates_index_with_options
         with_change_table do |t|
-          @connection.expect :add_index, nil, [:delete_me, :bar, { unique: true }]
+          expect :add_index, nil, [:delete_me, :bar], unique: true
           t.index :bar, unique: true
         end
       end
 
       def test_index_exists
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar]
+          expect :index_exists?, nil, [:delete_me, :bar]
           t.index_exists?(:bar)
         end
       end
 
       def test_index_exists_with_options
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar, { unique: true }]
+          expect :index_exists?, nil, [:delete_me, :bar], unique: true
           t.index_exists?(:bar, unique: true)
         end
       end
 
       def test_rename_index_renames_index
         with_change_table do |t|
-          @connection.expect :rename_index, nil, [:delete_me, :bar, :baz]
+          expect :rename_index, nil, [:delete_me, :bar, :baz]
           t.rename_index :bar, :baz
         end
       end
 
       def test_change_changes_column
         with_change_table do |t|
-          @connection.expect :change_column, nil, [:delete_me, :bar, :string]
+          expect :change_column, nil, [:delete_me, :bar, :string]
           t.change :bar, :string
         end
       end
 
       def test_change_changes_column_with_options
         with_change_table do |t|
-          @connection.expect :change_column, nil, [:delete_me, :bar, :string, { null: true }]
+          expect :change_column, nil, [:delete_me, :bar, :string], null: true
           t.change :bar, :string, null: true
         end
       end
 
       def test_change_default_changes_column
         with_change_table do |t|
-          @connection.expect :change_column_default, nil, [:delete_me, :bar, :string]
+          expect :change_column_default, nil, [:delete_me, :bar, :string]
           t.change_default :bar, :string
         end
       end
 
       def test_change_null_changes_column
         with_change_table do |t|
-          @connection.expect :change_column_null, nil, [:delete_me, :bar, true, nil]
+          expect :change_column_null, nil, [:delete_me, :bar, true, nil]
           t.change_null :bar, true
         end
       end
 
       def test_remove_drops_single_column
         with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar]
+          expect :remove_columns, nil, [:delete_me, :bar]
           t.remove :bar
         end
       end
 
       def test_remove_drops_multiple_columns
         with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz]
+          expect :remove_columns, nil, [:delete_me, :bar, :baz]
           t.remove :bar, :baz
         end
       end
 
       def test_remove_drops_multiple_columns_when_column_options_are_given
         with_change_table do |t|
-          @connection.expect :remove_columns, nil, [:delete_me, :bar, :baz, type: :string, null: false]
+          expect :remove_columns, nil, [:delete_me, :bar, :baz], type: :string, null: false
           t.remove :bar, :baz, type: :string, null: false
         end
       end
 
       def test_remove_index_removes_index_with_options
         with_change_table do |t|
-          @connection.expect :remove_index, nil, [:delete_me, :bar, { unique: true }]
+          expect :remove_index, nil, [:delete_me, :bar], unique: true
           t.remove_index :bar, unique: true
         end
       end
 
       def test_rename_renames_column
         with_change_table do |t|
-          @connection.expect :rename_column, nil, [:delete_me, :bar, :baz]
+          expect :rename_column, nil, [:delete_me, :bar, :baz]
           t.rename :bar, :baz
         end
       end
@@ -292,14 +306,14 @@ module ActiveRecord
 
       def test_check_constraint_creates_check_constraint
         with_change_table do |t|
-          @connection.expect :add_check_constraint, nil, [:delete_me, "price > discounted_price", name: "price_check"]
+          expect :add_check_constraint, nil, [:delete_me, "price > discounted_price"], name: "price_check"
           t.check_constraint "price > discounted_price", name: "price_check"
         end
       end
 
       def test_remove_check_constraint_removes_check_constraint
         with_change_table do |t|
-          @connection.expect :remove_check_constraint, nil, [:delete_me, name: "price_check"]
+          expect :remove_check_constraint, nil, [:delete_me], name: "price_check"
           t.remove_check_constraint name: "price_check"
         end
       end

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -221,8 +221,9 @@ if current_adapter?(:SQLite3Adapter)
         assert_called_with(
           Kernel,
           :system,
-          ["sqlite3", "--noop", "db_create.sqlite3", ".schema", out: "awesome-file.sql"],
-          returns: nil
+          ["sqlite3", "--noop", "db_create.sqlite3", ".schema"],
+          returns: nil,
+          out: "awesome-file.sql"
         ) do
           e = assert_raise(RuntimeError) do
             with_structure_dump_flags(["--noop"]) do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -31,8 +31,8 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching an existing blob from a signed ID passes record" do
     blob = create_blob(filename: "funky.jpg")
-    arguments = [blob.signed_id, record: @user]
-    assert_called_with(ActiveStorage::Blob, :find_signed!, arguments, returns: blob) do
+
+    assert_called_with(ActiveStorage::Blob, :find_signed!, [blob.signed_id], returns: blob, record: @user) do
       @user.avatar.attach blob.signed_id
     end
   end
@@ -45,8 +45,8 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from a Hash to an existing record passes record" do
     hash = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" }
     blob = ActiveStorage::Blob.build_after_unfurling(**hash)
-    arguments = [hash.merge(record: @user, service_name: nil)]
-    assert_called_with(ActiveStorage::Blob, :build_after_unfurling, arguments, returns: blob) do
+    arguments = hash.merge(record: @user, service_name: nil)
+    assert_called_with(ActiveStorage::Blob, :build_after_unfurling, [], **arguments, returns: blob) do
       @user.avatar.attach hash
     end
   end
@@ -63,7 +63,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
     arguments = { io: upload.open, filename: upload.original_filename, content_type: upload.content_type, record: @user, service_name: nil }
     blob = ActiveStorage::Blob.build_after_unfurling(**arguments)
-    assert_called_with(ActiveStorage::Blob, :build_after_unfurling, [arguments], returns: blob) do
+    assert_called_with(ActiveStorage::Blob, :build_after_unfurling, [], returns: blob, **arguments) do
       @user.avatar.attach upload
     end
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -210,15 +210,18 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     blob = create_blob(filename: "original.txt")
 
     arguments = [
-      blob.key,
+      blob.key
+    ]
+
+    kwargs = {
       expires_in: ActiveStorage.service_urls_expire_in,
       disposition: :attachment,
       content_type: blob.content_type,
       filename: blob.filename,
       thumb_size: "300x300",
       thumb_mode: "crop"
-    ]
-    assert_called_with(blob.service, :url, arguments) do
+    }
+    assert_called_with(blob.service, :url, arguments, **kwargs) do
       blob.url(thumb_size: "300x300", thumb_mode: "crop")
     end
   end
@@ -279,9 +282,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   test "updating the content_type updates service metadata" do
     blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
 
-    expected_arguments = [blob.key, content_type: "image/jpeg", custom_metadata: {}]
-
-    assert_called_with(blob.service, :update_metadata, expected_arguments) do
+    assert_called_with(blob.service, :update_metadata, [blob.key], content_type: "image/jpeg", custom_metadata: {}) do
       blob.update!(content_type: "image/jpeg")
     end
   end
@@ -290,16 +291,17 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
 
     expected_arguments = [
-      blob.key,
-      {
-        content_type: "application/octet-stream",
-        disposition: :attachment,
-        filename: blob.filename,
-        custom_metadata: { "test" => true }
-      }
+      blob.key
     ]
 
-    assert_called_with(blob.service, :update_metadata, expected_arguments) do
+    expected_kwargs = {
+      content_type: "application/octet-stream",
+      disposition: :attachment,
+      filename: blob.filename,
+      custom_metadata: { "test" => true }
+    }
+
+    assert_called_with(blob.service, :update_metadata, expected_arguments, **expected_kwargs) do
       blob.update!(metadata: { custom: { "test" => true } })
     end
   end

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -17,9 +17,9 @@ module ActiveSupport
           assert_equal times, times_called, error
         end
 
-        def assert_called_with(object, method_name, args, returns: nil, &block)
+        def assert_called_with(object, method_name, args, returns: false, **kwargs, &block)
           mock = Minitest::Mock.new
-          mock.expect(:call, returns, args)
+          expect_called_with(mock, args, returns: returns, **kwargs)
 
           object.stub(method_name, mock, &block)
 
@@ -28,6 +28,24 @@ module ActiveSupport
 
         def assert_not_called(object, method_name, message = nil, &block)
           assert_called(object, method_name, message, times: 0, &block)
+        end
+
+        #--
+        # This method is a temporary wrapper for mock.expect as part of
+        # the Minitest 5.16 / Ruby 3.0 kwargs transition. It can go away
+        # when we drop support for Ruby 2.7.
+        if Minitest::Mock.instance_method(:expect).parameters.map(&:first).include?(:keyrest)
+          def expect_called_with(mock, args, returns: false, **kwargs)
+            mock.expect(:call, returns, args, **kwargs)
+          end
+        else
+          def expect_called_with(mock, args, returns: false, **kwargs)
+            if !kwargs.empty?
+              mock.expect(:call, returns, [*args, kwargs])
+            else
+              mock.expect(:call, returns, args)
+            end
+          end
         end
 
         def assert_called_on_instance_of(klass, method_name, message = nil, times: 1, returns: nil)

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -175,7 +175,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     cache = lookup_store(raw: true, namespace: nil)
 
     Time.stub(:now, Time.now) do
-      assert_called_with client(cache), :set, [ "key_with_expires_at", "bar", 30 * 60, Hash ] do
+      assert_called_with client(cache), :set, ["key_with_expires_at", "bar", 30 * 60], namespace: nil, pool: false, raw: true, compress_threshold: 1024, expires_in: 1800.0 do
         cache.write("key_with_expires_at", "bar", expires_at: 30.minutes.from_now)
       end
     end
@@ -260,7 +260,8 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
   def test_unless_exist_expires_when_configured
     cache = lookup_store(namespace: nil)
-    assert_called_with client(cache), :add, [ "foo", Object, 1, Hash ] do
+
+    assert_called_with client(cache), :add, ["foo", Object, 1], namespace: nil, pool: false, compress_threshold: 1024, expires_in: 1, unless_exist: true do
       cache.write("foo", "bar", expires_in: 1, unless_exist: true)
     end
   end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -747,7 +747,7 @@ module ApplicationTests
 
       output = run_test_command(file)
 
-      assert_match "RuntimeError: Wrapped undumpable exception for: FailTest::BadError", output
+      assert_match(/RuntimeError: (Wrapped undumpable exception|result not reported)/, output)
       assert_match "1 runs, 0 assertions, 0 failures, 1 errors", output
     end
 


### PR DESCRIPTION
In minitest/minitest@6e06ac9 minitest changed such that it now accepts
`kwargs` instead of requiring kwargs to be shoved into the args array.
This is a good change but required some updates to our test code to get
the new version of minitest passing.

Changes are as follows:

1) Lock minitest to 5.15 for Ruby 2.7. We don't love this change but
it's pretty difficult to get 2.7 and 3.0 to play nicely together with
the new kwargs changes. Dropping 2.7 support isn't an option right
now for Rails. This is safe because all of the code changes here are
internal methods to Rails like assert_called_with. Applications
shouldn't be consuming them as they are no-doc'd.
2) Update the `assert_called_with` method to take any kwargs but also
the returns kwarg.
3) Update callers of `assert_called_with` to move the kwargs outside the
args array.
4) Update the message from marshaled exceptions. In 5.16 the exception
message is "result not reported" instead of "Wrapped undumpable
exception".

Co-authored-by: Matthew Draper <matthew@trebex.net>