### PR TITLE
Let sqlite `strict` config read from `database.yml` or config

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -32,9 +32,10 @@ module ActiveRecord
         Dir.mkdir(dirname) unless File.directory?(dirname)
       end
 
+      config[:strict] = ConnectionAdapters::SQLite3Adapter.strict_strings_by_default unless config.key?(:strict)
       db = SQLite3::Database.new(
         config[:database].to_s,
-        config.merge(results_as_hash: true, strict: ConnectionAdapters::SQLite3Adapter.strict_strings_by_default)
+        config.merge(results_as_hash: true)
       )
 
       ConnectionAdapters::SQLite3Adapter.new(db, logger, nil, config)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -635,6 +635,44 @@ module ActiveRecord
         end
       end
 
+      def test_strict_strings_by_default_and_true_in_database_yml
+        conn = Base.sqlite3_connection(database: ":memory:", adapter: "sqlite3", strict: true)
+        conn.create_table :testings
+
+        error = assert_raises(StandardError) do
+          conn.add_index :testings, :non_existent
+        end
+        assert_match(/no such column: non_existent/, error.message)
+
+        with_strict_strings_by_default do
+          conn = Base.sqlite3_connection(database: ":memory:", adapter: "sqlite3", strict: true)
+          conn.create_table :testings
+
+          error = assert_raises(StandardError) do
+            conn.add_index :testings, :non_existent2
+          end
+          assert_match(/no such column: non_existent2/, error.message)
+        end
+      end
+
+      def test_strict_strings_by_default_and_false_in_database_yml
+        conn = Base.sqlite3_connection(database: ":memory:", adapter: "sqlite3", strict: false)
+        conn.create_table :testings
+
+        assert_nothing_raised do
+          conn.add_index :testings, :non_existent
+        end
+
+        with_strict_strings_by_default do
+          conn = Base.sqlite3_connection(database: ":memory:", adapter: "sqlite3", strict: false)
+          conn.create_table :testings
+
+          assert_nothing_raised do
+            conn.add_index :testings, :non_existent
+          end
+        end
+      end
+
       private
         def assert_logged(logs)
           subscriber = SQLSubscriber.new


### PR DESCRIPTION
Per this discussion: https://github.com/rails/rails/pull/45346#discussion_r898376510

The adapter should read from `database.yml`, if a value is provided for `strict`. If no value is provided then it should fall back to `config.active_record.strict_strings_by_default`.

cc @fatkodima 