### PR TITLE
Allow running specific initializers (new framework defaults) earlier in the boot sequence

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -11,10 +11,8 @@ module ActiveSupport
     config.eager_load_namespaces << ActiveSupport
 
     initializer "active_support.isolation_level" do |app|
-      config.after_initialize do
-        if level = app.config.active_support.delete(:isolation_level)
-          ActiveSupport::IsolatedExecutionState.isolation_level = level
-        end
+      if level = app.config.active_support.delete(:isolation_level)
+        ActiveSupport::IsolatedExecutionState.isolation_level = level
       end
     end
 
@@ -28,11 +26,9 @@ module ActiveSupport
     end
 
     initializer "active_support.set_authenticated_message_encryption" do |app|
-      config.after_initialize do
-        unless app.config.active_support.use_authenticated_message_encryption.nil?
-          ActiveSupport::MessageEncryptor.use_authenticated_message_encryption =
-            app.config.active_support.use_authenticated_message_encryption
-        end
+      unless app.config.active_support.use_authenticated_message_encryption.nil?
+        ActiveSupport::MessageEncryptor.use_authenticated_message_encryption =
+          app.config.active_support.use_authenticated_message_encryption
       end
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,7 +21,7 @@ module Rails
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :rake_eager_load, :server_timing, :log_file_size
+                    :rake_eager_load, :server_timing, :log_file_size, :eager_load_initializers
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -80,6 +80,7 @@ module Rails
         @permissions_policy                      = nil
         @rake_eager_load                         = false
         @server_timing                           = false
+        @eager_load_initializers                 = nil
       end
 
       # Loads default configuration values for a target version. This includes
@@ -257,6 +258,7 @@ module Rails
           load_defaults "7.0"
 
           self.add_autoload_paths_to_load_path = false
+          self.eager_load_initializers = /new_framework_defaults/
 
           if Rails.env.development? || Rails.env.test?
             self.log_file_size = (100 * 1024 * 1024)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -556,9 +556,14 @@ module Rails
       run_callbacks(:load_seed) { load(seed_file) } if seed_file
     end
 
-    initializer :load_environment_config, before: :load_environment_hook, group: :all do
+    initializer :load_environment_config, before: :load_environment_hook, group: :all do |app|
       paths["config/environments"].existent.each do |environment|
         require environment
+      end
+      if app.config.eager_load_initializers
+        paths["config/initializers"].existent.select { |f| f.match(config.eager_load_initializers) }.each do |initializer|
+          require initializer
+        end
       end
     end
 


### PR DESCRIPTION
**Context**

Numerous recent PRs have been around fixing load order for initializers. https://github.com/rails/rails/issues/45105 discusses the issue, some recent examples are https://github.com/rails/rails/pull/45372 and https://github.com/rails/rails/pull/44980.

A common pattern is:

- The config is ignored if it's set in `new_framework_defaults`
- A fix is adding `config.after_initialize` to the framework initializer

**Proposal**

Rather than introducing a [new directory structure](https://github.com/rails/rails/pull/44996), the proposal here is to recognise that `new_framework_defaults_` is a "special" file, that should be run earlier in the boot sequence than other initializers.

A configuration, `config.eager_load_initializers`, is introduced. On 7.1 it will default to `/new_framework_defaults/`. Any files in `config/initializers` that match that regex will be required immediately after `config/environments`. This is significantly before other initializers, so the idea is that you can do all your framework configuration (`application.rb`, `config/environments`, `config/initializers/new_framework_defaults_xx.rb` at once).

Note that this doesn't replace https://github.com/rails/rails/pull/45297 which I think is also a good idea for a safety net. But it should mean that the errors that PR is trying to catch will happen a lot less with first party code.

**This PR**

In this PR I've changed some exising railties and tests to demonstrate how this works, if this proposal gets a :+1: I'd need to polish it a bit more, since ideally those railties would still need to work even if users don't adopt this config.

The **big** benefit of this PR is it will make it much harder that future Rails developers to forget to write the initializer correctly. For example, https://github.com/rails/rails/pull/45372 wouldn't be necessary with this change (note how I've added the tests from that PR and they pass without the code changes in that PR).
