### PR TITLE
Use suggested version of note [ci-skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -28,7 +28,7 @@ INFO: You can install the rails gem by typing `gem install rails`, if you don't 
 The first argument we'll pass to the `rails new` command is the application name.
 
 ```bash
-$ rails new commandsapp
+$ rails new my_app
      create
      create  README.md
      create  Rakefile
@@ -65,7 +65,7 @@ If you wish to skip some files from being generated or skip some libraries, you 
 | `--skip-system-test`    | Skip system test files                                      |
 | `--skip-bootsnap`       | Skip bootsnap gem                                           |
 
-These are just some of the options you can append to `rails new`. For a comprehensive list of options, type `rails new --help`.
+These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`.
 
 ### Preconfigure a Different Database
 
@@ -178,7 +178,7 @@ The `bin/rails server` command launches a web server named Puma which comes bund
 With no further work, `bin/rails server` will run our new shiny Rails app:
 
 ```bash
-$ cd commandsapp
+$ cd my_app
 $ bin/rails server
 => Booting Puma
 => Rails 7.0.0 application starting in development
@@ -510,7 +510,7 @@ RubyGems version          2.7.3
 Rack version              2.0.4
 JavaScript Runtime        Node.js (V8)
 Middleware:               Rack::Sendfile, ActionDispatch::Static, ActionDispatch::Executor, ActiveSupport::Cache::Strategy::LocalCache::Middleware, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, ActionDispatch::RemoteIp, Sprockets::Rails::QuietAssets, Rails::Rack::Logger, ActionDispatch::ShowExceptions, WebConsole::Middleware, ActionDispatch::DebugExceptions, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, Rack::Head, Rack::ConditionalGet, Rack::ETag
-Application root          /home/foobar/commandsapp
+Application root          /home/foobar/my_app
 Environment               development
 Database adapter          sqlite3
 Database schema version   20180205173523

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -95,7 +95,7 @@ For starters, it helps just to verify bug reports. Can you reproduce the reporte
 
 If an issue is very vague, can you help narrow it down to something more specific? Maybe you can provide additional information to reproduce the bug, or maybe you can eliminate unnecessary steps that aren't required to demonstrate the problem.
 
-If you find a bug report without a test, it's very useful to contribute a failing test. This is also a great way to explore the source code: looking at the existing test files will teach you how to write more tests. New tests are best contributed in the form of a patch, as explained later on in the "[Contributing to the Rails Code](#contributing-to-the-rails-code)" section.
+If you find a bug report without a test, it's very useful to contribute a failing test. This is also a great way to explore the source code: looking at the existing test files will teach you how to write more tests. New tests are best contributed in the form of a patch, as explained later on in the [Contributing to the Rails Code](#contributing-to-the-rails-code) section.
 
 Anything you can do to make bug reports more succinct or easier to reproduce helps folks trying to write code to fix those bugs - whether you end up writing the code yourself or not.
 


### PR DESCRIPTION
my_app seems to be what Rails docs use mostly. Changed it for some
consistency

@jonathanhefner I missed you made a better suggestion on sentencing. Fixing it here, I didn't ignore it on purpose.

Talking about the "These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`." part :)