### PR TITLE
Connections Map changed to Each in ping task

### DIFF
--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -24,7 +24,7 @@ module ActionCable
       # disconnect.
       def setup_heartbeat_timer
         @heartbeat_timer ||= event_loop.timer(BEAT_INTERVAL) do
-          event_loop.post { connections.map(&:beat) }
+          event_loop.post { connections.each(&:beat) }
         end
       end
 


### PR DESCRIPTION
No need to make new array containing all connections because returned value of map is not used.

New array of size of connections was allocated every BEAT_INTERVAL (default 3 seconds) for garbage collector to clean up right after.