### PR TITLE
Add `Arel.safe` and `Arel::SafeValue` to handle quoting edge cases

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Arel.safe()` to bypass quoting and to pass through known safe values.
+
+    *Kevin McPhillips*
+
 *   Add adapter option disallowing foreign keys
 
     This adds a new option to be added to `database.yml` which enables skipping

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -10,6 +10,7 @@ module ActiveRecord
       # {SQL injection attacks}[https://en.wikipedia.org/wiki/SQL_injection].
       def quote(value)
         case value
+        when Arel::Nodes::SqlLiteral then value
         when String, Symbol, ActiveSupport::Multibyte::Chars
           "'#{quote_string(value.to_s)}'"
         when true       then quoted_true

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -59,6 +59,12 @@ module ActiveRecord
       #
       #   sanitize_sql_for_order("id ASC")
       #   # => "id ASC"
+      #
+      # For cases where a value is being quoted for safety and it should not be, it can be marked
+      # as `Arel.safe`. This should only be used in cases where the data is known to be safe.
+      #
+      #   sanitize_sql_for_order([Arel.sql("field(val, ?)"), Arel.sql(999)])
+      #   # => "field(val, 999)"
       def sanitize_sql_for_order(condition)
         if condition.is_a?(Array) && condition.first.to_s.include?("?")
           disallow_raw_sql!(

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -5,14 +5,14 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Accepts an array or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for a WHERE clause.
+      # Accepts an array or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for a WHERE clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
-      #   # => "name='foo''bar' and group_id='4'"
+      #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id='4'"
@@ -29,8 +29,8 @@ module ActiveRecord
       end
       alias :sanitize_sql :sanitize_sql_for_conditions
 
-      # Accepts an array, hash, or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for a SET clause.
+      # Accepts an array, hash, or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for a SET clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
       #   # => "name=NULL and group_id=4"
@@ -39,7 +39,7 @@ module ActiveRecord
       #   # => "name=NULL and group_id=4"
       #
       #   Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
-      #   # => "`posts`.`name` = NULL, `posts`.`group_id` = 4"
+      #   # => "\"name\" = NULL, \"group_id\" = 4"
       #
       #   sanitize_sql_for_assignment("name=NULL and group_id='4'")
       #   # => "name=NULL and group_id='4'"
@@ -51,10 +51,10 @@ module ActiveRecord
         end
       end
 
-      # Accepts an array, or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for an ORDER clause.
+      # Accepts an array, or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for an ORDER clause, using the adapter of the current `connection`.
       #
-      #   sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1,3,2]])
+      #   sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
       #   # => "field(id, 1,3,2)"
       #
       #   sanitize_sql_for_order("id ASC")
@@ -78,10 +78,11 @@ module ActiveRecord
         end
       end
 
-      # Sanitizes a hash of attribute/value pairs into SQL conditions for a SET clause.
+      # Sanitizes a hash of attribute/value pairs into SQL conditions for a SET
+      # clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
-      #   # => "`posts`.`status` = NULL, `posts`.`group_id` = 1"
+      #   # => "\"status\" = NULL, \"group_id\" = 1"
       def sanitize_sql_hash_for_assignment(attrs, table)
         c = connection
         attrs.map do |attr, value|
@@ -114,8 +115,8 @@ module ActiveRecord
         string.gsub(/(?=[%_])/, escape_character)
       end
 
-      # Accepts an array of conditions. The array has each value
-      # sanitized and interpolated into the SQL statement.
+      # Accepts an array of conditions. The array has each value sanitized and interpolated into
+      # the SQL statement, valid for the adapter of the current `connection`
       #
       #   sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id=4"

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -28,28 +28,35 @@ require "arel/nodes"
 module Arel
   VERSION = "10.0.0"
 
-  # Wrap a known-safe SQL string for passing to query methods, e.g.
-  #
-  #   Post.order(Arel.sql("REPLACE(title, 'misc', 'zzzz') asc")).pluck(:id)
-  #
-  # Great caution should be taken to avoid SQL injection vulnerabilities.
-  # This method should not be used with unsafe values such as request
-  # parameters or model attributes.
-  def self.sql(raw_sql)
-    Arel::Nodes::SqlLiteral.new raw_sql
-  end
+  class << self
+    # Wrap a known-safe SQL string for passing to query methods, e.g.
+    #
+    #   Post.order(Arel.sql("REPLACE(title, 'misc', 'zzzz') asc")).pluck(:id)
+    #
+    # Wrap a known-save value to bypass sanitization, e.g.
+    #
+    #   Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [Arel.sql(1)]])
+    #
+    # Great caution should be taken to avoid SQL injection vulnerabilities.
+    # This method should not be used with unsafe values such as request
+    # parameters or model attributes.
+    def sql(raw)
+      Arel::Nodes::SqlLiteral.new(raw.to_s)
+    end
+    alias :safe :sql
 
-  def self.star # :nodoc:
-    sql "*"
-  end
+    def star # :nodoc:
+      sql "*"
+    end
 
-  def self.arel_node?(value) # :nodoc:
-    value.is_a?(Arel::Nodes::Node) || value.is_a?(Arel::Attribute) || value.is_a?(Arel::Nodes::SqlLiteral)
-  end
+    def arel_node?(value) # :nodoc:
+      value.is_a?(Arel::Nodes::Node) || value.is_a?(Arel::Attribute) || value.is_a?(Arel::Nodes::SqlLiteral)
+    end
 
-  def self.fetch_attribute(value, &block) # :nodoc:
-    unless String === value
-      value.fetch_attribute(&block)
+    def fetch_attribute(value, &block) # :nodoc:
+      unless String === value
+        value.fetch_attribute(&block)
+      end
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
@@ -41,13 +41,20 @@ class Mysql2SanitizeTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_sanitize_sql_for_order
-    skip "See https://github.com/rails/rails/issues/44312"
     actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, '1','3','2')" # this is invalid SQL but expected behaviour
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [Arel.sql(1), Arel.sql(3), Arel.sql(2)]])
     expected = "field(id, 1,3,2)"
     assert_equal expected, actual
 
     actual = Post.sanitize_sql_for_order("id ASC")
     expected = "id ASC"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(val, ?)"), Arel.sql(999)])
+    expected = "field(val, 999)"
     assert_equal expected, actual
   end
 

--- a/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class Mysql2SanitizeTest < ActiveRecord::Mysql2TestCase
+  def test_sanitize_sql_for_conditions
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "`posts`.`name` = NULL, `posts`.`group_id` = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order
+    skip "See https://github.com/rails/rails/issues/44312"
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "`posts`.`status` = NULL, `posts`.`group_id` = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
@@ -48,6 +48,10 @@ class PostgreSQLSanitizeTest < ActiveRecord::PostgreSQLTestCase
     actual = Post.sanitize_sql_for_order("id ASC")
     expected = "id ASC"
     assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(val, ?)"), Arel.sql(999)])
+    expected = "field(val, 999)"
+    assert_equal expected, actual
   end
 
   def test_sanitize_sql_hash_for_assignment

--- a/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class PostgreSQLSanitizeTest < ActiveRecord::PostgreSQLTestCase
+  def test_sanitize_sql_for_conditions
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "\"name\" = NULL, \"group_id\" = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "\"status\" = NULL, \"group_id\" = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
@@ -48,6 +48,10 @@ class SQLite3SanitizeTest < ActiveRecord::SQLite3TestCase
     actual = Post.sanitize_sql_for_order("id ASC")
     expected = "id ASC"
     assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(val, ?)"), Arel.sql(999)])
+    expected = "field(val, 999)"
+    assert_equal expected, actual
   end
 
   def test_sanitize_sql_hash_for_assignment

--- a/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class SQLite3SanitizeTest < ActiveRecord::SQLite3TestCase
+  def test_sanitize_sql_for_conditions
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "\"name\" = NULL, \"group_id\" = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "\"status\" = NULL, \"group_id\" = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end

--- a/activerecord/test/cases/arel_test.rb
+++ b/activerecord/test/cases/arel_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class ArelTest < ActiveRecord::TestCase
+  test ".sql returns a Arel::Nodes::SqlLiteral node" do
+    value = Arel.sql("FUNCTION()")
+    assert_kind_of Arel::Nodes::SqlLiteral, value
+    assert_equal "FUNCTION()", value
+  end
+
+  test ".safe returns a Arel::Nodes::SqlLiteral node" do
+    value = Arel.safe(12)
+    assert_kind_of Arel::Nodes::SqlLiteral, value
+    assert_equal "12", value
+  end
+
+  test ".star returns a Arel::Nodes::SqlLiteral '*'" do
+    value = Arel.star
+    assert_kind_of Arel::Nodes::SqlLiteral, value
+    assert_equal "*", value
+  end
+
+  test ".arel_node? checks if the object is an Arel node" do
+    assert Arel.arel_node?(Arel::Nodes::Node.new)
+    assert Arel.arel_node?(Arel::Attribute.new)
+    assert Arel.arel_node?(Arel::Nodes::SqlLiteral.new(""))
+    assert_not Arel.arel_node?(Object.new)
+  end
+
+  test ".fetch_attribute delegates to the value" do
+    mock = Minitest::Mock.new
+    mock.expect(:fetch_attribute, "value")
+    assert_equal "value", Arel.fetch_attribute(mock)
+  end
+
+  test ".fetch_attribute does not delegate if the value is String" do
+    assert_nil Arel.fetch_attribute("str")
+  end
+end


### PR DESCRIPTION
## Problem

Fixes #44312

In some cases, SQL sanitation adds quotes around values in ways that are incorrect or can produce invalid SQL. This behaviour is mostly desired because we wish to be safe by default, and assume passed in values are unsafe. There is however no built in mechanism to bypass this in cases where the values are known to be safe.

ex:
```ruby
ActiveRecord::Base.sanitize_sql(["LIMIT :offset, :per_page", { offset: 12, per_page: 32 }])
> "LIMIT '12', '32'"
```


## Solution

Add an `Arel::SafeValue` class which simply tells the query builder and sanitization to pass through the value without quoting. Add a helper `Arel.safe()` for brevity and discoverability.

ex:
```ruby
ActiveRecord::Base.sanitize_sql(["LIMIT :offset, :per_page", { offset: Arel.safe(12), per_page: Arel.safe(32) }])
> "LIMIT 12, 32"
```

In trying to write some failing test cases I found that most of [ActiveRecord::Sanitization](https://github.com/rails/rails/blob/7ac90d9ad75c50129850572ed6c7dcd42fecbf3b/activerecord/lib/active_record/sanitization.rb) is untested. [Only a subset of it has test coverage](https://github.com/rails/rails/blob/7ac90d9ad75c50129850572ed6c7dcd42fecbf3b/activerecord/test/cases/sanitize_test.rb), and much of that coverage is agnostic to the underlying connection adapter. This PR pulls in the tests from and closes #44429 (@rbgrouleff).

It is difficult to write good clear examples because *the behaviour of the sanitization depends on the underlying adapter that is currently selected*. That was not clearly reflected in the docs or in tests, but is now.

@byroot @casperisfine as the regression was introduced in #42440.