### PR TITLE
Remove the multi-call form of assert_called_with

### DIFF
--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -146,9 +146,15 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
   end
 
   def test_date_or_time_select_given_no_order_options_translates_order
-    assert_called_with(I18n, :translate, [ [:'date.order', locale: "en", default: []], [:"date.month_names", { locale: "en" }] ], returns: %w(year month day)) do
+    mock = Minitest::Mock.new
+    mock.expect(:call, ["year", "month", "day"], [:'date.order', { locale: "en", default: [] }])
+    mock.expect(:call, [], [:'date.month_names', { locale: "en" }])
+
+    I18n.stub(:translate, mock) do
       datetime_select("post", "updated_at", locale: "en")
     end
+
+    assert_mock(mock)
   end
 
   def test_date_or_time_select_given_invalid_order
@@ -160,8 +166,14 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
   end
 
   def test_date_or_time_select_given_symbol_keys
-    assert_called_with(I18n, :translate, [ [:'date.order', locale: "en", default: []], [:"date.month_names", { locale: "en" }] ], returns: [:year, :month, :day]) do
+    mock = Minitest::Mock.new
+    mock.expect(:call, [:year, :month, :day], [:'date.order', { locale: "en", default: [] }])
+    mock.expect(:call, [], [:'date.month_names', { locale: "en" }])
+
+    I18n.stub(:translate, mock) do
       datetime_select("post", "updated_at", locale: "en")
     end
+
+    assert_mock(mock)
   end
 end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -1766,14 +1766,20 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_nested_fields_label_translation_with_more_than_10_records
     @post.comments = Array.new(11) { |id| Comment.new(id + 1) }
 
-    params = 11.times.map { ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"] }
-    assert_called_with(I18n, :t, params, returns: "Write body here") do
+    mock = Minitest::Mock.new
+    @post.comments.each do
+      mock.expect(:call, "body", ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"])
+    end
+
+    I18n.stub(:t, mock) do
       form_with(model: @post) do |f|
         f.fields(:comments) do |cf|
           concat cf.label(:body)
         end
       end
     end
+
+    assert_mock(mock)
   end
 
   def test_nested_fields_with_existing_records_on_a_supplied_nested_attributes_collection_different_from_record_one

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3300,14 +3300,20 @@ class FormHelperTest < ActionView::TestCase
   def test_nested_fields_label_translation_with_more_than_10_records
     @post.comments = Array.new(11) { |id| Comment.new(id + 1) }
 
-    params = 11.times.map { ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"] }
-    assert_called_with(I18n, :t, params, returns: "Write body here") do
+    mock = Minitest::Mock.new
+    @post.comments.each do
+      mock.expect(:call, "body", ["post.comments.body", default: [:"comment.body", ""], scope: "helpers.label"])
+    end
+
+    I18n.stub(:t, mock) do
       form_for(@post) do |f|
         f.fields_for(:comments) do |cf|
           concat cf.label(:body)
         end
       end
     end
+
+    assert_mock(mock)
   end
 
   def test_nested_fields_for_with_existing_records_on_a_supplied_nested_attributes_collection_different_from_record_one

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -39,6 +39,16 @@ module ActiveRecord
     end
   end
 
+  module DatabaseTasksHelper
+    def assert_called_for_configs(method_name, configs, &block)
+      mock = Minitest::Mock.new
+      configs.each { |config| mock.expect(:call, nil, config) }
+
+      ActiveRecord::Tasks::DatabaseTasks.stub(method_name, mock, &block)
+      assert_mock(mock)
+    end
+  end
+
   ADAPTERS_TASKS = {
     mysql2:     :mysql_tasks,
     postgresql: :postgresql_tasks,
@@ -368,6 +378,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksCreateCurrentTest < ActiveRecord::TestCase
+    include DatabaseTasksHelper
+
     def setup
       @configurations = {
         "development" => { "database" => "dev-db" },
@@ -406,8 +418,7 @@ module ActiveRecord
 
     def test_creates_test_and_development_databases_when_env_was_not_specified
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("development", "primary")],
@@ -426,8 +437,7 @@ module ActiveRecord
       ENV["RAILS_ENV"] = "development"
 
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("development", "primary")],
@@ -449,8 +459,7 @@ module ActiveRecord
       ENV["SKIP_TEST_DATABASE"] = "true"
 
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("development", "primary")]
@@ -492,6 +501,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksCreateCurrentThreeTierTest < ActiveRecord::TestCase
+    include DatabaseTasksHelper
+
     def setup
       @configurations = {
         "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
@@ -502,8 +513,7 @@ module ActiveRecord
 
     def test_creates_current_environment_database
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("test", "primary")],
@@ -519,8 +529,7 @@ module ActiveRecord
 
     def test_creates_current_environment_database_with_url
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("production", "primary")],
@@ -536,8 +545,7 @@ module ActiveRecord
 
     def test_creates_test_and_development_databases_when_env_was_not_specified
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("development", "primary")],
@@ -558,8 +566,7 @@ module ActiveRecord
       ENV["RAILS_ENV"] = "development"
 
       with_stubbed_configurations_establish_connection do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :create,
           [
             [config_for("development", "primary")],
@@ -705,6 +712,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksDropCurrentTest < ActiveRecord::TestCase
+    include DatabaseTasksHelper
+
     def setup
       @configurations = {
         "development" => { "database" => "dev-db" },
@@ -743,8 +752,7 @@ module ActiveRecord
 
     def test_drops_test_and_development_databases_when_env_was_not_specified
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("development", "primary")],
@@ -763,8 +771,7 @@ module ActiveRecord
       ENV["RAILS_ENV"] = "development"
 
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("development", "primary")],
@@ -796,6 +803,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksDropCurrentThreeTierTest < ActiveRecord::TestCase
+    include DatabaseTasksHelper
+
     def setup
       @configurations = {
         "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
@@ -806,8 +815,7 @@ module ActiveRecord
 
     def test_drops_current_environment_database
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("test", "primary")],
@@ -823,8 +831,7 @@ module ActiveRecord
 
     def test_drops_current_environment_database_with_url
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("production", "primary")],
@@ -840,8 +847,7 @@ module ActiveRecord
 
     def test_drops_test_and_development_databases_when_env_was_not_specified
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("development", "primary")],
@@ -862,8 +868,7 @@ module ActiveRecord
       ENV["RAILS_ENV"] = "development"
 
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :drop,
           [
             [config_for("development", "primary")],
@@ -1236,6 +1241,8 @@ module ActiveRecord
   end
 
   class DatabaseTasksTruncateAllWithMultipleDatabasesTest < ActiveRecord::TestCase
+    include DatabaseTasksHelper
+
     def setup
       @configurations = {
         "development" => { "primary" => { "database" => "dev-db" }, "secondary" => { "database" => "secondary-dev-db" } },
@@ -1246,8 +1253,7 @@ module ActiveRecord
 
     def test_truncate_all_databases_for_environment
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :truncate_tables,
           [
             [config_for("test", "primary")],
@@ -1263,8 +1269,7 @@ module ActiveRecord
 
     def test_truncate_all_databases_with_url_for_environment
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :truncate_tables,
           [
             [config_for("production", "primary")],
@@ -1280,8 +1285,7 @@ module ActiveRecord
 
     def test_truncate_all_development_databases_when_env_is_not_specified
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :truncate_tables,
           [
             [config_for("development", "primary")],
@@ -1300,8 +1304,7 @@ module ActiveRecord
       ENV["RAILS_ENV"] = "development"
 
       with_stubbed_configurations do
-        assert_called_with(
-          ActiveRecord::Tasks::DatabaseTasks,
+        assert_called_for_configs(
           :truncate_tables,
           [
             [config_for("development", "primary")],

--- a/activerecord/test/cases/tasks/mysql_rake_test.rb
+++ b/activerecord/test/cases/tasks/mysql_rake_test.rb
@@ -26,18 +26,17 @@ if current_adapter?(:Mysql2Adapter)
       def test_establishes_connection_without_database
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
+        mock = Minitest::Mock.new
+        mock.expect(:call, nil, [adapter: "mysql2", database: nil])
+        mock.expect(:call, nil, [db_config])
+
         ActiveRecord::Base.stub(:connection, @connection) do
-          assert_called_with(
-            ActiveRecord::Base,
-            :establish_connection,
-            [
-              [adapter: "mysql2", database: nil],
-              [db_config]
-            ]
-          ) do
+          ActiveRecord::Base.stub(:establish_connection, mock) do
             ActiveRecord::Tasks::DatabaseTasks.create(db_config)
           end
         end
+
+        assert_mock(mock)
       end
 
       def test_creates_database_with_no_default_options

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -23,22 +23,17 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_establishes_connection_to_postgresql_database
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
+        mock = Minitest::Mock.new
+        mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+        mock.expect(:call, nil, [db_config])
+
         ActiveRecord::Base.stub(:connection, @connection) do
-          assert_called_with(
-            ActiveRecord::Base,
-            :establish_connection,
-            [
-              [
-                adapter: "postgresql",
-                database: "postgres",
-                schema_search_path: "public"
-              ],
-              [db_config]
-            ]
-          ) do
+          ActiveRecord::Base.stub(:establish_connection, mock) do
             ActiveRecord::Tasks::DatabaseTasks.create(db_config)
           end
         end
+
+        assert_mock(mock)
       end
 
       def test_creates_database_with_default_encoding
@@ -89,22 +84,17 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_establishes_connection_to_new_database
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
+        mock = Minitest::Mock.new
+        mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+        mock.expect(:call, nil, [db_config])
+
         ActiveRecord::Base.stub(:connection, @connection) do
-          assert_called_with(
-            ActiveRecord::Base,
-            :establish_connection,
-            [
-              [
-                adapter: "postgresql",
-                database: "postgres",
-                schema_search_path: "public"
-              ],
-              [db_config]
-            ]
-          ) do
+          ActiveRecord::Base.stub(:establish_connection, mock) do
             ActiveRecord::Tasks::DatabaseTasks.create(db_config)
           end
         end
+
+        assert_mock(mock)
       end
 
       def test_db_create_with_error_prints_message
@@ -229,22 +219,17 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_establishes_connection_to_postgresql_database
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
+        mock = Minitest::Mock.new
+        mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+        mock.expect(:call, nil, [db_config])
+
         with_stubbed_connection do
-          assert_called_with(
-            ActiveRecord::Base,
-            :establish_connection,
-            [
-              [
-                adapter: "postgresql",
-                database: "postgres",
-                schema_search_path: "public"
-              ],
-              [db_config]
-            ]
-          ) do
+          ActiveRecord::Base.stub(:establish_connection, mock) do
             ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
           end
         end
+
+        assert_mock(mock)
       end
 
       def test_drops_database
@@ -274,22 +259,17 @@ if current_adapter?(:PostgreSQLAdapter)
       def test_establishes_connection
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
+        mock = Minitest::Mock.new
+        mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
+        mock.expect(:call, nil, [db_config])
+
         with_stubbed_connection do
-          assert_called_with(
-            ActiveRecord::Base,
-            :establish_connection,
-            [
-              [
-                adapter: "postgresql",
-                database: "postgres",
-                schema_search_path: "public"
-              ],
-              [db_config]
-            ]
-          ) do
+          ActiveRecord::Base.stub(:establish_connection, mock) do
             ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
           end
         end
+
+        assert_mock(mock)
       end
 
       private

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -19,12 +19,7 @@ module ActiveSupport
 
         def assert_called_with(object, method_name, args, returns: nil, &block)
           mock = Minitest::Mock.new
-
-          if !args.empty? && args.all?(Array)
-            args.each { |argv| mock.expect(:call, returns, argv) }
-          else
-            mock.expect(:call, returns, args)
-          end
+          mock.expect(:call, returns, args)
 
           object.stub(method_name, mock, &block)
 

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -82,13 +82,6 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_assert_called_with_multiple_expected_arguments
-    assert_called_with(@object, :<<, [ [ 1 ], [ 2 ] ]) do
-      @object << 1
-      @object << 2
-    end
-  end
-
   def test_assert_called_on_instance_of_with_defaults_to_expect_once
     assert_called_on_instance_of Level, :increment do
       @object.increment

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -734,15 +734,19 @@ class ActionsTest < Rails::Generators::TestCase
       config_matcher = ->(actual_config) do
         assert_equal config, actual_config.slice(*config.keys)
       end if config
-      args = Array(commands).map do |command|
+
+      mock = Minitest::Mock.new
+
+      Array(commands).each do |command|
         command_matcher = Regexp.escape(command)
         command_matcher = command_matcher.sub(/^sudo\\ /, '\A\1.*')
-        [/#{command_matcher}\z/, *config_matcher]
+        args = [/#{command_matcher}\z/, *config_matcher]
+        mock.expect(:call, nil, args)
       end
 
-      assert_called_with(generator, :run, args) do
-        block.call
-      end
+      generator.stub(:run, mock, &block)
+
+      assert_mock(mock)
     end
 
     def assert_routes(*route_commands)


### PR DESCRIPTION
The `assert_called_with` helper allows passing a multi-dimensional array to
mock multiple calls to the same method for a given block. This works
fine now, but when adding support for real kwargs arguments to line up with
recent upgrades in Minitest, this approach is no longer workable because
we can't pass multiple sets of differing kwargs.

Rather than complicated this method further, this commit removes the
multi-call form of `assert_called_with` and modifies the tests that
currently make use of that functionality to just use the underlying
`Minitest::Mock` calls.

Co-authored-by: Eileen M. Uchitelle <eileencodes@gmail.com>

cc / @eileencodes 