### PR TITLE
Makes the inheritance_column api documentation visible [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -126,6 +126,27 @@ module ActiveRecord
     # +:immutable_string+. This setting does not affect the behavior of
     # <tt>attribute :foo, :string</tt>. Defaults to false.
 
+    ##
+    # :singleton-method: inheritance_column
+    # :call-seq: inheritance_column
+    #
+    # The name of the table column which stores the class name on single-table
+    # inheritance situations.
+    #
+    # The default inheritance column name is +type+, which means it's a
+    # reserved word inside Active Record. To be able to use single-table
+    # inheritance with another column name, or to use the column +type+ in
+    # your own model for something else, you can set +inheritance_column+:
+    #
+    #     self.inheritance_column = 'zoink'
+
+    ##
+    # :singleton-method: inheritance_column=
+    # :call-seq: inheritance_column=(column)
+    #
+    # Defines the name of the table column which will store the class name on single-table
+    # inheritance situations.
+
     included do
       class_attribute :primary_key_prefix_type, instance_writer: false
       class_attribute :table_name_prefix, instance_writer: false, default: ""
@@ -136,15 +157,6 @@ module ActiveRecord
       class_attribute :implicit_order_column, instance_accessor: false
       class_attribute :immutable_strings_by_default, instance_accessor: false
 
-      # Defines the name of the table column which will store the class name on single-table
-      # inheritance situations.
-      #
-      # The default inheritance column name is +type+, which means it's a
-      # reserved word inside Active Record. To be able to use single-table
-      # inheritance with another column name, or to use the column +type+ in
-      # your own model for something else, you can set +inheritance_column+:
-      #
-      #     self.inheritance_column = 'zoink'
       class_attribute :inheritance_column, instance_accessor: false, default: "type"
       singleton_class.class_eval do
         alias_method :_inheritance_column=, :inheritance_column=


### PR DESCRIPTION
### Summary

This PR makes the inheritance_column searchable in the api documentation.

When trying to configure Single table inheritance for a model. I knew I could configure the column name. I couldn't find it in the api search bar. I expected to find it using the _inheritance_ word.
The `inheritance_column` is mentioned here  https://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html.

The current '_inheritance_' search yields
![image](https://user-images.githubusercontent.com/1558372/174113190-dc4032d2-1200-4063-a5a5-de7b2854c3a1.png)

With this change it yields
![image](https://user-images.githubusercontent.com/1558372/174113315-914177bc-cf88-4af2-ad2e-8a27db71ffc2.png)

