### PR TITLE
Scaffold destroy action returns status code 303

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -486,7 +486,7 @@ class LoginsController < ApplicationController
     session.delete(:current_user_id)
     # Clear the memoized current user
     @_current_user = nil
-    redirect_to root_url
+    redirect_to root_url, status: :see_other
   end
 end
 ```
@@ -508,7 +508,7 @@ class LoginsController < ApplicationController
   def destroy
     session.delete(:current_user_id)
     flash[:notice] = "You have successfully logged out."
-    redirect_to root_url
+    redirect_to root_url, status: :see_other
   end
 end
 ```

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Send 303 See Other status code back for the destroy action on newly generated
+    scaffold controllers.
+
+    *Tony Drake*
+
 *   Add `Rails.application.deprecators` as a central point to manage deprecators
     for an application.
 

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def destroy
     @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>
+    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
   end
 
   private

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -44,6 +44,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :destroy, content do |m|
         assert_match(/@user\.destroy/, m)
         assert_match(/User was successfully destroyed/, m)
+        assert_match(/status: :see_other/, m)
       end
 
       assert_instance_method :set_user, content do |m|


### PR DESCRIPTION
### Summary

The default controller scaffolding currently sends back a 302 for its destroy action.

Since Hotwire is the default for Rails going forward, this can be problimatic. Turbo uses the fetch API internally which is particular on how it handles redirects.

As outlined in this table in this Turbo issue, https://github.com/hotwired/turbo/issues/84#issuecomment-862656931, Turbo making a DELETE request (not POST + hidden _method field) and recieving a 303 back will result in another DELETE request instead of a GET request for the redirect.

This updates the controller template used for the scaffold generator to send back the 302 see other for the destroy action.

### Other Information

For consistancy-sake, the Action Controller Overview guide examples were also updated. The main Getting Started guide page already has see other used in its example destroy action.

For non-Hotwire users, the browser will still properly redirect on a 303 as it does with a 302.