### PR TITLE
Adding Backward compatibility

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "i18n",       ">= 0.7", "< 2"
   s.add_dependency "tzinfo",     "~> 1.1"
-  s.add_dependency "minitest",   "~> 5.1"
+  s.add_dependency "minitest",   "> 5.1"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
 end


### PR DESCRIPTION
 **Summary**
Minitest upgraded to 5.16 in June 2022 which requires ruby >= 2.6, This is a breaking change and broking existing applications that are using rails 5.2.3 and ruby version >2.5 and <2.6.

`ERROR: Error installing rails:
minitest requires Ruby version < 4.0, >= 2.6. The current ruby version is 2.5.0.`

can we do suggested change in dependency, it will provide Backward compatibility.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
