### PR TITLE
Update Contributing to Ruby on Rails guide to specify that rails-dev-box will not work with any Apple silicon Mac

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -198,7 +198,7 @@ If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](htt
 
 #### Using rails-dev-box
 
-It's also possible to use the [rails-dev-box](https://github.com/rails/rails-dev-box) to get a development environment ready. However, the rails-dev-box uses Vagrant and Virtual Box which will not work with the M1 processors.
+It's also possible to use the [rails-dev-box](https://github.com/rails/rails-dev-box) to get a development environment ready. However, the rails-dev-box uses Vagrant and Virtual Box which will not work on Macs with Apple silicon.
 
 #### Local Development
 


### PR DESCRIPTION
### Summary

Currently the "Contributing to Ruby on Rails" guide specifies that `rails-dev-box` won't work with M1 Macs, but this is actually true of any Mac with Apple silicon including M1 Pro/Max/Ultra and the new M2 Macs.

I reworded this part of the guide to be more future-proof, as otherwise it may need to be updated for any future Apple silicon Macs (i.e. M3, M4) to specify that `rails-dev-box` will not work for them.