### PR TITLE
Fix string interpolation in testing guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1559,7 +1559,7 @@ One good place to store them is `test/lib` or `test/test_helpers`.
 # test/test_helpers/multiple_assertions.rb
 module MultipleAssertions
   def assert_multiple_of_forty_two(number)
-    assert (number % 42 == 0), 'expected #{number} to be a multiple of 42'
+    assert (number % 42 == 0), "expected #{number} to be a multiple of 42"
   end
 end
 ```


### PR DESCRIPTION
### Summary

Fix string interpolation in testing guide: example now produces the expected output in the terminal instead of `expected #{number} to be a multiple of 42`.