### PR TITLE
Add `redirect_code_for_unsafe_http_methods` config

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Add `config.action_controller.redirect_code_for_unsafe_http_methods`
+
+    When a client follows an HTTP 302 redirect, it will typically use the same
+    HTTP method as the original request.  This can cause issues when, for
+    example, redirecting an XHR `DELETE` request after a `destroy`.
+
+    The solution so far has been to specify an explicit response code in such
+    cases.  For example:
+
+      ```ruby
+      def destroy
+        Post.destroy(params[:id])
+        redirect_to root_path, status: 303
+      end
+      ```
+
+    The `config.action_controller.redirect_code_for_unsafe_http_methods` setting
+    allows specifying a default HTTP response code to use when redirecting a
+    request made with an [unsafe HTTP method][], such as `POST` or `DELETE`.
+    For example, when set to 303, the explicit response code may be omitted:
+
+      ```ruby
+      def destroy
+        Post.destroy(params[:id])
+        redirect_to root_path
+      end
+      ```
+
+    This setting defaults to `303` when using `config.load_defaults 7.1`.
+
+    [unsafe HTTP method]: https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP
+
+    *Jonathan Hefner*
+
 *   Add the following permissions policy directives: `hid`, `idle-detection`, `screen-wake-lock`,
     `serial`, `sync-xhr`, `web-share`.
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -11,6 +11,7 @@ module ActionController
   class Railtie < Rails::Railtie # :nodoc:
     config.action_controller = ActiveSupport::OrderedOptions.new
     config.action_controller.raise_on_open_redirects = false
+    config.action_controller.redirect_code_for_unsafe_http_methods = 302
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -127,6 +127,8 @@ module ActionDispatch
 
     HTTP_METHODS = RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789
 
+    SAFE_HTTP_METHODS = %w(GET HEAD OPTIONS SEARCH)
+
     HTTP_METHOD_LOOKUP = {}
 
     # Populate the HTTP method lookup cache.
@@ -213,6 +215,13 @@ module ActionDispatch
     # Returns a symbol form of the #method.
     def method_symbol
       HTTP_METHOD_LOOKUP[method]
+    end
+
+    # Returns true if #method is a safe HTTP method. A safe HTTP method
+    # indicates that the request should not alter the state of the server. For
+    # example, +GET+ is safe, but +POST+ is not.
+    def method_safe? # :nodoc:
+      SAFE_HTTP_METHODS.include?(method)
     end
 
     # Provides access to the request's HTTP headers, for example:

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -222,6 +222,19 @@ class RedirectTest < ActionController::TestCase
     assert_equal "http://test.host/redirect/hello_world", redirect_to_url
   end
 
+  def test_redirect_with_no_status_using_unsafe_http_method
+    post :simple_redirect
+    assert_response 302
+
+    original_redirect_code_for_unsafe_http_methods = ActionController::Base.redirect_code_for_unsafe_http_methods
+    ActionController::Base.redirect_code_for_unsafe_http_methods = 303
+
+    post :simple_redirect
+    assert_response 303
+  ensure
+    ActionController::Base.redirect_code_for_unsafe_http_methods = original_redirect_code_for_unsafe_http_methods
+  end
+
   def test_redirect_with_status
     get :redirect_with_status
     assert_response 301

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -486,7 +486,7 @@ class LoginsController < ApplicationController
     session.delete(:current_user_id)
     # Clear the memoized current user
     @_current_user = nil
-    redirect_to root_url, status: :see_other
+    redirect_to root_url
   end
 end
 ```
@@ -508,7 +508,7 @@ class LoginsController < ApplicationController
   def destroy
     session.delete(:current_user_id)
     flash[:notice] = "You have successfully logged out."
-    redirect_to root_url, status: :see_other
+    redirect_to root_url
   end
 end
 ```

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,6 +61,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 7.1
 
 - [`config.action_controller.allow_deprecated_parameters_hash_equality`](#config-action-controller-allow-deprecated-parameters-hash-equality): `false`
+- [`config.action_controller.redirect_code_for_unsafe_http_methods`](#config-action-controller-redirect-code-for-unsafe-http-methods): `303`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.active_job.use_big_decimal_serializer`](#config-active-job-use-big-decimal-serializer): `true`
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
@@ -1374,6 +1375,29 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.0                   | `true`               |
+
+#### `config.action_controller.redirect_code_for_unsafe_http_methods`
+
+The default HTTP response code to send when redirecting a request made with an
+[unsafe HTTP method](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP),
+such as `POST` or `DELETE`. This can be overridden on a per-request basis by
+passing a `:status` option to [`redirect_to`](
+https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to)
+et al.
+
+For most unsafe HTTP methods, a response code of `302` will cause the browser to
+use the same HTTP method when following the redirect. A response code of `303`
+will cause the browser to use `GET` instead.
+
+WARNING: Changing this value in a previously-deployed application could break
+any non-browser HTTP clients that expect the old response code.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `302`                |
+| 7.1                   | `303`                |
 
 #### `config.action_controller.log_query_tags_around_actions`
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1247,7 +1247,7 @@ class ArticlesController < ApplicationController
     @article = Article.find(params[:id])
     @article.destroy
 
-    redirect_to root_path, status: :see_other
+    redirect_to root_path
   end
 
   private
@@ -1259,8 +1259,7 @@ end
 
 The `destroy` action fetches the article from the database, and calls [`destroy`](
 https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-destroy)
-on it. Then, it redirects the browser to the root path with status code
-[303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303).
+on it. Then, it redirects the browser to the root path.
 
 We have chosen to redirect to the root path because that is our main access
 point for articles. But, in other circumstances, you might choose to redirect to
@@ -1981,7 +1980,7 @@ class CommentsController < ApplicationController
     @article = Article.find(params[:article_id])
     @comment = @article.comments.find(params[:id])
     @comment.destroy
-    redirect_to article_path(@article), status: :see_other
+    redirect_to article_path(@article)
   end
 
   private

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -297,6 +297,39 @@ Option `config.action_mailer.preview_path` is deprecated in favor of `config.act
 config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
 ```
 
+### `redirect_code_for_unsafe_http_methods` setting
+
+[`config.action_controller.redirect_code_for_unsafe_http_methods`][] allows you
+to set the default HTTP response code that Rails will send when redirecting a
+request made with an [unsafe HTTP method](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP),
+such as `POST` or `DELETE`.
+
+Previously, the default HTTP response code was always `302`. With
+`config.load_defaults 7.1` (or higher), the default HTTP response code for
+unsafe HTTP methods is `303`.
+
+Note that using a `303` response code in a previously-deployed application
+**could break any non-browser HTTP clients that expect the old `302` response
+code.** If you need to continue supporting such clients, you can set
+`redirect_code_for_unsafe_http_methods` explicitly:
+
+```ruby
+# config/application.rb
+config.load_defaults 7.1
+config.action_controller.redirect_code_for_unsafe_http_methods = 302
+```
+
+Alternatively, you can set `redirect_code_for_unsafe_http_methods` on a
+per-controller basis:
+
+```ruby
+class PostsController < ApplicationController
+  self.redirect_code_for_unsafe_http_methods = 302
+end
+```
+
+[`config.action_controller.redirect_code_for_unsafe_http_methods`]: configuring.html#config-action-controller-redirect-code-for-unsafe-http-methods
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,8 +1,3 @@
-*   Send 303 See Other status code back for the destroy action on newly generated
-    scaffold controllers.
-
-    *Tony Drake*
-
 *   Add `Rails.application.deprecators` as a central point to manage deprecators
     for an application.
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -312,6 +312,7 @@ module Rails
 
           if respond_to?(:action_controller)
             action_controller.allow_deprecated_parameters_hash_equality = false
+            action_controller.redirect_code_for_unsafe_http_methods = 303
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -29,6 +29,13 @@
 # as equal to an equivalent `Hash` by default.
 # Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
+# Use HTTP 303 as the default response code when redirecting a request made with
+# an unsafe HTTP method, such as `POST` or `DELETE`.
+#
+# Note that using a 303 response code in a previously-deployed application could
+# break any non-browser HTTP clients that expect the old 302 response code.
+# Rails.application.config.action_controller.redirect_code_for_unsafe_http_methods = 303
+
 # No longer run after_commit callbacks on the first of multiple Active Record
 # instances to save changes to the same database row within a transaction.
 # Instead, run these callbacks on the instance most likely to have internal

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def destroy
     @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
+    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>
   end
 
   private

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1422,6 +1422,32 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_open_redirects
     end
 
+    test "ActionController::Base.redirect_code_for_unsafe_http_methods is 303 by default for new apps" do
+      app "development"
+
+      assert_equal 303, ActionController::Base.redirect_code_for_unsafe_http_methods
+    end
+
+    test "ActionController::Base.redirect_code_for_unsafe_http_methods is 302 by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app "development"
+
+      assert_equal 302, ActionController::Base.redirect_code_for_unsafe_http_methods
+    end
+
+    test "ActionController::Base.redirect_code_for_unsafe_http_methods can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
+        Rails.application.config.action_controller.redirect_code_for_unsafe_http_methods = 303
+      RUBY
+
+      app "development"
+
+      assert_equal 303, ActionController::Base.redirect_code_for_unsafe_http_methods
+    end
+
     test "config.action_dispatch.show_exceptions is sent in env" do
       make_basic_app do |application|
         application.config.action_dispatch.show_exceptions = true

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -44,7 +44,6 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :destroy, content do |m|
         assert_match(/@user\.destroy/, m)
         assert_match(/User was successfully destroyed/, m)
-        assert_match(/status: :see_other/, m)
       end
 
       assert_instance_method :set_user, content do |m|


### PR DESCRIPTION
When a client follows an HTTP 302 redirect, it will typically use the same HTTP method as the original request.  This can cause issues when, for example, redirecting an XHR `DELETE` request after a `destroy`.  (Note that many clients make an exception for `POST`, and will use `GET` to follow a 302 redirect in that case.)

The solution so far has been for users to specify an explicit response code in such cases.  For example:

```ruby
def destroy
  Post.destroy(params[:id])
  redirect_to root_path, status: 303
end
```

This commit adds a `redirect_code_for_unsafe_http_methods` configuration setting that allows users to specify a default HTTP response code to use when redirecting a request made with an [unsafe HTTP method][], such as `POST` or `DELETE`.  For example, when set to 303, the explicit response code may be omitted:

```ruby
def destroy
  Post.destroy(params[:id])
  redirect_to root_path
end
```

[unsafe HTTP method]: https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP
