### PR TITLE
Add link to Edge Guides [ci-skip]

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -12,6 +12,7 @@
 <p>
   These are the new guides for Rails 7.1 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
+  You can find Edge Guides <a href="https://edgeguides.rubyonrails.org/">here</a>.
 </p>
 <% end %>
 <p>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -33,7 +33,6 @@
       </span>
       <ul class="more-info-links s-hidden">
         <li class="more-info"><a href="https://rubyonrails.org/blog">Blog</a></li>
-        <li class="more-info"><a href="https://guides.rubyonrails.org/">Guides</a></li>
         <li class="more-info"><a href="https://api.rubyonrails.org/">API</a></li>
         <li class="more-info"><a href="https://discuss.rubyonrails.org/">Forum</a></li>
         <li class="more-info"><a href="https://github.com/rails/rails">Contribute on GitHub</a></li>


### PR DESCRIPTION
Remove guides link from the guides page unless I'm missing why
the guides page links to itself

### Summary

Provide easy access to Edge Guides.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
