### PR TITLE
docs: Fix breaking code block formatting

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -100,7 +100,8 @@ The `MessageEncryptor` offers the ability to migrate the default serializer from
 If you would like to ignore this change in existing applications, set the following: `config.active_support.default_message_encryptor_serializer = :marshal`.
 
 In order to roll out the new default when upgrading from `7.0` to `7.1`, there are three configuration variables to keep in mind.
-```
+
+```ruby
 config.active_support.default_message_encryptor_serializer
 config.active_support.fallback_to_marshal_deserialization
 config.active_support.use_marshal_serialization
@@ -109,6 +110,7 @@ config.active_support.use_marshal_serialization
 `default_message_encryptor_serializer` defaults to `:json` as of `7.1` but it offers both a `:hybrid` and `:marshal` option.
 
 In order to migrate an older deployment to `:json`, first ensure that the `default_message_encryptor_serializer` is set to `:marshal`.
+
 ```ruby
 # config/application.rb
 config.load_defaults 7.0
@@ -137,6 +139,7 @@ config.active_support.use_marshal_serialization = false
 Allow this configuration to run on all processes for a considerable amount of time.
 `ActiveSupport::JsonWithMarshalFallback` logs the following each time the `Marshal` fallback
 is used:
+
 ```
 JsonWithMarshalFallback: Marshal load fallback occurred.
 ```
@@ -164,6 +167,7 @@ config.active_support.default_message_encryptor_serializer = :json
 ```
 
 Alternatively, you could load defaults for 7.1
+
 ```ruby
 # config/application.rb
 config.load_defaults 7.1
@@ -179,7 +183,8 @@ The `MessageVerifier` offers the ability to migrate the default serializer from 
 If you would like to ignore this change in existing applications, set the following: `config.active_support.default_message_verifier_serializer = :marshal`.
 
 In order to roll out the new default when upgrading from `7.0` to `7.1`, there are three configuration variables to keep in mind.
-```
+
+```ruby
 config.active_support.default_verifier_serializer
 config.active_support.fallback_to_marshal_deserialization
 config.active_support.use_marshal_serialization
@@ -188,6 +193,7 @@ config.active_support.use_marshal_serialization
 `default_message_verifier_serializer` defaults to `:json` as of `7.1` but it offers both a `:hybrid` and `:marshal` option.
 
 In order to migrate an older deployment to `:json`, first ensure that the `default_message_verifier_serializer` is set to `:marshal`.
+
 ```ruby
 # config/application.rb
 config.load_defaults 7.0
@@ -216,6 +222,7 @@ config.active_support.use_marshal_serialization = false
 Allow this configuration to run on all processes for a considerable amount of time.
 `ActiveSupport::JsonWithMarshalFallback` logs the following each time the `Marshal` fallback
 is used:
+
 ```
 JsonWithMarshalFallback: Marshal load fallback occurred.
 ```
@@ -243,6 +250,7 @@ config.active_support.default_message_verifier_serializer = :json
 ```
 
 Alternatively, you could load defaults for 7.1
+
 ```ruby
 # config/application.rb
 config.load_defaults 7.1


### PR DESCRIPTION
### Summary

The code block formatting breaks due to a missing new line.
Attaching the screenshots 

## Screenshot 1 

<img width="691" alt="Screenshot 2022-06-18 at 10 57 26" src="https://user-images.githubusercontent.com/14993828/174424251-18c3d588-d8f6-450b-9970-c32fa256c7a9.png">

## Screenshot 2
<img width="677" alt="Screenshot 2022-06-18 at 10 57 14" src="https://user-images.githubusercontent.com/14993828/174424551-91b0691b-69bc-45a6-98b3-982b265ef863.png">

https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-messageencryptor-default-serializer

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
