### PR TITLE
Make ActiveStorage attach method be consistent between one and many

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Method `attach` always returns the attachments except when the record
+    is persisted, unchanged, and saving it fails, in which case it returns `nil`.
+
+    *Santiago Bartesaghi*
+
 *   Fixes multiple `attach` calls within transaction not uploading files correctly.
 
     In the following example, the code failed to upload all but the last file to the configured service.

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -48,7 +48,9 @@ module ActiveStorage
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
       record.public_send("#{name}=", blobs + attachables.flatten)
-      return false if record.persisted? && !record.changed? && !record.save
+      if record.persisted? && !record.changed?
+        return if !record.save
+      end
       record.public_send("#{name}")
     end
 

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -54,16 +54,11 @@ module ActiveStorage
     #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
     def attach(attachable)
+      record.public_send("#{name}=", attachable)
       if record.persisted? && !record.changed?
-        record.public_send("#{name}=", attachable)
-        if record.save
-          record.public_send("#{name}")
-        else
-          false
-        end
-      else
-        record.public_send("#{name}=", attachable)
+        return if !record.save
       end
+      record.public_send("#{name}")
     end
 
     # Returns +true+ if an attachment has been made.

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -68,12 +68,29 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
-  test "attaching a blob to a record returns the attachment" do
-    avatar = @user.avatar.attach create_blob(filename: "funky.jpg")
-    assert_instance_of ActiveStorage::Attached::One, avatar
-    assert_equal avatar.key, @user.avatar.key
-    assert_equal avatar.name.to_s, @user.avatar.name.to_s
-    assert_equal avatar.filename.to_s, @user.avatar.filename.to_s
+  test "attaching a blob to a persisted, unchanged, and valid record, returns the attachment" do
+    return_value = @user.avatar.attach create_blob(filename: "funky.jpg")
+    assert_equal @user.avatar, return_value
+  end
+
+  test "attaching a blob to a persisted, unchanged, and invalid record, returns nil" do
+    @user.update_attribute(:name, nil)
+    assert_not @user.valid?
+
+    return_value = @user.avatar.attach create_blob(filename: "funky.jpg")
+    assert_nil return_value
+  end
+
+  test "attaching a blob to a changed record, returns the attachment" do
+    @user.name = "Tina"
+    return_value = @user.avatar.attach create_blob(filename: "funky.jpg")
+    assert_equal @user.avatar, return_value
+  end
+
+  test "attaching a blob to a non persisted record, returns the attachment" do
+    user = User.new(name: "John")
+    return_value = user.avatar.attach create_blob(filename: "funky.jpg")
+    assert_equal user.avatar, return_value
   end
 
   test "attaching an existing blob to an existing, changed record" do


### PR DESCRIPTION
### Summary

After the code change done [#45345 ](https://github.com/rails/rails/pull/45345#discussion_r899472836) I realized that `ActiveStorage::Attached::One` had a very similar `attach` method to `ActiveStorage::Attached::Many#attach`. Given that it's not just a refactor and that the return value was changed for some branches, it'd be good to have them be consistent.

cc @jonathanhefner 


question: do we want to add tests for the return values for all the branches? I guess it'd help "documenting" how the method behaves