### PR TITLE
Set `skip_dev_gems` to be a `class_option`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `--skip-dev-gems` option to app generator to skip adding development
+    gems (like `web-console`) to the Gemfile.
+
+    *Brad Trick*
+
 *   Skip Active Storage and Action Mailer if Active Job is skipped.
 
     *Étienne Barrié*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -84,6 +84,9 @@ module Rails
         class_option :skip_bootsnap,       type: :boolean, default: false,
                                            desc: "Skip bootsnap gem"
 
+        class_option :skip_dev_gems,       type: :boolean, default: false,
+                                           desc: "Skip development gems (e.g., web-console)"
+
         class_option :dev,                 type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -236,10 +239,6 @@ module Rails
 
       def skip_action_text? # :doc:
         options[:skip_action_text] || skip_active_storage?
-      end
-
-      def skip_dev_gems? # :doc:
-        options[:skip_dev_gems]
       end
 
       def skip_sprockets?

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -917,6 +917,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "app/assets/stylesheets/application.postcss.css"
   end
 
+  def test_dev_gems
+    run_generator [destination_root, "--no-skip-dev-gems"]
+    assert_gem "web-console"
+  end
+
+  def test_skip_dev_gems
+    run_generator [destination_root, "--skip-dev-gems"]
+    assert_no_gem "web-console"
+  end
+
   def test_bootsnap
     run_generator [destination_root, "--no-skip-bootsnap"]
 


### PR DESCRIPTION
Set `skip_dev_gems` to be a `class_option` so it can be invoked from the
command line.

### Summary

`skip_dev_gems` was introduced as an option to be set in a `--minimal` 
build (#39282). This PR changes it to a `class_option` so it can be set--like
all the other options--from the command line and handled by Thor.

This will be especially useful for allowing individual components to be
added back into a `--minimal` build. (See #45205, from which this feature
has been extracted.)

PR also introduces tests for `--skip-dev-gems` and `--no-skip-dev-gems`.
