### PR TITLE
Ignore order of SQL joins, select, includes, left_outer_joins, eager_load and preload for ActiveRecord::Relation#or & for ActiveRecord::Relation#and

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1731,6 +1731,8 @@ module ActiveRecord
         [:extending, :where, :having, :unscope, :references, :annotate, :optimizer_hints]
       ).freeze # :nodoc:
 
+      STRUCTURAL_VALUE_METHODS_TO_IGNORE_ORDER = [:eager_load, :includes, :joins, :left_outer_joins, :preload, :select].freeze # :nodoc:
+
       def structurally_incompatible_values_for(other)
         values = other.values
         STRUCTURAL_VALUE_METHODS.reject do |method|
@@ -1739,6 +1741,10 @@ module ActiveRecord
             next true unless v2.is_a?(Array)
             v1 = v1.uniq
             v2 = v2.uniq
+            if STRUCTURAL_VALUE_METHODS_TO_IGNORE_ORDER.include?(method)
+              v1 = v1.sort
+              v2 = v2.sort
+            end
           end
           v1 == v2
         end

--- a/activerecord/test/cases/relation/and_test.rb
+++ b/activerecord/test/cases/relation/and_test.rb
@@ -39,5 +39,16 @@ module ActiveRecord
         error.message
       )
     end
+
+    def test_and_with_random_ordered_multiple_values
+      assert_nothing_raised do
+        Author.includes(:posts, :comments).and(Author.includes(:comments, :posts))
+        Author.eager_load(:posts, :comments).and(Author.eager_load(:comments, :posts))
+        Author.preload(:posts, :comments).and(Author.preload(:comments, :posts))
+        Author.joins(:posts, :comments).and(Author.joins(:comments, :posts))
+        Author.left_outer_joins(:posts, :comments).and(Author.left_outer_joins(:comments, :posts))
+        Author.select(:name, :id).and(Author.select(:id, :name))
+      end
+    end
   end
 end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -174,6 +174,17 @@ module ActiveRecord
         Post.from("posts").or(Post.from("posts"))
       end
     end
+
+    def test_or_with_random_ordered_multiple_values
+      assert_nothing_raised do
+        Post.includes(:author, :comments).or(Post.includes(:comments, :author))
+        Post.eager_load(:author, :comments).or(Post.eager_load(:comments, :author))
+        Post.preload(:author, :comments).or(Post.preload(:comments, :author))
+        Post.joins(:author, :comments).or(Post.joins(:comments, :author))
+        Post.left_outer_joins(:author, :comments).or(Post.left_outer_joins(:comments, :author))
+        Post.select(:body, :title).or(Post.select(:title, :body))
+      end
+    end
   end
 
   # The maximum expression tree depth is 1000 by default for SQLite3.


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/45398

Ignore order of SQL joins, select, includes, left_outer_joins, eager_load and preload for ActiveRecord::Relation#or & for ActiveRecord::Relation#and