### PR TITLE
Remove load path modification from Rails 3 days

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-activesupport_path = File.expand_path("../../../activesupport/lib", __dir__)
-$:.unshift(activesupport_path) if File.directory?(activesupport_path) && !$:.include?(activesupport_path)
-
 require "thor/group"
 require "rails/command"
 


### PR DESCRIPTION
### Summary

This seems to be a pattern that was common around Rails 3 (for example,
it was last changed in 7ee5843). However, most of the usages were
removed in 36dd185 and this one looks like it was missed.

Some of the other files changed in 7ee5843 were later consolidated into
a root `load_paths.rb` file in 9f01dff which was later removed in
2abcdfd.
