### PR TITLE
Revert "Optimize Active Record batching"

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -223,53 +223,45 @@ module ActiveRecord
       end
 
       relation = relation.reorder(batch_order(order)).limit(batch_limit)
-      relation = apply_finish_limit(relation, finish, order) if finish
+      relation = apply_limits(relation, start, finish, order)
+      relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
       batch_relation = relation
 
       loop do
-        batch_relation = apply_start_limit(relation, start, order) if start
-
         if load
-          records = batch_relation.uncached do
-            batch_relation.limit(batch_limit + 1).records
-          end
-
-          start = records[batch_limit]&.id
-          records = records.take(batch_limit)
-
-          break if records.empty?
-
-          raise ArgumentError.new("Primary key not included in the custom select clause") unless records.first.id
-
-          batch_relation.load_records(records)
+          records = batch_relation.records
+          ids = records.map(&:id)
+          yielded_relation = where(primary_key => ids)
+          yielded_relation.load_records(records)
         else
-          stop = batch_relation.uncached do
-            batch_relation.offset(batch_limit).pick(primary_key)
-          end
-
-          if stop
-            batch_relation = apply_finish_limit(batch_relation, stop, order, inclusive: false)
-          end
-
-          start = stop
+          ids = batch_relation.pluck(primary_key)
+          yielded_relation = where(primary_key => ids)
         end
 
-        yield batch_relation
+        break if ids.empty?
 
-        break unless start
+        primary_key_offset = ids.last
+        raise ArgumentError.new("Primary key not included in the custom select clause") unless primary_key_offset
+
+        yield yielded_relation
+
+        break if ids.length < batch_limit
 
         if limit_value
-          remaining -= batch_relation.size
+          remaining -= ids.length
 
           if remaining == 0
             # Saves a useless iteration when the limit is a multiple of the
             # batch size.
             break
           elsif remaining < batch_limit
-            batch_limit = remaining
             relation = relation.limit(remaining)
           end
         end
+
+        batch_relation = relation.where(
+          predicate_builder[primary_key, primary_key_offset, order == :desc ? :lt : :gt]
+        )
       end
     end
 
@@ -284,12 +276,8 @@ module ActiveRecord
         relation.where(predicate_builder[primary_key, start, order == :desc ? :lteq : :gteq])
       end
 
-      def apply_finish_limit(relation, finish, order, inclusive: true)
-        operator = (order == :desc) ?
-                    (inclusive ? :gteq : :gt) :
-                    (inclusive ? :lteq : :lt)
-
-        relation.where(predicate_builder[primary_key, finish, operator])
+      def apply_finish_limit(relation, finish, order)
+        relation.where(predicate_builder[primary_key, finish, order == :desc ? :gteq : :lteq])
       end
 
       def batch_order(order)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -830,7 +830,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries(3) do
+    assert_queries(4) do
       firm.clients.find_each(batch_size: 1) { |c| assert_equal firm.id, c.firm_id }
     end
 
@@ -840,7 +840,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_find_each_with_conditions
     firm = companies(:first_firm)
 
-    assert_queries(1) do
+    assert_queries(2) do
       firm.clients.where(name: "Microsoft").find_each(batch_size: 1) do |c|
         assert_equal firm.id, c.firm_id
         assert_equal "Microsoft", c.name

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -15,7 +15,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_should_execute_one_query_per_batch
-    assert_queries(@total) do
+    assert_queries(@total + 1) do
       Post.find_each(batch_size: 1) do |post|
         assert_kind_of Post, post
       end
@@ -45,7 +45,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_enumerator_should_execute_one_query_per_batch
-    assert_queries(@total) do
+    assert_queries(@total + 1) do
       Post.find_each(batch_size: 1).with_index do |post, index|
         assert_kind_of Post, post
         assert_kind_of Integer, index
@@ -54,12 +54,11 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_each_should_raise_if_select_is_set_without_id
-    error = assert_raise(ArgumentError) do
+    assert_raise(ArgumentError) do
       Post.select(:title).find_each(batch_size: 1) { |post|
         flunk "should not call this block"
       }
     end
-    assert_equal "Primary key not included in the custom select clause", error.message
   end
 
   def test_each_should_execute_if_id_is_in_select
@@ -109,7 +108,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_return_batches
-    assert_queries(@total) do
+    assert_queries(@total + 1) do
       Post.find_in_batches(batch_size: 1) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Post, batch.first
@@ -118,7 +117,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_start_from_the_start_option
-    assert_queries(@total - 1) do
+    assert_queries(@total) do
       Post.find_in_batches(batch_size: 1, start: 2) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Post, batch.first
@@ -127,7 +126,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_end_at_the_finish_option
-    assert_queries(5) do
+    assert_queries(6) do
       Post.find_in_batches(batch_size: 1, finish: 5) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Post, batch.first
@@ -136,7 +135,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_shouldnt_execute_query_unless_needed
-    assert_queries(1) do
+    assert_queries(2) do
       Post.find_in_batches(batch_size: @total) { |batch| assert_kind_of Array, batch }
     end
 
@@ -264,7 +263,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
-    assert_queries(Subscriber.count) do
+    assert_queries(Subscriber.count + 1) do
       Subscriber.find_in_batches(batch_size: 1) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Subscriber, batch.first
@@ -411,7 +410,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_if_not_loaded_executes_more_queries
-    assert_queries(@total) do
+    assert_queries(@total + 1) do
       Post.in_batches(of: 1, load: false) do |relation|
         assert_not_predicate relation, :loaded?
       end
@@ -419,7 +418,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_return_relations
-    assert_queries(@total) do
+    assert_queries(@total + 1) do
       Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
       end
@@ -436,14 +435,14 @@ class EachTest < ActiveRecord::TestCase
 
   def test_in_batches_should_end_at_the_finish_option
     post = Post.order("id DESC").where("id <= ?", 5).first
-    assert_queries(6) do
+    assert_queries(7) do
       relation = Post.in_batches(of: 1, finish: 5, load: true).reverse_each.first
       assert_equal post, relation.last
     end
   end
 
   def test_in_batches_shouldnt_execute_query_unless_needed
-    assert_queries(1) do
+    assert_queries(2) do
       Post.in_batches(of: @total) { |relation| assert_kind_of ActiveRecord::Relation, relation }
     end
 
@@ -528,7 +527,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_use_any_column_as_primary_key_when_start_is_not_specified
-    assert_queries(Subscriber.count) do
+    assert_queries(Subscriber.count + 1) do
       Subscriber.in_batches(of: 1, load: true) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Subscriber, relation.first

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -495,11 +495,11 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_scopes_batch_finders
     assert_equal 4, Topic.approved.count
 
-    assert_queries(4) do
+    assert_queries(5) do
       Topic.approved.find_each(batch_size: 1) { |t| assert t.approved? }
     end
 
-    assert_queries(2) do
+    assert_queries(3) do
       Topic.approved.find_in_batches(batch_size: 2) do |group|
         group.each { |t| assert t.approved? }
       end


### PR DESCRIPTION
Reverts rails/rails#44945

Turns out this is a nice win when iterating over the whole table, but as soon as there are additional criterias to the query, passing a list of ideas is much less work for the database.

cc @fatkodima, as mentioned on the original PR, please resubmit again as an optional feature, and we'll consider it.