### PR TITLE
Fix actiontext js not pointing to compiled file

### DIFF
--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -2,10 +2,10 @@
   "name": "@rails/actiontext",
   "version": "7.1.0-alpha",
   "description": "Edit and display rich text in Rails applications",
-  "main": "app/javascript/actiontext/index.js",
+  "main": "app/assets/javascripts/actiontext.js",
   "type": "module",
   "files": [
-    "app/javascript/actiontext/*.js"
+    "app/assets/javascripts/*.js"
   ],
   "homepage": "https://rubyonrails.org/",
   "repository": {


### PR DESCRIPTION
### Summary

This caused issues with bundlers like Webpack since it tries to strictly
follow the ESM spec which says that imports must include file
extensions.

### Other Information

Tested in fresh Vite and Webpack applications. Vite works before and after, Webpack fails before but works after this fix.

Fixes #43973 
