### PR TITLE
Optimize Active Record batching for whole table iterations

### DIFF
--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -5,12 +5,13 @@ module ActiveRecord
     class BatchEnumerator
       include Enumerable
 
-      def initialize(of: 1000, start: nil, finish: nil, relation:, order: :asc) # :nodoc:
+      def initialize(of: 1000, start: nil, finish: nil, relation:, order: :asc, use_ranges: nil) # :nodoc:
         @of       = of
         @relation = relation
         @start = start
         @finish = finish
         @order = order
+        @use_ranges = use_ranges
       end
 
       # The primary key value from which the BatchEnumerator starts, inclusive of the value.
@@ -91,7 +92,7 @@ module ActiveRecord
       #     relation.update_all(awesome: true)
       #   end
       def each(&block)
-        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false, order: @order)
+        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false, order: @order, use_ranges: @use_ranges)
         return enum.each(&block) if block_given?
         enum
       end


### PR DESCRIPTION
Reference #44945.

Tested on a table with 10M records.

```sql
CREATE TABLE users (id bigserial PRIMARY KEY, val integer DEFAULT 0);
INSERT INTO users SELECT i FROM generate_series(1, 10000000) AS i;
```

### Selecting

```ruby
start = Process.clock_gettime(Process::CLOCK_MONOTONIC)

count = 0
User.in_batches do |batch|
  count += batch.count
end

puts "Count = #{count}"
elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
puts "Elapsed: #{elapsed}s"
```

Before - `253s`, after: `30s` 🔥.

**Single batch plan before**:
```
explain analyze SELECT COUNT(*) FROM "users" WHERE "users"."id" IN (1, 2, 3, 4, 5....

 Aggregate  (cost=4387.00..4387.01 rows=1 width=8) (actual time=1.767..1.768 rows=1 loops=1)
   ->  Index Only Scan using users_pkey on users  (cost=0.43..4384.50 rows=1000 width=0) (actual time=0.049..1.668 rows=1000 loops=1)
         Index Cond: (id = ANY ('{1,2,3,4,5....
         Heap Fetches: 0
 Planning Time: 1.616 ms
 Execution Time: 1.803 ms
```

**Single batch plan after**:
```
explain analyze SELECT COUNT(*) FROM (SELECT 1 AS one FROM "users" WHERE "users"."id" <= 1000 ORDER BY "users"."id" ASC LIMIT 1000) subquery_for_count;
                                                                QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=44.34..44.35 rows=1 width=8) (actual time=0.404..0.405 rows=1 loops=1)
   ->  Limit  (cost=0.43..31.84 rows=1000 width=12) (actual time=0.036..0.318 rows=1000 loops=1)
         ->  Index Only Scan using users_pkey on users  (cost=0.43..36.58 rows=1151 width=12) (actual time=0.031..0.184 rows=1000 loops=1)
               Index Cond: (id <= 1000)
               Heap Fetches: 0
 Planning Time: 0.137 ms
 Execution Time: 0.436 ms
(7 rows)
```

### Updating

```ruby
start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
User.in_batches.update_all("val = val + 1")
elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
puts "Elapsed: #{elapsed}s"
```

Before - `288s`, after: `124s` 🔥.

**Single batch plan before**:
```
explain analyze UPDATE "users" SET val = val + 1 WHERE "users"."id" IN (1001, 1002, 1003, ..., 2000)

 Update on users  (cost=0.43..4396.00 rows=0 width=0) (actual time=27.615..27.616 rows=0 loops=1)
   ->  Index Scan using users_pkey on users  (cost=0.43..4396.00 rows=1000 width=10) (actual time=0.054..4.064 rows=1000 loops=1)
         Index Cond: (id = ANY ('{1001,1002,1003,1004,...
 Planning Time: 1.154 ms
 Execution Time: 9.645 ms
```

**Single batch plan after**:
```
explain analyze UPDATE "users" SET val = val + 1 WHERE "users"."id" IN (SELECT "users"."id" FROM "users" WHERE "users"."id" > 1000 AND "users"."id" <= 2000 ORDER BY "users"."id" ASC LIMIT 1000)

 Update on users  (cost=50.67..8411.24 rows=0 width=0) (actual time=13.461..13.463 rows=0 loops=1)
   ->  Nested Loop  (cost=50.67..8411.24 rows=1000 width=42) (actual time=2.040..5.586 rows=1000 loops=1)
         ->  HashAggregate  (cost=50.24..60.24 rows=1000 width=40) (actual time=2.012..2.345 rows=1000 loops=1)
               Group Key: "ANY_subquery".id
               Batches: 1  Memory Usage: 193kB
               ->  Subquery Scan on "ANY_subquery"  (cost=0.43..47.74 rows=1000 width=40) (actual time=0.023..1.675 rows=1000 loops=1)
                     ->  Limit  (cost=0.43..37.74 rows=1000 width=8) (actual time=0.019..1.417 rows=1000 loops=1)
                           ->  Index Only Scan using users_pkey on users users_1  (cost=0.43..43.56 rows=1156 width=8) (actual time=0.018..1.284 rows=1000 loops=1)
                                 Index Cond: ((id > 1000) AND (id <= 2000))
                                 Heap Fetches: 2097
         ->  Index Scan using users_pkey on users  (cost=0.43..8.35 rows=1 width=18) (actual time=0.003..0.003 rows=1 loops=1000)
               Index Cond: (id = "ANY_subquery".id)
 Planning Time: 0.216 ms
 Execution Time: 13.555 ms
```

### Deleting

```ruby
start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
User.in_batches.delete_all
elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
puts "Elapsed: #{elapsed}s"
```

Before - `268s`, after: `83s` 🔥.

cc @byroot @nvasilevski @simi @etiennebarrie 