### PR TITLE
require mini_magick at the level it is being used

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -10,9 +10,14 @@ module ActiveStorage
 
     private
       def read_image
-        download_blob_to_tempfile do |file|
+        begin
           require "mini_magick"
+        rescue LoadError
+          logger.info "Skipping image analysis because the mini_magick gem isn't installed"
+          return {}
+        end
 
+        download_blob_to_tempfile do |file|
           image = instrument("mini_magick") do
             MiniMagick::Image.new(file.path)
           end
@@ -23,13 +28,10 @@ module ActiveStorage
             logger.info "Skipping image analysis because ImageMagick doesn't support the file"
             {}
           end
+        rescue MiniMagick::Error => error
+          logger.error "Skipping image analysis due to an ImageMagick error: #{error.message}"
+          {}
         end
-      rescue LoadError
-        logger.info "Skipping image analysis because the mini_magick gem isn't installed"
-        {}
-      rescue MiniMagick::Error => error
-        logger.error "Skipping image analysis due to an ImageMagick error: #{error.message}"
-        {}
       end
 
       def rotated_image?(image)


### PR DESCRIPTION
### Summary

[Discussion on rubyonrails-core](https://discuss.rubyonrails.org/t/mini-magick-is-required-inside-download-blob-to-tempfile-block-but-used-outside/80867)

`require "mini_magick"` is called inside the block passed to `download_blob_to_tempfile`, but used outside that block at L30:
```
rescue MiniMagick::Error => error
```

`MiniMagick::Error` needs to be defined outside the block, or a `NameError` will occur if `download_blob_to_tempfile` fails and the block is never yielded, so mini_magick is never required.

I have witnessed the error on a live app, because the file was removed from S3 causing `download_blob_to_tempfile` to fail and never yield the block. Because mini_magick hadn't been required before, `MiniMagick::Error` is not defined, and a `NameError` is raised instead of the current error being propagated.

