### PR TITLE
Add separate guides page listing Rails versions

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -788,3 +788,8 @@ code.highlight.console span.w, code.highlight.irb span.w {
   text-shadow: 2px 2px 4px #5400007d;
   background: radial-gradient(circle, rgb(255, 10, 0) 0%, rgb(200, 0, 0) 90%);
 }
+
+#version-badge a {
+  color: inherit;
+  text-decoration: inherit;
+}

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -771,3 +771,8 @@ div.important p, div.caution p, div.warning p, div.note p, div.info p {
   z-index: 100;
   border: none;
 }
+
+#version-badge a {
+  color: inherit;
+  text-decoration: inherit;
+}

--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -5,28 +5,15 @@
   These are <b>Edge Guides</b>, based on <a href="https://github.com/rails/rails/tree/<%= @edge %>">main@<%= @edge[0, 7] %></a>.
 </p>
 <p>
-  If you are looking for the ones for the stable version, please check
+  If you are looking for guides for the latest stable release of Rails, please see
   <a href="https://guides.rubyonrails.org">https://guides.rubyonrails.org</a> instead.
 </p>
 <% else %>
 <p>
-  These are the new guides for Rails 7.1 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
+  These are guides for Rails 7.1 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>
 <p>
-The guides for earlier releases:
-<a href="https://guides.rubyonrails.org/v7.0/" data-turbolinks="false">Rails 7.0</a>,
-<a href="https://guides.rubyonrails.org/v6.1/" data-turbolinks="false">Rails 6.1</a>,
-<a href="https://guides.rubyonrails.org/v6.0/" data-turbolinks="false">Rails 6.0</a>,
-<a href="https://guides.rubyonrails.org/v5.2/" data-turbolinks="false">Rails 5.2</a>,
-<a href="https://guides.rubyonrails.org/v5.1/" data-turbolinks="false">Rails 5.1</a>,
-<a href="https://guides.rubyonrails.org/v5.0/" data-turbolinks="false">Rails 5.0</a>,
-<a href="https://guides.rubyonrails.org/v4.2/" data-turbolinks="false">Rails 4.2</a>,
-<a href="https://guides.rubyonrails.org/v4.1/" data-turbolinks="false">Rails 4.1</a>,
-<a href="https://guides.rubyonrails.org/v4.0/" data-turbolinks="false">Rails 4.0</a>,
-<a href="https://guides.rubyonrails.org/v3.2/" data-turbolinks="false">Rails 3.2</a>,
-<a href="https://guides.rubyonrails.org/v3.1/" data-turbolinks="false">Rails 3.1</a>,
-<a href="https://guides.rubyonrails.org/v3.0/" data-turbolinks="false">Rails 3.0</a>, and
-<a href="https://guides.rubyonrails.org/v2.3/" data-turbolinks="false">Rails 2.3</a>.
+  <a href="/versions.html">Guides for other versions of Rails</a> are also available.
 </p>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -22,7 +22,7 @@
 <body class="guide">
   <% if badge_version = @edge ? "edge" : @version %>
   <div>
-    <div id="version-badge"><%= badge_version %></div>
+    <div id="version-badge"><a href="/versions.html"><%= badge_version %></a></div>
   </div>
   <% end %>
   <div id="topNav">

--- a/guides/source/versions.html.erb
+++ b/guides/source/versions.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title, "Specific Rails Versions — Ruby on Rails Guides" %>
+<% content_for :description, "Guides for Specific Rails Versions" %>
+
+<% content_for :header_section do %>
+<h2>Guides for Specific Rails Versions</h2>
+
+<p>
+  Guides for the latest stable release of Rails can be found at <a href="https://guides.rubyonrails.org">https://guides.rubyonrails.org</a>.
+</p>
+
+<p>
+  Edge guides, based on the <a href="https://github.com/rails/rails/tree/main">current development branch</a>, can be found at <a href="https://edgeguides.rubyonrails.org">https://edgeguides.rubyonrails.org</a>.
+</p>
+
+<p>
+  Guides for specific Rails versions are listed below.
+</p>
+<% end %>
+
+<h3>Versions</h3>
+
+<ul>
+<li><a href="https://guides.rubyonrails.org/v7.0/" data-turbolinks="false">Rails 7.0</a>
+<li><a href="https://guides.rubyonrails.org/v6.1/" data-turbolinks="false">Rails 6.1</a>
+<li><a href="https://guides.rubyonrails.org/v6.0/" data-turbolinks="false">Rails 6.0</a>
+<li><a href="https://guides.rubyonrails.org/v5.2/" data-turbolinks="false">Rails 5.2</a>
+<li><a href="https://guides.rubyonrails.org/v5.1/" data-turbolinks="false">Rails 5.1</a>
+<li><a href="https://guides.rubyonrails.org/v5.0/" data-turbolinks="false">Rails 5.0</a>
+<li><a href="https://guides.rubyonrails.org/v4.2/" data-turbolinks="false">Rails 4.2</a>
+<li><a href="https://guides.rubyonrails.org/v4.1/" data-turbolinks="false">Rails 4.1</a>
+<li><a href="https://guides.rubyonrails.org/v4.0/" data-turbolinks="false">Rails 4.0</a>
+<li><a href="https://guides.rubyonrails.org/v3.2/" data-turbolinks="false">Rails 3.2</a>
+<li><a href="https://guides.rubyonrails.org/v3.1/" data-turbolinks="false">Rails 3.1</a>
+<li><a href="https://guides.rubyonrails.org/v3.0/" data-turbolinks="false">Rails 3.0</a>
+<li><a href="https://guides.rubyonrails.org/v2.3/" data-turbolinks="false">Rails 2.3</a>
+</ul>


### PR DESCRIPTION
The purpose of this page is to provide a single location that any version of the guides can link to in order for the user to navigate to any other version of the guides.

For example, https://guides.rubyonrails.org/v6.1/index.html can link to https://guides.rubyonrails.org/versions.html, and the user will be able to navigate to https://guides.rubyonrails.org/v7.0/index.html, even after v7.0 is no longer the latest release and the v6.1 guides are no longer updated.

This commit also links the version badge displayed at the top of each page to the versions page.

| Before | After |
| --- | --- |
| ![stable-guides-before](https://user-images.githubusercontent.com/771968/174896347-a20f2764-9fea-44e6-9a7e-0905efbe64e7.png) | ![stable-guides-after](https://user-images.githubusercontent.com/771968/174896365-a743f0e7-6a95-4365-bb04-10b57df0eba6.png) |
| ![edge-guides-before](https://user-images.githubusercontent.com/771968/174896379-80d8ddf8-f447-4ce1-98b2-2b9072c1dec1.png) | ![edge-guides-after](https://user-images.githubusercontent.com/771968/174896397-c174161e-c466-4f30-bfc3-58eec9ddcd1e.png) |
| | ![versions](https://user-images.githubusercontent.com/771968/174896420-3b9bf8e3-c55f-4f2c-84c6-b0f64f5bc17b.png) |
