### PR TITLE
Fix urlsafe MessageVerifier not to include padding

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -210,7 +210,7 @@ module ActiveSupport
 
     private
       def encode(data)
-        @urlsafe ? Base64.urlsafe_encode64(data) : Base64.strict_encode64(data)
+        @urlsafe ? Base64.urlsafe_encode64(data, padding: false) : Base64.strict_encode64(data)
       end
 
       def decode(data)

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -360,6 +360,11 @@ class MessageVerifierUrlsafeTest < MessageVerifierMetadataTest
     assert_equal message, URI.encode_www_form_component(message)
   end
 
+  def test_no_padding
+    message = generate("a")
+    assert_not_includes message, "="
+  end
+
   private
     def verifier_options
       { urlsafe: true }


### PR DESCRIPTION
### Summary

urlsafe option was introduced to MessageVerifier in
09c3f36a962a7ffd350dfda643d2f980734cb5c9 but it can generate strings
containing padding character ("=") which is not urlsafe.

Fix not to pad when base64 encode.

Sorry, I forgot to specify the option!