### PR TITLE
Update permissions policy list

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -95,15 +95,21 @@ module ActionDispatch # :nodoc:
       fullscreen:           "fullscreen",
       geolocation:          "geolocation",
       gyroscope:            "gyroscope",
+      hid:                  "hid",
+      idle_detection:       "idle_detection",
       magnetometer:         "magnetometer",
       microphone:           "microphone",
       midi:                 "midi",
       payment:              "payment",
       picture_in_picture:   "picture-in-picture",
+      screen_wake_lock:     "screen-wake-lock",
+      serial:               "serial",
       speaker:              "speaker",
+      sync_xhr:             "sync-xhr",
       usb:                  "usb",
       vibrate:              "vibrate",
       vr:                   "vr",
+      web_share:            "web-share",
     }.freeze
 
     private_constant :MAPPINGS, :DIRECTIVES


### PR DESCRIPTION
### Summary

The list of available [Permissions Policy](https://github.com/w3c/webappsec-permissions-policy/blob/master/features.md#policy-controlled-features) has evolved.

This pull request add the new stable features to `ActionDispatch::PermissionsPolicy`.

List of features supported in Chrome (version) added with this pull request:
- hid (Chrome 89)
- idle-detection (Chrome 94)
- screen-wake-lock (Chrome 84)
- serial (Chrome 89)
- sync-xhr (Chrome 65)
- web-share (Chrome 86)

### Other Information

There also features not present in the W3C list and I don't know what we should do about them:
- speaker
- vibrate
- vr
