### PR TITLE
Allow controller#render to pass blocks to renderables

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -113,6 +113,7 @@ module AbstractController
     # Normalize args and options.
     def _normalize_render(*args, &block) # :nodoc:
       options = _normalize_args(*args, &block)
+      options[:block] = block
       _process_variant(options)
       _normalize_options(options)
       options

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -112,20 +112,37 @@ module ActionController
       end
     end
 
-    def defaults
-      @defaults = @defaults.dup if @defaults.frozen?
-      @defaults
-    end
+    # Render templates with any options from ActionController::Base#render_to_string.
+    #
+    # The primary options are:
+    # * <tt>:partial</tt> - See ActionView::PartialRenderer for details.
+    # * <tt>:file</tt> - Renders an explicit template file. Add <tt>:locals</tt> to pass in, if so desired.
+    #   It shouldn’t be used directly with unsanitized user input due to lack of validation.
+    # * <tt>:inline</tt> - Renders an ERB template string.
+    # * <tt>:plain</tt> - Renders provided text and sets the content type as <tt>text/plain</tt>.
+    # * <tt>:html</tt> - Renders the provided HTML safe string, otherwise
+    #   performs HTML escape on the string first. Sets the content type as <tt>text/html</tt>.
+    # * <tt>:json</tt> - Renders the provided hash or object in JSON. You don't
+    #   need to call <tt>.to_json</tt> on the object you want to render.
+    # * <tt>:body</tt> - Renders provided text and sets content type of <tt>text/plain</tt>.
+    #
+    # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, then:
+    #
+    # If an object responding to +render_in+ is passed, +render_in+ is called on the object,
+    # passing in the current view context.
+    #
+    # Otherwise, a partial is rendered using the second parameter as the locals hash.
+    def render(*args, &block)
 
     # Renders a template to a string, just like ActionController::Rendering#render_to_string.
-    def render(*args)
+    def render(*args, &block)
       request = ActionDispatch::Request.new(env_for_request)
       request.routes = controller._routes
 
       instance = controller.new
       instance.set_request! request
       instance.set_response! controller.make_response!(request)
-      instance.render_to_string(*args)
+      instance.render_to_string(*args, &block)
     end
     alias_method :render_to_string, :render # :nodoc:
 

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -75,6 +75,17 @@ class RendererTest < ActiveSupport::TestCase
     )
   end
 
+  test "render a renderable object with block" do
+    renderer = ApplicationController.renderer
+
+    assert_equal(
+      %(<h1>Hello, block!</h1>),
+      renderer.render(TestRenderable.new) do
+        "Hello, block!"
+      end
+    )
+  end
+
   test "rendering with custom env" do
     renderer = ApplicationController.renderer.new method: "post"
     content  = renderer.render inline: "<%= request.post? %>"

--- a/actionpack/test/lib/test_renderable.rb
+++ b/actionpack/test/lib/test_renderable.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class TestRenderable
-  def render_in(_view_context)
-    "Hello, World!"
+  def render_in(_view_context, &block)
+    if block_given?
+      "<h1>#{block.call}</h1>"
+    else
+      "Hello, World!"
+    end
   end
 
   def format

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -41,7 +41,7 @@ module ActionView
           end
           Template::Inline.new(options[:inline], "inline template", handler, locals: keys, format: format)
         elsif options.key?(:renderable)
-          Template::Renderable.new(options[:renderable])
+          Template::Renderable.new(options[:renderable], options[:block])
         elsif options.key?(:template)
           if options[:template].respond_to?(:render)
             options[:template]

--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -4,8 +4,9 @@ module ActionView
   # = Action View Renderable Template for objects that respond to #render_in
   class Template
     class Renderable # :nodoc:
-      def initialize(renderable)
+      def initialize(renderable, block)
         @renderable = renderable
+        @block = block
       end
 
       def identifier
@@ -13,7 +14,7 @@ module ActionView
       end
 
       def render(context, *args)
-        @renderable.render_in(context)
+        @renderable.render_in(context, &@block)
       end
 
       def format


### PR DESCRIPTION
### Summary

Currently when controllers render Renderables (objects that respond to
`#render_in`) blocks aren't passed to the renderable object. This
differs from the `render` method in the view which does allow blocks to
be passed.

e.g.

```erb
<%= render MyRenderable.new do %>
  Hello, world
<% end %>
```

In controllers, the block in the following example will be silently ignored without 
this patch:

```ruby
class MyController < ApplicationController
  def show
    # Block is silently ignored
    render MyRenderable.new do
      "Hello, world"
    end
  end
end
```

This change allows controllers to pass blocks to renderables, matching
the behavior of the view `render` method. It does so by passing the
block through the call chain until it can be stored in the `options`
hash. From there we pass the block to
`ActionView::Template::Renderable.new` and the block is properly passed
to the `render_in` method when `ActionView::Template::Renderable#render`
is called.

* Updates controller code to pass the block from `#render` until
  arguments are normalized.
* Stores `block` in the `options` hash that is passed throughout the
  rendering call stack.
* Updates `ActionView::Template::Renderable` to accept a block, which is
  then passed to the renderables `render_in` method.
* Adds a test validating that blocks can be passed from controller
  renderers.