### PR TITLE
Fix wrong sample code about allow_deprecated_singular_associations_name [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1037,15 +1037,15 @@ before,
 
 ```ruby
 class Post
-  self.table_name = "blog_posts"
 end
 
 class Comment
   belongs_to :post
 end
 
-Comment.join(:post).where(posts: { id: 1 }) # deprecated if the table name is not `posts`
-Comment.join(:post).where(post: { id: 1 }) # instead use the relation's name
+post = Post.first
+Comment.where(posts: post) # deprecated
+Comment.where(post: post) # instead use the relation's name
 ```
 
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans`


### PR DESCRIPTION
### Summary

The only time #45163 and #45344 have an effect is when the hash value passed to `where` is a model object. The current sample code does not change behavior between Rails 7.0 and 7.1



