### PR TITLE
Pass options to the test runner for test:{all,system,generators}

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -37,24 +37,24 @@ module Rails
 
       Rails::TestUnit::Runner::TEST_FOLDERS.each do |name|
         define_method(name) do |*|
-          self.args.prepend("test/#{name}")
+          args.prepend("test/#{name}")
           perform
         end
       end
 
       desc "test:all", "Runs all tests, including system tests", hide: true
-      def all
-        self.args = ["test/**/*_test.rb"]
+      def all(*)
+        args.prepend("test/**/*_test.rb")
         perform
       end
 
-      def system
-        self.args = ["test/system"]
+      def system(*)
+        args.prepend("test/system")
         perform
       end
 
-      def generators
-        self.args = ["test/lib/generators"]
+      def generators(*)
+        args.prepend("test/lib/generators")
         perform
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -98,6 +98,21 @@ module ApplicationTests
       end
     end
 
+    def test_run_all_takes_options
+      create_test_file :system, "foo"
+      assert_match "FooTest", rails("test:all", "--verbose")
+    end
+
+    def test_run_system_takes_options
+      create_test_file :system, "foo"
+      assert_match "FooTest", rails("test:system", "--verbose")
+    end
+
+    def test_run_generators_takes_options
+      create_test_file "lib/generators", "foo"
+      assert_match "FooTest", rails("test:generators", "--verbose")
+    end
+
     def test_run_channels
       create_test_file :channels, "foo_channel"
       create_test_file :channels, "bar_channel"


### PR DESCRIPTION
### Summary

In #44106 I forgot to pass the options for all the commands, only those based on folders, so `test:system`, `test:all` and `test:generators` don't accept options like `--verbose`.

Fixes #41976

### Other Information

~~The error message is also not great, I'll take a look and see if I can fix it as part of this.~~ 

Actually taking and passing the arguments fixes the error message, minitest handles it.