### PR TITLE
Bump ruby version for Rubocop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.1
         bundler-cache: true
 
     - name: Run RuboCop


### PR DESCRIPTION
We should run rubocop using the latest Ruby version.
