### PR TITLE
Add optional HTTP method for service direct uploads

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -574,9 +574,9 @@ class BlobUpload {
   constructor(blob) {
     this.blob = blob;
     this.file = blob.file;
-    const {url: url, headers: headers} = blob.directUploadData;
+    const {url: url, headers: headers, method: method} = blob.directUploadData;
     this.xhr = new XMLHttpRequest;
-    this.xhr.open("PUT", url, true);
+    this.xhr.open(method, url, true);
     this.xhr.responseType = "text";
     for (const key in headers) {
       this.xhr.setRequestHeader(key, headers[key]);

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -568,9 +568,9 @@
     constructor(blob) {
       this.blob = blob;
       this.file = blob.file;
-      const {url: url, headers: headers} = blob.directUploadData;
+      const {url: url, headers: headers, method: method} = blob.directUploadData;
       this.xhr = new XMLHttpRequest;
-      this.xhr.open("PUT", url, true);
+      this.xhr.open(method, url, true);
       this.xhr.responseType = "text";
       for (const key in headers) {
         this.xhr.setRequestHeader(key, headers[key]);

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -17,7 +17,8 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
     def direct_upload_json(blob)
       blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
         url: blob.service_url_for_direct_upload,
-        headers: blob.service_headers_for_direct_upload
+        headers: blob.service_headers_for_direct_upload,
+        method: blob.service_method_for_direct_upload
       })
     end
 end

--- a/activestorage/app/javascript/activestorage/blob_upload.js
+++ b/activestorage/app/javascript/activestorage/blob_upload.js
@@ -3,10 +3,10 @@ export class BlobUpload {
     this.blob = blob
     this.file = blob.file
 
-    const { url, headers } = blob.directUploadData
+    const { url, headers, method } = blob.directUploadData
 
     this.xhr = new XMLHttpRequest
-    this.xhr.open("PUT", url, true)
+    this.xhr.open(method, url, true)
     this.xhr.responseType = "text"
     for (const key in headers) {
       this.xhr.setRequestHeader(key, headers[key])

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -229,6 +229,11 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.headers_for_direct_upload key, filename: filename, content_type: content_type, content_length: byte_size, checksum: checksum, custom_metadata: custom_metadata
   end
 
+  # Returns the HTTP method for +service_url_for_direct_upload+ requests.
+  def service_method_for_direct_upload
+    service.method_for_direct_upload
+  end
+
   def content_type_for_serving # :nodoc:
     forcibly_serve_as_binary? ? ActiveStorage.binary_content_type : content_type
   end

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -142,6 +142,10 @@ module ActiveStorage
       {}
     end
 
+    def method_for_direct_upload
+      "PUT"
+    end
+
     def public?
       @public
     end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -40,6 +40,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
         assert_match(/s3(-[-a-z0-9]+)?\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"])
         assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-amz-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])
+        assert_equal("PUT", details["direct_upload"]["method"])
       end
     end
   end
@@ -85,6 +86,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["direct_upload"]["url"]
         assert_equal({ "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-goog-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])
+        assert_equal("PUT", details["direct_upload"]["method"])
       end
     end
   end
@@ -127,6 +129,7 @@ if SERVICE_CONFIGURATIONS[:azure]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{#{@config[:storage_account_name]}\.blob\.core\.windows\.net/#{@config[:container]}}, details["direct_upload"]["url"]
         assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum, "x-ms-blob-content-disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-ms-blob-type" => "BlockBlob" }, details["direct_upload"]["headers"])
+        assert_equal("PUT", details["direct_upload"]["method"])
       end
     end
   end
@@ -157,6 +160,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       assert_equal "text/plain", details["content_type"]
       assert_match(/rails\/active_storage\/disk/, details["direct_upload"]["url"])
       assert_equal({ "Content-Type" => "text/plain" }, details["direct_upload"]["headers"])
+      assert_equal("PUT", details["direct_upload"]["method"])
     end
   end
 

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -67,6 +67,10 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
     assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
   end
 
+  test "method_for_direct_upload generation default" do
+    assert_equal("PUT", @service.method_for_direct_upload)
+  end
+
   test "root" do
     assert_equal tmp_config.dig(:tmp, :root), @service.root
   end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -166,6 +166,10 @@ if SERVICE_CONFIGURATIONS[:gcs]
         @service.url(@key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
     end
 
+    test "method_for_direct_upload generation default" do
+      assert_equal("PUT", @service.method_for_direct_upload)
+    end
+
     if SERVICE_CONFIGURATIONS[:gcs].key?(:gsa_email)
       test "direct upload with IAM signing" do
         config_with_iam = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ iam: true }) }

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -93,6 +93,10 @@ if SERVICE_CONFIGURATIONS[:s3]
       assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], url
     end
 
+    test "method_for_direct_upload generation default" do
+      assert_equal("PUT", @service.method_for_direct_upload)
+    end
+
     test "uploading with server-side encryption" do
       service = build_service(upload: { server_side_encryption: "AES256" })
 


### PR DESCRIPTION
### Summary

When building a new `Service` for ActiveStorage, one only can `PUT` requests to the direct upload endpoints for that service. Or, some services accept `POST` to their endpoint (such as Cloudinary and Wistia), which makes implementing such services with `ActiveStorage` harder, it requires more custom code and deep dive into the lib.

In this PR, a default HTTP method for direct uploads is added to the `Service` class. It defaults to `PUT` so previously developed service work exactly the same. 

One can override this method in their service class by simply declaring : 

```ruby 
class ActiveStorage::Service::MyCustomService < ActiveStorage::Service
 # [...]
  def method_for_direct_upload 
    "POST"
  end
  # [...]
end

```
