### PR TITLE
[7-0-stable] Pass deserialized defaults when copying tables in sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -477,8 +477,13 @@ module ActiveRecord
                  options[:rename][column.name.to_sym] ||
                  column.name) : column.name
 
+              if column.has_default?
+                type = lookup_cast_type_from_column(column)
+                default = type.deserialize(column.default)
+              end
+
               @definition.column(column_name, column.type,
-                limit: column.limit, default: column.default,
+                limit: column.limit, default: default,
                 precision: column.precision, scale: column.scale,
                 null: column.null, collation: column.collation,
                 primary_key: column_name == from_primary_key

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -25,6 +25,16 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
     @connection.drop_table(to) rescue nil
   end
 
+  def test_copy_table_with_column_with_default
+    test_copy_table("comments", "comments_with_default") do
+      @connection.add_column("comments_with_default", "options", "json", default: {})
+      test_copy_table("comments_with_default", "comments_with_default2") do
+        column = @connection.columns("comments_with_default2").find { |col| col.name == "options" }
+        assert_equal "{}", column.default
+      end
+    end
+  end
+
   def test_copy_table_renaming_column
     test_copy_table("customers", "customers2",
         rename: { "name" => "person_name" }) do |from, to, options|


### PR DESCRIPTION
Backport of #45435, fixing #45430 for 7-0-stable.