### PR TITLE
Action cable command callbacks testing

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -45,14 +45,20 @@ module ActionCable
     end
 
     module TestConnection
-      attr_reader :logger, :request
+      attr_reader :logger, :request, :transmissions
 
       def initialize(request)
         inner_logger = ActiveSupport::Logger.new(StringIO.new)
         tagged_logging = ActiveSupport::TaggedLogging.new(inner_logger)
         @logger = ActionCable::Connection::TaggedLoggerProxy.new(tagged_logging, tags: [])
+        @transmissions = []
+        @subscriptions = ActionCable::Connection::Subscriptions.new(self)
         @request = request
         @env = request.env
+      end
+
+      def transmit(cable_message)
+        transmissions << cable_message.with_indifferent_access
       end
     end
 
@@ -186,7 +192,7 @@ module ActionCable
           path ||= DEFAULT_PATH
 
           connection = self.class.connection_class.allocate
-          connection.singleton_class.include(TestConnection)
+          connection.singleton_class.prepend(TestConnection)
           connection.send(:initialize, build_test_request(path, **request_params))
           connection.connect if connection.respond_to?(:connect)
 
@@ -204,6 +210,12 @@ module ActionCable
 
         def cookies
           @cookie_jar ||= TestCookieJar.new
+        end
+
+        def transmissions
+          raise "Must be connected!" if connection.nil?
+
+          connection.transmissions
         end
 
         private

--- a/actioncable/test/connection/test_case_test.rb
+++ b/actioncable/test/connection/test_case_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "json"
 
 class SimpleConnection < ActionCable::Connection::Base
   identified_by :user_id
@@ -193,5 +194,42 @@ class EnvConnectionTest < ActionCable::Connection::TestCase
 
   def test_connection_rejected
     assert_reject_connection { connect }
+  end
+end
+
+
+class CallbackedConnection < ActionCable::Connection::Base
+  identified_by :user_id
+
+  around_command :set_current_context
+
+  def connect
+    self.user_id = request.params[:user_id]
+  end
+
+  private
+    def set_current_context
+      Thread.current[:user_id] = user_id
+      yield
+      Thread.current[:user_id] = nil
+    end
+end
+
+class CallbackedConnection::Channel < ActionCable::Channel::Base
+  def subscribed
+    transmit({ user_id: Thread.current[:user_id] })
+  end
+end
+
+class CallbackedConnectionTest < ActionCable::Connection::TestCase
+  tests CallbackedConnection
+
+  def test_connection_callbacks
+    connect "/cable?user_id=2022"
+
+    identifier = { channel: "CallbackedConnection::Channel" }.to_json
+    connection.handle_channel_command({ "command" => "subscribe", "identifier" => identifier })
+
+    assert_equal({ "user_id" => "2022" }, transmissions.first["message"])
   end
 end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2008,6 +2008,20 @@ test "connects with cookies" do
 end
 ```
 
+You can test command callbacks by invoking the `#handle_channel_command` method on a connection object:
+
+```ruby
+test "command callbacks" do
+  connect
+
+  identifier = { channel: "ChatChannel" }.to_json
+
+  connection.handle_channel_command({ "command": "subscribe", "identifier": identifier })
+
+  # write your assertions here
+end
+```
+
 See the API documentation for [`ActionCable::Connection::TestCase`](https://api.rubyonrails.org/classes/ActionCable/Connection/TestCase.html) for more information.
 
 ### Channel Test Case


### PR DESCRIPTION
### Summary

This is the follow-up for #44696.

I found that testing callbacks is currently not supported due to some limitations of our test stubs.

### Other Information

I don't really like the way Action Cable testing currently uses connection stubs, but this is the limitation of the current library design (connections are highly coupled with event loops and servers). Back in a while, I tried to tackle this: https://github.com/rails/rails/pull/27648. Maybe, we should re-visit this problem in the future (for Rails 8, maybe?).