### PR TITLE
Fix `allow_deprecated_singular_associations_name` framework default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -46,4 +46,4 @@
 # Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
 
 # Disable deprecated singular associations names
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = true
+# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2383,6 +2383,32 @@ module ApplicationTests
       assert_equal true, ActiveRecord.verify_foreign_keys_for_fixtures
     end
 
+    test "ActiveRecord.allow_deprecated_singular_associations_name is false by default for new apps" do
+      app "development"
+
+      assert_equal false, ActiveRecord.allow_deprecated_singular_associations_name
+    end
+
+    test "ActiveRecord.allow_deprecated_singular_associations_name is true by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal true, ActiveRecord.allow_deprecated_singular_associations_name
+    end
+
+    test "ActiveRecord.allow_deprecated_singular_associations_name can be configured via config.active_record.allow_deprecated_singular_associations_name" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
+        Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActiveRecord.allow_deprecated_singular_associations_name
+    end
+
     test "ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction is false by default for new apps" do
       app "development"
 


### PR DESCRIPTION
Follow-up to #45344.

When using `config.load_default "7.1"`, [the value is `false`](https://github.com/rails/rails/blob/9badb0f79407f1b31e7b54b39877113335ddb19d/railties/lib/rails/application/configuration.rb#L267), so the value in `new_framework_defaults_7_1.rb` should be `false` as well.

This commit also adds configuration tests.
