### PR TITLE
Clarify `allow_deprecated_singular_associations_name` deprecation warning

### DIFF
--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -27,9 +27,9 @@ module ActiveRecord
         reflection
       elsif ActiveRecord.allow_deprecated_singular_associations_name && reflection = klass&._reflect_on_association(table_name.singularize)
         ActiveSupport::Deprecation.warn(<<~MSG)
-          In Rails 7.2, referring to singular associations by their plural name will be deprecated.
-          To continue querying `#{table_name.singularize}` use `#{table_name}` instead.
-          You can get the new more performant behavior now by setting config.active_record.allow_deprecated_singular_associations_name = false
+          Referring to a singular association (e.g. `#{reflection.name}`) by its plural name (e.g. `#{reflection.plural_name}`) is deprecated.
+
+          To convert this deprecation warning to an error and enable more performant behavior, set config.active_record.allow_deprecated_singular_associations_name = false.
         MSG
         reflection
       end


### PR DESCRIPTION
Follow-up to #45344.

Currently, when `allow_deprecated_singular_associations_name` is true, a deprecation warning like the following is displayed:

```console
> Comment.belongs_to :post
> Comment.where(posts: 1).count
DEPRECATION WARNING: In Rails 7.2, referring to singular associations by their plural name will be deprecated.
To continue querying `post` use `posts` instead.
You can get the new more performant behavior now by setting config.active_record.allow_deprecated_singular_associations_name = false
```

The warning advises "use `posts` instead", but the user's code should actually use `post`, i.e. `Comment.where(post: 1).count`.  The mismatch is likely due to the level at which the deprecation warning is emitted. `associated_with?` does indeed expect `table_name` to be `posts`, but `where` expects `post`.

This commit changes the deprecation warning to avoid advising a specific usage, but still be explicit about what is wrong:

```console
> Comment.where(posts: 1).count
DEPRECATION WARNING: Referring to a singular association (e.g. `post`) by its plural name (e.g. `posts`) is deprecated.

To convert this deprecation warning to an error and enable more performant behavior, set config.active_record.allow_deprecated_singular_associations_name = false.
```
