### PR TITLE
Make urlsafe MessageVerifier backward/forward compatible

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -225,7 +225,18 @@ module ActiveSupport
       end
 
       def decode(data)
-        @urlsafe ? Base64.urlsafe_decode64(data) : Base64.strict_decode64(data)
+        if @urlsafe
+          # Because urlsafe_decode64 can accept strings encoded with
+          # strict_encode64, simply calling urlsafe_decode64 works.
+          # https://github.com/ruby/ruby/blob/12a5fa408bd318f8fb242e86beb225f2dcae8df9/lib/base64.rb#L98-L108
+          Base64.urlsafe_decode64(data)
+        else
+          begin
+            Base64.strict_decode64(data)
+          rescue
+            Base64.urlsafe_decode64(data)
+          end
+        end
       end
 
       def generate_digest(data)

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -370,3 +370,22 @@ class MessageVerifierUrlsafeTest < MessageVerifierMetadataTest
       { urlsafe: true }
     end
 end
+
+class UrlsafeMessageVerifierCompatibilityTest < ActiveSupport::TestCase
+  def setup
+    secret = "Hey, I'm a secret!"
+    @urlsafe_verifier = ActiveSupport::MessageVerifier.new(secret, urlsafe: true)
+    @non_urlsafe_verifier = ActiveSupport::MessageVerifier.new(secret, urlsafe: false)
+    @data = "hello"
+  end
+
+  def test_backward_compatibility
+    message = @non_urlsafe_verifier.generate(@data)
+    assert_equal @data, @urlsafe_verifier.verify(message)
+  end
+
+  def test_forward_compatibility
+    message = @urlsafe_verifier.generate(@data)
+    assert_equal @data, @non_urlsafe_verifier.verify(message)
+  end
+end


### PR DESCRIPTION
To make MessageVerifier urlsafe by default, it needs to be both backward
and forward compatible. When apps are deployed in the rolling update
fashion, servers running old version of the app can receive requests
containing urlsafe messages generated by servers running new version of
the app, and vice versa.
