### PR TITLE
turbolinks:load to turbo:load in ActionCable guide [ci-skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -573,14 +573,14 @@ consumer.subscriptions.create("AppearanceChannel", {
   install() {
     window.addEventListener("focus", this.update)
     window.addEventListener("blur", this.update)
-    document.addEventListener("turbolinks:load", this.update)
+    document.addEventListener("turbo:load", this.update)
     document.addEventListener("visibilitychange", this.update)
   },
 
   uninstall() {
     window.removeEventListener("focus", this.update)
     window.removeEventListener("blur", this.update)
-    document.removeEventListener("turbolinks:load", this.update)
+    document.removeEventListener("turbo:load", this.update)
     document.removeEventListener("visibilitychange", this.update)
   },
 


### PR DESCRIPTION
### Summary

Update ActionCable guide https://guides.rubyonrails.org/action_cable_overview.html#example-1-user-appearances
In the example an event listener is created on the `turbolinks:load` event.
This PR changes the event to `turbo:load`
