### PR TITLE
Allow configuration of embeddable storage service for ActionText via `has_rich_text`

### DIFF
--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -12,7 +12,6 @@ module ActionText
     delegate :to_s, :nil?, to: :body
 
     belongs_to :record, polymorphic: true, touch: true
-    has_many_attached :embeds
 
     before_save do
       self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -30,7 +30,7 @@ module ActionText
       #
       # * <tt>:encrypted</tt> - Pass true to encrypt the rich text attribute. The encryption will be non-deterministic. See
       #   +ActiveRecord::Encryption::EncryptableRecord.encrypts+. Default: false.
-      def has_rich_text(name, encrypted: false, **options)
+      def has_rich_text(name, encrypted: false, attachment_service: nil)
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
             rich_text_#{name} || build_rich_text_#{name}
@@ -47,14 +47,8 @@ module ActionText
 
         rich_text_class_name = encrypted ? "ActionText::EncryptedRichText" : "ActionText::RichText"
 
-        raise "Can't use strict_loading on attachment when rich text attribute is encrypted" if encrypted && options[:attachment_strict_loading]
-
         rich_text_class_name.safe_constantize.class_eval do
-          if encrypted
-            has_many_attached :embeds, service: options[:attachment_service]
-          else
-            has_many_attached :embeds, service: options[:attachment_service], strict_loading: options[:attachment_strict_loading] || false
-          end
+          has_many_attached :embeds, service: attachment_service
         end
 
         has_one :"rich_text_#{name}", -> { where(name: name) },

--- a/actiontext/test/unit/model_encryption_test.rb
+++ b/actiontext/test/unit/model_encryption_test.rb
@@ -23,6 +23,33 @@ class ActionText::ModelEncryptionTest < ActiveSupport::TestCase
     assert_encrypted_rich_text_attribute(message, :content, content)
   end
 
+  test "attachment_service is nil" do
+    default_reflection = EncryptedMessage.reflect_on_association(:rich_text_content).class_name.safe_constantize.reflect_on_attachment(:embeds)
+    assert_nil default_reflection.options[:service_name]
+  end
+
+  test "raises error when misconfigured service is passed" do
+    error = assert_raises ArgumentError do
+      EncryptedMessage.class_eval do
+        has_rich_text :content, encrypted: true, attachment_service: :unknown
+      end
+    end
+
+    assert_match(/Cannot configure service :unknown for ActionText::EncryptedRichText#embeds/, error.message)
+  end
+
+  test "attachment_service is set to the one provided" do
+    EncryptedMessage.class_eval do
+      has_rich_text :content, encrypted: true, attachment_service: :local
+    end
+    reflection = EncryptedMessage.reflect_on_association(:rich_text_content).class_name.safe_constantize.reflect_on_attachment(:embeds)
+    assert_equal :local, reflection.options[:service_name]
+  ensure
+    EncryptedMessage.class_eval do
+      has_rich_text :content, encrypted: true
+    end
+  end
+
   private
     def assert_encrypted_rich_text_attribute(model, attribute_name, expected_value)
       assert_not_equal expected_value, model.send(attribute_name).ciphertext_for(:body)

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -112,4 +112,31 @@ class ActionText::ModelTest < ActiveSupport::TestCase
       assert_equal "Body", message.body.to_plain_text
     end
   end
+
+  test "attachment_service is nil" do
+    default_reflection = Message.reflect_on_association(:rich_text_content).class_name.safe_constantize.reflect_on_attachment(:embeds)
+    assert_nil default_reflection.options[:service_name]
+  end
+
+  test "raises error when misconfigured service is passed" do
+    error = assert_raises ArgumentError do
+      Message.class_eval do
+        has_rich_text :content, attachment_service: :unknown
+      end
+    end
+
+    assert_match(/Cannot configure service :unknown for ActionText::RichText#embeds/, error.message)
+  end
+
+  test "attachment_service is set to the one provided" do
+    Message.class_eval do
+      has_rich_text :content, attachment_service: :local
+    end
+    reflection = Message.reflect_on_association(:rich_text_content).class_name.safe_constantize.reflect_on_attachment(:embeds)
+    assert_equal :local, reflection.options[:service_name]
+  ensure
+    Message.class_eval do
+      has_rich_text :content
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Fixes: https://github.com/rails/rails/issues/45405

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

This is what I came up with. Essentially, it allows specifying `attachment_service` when defining `has_rich_text` association on a model.

Not sure how to write the tests for it though.

cc @skipkayhil 