### PR TITLE
Fix code cache namespacing for proxied attribute methods

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -398,7 +398,7 @@ module ActiveModel
             mangled_name = "__temp__#{name.unpack1("h*")}"
           end
 
-          code_generator.define_cached_method(name, as: mangled_name, namespace: namespace) do |batch|
+          code_generator.define_cached_method(name, as: mangled_name, namespace: :"#{namespace}_#{proxy_target}") do |batch|
             call_args.map!(&:inspect)
             call_args << parameters if parameters
 

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -288,4 +288,35 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal "foo",            match.attr_name
     assert_equal "attribute_test", match.proxy_target
   end
+
+  module NameClash
+    class Model1
+      include ActiveModel::AttributeMethods
+      attribute_method_suffix "_changed?"
+      define_attribute_methods :x
+      attr_accessor :x
+
+      private
+        def attribute_changed?(name)
+          :model_1
+        end
+    end
+
+    class Model2
+      include ActiveModel::AttributeMethods
+      attribute_method_suffix "?"
+      define_attribute_methods :x_changed
+      attr_accessor :x_changed
+
+      private
+        def attribute?(name)
+          :model_2
+        end
+    end
+  end
+
+  test "name clashes are handled" do
+    assert_equal :model_1, NameClash::Model1.new.x_changed?
+    assert_equal :model_2, NameClash::Model2.new.x_changed?
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/45416

The suffix need to be included in the namespace as it is used to generate the code.
