### PR TITLE
Fix retrieving sqlite3 expression indexes created by sql annotated with trailing comment

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -21,7 +21,7 @@ module ActiveRecord
               WHERE name = #{quote(row['name'])} AND type = 'index'
             SQL
 
-            /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+))?\z/i =~ index_sql
+            /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+))?(?:\s*\/\*.*\*\/)?\z/i =~ index_sql
 
             columns = exec_query("PRAGMA index_info(#{quote(row['name'])})", "SCHEMA").map do |col|
               col["name"]

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -390,6 +390,14 @@ module ActiveRecord
           end
         end
 
+        def test_expression_index_with_trailing_comment
+          with_example_table do
+            @conn.execute "CREATE INDEX expression on ex (number % 10) /* comment */"
+            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            assert_equal "number % 10", index.columns
+          end
+        end
+
         def test_expression_index_with_where
           with_example_table do
             @conn.add_index "ex", "id % 10, max(id, number)", name: "expression", where: "id > 1000"


### PR DESCRIPTION
When query comments are enabled via `config.active_record.query_log_tags_enabled`, sqlite3 is unable to correctly parse expression indexes from the creation sql with the added trailing comment in it.

It raises an error similar to
```ruby
NoMethodError: undefined method `size' for nil:NilClass

          if columns.size == options.size && options.values.uniq.size == 1
                    ^^^^^
```