### PR TITLE
Allow `db:prepare` to load schema if database already exists but is empty; also dumps schema after migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update `db:prepare` task to load schema when an uninitialized database exists, and dump schema after migrations.
+
+    *Ben Sheldon*
+
 *   Fix supporting timezone awareness for `tsrange` and `tstzrange` array columns.
 
     ```ruby

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -687,35 +687,54 @@ module ApplicationTests
         end
       end
 
-      test "db:prepare setup the database" do
+      test "db:prepare loads schema, runs pending migrations, and updates schema" do
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           output = rails("db:prepare")
           assert_match(/CreateBooks: migrated/, output)
+          assert_match(/create_table "books"/, File.read("db/schema.rb"))
 
           output = rails("db:drop")
           assert_match(/Dropped database/, output)
 
           rails "generate", "model", "recipe", "title:string"
           output = rails("db:prepare")
-          assert_match(/CreateBooks: migrated/, output)
+          assert_no_match(/CreateBooks: migrated/, output) # loaded from schema
           assert_match(/CreateRecipes: migrated/, output)
+
+          schema = File.read("db/schema.rb")
+          assert_match(/create_table "books"/, schema)
+          assert_match(/create_table "recipes"/, schema)
+
+          tables = rails("runner", "p ActiveRecord::Base.connection.tables.sort").strip
+          assert_equal('["ar_internal_metadata", "books", "recipes", "schema_migrations"]', tables)
         end
       end
 
-      test "db:prepare does not touch schema when dumping is disabled" do
+      test "db:prepare loads schema when database exists but is empty" do
+        rails "generate", "model", "book", "title:string"
+        rails("db:prepare", "db:drop", "db:create")
+
+        output = rails("db:prepare")
+        assert_no_match(/CreateBooks: migrated/, output)
+
+        tables = rails("runner", "p ActiveRecord::Base.connection.tables.sort").strip
+        assert_equal('["ar_internal_metadata", "books", "schema_migrations"]', tables)
+      end
+
+      test "db:prepare does not dump schema when dumping is disabled" do
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           rails "db:create", "db:migrate"
 
-          app_file "db/schema.rb", "Not touched"
+          app_file "db/schema.rb", "# Not touched"
           app_file "config/initializers/disable_dumping_schema.rb", <<-RUBY
             Rails.application.config.active_record.dump_schema_after_migration = false
           RUBY
 
           rails "db:prepare"
 
-          assert_equal("Not touched", File.read("db/schema.rb").strip)
+          assert_equal("# Not touched", File.read("db/schema.rb").strip)
         end
       end
 


### PR DESCRIPTION
### Summary

Rails 6.0 [introduced](https://github.com/rails/rails/pull/35768) a `db:prepare` rake task that idempotently sets up a database (creating the database, loading schema, and/or migrations).

**Existing Behavior:** If the database exists, but has not been populated with tables, `db:prepare` _will run all migrations_ to bring the database up to state.

**Proposed Behavior in this PR:** if the database exists, but has not been populated with tables, `db:prepare` _will load the schema_, then run any remaining migrations, to bring the database up to state.

### Why?

Platforms as a Service, like Heroku, Render, DOAP, Fly, etc. provision an empty database for the application on initial setup, which can take place regularly with "1-click deploy"-features, Heroku Review Apps, or Render Preview Environments, for example. Running the existing `db:prepare` in this situation will cause all of the migrations to run. **Loading the schema instead is the more correct and efficient action.** Also, for large/legacy applications that prune migration files, running all migrations may not produce the desired end state.

I believe that this PR does not deviate from the original purpose of the `db:prepare` task, but simply covers a not-uncommon scenario.  

### How?

This PR uses the value of `ActiveRecord::SchemaMigration.table_exists?` to determine if the database has been populated with tables. 

### Outstanding work

- [x] Tests passing
- [x] Add test for new behavior
- [x] Add changelog entry