### PR TITLE
Add `ActiveSupport::Processing`

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -80,6 +80,7 @@ module ActiveSupport
     autoload :TaggedLogging
     autoload :XmlMini
     autoload :ArrayInquirer
+    autoload :Processing
   end
 
   autoload :Rescuable

--- a/activesupport/lib/active_support/processing.rb
+++ b/activesupport/lib/active_support/processing.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Processing
+    extend Concern
+
+    included do
+      def process(element)
+        id         = identify element
+        on_element = :"on_#{id}"
+
+        if respond_to? on_element
+          public_send(on_element, element)
+        else
+          handler_missing(element)
+        end
+      end
+
+      def process_each(elements)
+        elements.filter_map do |element|
+          process element
+        end
+      end
+
+      def handler_missing(element)
+      end
+    end
+
+    class_methods do
+      def process(elements)
+        new.process_each(elements)
+      end
+    end
+  end
+end

--- a/activesupport/test/processing_test.rb
+++ b/activesupport/test/processing_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class ProcessingTest < ActiveSupport::TestCase
+  class HTMLElement
+    attr_reader :tag
+
+    def initialize(tag:)
+      @tag = tag
+    end
+  end
+
+  class HTMLButtonElement < HTMLElement
+    def initialize
+      super(tag: :button)
+    end
+  end
+
+  class HTMLFormElement < HTMLElement
+    def initialize
+      super(tag: :form)
+    end
+  end
+
+  class HTMLLinkElement < HTMLElement
+    def initialize
+      super(tag: :link)
+    end
+  end
+
+  class HTMLProcessor
+    include ActiveSupport::Processing
+
+    # Implement `#identify` to identify HTML elements, and dispatch them to
+    # right handlers
+    def identify(element)
+      element.tag
+    end
+
+    # Invoked if `element.tag == :button`
+    def on_button(element)
+      element.class
+    end
+
+    # Invoked if `element.tag == :form`
+    def on_form(element)
+      element.class
+    end
+  end
+
+  def test_should_process_elements_with_handlers
+    elements  = [
+      HTMLButtonElement.new,
+      HTMLFormElement.new,
+      HTMLLinkElement.new
+    ]
+
+    assert_equal [HTMLButtonElement, HTMLFormElement], HTMLProcessor.process(elements)
+  end
+end


### PR DESCRIPTION
This PR adds a pattern extracted from the [ast](https://github.com/whitequark/ast/blob/master/lib/ast/processor/mixin.rb#L251) gem, which uses [dynamic dispatch](https://en.wikipedia.org/wiki/Dynamic_dispatch) to process any kind of [semi-structured data](https://en.wikipedia.org/wiki/Semi-structured_data#:~:text=Semi%2Dstructured%20data%20is%20a,and%20fields%20within%20the%20data.). 

Let's say that you have to deal with HTML data in your application. You might have a class named `HTMLElement`, and subclasses like `HTMLButtonElement`, `HTMLFormElement`, or `HTMLLinkElement`.
```ruby
class HTMLElement
  attr_reader :tag

  def initialize(tag:)
    @tag = tag
  end
end

class HTMLButtonElement < HTMLElement
  def initialize
    super(tag: :button)
  end
end

class HTMLFormElement < HTMLElement
  def initialize
    super(tag: :form)
  end
end

class HTMLLinkElement < HTMLElement
  def initialize
    super(tag: :link)
  end
end
```
To process this kind of data without coupling the processing logic with your models, you can proceed like so:
```ruby
class HTMLProcessor
  include ActiveSupport::Processing

  # Implement `#identify` to identify `element`, and dispatch it to the right handler
  def identify(element)
    element.tag
  end

  # Invoked if `element.tag == :button`
  def on_button(element)
    element.class
  end

  # Invoked if `element.tag == :form`
  def on_form(element)
    element.class
  end
end

elements  = [
  HTMLButtonElement.new,
  HTMLFormElement.new,
  HTMLLinkElement.new
]

HTMLProcessor.process(elements) # => [HTMLButtonElement, HTMLFormElement]
```
## TODO
- [ ] Provide more context to clarify the purpose of this PR.
- [ ] Write more tests.
- [ ] Write documentation.