### PR TITLE
Quieter postgres load

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Quieter structure load for postgres
+
+    Discard noisy output from structure load via psql into /dev/null for
+    successful queries, preserving error reporting, increasing signal to noise
+    ratio for regular database rake tasks.
+
+    *Samuel Cochran*
+
 *   Introduce strategy pattern for executing migrations.
 
     By default, migrations will use a strategy object that delegates the method

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -75,7 +75,7 @@ module ActiveRecord
         end
 
         args << db_config.database
-        run_cmd("pg_dump", args, "dumping")
+        run_cmd("dumping", "pg_dump", *args)
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
@@ -84,7 +84,7 @@ module ActiveRecord
         args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
-        run_cmd("psql", args, "loading")
+        run_cmd("loading", "psql", *args)
       end
 
       private
@@ -114,11 +114,11 @@ module ActiveRecord
           end
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        def run_cmd(action, cmd, *args, **kwargs)
+          fail run_cmd_error(action, cmd, args) unless Kernel.system(psql_env, cmd, *args, **kwargs)
         end
 
-        def run_cmd_error(cmd, args, action)
+        def run_cmd_error(action, cmd, args)
           msg = +"failed to execute:\n"
           msg << "#{cmd} #{args.join(' ')}\n\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -84,7 +84,7 @@ module ActiveRecord
         args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
-        run_cmd("loading", "psql", *args)
+        run_cmd("loading", "psql", *args, out: File::NULL)
       end
 
       private

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -510,6 +510,7 @@ if current_adapter?(:PostgreSQLAdapter)
           Kernel,
           :system,
           [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, @configuration["database"]],
+          out: File::NULL,
           returns: true
         ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
@@ -520,7 +521,7 @@ if current_adapter?(:PostgreSQLAdapter)
         filename = "awesome-file.sql"
         expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
 
-        assert_called_with(Kernel, :system, expected_command, returns: true) do
+        assert_called_with(Kernel, :system, expected_command, out: File::NULL, returns: true) do
           with_structure_load_flags(["--noop"]) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
           end
@@ -532,7 +533,7 @@ if current_adapter?(:PostgreSQLAdapter)
         expected_env = { "PGHOST" => "my.server.tld", "PGPORT" => "2345", "PGUSER" => "jane", "PGPASSWORD" => "s3cr3t" }
         expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
 
-        assert_called_with(Kernel, :system, expected_command, returns: true) do
+        assert_called_with(Kernel, :system, expected_command, out: File::NULL, returns: true) do
           with_structure_load_flags(["--noop"]) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load(
               @configuration.merge(host: "my.server.tld", port: 2345, username: "jane", password: "s3cr3t"),
@@ -547,7 +548,7 @@ if current_adapter?(:PostgreSQLAdapter)
         expected_env = { "PGSSLMODE" => "verify-full", "PGSSLCERT" => "client.crt", "PGSSLKEY" => "client.key", "PGSSLROOTCERT" => "root.crt" }
         expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
 
-        assert_called_with(Kernel, :system, expected_command, returns: true) do
+        assert_called_with(Kernel, :system, expected_command, out: File::NULL, returns: true) do
           with_structure_load_flags(["--noop"]) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load(
               @configuration.merge(sslmode: "verify-full", sslcert: "client.crt", sslkey: "client.key", sslrootcert: "root.crt"),
@@ -561,7 +562,7 @@ if current_adapter?(:PostgreSQLAdapter)
         filename = "awesome-file.sql"
         expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, @configuration["database"]]
 
-        assert_called_with(Kernel, :system, expected_command, returns: true) do
+        assert_called_with(Kernel, :system, expected_command, out: File::NULL, returns: true) do
           with_structure_load_flags({ mysql2: ["--noop"] }) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
           end
@@ -572,7 +573,7 @@ if current_adapter?(:PostgreSQLAdapter)
         filename = "awesome-file.sql"
         expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
 
-        assert_called_with(Kernel, :system, expected_command, returns: true) do
+        assert_called_with(Kernel, :system, expected_command, out: File::NULL, returns: true) do
           with_structure_load_flags({ postgresql: ["--noop"] }) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
           end
@@ -585,6 +586,7 @@ if current_adapter?(:PostgreSQLAdapter)
           Kernel,
           :system,
           [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, @configuration["database"]],
+          out: File::NULL,
           returns: true
         ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)


### PR DESCRIPTION
### Summary

Postgres structure load is currently quite noisy. The structure dump includes several queries which create useless output, and condition developers to ignore output entirely. By removing this noise, the default case is more pleasant on the command line, but more importantly it makes failures more obvious and actionable.

### Example

Our rails application has several databases, and the output of a `db:reset` currently looks like this:

```
$ bin/rails db:reset
Dropped database 'buildkite_development'
Dropped database 'buildkite_buffer_development'
Dropped database 'buildkite_analytics_development'
Dropped database 'job_log_chunks_development'
Dropped database 'buildkite_artifacts_development'
Dropped database 'buildkite_test'
Dropped database 'buildkite_buffer_test'
Dropped database 'buildkite_analytics_test'
Dropped database 'buildkite_artifacts_test'
Dropped database 'job_log_chunks_test'
Created database 'buildkite_development'
Created database 'buildkite_buffer_development'
Created database 'buildkite_analytics_development'
Created database 'job_log_chunks_development'
Created database 'buildkite_artifacts_development'
Created database 'buildkite_test'
Created database 'buildkite_buffer_test'
Created database 'buildkite_analytics_test'
Created database 'buildkite_artifacts_test'
Created database 'job_log_chunks_test'
 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 set_config
------------

(1 row)

 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 create_partition_time
-----------------------
 t
(1 row)

 set_config
------------

(1 row)

 set_config
------------

(1 row)

Done!
```

We have append some extra statements into the structure, but the vanilla version still outputs the "set_config" query results several times, at least once per database.

After this change, the successful output looks like:

```
$ bin/rails db:reset
Dropped database 'buildkite_development'
Dropped database 'buildkite_buffer_development'
Dropped database 'buildkite_analytics_development'
Dropped database 'job_log_chunks_development'
Dropped database 'buildkite_artifacts_development'
Dropped database 'buildkite_test'
Dropped database 'buildkite_buffer_test'
Dropped database 'buildkite_analytics_test'
Dropped database 'buildkite_artifacts_test'
Dropped database 'job_log_chunks_test'
Created database 'buildkite_development'
Created database 'buildkite_buffer_development'
Created database 'buildkite_analytics_development'
Created database 'job_log_chunks_development'
Created database 'buildkite_artifacts_development'
Created database 'buildkite_test'
Created database 'buildkite_buffer_test'
Created database 'buildkite_analytics_test'
Created database 'buildkite_artifacts_test'
Created database 'job_log_chunks_test'
Done!
```

And if an error is introduced, it still appears loudly:

```
$ bin/rails db:reset
Dropped database 'buildkite_development'
Dropped database 'buildkite_buffer_development'
Dropped database 'buildkite_analytics_development'
Dropped database 'job_log_chunks_development'
Dropped database 'buildkite_artifacts_development'
Dropped database 'buildkite_test'
Dropped database 'buildkite_buffer_test'
Dropped database 'buildkite_analytics_test'
Dropped database 'buildkite_artifacts_test'
Dropped database 'job_log_chunks_test'
Created database 'buildkite_development'
Created database 'buildkite_buffer_development'
Created database 'buildkite_analytics_development'
Created database 'job_log_chunks_development'
Created database 'buildkite_artifacts_development'
Created database 'buildkite_test'
Created database 'buildkite_buffer_test'
Created database 'buildkite_analytics_test'
Created database 'buildkite_artifacts_test'
Created database 'job_log_chunks_test'
psql:.../db/structure.sql:18: ERROR:  schema "partman" already exists
rails aborted!
failed to execute:
psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --file .../db/structure.sql buildkite_development

Please check the output above for any errors and make sure that `psql` is installed in your PATH and has proper permissions.


Tasks: TOP => db:reset => db:setup => db:schema:load
(See full trace by running task with --trace)
```