### PR TITLE
Fix: incorrect value regarding overhead and encryption

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -84,7 +84,7 @@ Some examples:
 | ------------------------------------------------- | -------------------- | --------------------------------- | ----------------------------- |
 | Email addresses                                   | string(255)          | string(510)                       | 255 bytes                     |
 | Short sequence of emojis                          | string(255)          | string(1020)                      | 255 bytes                     |
-| Summary of texts written in non-western alphabets | string(500)          | string(2000)                      | negligible                    |
+| Summary of texts written in non-western alphabets | string(500)          | string(2000)                      | 255 bytes                     |
 | Arbitrary long text                               | text                 | text                              | negligible                    |
 
 ### Deterministic and Non-deterministic Encryption


### PR DESCRIPTION
There was an error in the table of examples: when storing 500-character payloads the overhead is not negligible.

CC @jeremy 