### PR TITLE
Added ability to add format to model attribute error key

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -12,7 +12,7 @@ module ActiveModel
 
     class_attribute :i18n_customize_full_message, default: false
 
-    def self.full_message(attribute, message, base) # :nodoc:
+    def self.full_message(attribute, message, base, raw_type = nil) # :nodoc:
       return message if attribute == :base
 
       base_class = base.class
@@ -28,6 +28,7 @@ module ActiveModel
         if namespace
           defaults = base_class.lookup_ancestors.map do |klass|
             [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.#{raw_type}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
             ]
@@ -35,6 +36,7 @@ module ActiveModel
         else
           defaults = base_class.lookup_ancestors.map do |klass|
             [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.#{raw_type}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
             ]
@@ -77,8 +79,11 @@ module ActiveModel
         attribute = attribute.to_s.remove(/\[\d+\]/)
 
         defaults = base.class.lookup_ancestors.flat_map do |klass|
-          [ :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
-            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}" ]
+          [
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}.message",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.attributes.#{attribute}.#{type}",
+            :"#{i18n_scope}.errors.models.#{klass.model_name.i18n_key}.#{type}"
+          ]
         end
         defaults << :"#{i18n_scope}.errors.messages.#{type}"
 
@@ -156,7 +161,7 @@ module ActiveModel
     #   error.full_message
     #   # => "Name is too short (minimum is 5 characters)"
     def full_message
-      self.class.full_message(attribute, message, @base)
+      self.class.full_message(attribute, message, @base, raw_type)
     end
 
     # See if error matches provided +attribute+, +type+, and +options+.


### PR DESCRIPTION
I've added ability to add format to model attribute error key
What problem does it solve?
For example we have following locale.yaml:
```
company:
  attributes:
    provider:
      already_used_by_other_provider: "Already used by other provider"
      already_registered_by_another_provider: "already registered by another provider"
```
We want to show full_error of **already_used_by_other_provider** key as `%{message}`, but want the **already_registered_by_another_provider** error key as `%{attribute} %{message}`

This can now be achieved by declaring the format like this:
```
company:
  attributes:
    provider:
      already_used_by_other_provider: 
        message: "Already used by other provider"
        format: "%{message}"
      already_registered_by_another_provider: "already registered by another provider"
```