### PR TITLE
Fix timezone awareness of ActiveSupport::Messages::Metadata

### DIFF
--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -32,7 +32,7 @@ module ActiveSupport
             if expires_at
               expires_at.utc.iso8601(3)
             elsif expires_in
-              Time.now.utc.advance(seconds: expires_in).iso8601(3)
+              Time.now.advance(seconds: expires_in).utc.iso8601(3)
             end
           end
 


### PR DESCRIPTION
### Summary

Fix timezone awareness of ActiveSupport::Messages::Metadata

Problem:

expires_at and expires_in can yield different expiry depending on the
current time and timezone. This is because

- expires_at: advances the time, then converts it to UTC.
- expires_in: converts the time to UTC, then advances it.

Solution:

Fix expires_in to match expires_at behavior (advance the time, then
converts to UTC).

### Other Information

Can someone help me write unit tests for this? I could write clean unit tests without calling the private method (`pick_expiry`).

Closes https://github.com/rails/rails/issues/44808.