### PR TITLE
Support `:urlsafe` option for `MessageEncryptor`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support `:urlsafe` option for `MessageEncryptor`.
+
+    The `MessageEncryptor` constructor now accepts a `:urlsafe` option, similar
+    to the `MessageVerifier` constructor.  When enabled, this option ensures
+    that messages use a URL-safe encoding.
+
+    *Jonathan Hefner*
+
 *   Add `urlsafe` option to `ActiveSupport::MessageVerifier` initializer
 
     `ActiveSupport::MessageVerifier.new` now takes optional `urlsafe` argument.


### PR DESCRIPTION
This PR is split into two related but separate commits:

The 1st commit refactors `MessageEncryptor` to make the 2nd commit simpler, and provide a small performance increase.

The 2nd commit adds support for `urlsafe: true` to `MessageEncryptor`, a la `MessageVerifier` since #45419.
