### PR TITLE
Avoid removing a PostgreSQL extension when there are dependent objects

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Avoid removing a PostgreSQL extension when there are dependent objects.
+
+    Previously, removing an extension also implicitly removed dependent objects. Now, this will raise an error.
+
+    You can force removing the extension:
+
+    ```ruby
+    disable_extension :citext, force: :cascade
+    ```
+
+    Fixes #29091.
+
+    *fatkodima*
+
 *   Allow nested functions as safe SQL string
 
     *Michael Siegfried*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -493,11 +493,11 @@ module ActiveRecord
       end
 
       # This is meant to be implemented by the adapters that support extensions
-      def disable_extension(name)
+      def disable_extension(name, **)
       end
 
       # This is meant to be implemented by the adapters that support extensions
-      def enable_extension(name)
+      def enable_extension(name, **)
       end
 
       # This is meant to be implemented by the adapters that support custom enum types

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -437,14 +437,19 @@ module ActiveRecord
         query_value("SELECT pg_advisory_unlock(#{lock_id})")
       end
 
-      def enable_extension(name)
+      def enable_extension(name, **)
         exec_query("CREATE EXTENSION IF NOT EXISTS \"#{name}\"").tap {
           reload_type_map
         }
       end
 
-      def disable_extension(name)
-        exec_query("DROP EXTENSION IF EXISTS \"#{name}\" CASCADE").tap {
+      # Removes an extension from the database.
+      #
+      # [<tt>:force</tt>]
+      #   Set to +:cascade+ to drop dependent objects as well.
+      #   Defaults to false.
+      def disable_extension(name, force: false)
+        exec_query("DROP EXTENSION IF EXISTS \"#{name}\"#{' CASCADE' if force == :cascade}").tap {
           reload_type_map
         }
       end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -65,6 +65,13 @@ module ActiveRecord
           super(table_name, column_name, !!null, default)
         end
 
+        def disable_extension(name, **options)
+          if connection.adapter_name == "PostgreSQL"
+            options[:force] = :cascade
+          end
+          super
+        end
+
         private
           def compatible_table_definition(t)
             class << t

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -41,7 +41,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
 
   def test_disable_enable_hstore
     assert @connection.extension_enabled?("hstore")
-    @connection.disable_extension "hstore"
+    @connection.disable_extension "hstore", force: :cascade
     assert_not @connection.extension_enabled?("hstore")
     @connection.enable_extension "hstore"
     assert @connection.extension_enabled?("hstore")

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -178,7 +178,7 @@ def disable_extension!(extension, connection)
   return false unless connection.supports_extensions?
   return true unless connection.extension_enabled?(extension)
 
-  connection.disable_extension extension
+  connection.disable_extension(extension, force: :cascade)
   connection.reconnect!
 end
 

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -149,7 +149,7 @@ module ActiveRecord
 
     class DisableExtension2 < SilentMigration
       def change
-        disable_extension "hstore"
+        disable_extension "hstore", force: :cascade
       end
     end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -639,6 +639,24 @@ module ActiveRecord
         end
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_disable_extension_on_7_0
+          enable_extension!(:hstore, connection)
+
+          migration = Class.new(ActiveRecord::Migration[7.0]) do
+            def up
+              add_column :testings, :settings, :hstore
+              disable_extension :hstore
+            end
+          end
+
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+          assert_not connection.extension_enabled?(:hstore)
+        ensure
+          disable_extension!(:hstore, connection)
+        end
+      end
+
       private
         def precision_implicit_default
           if current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
See #29091 for the detailed description of the problem. This PR also preserves backwards compatibility with older migrations. 

Fixes #29091.