### PR TITLE
Makes the  API documentation link relative

### DIFF
--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -79,7 +79,7 @@ and may also be used independently outside \Rails.
    * The \README file created within your application.
    * {Getting Started with \Rails}[https://guides.rubyonrails.org/getting_started.html].
    * {Ruby on \Rails Guides}[https://guides.rubyonrails.org].
-   * {The API Documentation}[https://api.rubyonrails.org].
+   * {The API Documentation}[link:/files/railties/RDOC_MAIN_rdoc.html].
 
 == Contributing
 


### PR DESCRIPTION
This has been mentioned in #45001 and helps avoiding switching the api version unintentionally.

I'm not sure if there's a way to update the guides.rubyonrails.org links as well with the correct version number, since they refer to the guides and not the rdocs.
