### PR TITLE
Lock rack-test version to v1 until #45467 is resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
+# Lock rack-test to v1 until #45467 is fixed
+gem "rack-test", "< 2"
+
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,6 +600,7 @@ DEPENDENCIES
   queue_classic (>= 4.0.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
+  rack-test (< 2)
   rails!
   rake (>= 11.1)
   redcarpet (~> 3.2.3)


### PR DESCRIPTION
### Summary

This pull request locks rack-test version to v1 until #45467 is resolved

Action Pack CI has been failing since rack-test v2.0.0.
Refer to https://github.com/rails/rails/pull/45177
