### PR TITLE
Restart Action Cable server on Redis connection failures

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Restart Action Cable when Redis disconnects.
+
+    *Heinrich Lee Yu, Chris Wilson*
+
 *   The Action Cable server is now mounted with `anchor: true`.
 
     This means that routes that also start with `/cable` will no longer clash with Action Cable.

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -150,6 +150,9 @@ module ActionCable
 
                 conn = @adapter.redis_connection_for_subscriptions
                 listen conn
+              rescue ::Redis::BaseConnectionError
+                @thread = @raw_client = nil
+                ActionCable.server.restart
               end
             end
 

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -25,14 +25,14 @@ module CommonSubscriptionAdapterTest
     [@rx_adapter, @tx_adapter].uniq.compact.each(&:shutdown)
   end
 
-  def subscribe_as_queue(channel, adapter = @rx_adapter)
+  def subscribe_as_queue(channel, adapter = @rx_adapter, expect_success: true)
     queue = Queue.new
 
     callback = -> data { queue << data }
     subscribed = Concurrent::Event.new
     adapter.subscribe(channel, callback, Proc.new { subscribed.set })
     subscribed.wait(WAIT_WHEN_EXPECTING_EVENT)
-    assert_predicate subscribed, :set?
+    assert_predicate subscribed, :set? if expect_success
 
     yield queue
 


### PR DESCRIPTION
### Summary

Adapted from https://github.com/rails/rails/pull/44626 this restarts the Action Cable server on Redis connection failures, **adding tests and a changelog entry**. 

Closes https://github.com/rails/rails/issues/27659

@treacher @engwan @jorgemanrubia