### PR TITLE
Add support for bulk change_table revert

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -124,7 +124,15 @@ module ActiveRecord
       alias :remove_belongs_to :remove_reference
 
       def change_table(table_name, **options) # :nodoc:
-        yield delegate.update_table_definition(table_name, self)
+        if delegate.supports_bulk_alter? && options[:bulk]
+          recorder = self.class.new(self.delegate)
+          recorder.reverting = @reverting
+          yield recorder.delegate.update_table_definition(table_name, recorder)
+          commands = recorder.commands
+          @commands << [:change_table, [table_name], -> t { bulk_change_table(table_name, commands) }]
+        else
+          yield delegate.update_table_definition(table_name, self)
+        end
       end
 
       def replay(migration)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1561,6 +1561,47 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         @indexes ||= Person.connection.indexes("delete_me")
       end
   end # AlterTableMigrationsTest
+
+  class RevertBulkAlterTableMigrationsTest < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    def setup
+      @connection = Person.connection
+      Person.reset_column_information
+      Person.reset_sequence_name
+    end
+
+    teardown do
+      @connection.remove_columns(:people, :column1, :column2) rescue nil
+    end
+
+    def test_bulk_revert
+      @connection.add_column(:people, :column1, :string)
+      @connection.add_column(:people, :column2, :string)
+      assert_column Person, :column1
+      assert_column Person, :column2
+
+      migration = Class.new(ActiveRecord::Migration::Current) {
+        disable_ddl_transaction!
+
+        def write(text = ""); end
+
+        def change
+          change_table :people, bulk: true do |t|
+            t.column :column1, :string
+            t.column :column2, :string
+          end
+        end
+      }.new
+
+      assert_queries(1) do
+        migration.migrate(:down)
+      end
+
+      assert_no_column Person, :column1
+      assert_no_column Person, :column2
+    end
+  end
 end
 
 class CopyMigrationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Last year @eugeneius pointed out that rolling back a migration with a `change_table` using `bulk: true` does NOT result in a single `ALTER`. Instead it produces separate `ALTER` statements that doesn't match the `up` direction behavior.

Here's a script to reproduce the problem:

<details>
<summary>Reproduction</summary>

```ruby
require 'active_support'
require 'active_record'
require 'mysql2'

class BulkChange < ActiveRecord::Migration[7.1]
  def change
    change_table :my_table, bulk: true do |t|
      t.column :name, :string
      t.column :content, :string
    end
  end
end

ActiveRecord::Base.establish_connection(
  adapter: 'mysql2',
  encoding: 'utf8mb4',
  pool: 5,
  username: 'user1',
  password: 'password1',
  socket: '/var/run/mysqld/mysqld.sock',
  database: 'my_test_app_development'
)
ActiveRecord::Base.logger = Logger.new($stdout)
ActiveRecord::Base.connection.execute('DROP TABLE my_table')
ActiveRecord::Base.connection.execute('CREATE TABLE my_table (id INT)')

BulkChange.new.migrate(:up)
BulkChange.new.migrate(:down)
```

</details>

Running it produces the following output – single `ALTER` on `up` and two `ALTER`s on `down`:
```ruby
D, [2022-06-28T18:19:24.474009 #19600] DEBUG -- :    (47.2ms)  DROP TABLE my_table
D, [2022-06-28T18:19:24.579683 #19600] DEBUG -- :    (105.3ms)  CREATE TABLE my_table (id INT)
==  BulkChange: migrating =====================================================
-- change_table(:my_table, {:bulk=>true})
D, [2022-06-28T18:19:24.611983 #19600] DEBUG -- :    (29.0ms)  ALTER TABLE `my_table` ADD `name` varchar(255), ADD `content` varchar(255)
   -> 0.0321s
==  BulkChange: migrated (0.0322s) ============================================

==  BulkChange: reverting =====================================================
-- remove_column(:my_table, :content, :string)
D, [2022-06-28T18:19:24.651304 #19600] DEBUG -- :    (35.2ms)  ALTER TABLE `my_table` DROP COLUMN `content`
   -> 0.0390s
-- remove_column(:my_table, :name, :string)
D, [2022-06-28T18:19:24.705775 #19600] DEBUG -- :    (52.9ms)  ALTER TABLE `my_table` DROP COLUMN `name`
   -> 0.0544s
==  BulkChange: reverted (0.0937s) ============================================
```


This PR fixes the problem by adding an undocumented method `bulk_change_table` to `SchemaStatements`. This new method is an extraction out of the `change_table` with the only change that it accepts `reverting` argument.
During migration reversal command recorder puts `bulk_change_table` in the stack of `@commands`. `reverting` is passed to support nested `revert` invocations. When recorder commands are executed on the real connection (`delegate`) `bulk_change_table` instantiates a new recorder, records `change_table` operations and then executes them in a single `ALTER` statement.

As a result of this fix, new output looks like this:
```ruby
D, [2022-06-28T18:27:05.538261 #23235] DEBUG -- :    (41.7ms)  DROP TABLE my_table
D, [2022-06-28T18:27:05.652020 #23235] DEBUG -- :    (113.5ms)  CREATE TABLE my_table (id INT)
==  BulkChange: migrating =====================================================
-- change_table(:my_table, {:bulk=>true})
D, [2022-06-28T18:27:05.696682 #23235] DEBUG -- :    (40.8ms)  ALTER TABLE `my_table` ADD `name` varchar(255), ADD `content` varchar(255)
   -> 0.0445s
==  BulkChange: migrated (0.0446s) ============================================

==  BulkChange: reverting =====================================================
-- bulk_change_table(:my_table, true)
D, [2022-06-28T18:27:05.735109 #23235] DEBUG -- :    (37.8ms)  ALTER TABLE `my_table` DROP COLUMN `name`, DROP COLUMN `content`
   -> 0.0381s
==  BulkChange: reverted (0.0383s) ============================================
```

We investigated other opportunities, most notable [this one](https://github.com/rails/rails/compare/main...gregolsen:rails:migration_bulk_rollback2). However this requires a signature change of the `change_table` as passing hash as a keyword argument produces a warning. While the warning could be mitigated by using `Hash.ruby2_keywords_hash(options.merge!(revert: @reverting))` having undocumented `revert` option on the `change_table` didn't seem like a good idea.

@eugeneius made a point that we already have an undocumented `add_columns` method that was introduced as a counterpart for `remove_columns` specifically to support the reversal. Hence, we decided to go with a `bulk_change_table` as a bulkified version of a `change_table` used on revert.

This PR also adds a test for the `bulk: true` `change_table` reversal which seems like was missing before.
W/o the fix the test fails like this:
```
@gregolsen ➜ /workspaces/rails/activerecord (main ✗) $ ARCONN=mysql2 bundle exec ruby -w -Itest test/cases/migration_test.rb -n test_bulk_revert
Using mysql2
Run options: -n test_bulk_revert --seed 5885

# Running:

F

Failure:
RevertBulkAlterTableMigrationsTest#test_bulk_revert [test/cases/migration_test.rb:1560]:
2 instead of 1 queries were executed.
Queries:
ALTER TABLE `people` DROP COLUMN `column2`
ALTER TABLE `people` DROP COLUMN `column1`.
Expected: 1
  Actual: 2
```