### PR TITLE
Fix vulnerability in open redirects

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -195,7 +195,8 @@ module ActionController
       end
 
       def _url_host_allowed?(url)
-        [request.host, nil].include?(URI(url.to_s).host)
+        host = URI(url.to_s).host
+        host == request.host || host.nil? && url.to_s.start_with?("/")
       rescue ArgumentError, URI::Error
         false
       end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -88,6 +88,10 @@ class RedirectController < ActionController::Base
     redirect_back_or_to "http://www.rubyonrails.org/"
   end
 
+  def unsafe_redirect_malformed
+    redirect_to "http:///www.rubyonrails.org/"
+  end
+
   def only_path_redirect
     redirect_to action: "other_host", only_path: true
   end
@@ -501,6 +505,16 @@ class RedirectTest < ActionController::TestCase
       end
 
       assert_equal "Unsafe redirect to \"http://www.rubyonrails.org/\", pass allow_other_host: true to redirect anyway.", error.message
+    end
+  end
+
+  def test_unsafe_redirect_with_malformed_url
+    with_raise_on_open_redirects do
+      error = assert_raise(ActionController::Redirecting::UnsafeRedirectError) do
+        get :unsafe_redirect_malformed
+      end
+
+      assert_equal "Unsafe redirect to \"http:///www.rubyonrails.org/\", pass allow_other_host: true to redirect anyway.", error.message
     end
   end
 


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/44650 allows `nil` as the `host` assuming that `URI` works in a way that unfortunately it doesn't 😅 

As an example:
```
[2] pry(main)> URI("http:///www.rubyonrails.org/").host
=> nil
[3] pry(main)> URI("http:///www.rubyonrails.org/").path
=> "/www.rubyonrails.org/"
```

This solution will additionally check that the provided string starts with a `/`. ~Another possible solution could be using a single source of truth of the redirection location instead of `URI`~. So yeah, there might be better ways to fix it, so it's open to discussion cc @tenderlove 