### PR TITLE
Defer constant loading of `ActionMailer::MailDeliveryJob` until ActiveJob and ActionMailer is loaded

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -486,7 +486,7 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
+    class_attribute :delivery_job, default: nil
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -41,8 +41,9 @@ module ActionMailer
         register_preview_interceptors(options.delete(:preview_interceptors))
         register_observers(options.delete(:observers))
 
-        if delivery_job = options.delete(:delivery_job)
-          self.delivery_job = delivery_job.constantize
+        delivery_job = options.delete(:delivery_job)
+        ActiveSupport.on_load(:active_job) do
+          ::ActionMailer::Base.delivery_job ||= delivery_job.present? ? delivery_job.constantize : ::ActionMailer::MailDeliveryJob
         end
 
         if options.smtp_settings


### PR DESCRIPTION
Sibling PR to #45476, where this was initially split off from.

Connects to #45434.
