### PR TITLE
Changes to/for minitest 5.16.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-if RUBY_VERSION < "3"
-  gem "minitest", ">= 5.15.0", "< 5.16"
-else
-  gem "minitest", ">= 5.15.0"
-end
+gem "minitest", "~> 5.16"
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,7 +593,7 @@ DEPENDENCIES
   json (>= 2.0.0)
   libxml-ruby
   listen (~> 3.3)
-  minitest (>= 5.15.0)
+  minitest (~> 5.16)
   minitest-bisect
   minitest-ci
   minitest-retry

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "cases/helper"
+require_relative "../helper"
 
-require "models/topic"
+require_relative "../../models/topic"
 
 class ValidatesWithTest < ActiveModel::TestCase
   def teardown

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -5,3 +5,5 @@ if ENV["BUILDKITE"]
 
   Minitest::Ci.report_dir = File.join(__dir__, "../test-reports/#{ENV['BUILDKITE_JOB_ID']}")
 end
+
+ENV["MT_KWARGS_HACK"] = "1" if RUBY_VERSION < "3"


### PR DESCRIPTION
### Summary

This bumps to minitest 5.16.1 and adds `MT_KWARGS_HACK=1` to the env for CI.

Happy to jettison the AM hack and/or put it in a different PR.

### Other Information

This is an attempt to fix failures as reported by @eileencodes in minitest/minitest#912

Boy I hope contributor PRs run the CI...