### PR TITLE
Fix flaky test in`ForeignKeyChangeColumnTest#test_change_column_of_parent_table`

### DIFF
--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -580,7 +580,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             connection.drop_table "astronauts", if_exists: true rescue nil
             connection.drop_table "rockets", if_exists: true rescue nil
 
-            ActiveRecord::Base.establish_connection(:arunit)
+            @connection = ActiveRecord::Base.establish_connection(:arunit).connection unless @connection.active?
           end
         end
 


### PR DESCRIPTION
### Summary

Reference:

https://buildkite.com/rails/rails/builds/87688#0181ac6d-acbc-4b9f-9537-735c4540d844/1071-1082

Reproduction steps:

```
rake db:mysql:rebuild

bin/test --verbose -a mysql2 --seed 45653 -n "/^(?:EagerLoadPolyAssocsTest#(?:test_include_query)|ActiveRecord::Migration::ForeignKeyTest#(?:test_does_not_create_foreign_keys_when_bypassed_by_config)|ActiveRecord::Migration::ForeignKeyChangeColumnTest#(?:test_change_column_of_parent_table))$/"

Ok

bin/test --verbose -a mysql2 --seed 45653 -n "/^(?:EagerLoadPolyAssocsTest#(?:test_include_query)|ActiveRecord::Migration::ForeignKeyTest#(?:test_does_not_create_foreign_keys_when_bypassed_by_config)|ActiveRecord::Migration::ForeignKeyChangeColumnTest#(?:test_change_column_of_parent_table))$/"

Error:
ActiveRecord::Migration::ForeignKeyChangeColumnTest#test_change_column_of_parent_table:
ActiveRecord::StatementInvalid: Mysql2::Error: Table 'rockets' already exists
```

The second run fails because the following test

```
ActiveRecord::Migration::ForeignKeyTest#:test_does_not_create_foreign_keys_when_bypassed_by_config
```

Creates an SQLite connection and then the AR connection in the `@connection` variable is disconnected.

So, the teardown method isn't able to remove the `rockets` table and fails silently.

Another solution could be to re-establish the connection in `@connection` like this

```diff
--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -580,7 +580,7 @@ def test_does_not_create_foreign_keys_when_bypassed_by_config
             connection.drop_table "astronauts", if_exists: true rescue nil
             connection.drop_table "rockets", if_exists: true rescue nil
 
-            ActiveRecord::Base.establish_connection(:arunit)
+            @connection = ActiveRecord::Base.establish_connection(:arunit).connection
           end
         end
 ```

But I couldn't see similar uses.