### PR TITLE
Update Pull Request Template [ci-skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,28 +1,47 @@
-### Summary
+<!--
+About this template
 
-<!-- Provide a general description of the code changes in your pull
-request... were there any bugs you had fixed? If so, mention them. If
-these bugs have open GitHub issues, be sure to tag them here as well,
-to keep the conversation linked together. -->
+The following template aims to help contributors write a good description for their pull requests.
+We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.
 
-### Other Information
+Feel free to discard it if you need to (e.g. when you just fix a typo). -->
 
-<!-- If there's anything else that's important and relevant to your pull
-request, mention that information here. This could include
-benchmarks, or other information.
+### Motivation / Background
 
-If you are updating any of the CHANGELOG files or are asked to update the
-CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.
+<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->
 
-Finally, if your pull request affects documentation or any non-code
-changes, guidelines for those changes are [available
-here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
+This Pull Request has been created because [REPLACE ME]
 
-Thanks for contributing to Rails! -->
+### Detail
+
+This Pull Request changes [REPLACE ME]
+
+### Additional information
+
+<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
+
+### Checklist
+
+Before submitting the PR make sure the following are checked:
+
+* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
+* [ ] There are no typos in commit messages and comments.
+* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
+* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
+* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
+* [ ] Tests are added if you fix a bug or add a feature.
+* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
+* [ ] PR is not in a draft state.
+* [ ] CI is passing.
 
 <!--
 Note: Please avoid making *Draft* pull requests, as they still send
 notifications to everyone watching the Rails repo.
 Create a pull request when it is ready for review and feedback
 from the Rails team :).
--->
+
+If your pull request affects documentation or any non-code
+changes, guidelines for those changes are [available
+here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
+
+Thanks for contributing to Rails! -->


### PR DESCRIPTION
### Summary

This change aims to help contributors to write better Pull Request description, especially new contributors.
From my experience new contributors cannot tell if they can discard a template even when they just fix a typo, so here it's clearly documented that it's discardable.
