### PR TITLE
Allow opting out of the `SameSite` cookie attribute when setting a cookie

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow opting out of the `SameSite` cookie attribute when setting a cookie.
+
+    You can opt out of `SameSite` by passing `same_site: nil`.
+
+    `cookies[:foo] = { value: "bar", same_site: nil }`
+
+    Previously, this incorrectly set the `SameSite` attribute to the value of the `cookies_same_site_protection` setting.
+
+    *Alex Ghiculescu*
+
 *   Allow using `helper_method`s in `content_security_policy` and `permissions_policy`
 
     Previously you could access basic helpers (defined in helper modules), but not

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -453,8 +453,9 @@ module ActionDispatch
 
           options[:path]      ||= "/"
 
-          cookies_same_site_protection = request.cookies_same_site_protection
-          options[:same_site] ||= cookies_same_site_protection.call(request)
+          unless options.key?(:same_site)
+            options[:same_site] = request.cookies_same_site_protection.call(request)
+          end
 
           if options[:domain] == :all || options[:domain] == "all"
             # If there is a provided tld length then we use it otherwise default domain regexp.


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/37974 it's not been possible to not include `SameSite` on your cookies. `SameSite` is recommended, but it's not a required field, and you should be able to opt out of it.

This PR introduces that ability: you can opt out of `SameSite` by passing `same_site: nil`.

```ruby
cookies[:foo] = { value: "bar", same_site: nil }
```

Previously, this incorrectly set the `SameSite` attribute to the value of the `cookies_same_site_protection` setting. https://github.com/rails/rails/pull/44934 added docs saying that you could pass `nil` as a value, but that also would fall back to the default (`:lax`).
