### PR TITLE
Add MIT-LICENSE file to Rails gem

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.email    = "david@loudthinking.com"
   s.homepage = "https://rubyonrails.org"
 
-  s.files = ["README.md"]
+  s.files = ["README.md", "MIT-LICENSE"]
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rails/rails/issues",


### PR DESCRIPTION
The rest of the gemspec's in the repository already include the license file in the generated gem, this is the only gap. Including this helps downstream packaging (e.g. RPM / deb) incorporate the license file in the source packages that are generated and distributed.

Backports to any upcoming releases on the 6 line would also be appreciated.