### PR TITLE
Optimize data sources sql for MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -225,14 +225,15 @@ module ActiveRecord
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)
 
-            sql = +"SELECT table_name FROM (SELECT table_name, table_type FROM information_schema.tables "
-            sql << " WHERE table_schema = #{scope[:schema]}) _subquery"
-            if scope[:type] || scope[:name]
-              conditions = []
-              conditions << "_subquery.table_type = #{scope[:type]}" if scope[:type]
-              conditions << "_subquery.table_name = #{scope[:name]}" if scope[:name]
-              sql << " WHERE #{conditions.join(" AND ")}"
+            sql = +"SELECT table_name FROM information_schema.tables"
+            sql << " WHERE table_schema = #{scope[:schema]}"
+
+            if scope[:name]
+              sql << " AND table_name = #{scope[:name]}"
+              sql << " AND table_name IN (SELECT table_name FROM information_schema.tables WHERE table_schema = #{scope[:schema]})"
             end
+
+            sql << " AND table_type = #{scope[:type]}" if scope[:type]
             sql
           end
 


### PR DESCRIPTION
Fixes #45503.

This uses queries like `SELECT table_name FROM information_schema.tables WHERE table_schema = database() AND table_name =
 "schema_migrations" AND table_name IN (SELECT table_name FROM information_schema.tables WHERE table_schema = database())` (note the `IN`).

With these changes for 1000 runs I got:
1. For the original query: `72s`
2. For the query before changes in https://github.com/rails/rails/pull/39712: `1.53s`
3. For this PR: `6.8s`

@blowfishpro Can you verify these changes improved the case you provided? 