### PR TITLE
Reading form's method by getAttribute instead of form.method

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/features/remote.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/features/remote.coffee
@@ -27,7 +27,7 @@ Rails.handleRemote = (e) ->
   if matches(element, Rails.formSubmitSelector)
     # memoized value from clicked submit button
     button = getData(element, 'ujs:submit-button')
-    method = getData(element, 'ujs:submit-button-formmethod') or element.method
+    method = getData(element, 'ujs:submit-button-formmethod') or element.getAttribute('method') or "get"
     url = getData(element, 'ujs:submit-button-formaction') or element.getAttribute('action') or location.href
 
     # strip query string if it's a GET request


### PR DESCRIPTION
Browsers map form elements by their name as attributes of form object. This PR changes accessing of form's method (GET/POST...) to getAttribute('method') instead of form.method as this property may return named form element if there is any named "method". Then calling .toUpperCase() on the result later resulted in exception as the result is not a string.

I have tested Chrome, Firefox and Safari and all of them return element named "method" instead of original method property. Reading property by getAttribute always returns original value or null. When null is returned default value by specification is used (GET).

Further reading: https://html.spec.whatwg.org/multipage/forms.html#the-form-element