### PR TITLE
Update migration near bottom of Active Record Basic guide

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -380,13 +380,11 @@ class CreatePublications < ActiveRecord::Migration[7.1]
       t.string :title
       t.text :description
       t.references :publication_type
-      t.integer :publisher_id
-      t.string :publisher_type
+      t.references :publisher, polymorphic: true
       t.boolean :single_issue
 
       t.timestamps
     end
-    add_index :publications, :publication_type_id
   end
 end
 ```


### PR DESCRIPTION
### Summary

The index that's displayed in the migration near the bottom of the Active Record Basics guide is redundant/unnecessary since the t.references :publication_type line above will create the same index.  Also, the publisher_id/type columns would be better represented with t.references :publisher, polymorphic: true.