### PR TITLE
Remove return_false_on_aborted_enqueue again

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -28,7 +28,6 @@ module ActiveJob
     end
 
     included do
-      class_attribute :return_false_on_aborted_enqueue, instance_accessor: false, instance_predicate: false, default: false
       cattr_accessor :skip_after_callbacks_if_terminated, instance_accessor: false, default: false
       singleton_class.deprecate :skip_after_callbacks_if_terminated, :skip_after_callbacks_if_terminated=
 


### PR DESCRIPTION
### Summary

This was supposed to be removed in 7c788e91 but only the deprecation was
actually removed.

### Other Information

I think this should be backported to `7-0-stable` since it was supposed to be removed for the first 7.0 release
