### PR TITLE
Add urlsafe option to application message verifier

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -176,10 +176,10 @@ module Rails
     #     # => 'my sensible data'
     #
     # See the ActiveSupport::MessageVerifier documentation for more information.
-    def message_verifier(verifier_name)
+    def message_verifier(verifier_name, urlsafe: false)
       @message_verifiers[verifier_name] ||= begin
         secret = key_generator.generate_key(verifier_name.to_s)
-        ActiveSupport::MessageVerifier.new(secret)
+        ActiveSupport::MessageVerifier.new(secret, urlsafe: urlsafe)
       end
     end
 


### PR DESCRIPTION
### Summary

On the back on https://github.com/rails/rails/pull/45419, I think it's useful to have the `urlsafe` option in `Rails.application.message_verifier` as well and pass it through to the constructor.
