### PR TITLE
Fix remove_check_constraint by symbol name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1586,7 +1586,7 @@ module ActiveRecord
         def check_constraint_for(table_name, **options)
           return unless supports_check_constraints?
           chk_name = check_constraint_name(table_name, **options)
-          check_constraints(table_name).detect { |chk| chk.name == chk_name }
+          check_constraints(table_name).detect { |chk| chk.name == chk_name.to_s }
         end
 
         def check_constraint_for!(table_name, expression: nil, **options)

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -179,6 +179,9 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           else
             assert_equal "price > 0", constraint.expression
           end
+
+          @connection.remove_check_constraint :trades, name: :price_check # name as a symbol
+          assert_empty @connection.check_constraints("trades")
         end
 
         def test_remove_non_existing_check_constraint


### PR DESCRIPTION
```ruby
remove_check_constraint :trades, name: :price_check # note name is a symbol
```

raises `ArgumentError: Table 'trades' has no check constraint for {:name=>:price_check}`.