### PR TITLE
Improve working with PostgreSQL schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -380,7 +380,7 @@ module ActiveRecord
 
         column_options.reverse_merge!(null: false, index: false)
 
-        t1_ref, t2_ref = [table_1, table_2].map { |t| t.to_s.singularize }
+        t1_ref, t2_ref = [table_1, table_2].map { |t| reference_name_for_table(t) }
 
         create_table(join_table_name, **options.merge!(id: false)) do |td|
           td.references t1_ref, **column_options
@@ -1617,6 +1617,10 @@ module ActiveRecord
 
         def can_remove_index_by_name?(column_name, options)
           column_name.nil? && options.key?(:name) && options.except(:name, :algorithm).empty?
+        end
+
+        def reference_name_for_table(table_name)
+          table_name.to_s.singularize
         end
 
         def bulk_change_table(table_name, operations)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -180,8 +180,9 @@ module ActiveRecord
     #   artists, records => artists_records
     #   records, artists => artists_records
     #   music_artists, music_records => music_artists_records
+    #   music.artists, music.records => music.artists_records
     def self.derive_join_table_name(first_table, second_table) # :nodoc:
-      [first_table.to_s, second_table.to_s].sort.join("\0").gsub(/^(.*_)(.+)\0\1(.+)/, '\1\2_\3').tr("\0", "_")
+      [first_table.to_s, second_table.to_s].sort.join("\0").gsub(/^(.*[_.])(.+)\0\1(.+)/, '\1\2_\3').tr("\0", "_")
     end
 
     module ClassMethods

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -323,6 +323,8 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
         assert @connection.index_name_exists?(PARTITIONED_TABLE, PARTITIONED_TABLE_INDEX)
       end
     end
+
+    assert @connection.index_name_exists?("#{SCHEMA_NAME}.#{TABLE_NAME}", INDEX_A_NAME)
   end
 
   def test_dump_indexes_for_schema_one
@@ -477,6 +479,14 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.reset_pk_sequence! table_name
   end
 
+  def test_rename_index
+    old_name = INDEX_A_NAME
+    new_name = "#{old_name}_new"
+    @connection.rename_index("#{SCHEMA_NAME}.#{TABLE_NAME}", old_name, new_name)
+    assert_not @connection.index_name_exists?("#{SCHEMA_NAME}.#{TABLE_NAME}", old_name)
+    assert @connection.index_name_exists?("#{SCHEMA_NAME}.#{TABLE_NAME}", new_name)
+  end
+
   private
     def columns(table_name)
       @connection.send(:column_definitions, table_name).map do |name, type, default|
@@ -531,23 +541,47 @@ class SchemaForeignKeyTest < ActiveRecord::PostgreSQLTestCase
 
   setup do
     @connection = ActiveRecord::Base.connection
+    @connection.create_schema("my_schema")
+  end
+
+  teardown do
+    @connection.drop_schema("my_schema", if_exists: true)
   end
 
   def test_dump_foreign_key_targeting_different_schema
-    @connection.create_schema "my_schema"
     @connection.create_table "my_schema.trains" do |t|
       t.string :name
     end
     @connection.create_table "wagons" do |t|
       t.integer :train_id
     end
-    @connection.add_foreign_key "wagons", "my_schema.trains", column: "train_id"
+    @connection.add_foreign_key "wagons", "my_schema.trains"
     output = dump_table_schema "wagons"
-    assert_match %r{\s+add_foreign_key "wagons", "my_schema\.trains", column: "train_id"$}, output
+    assert_match %r{\s+add_foreign_key "wagons", "my_schema\.trains"$}, output
   ensure
     @connection.drop_table "wagons", if_exists: true
     @connection.drop_table "my_schema.trains", if_exists: true
-    @connection.drop_schema "my_schema", if_exists: true
+  end
+
+  def test_create_foreign_key_same_schema
+    @connection.create_table "my_schema.trains"
+    @connection.create_table "my_schema.wagons" do |t|
+      t.integer :train_id
+    end
+    @connection.add_foreign_key "my_schema.wagons", "my_schema.trains"
+    assert @connection.foreign_key_exists?("my_schema.wagons", "my_schema.trains")
+  end
+
+  def test_create_foreign_key_different_schemas
+    @connection.create_schema "my_other_schema"
+    @connection.create_table "my_schema.trains"
+    @connection.create_table "my_other_schema.wagons" do |t|
+      t.integer :train_id
+    end
+    @connection.add_foreign_key "my_other_schema.wagons", "my_schema.trains"
+    assert @connection.foreign_key_exists?("my_other_schema.wagons", "my_schema.trains")
+  ensure
+    @connection.drop_schema "my_other_schema", if_exists: true
   end
 end
 
@@ -711,5 +745,26 @@ class SchemaWithDotsTest < ActiveRecord::PostgreSQLTestCase
       welcome_article = article_class.last
       assert_equal "zOMG, welcome to my blorgh!", welcome_article.title
     end
+  end
+end
+
+class SchemaJoinTablesTest < ActiveRecord::PostgreSQLTestCase
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_schema("test_schema")
+  end
+
+  def teardown
+    @connection.drop_schema("test_schema", if_exists: true)
+  end
+
+  def test_create_join_table
+    @connection.create_join_table("test_schema.posts", "test_schema.comments")
+    assert @connection.table_exists?("test_schema.comments_posts")
+    columns = @connection.columns("test_schema.comments_posts").map(&:name)
+    assert_equal ["comment_id", "post_id"], columns.sort
+
+    @connection.drop_join_table("test_schema.posts", "test_schema.comments")
+    assert_not @connection.table_exists?("test_schema.comments_posts")
   end
 end


### PR DESCRIPTION
Active Record already provides some support for working with PostgreSQL schemas. For example, it can create tables or indexes with scoped names (like `my_schema.my_table`), several other operations, like adding a foreign key, renaming an index or creating a join table aren't working correctly or are not working at all.

It is possible to use a workaround like
```ruby
execute("SET search_path TO my_schema")
create_join_table(:my_table_1, :my_table_2)
execute('SET search_path TO "$user", public')
```

But it will not work, for example, when adding a foreign key from the table in one schema to the table in other.

So, this PR makes working with schemas a little bit easier. Specifically, it fixes:
* `create_join_table`/`drop_join_table`
* `add_foreign_key`
* `rename_index` and `index_name_exists?`

All other helper methods already work as expected with schemas.