### PR TITLE
Improve generator implied option handling

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,42 @@
+*   `--no-*` options now work with the app generator's `--minimal` option, and
+    are both comprehensive and precise.  For example:
+
+    ```console
+    $ rails new my_cool_app --minimal
+    Based on the specified options, the following options will also be activated:
+
+      --skip-active-job [due to --minimal]
+      --skip-action-mailer [due to --skip-active-job, --minimal]
+      --skip-active-storage [due to --skip-active-job, --minimal]
+      --skip-action-mailbox [due to --skip-active-storage, --minimal]
+      --skip-action-text [due to --skip-active-storage, --minimal]
+      --skip-javascript [due to --minimal]
+      --skip-hotwire [due to --skip-javascript, --minimal]
+      --skip-action-cable [due to --minimal]
+      --skip-bootsnap [due to --minimal]
+      --skip-dev-gems [due to --minimal]
+      --skip-system-test [due to --minimal]
+
+    ...
+
+    $ rails new my_cool_app --minimal --no-skip-active-storage
+    Based on the specified options, the following options will also be activated:
+
+      --skip-action-mailer [due to --minimal]
+      --skip-action-mailbox [due to --minimal]
+      --skip-action-text [due to --minimal]
+      --skip-javascript [due to --minimal]
+      --skip-hotwire [due to --skip-javascript, --minimal]
+      --skip-action-cable [due to --minimal]
+      --skip-bootsnap [due to --minimal]
+      --skip-dev-gems [due to --minimal]
+      --skip-system-test [due to --minimal]
+
+    ...
+    ```
+
+    *Brad Trick* and *Jonathan Hefner*
+
 *   Add `--skip-dev-gems` option to app generator to skip adding development
     gems (like `web-console`) to the Gemfile.
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -218,12 +218,14 @@ module Rails
       def initialize(*args)
         @dummy_path = nil
         super
+        imply_options
 
         if !engine? || !with_dummy_app?
           self.options = options.merge(skip_asset_pipeline: true).freeze
         end
       end
 
+      public_task :report_implied_options
       public_task :set_default_accessors!
       public_task :create_root
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1092,35 +1092,43 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_minimal_rails_app
-    run_generator [destination_root, "--minimal"]
+    generator([destination_root], ["--minimal"])
 
-    assert_no_file "config/storage.yml"
-    assert_no_file "config/cable.yml"
-    assert_no_file "app/views/layouts/mailer.html.erb"
-    assert_no_file "app/jobs/application_job.rb"
-    assert_file "app/views/layouts/application.html.erb" do |content|
-      assert_no_match(/data-turbo-track/, content)
-    end
-    assert_file "config/environments/development.rb" do |content|
-      assert_no_match(/config\.active_storage/, content)
-    end
-    assert_file "config/environments/production.rb" do |content|
-      assert_no_match(/config\.active_job/, content)
-    end
-    assert_file "config/boot.rb" do |content|
-      assert_no_match(/require "bootsnap\/setup"/, content)
-    end
-    assert_file "config/application.rb" do |content|
-      assert_match(/#\s+require\s+["']active_job\/railtie["']/, content)
-      assert_match(/#\s+require\s+["']active_storage\/engine["']/, content)
-      assert_match(/#\s+require\s+["']action_mailer\/railtie["']/, content)
-      assert_match(/#\s+require\s+["']action_mailbox\/engine["']/, content)
-      assert_match(/#\s+require\s+["']action_text\/engine["']/, content)
-      assert_match(/#\s+require\s+["']action_cable\/engine["']/, content)
-    end
+    assert_option :minimal
+    assert_option :skip_action_cable
+    assert_option :skip_action_mailbox
+    assert_option :skip_action_mailer
+    assert_option :skip_action_text
+    assert_option :skip_active_job
+    assert_option :skip_active_storage
+    assert_option :skip_bootsnap
+    assert_option :skip_dev_gems
+    assert_option :skip_hotwire
+    assert_option :skip_javascript
+    assert_option :skip_jbuilder
+    assert_option :skip_system_test
+  end
 
-    assert_no_gem "jbuilder"
-    assert_no_gem "web-console"
+  def test_minimal_rails_app_with_no_skip_implied_option
+    generator([destination_root], ["--minimal", "--no-skip-action-text"])
+
+    assert_not_option :skip_action_text
+    assert_not_option :skip_active_storage
+    assert_not_option :skip_active_job
+    assert_option :skip_action_mailbox
+    assert_option :skip_action_mailer
+    assert_option :minimal
+  end
+
+  def test_minimal_rails_app_with_no_skip_intermediary_implied_option
+    generator([destination_root], ["--minimal", "--no-skip-active-storage"])
+
+    assert_not_option :skip_active_storage
+    assert_not_option :skip_active_job
+    assert_option :skip_action_text
+    assert_option :skip_action_mailbox
+    assert_option :skip_action_mailer
+    assert_option :minimal
   end
 
   def test_name_option


### PR DESCRIPTION
This commit improves handling of implied options for `AppGenerator` and `PluginGenerator` in a few different ways.

Implied options are now reported:

```console
$ rails new my_cool_app --skip-active-job
Based on the specified options, the following options will also be activated:

  --skip-action-mailer [due to --skip-active-job]
  --skip-active-storage [due to --skip-active-job]
  --skip-action-mailbox [due to --skip-active-storage]
  --skip-action-text [due to --skip-active-storage]

...
```

Option conflicts raise an error:

```console
$ rails new my_cool_app --skip-active-job --no-skip-active-storage
Based on the specified options, the following options will also be activated:

  --skip-action-mailer [due to --skip-active-job]
  --skip-active-storage [due to --skip-active-job]
    ERROR: Conflicts with --no-skip-active-storage
  --skip-action-mailbox [due to --skip-active-storage]
  --skip-action-text [due to --skip-active-storage]

railties/lib/rails/generators/app_base.rb:206:in `report_implied_options': Cannot proceed due to conflicting options (RuntimeError)
```

Meta option (e.g. `--minimal`) implications are also reported:

```console
$ rails new my_cool_app --minimal
Based on the specified options, the following options will also be activated:

  --skip-active-job [due to --minimal]
  --skip-action-mailer [due to --skip-active-job, --minimal]
  --skip-active-storage [due to --skip-active-job, --minimal]
  --skip-action-mailbox [due to --skip-active-storage, --minimal]
  --skip-action-text [due to --skip-active-storage, --minimal]
  --skip-javascript [due to --minimal]
  --skip-hotwire [due to --skip-javascript, --minimal]
  --skip-action-cable [due to --minimal]
  --skip-bootsnap [due to --minimal]
  --skip-dev-gems [due to --minimal]
  --skip-system-test [due to --minimal]

...
```

`--no-*` options now work with meta options, and are both comprehensive and precise:

```console
$ rails new my_cool_app --minimal --no-skip-active-storage
Based on the specified options, the following options will also be activated:

  --skip-action-mailer [due to --minimal]
  --skip-action-mailbox [due to --minimal]
  --skip-action-text [due to --minimal]
  --skip-javascript [due to --minimal]
  --skip-hotwire [due to --skip-javascript, --minimal]
  --skip-action-cable [due to --minimal]
  --skip-bootsnap [due to --minimal]
  --skip-dev-gems [due to --minimal]
  --skip-system-test [due to --minimal]

...
```

Closes #45223.
Closes #45205.

---

@brtrick I've added you as a co-author for your work on #45205 and #45223.
