### PR TITLE
Fix NoMethodError on custom ActiveSupport::Deprecation behavior

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `NoMethodError` on custom `ActiveSupport::Deprecation` behavior.
+
+    `ActiveSupport::Deprecation.behavior=` was supposed to accept any object
+    that responds to `call`, but in fact its internal implementation assumed that
+    this object could respond to `arity`, so it was restricted to only `Proc` objects.
+
+    This change removes this `arity` restriction of custom behaviors.
+
+    *Ryo Nakamura*
+
 *   Support `:urlsafe` option for `MessageEncryptor`.
 
     The `MessageEncryptor` constructor now accepts a `:urlsafe` option, similar

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -114,10 +114,10 @@ module ActiveSupport
             raise ArgumentError, "#{behavior.inspect} is not a valid deprecation behavior."
           end
 
-          if behavior.arity == 4 || behavior.arity == -1
-            behavior
-          else
+          if behavior.respond_to?(:arity) && behavior.arity == 2
             -> message, callstack, _, _ { behavior.call(message, callstack) }
+          else
+            behavior
           end
         end
     end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -210,6 +210,21 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_equal ":invalid is not a valid deprecation behavior.", e.message
   end
 
+  def test_custom_behavior
+    custom_behavior_class = Class.new do
+      def call(message, callstack, horizon, gem_name)
+        $stderr.puts message
+      end
+    end
+    ActiveSupport::Deprecation.behavior = custom_behavior_class.new
+
+    content = capture(:stderr) do
+      ActiveSupport::Deprecation.warn("foo")
+    end
+
+    assert_match(/foo/, content)
+  end
+
   def test_deprecated_instance_variable_proxy
     assert_not_deprecated { @dtc.request.size }
 


### PR DESCRIPTION
### Summary

`ActiveSupport::Deprecation.behavior=` was supposed to accept any object that responds to `call`, but in fact its internal implementation assumed that this object could respond to `arity`, so it was restricted to only `Proc` objects.

This change removes this `arity` restriction of custom behaviors.

### Other Information

The specification of custom behavior is mentioned in the following comment:

https://github.com/rails/rails/blob/dadf171db8e706dac42d5dff06ca8480bb6ff14c/activesupport/lib/active_support/deprecation/behaviors.rb#L75-L76

Without this change, the test I added would fail as follows.

```
$ bundle exec ruby test/deprecation_test.rb
Running 61 tests in parallel using 12 processes
Run options: --seed 48446

# Running:

.................................................E

Error:
DeprecationTest#test_custom_behavior:
NoMethodError: undefined method `arity' for #<#<Class:0x00007f406a20d418>:0x00007f406a20d2d8>
    /home/r7kamura/ghq/github.com/rails/rails/activesupport/lib/active_support/deprecation/behaviors.rb:117:in `arity_coerce'
    /home/r7kamura/ghq/github.com/rails/rails/activesupport/lib/active_support/deprecation/behaviors.rb:100:in `block in behavior='
    /home/r7kamura/ghq/github.com/rails/rails/activesupport/lib/active_support/deprecation/behaviors.rb:100:in `map'
    /home/r7kamura/ghq/github.com/rails/rails/activesupport/lib/active_support/deprecation/behaviors.rb:100:in `behavior='
    /home/r7kamura/ghq/github.com/rails/rails/activesupport/lib/active_support/deprecation/instance_delegator.rb:21:in `behavior='
    test/deprecation_test.rb:220:in `test_custom_behavior'


rails test test/deprecation_test.rb:213

...........

Finished in 0.203086s, 300.3660 runs/s, 1240.8561 assertions/s.
61 runs, 252 assertions, 0 failures, 1 errors, 0 skips
```