### PR TITLE
Fixes 'ActionView::FormBuilder#field_id' and 'ActionView::FormBuilder#field_name' nesting

### DIFF
--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2059,6 +2059,40 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_field_id_with_nested_attribute
+    post, comment, tag = Post.new, Comment.new, Tag.new
+    comment.relevances = [tag]
+    post.comments = [comment]
+    form_for(post) do |f|
+      concat(f.fields_for(:comments) do |comment_f|
+        concat comment_f.field_id :relevance_attributes
+      end)
+    end
+
+    expected = whole_form("/posts", "new_post", "new_post") do
+      "post_comments_attributes_0_relevance_attributes"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_field_name_with_nested_attribute_with_multiple
+    post, comment, tag = Post.new, Comment.new, Tag.new
+    comment.relevances = [tag]
+    post.comments = [comment]
+    form_for(post) do |f|
+      concat(f.fields_for(:comments) do |comment_f|
+        concat comment_f.field_name :relevance_attributes, multiple: true
+      end)
+    end
+
+    expected = whole_form("/posts", "new_post", "new_post") do
+      "post[comments_attributes][0][relevance_attributes][]"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_with_index_and_with_collection_check_boxes
     post = Post.new
     def post.tag_ids; [1]; end


### PR DESCRIPTION
### Summary

Fixed `ActionView::FormBuilder#field_id` and `ActionView::FormBuilder#field_name` nesting

### Issue Explanation

- When we call `ActionView::FormBuilder#fields_for` without any index. Then, it uses index as 0 when creating a field using `ActionView::FormBuilder#field_id` and `ActionView::FormBuilder#field_name` as it has been set to the value of child_index. This pull request will fix this issue and will set the index as child_index only if index has not been given and child_index has been given explicitly.

### Other Information
Closes https://github.com/rails/rails/issues/45483

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
