### PR TITLE
Remove owner_name from db_config

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -8,8 +8,6 @@ module ActiveRecord
     class DatabaseConfig # :nodoc:
       attr_reader :env_name, :name
 
-      attr_accessor :owner_name
-
       def initialize(env_name, name)
         @env_name = env_name
         @name = name

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -440,14 +440,13 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_cache_is_available_when_using_a_not_connected_connection
     skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").dup
-    db_config.owner_name = "test2"
-    ActiveRecord::Base.connection_handler.establish_connection(db_config)
+    new_conn = ActiveRecord::Base.connection_handler.establish_connection(db_config)
     assert_not_predicate Task, :connected?
 
     Task.cache do
       assert_queries(1) { Task.find(1); Task.find(1) }
     ensure
-      ActiveRecord::Base.connection_handler.remove_connection_pool(db_config.owner_name)
+      ActiveRecord::Base.connection_handler.remove_connection_pool(new_conn)
     end
   end
 


### PR DESCRIPTION
The majority of where this functionality was removed in #38672.
`owner_name` was never used publicaly in the db_config and was at a time
used for identifying connection owners. Now the connection owner is
always stored in the PoolConfig (same place as the db_config) so the
db_config doesn't need this information.