### PR TITLE
Add `--parent` option to job generator to specify parent class of job.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `--parent` option to job generator to specify parent class of job.
+
+    Example:
+
+    `bin/rails g job process_payment --parent=payment_job` generates:
+
+    ```ruby
+    class ProcessPaymentJob < PaymentJob
+      # ...
+    end
+    ```
+
+    *Gannon McGibbon*
+
 *   Add more detailed description to job generator.
 
     *Gannon McGibbon*

--- a/activejob/lib/rails/generators/job/USAGE
+++ b/activejob/lib/rails/generators/job/USAGE
@@ -13,3 +13,7 @@ Examples:
     `bin/rails generate job send_sms --queue=sms`
 
       Creates a job and test with a custom sms queue.
+
+    `bin/rails generate job process_payment --parent=payment_job`
+
+      Creates a job and test with a `PaymentJob` parent class.

--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -7,6 +7,8 @@ module Rails # :nodoc:
     class JobGenerator < Rails::Generators::NamedBase # :nodoc:
       class_option :queue, type: :string, default: "default", desc: "The queue name for the generated job"
 
+      class_option :parent, type: :string, desc: "The parent class for the generated job"
+
       check_class_collision suffix: "Job"
 
       hook_for :test_framework
@@ -26,6 +28,18 @@ module Rails # :nodoc:
       end
 
       private
+        def parent
+          options[:parent]
+        end
+
+        def parent_class_name
+          if parent
+            parent
+          else
+            "ApplicationJob"
+          end
+        end
+
         def file_name
           @_file_name ||= super.sub(/_job\z/i, "")
         end

--- a/activejob/lib/rails/generators/job/templates/job.rb.tt
+++ b/activejob/lib/rails/generators/job/templates/job.rb.tt
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= class_name %>Job < ApplicationJob
+class <%= class_name %>Job < <%= parent_class_name.classify %>
   queue_as :<%= options[:queue] %>
 
   def perform(*args)

--- a/railties/test/generators/job_generator_test.rb
+++ b/railties/test/generators/job_generator_test.rb
@@ -21,6 +21,13 @@ class JobGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_job_parent_param
+    run_generator ["refresh_counters", "--parent", "awesome_job"]
+    assert_file "app/jobs/refresh_counters_job.rb" do |job|
+      assert_match(/class RefreshCountersJob < AwesomeJob/, job)
+    end
+  end
+
   def test_job_namespace
     run_generator ["admin/refresh_counters", "--queue", "admin"]
     assert_file "app/jobs/admin/refresh_counters_job.rb" do |job|


### PR DESCRIPTION
Adds superclass option, usage docs, and test for job generator.

Example:

`bin/rails g job process_payment --parent=payment_job` generates:

```ruby
class ProcessPaymentJob < PaymentJob
  # ...
end
```

Similar to the model generator's implementation of `--parent`.