### PR TITLE
Remove adding sprockets during app:update

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -160,10 +160,6 @@ module Rails
           remove_file "config/initializers/permissions_policy.rb"
         end
       end
-
-      if !skip_sprockets?
-        insert_into_file "config/application.rb", %(require "sprockets/railtie"), after: /require\(["']rails\/all["']\)\n/
-      end
     end
 
     def master_key


### PR DESCRIPTION
### Summary

This was useful during the upgrade to Rails 7, but apps upgrading from 7
to 7.1 shouldn't need this line added again.
