### PR TITLE
Fewer object allocations in Encryption::Properties

### DIFF
--- a/activerecord/lib/active_record/encryption/properties.rb
+++ b/activerecord/lib/active_record/encryption/properties.rb
@@ -14,10 +14,10 @@ module ActiveRecord
     #
     # See +Properties#DEFAULT_PROPERTIES+, +Key+, +Message+
     class Properties
-      ALLOWED_VALUE_CLASSES = [String, ActiveRecord::Encryption::Message, Numeric, TrueClass, FalseClass, Symbol, NilClass]
+      ALLOWED_VALUE_CLASSES = [String, ActiveRecord::Encryption::Message, Numeric, Integer, Float, BigDecimal, TrueClass, FalseClass, Symbol, NilClass]
 
       delegate_missing_to :data
-      delegate :==, to: :data
+      delegate :==, :[], :each, :key?, to: :data
 
       # For each entry it generates an accessor exposing the full name
       DEFAULT_PROPERTIES = {
@@ -54,7 +54,7 @@ module ActiveRecord
       end
 
       def validate_value_type(value)
-        unless ALLOWED_VALUE_CLASSES.find { |klass| value.is_a?(klass) }
+        unless ALLOWED_VALUE_CLASSES.include?(value.class) || ALLOWED_VALUE_CLASSES.any? { |klass| value.is_a?(klass) }
           raise ActiveRecord::Encryption::Errors::ForbiddenClass, "Can't store a #{value.class}, only properties of type #{ALLOWED_VALUE_CLASSES.inspect} are allowed"
         end
       end

--- a/activerecord/test/cases/encryption/properties_test.rb
+++ b/activerecord/test/cases/encryption/properties_test.rb
@@ -60,7 +60,10 @@ class ActiveRecord::EncryptionPropertiesTest < ActiveRecord::EncryptionTestCase
 
   MyClass = Struct.new(:some_value)
 
+  class EncryptionMessageSubClass < ActiveRecord::Encryption::Message
+  end
+
   def example_of_valid_values
-    ["a string", 123, 123.5, true, false, nil, :a_symbol, ActiveRecord::Encryption::Message.new]
+    ["a string", 123, 123.5, true, false, nil, :a_symbol, ActiveRecord::Encryption::Message.new, EncryptionMessageSubClass.new]
   end
 end


### PR DESCRIPTION
### Summary

`delegate_missing_to` and `Enumerable#find` both allocate objects. When selecting a large number of encrypted values with can lead to a significant number of allocations.

We can avoid these by:
1. Not delegating the most commonly called methods
2. Caching the results of the `ALLOWED_VALUE_CLASSES` lookup

The benchmark loads 1000 encrypted values - for it I saw a 15% faster with a 30% reduction in allocations.

### Other Information

```

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "activerecord", "~> 7.0.0"
  gem "sqlite3"
  gem "benchmark-ips"
end

require "active_record"
require 'benchmark/ips'

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Encryption.configure \
  primary_key: "test master key",
  deterministic_key: "test deterministic key",
  key_derivation_salt: "testing key derivation salt",
  support_unencrypted_data: true

ActiveRecord::Schema.define do
  create_table :comments, force: true do |t|
    t.string :message, length: 1000
  end
end

class Comment < ActiveRecord::Base
  encrypts :message
end

srand(123456)
1000.times { Comment.create!(message: 100.times.map { ("A".."Z").to_a.sample }.join) }

if ENV['OPTIMIZED']
  module ActiveRecord
    module EncryptionPropertiesAvoidAllocations
      extend ActiveSupport::Concern

      ALLOWED_VALUE_CLASSES_CACHE = Set.new

      if %w{delegation all}.include?(ENV['OPTIMIZED'])
        # Delegation involves object creation. Defining the commonly called methods
        # can saves a many allocations when loading large number of encrypted attributes.
        def each(*args, &block)
          data.each(*args, &block)
        end

        def [](*args)
          data.[](*args)
        end

        def key?(*args)
          data.key?(*args)
        end
      end

      if %w{find all}.include?(ENV['OPTIMIZED'])
        # find also involves allocations, so we can cache the results which classes
        # are valid to avoid the call
        def validate_value_type(value)
          unless ALLOWED_VALUE_CLASSES_CACHE.include?(value.class)
            unless ActiveRecord::Encryption::Properties::ALLOWED_VALUE_CLASSES.find { |klass| value.is_a?(klass) }
              raise ActiveRecord::Encryption::Errors::ForbiddenClass, "Can't store a #{value.class}, only properties of type #{ALLOWED_VALUE_CLASSES.inspect} are allowed"
            end
            ALLOWED_VALUE_CLASSES_CACHE << value.class
          end
        end
      end
    end
  end

  ActiveRecord::Encryption::Properties.prepend(ActiveRecord::EncryptionPropertiesAvoidAllocations);
end

def allocation_count
  before = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - before
end

allocated_objects = allocation_count { Comment.pluck(:message) }
puts "Optimization: #{ENV['OPTIMIZED'] || "none"}, allocations: #{allocated_objects}"

Benchmark.ips do |x|
  x.config(time: 30)
  x.report("default")                 { Comment.pluck(:message) }
  x.report("delegation_optimization") { Comment.pluck(:message) }
  x.report("find_optimization")       { Comment.pluck(:message) }
  x.report("all_optimization")        { Comment.pluck(:message) }
  x.hold! "temp_results"
  x.compare!
end
```

Results:
```
$ ruby encryption_properties_benchmark.rb; OPTIMIZED=delegation ruby encryption_properties_benchmark.rb; OPTIMIZED=find ruby encryption_properties_benchmark.rb; OPTIMIZED=all ruby encryption_properties_benchmark.rb
...snip...
Optimization: none, allocations: 72238
Warming up --------------------------------------
             default     7.000  i/100ms
Calculating -------------------------------------
             default     71.004  (± 4.2%) i/s -      2.128k in  30.033905s

...snip...
Optimization: delegation, allocations: 62313
Warming up --------------------------------------
delegation_optimization
                         7.000  i/100ms
Calculating -------------------------------------
delegation_optimization
                         80.773  (± 6.2%) i/s -      2.415k in  30.038937s

Pausing here -- run Ruby again to measure the next benchmark...

Comparison:
delegation_optimization:       80.8 i/s
             default:       71.0 i/s - 1.14x  (± 0.00) slower

...snip...
Optimization: find, allocations: 60311
Warming up --------------------------------------
   find_optimization     7.000  i/100ms
Calculating -------------------------------------
   find_optimization     77.581  (± 3.9%) i/s -      2.324k in  30.027488s

Pausing here -- run Ruby again to measure the next benchmark...

Comparison:
delegation_optimization:       80.8 i/s
   find_optimization:       77.6 i/s - same-ish: difference falls within error
             default:       71.0 i/s - 1.14x  (± 0.00) slower

...snip...
Optimization: all, allocations: 50320
Warming up --------------------------------------
    all_optimization     8.000  i/100ms
Calculating -------------------------------------
    all_optimization     84.011  (± 8.3%) i/s -      2.496k in  30.008758s

Comparison:
    all_optimization:       84.0 i/s
delegation_optimization:       80.8 i/s - same-ish: difference falls within error
   find_optimization:       77.6 i/s - same-ish: difference falls within error
             default:       71.0 i/s - 1.18x  (± 0.00) slower
```
