### PR TITLE
Backport Active Storage migration fixes to 6.1

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Respect Active Record's primary_key_type in Active Storage migrations. Backported from 7.0.
+
+    *fatkodima*
+
 ## Rails 6.1.6 (May 09, 2022) ##
 
 *   No changes.

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,6 +1,9 @@
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
-    create_table :active_storage_blobs do |t|
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false
       t.string   :content_type
@@ -13,10 +16,10 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.index [ :key ], unique: true
     end
 
-    create_table :active_storage_attachments do |t|
+    create_table :active_storage_attachments, id: primary_key_type do |t|
       t.string     :name,     null: false
-      t.references :record,   null: false, polymorphic: true, index: false
-      t.references :blob,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
 
       t.datetime :created_at, null: false
 
@@ -24,12 +27,21 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    create_table :active_storage_variant_records do |t|
-      t.belongs_to :blob, null: false, index: false
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
       t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
 end

--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -1,5 +1,7 @@
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up
+    return unless table_exists?(:active_storage_blobs)
+
     unless column_exists?(:active_storage_blobs, :service_name)
       add_column :active_storage_blobs, :service_name, :string
 
@@ -12,6 +14,8 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   end
 
   def down
+    return unless table_exists?(:active_storage_blobs)
+
     remove_column :active_storage_blobs, :service_name
   end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,14 +1,12 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    unless table_exists?(:active_storage_variant_records)
-      # Use Active Record's configured type for primary key
-      create_table :active_storage_variant_records, id: primary_key_type do |t|
-        t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
-        t.string :variation_digest, null: false
+    # Use Active Record's configured type for primary key
+    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
+      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+      t.string :variation_digest, null: false
 
-        t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
-        t.foreign_key :active_storage_blobs, column: :blob_id
-      end
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,12 +1,14 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    # Use Active Record's configured type for primary key
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
-      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
-      t.string :variation_digest, null: false
+    unless table_exists?(:active_storage_variant_records)
+      # Use Active Record's configured type for primary key
+      create_table :active_storage_variant_records, id: primary_key_type do |t|
+        t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+        t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+        t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+        t.foreign_key :active_storage_blobs, column: :blob_id
+      end
     end
   end
 

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,11 +1,24 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    create_table :active_storage_variant_records do |t|
-      t.belongs_to :blob, null: false, index: false
+    # Use Active Record's configured type for primary key
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
 
       t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
+
+    def blobs_primary_key_type
+      pkey_name = connection.primary_key(:active_storage_blobs)
+      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+      pkey_column.bigint? ? :bigint : pkey_column.type
+    end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,5 +1,7 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
+    return unless table_exists?(:active_storage_blobs)
+
     # Use Active Record's configured type for primary key
     create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type

--- a/activestorage/test/migrations_test.rb
+++ b/activestorage/test/migrations_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::MigrationsTest < ActiveSupport::TestCase
+  setup do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    @connection = ActiveRecord::Base.connection
+    @original_options = Rails.configuration.generators.options.deep_dup
+  end
+
+  teardown do
+    Rails.configuration.generators.options = @original_options
+    rerun_migration
+    ActiveRecord::Migration.verbose = @original_verbose
+  end
+
+  test "migration creates tables with default primary and foreign key types" do
+    rerun_migration
+
+    active_storage_tables.each do |table|
+      assert_equal :integer, primary_key(table).type
+
+      foreign_keys(table).each do |foreign_key|
+        assert_equal :integer, foreign_key.type
+      end
+    end
+  end
+
+  test "migration creates tables with configured primary and foreign key types" do
+    Rails.configuration.generators do |g|
+      g.orm :active_record, primary_key_type: :string
+    end
+
+    rerun_migration
+
+    active_storage_tables.each do |table|
+      assert_equal :string, primary_key(table).type
+
+      foreign_keys(table).each do |foreign_key|
+        assert_equal :string, foreign_key.type
+      end
+    end
+  end
+
+  private
+    def rerun_migration
+      CreateActiveStorageTables.migrate(:down)
+      CreateActiveStorageTables.migrate(:up)
+    end
+
+    def active_storage_tables
+      [:active_storage_blobs, :active_storage_attachments, :active_storage_variant_records]
+    end
+
+    def primary_key(table)
+      @connection.columns(table).find { |c| c.name == "id" }
+    end
+
+    def foreign_keys(table)
+      columns = @connection.foreign_keys(table).map(&:column)
+      @connection.columns(table).select { |c| columns.include?(c.name) }
+    end
+end


### PR DESCRIPTION
### Summary

While running `app:update` on a 6.1 app using 6.0 defaults, I hit a bug which is already fixed in 7.0: #44387

I asked for a backport, but figured I would check if it applied cleanly first, and I had conflicts. So I pulled all the changes that made this necessary:
- #42378
- #43776 (and subsequent 8b6342e3419a2332a425d8a665c0f8d9b5181c1d)

### Other Information
