### PR TITLE
Fix test with rack-test >= 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
-# Lock rack-test to v1 until #45467 is fixed
-gem "rack-test", "< 2"
-
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,6 @@ DEPENDENCIES
   queue_classic (>= 4.0.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
-  rack-test (< 2)
   rails!
   rake (>= 11.1)
   redcarpet (~> 3.2.3)

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -71,13 +71,13 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         get "/set_session_value"
         assert_response :success
         assert cookies["_session_id"]
-        session_cookie = cookies.send(:hash_for)["_session_id"]
+        session_cookie = cookies.for(nil)
 
         get "/call_reset_session"
         assert_response :success
         assert_not_equal [], headers["Set-Cookie"]
 
-        cookies << session_cookie # replace our new session_id with our old, pre-reset session_id
+        cookies.merge(session_cookie) # replace our new session_id with our old, pre-reset session_id
 
         get "/get_session_value"
         assert_response :success


### PR DESCRIPTION
Use public APIs instead of private APIs.

### Summary

`#for` returns a raw cookie, `#merge` takes a raw cookie in, that solves the issue of using `<<` which takes a (undocumented class) `Cookie` instance.

### Other Information

We were using [`CookieJar#hash_for`](https://github.com/rack/rack-test/blob/v1.1.0/lib/rack/test/cookie_jar.rb#L178) which has been renamed. [`#for`](https://github.com/rack/rack-test/blob/v1.1.0/lib/rack/test/cookie_jar.rb#L161) was private API but was [made public in 2.0](https://github.com/rack/rack-test/blob/v2.0.0/lib/rack/test/cookie_jar.rb#L201-L203) so I think that's OK.

There's a spec for [passing `nil` to `#for`](https://github.com/rack/rack-test/blob/v2.0.0/spec/rack/test/cookie_jar_spec.rb#L30) so even though it's a bit weird it should be fine.
