### PR TITLE
Fix actionpack test with rack test 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
-# Lock rack-test to v1 until #45467 is fixed
-gem "rack-test", "< 2"
-
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,7 +600,6 @@ DEPENDENCIES
   queue_classic (>= 4.0.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
-  rack-test (< 2)
   rails!
   rake (>= 11.1)
   redcarpet (~> 3.2.3)

--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -44,6 +44,10 @@ module RenderStreaming
   end
 
   class StreamingTest < Rack::TestCase
+    def get(path, headers: { "SERVER_PROTOCOL" => "HTTP/1.1", "HTTP_VERSION" => "HTTP/1.1" })
+      super
+    end
+
     test "rendering with streaming enabled at the class level" do
       get "/render_streaming/basic/hello_world"
       assert_body "b\r\nHello world\r\nb\r\n, I'm here!\r\n0\r\n\r\n"

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -59,7 +59,7 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
       get "/set_session_value"
       assert_response :success
       assert cookies["_session_id"]
-      session_cookie = cookies.send(:hash_for)["_session_id"]
+      session_cookie = cookies.get_cookie("_session_id")
 
       get "/call_reset_session"
       assert_response :success

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -71,7 +71,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         get "/set_session_value"
         assert_response :success
         assert cookies["_session_id"]
-        session_cookie = cookies.send(:hash_for)["_session_id"]
+        session_cookie = cookies.get_cookie("_session_id")
 
         get "/call_reset_session"
         assert_response :success


### PR DESCRIPTION
Fixes #45467

It's just #45177 + another usage of `hash_for` + revert of #45477