### PR TITLE
Clear cache in MemCacheStore tests

### DIFF
--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -59,6 +59,10 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     @cache.logger = ActiveSupport::Logger.new(File::NULL)
   end
 
+  def teardown
+    @cache.clear
+  end
+
   def after_teardown
     return unless defined?(@_stores) # because skipped test
 


### PR DESCRIPTION
Fixes flaky memcached tests, for example - https://buildkite.com/rails/rails/builds/87869#0181d43c-d9ff-4e6e-8f4a-93e77a568a1d/1051-1205

To reproduce:
```
git checkout 54e3f8c381d00a79ac5ab57fa444709c3f3ee0c1
cd activesupport
PARALLEL_WORKERS=1 SEED=41342 bin/test test/cache/stores/mem_cache_store_test.rb
```