### PR TITLE
Clarify how `EachValidator` is automatically loaded [ci-skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1078,8 +1078,7 @@ class MyValidator < ActiveModel::Validator
   end
 end
 
-class Person
-  include ActiveModel::Validations
+class Person < ApplicationRecord
   validates_with MyValidator
 end
 ```


### PR DESCRIPTION
The [Active Record Custom Validators documentation](https://guides.rubyonrails.org/active_record_validations.html#custom-validators) has two examples.

In the first example, the line  `include ActiveModel::Validations` is added. But for the second one, it's not clear how `EachValidator` works.

With this note, the reader will understand right away how it works, without having to go through the code to use it confidently.

### Summary
Adding a note to clarify more why `EachValidator` works out straight out the box by using `email:true`.

### Other Information
I'm not sure this is helpful for someone else, but it took me some time to understand what was going on. I hope this can save someone's else time :)
