### PR TITLE
Generate `secret_key_base` for all new credentials

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Newly generated per-environment credentials files (e.g.
+    `config/credentials/production.yml.enc`) now include a `secret_key_base` for
+    convenience, just as `config/credentials.yml.enc` does.
+
+    *Jonathan Hefner*
+
 *   `--no-*` options now work with the app generator's `--minimal` option, and
     are both comprehensive and precise.  For example:
 

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -82,11 +82,7 @@ module Rails
         end
 
         def ensure_credentials_have_been_added
-          if options[:environment]
-            encrypted_file_generator.add_encrypted_file_silently(content_path, key_path)
-          else
-            credentials_generator.add_credentials_file_silently
-          end
+          credentials_generator.add_credentials_file
         end
 
         def change_credentials_in_system_editor
@@ -122,18 +118,11 @@ module Rails
           Rails::Generators::EncryptionKeyFileGenerator.new
         end
 
-        def encrypted_file_generator
-          require "rails/generators"
-          require "rails/generators/rails/encrypted_file/encrypted_file_generator"
-
-          Rails::Generators::EncryptedFileGenerator.new
-        end
-
         def credentials_generator
           require "rails/generators"
           require "rails/generators/rails/credentials/credentials_generator"
 
-          Rails::Generators::CredentialsGenerator.new
+          Rails::Generators::CredentialsGenerator.new([content_path, key_path], quiet: true)
         end
     end
   end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -179,7 +179,7 @@ module Rails
       return if options[:pretend] || options[:dummy_app]
 
       require "rails/generators/rails/credentials/credentials_generator"
-      Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file_silently
+      Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file
     end
 
     def credentials_diff_enroll


### PR DESCRIPTION
Currently, when `config/credentials.yml.enc` is generated by `CredentialsGenerator`, it includes a `secret_key_base` for convenience.  However, because `config/credentials/#{environment}.yml.enc` files are generated by a different generator (`EncryptedFileGenerator`), they do not include a `secret_key_base`.

This commit revises `CredentialsGenerator` to be more generator-like, and changes `rails credentials:edit` to use it for generating both `config/credentials.yml.enc` and `config/credentials/#{environment}.yml.enc` files, thereby always including a `secret_key_base`.
