### PR TITLE
Support custom credentials templates

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   In-app custom credentials templates are now supported.  When a credentials
+    file does not exist, `rails credentials:edit` will now try to use
+    `lib/templates/rails/credentials/credentials.yml.tt` to generate the
+    credentials file, before falling back to the default template.
+
+    This allows e.g. an open-source Rails app (which would not include encrypted
+    credentials files in its repo) to include a credentials template, so that
+    users who install the app will get a custom pre-filled credentials file when
+    they run `rails credentials:edit`.
+
+    *Jonathan Hefner*
+
 *   Newly generated per-environment credentials files (e.g.
     `config/credentials/production.yml.enc`) now include a `secret_key_base` for
     convenience, just as `config/credentials.yml.enc` does.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -493,6 +493,11 @@ module Rails
       ordered_railties.flatten - [self]
     end
 
+    def load_generators(app = self) # :nodoc:
+      app.ensure_generator_templates_added
+      super
+    end
+
     # Eager loads the application code.
     def eager_load!
       Rails.autoloaders.each(&:eager_load)
@@ -580,6 +585,11 @@ module Rails
       else
         raise ArgumentError, "Missing `secret_key_base` for '#{Rails.env}' environment, set this string with `bin/rails credentials:edit`"
       end
+    end
+
+    def ensure_generator_templates_added
+      configured_paths = config.generators.templates
+      configured_paths.unshift(*(paths["lib/templates"].existent - configured_paths))
     end
 
     private

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -11,7 +11,7 @@ module Rails
       include Initializable
 
       initializer :add_generator_templates do
-        config.generators.templates.unshift(*paths["lib/templates"].existent)
+        ensure_generator_templates_added
       end
 
       initializer :setup_main_autoloader do

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -17,7 +17,7 @@ module Rails
           say "Adding #{content_path} to store encrypted credentials."
           say ""
 
-          encrypted_file.write(content)
+          content = render_template_to_encrypted_file
 
           say "The following content has been encrypted with the Rails master key:"
           say ""
@@ -38,15 +38,20 @@ module Rails
           )
         end
 
-        def content
-          @content ||= <<~YAML
-            # aws:
-            #   access_key_id: 123
-            #   secret_access_key: 345
+        def secret_key_base
+          @secret_key_base ||= SecureRandom.hex(64)
+        end
 
-            # Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
-            secret_key_base: #{SecureRandom.hex(64)}
-          YAML
+        def render_template_to_encrypted_file
+          content = nil
+
+          encrypted_file.change do |tmp_path|
+            template("credentials.yml", tmp_path, force: true, verbose: false) do |rendered|
+              content = rendered
+            end
+          end
+
+          content
         end
     end
   end

--- a/railties/lib/rails/generators/rails/credentials/templates/credentials.yml.tt
+++ b/railties/lib/rails/generators/rails/credentials/templates/credentials.yml.tt
@@ -1,0 +1,6 @@
+# aws:
+#   access_key_id: 123
+#   secret_access_key: 345
+
+# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
+secret_key_base: <%= secret_key_base %>

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -91,6 +91,15 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_file "config/credentials.yml.enc"
   end
 
+  test "edit command can use custom template to generate credentials file" do
+    app_file "lib/templates/rails/credentials/credentials.yml.tt", <<~ERB
+      provides_secret_key_base: <%= [secret_key_base] == [secret_key_base].compact %>
+    ERB
+    remove_file "config/credentials.yml.enc"
+
+    assert_match %r/provides_secret_key_base: true/, run_edit_command
+  end
+
 
   test "show credentials" do
     assert_match DEFAULT_CREDENTIALS_PATTERN, run_show_command


### PR DESCRIPTION
This commit adds support for in-app custom credentials templates.  When a credentials file does not exist, `rails credentials:edit` will now try to use `lib/templates/rails/credentials/credentials.yml.tt` to generate the credentials file, before falling back to the default template.

This allows e.g. an open-source Rails app (which would not include encrypted credentials files in its repo) to include a credentials template, so that users who install the app will get a custom pre-filled credentials file when they run `rails credentials:edit`.
