### PR TITLE
Support parameter filtering based on allow lists

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -45,14 +45,14 @@ module ActionDispatch
 
       # Returns a hash of parameters with all sensitive data replaced.
       def filtered_parameters
-        @filtered_parameters ||= parameter_filter.filter(parameters)
+        @filtered_parameters ||= (allow_filter || parameter_filter).filter(parameters)
       rescue ActionDispatch::Http::Parameters::ParseError
         @filtered_parameters = {}
       end
 
       # Returns a hash of request.env with all sensitive data replaced.
       def filtered_env
-        @filtered_env ||= env_filter.filter(@env)
+        @filtered_env ||= (allow_filter || env_filter).filter(@env)
       end
 
       # Reconstructs a path with all sensitive GET parameters replaced.
@@ -74,6 +74,12 @@ module ActionDispatch
         parameter_filter_for(Array(user_key) + ENV_MATCH)
       end
 
+      def allow_filter
+        if allow_filter = get_header("action_dispatch.parameter_allow_filter")
+          ActiveSupport::ParameterAllowFilter.new(allow_filter)
+        end
+      end
+
       def parameter_filter_for(filters) # :doc:
         ActiveSupport::ParameterFilter.new(filters)
       end
@@ -82,7 +88,7 @@ module ActionDispatch
       PAIR_RE = %r{(#{KV_RE})=(#{KV_RE})}
       def filtered_query_string # :doc:
         query_string.gsub(PAIR_RE) do |_|
-          parameter_filter.filter($1 => $2).first.join("=")
+          (allow_filter || parameter_filter).filter($1 => $2).first.join("=")
         end
       end
     end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -218,6 +218,20 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal "Rails Testing", @controller.last_payload[:headers]["User-Agent"]
   end
 
+  def test_process_action_with_allow_parameters
+    @request.env["action_dispatch.parameter_allow_filter"] = [:step]
+
+    get :show, params: {
+      lifo: "Pratik", amount: "420", step: "1"
+    }
+    wait
+
+    params = logs[1]
+    assert_match(/"amount"=>"\[FILTERED\]"/, params)
+    assert_match(/"lifo"=>"\[FILTERED\]"/, params)
+    assert_match(/"step"=>"1"/, params)
+  end
+
   def test_process_action_with_filter_parameters
     @request.env["action_dispatch.parameter_filter"] = [:lifo, :amount]
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -324,6 +324,9 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
     initializer "active_record.set_filter_attributes" do
       ActiveSupport.on_load(:active_record) do
+        if allow_attributes = Rails.application.config.allow_parameters
+          self.allow_attributes = allow_attributes
+        end
         self.filter_attributes += Rails.application.config.filter_parameters
       end
     end

--- a/activerecord/test/cases/allow_attributes_test.rb
+++ b/activerecord/test/cases/allow_attributes_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/admin"
+require "models/admin/user"
+require "models/admin/account"
+require "models/user"
+require "pp"
+
+class AllowAttributesTest < ActiveRecord::TestCase
+  fixtures :"admin/users", :"admin/accounts"
+
+  setup do
+    @previous_filter_attributes = ActiveRecord::Base.filter_attributes
+    ActiveRecord::Base.allow_attributes = [:name]
+    ActiveRecord::Base.remove_instance_variable(:@filter_attributes)
+  end
+
+  teardown do
+    ActiveRecord::Base.remove_instance_variable(:@allow_attributes)
+    ActiveRecord::Base.filter_attributes = @previous_filter_attributes
+  end
+
+  test "allow_attributes" do
+    Admin::User.all.each do |user|
+      assert_includes user.inspect, "settings: [FILTERED]"
+      assert_equal 10, user.inspect.scan("[FILTERED]").length
+    end
+
+    Admin::Account.all.each do |account|
+      assert_includes account.inspect, "id: [FILTERED]"
+    end
+  end
+
+  test "allow_attributes affects attribute_for_inspect" do
+    Admin::User.all.each do |user|
+      assert_equal "[FILTERED]", user.attribute_for_inspect(:settings)
+    end
+  end
+
+  test "string allow_attributes perform partial match" do
+    ActiveRecord::Base.allow_attributes = ["n"]
+    Admin::User.all.each do |user|
+      assert_not_includes user.inspect, "name: [FILTERED]"
+      assert_equal 3, user.inspect.scan("[FILTERED]").length
+    end
+  end
+
+  test "regex allow_attributes are accepted" do
+    ActiveRecord::Base.allow_attributes = [/\An\z/]
+    account = Admin::Account.find_by(name: "37signals")
+    assert_includes account.reload.inspect, "name: [FILTERED]"
+
+    ActiveRecord::Base.allow_attributes = [/\An/]
+    account = Admin::Account.find_by(name: "37signals")
+    assert_includes account.inspect, 'name: "37signals"'
+    assert_operator account.inspect.scan("[FILTERED]").length, :>, 0
+  end
+
+  test "proc allow_attributes are accepted" do
+    ActiveRecord::Base.allow_attributes = [:name, lambda { |key, value| value.reverse! if key == "name" } ]
+    account = Admin::Account.find_by(name: "37signals")
+    assert_includes account.inspect, 'name: "slangis73"'
+  end
+
+  test "proc allow_attributes don't prevent marshal dump" do
+    ActiveRecord::Base.allow_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
+    account = Admin::Account.new(id: 123, name: "37signals")
+    account.inspect
+    assert_equal account, Marshal.load(Marshal.dump(account))
+  end
+
+  test "allow_attributes could be overwritten by models" do
+    Admin::Account.all.each do |account|
+      assert_includes account.inspect, "id: [FILTERED]"
+      assert_equal 1, account.inspect.scan("[FILTERED]").length
+    end
+
+    begin
+      Admin::Account.allow_attributes = []
+
+      # Above changes should not impact other models
+      Admin::User.all.each do |user|
+        assert_not_includes user.inspect, "name: [FILTERED]"
+        assert_equal 10, user.inspect.scan("[FILTERED]").length
+      end
+
+      Admin::Account.all.each do |account|
+        assert_includes account.inspect, "name: [FILTERED]"
+        assert_equal 2, account.inspect.scan("[FILTERED]").length
+      end
+    ensure
+      Admin::Account.remove_instance_variable(:@allow_attributes)
+    end
+  end
+
+  test "allow_attributes should not filter nil value" do
+    account = Admin::Account.new
+
+    assert_includes account.inspect, "name: nil"
+    assert_not_includes account.inspect, "name: [FILTERED]"
+    assert_equal 0, account.inspect.scan("[FILTERED]").length
+  end
+
+  test "allow_attributes should handle [FILTERED] value properly" do
+    User.allow_attributes = ["auth"]
+    user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
+
+    assert_includes user.inspect, 'auth_token: "[FILTERED]"'
+    assert_includes user.inspect, "token: [FILTERED]"
+  ensure
+    User.remove_instance_variable(:@allow_attributes)
+  end
+
+  test "allow_attributes on pretty_print" do
+    user = admin_users(:jamis)
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
+
+    assert_includes actual, 'name: "Jamis"'
+    assert_includes actual, 'id: "[FILTERED]"'
+    assert_equal 4, actual.scan("[FILTERED]").length
+  end
+
+  test "allow_attributes on pretty_print should not filter nil value" do
+    user = Admin::User.new
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
+
+    assert_includes actual, "name: nil"
+    assert_not_includes actual, "name: [FILTERED]"
+    assert_equal 0, actual.scan("[FILTERED]").length
+  end
+
+  test "allow_attributes on pretty_print should handle [FILTERED] value properly" do
+    User.allow_attributes = ["auth"]
+    user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
+    actual = "".dup
+    PP.pp(user, StringIO.new(actual))
+
+    assert_includes actual, 'auth_token: "[FILTERED]"'
+    assert_includes actual, 'token: "[FILTERED]"'
+  ensure
+    User.remove_instance_variable(:@allow_attributes)
+  end
+end

--- a/activesupport/test/parameter_filter_test.rb
+++ b/activesupport/test/parameter_filter_test.rb
@@ -122,3 +122,119 @@ class ParameterFilterTest < ActiveSupport::TestCase
     end
   end
 end
+
+class ParameterAllowFilterTest < ActiveSupport::TestCase
+  test "process parameter filter" do
+    test_hashes = [
+      [{ "foo" => "bar" }, { "foo" => "[FILTERED]" }, %w'food'],
+      [{ "foo" => "bar" }, { "foo" => "bar" }, %w'foo'],
+      [{ "foo" => "bar", "bar" => "foo" }, { "foo" => "bar", "bar" => "[FILTERED]" }, %w'foo baz'],
+      [{ "foo" => "bar", "baz" => "foo" }, { "foo" => "bar", "baz" => "foo" }, %w'foo baz'],
+      [{ "bar" => { "foo" => "bar", "bar" => "foo" } }, { "bar" => { "foo" => "bar", "bar" => "[FILTERED]" } }, %w'fo'],
+      [{ "foo" => { "foo" => "bar", "bar" => "foo" } }, { "foo" => { "foo" => "bar", "bar" => "[FILTERED]" } }, %w'f banana'],
+      [{ "deep" => { "cc" => { "code" => "bar", "bar" => "foo" }, "ss" => { "code" => "bar" } } }, { "deep" => { "cc" => { "code" => "bar", "bar" => "[FILTERED]" }, "ss" => { "code" => "[FILTERED]" } } }, %w'deep.cc.code'],
+      [{ "baz" => [{ "foo" => "baz" }, "1"] }, { "baz" => [{ "foo" => "baz" }, "[FILTERED]"] }, [/foo/]]
+    ]
+
+    test_hashes.each do |before_filter, after_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words)
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+
+      filter_words << "blah"
+      filter_words << "barg"
+      filter_words << "hello"
+      filter_words << "array_elements"
+      filter_words << lambda { |key, value|
+        value.reverse! if /bargain/.match?(key)
+      }
+      filter_words << lambda { |key, value, original_params|
+        value.replace("world!") if original_params["barg"]["blah"] == "bar" && key == "hello"
+      }
+
+      filter_words << lambda { |key, value|
+        value.upcase! if key == "array_elements"
+      }
+
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words)
+      before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world" } } }
+      after_filter["barg"]  = { :bargain => "niag", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world!" } } }
+
+      before_filter["array_elements"] = %w(element1 element2)
+      after_filter["array_elements"] = %w(ELEMENT1 ELEMENT2)
+
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+    end
+  end
+
+  test "filter should return mask option when value is filtered" do
+    mask = Object.new.freeze
+    test_hashes = [
+    [{ "foo" => "bar" }, { "foo" => mask }, %w'food'],
+    [{ "foo" => "bar" }, { "foo" => "bar" }, %w'foo'],
+    [{ "foo" => "bar", "bar" => "foo" }, { "foo" => "bar", "bar" => mask }, %w'foo baz'],
+    [{ "foo" => "bar", "baz" => "foo" }, { "foo" => "bar", "baz" => "foo" }, %w'foo baz'],
+    [{ "bar" => { "foo" => "bar", "bar" => "foo" } }, { "bar" => { "foo" => "bar", "bar" => mask } }, %w'fo'],
+    [{ "foo" => { "foo" => "bar", "bar" => "foo" } }, { "foo" => { "foo" => "bar", "bar" => mask } }, %w'f banana'], # should fail
+    [{ "deep" => { "cc" => { "code" => "bar", "bar" => "foo" }, "ss" => { "code" => "bar" } } }, { "deep" => { "cc" => { "code" => "bar", "bar" => mask }, "ss" => { "code" => mask } } }, %w'deep.cc.code'],
+    [{ "baz" => [{ "foo" => "baz" }, "1"] }, { "baz" => [{ "foo" => "baz" }, mask] }, [/foo/]]
+    ]
+
+    test_hashes.each do |before_filter, after_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words, mask: mask)
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+
+      filter_words << "blah"
+      filter_words << "barg"
+      filter_words << "hello"
+      filter_words << lambda { |key, value|
+        value.reverse! if /bargain/.match?(key)
+      }
+      filter_words << lambda { |key, value, original_params|
+        value.replace("world!") if original_params["barg"]["blah"] == "bar" && key == "hello"
+      }
+
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words, mask: mask)
+      before_filter["barg"] = { :bargain => "gain", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world" } } }
+      after_filter["barg"]  = { :bargain => "niag", "blah" => "bar", "bar" => { "bargain" => { "blah" => "foo", "hello" => "world!" } } }
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+    end
+  end
+
+  test "filter_param" do
+    parameter_filter = ActiveSupport::ParameterAllowFilter.new(["foo", /bar/])
+    assert_equal "non secret value", parameter_filter.filter_param("food", "non secret value")
+    assert_equal "non secret value", parameter_filter.filter_param("baz.foo", "non secret value")
+    assert_equal "non secret value", parameter_filter.filter_param("barbar", "non secret value")
+    assert_equal "[FILTERED]", parameter_filter.filter_param("baz", "secret value")
+  end
+
+  test "filter_param with can work with empty filters" do
+    parameter_filter = ActiveSupport::ParameterAllowFilter.new
+    assert_equal "[FILTERED]", parameter_filter.filter_param("foo", "bar")
+  end
+
+  test "parameter filter should maintain hash with indifferent access" do
+    test_hashes = [
+      [{ "foo" => "bar" }.with_indifferent_access, ["blah"]],
+      [{ "foo" => "bar" }.with_indifferent_access, []]
+    ]
+
+    test_hashes.each do |before_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words)
+      assert_instance_of ActiveSupport::HashWithIndifferentAccess,
+                         parameter_filter.filter(before_filter)
+    end
+  end
+
+  test "process parameter filter with hash having integer keys" do
+    test_hashes = [
+      [{ 13 => "bar" }, { 13 => "bar" }, %w'13'],
+      [{ 20 => "bar" }, { 20 => "[FILTERED]" }, %w'13'],
+    ]
+
+    test_hashes.each do |before_filter, after_filter, filter_words|
+      parameter_filter = ActiveSupport::ParameterAllowFilter.new(filter_words)
+      assert_equal after_filter, parameter_filter.filter(before_filter)
+    end
+  end
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -249,6 +249,7 @@ module Rails
     # will be used by middlewares and engines to configure themselves.
     def env_config
       @app_env_config ||= super.merge(
+          "action_dispatch.parameter_allow_filter" => config.allow_parameters,
           "action_dispatch.parameter_filter" => config.filter_parameters,
           "action_dispatch.redirect_filter" => config.filter_redirect,
           "action_dispatch.secret_key_base" => secret_key_base,

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -10,7 +10,7 @@ require "rails/source_annotation_extractor"
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
-      attr_accessor :allow_concurrency, :asset_host, :autoflush_log,
+      attr_accessor :allow_concurrency, :allow_parameters, :asset_host, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3268,6 +3268,15 @@ module ApplicationTests
       assert_equal ActionMailer::MailDeliveryJob, ActionMailer::Base.delivery_job
     end
 
+    test "ActiveRecord::Base.allow_attributes should equal to allow_parameters" do
+      app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
+        Rails.application.config.allow_parameters = [ :id, :name ]
+      RUBY
+      app "development"
+      assert_equal [ :id, :name ], Rails.application.config.allow_parameters
+      assert_equal [ :id, :name ], ActiveRecord::Base.allow_attributes
+    end
+
     test "ActiveRecord::Base.filter_attributes should equal to filter_parameters" do
       app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
         Rails.application.config.filter_parameters += [ :password, :credit_card_number ]


### PR DESCRIPTION
### Summary

`ActiveSupport::ParameterFilter` currently works as a deny list: you
specify the parameters that should be filtered.

```ruby
Rails.application.config.filter_parameters += [:passw]
```

If you want use an allow list and specify the parameters that should be allowed
you could do it with a lambda. For example:

```ruby
Rails.application.config.filter_parameters += [
  lambda { |key, value|
    # filter all parameters that aren't :id
    value.replace('[FILTERED]') unless key.in?(:id)
  }
]
```

But this can be error prone. For example this doesn't work if a value is
`nil`.

This change makes it possible to list the parameters that are allowed.
All other parameters will be masked.

For example, to only allow primary keys and foreign keys you could
configure the following:
```ruby
Rails.application.config.allow_parameters = [:id, /_id\z/]
```

`allow_parameters` takes precedence over `filter_parameters`. So if the
`allow_parameters` are defined `filter_parameters` will be ignored.

The majority of the tests are based on the deny list equivalent:
- The `RequestParameterAllowFilter` test is based on `RequestParameterFilter` test.
- `activerecord/test/cases/allow_attributes_test.rb` is based on `activerecord/test/cases/filter_attributes_test.rb`

The current implementation of ParameterAllowFilter supports all features
from ParameterFilter, including lambdas. But maybe it should be
simplified instead by removing lambda support.