### PR TITLE
Include `:rich_text_area` Capybara selector in `:_field` filter set

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `:rich_text_area` Capybara selector to the `:_field` filter set
+
+    *Sean Doyle*
+
 *   Use `Rails::HTML5::SafeListSanitizer` by default in the Rails 7.1 configuration if it is
     supported.
 

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -36,6 +36,8 @@ module ActionText
 end
 
 Capybara.add_selector :rich_text_area do
+  filter_set :_field
+
   label "rich-text area"
   xpath do |locator|
     if locator.nil?

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -9,24 +9,28 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
 
   test "filling in a rich-text area by ID" do
     assert_selector "trix-editor#message_content"
+    assert_selector :field, "message_content"
     fill_in_rich_text_area "message_content", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by placeholder" do
     assert_selector "trix-editor[placeholder='Your message here']"
+    assert_selector :field, "Your message here"
     fill_in_rich_text_area "Your message here", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by aria-label" do
     assert_selector "trix-editor[aria-label='Message content aria-label']"
+    assert_selector :field, "Message content aria-label"
     fill_in_rich_text_area "Message content aria-label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by label" do
     assert_selector "label", text: "Message content label"
+    assert_selector :field, "Message content label"
     fill_in_rich_text_area "Message content label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end


### PR DESCRIPTION
### Summary

Add the `:rich_text_area` to the `:_field` filter set, along with other
form controls like `<input>` and `<textarea>` elements so that
`assert_field` and `find(:field, ...)` can resolve to `<trix-editor>`
elements.