### PR TITLE
Revert "Provide pattern matching for ActiveModel"

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -28,22 +28,6 @@
 
 *   Define `deconstruct_keys` in `ActiveModel::AttributeMethods`
 
-    This provides the Ruby 2.7+ pattern matching interface for hash patterns,
-    which allows the user to pattern match against anything that includes the
-    `ActiveModel::AttributeMethods` module (e.g., `ActiveRecord::Base`). As an
-    example, you can now:
-
-    ```ruby
-    class Person < ActiveRecord::Base
-    end
-
-    person = Person.new(name: "Mary")
-    person => { name: }
-    name # => "Mary"
-    ```
-
-    *Kevin Newton*
-
 *   Fix casting long strings to `Date`, `Time` or `DateTime`
 
     *fatkodima*

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -489,43 +489,6 @@ module ActiveModel
       end
     end
 
-    # Returns a hash of attributes for the given keys. Provides the pattern
-    # matching interface for matching against hash patterns. For example:
-    #
-    #   class Person
-    #     include ActiveModel::AttributeMethods
-    #
-    #     attr_accessor :name
-    #     define_attribute_method :name
-    #   end
-    #
-    #   def greeting_for(person)
-    #     case person
-    #     in { name: "Mary" }
-    #       "Welcome back, Mary!"
-    #     in { name: }
-    #       "Welcome, stranger!"
-    #     end
-    #   end
-    #
-    #   person = Person.new
-    #   person.name = "Mary"
-    #   greeting_for(person) # => "Welcome back, Mary!"
-    #
-    #   person = Person.new
-    #   person.name = "Bob"
-    #   greeting_for(person) # => "Welcome, stranger!"
-    def deconstruct_keys(keys)
-      deconstructed = {}
-
-      keys.each do |key|
-        string_key = key.to_s
-        deconstructed[key] = _read_attribute(string_key) if attribute_method?(string_key)
-      end
-
-      deconstructed
-    end
-
     private
       def attribute_method?(attr_name)
         respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -175,14 +175,5 @@ module ActiveModel
         ModelForAttributesTest.attribute :foo, :unknown
       end
     end
-
-    test "pattern matching against keys" do
-      case ModelForAttributesTest.new(integer_field: 1)
-      in { integer_field: 1 }
-        assert(true)
-      else
-        assert(false, "Failed to pattern match")
-      end
-    end
   end
 end


### PR DESCRIPTION
This reverts commit 7e499b25acd5e1bfdd54ca2af66678b0ed05def1.


#45035 
#45070 

This feature needs more discussion before we decide on a direction for pattern matching in Rails.