### PR TITLE
Fix rdoc for ActiveRecord::Associations::ClassMethods

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -628,15 +628,15 @@ module ActiveRecord
       #
       # Note: To trigger remove callbacks, you must use +destroy+ / +destroy_all+ methods. For example:
       #
-      #   * <tt>firm.clients.destroy(client)</tt>
-      #   * <tt>firm.clients.destroy(*clients)</tt>
-      #   * <tt>firm.clients.destroy_all</tt>
+      # * <tt>firm.clients.destroy(client)</tt>
+      # * <tt>firm.clients.destroy(*clients)</tt>
+      # * <tt>firm.clients.destroy_all</tt>
       #
       # +delete+ / +delete_all+ methods like the following do *not* trigger remove callbacks:
       #
-      #   * <tt>firm.clients.delete(client)</tt>
-      #   * <tt>firm.clients.delete(*clients)</tt>
-      #   * <tt>firm.clients.delete_all</tt>
+      # * <tt>firm.clients.delete(client)</tt>
+      # * <tt>firm.clients.delete(*clients)</tt>
+      # * <tt>firm.clients.delete_all</tt>
       #
       # == Association extensions
       #


### PR DESCRIPTION
Currently, the [changed sections in the API doc](https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Association+callbacks) are rendered as code blocks (see image below). This is due to the indention. Removing it should result in the indented rendering of the sections.

![image](https://user-images.githubusercontent.com/32938211/178124196-e8e91121-6039-4f02-ac16-ea80ef02e86d.png)