### PR TITLE
Fix Time#change and Time#advance to return self when options are empty

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -136,6 +136,8 @@ class Time
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => Time.new(1981, 8, 29, 0, 0, 0)
   def change(options)
+    return self if options.empty?
+
     new_year   = options.fetch(:year, year)
     new_month  = options.fetch(:month, month)
     new_day    = options.fetch(:day, day)
@@ -180,6 +182,8 @@ class Time
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(days: 1)    # => 2015-08-02 14:35:00 -0700
   #   Time.new(2015, 8, 1, 14, 35, 0).advance(weeks: 1)   # => 2015-08-08 14:35:00 -0700
   def advance(options)
+    return self if options.empty?
+
     unless options[:weeks].nil?
       options[:weeks], partial_weeks = options[:weeks].divmod(1)
       options[:days] = options.fetch(:days, 0) + 7 * partial_weeks

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -430,6 +430,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2005, 1, 2, 11, 22, 33, 8), Time.local(2005, 1, 2, 11, 22, 33, 2).change(nsec: 8000)
     assert_raise(ArgumentError) { Time.local(2005, 1, 2, 11, 22, 33, 8).change(usec: 1, nsec: 1) }
     assert_nothing_raised { Time.new(2015, 5, 9, 10, 00, 00, "+03:00").change(nsec: 999999999) }
+
+    with_env_tz "US/Eastern" do
+      assert_equal 0, Time.new(2005, 10, 30, 0, 59, 59).advance(hours: 1).change({}) - Time.new(2005, 10, 30, 0, 59, 59).advance(hours: 1)
+    end
   end
 
   def test_utc_change
@@ -491,6 +495,10 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.new(2021, 5, 29, 0, 0, 0, "+03:00"), ActiveSupport::TimeZone["Moscow"].local(2021, 5, 29, 0, 0, 0)
     assert_equal Time.new(2021, 5, 29, 0, 0, 0, "+03:00").advance(seconds: 60), ActiveSupport::TimeZone["Moscow"].local(2021, 5, 29, 0, 0, 0).advance(seconds: 60)
     assert_equal Time.new(2021, 5, 29, 0, 0, 0, "+03:00").advance(days: 3), ActiveSupport::TimeZone["Moscow"].local(2021, 5, 29, 0, 0, 0).advance(days: 3)
+
+    with_env_tz "US/Eastern" do
+      assert_equal 0, Time.new(2005, 10, 30, 0, 59, 59).advance(hours: 1).advance({}) - Time.new(2005, 10, 30, 0, 59, 59).advance(hours: 1)
+    end
   end
 
   def test_utc_advance


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

When time zone is DST-related, `Time#change` and `Time#advance` returns different times if empty options are given. This PR fixes them to return self when the options are empty.

The original implementation returns new Time object, however, I think it's ok to return the same object because options are empty.
>https://github.com/rails/rails/blob/c3fd9f177668f757d7c5f3b3bdbf64c917db354a/activesupport/lib/active_support/core_ext/time/calculations.rb#L126

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

This PR relates to https://github.com/rails/rails/issues/45055, but it will not be fully resolved by this.
