### PR TITLE
Fix TimeWithZone#time to return local time

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -56,7 +56,7 @@ module ActiveSupport
 
     # Returns a <tt>Time</tt> instance that represents the time in +time_zone+.
     def time
-      @time ||= incorporate_utc_offset(@utc, utc_offset)
+      @time ||= @utc.getlocal(@time_zone)
     end
 
     # Returns a <tt>Time</tt> instance of the simultaneous time in the UTC timezone.
@@ -531,7 +531,7 @@ module ActiveSupport
     end
 
     def marshal_load(variables)
-      initialize(variables[0].utc, ::Time.find_zone(variables[1]), variables[2].utc)
+      initialize(variables[0].utc, ::Time.find_zone(variables[1]), variables[2])
     end
 
     # respond_to_missing? is not called in some cases, such as when type conversion is

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -10,6 +10,7 @@ module TimeZoneTestHelpers
   end
 
   def with_env_tz(new_tz = "US/Eastern")
+    new_tz = new_tz.tzinfo.canonical_identifier if new_tz.is_a? ActiveSupport::TimeZone
     old_tz, ENV["TZ"] = ENV["TZ"], new_tz
     yield
   ensure


### PR DESCRIPTION
### Summary

Currently, `TimeWithZone#time` returns UTC where time zone offset is
added/subtracted. So the value is semantically incorrect. This PR fixes it to
return local time.

Close https://github.com/rails/rails/issues/45548.

### Other Information

None.