### PR TITLE
Add bury to Hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/bury.rb
+++ b/activesupport/lib/active_support/core_ext/hash/bury.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Hash
+  # Easily build a new deep hash
+  #
+  #   Hash.bury(:conferences, :tracks, :sessions, :keynote, presenter: '@tenderlove', topic: 'hotwire')
+  #   # => { conferences: { tracks: { sessions: { keynote: { presenter: "@tenderlove", :topic=>"hotwire" } } } } }
+  #
+  #   Hash.bury(:a, 0, c: 42)
+  #   # => { a: { 0 => { c: 42 } } }
+  #
+  # Use bury with deep_merge to make modifications deep in the hash structure:
+  #
+  #   h1 = { a: { b: { c: { c1: 100 } } } }
+  #   h1.deep_merge(Hash.bury(:a, :b, :c, c2: 200, c3: 300))
+  #   # => { a: { b: { c: { c1: 100, c2: 200, c3: 300 } } } }
+  def self.bury(*args, **kwargs)
+    args.reverse.reduce(Hash.new.merge(**kwargs)) do |hash, arg|
+      { arg => hash }
+    end
+  end
+end

--- a/activesupport/test/core_ext/hash/bury_test.rb
+++ b/activesupport/test/core_ext/hash/bury_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# require_relative "../../abstract_unit"
+require "active_support/core_ext/hash/bury"
+
+class HashBuryTest < ActiveSupport::TestCase
+  test "build a deep nested hash structure" do
+    actual = Hash.bury(:conference, :tracks, :sessions, :keynote, presenter: "@tenderlove", topic: "hotwire")
+    expected = { conference: { tracks: { sessions: { keynote: { presenter: "@tenderlove", topic: "hotwire" } } } } }
+
+    assert actual.equal?(expected)
+  end
+
+  test "works with index numbers" do
+    actual = Hash.bury(:a, 0, :c, 42)
+    expected = { a: { 0 => { c: 42 } } }
+
+    assert actual.equal?(expected)
+  end
+end


### PR DESCRIPTION
### Summary

Adds a method called `bury` to Hash that creates a new hash with a deep structure quickly. `bury` makes it easy to make modifications deep in the hash structure when combined with `deep_merge`

```
h1 = { a: { b: { c: { c1: 100 } } } }
h1.deep_merge(Hash.bury(:a, :b, :c, c2: 200, c3: 300))
{:a=>{:b=>{:c=>{:c1=>100, :c2=>200, :c3=>300}}}}
# => { a: { b: { c: { c1: 100, c2: 200, c3: 300 } } } }
```

