### PR TITLE
Ensure connection_name is used everywhere internally

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -171,17 +171,17 @@ module ActiveRecord
       def schema_migration # :nodoc:
         @schema_migration ||= begin
                                 conn = self
-                                spec_name = conn.pool.pool_config.connection_specification_name
+                                connection_name = conn.pool.pool_config.connection_name
 
-                                return ActiveRecord::SchemaMigration if spec_name == "ActiveRecord::Base"
+                                return ActiveRecord::SchemaMigration if connection_name == "ActiveRecord::Base"
 
-                                schema_migration_name = "#{spec_name}::SchemaMigration"
+                                schema_migration_name = "#{connection_name}::SchemaMigration"
 
                                 Class.new(ActiveRecord::SchemaMigration) do
                                   define_singleton_method(:name) { schema_migration_name }
                                   define_singleton_method(:to_s) { schema_migration_name }
 
-                                  self.connection_specification_name = spec_name
+                                  self.connection_specification_name = connection_name
                                 end
                               end
       end

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         INSTANCES[self] = self
       end
 
-      def connection_specification_name
+      def connection_name
         if connection_class.primary_class?
           "ActiveRecord::Base"
         else

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -48,8 +48,8 @@ module ActiveRecord
     # may be returned on an error.
     def establish_connection(config_or_env = nil)
       config_or_env ||= DEFAULT_ENV.call.to_sym
-      db_config, owner_name = resolve_config_for_connection(config_or_env)
-      connection_handler.establish_connection(db_config, owner_name: owner_name, role: current_role, shard: current_shard)
+      db_config, connection_class = resolve_config_for_connection(config_or_env)
+      connection_handler.establish_connection(db_config, owner_name: connection_class, role: current_role, shard: current_shard)
     end
 
     # Connects a model to the databases specified. The +database+ keyword
@@ -87,18 +87,18 @@ module ActiveRecord
       connections = []
 
       database.each do |role, database_key|
-        db_config, owner_name = resolve_config_for_connection(database_key)
+        db_config, connection_class = resolve_config_for_connection(database_key)
 
         self.connection_class = true
-        connections << connection_handler.establish_connection(db_config, owner_name: owner_name, role: role)
+        connections << connection_handler.establish_connection(db_config, owner_name: connection_class, role: role)
       end
 
       shards.each do |shard, database_keys|
         database_keys.each do |role, database_key|
-          db_config, owner_name = resolve_config_for_connection(database_key)
+          db_config, connection_class = resolve_config_for_connection(database_key)
 
           self.connection_class = true
-          connections << connection_handler.establish_connection(db_config, owner_name: owner_name, role: role, shard: shard.to_sym)
+          connections << connection_handler.establish_connection(db_config, owner_name: connection_class, role: role, shard: shard.to_sym)
         end
       end
 
@@ -315,8 +315,8 @@ module ActiveRecord
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name
 
-        owner_name = primary_class? ? Base.name : name
-        self.connection_specification_name = owner_name
+        connection_name = primary_class? ? Base.name : name
+        self.connection_specification_name = connection_name
 
         db_config = Base.configurations.resolve(config_or_env)
         [db_config, self]

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       def setup
         @handler = ConnectionHandler.new
-        @owner_name = "ActiveRecord::Base"
+        @connection_name = "ActiveRecord::Base"
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         @pool = @handler.establish_connection(db_config)
       end
@@ -210,19 +210,19 @@ module ActiveRecord
       end
 
       def test_retrieve_connection
-        assert @handler.retrieve_connection(@owner_name)
+        assert @handler.retrieve_connection(@connection_name)
       end
 
       def test_active_connections?
         assert_not_predicate @handler, :active_connections?
-        assert @handler.retrieve_connection(@owner_name)
+        assert @handler.retrieve_connection(@connection_name)
         assert_predicate @handler, :active_connections?
         @handler.clear_active_connections!
         assert_not_predicate @handler, :active_connections?
       end
 
       def test_retrieve_connection_pool
-        assert_not_nil @handler.retrieve_connection_pool(@owner_name)
+        assert_not_nil @handler.retrieve_connection_pool(@connection_name)
       end
 
       def test_retrieve_connection_pool_with_invalid_id
@@ -391,7 +391,7 @@ module ActiveRecord
 
           pid = fork {
             rd.close
-            pool = @handler.retrieve_connection_pool(@owner_name)
+            pool = @handler.retrieve_connection_pool(@connection_name)
             wr.write Marshal.dump pool.schema_cache.size
             wr.close
             exit!

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       def setup
         @handler = ConnectionHandler.new
-        @owner_name = "ActiveRecord::Base"
+        @connection_name = "ActiveRecord::Base"
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         @rw_pool = @handler.establish_connection(db_config)
         @ro_pool = @handler.establish_connection(db_config, role: :reading)
@@ -325,15 +325,15 @@ module ActiveRecord
       end
 
       def test_retrieve_connection
-        assert @handler.retrieve_connection(@owner_name)
-        assert @handler.retrieve_connection(@owner_name, role: :reading)
+        assert @handler.retrieve_connection(@connection_name)
+        assert @handler.retrieve_connection(@connection_name, role: :reading)
       end
 
       def test_active_connections?
         assert_not_predicate @handler, :active_connections?
 
-        assert @handler.retrieve_connection(@owner_name)
-        assert @handler.retrieve_connection(@owner_name, role: :reading)
+        assert @handler.retrieve_connection(@connection_name)
+        assert @handler.retrieve_connection(@connection_name, role: :reading)
 
         assert_predicate @handler, :active_connections?
 
@@ -342,8 +342,8 @@ module ActiveRecord
       end
 
       def test_retrieve_connection_pool
-        assert_not_nil @handler.retrieve_connection_pool(@owner_name)
-        assert_not_nil @handler.retrieve_connection_pool(@owner_name, role: :reading)
+        assert_not_nil @handler.retrieve_connection_pool(@connection_name)
+        assert_not_nil @handler.retrieve_connection_pool(@connection_name, role: :reading)
       end
 
       def test_retrieve_connection_pool_with_invalid_id

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -12,7 +12,6 @@ module ActiveRecord
 
       def setup
         @handler = ConnectionHandler.new
-        @owner_name = "ActiveRecord::Base"
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         @rw_pool = @handler.establish_connection(db_config)
         @ro_pool = @handler.establish_connection(db_config, role: :reading)
@@ -29,7 +28,7 @@ module ActiveRecord
             ActiveRecord::Base.establish_connection(db_config)
             assert_nothing_raised { Person.first }
 
-            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:owner_to_pool_manager).fetch("ActiveRecord::Base").instance_variable_get(:@name_to_role_mapping).values.flat_map(&:keys).uniq
+            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:connection_name_to_pool_manager).fetch("ActiveRecord::Base").instance_variable_get(:@name_to_role_mapping).values.flat_map(&:keys).uniq
           end
         end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -508,8 +508,8 @@ module ActiveRecord
 
         @connection_test_model_class.establish_connection :arunit
 
-        assert_equal [:config, :shard, :spec_name], payloads[0].keys.sort
-        assert_equal @connection_test_model_class.name, payloads[0][:spec_name]
+        assert_equal [:config, :connection_name, :shard], payloads[0].keys.sort
+        assert_equal @connection_test_model_class.name, payloads[0][:connection_name]
         assert_equal ActiveRecord::Base.default_shard, payloads[0][:shard]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
@@ -522,8 +522,8 @@ module ActiveRecord
         end
         @connection_test_model_class.connects_to shards: { shard_two: { writing: :arunit } }
 
-        assert_equal [:config, :shard, :spec_name], payloads[0].keys.sort
-        assert_equal @connection_test_model_class.name, payloads[0][:spec_name]
+        assert_equal [:config, :connection_name, :shard], payloads[0].keys.sort
+        assert_equal @connection_test_model_class.name, payloads[0][:connection_name]
         assert_equal :shard_two, payloads[0][:shard]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1045,9 +1045,9 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       assert_called_with(ActiveRecord::Base.connection_handler, :retrieve_connection, ["book"], returns: connection, shard: shard) do
         message_bus = ActiveSupport::Notifications.instrumenter
         payload = {
-          spec_name: "book",
+          connection_name: "book",
           shard: shard,
-          config: nil,
+          config: nil
         }
 
         message_bus.instrument("!connection.active_record", payload) { }

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -184,7 +184,7 @@ end
 
 def clean_up_connection_handler
   handler = ActiveRecord::Base.connection_handler
-  handler.instance_variable_get(:@owner_to_pool_manager).each do |owner, pool_manager|
+  handler.instance_variable_get(:@connection_name_to_pool_manager).each do |owner, pool_manager|
     pool_manager.role_names.each do |role_name|
       next if role_name == ActiveRecord::Base.default_role
       pool_manager.remove_role(role_name)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -618,7 +618,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   private
     def with_temporary_connection_pool(&block)
-      pool_config = ActiveRecord::Base.connection_handler.send(:owner_to_pool_manager).fetch("ActiveRecord::Base").get_pool_config(ActiveRecord.writing_role, :default)
+      pool_config = ActiveRecord::Base.connection_handler.send(:connection_name_to_pool_manager).fetch("ActiveRecord::Base").get_pool_config(ActiveRecord.writing_role, :default)
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
 
       pool_config.stub(:pool, new_pool, &block)

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -10,7 +10,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
 
   def setup
     @underlying = ActiveRecord::Base.connection
-    @specification = ActiveRecord::Base.remove_connection
+    @connection_name = ActiveRecord::Base.remove_connection
 
     # Clear out connection info from other pids (like a fork parent) too
     ActiveRecord::ConnectionAdapters::PoolConfig.discard_pools!
@@ -18,7 +18,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
 
   teardown do
     @underlying = nil
-    ActiveRecord::Base.establish_connection(@specification)
+    ActiveRecord::Base.establish_connection(@connection_name)
     load_schema if in_memory_db?
   end
 


### PR DESCRIPTION
Looking at connection management we were using `spec_name`,
`spec`, `owner_name`, `owner` and `connection_specification_name` to all mean
the "string representation of the name we use to lookup the connection".

In most applications this is the string representation of the class that
established the connection. In some rarer cases this is represented by
either passing a string to `owner_name` on `establish_connection` or
passing a config as a symbol which gets turned into an `owner_name`.
This behavior is undocumented and legacy, in most cases no longer
necessary. However I know that it is still in use so I'm going to slowly
work on replacing it so the behavior is less confusing.

For now this PR simply renames all the interal words to mean "string
that established the connection" to `connection_name`. In my next PR
I'll address the public APIs around `connection_specification_name` on
`Base` and `owner_name` on `ConnectionHandler`.

Note that the instrumentation in `establish_connection` is private
(denoted by the !), so it is safe to change without warning. Everything
else is internal naming or part of a private API.

---

cc/ @matthewd as we've been talking a lot about goals for connection management including name changes and API changes.