### PR TITLE
Fix caching of missed translations

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -90,7 +90,7 @@ module ActionView
 
           translated = ActiveSupport::HtmlSafeTranslation.translate(key, **options, default: default)
 
-          break translated unless translated.equal?(MISSING_TRANSLATION)
+          break translated unless translated == MISSING_TRANSLATION
 
           if alternatives.present? && !alternatives.first.is_a?(Symbol)
             break alternatives.first && I18n.translate(**options, default: alternatives)
@@ -119,7 +119,7 @@ module ActionView
       alias :l :localize
 
       private
-        MISSING_TRANSLATION = Object.new
+        MISSING_TRANSLATION = -(2**60)
         private_constant :MISSING_TRANSLATION
 
         NO_DEFAULT = [].freeze

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -211,7 +211,7 @@ module ActiveModel
     end
 
     private
-      MISSING_TRANSLATION = Object.new # :nodoc:
+      MISSING_TRANSLATION = -(2**60) # :nodoc:
 
       def _singularize(string)
         ActiveSupport::Inflector.underscore(string).tr("/", "_")

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -35,7 +35,7 @@ module ActiveModel
       ancestors.select { |x| x.respond_to?(:model_name) }
     end
 
-    MISSING_TRANSLATION = Object.new # :nodoc:
+    MISSING_TRANSLATION = -(2**60) # :nodoc:
 
     # Transforms attribute names into a more human format, such as "First name"
     # instead of "first_name".


### PR DESCRIPTION
Fixes #45571.

When using `Object.new` as a default, we get another object when it is fetched from the cache store - https://github.com/ruby-i18n/i18n/blob/5963031f2cc52847a6c431be2b2b38229b1793d2/lib/i18n/backend/cache.rb#L89

So I used some random number as a default.