### PR TITLE
Omit `secret_key_base` for dev and test credentials

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -10,9 +10,10 @@
 
     *Jonathan Hefner*
 
-*   Newly generated per-environment credentials files (e.g.
-    `config/credentials/production.yml.enc`) now include a `secret_key_base` for
-    convenience, just as `config/credentials.yml.enc` does.
+*   Except for `dev` and `test` environments, newly generated per-environment
+    credentials files (e.g. `config/credentials/production.yml.enc`) now include
+    a `secret_key_base` for convenience, just as `config/credentials.yml.enc`
+    does.
 
     *Jonathan Hefner*
 

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -79,6 +79,7 @@ module Rails
 
         def ensure_encryption_key_has_been_added
           require "rails/generators/rails/encryption_key_file/encryption_key_file_generator"
+
           encryption_key_file_generator = Rails::Generators::EncryptionKeyFileGenerator.new
           encryption_key_file_generator.add_key_file(key_path)
           encryption_key_file_generator.ignore_key_file(key_path)
@@ -86,7 +87,12 @@ module Rails
 
         def ensure_credentials_have_been_added
           require "rails/generators/rails/credentials/credentials_generator"
-          Rails::Generators::CredentialsGenerator.new([content_path, key_path], quiet: true).invoke_all
+
+          Rails::Generators::CredentialsGenerator.new(
+            [content_path, key_path],
+            skip_secret_key_base: %w[development test].include?(options[:environment]),
+            quiet: true
+          ).invoke_all
         end
 
         def change_credentials_in_system_editor

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -9,6 +9,7 @@ module Rails
     class CredentialsGenerator < Base # :nodoc:
       argument :content_path, default: "config/credentials.yml.enc"
       argument :key_path, default: "config/master.key"
+      class_option :skip_secret_key_base, type: :boolean
 
       def add_credentials_file
         in_root do

--- a/railties/lib/rails/generators/rails/credentials/templates/credentials.yml.tt
+++ b/railties/lib/rails/generators/rails/credentials/templates/credentials.yml.tt
@@ -1,6 +1,8 @@
 # aws:
 #   access_key_id: 123
 #   secret_access_key: 345
+<% unless options.skip_secret_key_base? -%>
 
 # Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
 secret_key_base: <%= secret_key_base %>
+<% end -%>

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -75,6 +75,16 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_file "config/credentials/production.yml.enc"
   end
 
+  test "edit command omits secret_key_base from generated credentials for dev environment" do
+    assert_no_match %r/^\s*secret_key_base: /, run_edit_command(environment: "dev")
+    assert_file "config/credentials/development.yml.enc"
+  end
+
+  test "edit command omits secret_key_base from generated credentials for test environment" do
+    assert_no_match %r/^\s*secret_key_base: /, run_edit_command(environment: "test")
+    assert_file "config/credentials/test.yml.enc"
+  end
+
   test "edit command does not raise when an initializer tries to access non-existent credentials" do
     app_file "config/initializers/raise_when_loaded.rb", <<-RUBY
       Rails.application.credentials.missing_key!


### PR DESCRIPTION
Follow-up to #45543.

This prevents confusion with the `secret_key_base` stored in `tmp/development_secret.txt`.

---

I would like to eventually allow `config/credentials/development.yml.enc` and `config/credentials/test.yml.enc` to take precedence over `tmp/development_secret.txt` if a user has generated them, but this seems prudent in the mean time.
