### PR TITLE
Fix did you mean tests for ruby-trunk (3.2)

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -178,7 +178,11 @@ class PerformActionTest < ActionController::TestCase
       exception = assert_raise AbstractController::ActionNotFound do
         get :non_existent
       end
-      assert_match "Did you mean?", exception.message
+      if exception.respond_to?(:detailed_message)
+        assert_match "Did you mean?", exception.detailed_message
+      else
+        assert_match "Did you mean?", exception.message
+      end
     end
   end
 

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -88,7 +88,9 @@ class HelpersTypoControllerTest < ActiveSupport::TestCase
   def test_helper_typo_error_message
     e = assert_raise(NameError) { HelpersTypoController.helper "admin/users" }
     # This message is better if autoloading.
-    if RUBY_VERSION >= "2.6"
+    if e.respond_to?(:detailed_message)
+      assert_includes e.detailed_message, "Did you mean?  Admin::UsersHelpeR"
+    elsif RUBY_VERSION >= "2.6"
       assert_equal "uninitialized constant Admin::UsersHelper\nDid you mean?  Admin::UsersHelpeR", e.message
     else
       assert_equal "uninitialized constant Admin::UsersHelper", e.message

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -27,12 +27,20 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
       error = assert_raise ActionController::ParameterMissing do
         post :create, params: { magazine: { name: "Mjallo!" } }
       end
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
 
       error = assert_raise ActionController::ParameterMissing do
         post :create, params: { book: { title: "Mjallo!" } }
       end
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
     end
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4904,7 +4904,11 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
   if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
     test "exceptions have suggestions for fix" do
       error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -853,7 +853,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
       error = assert_raise(ActiveRecord::AssociationNotFoundError) {
         Post.all.merge!(includes: :monkeys).find(6)
       }
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -343,7 +343,11 @@ class InverseHasOneTests < ActiveRecord::TestCase
         Human.first.confused_face
       }
 
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
       assert_equal "super_human", error.corrections.first
     end
   end
@@ -770,7 +774,11 @@ class InverseBelongsToTests < ActiveRecord::TestCase
         Face.first.puzzled_human
       }
 
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
       assert_equal "confused_face", error.corrections.first
     end
   end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -346,7 +346,11 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
       error = assert_raise(ActiveRecord::HasManyThroughAssociationNotFoundError) {
         authors(:david).nothings
       }
-      assert_match "Did you mean?", error.message
+      if error.respond_to?(:detailed_message)
+        assert_match "Did you mean?", error.detailed_message
+      else
+        assert_match "Did you mean?", error.message
+      end
     end
   end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -273,12 +273,16 @@ module ActiveRecord
       # See: https://bugs.ruby-lang.org/issues/15926
       test "#deep_duplicate does not modify the frozen/ufrozen state of untainted or tainted string arguments" do
         test_string = "banana"
-        [
+        test_methods = [
           test_string.dup,
-          test_string.dup.taint,
-          test_string.dup.freeze,
-          test_string.dup.taint.freeze
-        ].each do |str|
+          test_string.dup.freeze
+        ]
+
+        if RUBY_VERSION.start_with?("2.6")
+          test_methods.push(test_string.dup.taint, test_string.dup.taint.freeze)
+        end
+
+        test_methods.each do |str|
           starting_frozen_state = str.frozen?
           @cache.send(:deep_deduplicate, str)
           assert_equal(starting_frozen_state, str.frozen?)

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -32,10 +32,8 @@ module ActiveRecord
 
     test "#order! on non-string does not attempt regexp match for references" do
       obj = Object.new
-      assert_not_called(obj, :=~) do
-        assert relation.order!(obj)
-        assert_equal [obj], relation.order_values
-      end
+      assert relation.order!(obj)
+      assert_equal [obj], relation.order_values
     end
 
     test "extending!" do


### PR DESCRIPTION
Manual backport of #45322

Original commit message:
In https://github.com/ruby/ruby/commit/f075be3dcb4b82b89496d1820002bf3d80f653ef
did_you_mean and error_highlight now use `detailed_message` over
`message` to display errors.

For cases where we are testing `message`, in 3.2 and above we need to
test against `detailed_message` instead.

As far as I can tell in a Rails console when these errors are raised the
`detailed_message` is used so we shouldn't need to make other changes to
Rails. The only case where this isn't true is in the Railties changes -
we are explicitly formatting the did you mean message so we need to be
sure to call `detailed_message` here.

This fixes most of the failing tests for ruby-trunk.