### PR TITLE
Fix ivar name in PoolManager

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/pool_manager.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_manager.rb
@@ -4,40 +4,40 @@ module ActiveRecord
   module ConnectionAdapters
     class PoolManager # :nodoc:
       def initialize
-        @name_to_role_mapping = Hash.new { |h, k| h[k] = {} }
+        @role_to_shard_mapping = Hash.new { |h, k| h[k] = {} }
       end
 
       def shard_names
-        @name_to_role_mapping.values.flat_map { |shard_map| shard_map.keys }
+        @role_to_shard_mapping.values.flat_map { |shard_map| shard_map.keys }
       end
 
       def role_names
-        @name_to_role_mapping.keys
+        @role_to_shard_mapping.keys
       end
 
       def pool_configs(role = nil)
         if role
-          @name_to_role_mapping[role].values
+          @role_to_shard_mapping[role].values
         else
-          @name_to_role_mapping.flat_map { |_, shard_map| shard_map.values }
+          @role_to_shard_mapping.flat_map { |_, shard_map| shard_map.values }
         end
       end
 
       def remove_role(role)
-        @name_to_role_mapping.delete(role)
+        @role_to_shard_mapping.delete(role)
       end
 
       def remove_pool_config(role, shard)
-        @name_to_role_mapping[role].delete(shard)
+        @role_to_shard_mapping[role].delete(shard)
       end
 
       def get_pool_config(role, shard)
-        @name_to_role_mapping[role][shard]
+        @role_to_shard_mapping[role][shard]
       end
 
       def set_pool_config(role, shard, pool_config)
         if pool_config
-          @name_to_role_mapping[role][shard] = pool_config
+          @role_to_shard_mapping[role][shard] = pool_config
         else
           raise ArgumentError, "The `pool_config` for the :#{role} role and :#{shard} shard was `nil`. Please check your configuration. If you want your writing role to be something other than `:writing` set `config.active_record.writing_role` in your application configuration. The same setting should be applied for the `reading_role` if applicable."
         end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -28,7 +28,7 @@ module ActiveRecord
             ActiveRecord::Base.establish_connection(db_config)
             assert_nothing_raised { Person.first }
 
-            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:connection_name_to_pool_manager).fetch("ActiveRecord::Base").instance_variable_get(:@name_to_role_mapping).values.flat_map(&:keys).uniq
+            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:connection_name_to_pool_manager).fetch("ActiveRecord::Base").instance_variable_get(:@role_to_shard_mapping).values.flat_map(&:keys).uniq
           end
         end
 


### PR DESCRIPTION
This isn't a name to role mapping, it's a role to shard mapping. The
pool manager doesn't know it's name (only the connection handler does)
so it makes more sense to rename this ivar. Normally I wouldn't bother
since this is internal but since I'm doing a large refactor which
involves a lot of renaming, might as well get them all right.