### PR TITLE
Improve performance by removing respond_to? from runtime code

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -45,14 +45,20 @@ module ActiveRecord
           raise ArgumentError, "Cannot serialize #{object_class}. Classes passed to `serialize` must have a 0 argument constructor."
         end
 
-        def yaml_load(payload)
-          if !ActiveRecord.use_yaml_unsafe_load
-            YAML.safe_load(payload, permitted_classes: ActiveRecord.yaml_column_permitted_classes, aliases: true)
-          else
-            if YAML.respond_to?(:unsafe_load)
+        if YAML.respond_to?(:unsafe_load)
+          def yaml_load(payload)
+            if ActiveRecord.use_yaml_unsafe_load
               YAML.unsafe_load(payload)
             else
+              YAML.safe_load(payload, permitted_classes: ActiveRecord.yaml_column_permitted_classes, aliases: true)
+            end
+          end
+        else
+          def yaml_load(payload)
+            if ActiveRecord.use_yaml_unsafe_load
               YAML.load(payload)
+            else
+              YAML.safe_load(payload, permitted_classes: ActiveRecord.yaml_column_permitted_classes, aliases: true)
             end
           end
         end


### PR DESCRIPTION
respond_to? is inherently slow, and the YAML class won't change whether
it does or does not respond to unsafe_load, so just check it once
during file load, and define methods accordingly.

cc @byroot 