### PR TITLE
Touch model records after ActiveStorage::Blob is analyzed

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Touch all corresponding model records after ActiveStorage::Blob is analyzed
+
+    This fixes a race condition where a record can be requested and have a cache entry built, before
+    the initial `analyze_later` completes, which will not be invalidated until something else
+    updates the record. This also invalidates cache entries when a blob is re-analyzed, which
+    is helpful if a bug is fixed in an analyzer or a new analyzer is added.
+
+    *Nate Matykiewicz*
+
 *   Add ability to use pre-defined variants when calling `preview` or
     `representation` on an attachment.
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -52,6 +52,8 @@ class ActiveStorage::Blob < ActiveStorage::Record
     self.service_name ||= self.class.service&.name
   end
 
+  after_update :touch_attachment_records
+
   after_update_commit :update_service_metadata, if: -> { content_type_previously_changed? || metadata_previously_changed? }
 
   before_destroy(prepend: true) do
@@ -399,6 +401,12 @@ class ActiveStorage::Blob < ActiveStorage::Record
         { content_type: content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
       else
         { content_type: content_type, custom_metadata: custom_metadata }
+      end
+    end
+
+    def touch_attachment_records
+      attachments.includes(:record).each do |attachment|
+        attachment.touch
       end
     end
 

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -80,6 +80,21 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "record touched after analyze" do
+    user = User.create!(
+      name: "Nate",
+      avatar: {
+        content_type: "image/jpeg",
+        filename: "racecar.jpg",
+        io: file_fixture("racecar.jpg").open,
+      }
+    )
+
+    assert_changes -> { user.reload.updated_at } do
+      user.avatar.blob.analyze
+    end
+  end
+
   test "build_after_unfurling generates a 28-character base36 key" do
     assert_match(/^[a-z0-9]{28}$/, build_blob_after_unfurling.key)
   end


### PR DESCRIPTION
### Summary

This fixes a race condition where a record can be requested and have a
cache entry built, before the initial `analyze_later` completes, which
will not be invalidated until something else updates the record.

1. Upload attachment (this will create an ActiveStorage::Blob,
   ActiveStorage::Attachment, and touch the model)
2. Enqueue analyze job
3. Request record
4. Build a cache for that record
5. Analyze the attachment.
6. Request the record again
7. Serve a cache that doesn't include data from the analyzers, because
   the cache was built before it got analyzed, and the updated_at
   hasn't changed.

This also invalidates cache entries when a blob is re-analyzed, which
is helpful if a bug is fixed in an analyzer or a new analyzer is added.

Fixes #45567