### PR TITLE
Preserve `job.enqueued_at` timestamp precision

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Preserve full-precision `enqueued_at` timestamps for serialized jobs,
+    allowing more accurate reporting of how long a job spent waiting in the
+    queue before it was performed.
+
+    Retains IS08601 format compatibility.
+
+    *Jeremy Daer*
+
 *   Add `--parent` option to job generator to specify parent class of job.
 
     Example:

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -113,7 +113,7 @@ module ActiveJob
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
         "timezone"   => timezone,
-        "enqueued_at" => Time.now.utc.iso8601
+        "enqueued_at" => Time.now.utc.iso8601(9)
       }
     end
 

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -65,14 +65,13 @@ class JobSerializationTest < ActiveSupport::TestCase
     end
   end
 
-  test "serialize stores the enqueued_at time" do
-    h1 = HelloJob.new
-    type = h1.serialize["enqueued_at"].class
-    assert_equal String, type
+  test "serializes enqueued_at with full precision" do
+    freeze_time
 
-    h2 = HelloJob.deserialize(h1.serialize)
-    # We should be able to parse a timestamp
-    type = Time.parse(h2.enqueued_at).class
-    assert_equal Time, type
+    serialized = HelloJob.new.serialize
+    assert_kind_of String, serialized["enqueued_at"]
+
+    enqueued_at = HelloJob.deserialize(serialized).enqueued_at
+    assert_equal Time.now.utc, Time.iso8601(enqueued_at)
   end
 end


### PR DESCRIPTION
* Allows instrumenters to more accurately deduce queue wait time
* Retains IS08601 compatibility

References #39698