### PR TITLE
Allow symbols in YAML columns

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -365,7 +365,7 @@ module ActiveRecord
   # Application configurable array that provides additional permitted classes
   # to Psych safe_load in the YAML Coder
   singleton_class.attr_accessor :yaml_column_permitted_classes
-  self.yaml_column_permitted_classes = []
+  self.yaml_column_permitted_classes = [Symbol]
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -414,23 +414,5 @@ To keep using the current cache store, you can turn off cache versioning entirel
         end
       end
     end
-
-    initializer "active_record.use_yaml_unsafe_load" do |app|
-      config.after_initialize do
-        unless app.config.active_record.use_yaml_unsafe_load.nil?
-          ActiveRecord.use_yaml_unsafe_load =
-            app.config.active_record.use_yaml_unsafe_load
-        end
-      end
-    end
-
-    initializer "active_record.yaml_column_permitted_classes" do |app|
-      config.after_initialize do
-        unless app.config.active_record.yaml_column_permitted_classes.nil?
-          ActiveRecord.yaml_column_permitted_classes =
-            app.config.active_record.yaml_column_permitted_classes
-        end
-      end
-    end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1207,7 +1207,7 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_record.yaml_column_permitted_classes`
 
-Defaults to `[]`. Allows applications to include additional permitted classes to `safe_load()` on the `ActiveStorage::Coders::YamlColumn`.
+Defaults to `[Symbol]`. Allows applications to include additional permitted classes to `safe_load()` on the `ActiveStorage::Coders::YamlColumn`.
 
 #### `config.active_record.use_yaml_unsafe_load`
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1743,9 +1743,9 @@ module ApplicationTests
       assert ActiveRecord.use_yaml_unsafe_load
     end
 
-    test "config.active_record.yaml_column_permitted_classes is [] by default" do
+    test "config.active_record.yaml_column_permitted_classes is [Symbol] by default" do
       app "production"
-      assert_equal([], ActiveRecord.yaml_column_permitted_classes)
+      assert_equal([Symbol], ActiveRecord.yaml_column_permitted_classes)
     end
 
     test "config.active_record.yaml_column_permitted_classes can be configured" do


### PR DESCRIPTION
### Summary

Following up on 611990f1a6c137c2d56b1ba06b27e5d2434dcd6a, this defaults to allow `Symbol` because that's what Ruby does as well in Psych 4.0/Ruby 3.1:

https://docs.ruby-lang.org/en/3.1/Psych.html#method-c-load

### Other Information

I also removed the initializers since they were not necessary. We could also revert most of the test changes that were related to Symbols not being accepted.