### PR TITLE
Correct/update the pluralization docs

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -747,15 +747,15 @@ pluralization backend. By default, only the English pluralization rules are appl
 
 ```ruby
 I18n.backend.store_translations :en, inbox: {
-  zero: 'no messages', # optional
-  one: 'one message',
+  '0': 'no messages', # optional
+  one: '%{count} message',
   other: '%{count} messages'
 }
 I18n.translate :inbox, count: 2
 # => '2 messages'
 
 I18n.translate :inbox, count: 1
-# => 'one message'
+# => '1 message'
 
 I18n.translate :inbox, count: 0
 # => 'no messages'
@@ -764,12 +764,15 @@ I18n.translate :inbox, count: 0
 The algorithm for pluralizations in `:en` is as simple as:
 
 ```ruby
-lookup_key = :zero if count == 0 && entry.has_key?(:zero)
+lookup_key = :'0' if count == 0 && entry.has_key?(:'0')
+lookup_key = :'1' if count == 0 && entry.has_key?(:'1')
 lookup_key ||= count == 1 ? :one : :other
 entry[lookup_key]
 ```
 
-The translation denoted as `:one` is regarded as singular, and the `:other` is used as plural. If the count is zero, and a `:zero` entry is present, then it will be used instead of `:other`.
+The translation denoted as `:one` is regarded as singular, and the `:other` is used as plural.
+If the count is 0, and a `:'0'` entry is present, then it will be used instead of `:other`.
+If the count is 1, and a `:'1'` entry is present, then it will be used instead of `:one`.
 
 If the lookup for the key does not return a Hash suitable for pluralization, an `I18n::InvalidPluralizationData` exception is raised.
 


### PR DESCRIPTION
### Summary

The existing pluralization docs encouraged problematic i18n patterns:

* `zero` should not be used for locales that don't require the `zero` pluralization rule.
* `%{count}` should be used in `one` keys (if it is used in the `other` key)

[`ruby-i18n v1.11.0`](https://github.com/ruby-i18n/i18n/releases/tag/v1.11.0) changed/fixed its behavior to no longer use `zero` key in the case of `count == 0`.

### Other Information

`zero` is not a valid pluralization rule for most languages (including `en` (English)). Including `zero` in an `en` file (for example) would cause the translation of that key to collide when translating into a language that requires the `zero` key (e.g., `ar` (Arabic))

This `en` source file

```yaml
en:
  car:
    one: I have %{count} car
    other: I have %{count} cars
```

Would translate into `ar`/Arabic with this structure:

```yaml
ar:
  car:
    zero: ...
    one: ...
    other: ...
```

The required `zero` key for Arabic translation would collide with the translation of a `zero` key if it were to be provided in the `en` file.

CLDR defines [explicit `0` and `1` keys](https://unicode-org.github.io/cldr/ldml/tr35-numbers.html#Explicit_0_1_rules) for the cases where you need a special string for the cases of `count == 0` or `count == 1`.

[`ruby-i18n v1.11.0`](https://github.com/ruby-i18n/i18n/releases/tag/v1.11.0) has been updated to support explicit `0` and `1` keys.

----

In the provided example, the `one` key should also include the `%{count}` interpolation. A common mistake is to think that `one` is only for the number 1. Instead, `one` is a category for any number that behaves like 1.

* Some languages use `one` for almost every number.
* Some languages use `one` for numbers that end in "1" (like 1, 21, 151) but that don't end in 11 (like 11, 111, 10311).

The same is true for the `zero`, and `two` categories. They are not only used for 0 or 2, but any number that behaves like 0 or 2 in that language.