### PR TITLE
Remove unnecessary or incorrect calls to connection_handler

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -174,8 +174,6 @@ module ActiveRecord
         unless pool
           if shard != ActiveRecord::Base.default_shard
             message = "No connection pool for '#{connection_name}' found for the '#{shard}' shard."
-          elsif ActiveRecord::Base.connection_handler != ActiveRecord::Base.default_connection_handler
-            message = "No connection pool for '#{connection_name}' found for the '#{ActiveRecord::Base.current_role}' role."
           elsif role != ActiveRecord::Base.default_role
             message = "No connection pool for '#{connection_name}' found for the '#{role}' role."
           else

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -8,7 +8,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def setup
     @conn = ActiveRecord::Base.connection
-    @connection_handler = ActiveRecord::Base.connection_handler
   end
 
   def test_connection_error

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -13,7 +13,6 @@ module ActiveRecord
 
       def setup
         @connection = ActiveRecord::Base.connection
-        @connection_handler = ActiveRecord::Base.connection_handler
       end
 
       def test_connection_error

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -19,8 +19,6 @@ module ActiveRecord
         @conn = Base.sqlite3_connection database: ":memory:",
                                         adapter: "sqlite3",
                                         timeout: 100
-
-        @connection_handler = ActiveRecord::Base.connection_handler
       end
 
       def test_bad_connection

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -10,13 +10,6 @@ module ActiveRecord
 
       fixtures :people
 
-      def setup
-        @handler = ConnectionHandler.new
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        @rw_pool = @handler.establish_connection(db_config)
-        @ro_pool = @handler.establish_connection(db_config, role: :reading)
-      end
-
       def teardown
         clean_up_connection_handler
       end
@@ -28,7 +21,7 @@ module ActiveRecord
             ActiveRecord::Base.establish_connection(db_config)
             assert_nothing_raised { Person.first }
 
-            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:connection_name_to_pool_manager).fetch("ActiveRecord::Base").instance_variable_get(:@role_to_shard_mapping).values.flat_map(&:keys).uniq
+            assert_equal [:default, :shard_one], ActiveRecord::Base.connection_handler.send(:get_pool_manager, "ActiveRecord::Base").shard_names
           end
         end
 
@@ -230,11 +223,8 @@ module ActiveRecord
         end
 
         def test_retrieve_connection_pool_with_invalid_shard
-          assert_not_nil @handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_nil @handler.retrieve_connection_pool("ActiveRecord::Base", shard: :foo)
-
-          assert_not_nil @handler.retrieve_connection_pool("ActiveRecord::Base", role: :reading)
-          assert_nil @handler.retrieve_connection_pool("ActiveRecord::Base", role: :reading, shard: :foo)
+          assert_not_nil ActiveRecord::Base.connection_handler.retrieve_connection_pool("ActiveRecord::Base")
+          assert_nil ActiveRecord::Base.connection_handler.retrieve_connection_pool("ActiveRecord::Base", shard: :foo)
         end
 
         def test_calling_connected_to_on_a_non_existent_shard_raises

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -354,7 +354,6 @@ module ActiveRecord
         @old_config = ActiveRecord.async_query_executor
         ActiveRecord.async_query_executor = :multi_thread_pool
 
-        handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
         config_hash1 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
         new_config1 = config_hash1.merge(min_threads: 0, max_threads: 10)
         db_config1 = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", new_config1)
@@ -363,8 +362,11 @@ module ActiveRecord
         new_config2 = config_hash2.merge(min_threads: 0, max_threads: 10)
         db_config2 = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit2", "primary", new_config2)
 
-        handler.establish_connection(db_config1)
-        handler.establish_connection(db_config2, owner_name: ARUnit2Model)
+        ActiveRecord::Base.establish_connection(db_config1)
+        ARUnit2Model.establish_connection(db_config2)
+      ensure
+        ActiveRecord::Base.establish_connection(:arunit)
+        ARUnit2Model.establish_connection(:arunit2)
       end
 
       def teardown


### PR DESCRIPTION
In an effort to find all the internal callers of `connection_handler` I
decided to remove any uses that are either:

1) Unnecessary - we can call what we need on Base or elsewhere without
going through the handler
2) Incorrect - there's a better way call the same thing. For example
avoiding calling the ivar, and instead calling `send` on an existing
method.

Doing this will inform us what cases the connection handler is required
and how we can expand Base to provide everything an application or gem
could need without going through the handler. Reducing calls makes it
easier to replace or refactor in the future.
