### PR TITLE
Fix 6.1 compatability with ruby 2.5

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -49,16 +49,20 @@ module ActiveRecord
           def yaml_load(payload)
             if ActiveRecord::Base.use_yaml_unsafe_load
               YAML.unsafe_load(payload)
-            else
+            elsif YAML.method(:safe_load).parameters.include?([:key, :permitted_classes])
               YAML.safe_load(payload, permitted_classes: ActiveRecord::Base.yaml_column_permitted_classes, aliases: true)
+            else
+              YAML.safe_load(payload, ActiveRecord::Base.yaml_column_permitted_classes, [], true)
             end
           end
         else
           def yaml_load(payload)
             if ActiveRecord::Base.use_yaml_unsafe_load
               YAML.load(payload)
-            else
+            elsif YAML.method(:safe_load).parameters.include?([:key, :permitted_classes])
               YAML.safe_load(payload, permitted_classes: ActiveRecord::Base.yaml_column_permitted_classes, aliases: true)
+            else
+              YAML.safe_load(payload, ActiveRecord::Base.yaml_column_permitted_classes, [], true)
             end
           end
         end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2244,9 +2244,9 @@ module ApplicationTests
       assert ActiveRecord::Base.use_yaml_unsafe_load
     end
 
-    test "config.active_record.yaml_column_permitted_classes is [] by default" do
+    test "config.active_record.yaml_column_permitted_classes is [Symbol] by default" do
       app "production"
-      assert_equal([], ActiveRecord::Base.yaml_column_permitted_classes)
+      assert_equal([Symbol], ActiveRecord::Base.yaml_column_permitted_classes)
     end
 
     test "config.active_record.yaml_column_permitted_classes can be configured" do


### PR DESCRIPTION
### Summary

Ruby 2.5 ships with Psych 3.0.x, which doesn't include keyword params
for permitted_classes.

### Other Information

- We could maybe make this metaprogramming like the `respond_to?` check, but the code complexity will really start to balloon
- This probably won't apply cleanly to `6-0-stable` or `5-2-stable` unless #45578 is backported to those as well. I can make a new PR for the older branches if desired

Fixes #45590
