### PR TITLE
Fix testing changing yaml_column_permitted_classes

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1752,11 +1752,11 @@ module ApplicationTests
       remove_from_config '.*config\.load_defaults.*\n'
 
       app_file "config/initializers/yaml_permitted_classes.rb", <<-RUBY
-        Rails.application.config.active_record.yaml_column_permitted_classes = [Symbol]
+        Rails.application.config.active_record.yaml_column_permitted_classes = [Symbol, Time]
       RUBY
 
       app "production"
-      assert_equal([Symbol], ActiveRecord.yaml_column_permitted_classes)
+      assert_equal([Symbol, Time], ActiveRecord.yaml_column_permitted_classes)
     end
 
     test "config.annotations wrapping SourceAnnotationExtractor::Annotation class" do


### PR DESCRIPTION
### Summary

The default was changed in c2b96e3 but this test was not updated. Since
the assertion would pass even if the initializer failed, it needs to be
changed to something else.

### Other Information

- Should this be backported as far as the default Symbol change? 🤷 
