### PR TITLE
Allow :schema_format in database configuration to override ActiveRecord default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Override `schema_format` per database via configuration
+
+    Allow each database configuration to specify a `schema_format`, deprecating
+    passing the `format` argument passed to database tasks.
+
+    Fixes #45596 (and #43173)
+
+    *Ryan Kerr*
+
 *   Allow `destroy_association_async_job=` to be configured with a class string instead of a constant.
 
     Defers an autoloading dependency between `ActiveRecord::Base` and `ActiveJob::Base`

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -124,16 +124,25 @@ module ActiveRecord
       #
       # If the config option is set that will be used. Otherwise Rails
       # will generate the filename from the database config name.
-      def schema_dump(format = ActiveRecord.schema_format)
+      def schema_dump(format = nil)
+        ActiveSupport::Deprecation.warn("`format` will be removed as a parameter in future versions; it should be set by `schema_format` in your database.yml, or it will fall back to `ActiveRecord.schema_format`.") if format
+
+        format ||= schema_format
+
         if configuration_hash.key?(:schema_dump)
-          if config = configuration_hash[:schema_dump]
-            config
-          end
+          configuration_hash[:schema_dump] if configuration_hash[:schema_dump]
         elsif primary?
           schema_file_type(format)
         else
           "#{name}_#{schema_file_type(format)}"
         end
+      end
+
+      # The format to use for database schema dumping and loading.
+      # If omitted, the global default (+ActiveRecord.schema_format+)
+      # will be used.
+      def schema_format
+        ENV.fetch("SCHEMA_FORMAT", configuration_hash.fetch(:schema_format, ActiveRecord.schema_format)).to_sym
       end
 
       def database_tasks? # :nodoc:

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -641,7 +641,7 @@ module ActiveRecord
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
-          Tasks::DatabaseTasks.schema_up_to_date?(db_config, ActiveRecord.schema_format)
+          Tasks::DatabaseTasks.schema_up_to_date?(db_config)
         end
 
         if needs_update

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -454,32 +454,30 @@ db_namespace = namespace :db do
   end
 
   namespace :schema do
-    desc "Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`)"
+    desc "Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']`, the configured `schema_format`, or `config.active_record.schema_format`)"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
         if db_config.schema_dump
           ActiveRecord::Base.establish_connection(db_config)
-          schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, schema_format)
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
         end
       end
 
       db_namespace["schema:dump"].reenable
     end
 
-    desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) into the database"
+    desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']`, configured `schema_format`, or `config.active_record.schema_format`) into the database"
     task load: [:load_config, :check_protected_environments] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(ActiveRecord.schema_format, ENV["SCHEMA"])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current
     end
 
     namespace :dump do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
-        desc "Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) for #{name} database"
+        desc "Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']`, configured `schema_format`, or `config.active_record.schema_format`) for #{name} database"
         task name => :load_config do
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
-          schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, schema_format)
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
           db_namespace["schema:dump:#{name}"].reenable
         end
       end
@@ -487,12 +485,11 @@ db_namespace = namespace :db do
 
     namespace :load do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
-        desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) into the #{name} database"
+        desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']`, configured `schema_format`, or `config.active_record.schema_format`) into the #{name} database"
         task name => [:load_config, :check_protected_environments, "db:test:purge:#{name}"] do
           original_db_config = ActiveRecord::Base.connection_db_config
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
-          schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, schema_format)
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config)
         ensure
           ActiveRecord::Base.establish_connection(original_db_config) if original_db_config
         end
@@ -550,13 +547,12 @@ db_namespace = namespace :db do
       db_namespace["test:load_schema"].invoke
     end
 
-    # desc "Recreate the test database from an existent schema file (schema.rb or structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`)"
+    # desc "Recreate the test database from an existent schema file (schema.rb or structure.sql, depending on `ENV['SCHEMA_FORMAT']`, configured `schema_format`, or `config.active_record.schema_format`)"
     task load_schema: %w(db:test:purge) do
       should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-        schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, schema_format)
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config)
       end
     ensure
       if should_reconnect
@@ -592,8 +588,7 @@ db_namespace = namespace :db do
           should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
           ActiveRecord::Schema.verbose = false
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
-          schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, schema_format)
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config)
         ensure
           if should_reconnect
             ActiveRecord::Base.establish_connection(ActiveRecord::Tasks::DatabaseTasks.env.to_sym)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -425,7 +425,7 @@ module ActiveRecord
 
         ActiveSupport::Deprecation.warn("`format` will be removed as a parameter in future versions; it should be included in the passed `db_config`") if format
 
-        format ||= db_config.format
+        format ||= db_config.schema_format
         filename = schema_dump_path(db_config, format)
         return unless filename
 

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
         db_config._database = "#{db_config.database}-#{i}"
 
-        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, ActiveRecord.schema_format, nil)
+        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config)
       end
     ensure
       ActiveRecord::Base.establish_connection

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -123,6 +123,12 @@ module ActiveRecord
         assert_nil config.schema_dump
       end
 
+      def test_schema_dump_with_explicit_format_is_deprecated
+        config = HashConfig.new("default_env", "primary", {})
+        assert_deprecated { config.schema_dump(format: :ruby) }
+        assert_deprecated { config.schema_dump(format: :sql) }
+      end
+
       def test_database_tasks_defaults_to_true
         config = HashConfig.new("default_env", "primary", {})
         assert_equal true, config.database_tasks?
@@ -144,6 +150,40 @@ module ActiveRecord
       def test_schema_cache_path_configuration_hash
         config = HashConfig.new("default_env", "primary", { schema_cache_path: "db/config_schema_cache.yml" })
         assert_equal "db/config_schema_cache.yml", config.schema_cache_path
+      end
+
+      def test_default_schema_format
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal ActiveRecord.schema_format, config.schema_format
+      end
+
+      def test_schema_format_overrides_with_value
+        config = HashConfig.new("default_env", "primary", { schema_format: :ruby })
+        assert_equal :ruby, config.schema_format
+
+        config = HashConfig.new("default_env", "primary", { schema_format: :sql })
+        assert_equal :sql, config.schema_format
+      end
+
+      def test_schema_format_always_symbol
+        config = HashConfig.new("default_env", "primary", { schema_format: "ruby" })
+        assert_equal :ruby, config.schema_format
+
+        config = HashConfig.new("default_env", "primary", { schema_format: "sql" })
+        assert_equal :sql, config.schema_format
+      end
+
+      def test_env_always_overrides_schema_format
+        old_env = ENV["SCHEMA_FORMAT"]
+        ENV["SCHEMA_FORMAT"] = "overridden"
+
+        config = HashConfig.new("default_env", "primary", { schema_format: "ruby" })
+        assert_equal :overridden, config.schema_format
+
+        config = HashConfig.new("default_env", "primary", { schema_format: "sql" })
+        assert_equal :overridden, config.schema_format
+      ensure
+        ENV["SCHEMA_FORMAT"] = old_env
       end
     end
   end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -66,6 +66,7 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
 
     assert_equal "arunit2", config.env_name
     assert_equal "primary", config.name
+    assert_equal :ruby, config.schema_format
   end
 
   def test_find_db_config_prioritize_db_config_object_for_the_current_env

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -16,7 +16,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       expected_database = "#{base_db_config.database}-2"
 
-      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _ = nil, _ = nil) {
         assert_equal expected_database, db_config.database
       }) do
         ActiveRecord::TestDatabases.create_and_load_schema(2, env_name: "arunit")
@@ -39,7 +39,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       expected_database = "#{base_db_config.database}-#{idx}"
 
-      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _ = nil, _ = nil) {
         assert_equal expected_database, db_config.database
       }) do
         ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }
@@ -65,7 +65,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       idx = 42
       base_configs_order = ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:name)
 
-      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
+      ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _ = nil, _ = nil) {
         assert_equal base_configs_order, ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:name)
       }) do
         ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }


### PR DESCRIPTION
### Summary

The schema dump format (Ruby/SQL) can currently only be set globally, either via setting `ActiveRecord.schema_format` or by setting `ENV['SCHEMA_FORMAT']`. Thanks to #43530 we can set the dump _filename_, but that has no bearing on the _format_ Rails dumps or expects to load from. This PR allows you to set `schema_format` per-database in your configuration YAML. It will still be overridden by `ENV['SCHEMA_FORMAT']` when set and will fall back to `ActiveRecord.schema_format`.

Fixes #45596 (and the second half of #43173, at last).

### Changes

- `ActiveRecord::DatabaseConfigurations::HashConfig`:
  - Deprecate passing a format to `schema_dump`
  - New `schema_format` method that checks
    1. `ENV['SCHEMA_FORMAT']`
    2. the database's configuration hash
    3. the default `ActiveRecord.schema_format`
- Remove schema format from invocations of methods that otherwise have access to DB config hashes
  - Deprecate passing a format as a parameter to `load_schema`, `schema_up_to_date?`, `reconstruct_from_schema`, `dump_schema`, `schema_dump_path`, and `load_schema_current` in `DatabaseTasks`

### Notes

- Didn't specify a deprecation horizon in the deprecation messages.
- I like that this DRYs up the `ENV['SCHEMA_FORMAT']` override, which was in multiple places in databases.rake before, but it does seem smelly to me that the `HashConfig` is checking `ENV` vars; that felt a lot more natural in a Rakefile. However, there really isn't another place I saw it making sense, moving toward keeping the format in the DB config and removing it from being passed around separately. Open to feedback if anybody has thoughts on a cleaner place to put that override.