### PR TITLE
Use freeze_time instead of assert_in_delta

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -952,7 +952,7 @@ class DirtyTest < ActiveRecord::TestCase
       aircraft.reload
 
       assert_equal "Boeing", aircraft.name
-      assert_equal expected_manufactured_at, aircraft.manufactured_at
+      assert_equal expected_manufactured_at.to_i, aircraft.manufactured_at.to_i
     end
   end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -942,6 +942,7 @@ class DirtyTest < ActiveRecord::TestCase
   end
 
   test "partial insert off with unchanged default function attribute" do
+    freeze_time
     with_partial_writes Aircraft, false do
       aircraft = Aircraft.new(name: "Boeing")
       assert_equal "Boeing", aircraft.name
@@ -951,7 +952,7 @@ class DirtyTest < ActiveRecord::TestCase
       aircraft.reload
 
       assert_equal "Boeing", aircraft.name
-      assert_in_delta expected_manufactured_at, aircraft.manufactured_at, 1
+      assert_equal expected_manufactured_at, aircraft.manufactured_at
     end
   end
 


### PR DESCRIPTION
### Summary

The other day we had an intermittent failure because of `assert_in_delta`. They don't happen very often but I think they can be completely fixed by using `freeze_time`. I made the change only where it failed, but I feel tempted to replace every `assert_in_delta` with `freeze_time`. Thoughts?

https://buildkite.com/rails/rails/builds/88062#0181f92c-6643-45cc-ba73-31e6f6656f48