### PR TITLE
Allow templates to define which locals they accept

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Allow templates to set explicit locals.
+
+    By default, templates will accept any `locals` as keyword arguments. To define what `locals` a template accepts, add a `locals` magic comment:
+
+    ```erb
+    <%# locals: (message:) -%>
+    <%= message %>
+    ```
+
+    Default values can also be provided:
+
+    ```erb
+    <%# locals: (message: "Hello, world!") -%>
+    <%= message %>
+    ```
+
+    Or `locals` can be disabled entirely:
+
+    ```erb
+    <%# locals: () %>
+    ```
+
+    *Joel Hawksley*
+
 *   Add `include_seconds` option for `datetime_local_field`
 
     This allows to omit seconds part in the input field, by passing `include_seconds: false`

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -318,6 +318,28 @@ You can also specify a second partial to be rendered between instances of the ma
 
 Rails will render the `_product_ruler` partial (with no data passed to it) between each pair of `_product` partials.
 
+#### Explicit Locals
+
+By default, templates will accept any `locals` as keyword arguments. To define what `locals` a template accepts, add a `locals` magic comment:
+
+```erb
+<%# locals: (message:) -%>
+<%= message %>
+```
+
+Default values can also be provided:
+
+```erb
+<%# locals: (message: "Hello, world!") -%>
+<%= message %>
+```
+
+Or `locals` can be disabled entirely:
+
+```erb
+<%# locals: () %>
+```
+
 ### Layouts
 
 Layouts can be used to render a common view template around the results of Rails controller actions. Typically, a Rails application will have a couple of layouts that pages will be rendered within. For example, a site might have one layout for a logged in user and another for the marketing or sales side of the site. The logged in user layout might include top-level navigation that should be present across many controller actions. The sales layout for a SaaS app might include top-level navigation for things like "Pricing" and "Contact Us" pages. You would expect each layout to have a different look and feel. You can read about layouts in more detail in the [Layouts and Rendering in Rails](layouts_and_rendering.html) guide.


### PR DESCRIPTION
### Summary

This PR introduces an option that enables templates to have required arguments with default values.

This change will also unlock the ability to pre-compile templates during initialization in the future.

### Problem statement

Rails templates have an implicit API, accepting any locals passed to them. This can make template dependencies difficult to reason about. In addition, the underlying ActionView code that enables flexible locals means that templates have to be compiled for each unique combination of locals passed in at runtime.

### Proposed solution

In chatting with @tenderlove, @jhawthorn, and @byroot at RailsConf, we came up with the idea of allowing for optional template signatures using a magic comment. We would then compile these arguments as the method signature for the template. 

Doing so would allow us to pre-compile templates at application boot time, instead of at runtime in the future. For more information on this issue, see:

* https://www.johnhawthorn.com/2019/09/precompiling-rails-templates/
* Aaron Patterson's [RailsConf 2019 Keynote](https://www.youtube.com/watch?v=8Dld5kFWGCc)
* John Hawthorn's ["Parsing and Rewriting Ruby Templates" (slides)](https://www.slideshare.net/JohnHawthorn4/parsing-and-rewriting-ruby-templates)

### Example

Before:

```erb
<%# issues/_card.html.erb %>
<% title = local_assigns[:title] || "Default title" %>
<% comment_count = local_assigns[:comment_count] || 0 %>
<h2><%= title %></h2>
<span class="comment-count"><%= comment_count %></span>
```

After:

```erb
<%# issues/_card.html.erb %>
<%# locals: (title: "Default title", comment_count: 0) %>
<h2><%= title %></h2>
<span class="comment-count"><%= comment_count %></span>
```

### Alternatives considered

#### Compiling templates to one object per template, using object initializer for arguments

This is more or less what we've built with ViewComponent at GitHub. It's worked quite well for us, but wrapping a template in an object has its downsides when it comes to object allocations in heavy usage and we've had issues with form helpers.

#### Implicit signature compilation

We could, in theory, generate the signature for a template by traversing its AST or another form of static analysis. This has proven difficult in our experience and still does not allow one to set defaults for arguments or to require arguments.