### PR TITLE
Add `:constantize` option for `class_attribute`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -20,20 +20,11 @@ module ActiveRecord
       # retrieved on both a class and instance level by calling +logger+.
       class_attribute :logger, instance_writer: false
 
-      class_attribute :_destroy_association_async_job, instance_accessor: false, default: "ActiveRecord::DestroyAssociationAsyncJob"
-
-      # The job class used to destroy associations in the background.
-      def self.destroy_association_async_job
-        if _destroy_association_async_job.is_a?(String)
-          self._destroy_association_async_job = _destroy_association_async_job.constantize
-        end
-        _destroy_association_async_job
-      rescue NameError => error
-        raise NameError, "Unable to load destroy_association_async_job: #{error.message}"
-      end
-
-      singleton_class.alias_method :destroy_association_async_job=, :_destroy_association_async_job=
-      delegate :destroy_association_async_job, to: :class
+      ##
+      # :singleton-method:
+      #
+      class_attribute :destroy_association_async_job, instance_accessor: false,
+        constantize: true, default: "ActiveRecord::DestroyAssociationAsyncJob"
 
       ##
       # :singleton-method:

--- a/activerecord/test/activejob/destroy_association_async_job_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_job_test.rb
@@ -29,14 +29,14 @@ class DestroyAssociationAsyncJobTest < ActiveRecord::TestCase
     error = assert_raises NameError do
       UndefinedConstantAsync.belongs_to :essay_destroy_async, dependent: :destroy_async
     end
-    assert_match %r/destroy_association_async_job: uninitialized constant UndefinedConstantJob/, error.message
+    assert_match %r/uninitialized constant UndefinedConstantJob/, error.message
   end
 
   test "destroy_association_async_job error shows a missing parent job class, as if ActiveJob were missing" do
     error = assert_raises NameError do
       UnloadableBaseAsync.belongs_to :essay_destroy_async, dependent: :destroy_async
     end
-    assert_match %r/destroy_association_async_job: uninitialized constant PretendActiveJobIsNotPresent/, error.message
+    assert_match %r/uninitialized constant PretendActiveJobIsNotPresent/, error.message
   end
 
   test "deprecation of rescuing ActiveJobRequiredError which has been replaced by a NameError" do

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -82,9 +82,13 @@ class Class
   # To set a default value for the attribute, pass <tt>default:</tt>, like so:
   #
   #   class_attribute :settings, default: {}
-  def class_attribute(*attrs, instance_accessor: true,
-    instance_reader: instance_accessor, instance_writer: instance_accessor, instance_predicate: true, default: nil)
-
+  def class_attribute(
+    *attrs,
+    instance_accessor: true, instance_reader: instance_accessor, instance_writer: instance_accessor,
+    instance_predicate: true,
+    constantize: false,
+    default: nil
+  )
     class_methods, methods = [], []
     attrs.each do |name|
       unless name.is_a?(Symbol) || name.is_a?(String)
@@ -102,10 +106,12 @@ class Class
         end
       RUBY
 
+      constantize_value = "value = value.constantize if value.is_a?(::String)" if constantize
+
       class_methods << <<~RUBY
         silence_redefinition_of_method def #{name}=(value)
-          redefine_method(:#{name}) { value } if singleton_class?
-          redefine_singleton_method(:#{name}) { value }
+          redefine_method(:#{name}) { #{constantize_value}; value } if singleton_class?
+          redefine_singleton_method(:#{name}) { #{constantize_value}; value }
           value
         end
       RUBY


### PR DESCRIPTION
In #45476, `ActiveRecord::Base.destroy_association_async_job` was made to accept a string which would lazily be constantized, to avoid loading `ActiveJob::Base` too soon.

#45486 intends to solve the same problem for `ActionMailer::Base.delivery_job`.

While thinking about how to simplify the code from #45476 for #45486, I realized that #45476 allocates a `_destroy_association_async_job` method for every constantize.  e.g. Even if `Post` and `Comment` classes do not set a custom destroy job, [`self._destroy_association_async_job = _destroy_association_async_job.constantize`](https://github.com/rails/rails/pull/45476/files#diff-4411c7993e3f8ccfd8e09f44a81f10dfac3ea7dbd44cabd60b369040a00be324R28) will define a new singleton method for each class.

This could be addressed by calling `_destroy_association_async_job=` on the method owner:

```diff
index 0aa59fe885..b981f2e934 100644
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -25,7 +25,8 @@ module Core
       # The job class used to destroy associations in the background.
       def self.destroy_association_async_job
         if _destroy_association_async_job.is_a?(String)
-          self._destroy_association_async_job = _destroy_association_async_job.constantize
+          owner = method(:_destroy_association_async_job=).owner
+          owner._destroy_association_async_job = _destroy_association_async_job.constantize
         end
         _destroy_association_async_job
       rescue NameError => error
```

But that makes the code even more cumbersome to replicate for e.g. #45486.  And this seems like a pattern that may reoccur.

This **draft** PR proposes a `class_attribute` `:constantize` option that would auto-constantize string values without allocating any additional singleton methods.

On one hand, a `:constantize` option feels over-specific.  On the other hand, it is an extremely simple and efficient implementation.

Another alternative I considered was a [`class_attribute` `:lazy` option](https://github.com/jonathanhefner/rails/commit/8b533464fde986125f1f89580e1da4362937bbd5).  It feels less over-specific, but requires wrapping values in a proc.

And yet another alternative I considered was a [`ConstantizingProxy`](https://github.com/jonathanhefner/rails/commit/06b2db17ce59a371a1944843476b286323b5259d) class.  It is the least invasive / most orthogonal implementation, but it requires wrapping values in a proxy object, which is even less convenient than a proc.
