### PR TITLE
Fix extra changelog entry added in 959d46e

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,8 +2,6 @@
 
     *Matt Swanson*
 
-*   Add `urlsafe` option to `ActiveSupport::MessageVerifier` initializer
-
 *   Fix `NoMethodError` on custom `ActiveSupport::Deprecation` behavior.
 
     `ActiveSupport::Deprecation.behavior=` was supposed to accept any object


### PR DESCRIPTION
### Summary

The :urlsafe option was renamed to :url_safe in 7094d0f and the correct
entry is still below

### Other Information

cc @dhh 
