### PR TITLE
Allow attaching File or Pathname to has_one_attached

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow attaching File and Pathname when assigning attributes, e.g.
+
+    ```ruby
+    User.create!(avatar: File.open("image.jpg"))
+    User.create!(avatar: file_fixture("image.jpg"))
+    ```
+
+    *Dorian Marié*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Disables the session in `ActiveStorage::Blobs::ProxyController`

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -82,6 +82,20 @@ module ActiveStorage
           )
         when String
           ActiveStorage::Blob.find_signed!(attachable, record: record)
+        when File
+          ActiveStorage::Blob.build_after_unfurling(
+            io: attachable,
+            filename: File.basename(attachable),
+            record: record,
+            service_name: attachment_service_name
+          )
+        when Pathname
+          ActiveStorage::Blob.build_after_unfurling(
+            io: attachable.open,
+            filename: File.basename(attachable),
+            record: record,
+            service_name: attachment_service_name
+          )
         else
           raise ArgumentError, "Could not find or build blob: expected attachable, got #{attachable.inspect}"
         end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -16,6 +16,22 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     ActiveStorage::Blob.all.each(&:delete)
   end
 
+  test "creating a record with a File as attachable attribute" do
+    @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif").open)
+
+    assert_equal "image.gif", @user.avatar.filename.to_s
+    assert_not_nil @user.avatar_attachment
+    assert_not_nil @user.avatar_blob
+  end
+
+  test "creating a record with a Pathname as attachable attribute" do
+    @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif"))
+
+    assert_equal "image.gif", @user.avatar.filename.to_s
+    assert_not_nil @user.avatar_attachment
+    assert_not_nil @user.avatar_blob
+  end
+
   test "attaching an existing blob to an existing record" do
     @user.avatar.attach create_blob(filename: "funky.jpg")
     assert_equal "funky.jpg", @user.avatar.filename.to_s


### PR DESCRIPTION
### Why was this change necessary?

When creating models in tests, it's easier to pass a File or a Pathname
(from `file_fixture` for instance) to `Model.create` for instance

### How does it address the problem?

When attaching an attachable, we check if it's a File or a Pathname and
handle it appropriately.