### PR TITLE
Clarify Common Table Expression (CTE) support

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -326,8 +326,11 @@ module ActiveRecord
 
     # Add a Common Table Expression (CTE) that you can then reference within another SELECT statement.
     #
-    # Note: CTE's are only supported in MySQL for versions 8.0 and above. You will not be able to
-    # use CTE's with MySQL 5.7.
+    # Note: CTEs are only supported with the following database adapters:
+    # *   MariaDB (version 10.2.1 and above)
+    # *   MySQL (version 8.0.1 and above)
+    # *   PostgreSQL (all supported versions)
+    # *   SQLite (version 3.8.3 and above)
     #
     #   Post.with(posts_with_tags: Post.where("tags_count > ?", 0))
     #   # => ActiveRecord::Relation


### PR DESCRIPTION
### Summary

[change to documentation only]
I've attempted to provide some more comprehensive documentation
by listing the databases that **do** support CTEs.
In creating the list, I've included those databases whose adapter
responds truthy to `#supports_common_table_expressions?`

This is intended to enhance #45586

For reference, these are renderings of the documentation before and after this commit.

#### Before
![before](https://user-images.githubusercontent.com/121632/179905226-3ba5645c-8191-4fce-8523-64b8dc247d56.png)
#### After
![after](https://user-images.githubusercontent.com/121632/179905255-2390e6a7-6fff-440c-9f7a-3b043b57c293.png)

