### PR TITLE
Speedup ActionView::OutputBuffer

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -285,6 +285,9 @@ module ActionView
         pos = output_buffer.length
         yield
         output_safe = output_buffer.html_safe?
+        # We need to modify the buffer in place to be deal with the view handlers
+        # like `builder` that don't access the buffer through `@output_buffer` but
+        # keep the initial reference.
         fragment = output_buffer.slice!(pos..-1)
         if output_safe
           self.output_buffer = output_buffer.class.new(output_buffer)

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -43,8 +43,14 @@ module ActionView
       def capture(*args)
         value = nil
         buffer = with_output_buffer { value = yield(*args) }
-        if (string = buffer.presence || value) && string.is_a?(String)
-          ERB::Util.html_escape string
+
+        case string = buffer.presence || value
+        when OutputBuffer
+          string.to_s
+        when ActiveSupport::SafeBuffer
+          string
+        when String
+          ERB::Util.html_escape(string)
         end
       end
 

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -142,7 +142,7 @@ module ActionView
       attr_reader :body, :template
 
       def initialize(body, template)
-        @body = body
+        @body = body.to_s
         @template = template
       end
 

--- a/actionview/test/output_buffer_test.rb
+++ b/actionview/test/output_buffer_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class TestOutputBuffer < ActiveSupport::TestCase
+  setup do
+    @buffer = ActionView::OutputBuffer.new
+  end
+
+  test "#<< maintains HTML safety" do
+    @buffer << "<script>alert('pwned!')</script>"
+    assert_predicate @buffer, :html_safe?
+    assert_predicate @buffer.to_s, :html_safe?
+    assert_equal "&lt;script&gt;alert(&#39;pwned!&#39;)&lt;/script&gt;", @buffer.to_s
+  end
+
+  test "#safe_append= bypasses HTML safety" do
+    @buffer.safe_append = "<p>This is fine</p>"
+    assert_predicate @buffer, :html_safe?
+    assert_predicate @buffer.to_s, :html_safe?
+    assert_equal "<p>This is fine</p>", @buffer.to_s
+  end
+
+  test "can be duped" do
+    @buffer << "Hello"
+    copy = @buffer.dup
+    copy << " World!"
+    assert_equal "Hello World!", copy.to_s
+    assert_equal "Hello", @buffer.to_s
+  end
+end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -182,7 +182,7 @@ class CaptureHelperTest < ActionView::TestCase
     buffer = @av.with_output_buffer do
       @av.output_buffer << "."
     end
-    assert_equal ".", buffer
+    assert_equal ".", buffer.to_s
     assert_nil @av.output_buffer
   end
 
@@ -192,7 +192,7 @@ class CaptureHelperTest < ActionView::TestCase
     @av.with_output_buffer(buffer) do
       @av.output_buffer << "."
     end
-    assert_equal "..", buffer
+    assert_equal "..", buffer.to_s
     assert_nil @av.output_buffer
   end
 
@@ -219,7 +219,7 @@ class CaptureHelperTest < ActionView::TestCase
 
   def test_with_output_buffer_does_not_assume_there_is_an_output_buffer
     assert_nil @av.output_buffer
-    assert_equal "", @av.with_output_buffer { }
+    assert_equal "", @av.with_output_buffer { }.to_s
   end
 
   def alt_encoding(output_buffer)


### PR DESCRIPTION
MRI has a lot of optimizations for string concatenation that are only available when concatenating into a `String` instance.

Using a `String` subclass disable these optimizations.

The difference is even more important in Ruby 3.2 where both YJIT and the VM noticeably improve `String#<<` performance.

So ideally we want the buffer not to be a String subclass. Luckily, the Action View buffer is for internal use only, so we can replace inheritance by composition without much work.

Benchmark:

```
ActionView::OutputBuffer:   147644.2 i/s
    optimized buffer:   228001.4 i/s - 1.54x  (± 0.00) faster
```

Source: https://gist.github.com/casperisfine/7199579a138e268fda71d6a91366af49

NB: That 50% faster figure is to be contextualized, it can radically change
from one template to the other, but is always faster.

cc @jhawthorn @matthewd @noahgibbs @tenderlove 