### PR TITLE
Prevent ActionDispatch::ServerTiming from overwriting existing header value

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent `ActionDispatch::ServerTiming` from overwriting existing values in `Server-Timing`.
+
+    Previously, if another middleware down the chain set `Server-Timing` header,
+    it would overwritten by `ActionDispatch::ServerTiming`.
+
+    *Jakub Malinowski*
+
 *   Allow opting out of the `SameSite` cookie attribute when setting a cookie.
 
     You can opt out of `SameSite` by passing `same_site: nil`.

--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -25,6 +25,8 @@ module ActionDispatch
       header_info = events.group_by(&:name).map do |event_name, events_collection|
         "#{event_name};dur=#{events_collection.sum(&:duration)}"
       end
+
+      header_info.prepend(headers[SERVER_TIMING_HEADER]) if headers[SERVER_TIMING_HEADER].present?
       headers[SERVER_TIMING_HEADER] = header_info.join(", ")
 
       [ status, headers, body ]


### PR DESCRIPTION
### Summary

Fixes #45607 

Tiny fix, if a middleware adds anything to the `Server-Timing` header, and is down the chain from `ActionDispatch::ServerTiming`, the value it set will be overwritten, this PR changes this behaviour, so that `ActionDispatch::ServerTiming` appends its entries instead.

