### PR TITLE
Add `skip_nil:` support to `ActiveSupport::Cache::Store#fetch_multi`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `skip_nil:` support to `ActiveSupport::Cache::Store#fetch_multi`.
+
+    *Daniel Alfaro*
+
 *   Add `quarter` method to date/time
 
     *Matt Swanson*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -506,6 +506,7 @@ module ActiveSupport
           ordered = names.index_with do |name|
             reads.fetch(name) { writes[name] = yield(name) }
           end
+          writes.compact! if options[:skip_nil]
 
           payload[:hits] = reads.keys
           payload[:super_operation] = :fetch_multi

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -206,6 +206,16 @@ module CacheStoreBehavior
     assert_equal(other_key * 2, @cache.read(other_key))
   end
 
+  def test_fetch_multi_with_skip_nil
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+
+    values = @cache.fetch_multi(key, other_key, skip_nil: true) { |k| k == key ? k : nil }
+
+    assert_equal({ key => key, other_key => nil }, values)
+    assert_equal(false, @cache.exist?(other_key))
+  end
+
   # Use strings that are guaranteed to compress well, so we can easily tell if
   # the compression kicked in or not.
   SMALL_STRING = "0" * 100


### PR DESCRIPTION
### Summary

This adds the `skip_nil:` option to `#fetch_multi` so that it supports all of the same options as `#fetch` supports.