### PR TITLE
Avoid checking defined?(@html_safe) on Ruby 3+

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -261,9 +261,9 @@ module ActiveSupport # :nodoc:
       self.class.new(super(escaped_args))
     end
 
-    def html_safe?
-      defined?(@html_safe) && @html_safe
-    end
+    attr_reader :html_safe
+    alias_method :html_safe?, :html_safe
+    remove_method :html_safe
 
     def to_s
       self

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -171,6 +171,13 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert_not_predicate @buffer.dup, :html_safe?
   end
 
+  test "Can call html_safe on a safe buffer" do
+    @buffer = "hello".html_safe
+    extra_safe = @buffer.html_safe
+    assert_equal "hello", extra_safe
+    assert_predicate extra_safe, :html_safe?
+  end
+
   test "Should return safe buffer when added with another safe buffer" do
     clean = "<script>".html_safe
     result_buffer = @buffer + clean


### PR DESCRIPTION
We should not need to check defined? here because we are only interested in whether @html_safe is truthy or falsy.

In Ruby versions >= 3.0, there is no warning on access of undefined ivars. On previous versions, it can emit a warning.

cc @casperisfine @noahgibbs

```
$ cat benchmark_html_safe.rb
require 'rails'
require 'action_view'
require 'benchmark/ips'

SAFE_BUFFER = ActiveSupport::SafeBuffer.new

Benchmark.ips do |x|
  x.report("SAFE_BUFFER.html_safe?", "SAFE_BUFFER.html_safe?")
end
```

**Before**

```
$ be ruby benchmark_html_safe.rb
Warming up --------------------------------------
SAFE_BUFFER.html_safe?
                         1.300M i/100ms
Calculating -------------------------------------
SAFE_BUFFER.html_safe?
                         12.884M (± 0.8%) i/s -     65.005M in   5.045850s
```

**After**

```
$ be ruby benchmark_html_safe.rb
Warming up --------------------------------------
SAFE_BUFFER.html_safe?
                         2.456M i/100ms
Calculating -------------------------------------
SAFE_BUFFER.html_safe?
                         24.336M (± 1.0%) i/s -    122.821M in   5.047382s
```