### PR TITLE
Fix granular swapping for primary_abstract_class

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -116,6 +116,13 @@ module ActiveRecord
         existing_pool_config = pool_manager.get_pool_config(role, shard)
 
         if existing_pool_config && existing_pool_config.db_config == db_config
+          # Update the pool_config's connection class if it differs. This is used
+          # for ensuring that ActiveRecord::Base and the primary_abstract_class use
+          # the same pool. Without this granular swapping will not work correctly.
+          if owner_name.primary_class? && (existing_pool_config.connection_class != owner_name)
+            existing_pool_config.connection_class = owner_name
+          end
+
           existing_pool_config.pool
         else
           disconnect_pool_from_pool_manager(pool_manager, role, shard)

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -105,10 +105,8 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config, :connection_class, :async_executor, :role, :shard
+      attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
 
-      alias_method :connection_klass, :connection_class
-      deprecate :connection_klass
       delegate :schema_cache, :schema_cache=, to: :pool_config
 
       # Creates a new ConnectionPool object. +pool_config+ is a PoolConfig
@@ -122,7 +120,6 @@ module ActiveRecord
 
         @pool_config = pool_config
         @db_config = pool_config.db_config
-        @connection_class = pool_config.connection_class
         @role = pool_config.role
         @shard = pool_config.shard
 
@@ -180,6 +177,12 @@ module ActiveRecord
       def connection
         @thread_cached_conns[connection_cache_key(current_thread)] ||= checkout
       end
+
+      def connection_class # :nodoc:
+        pool_config.connection_class
+      end
+      alias :connection_klass :connection_class
+      deprecate :connection_klass
 
       # Returns true if there is an open connection being used for the current thread.
       #

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -5,8 +5,8 @@ module ActiveRecord
     class PoolConfig # :nodoc:
       include Mutex_m
 
-      attr_reader :db_config, :connection_class, :role, :shard
-      attr_accessor :schema_cache
+      attr_reader :db_config, :role, :shard
+      attr_accessor :schema_cache, :connection_class
 
       INSTANCES = ObjectSpace::WeakMap.new
       private_constant :INSTANCES

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -441,9 +441,16 @@ module ActiveRecord
 
           # Switch everything to writing
           ActiveRecord::Base.connected_to(role: :writing) do
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
             assert_not_predicate ApplicationRecord.connection, :preventing_writes?
 
             ApplicationRecord.connected_to(role: :reading) do
+              assert_predicate ApplicationRecord.connection, :preventing_writes?
+            end
+
+            # reading is fine bc it's looking up by AppRec but writing is not fine
+            # bc its looking up by ARB in the stack
+            ApplicationRecord.connected_to(role: :writing, prevent_writes: true) do
               assert_predicate ApplicationRecord.connection, :preventing_writes?
             end
           end


### PR DESCRIPTION
In #45450 we stopped removing connections when establish_connection was
called and an identical connection existed in the pool. Unfortunately
this broke granular connection swapping for the primary_abstract_class
because the class stored in the pool was incorrect.

What was happening was connection for the writing role were getting
stored with the class ActiveRecord::Base and connections for the reading
role were getting ApplicationRecord (or whatever the app set as their
`primary_abstract_class`. If we made sure that the reading connections
also got ActiveRecord::Base that would break granular swapping for both
writing and reading because Active Record doesn't know whether you
wanted global swapping or granular swapping for prevent writes. This bug
only manifests on prevent writes because it's the only value we actually
lookup on the connection pool (because at the point we need it we don't
have access to self).

To fix this I've decided to update the class on the existing pool if it
doesn't match the owner_name passed. This is kind of gross I admit, but
it's safe because the way we find connections is on the
`connection_name`. The class is only stored so that the connection can
find it's `current_preventing_writes` value. This also required me to
move the ivar to an instance method for connection_class on the pool
because we don't want to cache the value and want to make sure we're
getting it from the pool config directly.

cc/ thanks to @jhawthorn for the idea on how to fix this and for reporting the issue