### PR TITLE
Use `class_attribute` transform block for job config

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -486,7 +486,10 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
+    class_attribute :delivery_job, default: "ActionMailer::MailDeliveryJob" do |job|
+      job.is_a?(String) ? job.constantize : job
+    end
+
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -42,7 +42,7 @@ module ActionMailer
         register_observers(options.delete(:observers))
 
         if delivery_job = options.delete(:delivery_job)
-          self.delivery_job = delivery_job.constantize
+          self.delivery_job = delivery_job
         end
 
         if options.smtp_settings

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -20,20 +20,13 @@ module ActiveRecord
       # retrieved on both a class and instance level by calling +logger+.
       class_attribute :logger, instance_writer: false
 
-      class_attribute :_destroy_association_async_job, instance_accessor: false, default: "ActiveRecord::DestroyAssociationAsyncJob"
-
+      ##
+      # :singleton-method:
+      #
       # The job class used to destroy associations in the background.
-      def self.destroy_association_async_job
-        if _destroy_association_async_job.is_a?(String)
-          self._destroy_association_async_job = _destroy_association_async_job.constantize
-        end
-        _destroy_association_async_job
-      rescue NameError => error
-        raise NameError, "Unable to load destroy_association_async_job: #{error.message}"
+      class_attribute :destroy_association_async_job, instance_accessor: false, default: "ActiveRecord::DestroyAssociationAsyncJob" do |job|
+        job.is_a?(String) ? job.constantize : job
       end
-
-      singleton_class.alias_method :destroy_association_async_job=, :_destroy_association_async_job=
-      delegate :destroy_association_async_job, to: :class
 
       ##
       # :singleton-method:

--- a/activerecord/test/activejob/destroy_association_async_job_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_job_test.rb
@@ -29,14 +29,14 @@ class DestroyAssociationAsyncJobTest < ActiveRecord::TestCase
     error = assert_raises NameError do
       UndefinedConstantAsync.belongs_to :essay_destroy_async, dependent: :destroy_async
     end
-    assert_match %r/destroy_association_async_job: uninitialized constant UndefinedConstantJob/, error.message
+    assert_match %r/uninitialized constant UndefinedConstantJob/, error.message
   end
 
   test "destroy_association_async_job error shows a missing parent job class, as if ActiveJob were missing" do
     error = assert_raises NameError do
       UnloadableBaseAsync.belongs_to :essay_destroy_async, dependent: :destroy_async
     end
-    assert_match %r/destroy_association_async_job: uninitialized constant PretendActiveJobIsNotPresent/, error.message
+    assert_match %r/uninitialized constant PretendActiveJobIsNotPresent/, error.message
   end
 
   test "deprecation of rescuing ActiveJobRequiredError which has been replaced by a NameError" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3300,6 +3300,20 @@ module ApplicationTests
       assert_equal ActionMailer::MailDeliveryJob, ActionMailer::Base.delivery_job
     end
 
+    test "ActionMailer::Base.delivery_job can be configured via config.action_mailer.delivery_job" do
+      class ::DummyMailDeliveryJob; end
+
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_mailer.delivery_job = "DummyMailDeliveryJob"
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal ::DummyMailDeliveryJob, ActionMailer::Base.delivery_job
+    end
+
     test "ActiveRecord::Base.filter_attributes should equal to filter_parameters" do
       app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
         Rails.application.config.filter_parameters += [ :password, :credit_card_number ]


### PR DESCRIPTION
In #45476, `ActiveRecord::Base.destroy_association_async_job` was made to accept a string which would be lazily constantized, to avoid loading `ActiveJob::Base` too soon.  However, due to the way `class_attribute` values are written, *each subclass* calling `destroy_association_async_job` will [allocate a `_destroy_association_async_job` singleton method](https://github.com/rails/rails/pull/45476/files#diff-4411c7993e3f8ccfd8e09f44a81f10dfac3ea7dbd44cabd60b369040a00be324R28) regardless of whether the subclass assigns a custom job value.

Additionally, `class_attribute` requires using a dummy attribute name so that the post-processing reader method is not overwritten when the attribute is set.  This is particularly [cumbersome](https://github.com/rails/rails/pull/45476/files#diff-4411c7993e3f8ccfd8e09f44a81f10dfac3ea7dbd44cabd60b369040a00be324R35-R36) when instance accessors are involved.

This PR re-implements #45476 by adding support for a transform block to `class_attribute`.  A transform block is applied to an attribute value when that value is first read, and the result is memoized as the actual value of the attribute.  Thus, using a transform block, `destroy_association_async_job` can lazily constantize and memoize the result, without allocating additional singleton methods, and without juggling attribute names.

The PR also applies the same technique to `ActionMailer::Base.delivery_job`.  Closes #45486.

I wrote about a few of the alternatives I considered in #45603.  Closes #45603.
