### PR TITLE
Fix `QueryMethods#in_order_of` for non-integer columns in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -143,7 +143,7 @@ module ActiveRecord
       end
 
       def field_ordered_value(column, values) # :nodoc:
-        field = Arel::Nodes::NamedFunction.new("FIELD", [column, values.reverse])
+        field = Arel::Nodes::NamedFunction.new("FIELD", [column, values.reverse.map { |value| Arel::Nodes.build_quoted(value) }])
         Arel::Nodes::Descending.new(field)
       end
 

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -51,6 +51,18 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     assert_equal(order, posts.map(&:id))
   end
 
+  def test_in_order_of_with_string_column
+    Book.destroy_all
+    Book.create!(format: "paperback")
+    Book.create!(format: "ebook")
+    Book.create!(format: "hardcover")
+
+    order = %w[hardcover paperback ebook]
+    books = Book.in_order_of(:format, order)
+
+    assert_equal(order, books.map(&:format))
+  end
+
   def test_in_order_of_after_regular_order
     order = [3, 4, 1]
     posts = Post.where(type: "Post").order(:type).in_order_of(:id, order)


### PR DESCRIPTION
```ruby
CustomerOrder.in_order_of(:order_status, ['Completed', 'Cancelled', 'In Transit', 'Pending'])
=> (Object doesn't support #inspect)
```

Debugging the problem further revealed that it was throwing an error while constructing the SQL.
```
#<Arel::Visitors::UnsupportedVisitError: Unsupported argument type: String. Construct an Arel node instead.> rescued during inspection
```
The problem was discovered in [this blog post](https://blog.kiprosh.com/rails-7-in_order_of-method-for-activerecord-and-enumerable/).