### PR TITLE
Extract `#build_create_table_definition` method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -66,7 +66,7 @@ module ActiveRecord
           create_sql << "(#{statements.join(', ')})" if statements.present?
           add_table_options!(create_sql, o)
           create_sql << " AS #{to_sql(o.as)}" if o.as
-          create_sql
+          o.ddl = create_sql
         end
 
         def visit_PrimaryKeyDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -333,6 +333,7 @@ module ActiveRecord
       include ColumnMethods
 
       attr_reader :name, :temporary, :if_not_exists, :options, :as, :comment, :indexes, :foreign_keys, :check_constraints
+      attr_accessor :ddl
 
       def initialize(
         conn,
@@ -356,6 +357,23 @@ module ActiveRecord
         @as = as
         @name = name
         @comment = comment
+      end
+
+      def set_primary_key(table_name, id, primary_key, **options)
+        if id && !as
+          pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)
+
+          if id.is_a?(Hash)
+            options.merge!(id.except(:type))
+            id = id.fetch(:type, :primary_key)
+          end
+
+          if pk.is_a?(Array)
+            primary_keys(pk)
+          else
+            primary_key(pk, id, **options)
+          end
+        end
       end
 
       def primary_keys(name = nil) # :nodoc:

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class Migration
+    class SchemaDefinitionsTest < ActiveRecord::TestCase
+      attr_reader :connection
+
+      def setup
+        @connection = ActiveRecord::Base.connection
+      end
+
+      def test_build_create_table_definition_with_block
+        td = connection.build_create_table_definition :test do |t|
+          t.column :foo, :string
+        end
+
+        id_column = td.columns.find { |col| col.name == "id" }
+        assert_predicate id_column, :present?
+        assert id_column.type
+        assert id_column.sql_type
+
+        foo_column = td.columns.find { |col| col.name == "foo" }
+        assert_predicate foo_column, :present?
+        assert foo_column.type
+        assert foo_column.sql_type
+      end
+
+      def test_build_create_table_definition_without_block
+        td = connection.build_create_table_definition(:test)
+
+        id_column = td.columns.find { |col| col.name == "id" }
+        assert_predicate id_column, :present?
+        assert id_column.type
+        assert id_column.sql_type
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Related to: https://github.com/rails/rails/pull/45324

The above PR introduced swappable execution strategy objects for migrations, allowing applications to customize the behaviour of schema statements methods. I described our use case at Shopify for this kind of behaviour:
> At Shopify, we have a particular use case: in production, we don't want to execute SQL right away when a migration is run. Instead, we want to translate a migration into a JSON DDL and then submit that to another service for execution across all of our db shards. If we can customize the strategy object to be used by the Migration class, we can write our own object that produces JSON commands and makes an API call to send the JSON to another service.

Not only would we like to be able to swap in the object used to execute a migration, but we'd also like to understand the changes that would be made to the db if a migration were to run. Since our use case involves translating a migration into JSON DDL, we need to understand how Rails turns migration code into SQL strings to be executed on the database. In order to do this, we've decided to leverage the pre-existing concept of **schema definitions** in Rails. By exposing APIs on the connection adapter that build schema definitions, applications are able to gain insight into what their schema changes would look like, using a Rails-specific AST that is already defined. Beyond Shopify's use case, exposing these APIs offers apps the opportunity to dry run or safety check migrations, and offers a great deal of flexibility to consumers with custom execution strategies.

This PR defines an API for returning a `TableDefinition`, `#build_create_table_definition`, and refactors the existing code for `#create_table` to use this method. Consumers can call this method with the exact same arguments as they'd use for `#create_table`, and receive a `TableDefinition` instead of actually creating + executing SQL. For us, this would look something like this:

```ruby
class ShopifyExecutionStrategy < ExecutionStrategy
  def create_table(...)
    td = migration.connection.build_create_table_definition(...)

    # Now we have a table definition, let's turn it into JSON
    payload = {
      op: :create_table,
      params: {
      name: td.name,
      definition: td.ddl.sub(/^CREATE TABLE `#{td.name}` /, ""),
     }
   }
end
```

### Other Information

A couple changes in this PR that I'd like to highlight:
1) In certain cases, we'd like a schema definition _in addition to_ the actual SQL that would be produced. @eileencodes and I agreed that storing the `ddl` directly on the schema definition seems an appropriate way to handle this.
2) The existing `#create_table` method was quite long, and so I tried to clean it up a bit while extracting `#build_create_table_definition`. I moved some of the logic around setting the primary key to the `TableDefinition` class itself, since it seems more appropriate that _that_ class would handle setting the key.
3) There is a slight change in ordering in `#create_table`. Checking whether `force: true` is applied and dropping the table is now done _after_ we visit the table definition (`schema_creation.accept(table_definition)`) instead of before. I don't think this should have an impact.

cc @paarthmadan @Schwad 