### PR TITLE
Raise Argument error for invalid jitter values

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -152,8 +152,14 @@ module ActiveJob
       end
 
       def determine_jitter_for_delay(delay, jitter)
+        raise ArgumentError, "Invalid jitter value #{jitter.inspect}. Expected value is a positive numeric or zero" unless valid_jitter?(jitter)
+
         return 0.0 if jitter.zero?
         Kernel.rand * delay * jitter
+      end
+
+      def valid_jitter?(jitter)
+        jitter.is_a?(Numeric) && !jitter.negative?
       end
 
       def executions_for(exceptions)


### PR DESCRIPTION
### Summary

- Taking a cue from [this](https://github.com/rails/rails/pull/38545#discussion_r388377526) discussion with @jeremy, the PR attempts to fix an issue that is mainly concerned with negative jitter values.
- If the jitter value is negative, the resultant `scheduled_at` for the job may be set to a time before the current time.
- Which may result in unexpected behavior depending on the queuing backend used.
- #### Proposed Solution
  - The changes verify that the value is either positive numeric or zero and raise the associated error if not
  - Associated tests are added to validate the flow for negative jitter values and other probable invalid values like string or boolean
- #### Note
  - The chances of negative or invalid `jitter` value are very low considering the default flow and very good documentation around `jitter` usage. But cannot be ruled out in cases where for some reason the `jitter` value is dynamically passed


### Other Information

- Raising the PR more than 2 years after [the suggestion](https://github.com/rails/rails/pull/38545#discussion_r388377526) given by @jeremy , better late than never I guess :)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
