### PR TITLE
[ActiveRecord] ToSql#HomogeneousIn uses visitor pattern to produce Attribute sql

### DIFF
--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -36,14 +36,6 @@ module Arel # :nodoc: all
         attribute.quoted_array(values)
       end
 
-      def table_name
-        attribute.relation.table_alias || attribute.relation.name
-      end
-
-      def column_name
-        attribute.name
-      end
-
       def casted_values
         type = attribute.type_caster
 

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -333,7 +333,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           collector.preparable = false
 
-          collector << quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
+          visit o.left, collector
 
           if o.type == :in
             collector << " IN ("
@@ -350,7 +350,6 @@ module Arel # :nodoc: all
           end
 
           collector << ")"
-          collector
         end
 
         def visit_Arel_SelectManager(o, collector)

--- a/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
+++ b/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "active_record/type_caster/map"
+require "active_model"
+class Arel::Nodes::HomogeneousInTest < Arel::Spec
+  def test_in
+    table = Arel::Table.new :users, type_caster: fake_pg_caster
+
+    expr = Arel::Nodes::HomogeneousIn.new(["Bobby", "Robert"], table[:name], :in)
+
+    _(expr.to_sql).must_be_like %{
+      "users"."name" IN (?, ?)
+    }
+  end
+
+  def test_custom_attribute_node
+    table = Arel::Table.new :users, type_caster: fake_pg_caster
+
+    node = TypedNode.new("COALESCE",
+                         [table[:nickname], table[:name]],
+                         STRING_TYPE
+                        )
+    expr = Arel::Nodes::HomogeneousIn.new(["Bobby", "Robert"], node, :in)
+
+    _(expr.to_sql).must_be_like %{
+      COALESCE("users"."nickname", "users"."name") IN (?, ?)
+    }
+  end
+
+  private
+    STRING_TYPE = ActiveModel::Type::String.new.freeze
+
+    # this is a named function that also has a data type
+    class TypedNode < Arel::Nodes::NamedFunction
+      attr_reader :type_caster
+
+      def initialize(name, expr, type)
+        super(name, expr, nil)
+        @type_caster = type
+      end
+    end
+
+    # map that converts attribute names to a caster
+    def fake_pg_caster
+      Object.new.tap do |caster|
+        def caster.type_for_attribute(attr_name)
+          STRING_TYPE
+        end
+      end
+    end
+end


### PR DESCRIPTION
### Summary

In `ToSql`, operators that generate the sql for an `Attribute` use `visit(o.left, collector)`
This can be seen in `Equality` (and friends), `Case`, `SelectStatement`, and `In`.


### Before

`HomogeneousIn` manually produces the sql for an `Attribute`, introduced in 72fd0bae

To get this to work, knowledge of attributes and table aliases need to be in the node.

running the test it fails in this error:

```
Arel::Nodes::HomogeneousInTest#test_custom_attribute_node:
NoMethodError: undefined method `relation' for #<Arel::Nodes::HomogeneousInTest::TypedNode>
        attribute.relation.table_alias || attribute.relation.name
                 ^^^^^^^^^
    rails/activerecord/lib/arel/nodes/homogeneous_in.rb:40:in `table_name'
    rails/activerecord/lib/arel/visitors/to_sql.rb:336:in `visit_Arel_Nodes_HomogeneousIn'
```

### After

This change makes `HomogeneousIn` follow the pattern by delegating to `ToSql#Attribute`.

### Why

Our code base uses `Arel` on the left hand of the `where()` clauses. This change lets it flow nicely.

