### PR TITLE
Extract `#build_add_column_definition`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -26,6 +26,7 @@ module ActiveRecord
           sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
           sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
           sql << o.check_constraint_drops.map { |con| visit_DropCheckConstraint con }.join(" ")
+          o.ddl = sql
         end
 
         def visit_ColumnDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -580,6 +580,7 @@ module ActiveRecord
       attr_reader :adds
       attr_reader :foreign_key_adds, :foreign_key_drops
       attr_reader :check_constraint_adds, :check_constraint_drops
+      attr_accessor :ddl
 
       def initialize(td)
         @td   = td

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -10,6 +10,7 @@ module ActiveRecord
             sql << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
             sql << o.exclusion_constraint_adds.map { |con| visit_AddExclusionConstraint con }.join(" ")
             sql << o.exclusion_constraint_drops.map { |con| visit_DropExclusionConstraint con }.join(" ")
+            o.ddl = sql
           end
 
           def visit_AddForeignKey(o)

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -61,6 +61,23 @@ module ActiveRecord
           connection.drop_table(:test) if connection.table_exists?(:test)
         end
       end
+
+      def test_build_add_column_definition
+        connection.create_table(:test)
+        add_col_td = connection.build_add_column_definition(:test, :foo, :string)
+
+        assert_match "ALTER TABLE", add_col_td.ddl
+
+        add_cols = add_col_td.adds
+        assert_equal 1, add_cols.size
+
+        add_col = add_cols.first.column
+        assert_equal "foo", add_col.name
+        assert add_col.type
+        assert add_col.sql_type
+      ensure
+        connection.drop_table(:test) if connection.table_exists?(:test)
+      end
     end
   end
 end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/45625 for more context on exposing schema definition APIs.

### Summary

This PR exposes the `AlterTable` schema definition that is produced when adding columns to a table. It does so through a new API, `#build_add_column_definition`, and stores ddl on the schema definition.  It refactors the existing `#add_column` method to use this as an intermediate method to build the add_column definition.