### PR TITLE
Updating the `ActiveRecord::Store` and changing it back should not mark accessor as changed

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -225,10 +225,7 @@ module ActiveRecord
 
         def self.write(object, attribute, key, value)
           prepare(object, attribute)
-          if value != read(object, attribute, key)
-            object.public_send :"#{attribute}_will_change!"
-            object.public_send(attribute)[key] = value
-          end
+          object.public_send(attribute)[key] = value
         end
 
         def self.prepare(object, attribute)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -104,6 +104,14 @@ class StoreTest < ActiveRecord::TestCase
     assert_not @john.color_changed?
   end
 
+  test "updating the store and changing it back won't mark accessor as changed" do
+    @john.color = "red"
+    assert_equal "black", @john.color_was
+    @john.color = "black"
+    assert_not_predicate @john, :settings_changed?
+    assert_not_predicate @john, :color_changed?
+  end
+
   test "updating the store populates the accessor changed array correctly" do
     @john.color = "red"
     assert_equal "black", @john.color_was


### PR DESCRIPTION
Fixes #45640.

Unless I am missing something, we do not need to call the `:"#{attribute}_will_change!"` method as the dirty tracking is already done by the Active Record. See the following call sequence.

https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/dirty.rb#L270-L273
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/attribute_mutation_tracker.rb#L34-L38
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/attribute_mutation_tracker.rb#L44-L48
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/attribute_mutation_tracker.rb#L78-L80
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/attribute.rb#L63-L65
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/attribute.rb#L158-L160
And because hashes are comparable for equality, we get the correct result for the `changed?` method:
https://github.com/rails/rails/blob/97f13c2b820466f62ea8f12f49a373ac6eb2d9cb/activemodel/lib/active_model/type/value.rb#L80-L82