### PR TITLE
Remove duplicate 'updating' option from generator

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -31,7 +31,6 @@ module Rails
           options[:skip_test]           = !defined?(Rails::TestUnitRailtie)
           options[:skip_asset_pipeline] = !defined?(Sprockets::Railtie) && !defined?(Propshaft::Railtie)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
-          options[:updating]            = true
           options
         end
     end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -100,16 +100,16 @@ module Rails
       empty_directory "config"
 
       inside "config" do
-        template "routes.rb" unless options[:updating]
+        template "routes.rb" unless options[:update]
         template "application.rb"
         template "environment.rb"
-        template "cable.yml" unless options[:updating] || options[:skip_action_cable]
-        template "puma.rb"   unless options[:updating]
-        template "storage.yml" unless options[:updating] || skip_active_storage?
+        template "cable.yml" unless options[:update] || options[:skip_action_cable]
+        template "puma.rb"   unless options[:update]
+        template "storage.yml" unless options[:update] || skip_active_storage?
 
         directory "environments"
         directory "initializers"
-        directory "locales" unless options[:updating]
+        directory "locales" unless options[:update]
       end
     end
 


### PR DESCRIPTION
### Summary

`:update` has been defined since a7adec9, and both options serve the same
purpose