### PR TITLE
Fix skip_system_test not being preserved in update

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -29,6 +29,7 @@ module Rails
           options[:skip_action_text]    = !defined?(ActionText::Engine)
           options[:skip_action_cable]   = !defined?(ActionCable::Engine)
           options[:skip_test]           = !defined?(Rails::TestUnitRailtie)
+          options[:skip_system_test]    = Rails.application.config.generators.system_tests.nil?
           options[:skip_asset_pipeline] = !defined?(Sprockets::Railtie) && !defined?(Propshaft::Railtie)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options[:updating]            = true


### PR DESCRIPTION
### Summary

Previously running app:update always would template an application.rb
file without the `config.generators.system_tests = nil` set, even for
applications that previously had it set.