### PR TITLE
Fix extra line added to bin/setup in app:update

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -20,7 +20,6 @@ FileUtils.chdir APP_ROOT do
   # Install JavaScript dependencies
   system("yarn check --check-files") || system!("yarn install")
 <% end -%>
-
 <% unless options.skip_active_record? -%>
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
### Summary

155b757 added some yarn commands to bin/setup for apps that are using
Node. However, the blank line between the added block and the
skip_active_record block results in an extraneous blank line added to
apps when running app:update.