### PR TITLE
[ci-skip] Fix documentation on `accessed_fields` method.

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -352,7 +352,7 @@ module ActiveRecord
     #
     # For example:
     #
-    #   class PostsController < ActionController::Base
+    #   class PostsController < ApplicationController
     #     after_action :print_accessed_fields, only: :index
     #
     #     def index
@@ -360,15 +360,14 @@ module ActiveRecord
     #     end
     #
     #     private
-    #
-    #     def print_accessed_fields
-    #       p @posts.first.accessed_fields
-    #     end
+    #       def print_accessed_fields
+    #         p @posts.first.accessed_fields
+    #       end
     #   end
     #
     # Which allows you to quickly change your code to:
     #
-    #   class PostsController < ActionController::Base
+    #   class PostsController < ApplicationController
     #     def index
     #       @posts = Post.select(:id, :title, :author_id, :updated_at)
     #     end


### PR DESCRIPTION
Change `ActionController::Base` -> `ApplicationController`, on the usage
example.