### PR TITLE
Add SQL function UPPER to Arel::FactoryMethods

### DIFF
--- a/activerecord/lib/arel/attributes/attribute.rb
+++ b/activerecord/lib/arel/attributes/attribute.rb
@@ -19,6 +19,10 @@ module Arel # :nodoc: all
         relation.lower self
       end
 
+      def upper
+        relation.upper self
+      end
+
       def type_cast_for_database(value)
         relation.type_cast_for_database(name, value)
       end

--- a/activerecord/lib/arel/factory_methods.rb
+++ b/activerecord/lib/arel/factory_methods.rb
@@ -42,6 +42,10 @@ module Arel # :nodoc: all
       Nodes::NamedFunction.new "LOWER", [Nodes.build_quoted(column)]
     end
 
+    def upper(column)
+      Nodes::NamedFunction.new "UPPER", [Nodes.build_quoted(column)]
+    end
+
     def coalesce(*exprs)
       Nodes::NamedFunction.new "COALESCE", exprs
     end

--- a/activerecord/test/cases/arel/factory_methods_test.rb
+++ b/activerecord/test/cases/arel/factory_methods_test.rb
@@ -41,6 +41,13 @@ module Arel
         assert_equal "LOWER", lower.name
         assert_equal [:one], lower.expressions.map(&:expr)
       end
+
+      def test_upper
+        upper = @factory.upper :one
+        assert_instance_of Nodes::NamedFunction, upper
+        assert_equal "UPPER", upper.name
+        assert_equal [:one], upper.expressions.map(&:expr)
+      end
     end
   end
 end


### PR DESCRIPTION
This mirrors the LOWER function that already exists.

This SQL function is useful for string fields but also for PostgreSQL
range fields where UPPER returns the upper bound of the range.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.