### PR TITLE
Bump strscan to 3.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,7 +503,7 @@ GEM
     stackprof (0.2.17)
     stimulus-rails (1.0.2)
       railties (>= 6.0.0)
-    strscan (3.0.2)
+    strscan (3.0.4)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
     tailwindcss-rails (2.0.3)


### PR DESCRIPTION
### Summary

This commit addresses bug_report_templates/action_controller_gem.rb failures.

```ruby
% ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin22]
% cd guides/bug_report_templates
% ruby action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
... snip ...
Using rails 7.0.3.1
/Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated strscan 3.0.2, but your Gemfile requires strscan 3.0.4. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/runtime.rb:25:in `block in setup'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/spec_set.rb:138:in `each'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/spec_set.rb:138:in `each'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/runtime.rb:24:in `map'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/runtime.rb:24:in `setup'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/inline.rb:71:in `block in gemfile'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/settings.rb:131:in `temporary'
	from /Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.14/lib/bundler/inline.rb:55:in `gemfile'
	from action_controller_gem.rb:5:in `<main>'
%
```

strscan 3.0.4 has been released on July 23, 2022.
https://rubygems.org/gems/strscan/versions/3.0.4

Refer to https://github.com/rails/rails/pull/45052 for the similar change.
https://github.com/rubygems/rubygems/pull/5529
https://github.com/rubygems/rubygems/pull/5535