### PR TITLE
Make `EncryptedFile` more memoization-friendly

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -114,8 +114,7 @@ module ActiveSupport
       end
 
       def read_key_file
-        return @key_file_contents if defined?(@key_file_contents)
-        @key_file_contents = (key_path.binread.strip if key_path.exist?)
+        @key_file_contents ||= (key_path.binread.strip if key_path.exist?)
       end
 
       def handle_missing_key

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -74,7 +74,7 @@ module Rails
 
       private
         def credentials
-          Rails.application.encrypted(content_path, key_path: key_path)
+          @credentials ||= Rails.application.encrypted(content_path, key_path: key_path)
         end
 
         def ensure_encryption_key_has_been_added


### PR DESCRIPTION
Prior to this commit, `EncryptedFile` would internally memoize when a key file was non-existent.  This meant that a key file generated after checking `encrypted_file.key.nil?` would not be recognized, unless a new `EncryptedFile` instance was used.  (Though setting the key in a designated environment variable instead would entirely bypass this memoization.)

This commit changes `EncryptedFile` to only memoize when the key file has been read.  Consequently, this commit memoizes the `EncryptedFile` (or, specifically, `EncryptedConfiguration`) instance used by `CredentialsCommand`.

This commit also adds more test coverage around key file generation for `CredentialsCommand`.
