### PR TITLE
Parent option defaults

### DIFF
--- a/activejob/lib/rails/generators/job/job_generator.rb
+++ b/activejob/lib/rails/generators/job/job_generator.rb
@@ -7,7 +7,7 @@ module Rails # :nodoc:
     class JobGenerator < Rails::Generators::NamedBase # :nodoc:
       class_option :queue, type: :string, default: "default", desc: "The queue name for the generated job"
 
-      class_option :parent, type: :string, desc: "The parent class for the generated job"
+      class_option :parent, type: :string, default: "ApplicationJob", desc: "The parent class for the generated job"
 
       check_class_collision suffix: "Job"
 
@@ -28,16 +28,8 @@ module Rails # :nodoc:
       end
 
       private
-        def parent
-          options[:parent]
-        end
-
         def parent_class_name
-          if parent
-            parent
-          else
-            "ApplicationJob"
-          end
+          options[:parent]
         end
 
         def file_name

--- a/railties/lib/rails/generators/rails/controller/USAGE
+++ b/railties/lib/rails/generators/rails/controller/USAGE
@@ -19,7 +19,7 @@ Examples:
 
     `bin/rails generate controller users index --skip-routes`
 
-    This generates a `UsersController` with an index acion and no routes.
+    This generates a `UsersController` with an index action and no routes.
 
     `bin/rails generate controller admin/dashboard --parent=admin_controller`
 

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -6,7 +6,7 @@ module Rails
       argument :actions, type: :array, default: [], banner: "action action"
       class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
       class_option :helper, type: :boolean
-      class_option :parent, type: :string, desc: "The parent class for the generated controller"
+      class_option :parent, type: :string, default: "ApplicationController", desc: "The parent class for the generated controller"
 
       check_class_collision suffix: "Controller"
 
@@ -26,16 +26,8 @@ module Rails
       end
 
       private
-        def parent
-          options[:parent]
-        end
-
         def parent_class_name
-          if parent
-            parent
-          else
-            "ApplicationController"
-          end
+          options[:parent]
         end
 
         def file_name


### PR DESCRIPTION
Prints default parent class for controller, job, and model generators.

Before:

```
% bin/rails g job
Running via Spring preloader in process 14274
Usage:
  rails generate job NAME [options]

Options:
      [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
      [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
      [--queue=QUEUE]                                        # The queue name for the generated job
                                                             # Default: default
      [--parent=PARENT]                                      # The parent class for the generated job
  -t, [--test-framework=NAME]                                # Test framework to be invoked
                                                             # Default: test_unit

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a new job. Pass the job name, either CamelCased or
    under_scored, with or without the job postfix.

Examples:
    `bin/rails generate job checkout`

      Creates the the following files:

        Job:   app/jobs/checkout_job.rb
        Test:  test/jobs/checkout_job_test.rb

    `bin/rails generate job send_sms --queue=sms`

      Creates a job and test with a custom sms queue.

    `bin/rails generate job process_payment --parent=payment_job`

      Creates a job and test with a `PaymentJob` parent class.
```

After:

```
% bin/rails g job
Running via Spring preloader in process 14274
Usage:
  rails generate job NAME [options]

Options:
      [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
      [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
      [--queue=QUEUE]                                        # The queue name for the generated job
                                                             # Default: default
      [--parent=PARENT]                                      # The parent class for the generated job
                                                             # Default: ApplicationJob
  -t, [--test-framework=NAME]                                # Test framework to be invoked
                                                             # Default: test_unit

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a new job. Pass the job name, either CamelCased or
    under_scored, with or without the job postfix.

Examples:
    `bin/rails generate job checkout`

      Creates the the following files:

        Job:   app/jobs/checkout_job.rb
        Test:  test/jobs/checkout_job_test.rb

    `bin/rails generate job send_sms --queue=sms`

      Creates a job and test with a custom sms queue.

    `bin/rails generate job process_payment --parent=payment_job`

      Creates a job and test with a `PaymentJob` parent class.
```


Also fixes a typo in the controller generator help text.