### PR TITLE
Clean up hook generator method when hook is removed

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -208,6 +208,7 @@ module Rails
         remove_invocation(*names)
 
         names.each do |name|
+          singleton_class.undef_method("#{name}_generator")
           hooks.delete(name)
         end
       end

--- a/railties/test/generators/hook_generator_test.rb
+++ b/railties/test/generators/hook_generator_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+
+class HookGeneratorTest < ActiveSupport::TestCase
+  class GeneratorWithHook < Rails::Generators::Base
+    hook_for(:test_framework)
+  end
+
+  class GeneratorWithoutHook < GeneratorWithHook
+    remove_hook_for(:test_framework)
+  end
+
+  def test_hook_added
+    assert GeneratorWithHook.respond_to?(:test_framework_generator)
+    assert GeneratorWithHook.hooks.key?(:test_framework)
+  end
+
+  def test_hook_removed
+    assert_not GeneratorWithoutHook.respond_to?(:test_framework_generator)
+    assert_not GeneratorWithoutHook.hooks.key?(:test_framework)
+  end
+end


### PR DESCRIPTION
Removes `"#{name}_generator"` method for removed hooks introduced in #45315
