### PR TITLE
Teach `ActiveJob` to set configs on itself

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -46,7 +46,7 @@ module ActiveJob
   # :singleton-method:
   # If false, Rails will preserve the legacy serialization of BigDecimal job arguments as Strings.
   # If true, Rails will use the new BigDecimalSerializer to (de)serialize BigDecimal losslessly.
-  # This behavior will be removed in Rails 7.2.
+  # Legacy serialization will be removed in Rails 7.2, along with this config.
   singleton_class.attr_accessor :use_big_decimal_serializer
   self.use_big_decimal_serializer = false
 end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -25,6 +25,15 @@ module ActiveJob
       options = app.config.active_job
       options.queue_adapter ||= :async
 
+      config.after_initialize do
+        options.each do |k, v|
+          k = "#{k}="
+          if ActiveJob.respond_to?(k)
+            ActiveJob.send(k, v)
+          end
+        end
+      end
+
       ActiveSupport.on_load(:active_job) do
         # Configs used in other initializers
         options = options.except(
@@ -32,9 +41,13 @@ module ActiveJob
           :custom_serializers
         )
 
-        options.each do  |k, v|
+        options.each do |k, v|
           k = "#{k}="
-          send(k, v) if respond_to? k
+          if ActiveJob.respond_to?(k)
+            ActiveJob.send(k, v)
+          elsif respond_to? k
+            send(k, v)
+          end
         end
       end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -87,6 +87,20 @@ module Rails
       # {configuration guide}[https://guides.rubyonrails.org/configuring.html#versioned-default-values]
       # for the default values associated with a particular version.
       def load_defaults(target_version)
+        # To introduce a change in behavior, follow these steps:
+        # 1. Add an accessor on the target object (e.g. the ActiveJob class for global Active Job config).
+        # 2. Set a default value there preserving existing behavior for existing applications.
+        # 3. Implement the behavior change based on the config value.
+        # 4. In the section below corresponding to the next release of Rails, set the new value.
+        # 5. Add a commented out section in the `new_framework_defaults` template, setting the new value.
+        # 6. Update the guide in `configuration.md`.
+
+        # To remove configurable deprecated behavior, follow these steps:
+        # 1. Update or remove the entry in the guides.
+        # 2. Remove the references below.
+        # 3. Remove the legacy code paths and config check.
+        # 4. Remove the config accessor.
+
         case target_version.to_s
         when "5.0"
           if respond_to?(:action_controller)
@@ -279,7 +293,7 @@ module Rails
           end
 
           if respond_to?(:active_job)
-            active_job.use_big_decimal_serializer = false
+            active_job.use_big_decimal_serializer = true
           end
 
           if respond_to?(:active_support)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2656,6 +2656,43 @@ module ApplicationTests
       assert_includes ActiveJob::Serializers.serializers, DummySerializer
     end
 
+    test "use_big_decimal_serializer is enabled in new apps" do
+      app "development"
+
+      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
+      # Referencing the constant auto-loads it.
+      ActiveJob::Base
+
+      assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled in new apps"
+    end
+
+    test "use_big_decimal_serializer is disabled if using defaults prior to 7.1" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app "development"
+
+      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
+      # Referencing the constant auto-loads it.
+      ActiveJob::Base
+
+      assert_not ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be disabled in defaults prior to 7.1"
+    end
+
+    test "use_big_decimal_serializer can be enabled in config" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
+        Rails.application.config.active_job.use_big_decimal_serializer = true
+      RUBY
+      app "development"
+
+      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
+      # Referencing the constant auto-loads it.
+      ActiveJob::Base
+
+      assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled if set in config"
+    end
+
     test "active record job queue is set" do
       app "development"
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Previously configs of the form `config.active_job.X` were only forwarded to `ActiveJob::Base`. This teaches Active Job to set them on `ActiveJob` directly instead, if the setter exists.


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

This is a follow up to #45618, which introduces the first config set on `ActiveJob` directly. @adrianna-chang-shopify pointed out that despite having set the config

```ruby
# config/application.rb
config.active_job.use_big_decimal_serializer = true
```

the config was still set to the default value after the application was booted:

```ruby
Rails.application.config.active_job.use_big_decimal_serializer # => true
ActiveJob.use_big_decimal_serializer                           # => false
```

In #45618, I had considered if it was more appropriate to set the config on `ActiveJob::Base`. While that might have allowed individual job classes to opt or out of the serializer (which is of questionable value), it would have required a change to the `Arguments.serialize` API to inject the job class. I assumed that the config would be automatically forwarded, without realizing that each framework is responsible for setting their config independently (perhaps an opportunity for helper extraction).