### PR TITLE
Fix some deprecation warnings in many_test

### DIFF
--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -207,9 +207,11 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs within a transaction with append_on_assign config uploads all the files" do
     append_on_assign do
-      ActiveRecord::Base.transaction do
-        @user.highlights.attach fixture_file_upload("racecar.jpg")
-        @user.highlights.attach fixture_file_upload("video.mp4")
+      assert_deprecated do
+        ActiveRecord::Base.transaction do
+          @user.highlights.attach fixture_file_upload("racecar.jpg")
+          @user.highlights.attach fixture_file_upload("video.mp4")
+        end
       end
 
       assert_equal "racecar.jpg", @user.highlights.first.filename.to_s
@@ -221,10 +223,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs within a transaction with append_on_assign config create the exact amount of records" do
     append_on_assign do
-      assert_difference -> { ActiveStorage::Blob.count }, +2 do
-        ActiveRecord::Base.transaction do
-          @user.highlights.attach fixture_file_upload("racecar.jpg")
-          @user.highlights.attach fixture_file_upload("video.mp4")
+      assert_deprecated do
+        assert_difference -> { ActiveStorage::Blob.count }, +2 do
+          ActiveRecord::Base.transaction do
+            @user.highlights.attach fixture_file_upload("racecar.jpg")
+            @user.highlights.attach fixture_file_upload("video.mp4")
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

The `append_on_assign` helper function sets
`ActiveStorage.replace_on_assign_to_many = false`, which is deprecated.
Therefore, any tests using this helper should be using `assert_deprecated`
to not pollute test output. Some of them were doing this already, but
these two were not.

### Other Information

See https://buildkite.com/rails/rails/builds/88321#01823cdf-612e-4d91-bbb5-ce0aba0adba7/1166-1223 for an example of the uncaught deprecation messages.
