### PR TITLE
Allow base for `Table` schema definition to be injected into `#change_table`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -474,13 +474,13 @@ module ActiveRecord
       #  end
       #
       # See also Table for details on all of the various column transformations.
-      def change_table(table_name, **options)
+      def change_table(table_name, base = self, **options)
         if supports_bulk_alter? && options[:bulk]
           recorder = ActiveRecord::Migration::CommandRecorder.new(self)
           yield update_table_definition(table_name, recorder)
           bulk_change_table(table_name, recorder.commands)
         else
-          yield update_table_definition(table_name, self)
+          yield update_table_definition(table_name, base)
         end
       end
 


### PR DESCRIPTION
### Summary

This PR is a part of the work to allow users to customize migration behaviour by swapping in their own migration execution strategy objects, which can be used to perform schema statement methods. (See https://github.com/rails/rails/pull/45324 for more context).

`#change_table` (when not used in bulk alter query mode) operates by building a `Table` schema definition, and then yielding that object to the `#change_table` block. Any methods called within the block are sent to the `Table` object, which then forwards them to `@base`. For example, `#column`:
https://github.com/rails/rails/blob/ab325a920986187f9d1c13bdfba77682ab6f6503/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L677-L684
simply sends the `#add_column` message to `@base`, which is the connection adapter.

If apps are using a custom migration execution strategy and defining methods such as `#add_column`, `#add_index`, etc., they probably don't want `#change_table` to send commands to the connection adapter. Instead, it makes more sense that these methods would go to their strategy object. As such, I'm proposing that we simply allow `base` to be passed as an optional argument to `#change_table`, with the `Table` definition constructed using the supplied base. A custom strategy could then do something like this:

```ruby
class CustomStrategy < ActiveRecord::Migration::DefaultStrategy
  def change_table(table_name, **options, &block)
    super(table_name, self, **options, &block)
  end

  def add_column(table_name, column_name, type, **options)
    # Custom add column
  end

  def add_index(table_name, column_name, **options)
    # Custom add index
  end
end

class TestChangeTable < ActiveRecord::Migration[7.1]
  def change
    change_table(:users, bulk: true) do |t|
      t.column(:name, :string) # This will use the strategy's #add_column method
      t.index(:name, unique: true) # This will use the strategy's #add_index method
    end
  end
end
```