### PR TITLE
Fix `ActiveRecord::QueryMethods#in_order_of` to work with nils

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -795,15 +795,6 @@ module ActiveRecord
         migration_context.current_version
       end
 
-      def field_ordered_value(column, values) # :nodoc:
-        node = Arel::Nodes::Case.new(column)
-        values.each.with_index(1) do |value, order|
-          node.when(value).then(order)
-        end
-
-        Arel::Nodes::Ascending.new(node.else(values.length + 1))
-      end
-
       class << self
         def register_class_with_precision(mapping, key, klass, **kwargs) # :nodoc:
           mapping.register_type(key) do |*args|

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -138,11 +138,6 @@ module ActiveRecord
         true
       end
 
-      def field_ordered_value(column, values) # :nodoc:
-        field = Arel::Nodes::NamedFunction.new("FIELD", [column, values.reverse.map { |value| Arel::Nodes.build_quoted(value) }])
-        Arel::Nodes::Descending.new(field)
-      end
-
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -69,4 +69,16 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     assert_equal(order, posts.map(&:id))
   end
+
+  def test_in_order_of_with_nil
+    Book.destroy_all
+    Book.create!(format: "paperback")
+    Book.create!(format: "ebook")
+    Book.create!(format: nil)
+
+    order = ["ebook", nil, "paperback"]
+    books = Book.in_order_of(:format, order)
+
+    assert_equal(order, books.map(&:format))
+  end
 end


### PR DESCRIPTION
When passing `nil` to `in_order_of`, the invalid SQL query is generated (because `NULL != NULL`):

```ruby
Book.in_order_of(:format, ["hardcover", "ebook", nil]).to_sql
```

```sql
SELECT "books".* FROM "books" WHERE "books"."format" IN ('hardcover', 'ebook', NULL)
ORDER BY CASE "books"."format" WHEN 'hardcover' THEN 1
WHEN 'ebook' THEN 2 WHEN NULL THEN 3 ELSE 4 END ASC
```

This PR also removes the special order field generation (`ORDER BY FIELD`) for MYSQL, because it is
unable to work with `NULL`s and the default `ORDER BY CASE` works for it (tested on MariaDB and MySQL 5.7+).

cc @kddnewton (as a creator of this feature)

Reference: https://github.com/rails/rails/pull/42061