### PR TITLE
Delegate valid_encoding? for ActionView::OutputBuffer

### DIFF
--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -24,7 +24,7 @@ module ActionView
       @buffer.encode!
     end
 
-    delegate :length, :blank?, :encoding, :encode!, :force_encoding, to: :@buffer
+    delegate :length, :blank?, :encoding, :encode!, :force_encoding, :valid_encoding?, to: :@buffer
 
     def to_s
       @buffer.html_safe


### PR DESCRIPTION
### Summary

Adds `ActionView::OutputBuffer#valid_encoding?` as a delegated method.

`ActionView::OutputBuffer` used to inherit from `ActiveSupport::SafeBuffer`, which itself inherits from `String`, so it used to expose all public String methods. This was refactored as part of https://github.com/rails/rails/pull/45614, however I don't think that leaving out some string methods was intentional (it already delegates _some_ of them). 

We have encoding validation checks at GitHub so I think exposing what the encoding is (`encoding`) and whether it's valid (`valid_encoding?`) would be reasonable and something we need. 😃 

