### PR TITLE
Add linter for CHANGELOG formatting [ci skip]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,22 @@ permissions:
   contents: read
 
 jobs:
+  changelog-formatting:
+    name: Check CHANGELOGs formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: skipkayhil/rails-bin
+        ref: 44270430c14385fd7db002b47f0819af5d824352
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
+        bundler-cache: true
+    - uses: actions/checkout@v3
+      with:
+        path: rails
+    - run: bin/check-changelogs ./rails
   codespell:
     name: Check spelling all files with codespell
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

There have been a number of recent commits introducing incorrectly
formatted CHANGELOG entries:
- 9f0b8eb was missing an author
- 936a862 had trailing whitespace
- 238432d had wrong number of leading whitespace
- 51852d2 had wrong number of leading whitespace in the header

To prevent these inconsistencies from happening in the future, I wrote a
small linter for CHANGELOG files that catches all of the above errors.

### Other Information

- is this something `rails/rails` wants running on Pull Requests? Currently I have it running as a daily job in my repo but it would definitely be more effective on PRs
- if yes, where should it go? My repo/`rails/rails`/`rails/?`/a gem?

Very open to feedback on the approach and would appreciate any suggestions!

cc @yahonda ref https://github.com/rails/rails/pull/45559#issuecomment-1180019312
