### PR TITLE
Fixes Date Helper with locale

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -888,7 +888,7 @@ module ActionView
         def month_names
           @month_names ||= begin
             month_names = @options[:use_month_names] || translated_month_names
-            month_names.unshift(nil) if month_names.size < 13
+            month_names = [nil, *month_names] if month_names.size < 13
             month_names
           end
         end

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -114,6 +114,20 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
     end
   end
 
+  def test_select_month_with_frozen_month_names
+    month_names = Date::MONTHNAMES.dup.drop(1)
+    mock = Minitest::Mock.new
+    expect_called_with(mock, [:'date.month_names'], locale: "en", returns: month_names.freeze)
+
+    I18n.stub(:translate, mock) do
+      select_month(8, locale: "en")
+    end
+
+    assert_mock(mock)
+  end
+
+  # date_or_time_select
+
   def test_date_or_time_select_translates_prompts
     prompt_defaults = { year: "Year", month: "Month", day: "Day", hour: "Hour", minute: "Minute", second: "Seconds" }
     defaults = { [:'date.order', locale: "en", default: []] => %w(year month day) }
@@ -136,8 +150,6 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
     end
     assert_equal defaults.count, @prompt_called
   end
-
-  # date_or_time_select
 
   def test_date_or_time_select_given_an_order_options_does_not_translate_order
     assert_not_called(I18n, :translate) do


### PR DESCRIPTION
### Summary

The i18n gem (https://github.com/ruby-i18n/i18n) has been modified to `freeze`
locale setting values. This could cause the Date helper to not work correctly
under certain conditions. `dup` the configuration values fixes that problem.

### Other Information

It can be reproduced by taking the following steps:

First, create a new project in the cloned rails repository.

```
bundle exec rails new ../my-test-app --dev
cd ../my-test-app/
bin/rails generate controller DateSelectTest index
```

Create `config/locales/ja.yml` and set the locale as follows:

```
ja:
 date:
   abbr_day_names:
     - 日
     - 月
     - 火
     - 水
     - 木
     - 金
     - 土
   abbr_month_names:
     - 1月
     - 2月
     - 3月
     - 4月
     - 5月
     - 6月
     - 7月
     - 8月
     - 9月
     - 10月
     - 11月
     - 12月
   day_names:
     - 日曜日
     - 月曜日
     - 火曜日
     - 水曜日
     - 木曜日
     - 金曜日
     - 土曜日
   formats:
     default: "%Y年%m月%d日"
     long: "%Y年%m月%d日(%a)"
     short: "%m/%d"
   month_names:
     - 1月
     - 2月
     - 3月
     - 4月
     - 5月
     - 6月
     - 7月
     - 8月
     - 9月
     - 10月
     - 11月
     - 12月
   order:
     - :year
     - :month
     - :day
```

Add a date helper to the view file.
  
```
<h1>DateSelectTest#index</h1>
<p>Find me in app/views/date_select_test/index.html.erb</p>

<%= date_select :test, :date, start_year: 2020, locale: :ja %>
```

View the created page in your browser.

You will see the following error in the rails server logs:

```
Started GET "/date_select_test/index" for ::1 at 2022-07-28 14:49:44 +0900
Processing by DateSelectTestController#index as HTML
  Rendering layout layouts/application.html.erb
  Rendering date_select_test/index.html.erb within layouts/application
  Rendered date_select_test/index.html.erb within layouts/application (Duration: 11.3ms | Allocations: 4338)
  Rendered layout layouts/application.html.erb (Duration: 11.6ms | Allocations: 4469)
Completed 500 Internal Server Error in 32ms (ActiveRecord: 0.0ms | Allocations: 12824)



ActionView::Template::Error (can't modify frozen Array: ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"]):
    1: <h1>DateSelectTest#index</h1>
    2: <p>Find me in app/views/date_select_test/index.html.erb</p>
    3: 
    4: <%= date_select :test, :date, start_year: 2020, locale: :ja %>

app/views/date_select_test/index.html.erb:4 
```
  
