### PR TITLE
Detect colliding keys in Active Job Hash serialization

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -49,4 +49,10 @@ module ActiveJob
   # This behavior will be removed in Rails 7.2.
   singleton_class.attr_accessor :use_big_decimal_serializer
   self.use_big_decimal_serializer = false
+
+  ##
+  # :singleton-method:
+  # ...TBD...
+  singleton_class.attr_accessor :forbid_colliding_hash_key_serialization
+  self.forbid_colliding_hash_key_serialization = false
 end

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -145,7 +145,16 @@ module ActiveJob
 
       def serialize_hash(argument)
         argument.each_with_object({}) do |(key, value), hash|
-          hash[serialize_hash_key(key)] = serialize_argument(value)
+          serialized_key = serialize_hash_key(key)
+          if hash.key?(serialized_key)
+            if ActiveJob.forbid_colliding_hash_key_serialization
+              raise SerializationError, "ERROR PLACEHOLDER"
+            else
+              ActiveSupport::Deprecation.warn("DEPRECATION PLACEHOLDER")
+            end
+          end
+
+          hash[serialized_key] = serialize_argument(value)
         end
       end
 

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -188,6 +188,22 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     end
   end
 
+  test "serializing a hash with colliding String and Symbol keys is not deprecated" do
+    assert_not_deprecated do
+      assert_equal(
+        { "a" => 2, "_aj_symbol_keys" => ["a"] }, # :a wins
+        ActiveJob::Arguments.serialize([{ "a" => 1, a: 2 }]).first
+      )
+    end
+
+    assert_not_deprecated do
+      assert_equal(
+        { "a" => 2, "_aj_symbol_keys" => ["a"] }, # :a assigned "a"'s value
+        ActiveJob::Arguments.serialize([{ a: 1, "a" => 2 }]).first
+      )
+    end
+  end
+
   test "should not allow reserved hash keys" do
     ["_aj_globalid", :_aj_globalid,
      "_aj_symbol_keys", :_aj_symbol_keys,

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -280,6 +280,7 @@ module Rails
 
           if respond_to?(:active_job)
             active_job.use_big_decimal_serializer = false
+            active_job.forbid_colliding_hash_key_serialization = false
           end
 
           if respond_to?(:active_support)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -57,3 +57,5 @@
 # In such environments, it should be safe to enable this setting following
 # successful deployment of Rails 7.1 which introduces BigDecimalSerializer.
 # Rails.application.config.active_job.use_big_decimal_serializer = true
+
+# TODO: Add section for ActiveJob.forbid_colliding_hash_key_serialization

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2654,6 +2654,8 @@ module ApplicationTests
       assert_includes ActiveJob::Serializers.serializers, DummySerializer
     end
 
+    # TODO: Add a test that active_job.forbid_colliding_hash_key_serialization works
+
     test "active record job queue is set" do
       app "development"
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

ActiveJob serializes `Symbol` `Hash` keys by stringifying them, and storing an array of keys to be symbolized on deserialization as `_aj_symbol_keys`. This means that if a `Hash` has both `Symbol` and `String` keys with the same contents, they will collide.

Specifically, the resulting hash ends up containing only a pair consisting of:
- the symbol key
- the last value

This PR adds a check for this and logs a deprecation warning. It also introduces a setting to `raise` instead of logging the warning, with the intention of making this behavior the default in Rails 7.2/8.0.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

I have left a number of placeholders for the time being, because I wanted to get initial review and confirm we want to do this, before investing the time to write the docs, deprecation message, changelog, etc.

---
cc. @mangara, who mentioned this in Slack