### PR TITLE
Avoid explictly freezing literals strings when possible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ PATH
     actionview (7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       builder (~> 3.1)
-      erubi (~> 1.4)
+      erubi (~> 1.11)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
     activejob (7.1.0.alpha)
@@ -205,7 +205,7 @@ GEM
       http_parser.rb (>= 0.6.0)
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
-    erubi (1.10.0)
+    erubi (1.11.0)
     et-orbi (1.2.6)
       tzinfo
     event_emitter (0.2.6)

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
 
   s.add_dependency "builder",       "~> 3.1"
-  s.add_dependency "erubi",         "~> 1.4"
+  s.add_dependency "erubi",         "~> 1.11"
   s.add_dependency "rails-html-sanitizer", "~> 1.1", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"
 


### PR DESCRIPTION
Ref: https://github.com/jeremyevans/erubi/pull/33

If the template is compiled with `frozen_string_literals: true`, then explicitly freezing string is slightly wasteful as it will be compiled as `opt_str_freeze` instead of a simple `putobject`.

The former has to check wether `String#freeze` was redefined every time, which while fast is useless extra work.
