### PR TITLE
Get rid of Erubi#evaluate

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -23,15 +23,6 @@ module ActionView
             super
           end
 
-          def evaluate(action_view_erb_handler_context)
-            src = @src
-            view = Class.new(ActionView::Base) {
-              include action_view_erb_handler_context._routes.url_helpers
-              class_eval("define_method(:_template) { |local_assigns, output_buffer| #{src} }", defined?(@filename) ? @filename : "(erubi)", 0)
-            }.empty
-            view._run(:_template, nil, {}, ActionView::OutputBuffer.new)
-          end
-
         private
           def add_text(text)
             return if text.empty?

--- a/actionview/test/template/erb/helper.rb
+++ b/actionview/test/template/erb/helper.rb
@@ -13,15 +13,25 @@ module ERBTest
   end
 
   class BlockTestCase < ActiveSupport::TestCase
+    class Context < ActionView::Base
+    end
+
     def render_content(start, inside, routes = nil)
       routes ||= ActionDispatch::Routing::RouteSet.new.tap do |rs|
         rs.draw { }
       end
-      context = Class.new(ViewContext) {
-        include routes.url_helpers
-      }.new
-      template = block_helper(start, inside)
-      ActionView::Template::Handlers::ERB.erb_implementation.new(template).evaluate(context)
+
+      view = Class.new(Context)
+      view.include routes.url_helpers
+
+      ActionView::Template.new(
+        block_helper(start, inside),
+        "test#{rand}",
+        ActionView::Template::Handlers::ERB.new,
+        virtual_path: "partial",
+        format: :html,
+        locals: []
+      ).render(view.with_empty_template_cache.empty, {})
     end
 
     def block_helper(str, rest)


### PR DESCRIPTION
It's only used by a handful of tests, but having two ways to evaluate ERB makes it very confusing. The few tests using it can go through ActionView::Template instead.
