### PR TITLE
Add `action_controller.allowed_redirect_hosts` configuration

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -223,4 +223,8 @@
 
     *Petrik de Heus*
 
+*   Allow hosts redirects from `hosts` Rails configuration
+
+    *Kevin Robatel*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -16,6 +16,7 @@ module ActionController
     included do
       mattr_accessor :raise_on_open_redirects, default: false
       mattr_accessor :action_on_path_relative_redirect, default: :log
+      mattr_accessor :allowed_redirect_hosts, default: []
     end
 
     # Redirects the browser to the target specified in `options`. This parameter can
@@ -257,6 +258,7 @@ module ActionController
         host = URI(url.to_s).host
 
         return true if host == request.host
+        return true if _allowed_redirect_hosts_permissions.allows?(host)
         return false unless host.nil?
         return false unless url.to_s.start_with?("/")
         !url.to_s.start_with?("//")
@@ -289,6 +291,10 @@ module ActionController
         when :raise
           raise UnsafeRedirectError, message
         end
+      end
+
+      def _allowed_redirect_hosts_permissions
+        @allowed_redirect_hosts_permissions ||= ActionDispatch::HostAuthorization::Permissions.new(allowed_redirect_hosts)
       end
   end
 end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -34,7 +34,7 @@ module ActionController
     end
 
     initializer "action_controller.set_allowed_redirect_hosts" do |app|
-      config.action_controller.allowed_redirect_hosts << app.config.hosts
+      config.action_controller.allowed_redirect_hosts += app.config.hosts
     end
 
     initializer "action_controller.parameters_config" do |app|

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -16,6 +16,7 @@ module ActionController
     config.action_controller.action_on_path_relative_redirect = :log
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false
+    config.action_controller.allowed_redirect_hosts = []
 
     config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
@@ -30,6 +31,10 @@ module ActionController
 
     initializer "action_controller.set_helpers_path" do |app|
       ActionController::Helpers.helpers_path = app.helpers_paths
+    end
+
+    initializer "action_controller.set_allowed_redirect_hosts" do |app|
+      config.action_controller.allowed_redirect_hosts << app.config.hosts
     end
 
     initializer "action_controller.parameters_config" do |app|

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -34,7 +34,7 @@ module ActionController
     end
 
     initializer "action_controller.set_allowed_redirect_hosts" do |app|
-      config.action_controller.allowed_redirect_hosts += app.config.hosts
+      config.action_controller.allowed_redirect_hosts = []
     end
 
     initializer "action_controller.parameters_config" do |app|

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -815,6 +815,26 @@ class RedirectTest < ActionController::TestCase
     ActionController::Base.action_on_path_relative_redirect = old_config
   end
 
+  def test_redirect_with_allowed_redirect_hosts
+    with_raise_on_open_redirects do
+      with_allowed_redirect_hosts(hosts: ["www.rubyonrails.org"]) do
+        get :redirect_to_url
+        assert_response :redirect
+        assert_redirected_to "http://www.rubyonrails.org/"
+      end
+    end
+  end
+
+  def test_not_redirect_with_allowed_redirect_hosts
+    with_raise_on_open_redirects do
+      with_allowed_redirect_hosts(hosts: ["www.ruby-lang.org"]) do
+        assert_raise ActionController::Redirecting::UnsafeRedirectError do
+          get :redirect_to_url
+        end
+      end
+    end
+  end
+
   private
     def with_raise_on_open_redirects
       old_raise_on_open_redirects = ActionController::Base.raise_on_open_redirects
@@ -822,6 +842,14 @@ class RedirectTest < ActionController::TestCase
       yield
     ensure
       ActionController::Base.raise_on_open_redirects = old_raise_on_open_redirects
+    end
+
+    def with_allowed_redirect_hosts(hosts:)
+      old_allowed_redirect_hosts = ActionController::Base.allowed_redirect_hosts
+      ActionController::Base.allowed_redirect_hosts = hosts
+      yield
+    ensure
+      ActionController::Base.allowed_redirect_hosts = old_allowed_redirect_hosts
     end
 end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2021,6 +2021,10 @@ The default value depends on the `config.load_defaults` target version:
 
 [params_wrapper]: https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html
 
+#### `config.action_controller.allowed_redirect_hosts`
+
+Specifies a list of allowed hosts for redirects. `redirect_to` will allow redirects to them without raising an error.
+
 #### `ActionController::Base.wrap_parameters`
 
 Configures the [`ParamsWrapper`](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html). This can be called at


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

We use Rails with multiple domains (and subdomains). All these domains are configured with `config.hosts`.  
Sometimes we have dynamic redirect from one domain to an other.  
And `ActionController::Redirecting::UnsafeRedirectError` is raised.

It would be great to allow redirections to domains that the app accept in `config.hosts`.
This should not be considered as unsafe.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
