### PR TITLE
Extract `#build_change_column_definition`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -92,7 +92,7 @@ module ActiveRecord
 
     AddColumnDefinition = Struct.new(:column) # :nodoc:
 
-    ChangeColumnDefinition = Struct.new(:column, :name) # :nodoc:
+    ChangeColumnDefinition = Struct.new(:column, :name, :ddl) # :nodoc:
 
     CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists, :ddl) # :nodoc:
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -371,6 +371,39 @@ module ActiveRecord
         execute("ALTER TABLE #{quote_table_name(table_name)} #{change_column_for_alter(table_name, column_name, type, **options)}")
       end
 
+      # Builds a ChangeColumnDefinition object.
+      #
+      # This definition object contains information about the column change that would occur
+      # if the same arguments were passed to #change_column. See #change_column for information about
+      # passing a +table_name+, +column_name+, +type+ and other options that can be passed.
+      def build_change_column_definition(table_name, column_name, type, **options) # :nodoc:
+        column = column_for(table_name, column_name)
+        type ||= column.sql_type
+
+        unless options.key?(:default)
+          options[:default] = column.default
+        end
+
+        unless options.key?(:null)
+          options[:null] = column.null
+        end
+
+        unless options.key?(:comment)
+          options[:comment] = column.comment
+        end
+
+        unless options.key?(:auto_increment)
+          options[:auto_increment] = column.auto_increment?
+        end
+
+        td = create_table_definition(table_name)
+        cd = td.new_column_definition(column.name, type, **options)
+        change_column_def = ChangeColumnDefinition.new(cd, column.name)
+        schema_creation.accept(change_column_def)
+
+        change_column_def
+      end
+
       def rename_column(table_name, column_name, new_column_name) # :nodoc:
         execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}")
         rename_column_indexes(table_name, column_name, new_column_name)
@@ -726,28 +759,8 @@ module ActiveRecord
         end
 
         def change_column_for_alter(table_name, column_name, type, **options)
-          column = column_for(table_name, column_name)
-          type ||= column.sql_type
-
-          unless options.key?(:default)
-            options[:default] = column.default
-          end
-
-          unless options.key?(:null)
-            options[:null] = column.null
-          end
-
-          unless options.key?(:comment)
-            options[:comment] = column.comment
-          end
-
-          unless options.key?(:auto_increment)
-            options[:auto_increment] = column.auto_increment?
-          end
-
-          td = create_table_definition(table_name)
-          cd = td.new_column_definition(column.name, type, **options)
-          schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))
+          cd = build_change_column_definition(table_name, column_name, type, **options)
+          cd.ddl
         end
 
         def rename_column_for_alter(table_name, column_name, new_column_name)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -21,7 +21,7 @@ module ActiveRecord
 
           def visit_ChangeColumnDefinition(o)
             change_column_sql = +"CHANGE #{quote_column_name(o.name)} #{accept(o.column)}"
-            add_column_position!(change_column_sql, column_options(o.column))
+            o.ddl = add_column_position!(change_column_sql, column_options(o.column))
           end
 
           def visit_CreateIndexDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -84,7 +84,7 @@ module ActiveRecord
               change_column_sql << ", ALTER COLUMN #{quoted_column_name} #{options[:null] ? 'DROP' : 'SET'} NOT NULL"
             end
 
-            change_column_sql
+            o.ddl = change_column_sql
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -62,21 +62,22 @@ module ActiveRecord
         end
       end
 
-      def test_build_add_column_definition
-        connection.create_table(:test)
-        add_col_td = connection.build_add_column_definition(:test, :foo, :string)
+      unless current_adapter?(:SQLite3Adapter)
+        def test_build_change_column_definition
+          connection.create_table(:test) do |t|
+            t.column :foo, :string
+          end
 
-        assert_match "ALTER TABLE", add_col_td.ddl
+          change_cd = connection.build_change_column_definition(:test, :foo, :integer)
+          assert change_cd.ddl
 
-        add_cols = add_col_td.adds
-        assert_equal 1, add_cols.size
-
-        add_col = add_cols.first.column
-        assert_equal "foo", add_col.name
-        assert add_col.type
-        assert add_col.sql_type
-      ensure
-        connection.drop_table(:test) if connection.table_exists?(:test)
+          change_col = change_cd.column
+          assert_equal "foo", change_col.name.to_s
+          assert change_col.type
+          assert change_col.sql_type
+        ensure
+          connection.drop_table(:test) if connection.table_exists?(:test)
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

Define APIs on the MySQL and PostgreSQL connection adapters for building
ChangeColumnDefinition objects. These provide information on what a
column change would look like, when called with the same arguments as
would be passed to #change_column.

See https://github.com/rails/rails/pull/45625 for more context on exposing schema definition APIs.

### Other Information

I've left out a definition for SQLite3, because it performs `#change_column` by replacing the entire table definition:
https://github.com/rails/rails/blob/74a9929ce18a4e0ca01f81aad8eca03ae8369fe5/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L311-L318

We could define `#build_change_column_definition` to essentially wrap the new column definition, but this wouldn't actually be used by `#change_column`, and we wouldn't be able to set the `ddl`, so I opted to just ignore it.