### PR TITLE
Move schema definition APIs to separate module

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -27,6 +27,7 @@ module ActiveRecord
     end
 
     autoload_under "abstract" do
+      autoload :SchemaDefinitionBuilders
       autoload :SchemaStatements
       autoload :DatabaseStatements
       autoload :DatabaseLimits

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definition_builders.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definition_builders.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters # :nodoc:
+    module SchemaDefinitionBuilders
+      # Builds a TableDefinition object.
+      #
+      # This definition object contains information about the table that would be created
+      # if the same arguments were passed to #create_table. See #create_table for information about
+      # passing a +table_name+, and other additional options that can be passed.
+      def build_create_table_definition(table_name, id: :primary_key, primary_key: nil, force: nil, **options) # :nodoc:
+        table_definition = create_table_definition(table_name, **extract_table_options!(options))
+        table_definition.set_primary_key(table_name, id, primary_key, **options)
+
+        yield table_definition if block_given?
+
+        schema_creation.accept(table_definition)
+        table_definition
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -7,6 +7,7 @@ module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module SchemaStatements
       include ActiveRecord::Migration::JoinTable
+      include SchemaDefinitionBuilders
 
       # Returns a hash of mappings from the abstract data types to the native
       # database types. See TableDefinition#column for details on the recognized
@@ -318,19 +319,6 @@ module ActiveRecord
         end
 
         result
-      end
-
-      # Returns a TableDefinition object containing information about the table that would be created
-      # if the same arguments were passed to #create_table. See #create_table for information about
-      # passing a +table_name+, and other additional options that can be passed.
-      def build_create_table_definition(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
-        table_definition = create_table_definition(table_name, **extract_table_options!(options))
-        table_definition.set_primary_key(table_name, id, primary_key, **options)
-
-        yield table_definition if block_given?
-
-        schema_creation.accept(table_definition)
-        table_definition
       end
 
       # Creates a new join table with the name created using the lexical order of the first two


### PR DESCRIPTION
### Summary

From feedback here: https://github.com/rails/rails/pull/45630#discussion_r932418894

Let's separate out the new schema definition APIs from the other schema statement methods. I've pulled them into a `SchemaDefinitionBuilders` module for now. We can also `:nodoc` them, but perhaps this provides enough separation for now?