### PR TITLE
Save encrypted config even if YAML is invalid

### DIFF
--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -66,11 +66,19 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal "things", @credentials[:new]
   end
 
-  test "raise error when writing an invalid format value" do
-    assert_raise(Psych::SyntaxError) do
-      @credentials.change do |config_file|
-        config_file.write "login: *login\n  username: dummy"
-      end
+  test "raises helpful error when loading invalid content" do
+    @credentials.write("key: value\nbad")
+
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidContentError) do
+      @credentials.config
+    end
+  end
+
+  test "raises helpful error when validating invalid content" do
+    @credentials.write("key: value\nbad")
+
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidContentError) do
+      @credentials.validate!
     end
   end
 

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -41,6 +41,7 @@ module Rails
         end
 
         say "File encrypted and saved."
+        warn_if_credentials_are_invalid
       rescue ActiveSupport::MessageEncryptor::InvalidMessage
         say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
       end
@@ -101,6 +102,14 @@ module Rails
           credentials.change do |tmp_path|
             system(*Shellwords.split(ENV["EDITOR"]), tmp_path.to_s)
           end
+        end
+
+        def warn_if_credentials_are_invalid
+          credentials.validate!
+        rescue ActiveSupport::EncryptedConfiguration::InvalidContentError => error
+          say "WARNING: #{error.message}", :red
+          say ""
+          say "Your application will not be able to load '#{content_path}' until the error has been fixed.", :red
         end
 
         def missing_credentials_message

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -32,6 +32,7 @@ module Rails
         end
 
         say "File encrypted and saved."
+        warn_if_encrypted_configuration_is_invalid
       rescue ActiveSupport::MessageEncryptor::InvalidMessage
         say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
       end
@@ -71,6 +72,13 @@ module Rails
           end
         end
 
+        def warn_if_encrypted_configuration_is_invalid
+          encrypted_configuration.validate!
+        rescue ActiveSupport::EncryptedConfiguration::InvalidContentError => error
+          say "WARNING: #{error.message}", :red
+          say ""
+          say "Your application will not be able to load '#{content_path}' until the error has been fixed.", :red
+        end
 
         def encryption_key_file_generator
           require "rails/generators"

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -142,6 +142,13 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match %r/provides_secret_key_base: true/, run_edit_command
   end
 
+  test "edit command preserves user's content even if it contains invalid YAML" do
+    write_invalid_yaml = %(ruby -e "File.write ARGV[0], 'foo: bar: bad'")
+
+    assert_match %r/WARNING: Invalid YAML/, run_edit_command(editor: write_invalid_yaml)
+    assert_match %r/foo: bar: bad/, run_edit_command
+  end
+
 
   test "show credentials" do
     assert_match DEFAULT_CREDENTIALS_PATTERN, run_show_command

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -82,6 +82,14 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_edit_command(key: "config/tokens.key"))
   end
 
+  test "edit command preserves user's content even if it contains invalid YAML" do
+    write_invalid_yaml = %(ruby -e "File.write ARGV[0], 'foo: bar: bad'")
+
+    assert_match %r/WARNING: Invalid YAML/, run_edit_command(editor: write_invalid_yaml)
+    assert_match %r/foo: bar: bad/, run_edit_command
+  end
+
+
   test "show encrypted file with custom key" do
     run_edit_command(key: "config/tokens.key")
 


### PR DESCRIPTION
In #30893, the `credentials:edit` command was changed to prevent saving invalid YAML:

  ```yaml
  # some_invalid_yaml.yml
  secret_key_base: ...
  - new_key: new value
  ```

  ```console
  $ EDITOR='cp some_invalid_yaml.yml' bin/rails credentials:edit
  ruby-3.1.2/lib/ruby/3.1.0/psych.rb:455:in `parse': (<unknown>): did not find expected key while parsing a block mapping at line 3 column 1 (Psych::SyntaxError)

  $ bin/rails credentials:show
  secret_key_base: ...
  ```

However, throwing away user input is not ideal.  Such behavior can be particularly troublesome when copying secrets from ephemeral sources.

This commit changes the `credentials:edit` command to always save user input, and display a helpful warning when saving invalid YAML:

  ```console
  $ EDITOR='cp some_invalid_yaml.yml' bin/rails credentials:edit
  File encrypted and saved.
  WARNING: Invalid YAML in '/path/to/app/config/credentials.yml.enc'.

    (/path/to/app/config/credentials.yml.enc): did not find expected key while parsing a block mapping at line 3 column 1

  Your application will not be able to load 'config/credentials.yml.enc' until the error has been fixed.

  $ bin/rails credentials:show
  # some_invalid_yaml.yml
  secret_key_base: ...
  - new_key: new value
  ```

This commit also applies the same fix to the `encrypted:edit` command.
