### PR TITLE
Add a build persistence method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add a build persistence method
+
+    Provides a wrapper for `new`, to provide feature parity with `create`s
+    ability to create multiple records from an array of hashes, using the
+    same notation as the `build` method on associations.
+
+    - Associations can create multiple objects from an array of hashes
+    - Associations can build multiple objects from an array of hashes
+    - Classes can create multiple objects from an array of hashes
+    - Classes can build multiple objects from an array of hashes (<- You are here)
+
+    *Sean Denny*
+
 *   Clear locking column on #dup
 
     This change fixes not to duplicate locking_column like id and timestamps.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -58,6 +58,36 @@ module ActiveRecord
         end
       end
 
+      # Builds an object (or multiple objects) and returns either the built object or a list of built
+      # objects.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be built.
+      #
+      # ==== Examples
+      #   # Build a single new object
+      #   User.build(first_name: 'Jamie')
+      #
+      #   # Build an Array of new objects
+      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Build a single object and pass it into a block to set other attributes.
+      #   User.build(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Building an Array of new objects using a block, where the block is executed for each object:
+      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def build(attributes = nil, &block)
+        if attributes.is_a?(Array)
+          attributes.collect { |attr| build(attr, &block) }
+        else
+          new(attributes, &block)
+        end
+      end
+
       # Inserts a single record into the database in a single SQL INSERT
       # statement. It does not instantiate any models nor does it trigger
       # Active Record callbacks or validations. Though passed values

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -426,6 +426,40 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal("New Topic", topic_reloaded.title)
   end
 
+  def test_build
+    topic = Topic.build(title: "New Topic")
+    assert_equal "New Topic", topic.title
+    assert_not_predicate topic, :persisted?
+  end
+
+  def test_build_many
+    topics = Topic.build([{ title: "first" }, { title: "second" }])
+    assert_equal ["first", "second"], topics.map(&:title)
+    topics.each { |topic| assert_not_predicate topic, :persisted? }
+  end
+
+  def test_build_through_factory_with_block
+    topic = Topic.build("title" => "New Topic") do |t|
+      t.author_name = "David"
+    end
+    assert_equal("New Topic", topic.title)
+    assert_equal("David", topic.author_name)
+    assert_not_predicate topic, :persisted?
+  end
+
+  def test_build_many_through_factory_with_block
+    topics = Topic.build([{ "title" => "first" }, { "title" => "second" }]) do |t|
+      t.author_name = "David"
+    end
+    assert_equal 2, topics.size
+    topics.each { |topic| assert_not_predicate topic, :persisted? }
+    topic1, topic2 = topics
+    assert_equal "first", topic1.title
+    assert_equal "David", topic1.author_name
+    assert_equal "second", topic2.title
+    assert_equal "David", topic2.author_name
+  end
+
   def test_save_valid_record
     topic = Topic.new(title: "New Topic")
     assert topic.save!


### PR DESCRIPTION
### Summary

Provides a wrapper for `new`, to provide feature parity with `create`s
ability to create multiple records from an array of hashes, using the
same notation as the `build` method on associations.

- Associations can create multiple objects from an array of hashes
- Associations can build multiple objects from an array of hashes
- Classes can create multiple objects from an array of hashes
- Classes can build multiple objects from an array of hashes (<- You are here)

As discussed here: https://discuss.rubyonrails.org/t/allow-activerecord-inheritance-new-to-accept-an-array/80889
