### PR TITLE
Use SET DEFAULT when changing a column default in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -18,6 +18,7 @@ module ActiveRecord
       autoload :IndexDefinition
       autoload :ColumnDefinition
       autoload :ChangeColumnDefinition
+      autoload :ChangeColumnDefaultDefinition
       autoload :ForeignKeyDefinition
       autoload :CheckConstraintDefinition
       autoload :TableDefinition

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -94,6 +94,8 @@ module ActiveRecord
 
     ChangeColumnDefinition = Struct.new(:column, :name) # :nodoc:
 
+    ChangeColumnDefaultDefinition = Struct.new(:column, :default, :ddl) # :nodoc:
+
     CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists, :ddl) # :nodoc:
 
     PrimaryKeyDefinition = Struct.new(:name) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1674,6 +1674,14 @@ module ActiveRecord
           schema_creation.accept(AddColumnDefinition.new(cd))
         end
 
+        def change_column_default_for_alter(table_name, column_name, default_or_changes)
+          column = column_for(table_name, column_name)
+          return unless column
+
+          default = extract_new_default_value(default_or_changes)
+          schema_creation.accept(ChangeColumnDefaultDefinition.new(column, default))
+        end
+
         def rename_column_sql(table_name, column_name, new_column_name)
           "RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -348,8 +348,7 @@ module ActiveRecord
       end
 
       def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
-        default = extract_new_default_value(default_or_changes)
-        change_column table_name, column_name, nil, default: default
+        execute "ALTER TABLE #{quote_table_name(table_name)} #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
       end
 
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -24,6 +24,16 @@ module ActiveRecord
             add_column_position!(change_column_sql, column_options(o.column))
           end
 
+          def visit_ChangeColumnDefaultDefinition(o)
+            sql = +"ALTER COLUMN #{quote_column_name(o.column.name)} SET DEFAULT "
+            if o.default.nil?
+              sql << "NULL"
+            else
+              sql << quote_default_expression(o.default, o.column)
+            end
+            o.ddl = sql
+          end
+
           def visit_CreateIndexDefinition(o)
             sql = visit_IndexDefinition(o.index, true)
             sql << " #{o.algorithm}" if o.algorithm

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -87,6 +87,16 @@ module ActiveRecord
             change_column_sql
           end
 
+          def visit_ChangeColumnDefaultDefinition(o)
+            sql = +"ALTER COLUMN #{quote_column_name(o.column.name)} "
+            if o.default.nil?
+              sql << "DROP DEFAULT"
+            else
+              sql << "SET DEFAULT #{quote_default_expression(o.default, o.column)}"
+            end
+            o.ddl = sql
+          end
+
           def add_column_options!(sql, options)
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -842,21 +842,6 @@ module ActiveRecord
             sqls
           end
 
-          def change_column_default_for_alter(table_name, column_name, default_or_changes)
-            column = column_for(table_name, column_name)
-            return unless column
-
-            default = extract_new_default_value(default_or_changes)
-            alter_column_query = "ALTER COLUMN #{quote_column_name(column_name)} %s"
-            if default.nil?
-              # <tt>DEFAULT NULL</tt> results in the same behavior as <tt>DROP DEFAULT</tt>. However, PostgreSQL will
-              # cast the default to the columns type, which leaves us with a default like "default NULL::character varying".
-              alter_column_query % "DROP DEFAULT"
-            else
-              alter_column_query % "SET DEFAULT #{quote_default_expression(default, column)}"
-            end
-          end
-
           def change_column_null_for_alter(table_name, column_name, null, default = nil)
             if default.nil?
               "ALTER COLUMN #{quote_column_name(column_name)} #{null ? 'DROP' : 'SET'} NOT NULL"


### PR DESCRIPTION
### Summary

Aligns the SQL produced for changing a column default between MySQL and PostgreSQL.
MySQL is currently producing an `ALTER TABLE x CHANGE COLUMN y` query just to
change the default for a column, which is less efficient than using the SET DEFAULT syntax,
because every row in the table must be processed.

Additionally, this PR extracts `ChangeColumnDefaultDefinition` and moves the SQL generation to the visitor class. 
This will facilitate the eventual extraction of a `#build_change_column_default` method, as a part of the schema
definition API work (see https://github.com/rails/rails/pull/45625). Both MySQL and PostgreSQL can rely on the same schema definition here to produce the required SQL.

### Other Information

The `ChangeColumnDefaultDefinition` wraps a `Column` object (ie.`ActiveRecord::ConnectionAdapters::PostgreSQL::Column`) as opposed to a `ColumnDefinition` object, which is perhaps a bit unintuitive because all of the other schema definitions that wrap columns wrap `ColumnDefinition`s. This was necessary because `#quote_default_expression` for PostgreSQL relies on data on the `Column` object (the `oid`, whether the column responds to `#array`, etc.) to handle setting defaults like `[]` on a column.

Most of the information consumers care about (the `type`, `sql_type`, `name`, etc.) is identical between the two, but the format is different, and the `Column` object won't have the options hash. I'm not sure if this is problematic, but wanted to call it out.