### PR TITLE
Support using a method name to define the `ActiveSupport::CurrentAttributes.resets` callback

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `ActiveSupport::CurrentAttributes.resets` now accepts a method name
+
+    The block API is still the recommended approach, but now both APIs are supported:
+
+    ```ruby
+    class Current < ActiveSupport::CurrentAttributes
+      resets { Time.zone = nil }
+      resets :clear_time_zone
+    end
+    ```
+
+    *Alex Ghiculescu*
+
 *   `Class#subclasses` and `Class#descendants` now automatically filter reloaded classes.
 
     Previously they could return old implementations of reloadable classes that have been

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -133,14 +133,14 @@ module ActiveSupport
         end
       end
 
-      # Calls this block before #reset is called on the instance. Used for resetting external collaborators that depend on current values.
-      def before_reset(&block)
-        set_callback :reset, :before, &block
+      # Calls this callback before #reset is called on the instance. Used for resetting external collaborators that depend on current values.
+      def before_reset(*methods, &block)
+        set_callback :reset, :before, *methods, &block
       end
 
-      # Calls this block after #reset is called on the instance. Used for resetting external collaborators, like Time.zone.
-      def resets(&block)
-        set_callback :reset, :after, &block
+      # Calls this callback after #reset is called on the instance. Used for resetting external collaborators, like Time.zone.
+      def resets(*methods, &block)
+        set_callback :reset, :after, *methods, &block
       end
       alias_method :after_reset, :resets
 

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -17,9 +17,10 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     before_reset { Session.previous = person&.id }
 
     resets do
-      Time.zone = "UTC"
       Session.current = nil
     end
+
+    resets :clear_time_zone
 
     def account=(account)
       super
@@ -52,6 +53,11 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     def intro
       "#{person.name}, in #{time_zone}"
     end
+
+    private
+      def clear_time_zone
+        Time.zone = "UTC"
+      end
   end
 
   class Session < ActiveSupport::CurrentAttributes


### PR DESCRIPTION
Previously you could only use a block, which was inconsistent with other callback APIs in Rails. Now, you can use a block or a method name. The block API is still recommended in the docs. So now these do the same thing:

```ruby
class CurrentWithBlock < ActiveSupport::CurrentAttributes
  resets { Time.zone = nil }
end

class CurrentWithMethod < ActiveSupport::CurrentAttributes
  resets :clear_time_zone

  def clear_time_zone
    Time.zone = nil
  end
end
```

This also works for `before_reset`.

```ruby
class Current < ActiveSupport::CurrentAttributes
  before_reset :clear_time_zone
end
```
