### PR TITLE
Avoid dynamic constant get on SET.symbols

### DIFF
--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -38,18 +38,15 @@ module ActionView
       end
 
       class << self
-        attr_accessor :type_klass
+        attr_reader :symbols
 
         def delegate_to(klass)
-          self.type_klass = klass
+          @symbols = klass::SET.symbols
+          @type_klass = klass
         end
 
         def [](type)
-          type_klass[type]
-        end
-
-        def symbols
-          type_klass::SET.symbols
+          @type_klass[type]
         end
       end
 


### PR DESCRIPTION
Dynamic constant lookups (ie. x::SOME_CONST) are uncommon and slightly slow operations (not _that_ slow). We know that the ::SET constant won't change (this is a private API and it is called only with our own classes) so we can switch this to an attr_reader for fast access on the call to delgate_to.

It really isn't _that_ slow (this change takes `.symbols` from ~12M i/s to ~19M i/s) but this is the only relatively hot code path I saw this being used in railsbench, and since yjit doesn't currently implement `getconstant` this should avoid side-exits.

This also removes the unused `type_klass` attr_accessor.