### PR TITLE
Prevent "saved" message when edit command aborted

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -36,14 +36,7 @@ module Rails
         ensure_credentials_have_been_added
         ensure_diffing_driver_is_configured
 
-        catch_editing_exceptions do
-          change_credentials_in_system_editor
-        end
-
-        say "File encrypted and saved."
-        warn_if_credentials_are_invalid
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+        change_credentials_in_system_editor
       end
 
       def show
@@ -99,9 +92,16 @@ module Rails
         end
 
         def change_credentials_in_system_editor
-          credentials.change do |tmp_path|
-            system(*Shellwords.split(ENV["EDITOR"]), tmp_path.to_s)
+          catch_editing_exceptions do
+            credentials.change do |tmp_path|
+              system(*Shellwords.split(ENV["EDITOR"]), tmp_path.to_s)
+            end
+
+            say "File encrypted and saved."
+            warn_if_credentials_are_invalid
           end
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage
+          say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
         end
 
         def warn_if_credentials_are_invalid

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -27,14 +27,7 @@ module Rails
         ensure_encryption_key_has_been_added
         ensure_encrypted_configuration_has_been_added
 
-        catch_editing_exceptions do
-          change_encrypted_configuration_in_system_editor
-        end
-
-        say "File encrypted and saved."
-        warn_if_encrypted_configuration_is_invalid
-      rescue ActiveSupport::MessageEncryptor::InvalidMessage
-        say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
+        change_encrypted_configuration_in_system_editor
       end
 
       def show(*)
@@ -67,9 +60,16 @@ module Rails
         end
 
         def change_encrypted_configuration_in_system_editor
-          encrypted_configuration.change do |tmp_path|
-            system("#{ENV["EDITOR"]} #{tmp_path}")
+          catch_editing_exceptions do
+            encrypted_configuration.change do |tmp_path|
+              system("#{ENV["EDITOR"]} #{tmp_path}")
+            end
+
+            say "File encrypted and saved."
+            warn_if_encrypted_configuration_is_invalid
           end
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage
+          say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
         end
 
         def warn_if_encrypted_configuration_is_invalid

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -142,6 +142,16 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match %r/provides_secret_key_base: true/, run_edit_command
   end
 
+  test "edit command does not display save confirmation message if interrupted" do
+    assert_match %r/file encrypted and saved/i, run_edit_command
+
+    interrupt_command_process = %(ruby -e "Process.kill 'INT', Process.ppid")
+    output = run_edit_command(editor: interrupt_command_process)
+
+    assert_no_match %r/file encrypted and saved/i, output
+    assert_match %r/nothing saved/i, output
+  end
+
   test "edit command preserves user's content even if it contains invalid YAML" do
     write_invalid_yaml = %(ruby -e "File.write ARGV[0], 'foo: bar: bad'")
 

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -82,6 +82,16 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_edit_command(key: "config/tokens.key"))
   end
 
+  test "edit command does not display save confirmation message if interrupted" do
+    assert_match %r/file encrypted and saved/i, run_edit_command
+
+    interrupt_command_process = %(exec ruby -e "Process.kill 'INT', Process.ppid")
+    output = run_edit_command(editor: interrupt_command_process)
+
+    assert_no_match %r/file encrypted and saved/i, output
+    assert_match %r/nothing saved/i, output
+  end
+
   test "edit command preserves user's content even if it contains invalid YAML" do
     write_invalid_yaml = %(ruby -e "File.write ARGV[0], 'foo: bar: bad'")
 


### PR DESCRIPTION
Prior to this commit, the `credentials:edit` command would display a save confirmation message even if it was aborted via interrupt:

  ```console
  $ EDITOR='ruby -e "sleep 100"' bin/rails credentials:edit
  <Ctrl+C>
  Aborted changing file: nothing saved.
  File encrypted and saved.
  ```

This commit fixes that behavior:

  ```console
  $ EDITOR='ruby -e "sleep 100"' bin/rails credentials:edit
  <Ctrl+C>
  Aborted changing file: nothing saved.
  ```

This commit also applies the same fix to the `encrypted:edit` command.
