### PR TITLE
[ci-skip] Remove resolved debugger caveat from debugging guide

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -752,37 +752,6 @@ This technique can save you from repeated manual input and make the debugging ex
 
 You can find more commands and configuration options from its [documentation](https://github.com/ruby/debug).
 
-#### Autoloading Caveat
-
-Debugging with `debug` works fine most of the time, but there's an edge case: If you evaluate an expression in the console that autoloads a namespace defined in a file, constants in that namespace won't be found.
-
-For example, if the application has these two files:
-
-```ruby
-# hotel.rb
-class Hotel
-end
-
-# hotel/pricing.rb
-module Hotel::Pricing
-end
-```
-
-and `Hotel` is not yet loaded, then
-
-```
-(rdbg) p Hotel::Pricing
-```
-
-will raise a `NameError`. In some cases, Ruby will be able to resolve an unintended constant in a different scope.
-
-If you hit this, please restart your debugging session with eager loading enabled (`config.eager_load = true`).
-
-Stepping commands line `next`, `continue`, etc., do not present this issue. Namespaces defined implicitly only by
-subdirectories are not subject to this issue either.
-
-See [ruby/debug#408](https://github.com/ruby/debug/issues/408) for details.
-
 Debugging with the `web-console` gem
 ------------------------------------
 


### PR DESCRIPTION
The issue has been resolved in https://github.com/ruby/debug/pull/558 and has been released since version 1.5.0
