### PR TITLE
Add explicit regression tests for ActiveRecord::Migration's #say & #say_with_time

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "cases/migration/helper"
 require "bigdecimal/util"
 require "concurrent/atomic/count_down_latch"
+require "active_support/core_ext/object/with"
 
 require "models/person"
 require "models/topic"
@@ -1144,6 +1145,53 @@ class MigrationTest < ActiveRecord::TestCase
         e.message
       )
     end
+  end
+
+  def test_migration_say_basic
+    output, = capture_io do
+      ActiveRecord::Migration.with(verbose: true) do
+        ActiveRecord::Migration.say("Foo")
+      end
+    end
+
+    assert_equal "-- Foo\n", output
+  end
+
+  def test_migration_say_for_subitem
+    output, = capture_io do
+      ActiveRecord::Migration.with(verbose: true) do
+        ActiveRecord::Migration.say("Foo", true)
+      end
+    end
+
+    assert_equal "   -> Foo\n", output
+  end
+
+  def test_migration_say_with_time_with_integer_returning_in_block
+    output, = capture_io do
+      ActiveRecord::Migration.with(verbose: true) do
+        ActiveRecord::Migration.say_with_time("Bar") { 123 }
+      end
+    end
+
+    assert_equal <<~MSG, output
+      -- Bar
+         -> 0.0000s
+         -> 123 rows
+    MSG
+  end
+
+  def test_migration_say_with_time_with_non_integer_returning_in_block
+    output, = capture_io do
+      ActiveRecord::Migration.with(verbose: true) do
+        ActiveRecord::Migration.say_with_time("Bar") { "ignored" }
+      end
+    end
+
+    assert_equal <<~MSG, output
+      -- Bar
+         -> 0.0000s
+    MSG
   end
 
   private


### PR DESCRIPTION
related tests are in activerecord/test/cases/migrator_test.rb, but it checks puts(message_count) quantity only.

### Summary

I noticed that Migration's `#say` and `#say_with_time` methods didn't have explicit tests so this should increase test coverage a little bit.

Other than that(in the 2nd commit), after this update it fails with an explicit error in case #say_with_time was called without a block. I wasn't sure whether to put it in this PR or probably a future one.
LMKWYT