### PR TITLE
Improving assert_enqueued_email_with

### DIFF
--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -123,9 +123,15 @@ module ActionMailer
     #       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
     #     end
     #   end
-    def assert_enqueued_email_with(mailer, method, args: nil, queue: ActionMailer::Base.deliver_later_queue_name || "default", &block)
+    def assert_enqueued_email_with(mailer, method, params: nil, args: nil, queue: ActionMailer::Base.deliver_later_queue_name || "default", &block)
+      if mailer.is_a? ActionMailer::Parameterized::Mailer
+        params = mailer.instance_variable_get(:@params)
+        mailer = mailer.instance_variable_get(:@mailer)
+      end
       args = if args.is_a?(Hash)
         [mailer.to_s, method.to_s, "deliver_now", params: args, args: []]
+      elsif params.present?
+        [mailer.to_s, method.to_s, "deliver_now", params: params, args: Array(args)]
       else
         [mailer.to_s, method.to_s, "deliver_now", args: Array(args)]
       end

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -17,6 +17,12 @@ class TestHelperMailer < ActionMailer::Base
       from: "tester@example.com"
   end
 
+  def test_named_args(recipient:, name:)
+    mail body: render(inline: "Hello, #{name}"),
+      to: recipient,
+      from: "tester@example.com"
+  end
+
   def test_parameter_args
     mail body: render(inline: "All is #{params[:all]}"),
       to: "test@example.com",
@@ -383,11 +389,42 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
-  def test_assert_enqueued_email_with_with_parameterized_args
+  def test_assert_enqueued_email_with_parames
     assert_nothing_raised do
       assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" } do
         silence_stream($stdout) do
           TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_parameterized_mailer
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer.with(all: "good"), :test_parameter_args do
+        silence_stream($stdout) do
+          TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_named_args
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_named_args, args: [{ email: "some_email", name: "some_name" }] do
+        silence_stream($stdout) do
+          TestHelperMailer.test_named_args(email: "some_email", name: "some_name").deliver_later
+        end
+      end
+    end
+  end
+
+
+  def test_assert_enqueued_email_with_params_and_args
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_args, params: { all: "good" }, args: ["some_email", "some_name"] do
+        silence_stream($stdout) do
+          TestHelperMailer.with(all: "good").test_args("some_email", "some_name").deliver_later
         end
       end
     end

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -403,7 +403,6 @@ module ActiveJob
       else
         jobs = enqueued_jobs
       end
-
       matching_job = jobs.find do |enqueued_job|
         deserialized_job = deserialize_args_for_assertion(enqueued_job)
         potential_matches << deserialized_job


### PR DESCRIPTION
I've taken our work from Friday and added a little bit.

The `assert_enqueued_email_with` is now tested in several different scenarios:

**Args**
`TestHelperMailer.test_args("some_email", "some_name").deliver_later`
matches
`assert_enqueued_email_with TestHelperMailer, :test_args, args: ["some_email", "some_name"]`

**Params**
`TestHelperMailer.with(all: "good").test_parameter_args.deliver_later`
matches
`assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" }`

**Named Args**
`TestHelperMailer.test_named_args(email: "some_email", name: "some_name").deliver_later`
matches
`assert_enqueued_email_with TestHelperMailer, :test_named_args, args: [{ email: "some_email", name: "some_name" }]`

**Params and Args**
`TestHelperMailer.with(all: "good").test_args("some_email", "some_name").deliver_later`
matches
`assert_enqueued_email_with TestHelperMailer, :test_args, params: { all: "good" }, args: ["some_email", "some_name"]`

**Parameterized Mailer**
`TestHelperMailer.with(all: "good").test_parameter_args.deliver_later`
matches
`assert_enqueued_email_with TestHelperMailer.with(all: "good"), :test_parameter_args`

That last scenario is questionable, but I think very readable.