### PR TITLE
Support spaces in file path when invoking editor

### DIFF
--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "shellwords"
 require "active_support/encrypted_file"
 
 module Rails
@@ -20,6 +21,10 @@ module Rails
             else
               true
             end
+          end
+
+          def system_editor(file_path)
+            system(*Shellwords.split(ENV["EDITOR"]), file_path.to_s)
           end
 
           def catch_editing_exceptions

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "pathname"
-require "shellwords"
 require "active_support"
 require "rails/command/helpers/editor"
 require "rails/command/environment_argument"
@@ -93,10 +92,7 @@ module Rails
 
         def change_credentials_in_system_editor
           catch_editing_exceptions do
-            credentials.change do |tmp_path|
-              system(*Shellwords.split(ENV["EDITOR"]), tmp_path.to_s)
-            end
-
+            credentials.change { |tmp_path| system_editor(tmp_path) }
             say "File encrypted and saved."
             warn_if_credentials_are_invalid
           end

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -61,10 +61,7 @@ module Rails
 
         def change_encrypted_configuration_in_system_editor
           catch_editing_exceptions do
-            encrypted_configuration.change do |tmp_path|
-              system("#{ENV["EDITOR"]} #{tmp_path}")
-            end
-
+            encrypted_configuration.change { |tmp_path| system_editor(tmp_path) }
             say "File encrypted and saved."
             warn_if_encrypted_configuration_is_invalid
           end

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -85,7 +85,7 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
   test "edit command does not display save confirmation message if interrupted" do
     assert_match %r/file encrypted and saved/i, run_edit_command
 
-    interrupt_command_process = %(exec ruby -e "Process.kill 'INT', Process.ppid")
+    interrupt_command_process = %(ruby -e "Process.kill 'INT', Process.ppid")
     output = run_edit_command(editor: interrupt_command_process)
 
     assert_no_match %r/file encrypted and saved/i, output


### PR DESCRIPTION
In #44910, the `credentials:edit` command was fixed to support spaces in the temporary file path on Windows.  This commit applies the same fix to the `encrypted:edit` command.
