### PR TITLE
Optimize increment and decrement for `RedisCacheStore`

### DIFF
--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -209,43 +209,35 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
 
     def test_increment_expires_in
-      assert_called_with @cache.redis, :incrby, [ "#{@namespace}:foo", 1 ] do
-        assert_called_with @cache.redis, :expire, [ "#{@namespace}:foo", 60 ] do
-          @cache.increment "foo", 1, expires_in: 60
-        end
-      end
+      @cache.increment "foo", 1, expires_in: 60
+      assert @cache.redis.exists?("#{@namespace}:foo")
+      assert @cache.redis.ttl("#{@namespace}:foo") > 0
 
       # key and ttl exist
       @cache.redis.setex "#{@namespace}:bar", 120, 1
-      assert_not_called @cache.redis, :expire do
-        @cache.increment "bar", 1, expires_in: 2.minutes
-      end
+      @cache.increment "bar", 1, expires_in: 60
+      assert @cache.redis.ttl("#{@namespace}:bar") > 60
 
       # key exist but not have expire
       @cache.redis.set "#{@namespace}:dar", 10
-      assert_called_with @cache.redis, :expire, [ "#{@namespace}:dar", 60 ] do
-        @cache.increment "dar", 1, expires_in: 60
-      end
+      @cache.increment "dar", 1, expires_in: 60
+      assert @cache.redis.ttl("#{@namespace}:dar") > 0
     end
 
     def test_decrement_expires_in
-      assert_called_with @cache.redis, :decrby, [ "#{@namespace}:foo", 1 ] do
-        assert_called_with @cache.redis, :expire, [ "#{@namespace}:foo", 60 ] do
-          @cache.decrement "foo", 1, expires_in: 60
-        end
-      end
+      @cache.decrement "foo", 1, expires_in: 60
+      assert @cache.redis.exists?("#{@namespace}:foo")
+      assert @cache.redis.ttl("#{@namespace}:foo") > 0
 
       # key and ttl exist
       @cache.redis.setex "#{@namespace}:bar", 120, 1
-      assert_not_called @cache.redis, :expire do
-        @cache.decrement "bar", 1, expires_in: 2.minutes
-      end
+      @cache.decrement "bar", 1, expires_in: 60
+      assert @cache.redis.ttl("#{@namespace}:bar") > 60
 
       # key exist but not have expire
       @cache.redis.set "#{@namespace}:dar", 10
-      assert_called_with @cache.redis, :expire, [ "#{@namespace}:dar", 60 ] do
-        @cache.decrement "dar", 1, expires_in: 60
-      end
+      @cache.decrement "dar", 1, expires_in: 60
+      assert @cache.redis.ttl("#{@namespace}:dar") > 0
     end
 
     def test_large_string_with_default_compression_settings


### PR DESCRIPTION
Before this PR, when incrementing/decrementing a counter with `:expires_in` option, we will make 3 requests to Redis.

`increment`/`decrement`, for example, is very heavily used by `rack-attack` - https://github.com/rack/rack-attack/blob/95ce9fdd7c99a527a46ffc477b01e682fed48dce/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb#L13-L25 (that implementation currently also makes redundant calls and works around unsupported `expires_in` in older versions; the implementation should just use the native implementation from rails in the future). Increment can be called several times per request (for each throttling rule).

With this PR, we will make only 1 pipelined request, if possible.

cc @byroot 