### PR TITLE
Store previous verbose setting before it can fail in tests.

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -252,10 +252,10 @@ module ActiveRecord
       end
 
       def migrate(version = nil)
-        check_target_version
-
         scope = ENV["SCOPE"]
         verbose_was, Migration.verbose = Migration.verbose, verbose?
+
+        check_target_version
 
         Base.connection.migration_context.migrate(target_version) do |migration|
           if version.blank?


### PR DESCRIPTION
- thanks to hoisting it can be wrongly set to nil instead of previous value since `check_target_version` can raise (and that is tested in `database_tasks_test` leaking wrong value for `verbose` setting)

reproducible by running 

```bash
SEED=25051 bundle exec ruby -Itest:lib -e "require 'cases/tasks/database_tasks_test'; require 'cases/migration/say_test'"
```

in https://github.com/rails/rails/pull/45705 branch

---

:information_source: As a followup I can introduce block based setup to temporarily change `Migration.verbose` since it is used often in tests. Feel free to ping me if that's welcomed. Similar helper could be handy for temporarily changing `$stdout`.