### PR TITLE
Set collation for postgresql test DBs.

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -239,8 +239,8 @@ namespace :db do
     desc "Build the PostgreSQL test databases"
     task :build do
       config = ARTest.config["connections"]["postgresql"]
-      %x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} )
-      %x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} )
+      %x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} --lc-collate en_US.UTF-8 )
+      %x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} --lc-collate en_US.UTF-8 )
     end
 
     desc "Drop the PostgreSQL test databases"


### PR DESCRIPTION
I was facing test failures related to different order than expected since I have `lc_collate` set to `cs_CZ.UTF-8`.

I propose to set `lc_collate` on test DB creation to `en_US.UTF-8`. Similar strategy is used also for MySQL at https://github.com/rails/rails/blob/a01d6f8b087c9c97d740237af37b3857e5e25723/activerecord/Rakefile#L223-L224.

## example failure (fixed by this PR)

```bash
Using postgresql                                                                                                                                                                   [2260/7680]
Run options: --seed 10882                                                                                                                                                                     
                                                                                                                                                                                              
# Running:                                                                                                                                                                                    
                                                                                                                                                                                              
.................................F                                                                                                                                                            
                                                                                                                                                                                              
Failure:                                                                                                                                                                                      
CalculationsTest#test_pluck_loaded_relation_sql_fragment [test/cases/calculations_test.rb:1081]:                                                                                              
--- expected                                                                                                                                                                                  
+++ actual                                                                                                                                                                                    
@@ -1 +1 @@                                                                                                                                                                                   
-["37signals", "Apex", "Ex Nihilo"]                                                                                                                                                           
+["Apex", "Ex Nihilo", "Ex Nihilo Part Deux"]                                                                                                                                                 
                                                                                                                                                                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
rails test test/cases/calculations_test.rb:1078                                                                                                                                               
                                                                                                                                                                                              
......................................................................................................S..F                                                                                    
                                                                                                                                                                                              
Failure:                                                                                                                                                                                      
CalculationsTest#test_pick_loaded_relation_sql_fragment [test/cases/calculations_test.rb:1138]:                                                                                               
Expected: "37signals"                                                                                                                                                                         
  Actual: "Apex"                                                                                                                                                                              
                                                                                                                                                                                              
                                                                                                                                                                                              
rails test test/cases/calculations_test.rb:1135                                                                                                                                               
                                                                                                                                                                                              
....................................................                                                                                                                                          
                                                                                                                                                                                              
Finished in 1.409349s, 136.2331 runs/s, 366.1265 assertions/s.                                                                                                                                
192 runs, 516 assertions, 2 failures, 0 errors, 1 skips   
```