### PR TITLE
Consistently format commands in help messages

### DIFF
--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -3,6 +3,8 @@
 require "thor"
 require "erb"
 
+require "active_support/core_ext/class/attribute"
+require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/string/inflections"
 
@@ -33,6 +35,8 @@ module Rails
       end
 
       include Actions
+
+      class_attribute :bin, instance_accessor: false, default: "bin/rails"
 
       class << self
         def exit_on_failure? # :nodoc:
@@ -91,8 +95,8 @@ module Rails
           namespaced_commands
         end
 
-        def executable
-          "rails #{command_name}"
+        def executable(subcommand = nil)
+          "#{bin} #{command_name}#{":" if subcommand}#{subcommand}"
         end
 
         # Use Rails' default banner.
@@ -170,6 +174,10 @@ module Rails
               end
             end
           end
+      end
+
+      no_commands do
+        delegate :executable, to: :class
       end
 
       def help

--- a/railties/lib/rails/commands/application/application_command.rb
+++ b/railties/lib/rails/commands/application/application_command.rb
@@ -18,6 +18,8 @@ module Rails
     class ApplicationCommand < Base # :nodoc:
       hide_command!
 
+      self.bin = "rails"
+
       def help
         perform # Punt help output to the generator.
       end

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -14,7 +14,7 @@ that just contains the secret_key_base used by MessageVerifiers/MessageEncryptor
 signing and encrypting cookies.
 
 For applications created prior to Rails 5.2, we'll automatically generate a new
-credentials file in `config/credentials.yml.enc` the first time you run `bin/rails credentials:edit`.
+credentials file in `config/credentials.yml.enc` the first time you run `<%= executable(:edit) %>`.
 If you didn't have a master key saved in `config/master.key`, that'll be created too.
 
 Don't lose this master key! Put it in a password manager your team can access.
@@ -32,20 +32,20 @@ You could prepend that to your server's start command like this:
 
 === Set up Git to Diff Credentials
 
-Rails provides `bin/rails credentials:diff --enroll` to instruct Git to call
-`bin/rails credentials:diff` when `git diff` is run on a credentials file.
+Rails provides `<%= executable(:diff) %> --enroll` to instruct Git to call
+`<%= executable(:diff) %>` when `git diff` is run on a credentials file.
 
 Running the command enrolls the project such that all credentials files use the
 "rails_credentials" diff driver in .gitattributes.
 
 Additionally since Git requires the driver itself to be set up in a config file
 that isn't tracked Rails automatically ensures it's configured when running
-`credentials:edit`.
+`<%= executable(:edit) %>`.
 
 Otherwise each co-worker would have to run enable manually, including on each new
 repo clone.
 
-To disenroll from this feature, run `bin/rails credentials:diff --disenroll`.
+To disenroll from this feature, run `<%= executable(:diff) %> --disenroll`.
 
 === Editing Credentials
 
@@ -62,7 +62,7 @@ The `credentials` command supports passing an `--environment` option to create a
 environment specific override. That override will take precedence over the
 global `config/credentials.yml.enc` file when running in that environment. So:
 
-   bin/rails credentials:edit --environment development
+   <%= executable(:edit) %> --environment development
 
 will create `config/credentials/development.yml.enc` with the corresponding
 encryption key in `config/credentials/development.key` if the credentials file

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -30,7 +30,7 @@ module Rails
         require_application!
         load_generators
 
-        ensure_editor_available(command: "bin/rails credentials:edit") || (return)
+        ensure_editor_available(command: executable(:edit)) || (return)
 
         ensure_encryption_key_has_been_added
         ensure_credentials_have_been_added
@@ -114,9 +114,9 @@ module Rails
 
         def missing_credentials_message
           if !credentials.key?
-            "Missing '#{key_path}' to decrypt credentials. See `bin/rails credentials:help`"
+            "Missing '#{key_path}' to decrypt credentials. See `#{executable(:help)}`"
           else
-            "File '#{content_path}' does not exist. Use `bin/rails credentials:edit` to change that."
+            "File '#{content_path}' does not exist. Use `#{executable(:edit)}` to change that."
           end
         end
 

--- a/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
@@ -13,7 +13,7 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
       gitattributes.write(GITATTRIBUTES_ENTRY, mode: "a")
 
       say "Enrolled project in credentials file diffing!"
-      say "Rails ensures the rails_credentials diff driver is set when running `credentials:edit`. See `credentials:help` for more."
+      say "Rails ensures the rails_credentials diff driver is set when running `#{executable(:edit)}`. See `#{executable(:help)}` for more."
     end
   end
 
@@ -42,7 +42,7 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
     end
 
     def configure_diffing_driver
-      system "git config diff.rails_credentials.textconv 'bin/rails credentials:diff'"
+      system "git config diff.rails_credentials.textconv '#{executable(:diff)}'"
     end
 
     def gitattributes

--- a/railties/lib/rails/commands/dev/dev_command.rb
+++ b/railties/lib/rails/commands/dev/dev_command.rb
@@ -7,7 +7,7 @@ module Rails
     class DevCommand < Base # :nodoc:
       no_commands do
         def help
-          say "rails dev:cache # Toggle development mode caching on/off."
+          say "#{executable(:cache)} # Toggle development mode caching on/off."
         end
       end
 

--- a/railties/lib/rails/commands/encrypted/USAGE
+++ b/railties/lib/rails/commands/encrypted/USAGE
@@ -8,7 +8,7 @@ See the `Rails.application.encrypted` documentation for using them in your app.
 By default, Rails looks for the encryption key in `config/master.key` or
 `ENV["RAILS_MASTER_KEY"]`, but that lookup can be overridden with `--key`:
 
-   rails encrypted:edit config/encrypted_file.yml.enc --key config/encrypted_file.key
+   <%= executable(:edit) %> config/encrypted_file.yml.enc --key config/encrypted_file.key
 
 Don't commit the key! Add it to your source control's ignore file. If you use
 Git, Rails handles this for you.
@@ -17,7 +17,7 @@ Git, Rails handles this for you.
 
 To edit or create an encrypted file use:
 
-   rails encrypted:edit config/encrypted_file.yml.enc
+   <%= executable(:edit) %> config/encrypted_file.yml.enc
 
 This opens a temporary file in `$EDITOR` with the decrypted contents for editing.
 
@@ -25,4 +25,4 @@ This opens a temporary file in `$EDITOR` with the decrypted contents for editing
 
 To print the decrypted contents of an encrypted file use:
 
-   rails encrypted:show config/encrypted_file.yml.enc
+   <%= executable(:show) %> config/encrypted_file.yml.enc

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -23,7 +23,7 @@ module Rails
       def edit(*)
         require_application!
 
-        ensure_editor_available(command: "bin/rails encrypted:edit") || (return)
+        ensure_editor_available(command: executable(:edit)) || (return)
         ensure_encryption_key_has_been_added
         ensure_encrypted_configuration_has_been_added
 
@@ -96,9 +96,9 @@ module Rails
 
         def missing_encrypted_configuration_message
           if !encrypted_configuration.key?
-            "Missing '#{key_path}' to decrypt data. See `bin/rails encrypted:help`"
+            "Missing '#{key_path}' to decrypt data. See `#{executable(:help)}`"
           else
-            "File '#{content_path}' does not exist. Use `bin/rails encrypted:edit #{content_path}` to change that."
+            "File '#{content_path}' does not exist. Use `#{executable(:edit)} #{content_path}` to change that."
           end
         end
     end

--- a/railties/lib/rails/commands/new/new_command.rb
+++ b/railties/lib/rails/commands/new/new_command.rb
@@ -3,6 +3,8 @@
 module Rails
   module Command
     class NewCommand < Base # :nodoc:
+      self.bin = "rails"
+
       no_commands do
         def help
           Rails::Command.invoke :application, [ "--help" ]

--- a/railties/lib/rails/commands/plugin/plugin_command.rb
+++ b/railties/lib/rails/commands/plugin/plugin_command.rb
@@ -5,6 +5,8 @@ module Rails
     class PluginCommand < Base # :nodoc:
       hide_command!
 
+      self.bin = "rails"
+
       def help
         run_plugin_generator %w( --help )
       end

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -52,7 +52,7 @@ module Rails
             end
           rescue SyntaxError, NameError => e
             error "Please specify a valid ruby command or the path of a script to run."
-            error "Run '#{self.class.executable} -h' for help."
+            error "Run '#{executable} -h' for help."
             error ""
             error e
             exit 1

--- a/railties/lib/rails/commands/secrets/USAGE
+++ b/railties/lib/rails/commands/secrets/USAGE
@@ -2,7 +2,7 @@
 
 Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
 Please use the Rails `credentials` commands instead.
-Run `rails credentials:help` for more information.
+Run `bin/rails credentials:help` for more information.
 
 === Storing Encrypted Secrets in Source Control
 
@@ -13,7 +13,7 @@ with the code.
 
 === Setup
 
-Run `bin/rails secrets:setup` to opt in and generate the `config/secrets.yml.key`
+Run `<%= executable(:setup) %>` to opt in and generate the `config/secrets.yml.key`
 and `config/secrets.yml.enc` files.
 
 The latter contains all the keys to be encrypted while the former holds the
@@ -51,12 +51,12 @@ the key. Add this:
 
    config.read_encrypted_secrets = true
 
-to the environment you'd like to read encrypted secrets. `bin/rails secrets:setup`
+to the environment you'd like to read encrypted secrets. `<%= executable(:setup) %>`
 inserts this into the production environment by default.
 
 === Editing Secrets
 
-After `bin/rails secrets:setup`, run `bin/rails secrets:edit`.
+After `<%= executable(:setup) %>`, run `<%= executable(:edit) %>`.
 
 That command opens a temporary file in `$EDITOR` with the decrypted contents of
 `config/secrets.yml.enc` to edit the encrypted secrets.

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -22,7 +22,7 @@ module Rails
         if ENV["EDITOR"].to_s.empty?
           say "No $EDITOR to open decrypted secrets in. Assign one like this:"
           say ""
-          say %(EDITOR="mate --wait" rails secrets:edit)
+          say %(EDITOR="mate --wait" #{executable(:edit)})
           say ""
           say "For editors that fork and exit immediately, it's important to pass a wait flag,"
           say "otherwise the secrets will be saved immediately with no chance to edit."
@@ -56,7 +56,7 @@ module Rails
       private
         def deprecate_in_favor_of_credentials_and_exit
           say "Encrypted secrets is deprecated in favor of credentials. Run:"
-          say "rails credentials:help"
+          say "bin/rails credentials:help"
 
           exit 1
         end

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -228,7 +228,7 @@ module Rails
         end
 
         def restart_command
-          "bin/rails server #{@original_options.join(" ")} --restart"
+          "#{executable} #{@original_options.join(" ")} --restart"
         end
 
         def early_hints
@@ -246,7 +246,7 @@ module Rails
         end
 
         def self.banner(*)
-          "rails server -u [thin/puma/webrick] [options]"
+          "#{executable} -u [thin/puma/webrick] [options]"
         end
 
         def prepare_restart
@@ -260,7 +260,7 @@ module Rails
 
                 gem "#{RECOMMENDED_SERVER}"
 
-              Run `bin/rails server --help` for more options.
+              Run `#{executable} --help` for more options.
             MSG
           elsif server.in?(RACK_SERVERS)
             <<~MSG
@@ -268,7 +268,7 @@ module Rails
 
                 gem "#{server}"
 
-              Run `bin/rails server --help` for more options.
+              Run `#{executable} --help` for more options.
             MSG
           else
             error = CorrectableError.new("Could not find server '#{server}'.", server, RACK_SERVERS)
@@ -279,7 +279,7 @@ module Rails
             end
             <<~MSG
               #{formatted_message}
-              Run `bin/rails server --help` for more options.
+              Run `#{executable} --help` for more options.
             MSG
           end
         end
@@ -288,7 +288,7 @@ module Rails
           say <<~MSG
             => Booting #{ActiveSupport::Inflector.demodulize(server)}
             => Rails #{Rails.version} application starting in #{Rails.env} #{url}
-            => Run `bin/rails server --help` for more startup options
+            => Run `#{executable} --help` for more startup options
           MSG
         end
     end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -22,6 +22,22 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
     assert_equal [], Rails::Command::HiddenCommand.printing_commands
   end
 
+  test "::executable returns bin and command name" do
+    assert_equal "bin/rails generate", Rails::Command::GenerateCommand.executable
+  end
+
+  test "::executable integrates subcommand when given" do
+    assert_equal "bin/rails generate:help", Rails::Command::GenerateCommand.executable(:help)
+  end
+
+  test "::executable integrates ::bin" do
+    class Rails::Command::CustomBinCommand < Rails::Command::Base
+      self.bin = "FOO"
+    end
+
+    assert_equal "FOO custom_bin", Rails::Command::CustomBinCommand.executable
+  end
+
   test "ARGV is populated" do
     class Rails::Command::ArgvCommand < Rails::Command::Base
       def check_populated(*args)


### PR DESCRIPTION
This commit enhances the `Rails::Command::Base.executable` method to integrate a new `bin` class attribute and optional `subcommand` arg. So, for example, `CredentialsCommand.executable(:edit)` will now return `"bin/rails credentials:edit"`.

Additionally, this commit replaces occurrences of "bin/rails COMMAND", "rails COMMAND", and "COMMAND" in help messages with calls to `executable`, for improved consistency.
