### PR TITLE
TaggedLogging preserves formatter methods

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -83,7 +83,7 @@ module ActiveSupport
       logger = logger.clone
 
       if logger.formatter
-        logger.formatter = logger.formatter.dup
+        logger.formatter = logger.formatter.clone
       else
         # Ensure we set a default formatter so we aren't extending nil!
         logger.formatter = ActiveSupport::Logger::SimpleFormatter.new

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -238,7 +238,7 @@ class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
     assert_equal "[OMG] Broadcasting...\n", broadcast_output.string
   end
 
-  test "broadcasting when passing a block works and  keeps formatter untouched" do
+  test "broadcasting when passing a block works and keeps formatter untouched" do
     broadcast_output = StringIO.new
     broadcast_logger = ActiveSupport::TaggedLogging.new(Logger.new(broadcast_output))
     my_formatter = Class.new do
@@ -283,5 +283,19 @@ class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
 
     assert_equal "[OMG] Broadcasting...\n", @output.string
     assert_equal "Broadcasting...\n", broadcast_output.string
+  end
+
+  test "keeps formatter singleton class methods" do
+    plain_output = StringIO.new
+    plain_logger = Logger.new(plain_output)
+    plain_logger.formatter = Logger::Formatter.new
+    plain_logger.formatter.extend(Module.new {
+      def crozz_method
+      end
+    })
+
+    tagged_logger = ActiveSupport::TaggedLogging.new(plain_logger)
+    assert_respond_to tagged_logger.formatter, :tagged
+    assert_respond_to tagged_logger.formatter, :crozz_method
   end
 end


### PR DESCRIPTION
TaggedLogging preserves any methods that exist on the formatter's singleton class.

### Summary

TaggedLogging.new currently works by adding its own methods to a clone of the provided logger. Until #40759, there was a bug where TaggedLogging would lose any other singleton class methods that may have been added which would result in a return value that was missing behavior from the provided logger.

It turns out we still have this same bug, except on the formatter because `TaggedLogging.new` sets up its formatter using `#dup` instead of `#clone` which loses any singleton class methods that had been on the provided formatter.

This change preserves any methods that exist on the formatter that would otherwise be lost via `#dup`. Since TaggedLogging works by adding methods in this way, it seems we should allow other libraries to do the same without losing their behavior.