### PR TITLE
Introduce `check_constraint_exists?` and `if_exists` for `remove_check_constraint`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Introduce `check_constraint_exists?` method which checks
+    if a check constraint exists on a table.
+
+    Add support for `if_exists` option for removing a check constraint.
+
+    The `remove_check_constraint` method can take an `if_exists` option. If this is set
+    to true an error won't be raised if the check constraint doesn't exist.
+
+    *Aditya Bhutani and Margaret Parsa*
+
 *   `find_or_create_by` now try to find a second time if it hits a unicity constraint.
 
     `find_or_create_by` always has been inherently racy, either creating multiple

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -887,6 +887,15 @@ module ActiveRecord
         @base.remove_check_constraint(name, *args, **options)
       end
 
+      # Checks to see if a check constraint exists on a table.
+      #
+      #  t.remove_check_constraint(name: "price_check") unless t.check_constraint_exists?(name: "price_check")
+      #
+      # See {connection.check_constraint_exists?}[rdoc-ref:SchemaStatements#check_constraint_exists?]
+      def check_constraint_exists?(*args, **options)
+        @base.check_constraint_exists?(name, *args, **options)
+      end
+
       private
         def raise_on_if_exist_options(options)
           unrecognized_option = options.keys.find do |key|

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -103,6 +103,8 @@ module ActiveRecord
         end
 
         def remove_check_constraint(table_name, expression = nil, **options)
+          return if options[:if_exists] && !check_constraint_exists?(table_name, **options)
+
           check_constraints = check_constraints(table_name)
           chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
           check_constraints.delete_if { |chk| chk.name == chk_name_to_delete }

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -184,6 +184,20 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           assert_empty @connection.check_constraints("trades")
         end
 
+        def test_remove_check_constraint_which_does_not_exist_doesnt_raise_with_option
+          @connection.add_check_constraint :trades, "quantity > 0", name: "quantity_check"
+
+          @connection.remove_check_constraint :trades, name: "quantity_check"
+
+          assert_raises ArgumentError do
+            @connection.remove_check_constraint :trades, name: "quantity_check"
+          end
+
+          assert_nothing_raised do
+            @connection.remove_check_constraint :trades, name: "quantity_check", if_exists: true
+          end
+        end
+
         def test_remove_non_existing_check_constraint
           assert_raises(ArgumentError) do
             @connection.remove_check_constraint :trades, name: "nonexistent"
@@ -208,6 +222,13 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           end
 
           assert_equal 0, @connection.check_constraints("trades").size
+        end
+
+        def test_check_constraint_exists
+          @connection.add_check_constraint :trades, "price > 0", name: "price_check"
+
+          assert @connection.check_constraint_exists?(:trades, name: "price_check")
+          assert_not @connection.check_constraint_exists?(:trades, name: "nonexistent")
         end
       end
     end


### PR DESCRIPTION
### Summary

- This PR introduces `check_constraint_exists?` method which checks if a check constraint exists on a table.

  **Use case**: Guarantees that the constraint will exist before calling remove_constraint method in migration.

- Add support for `if_exists` option for removing an index.

  The `remove_check_constraint` method can take an `if_exists` option. If this is set to true an error won't be raised if the check constraint doesn't exist.

Fixes https://github.com/rails/rails/issues/45634

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
