### PR TITLE
Refactor ExtendedDeterministicQueries to not mutate the arguments

### DIFF
--- a/activerecord/test/cases/encryption/performance/storage_performance_test.rb
+++ b/activerecord/test/cases/encryption/performance/storage_performance_test.rb
@@ -35,7 +35,7 @@ class ActiveRecord::Encryption::StoragePerformanceTest < ActiveRecord::Encryptio
     with_envelope_encryption do
       assert_storage_performance size: 2, overload_less_than: 126
       assert_storage_performance size: 50, overload_less_than: 6.28
-      assert_storage_performance size: 255, overload_less_than: 2.2
+      assert_storage_performance size: 255, overload_less_than: 2.3
       assert_storage_performance size: 1.kilobyte, overload_less_than: 1.3
 
       [500.kilobytes, 1.megabyte, 10.megabyte].each do |size|


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/41659

Mutating the attributes hash requires to workaround the mutation in `find_or_create_by` etc.

One extra Hash dup is not big deal.

As discussed in https://github.com/rails/rails/pull/45720

cc @matthewd @jorgemanrubia 