### PR TITLE
Support distributed preloading calls

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -293,6 +293,8 @@ module ActiveRecord
       JoinDependency.eager_load!
     end
 
+    attr_accessor :preloading_bucket # :nodoc:
+
     # Returns the association instance for the given name, instantiating it if it doesn't already exist
     def association(name) # :nodoc:
       association = association_instance_get(name)

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -933,6 +933,7 @@ module ActiveRecord
       # Returns a <tt>Relation</tt> object for the records in this association
       def scope
         @scope ||= @association.scope
+        @scope.with_records!(loaded? ? records : nil)
       end
 
       # Equivalent to <tt>Array#==</tt>. Returns +true+ if the two arrays

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -48,6 +48,7 @@ module ActiveRecord
         autoload :Association,        "active_record/associations/preloader/association"
         autoload :Batch,              "active_record/associations/preloader/batch"
         autoload :Branch,             "active_record/associations/preloader/branch"
+        autoload :Bucketing,          "active_record/associations/preloader/bucketing"
         autoload :ThroughAssociation, "active_record/associations/preloader/through_association"
       end
 

--- a/activerecord/lib/active_record/associations/preloader/bucketing.rb
+++ b/activerecord/lib/active_record/associations/preloader/bucketing.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Associations
+    class Preloader
+      module Bucketing # :nodoc:
+        private
+          def build_bucket(source_records, association_name)
+            source_records.map { |record| WeakRef.new(record.association(association_name)) }
+          end
+
+          def link_records_to_bucket(target_records, bucket)
+            target_records.each { |record| record.preloading_bucket = bucket }
+          end
+
+          def gather_records_from_linked_buckets(source_records)
+            source_records.map(&:preloading_bucket).uniq.flat_map do |bucket|
+              bucket&.flat_map do |association|
+                association.target if association.weakref_alive?
+              end
+            end.compact.concat(source_records)
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -843,6 +843,11 @@ module ActiveRecord
     end
 
     protected
+      def with_records!(records)
+        @records = records
+        self
+      end
+
       def load_records(records)
         @records = records.freeze
         @loaded = true
@@ -917,20 +922,24 @@ module ActiveRecord
 
       def exec_queries(&block)
         skip_query_cache_if_necessary do
-          rows = if scheduled?
-            future = @future_result
-            @future_result = nil
-            future.result
+          if @records
+            records = @records.dup.freeze
           else
-            exec_main_query
+            rows = if scheduled?
+              future = @future_result
+              @future_result = nil
+              future.result
+            else
+              exec_main_query
+            end
+
+            records = instantiate_records(rows, &block)
+
+            records.each(&:readonly!) if readonly_value
+            records.each { |record| record.strict_loading!(strict_loading_value) } unless strict_loading_value.nil?
           end
 
-          records = instantiate_records(rows, &block)
           preload_associations(records) unless skip_preloading_value
-
-          records.each(&:readonly!) if readonly_value
-          records.each { |record| record.strict_loading!(strict_loading_value) } unless strict_loading_value.nil?
-
           records
         end
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -195,7 +195,7 @@ module ActiveRecord
     # other additional posts.
     def includes(*args)
       check_if_method_has_arguments!(__callee__, args)
-      spawn.includes!(*args)
+      spawn.with_records!(eager_loading? ? nil : @records).includes!(*args)
     end
 
     def includes!(*args) # :nodoc:
@@ -225,7 +225,7 @@ module ActiveRecord
     #   # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" IN (1, 2, 3)
     def preload(*args)
       check_if_method_has_arguments!(__callee__, args)
-      spawn.preload!(*args)
+      spawn.with_records!(@records).preload!(*args)
     end
 
     def preload!(*args) # :nodoc:

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1675,6 +1675,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  test "post-hoc preloading uses already-loaded owner records" do
+    posts = Author.first.posts.load
+
+    assert_queries(1) do
+      posts.includes(:comments).each { |post| post.comments.to_a }
+    end
+  end
+
   private
     def find_all_ordered(klass, include = nil)
       klass.order("#{klass.table_name}.#{klass.primary_key}").includes(include).to_a

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1683,6 +1683,19 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  test "post-hoc preloading loads records for entire preloading bucket" do
+    5.times { Author.create!(name: "A").posts.create!(title: "X", body: "Y") }
+    authors = Author.all
+
+    assert_queries(3) do
+      authors.includes(:posts).each do |author|
+        author.posts.includes(:comments).each do |post|
+          post.comments.to_a
+        end
+      end
+    end
+  end
+
   private
     def find_all_ordered(klass, include = nil)
       klass.order("#{klass.table_name}.#{klass.primary_key}").includes(include).to_a

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -662,6 +662,14 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  test "post-hoc preloading uses already-loaded owner records" do
+    posts = Post.all.load
+
+    assert_queries(1) do
+      posts.includes(:comments).each { |post| post.comments.to_a }
+    end
+  end
+
   def test_default_scoping_finder_methods
     developers = DeveloperCalledDavid.order("id").map(&:id).sort
     assert_equal Developer.where(name: "David").map(&:id).sort, developers


### PR DESCRIPTION
This PR is split into two commits.

The 1st commit allows records from already-loaded relations to be used when performing post-hoc preloads of downstream associations.

The 2nd commit modifies the `Preloader` to track preloaded associations in buckets, and, when preloading a downstream association, to preload that association for all owner records from the same bucket.

The goal of this PR is to allow individual `includes` and `preload` calls to be placed alongside the code that depends on them.  This makes it easier to add a preload when needed or remove a preload when it is no longer needed.

Consider the following code:

```ruby
def render_posts(posts)
  posts.includes(:comments).each do |post|
    post.comments.each do |comment|
      # ...
    end
  end
end

def render_authors(authors)
  authors.includes(:posts).each do |author|
    render_posts(author.posts)
  end
end

render_authors(Author.all)
```

Before the 1st commit, with N authors each having at least 1 post, the code would execute 2N + 2 queries.  For example, with 5 authors:

```
SELECT "authors".* FROM "authors"
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" IN (?, ?, ?, ?, ?)  [["author_id", 1], ["author_id", 2], ["author_id", 3], ["author_id", 4], ["author_id", 5]]
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 1]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 11]]
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 2]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 12]]
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 3]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 13]]
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 4]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 14]]
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" = ?  [["author_id", 5]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 15]]
```

After the 1st commit, the code executes N + 2 queries:

```
SELECT "authors".* FROM "authors"
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" IN (?, ?, ?, ?, ?)  [["author_id", 1], ["author_id", 2], ["author_id", 3], ["author_id", 4], ["author_id", 5]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 11]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 12]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 13]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 14]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 15]]
```

After the 2nd commit, the code executes 3 queries:

```
SELECT "authors".* FROM "authors"
SELECT "posts".* FROM "posts" WHERE "posts"."author_id" IN (?, ?, ?, ?, ?)  [["author_id", 1], ["author_id", 2], ["author_id", 3], ["author_id", 4], ["author_id", 5]]
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" IN (?, ?, ?, ?, ?)  [["post_id", 11], ["post_id", 12], ["post_id", 13], ["post_id", 14], ["post_id", 15]]
```

Related: #45161, #45413, #45231.  The primary difference of this PR is that users must still opt in to preloading via `includes` or `preload`.  The intent is to allow fine-grained control over when preloading happens, but to make cascading automatic.
