### PR TITLE
Allow users to attempt to remove check constraints that may or may not exist via the "if_exists" option.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -887,6 +887,17 @@ module ActiveRecord
         @base.remove_check_constraint(name, *args, **options)
       end
 
+      # Checks to see if a constraint exists.
+      #
+      #  unless t.check_constraint_exists?(name: "price_check")
+      #    t.check_constraint("price > 0", name: "price_check")
+      #  end
+      #
+      # See {connection.check_constraint_exists?}[rdoc-ref:SchemaStatements#check_constraint_exists?]
+      def check_constraint_exists?(*args, **options)
+        @base.check_constraint_exists?(name, *args, **options)
+      end
+
       private
         def raise_on_if_exist_options(options)
           unrecognized_option = options.keys.find do |key|

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1237,6 +1237,14 @@ module ActiveRecord
       def remove_check_constraint(table_name, expression = nil, **options)
         return unless supports_check_constraints?
 
+        unless check_constraint_exists?(table_name, expression: expression, **options)
+          if options[:if_exists]
+            return
+          else
+            raise(ArgumentError, "Table '#{table_name}' has no check constraint for #{expression || options}")
+          end
+        end
+
         chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
 
         at = create_alter_table(table_name)
@@ -1619,6 +1627,10 @@ module ActiveRecord
 
             "chk_rails_#{hashed_identifier}"
           end
+        end
+
+        def check_constraint_exists?(table_name, **options)
+          !check_constraint_for(table_name, **options).nil?
         end
 
         def check_constraint_for(table_name, **options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -103,6 +103,14 @@ module ActiveRecord
         end
 
         def remove_check_constraint(table_name, expression = nil, **options)
+          unless check_constraint_exists?(table_name, expression: expression, **options)
+            if options[:if_exists]
+              return
+            else
+              raise(ArgumentError, "Table '#{table_name}' has no check constraint for #{expression || options}")
+            end
+          end
+
           check_constraints = check_constraints(table_name)
           chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
           check_constraints.delete_if { |chk| chk.name == chk_name_to_delete }

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -190,6 +190,10 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           end
         end
 
+        def test_remove_non_existing_check_constraint_with_if_exists
+          @connection.remove_check_constraint :trades, name: "nonexistent", if_exists: true
+        end
+
         def test_add_constraint_from_change_table_with_options
           @connection.change_table :trades do |t|
             t.check_constraint "price > 0", name: "price_check"


### PR DESCRIPTION


### Summary

This is an improvement based upon a suggestion I made in:
https://github.com/rails/rails/issues/45634

Leverage the if_exists option within the remove_check_constraint method by adding a check_contraint_exists? method. This will allow users a path to removing constraints that may or may not exists. (Before, an error would be raised if the constraint didn't exist.)

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
