### PR TITLE
Fix `Cache::NullStore` with local caching for repeated reads

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -132,7 +132,7 @@ module ActiveSupport
 
             local_entries = local_cache.read_multi_entries(keys)
             local_entries.transform_values! do |payload|
-              deserialize_entry(payload).value
+              deserialize_entry(payload)&.value
             end
             missed_keys = keys - local_entries.keys
 

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -61,4 +61,14 @@ class NullStoreTest < ActiveSupport::TestCase
     end
     assert_nil @cache.read("name")
   end
+
+  def test_local_store_repeated_reads
+    @cache.with_local_cache do
+      @cache.read("foo")
+      assert_nil @cache.read("foo")
+
+      @cache.read_multi("foo", "bar")
+      assert_equal({ "foo" => nil, "bar" => nil }, @cache.read_multi("foo", "bar"))
+    end
+  end
 end


### PR DESCRIPTION
Fixes #45690, check it for the details.

It is reproducible by configuring null cache store and calling the same read operation (like `Rails.cache.read_multi("foo", "bar")`) multiple times. After the first call, the local cache will include all the keys with nils. In the second, we retrieve this nils and trying to call `.value` on it.

So I think, in the original issue one thread called read once, and another thread - again, so hence the error.

cc @CodingAnarchy @byroot 