### PR TITLE
Accept empty list of attributes for `insert_all`, `insert_all!` and `upsert_all`

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -63,9 +63,9 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_should_handle_empty_arrays
-    assert_raise ArgumentError do
-      Book.insert_all! []
-    end
+    assert_empty Book.insert_all([])
+    assert_empty Book.insert_all!([])
+    assert_empty Book.upsert_all([])
   end
 
   def test_insert_all_raises_on_duplicate_records


### PR DESCRIPTION
Fixes #45710.

Originally, I wanted to update `InsertAll` class (instead of changing 3 methods) to handle empty arrays, but that special handling become kinda ugly and more complex than needed. I think, it is better and simpler to just handle that case in each of the 3 methods. 

cc @byroot