### PR TITLE
Fix flaky tests for RedisCacheStore

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -131,9 +131,9 @@ module CacheStoreBehavior
   end
 
   def test_read_multi_with_empty_keys_and_a_logger_and_no_namespace
-    @cache.options[:namespace] = nil
-    @cache.logger = ActiveSupport::Logger.new(nil)
-    assert_equal({}, @cache.read_multi)
+    cache = lookup_store(namespace: nil)
+    cache.logger = ActiveSupport::Logger.new(nil)
+    assert_equal({}, cache.read_multi)
   end
 
   def test_fetch_multi


### PR DESCRIPTION
Rails uses several processes to run tests for `RedisCacheStore` via `bin/test test/cache/store/redis_cache_store_test.rb`.
When they run serially (with `PARALLEL_WORKERS=1`) - everything works as expected, but in parallel - I almost always saw failing tests. 

With this changes I ran tests 100 times and saw no errors.

cc @byroot  