### PR TITLE
fix/Error if of is non-numeric in in_batches methods

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -207,6 +207,7 @@ module ActiveRecord
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil)
+      raise ArgumentError, ":of should not be nil" if of.nil?
       relation = self
 
       unless [:asc, :desc].include?(order)
@@ -222,8 +223,6 @@ module ActiveRecord
       end
 
       batch_limit = of
-      raise ArgumentError, "batch_limit cannot be passed as nil" if batch_limit.nil?
-
       if limit_value
         remaining   = limit_value
         batch_limit = remaining if remaining < batch_limit

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -222,6 +222,8 @@ module ActiveRecord
       end
 
       batch_limit = of
+      raise ArgumentError, "batch_limit cannot be passed as nil" if batch_limit.nil?
+
       if limit_value
         remaining   = limit_value
         batch_limit = remaining if remaining < batch_limit

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -161,7 +161,7 @@ module ActiveRecord
     #   Person.in_batches.each_record(&:party_all_night!)
     #
     # ==== Options
-    # * <tt>:of</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:of</tt> - Specifies the size of the batch(should be a numeric). Defaults to 1000.
     # * <tt>:load</tt> - Specifies if the relation should be loaded. Defaults to false.
     # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
     # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
@@ -207,9 +207,11 @@ module ActiveRecord
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil)
-      raise ArgumentError, ":of should not be nil" if of.nil?
       relation = self
 
+      unless of.is_a?(Numeric)
+        raise ArgumentError, ":of must be a number, got #{of.inspect}"
+      end
       unless [:asc, :desc].include?(order)
         raise ArgumentError, ":order must be :asc or :desc, got #{order.inspect}"
       end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -545,9 +545,9 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  def test_in_batches_should_error_if_batch_limit_is_nil
+  def test_in_batches_should_error_if_of_is_nil
     error = assert_raise(ArgumentError) do
-      Post.in_batches(batch_size: nil) { }
+      Post.in_batches(of: nil) { }
     end
     assert_equal ":of should not be nil", error.message
   end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -545,6 +545,12 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_in_batches_should_error_if_batch_limit_is_nil
+    assert_raise(ArgumentError) do
+      Post.in_batches(batch_size: nil) { }
+    end
+  end
+
   def test_in_batches_should_not_ignore_default_scope_without_order_statements
     default_scope = SpecialPostWithDefaultScope.all
     posts = []

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -545,11 +545,13 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
-  def test_in_batches_should_error_if_of_is_nil
-    error = assert_raise(ArgumentError) do
-      Post.in_batches(of: nil) { }
+  test "test in_batches should error if of is non-numeric" do
+    [ nil, "foo", :bar, false ].each do |invalid|
+      error = assert_raise(ArgumentError) do
+        Post.in_batches(of: invalid) { }
+      end
+      assert_match(/:of must be a number/, error.message)
     end
-    assert_equal ":of should not be nil", error.message
   end
 
   def test_in_batches_should_not_ignore_default_scope_without_order_statements

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -546,9 +546,10 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_error_if_batch_limit_is_nil
-    assert_raise(ArgumentError) do
+    error = assert_raise(ArgumentError) do
       Post.in_batches(batch_size: nil) { }
     end
+    assert_equal ":of should not be nil", error.message
   end
 
   def test_in_batches_should_not_ignore_default_scope_without_order_statements


### PR DESCRIPTION
### Summary
When batch_limit is nil in in_batches method
`ArgumentError: comparison of Integer with nil failed` occurs.
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/batches.rb#L262

Fixed to generate an error when passing with nil.

as is:
```.rb
Post.in_batches(of: nil) { }
=> ArgumentError: comparison of Integer with nil failed
from /usr/local/bundle/gems/activerecord-6.0.3/lib/active_record/relation/batches.rb:240:in `<'
```

to be:
```.rb
Post.in_batches(of: nil) { }
=> ArgumentError: :of should not be nil
```