### PR TITLE
Raise when defining an enum not backed by a database column

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -121,6 +121,15 @@ module ActiveRecord
       super
     end
 
+    def load_schema! # :nodoc:
+      attributes_to_define_after_schema_loads.each do |name, (cast_type, _default)|
+        unless columns_hash.key?(name)
+          cast_type = cast_type[type_for_attribute(name)] if Proc === cast_type
+          raise "Unknown enum attribute '#{name}' for #{self.name}" if Enum::EnumType === cast_type
+        end
+      end
+    end
+
     class EnumType < Type::Value # :nodoc:
       delegate :type, to: :subtype
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -591,6 +591,8 @@ module ActiveRecord
               user_provided_default: false
             )
           end
+
+          super
         end
 
         def reload_schema_from_cache

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1006,4 +1006,18 @@ class EnumTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.logger = old_logger
   end
+
+  test "raises for columnless enums" do
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name
+        "Book"
+      end
+      enum columnless_genre: [:adventure, :comic]
+    end
+
+    error = assert_raises(RuntimeError) do
+      klass.columns # load schema
+    end
+    assert_equal "Unknown enum attribute 'columnless_genre' for Book", error.message
+  end
 end

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -112,29 +112,29 @@ module ActiveRecord
     end
 
     def test_find_by_does_not_use_statement_cache_if_table_name_is_changed
-      book = Book.create(name: "my book")
+      liquid = Liquid.create(name: "salty")
 
-      Book.find_by(name: book.name) # warming the statement cache.
+      Liquid.find_by(name: liquid.name) # warming the statement cache.
 
       # changing the table name should change the query that is not cached.
-      Book.table_name = :birds
-      assert_nil Book.find_by(name: book.name)
+      Liquid.table_name = :birds
+      assert_nil Liquid.find_by(name: liquid.name)
     ensure
-      Book.table_name = :books
+      Liquid.table_name = :liquid
     end
 
     def test_find_does_not_use_statement_cache_if_table_name_is_changed
-      book = Book.create(name: "my book")
+      liquid = Liquid.create(name: "salty")
 
-      Book.find(book.id) # warming the statement cache.
+      Liquid.find(liquid.id) # warming the statement cache.
 
       # changing the table name should change the query that is not cached.
-      Book.table_name = :birds
+      Liquid.table_name = :birds
       assert_raise ActiveRecord::RecordNotFound do
-        Book.find(book.id)
+        Liquid.find(liquid.id)
       end
     ensure
-      Book.table_name = :books
+      Liquid.table_name = :liquid
     end
 
     def test_find_association_does_not_use_statement_cache_if_table_name_is_changed


### PR DESCRIPTION
Fixes #45668. 
Look there for the details.