### PR TITLE
Add `drop_enum` command for Postgres

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `drop_enum` migration command for PostgreSQL
+
+    This does the inverse of `create_enum`. Before dropping an enum, ensure you have
+    dropped columns that depend on it.
+
+    *Alex Ghiculescu*
+
 *   Adds support for `if_exists` option when removing a check constraint.
 
     The `remove_check_constraint` method now accepts an `if_exists` option. If set

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -535,6 +535,10 @@ module ActiveRecord
       def create_enum(*) # :nodoc:
       end
 
+      # This is meant to be implemented by the adapters that support custom enum types
+      def drop_enum(*) # :nodoc:
+      end
+
       def advisory_locks_enabled? # :nodoc:
         supports_advisory_locks? && @advisory_locks_enabled
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -486,6 +486,17 @@ module ActiveRecord
         exec_query(query)
       end
 
+      # Drops an enum type.
+      # If the `if_exists: true` option is provided, the enum is only dropped if it exists.
+      # Otherwise, if the enum doesn't exist, an error is raised.
+      def drop_enum(name, *args)
+        options = args.extract_options!
+        query = <<~SQL
+          DROP TYPE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(name)};
+        SQL
+        exec_query(query)
+      end
+
       # Returns the configured supported identifier length supported by PostgreSQL
       def max_identifier_length
         @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -45,7 +45,8 @@ module ActiveRecord
         :add_foreign_key, :remove_foreign_key,
         :change_column_comment, :change_table_comment,
         :add_check_constraint, :remove_check_constraint,
-        :add_exclusion_constraint, :remove_exclusion_constraint
+        :add_exclusion_constraint, :remove_exclusion_constraint,
+        :create_enum, :drop_enum
       ]
       include JoinTable
 
@@ -144,7 +145,8 @@ module ActiveRecord
               add_foreign_key:   :remove_foreign_key,
               add_check_constraint: :remove_check_constraint,
               add_exclusion_constraint: :remove_exclusion_constraint,
-              enable_extension:  :disable_extension
+              enable_extension:  :disable_extension,
+              create_enum:       :drop_enum
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1

--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -20,6 +20,15 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  class CreateEnumMigration < SilentMigration
+    def change
+      create_enum :color, ["blue", "green"]
+      create_table :enums do |t|
+        t.enum :best_color, enum_type: "color", default: "blue", null: false
+      end
+    end
+  end
+
   self.use_transactional_tests = false
 
   setup do
@@ -28,6 +37,7 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
 
   teardown do
     @connection.drop_table "settings", if_exists: true
+    @connection.drop_table "enums", if_exists: true
   end
 
   def test_migrate_revert_add_index_with_expression
@@ -42,5 +52,17 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     assert_not @connection.table_exists?(:settings)
     assert_not @connection.index_exists?(:settings, nil, name: "index_settings_data_foo"),
                "index index_settings_data_foo should not exist"
+  end
+
+  def test_revert_create_enum
+    CreateEnumMigration.new.migrate(:up)
+
+    assert @connection.column_exists?(:enums, :best_color, sql_type: "color", default: "blue", null: false)
+    assert_equal [["color", "blue,green"]], @connection.enum_types
+
+    CreateEnumMigration.new.migrate(:down)
+
+    assert_not @connection.table_exists?(:enums)
+    assert_equal [], @connection.enum_types
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -396,12 +396,12 @@ module ActiveRecord
       end
 
       def test_reload_type_map_for_newly_defined_types
-        @connection.execute "CREATE TYPE feeling AS ENUM ('good', 'bad')"
+        @connection.create_enum "feeling", ["good", "bad"]
         result = @connection.select_all "SELECT 'good'::feeling"
         assert_instance_of(PostgreSQLAdapter::OID::Enum,
                            result.column_types["feeling"])
       ensure
-        @connection.execute "DROP TYPE IF EXISTS feeling"
+        @connection.drop_enum "feeling", if_exists: true
         reset_connection
       end
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -261,14 +261,12 @@ def up
   end
 end
 
-# There's no built in support for dropping enums, but you can do it manually.
-# You should first drop any table that depends on them.
+# The above migration is reversible (using #change), but you can
+# also define a #down method:
 def down
   drop_table :articles
 
-  execute <<-SQL
-    DROP TYPE article_status;
-  SQL
+  drop_enum :article_status
 end
 ```
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/41469

This PR adds support for `drop_enum`, so you can drop enum types explicitly or through a `db:migrate:down`.