### PR TITLE
Remove remnants from `Editor` command helper module

### DIFF
--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -178,6 +178,14 @@ module Rails
 
       no_commands do
         delegate :executable, to: :class
+        attr_reader :current_subcommand
+
+        def invoke_command(command, *) # :nodoc:
+          original_subcommand, @current_subcommand = @current_subcommand, command.name
+          super
+        ensure
+          @current_subcommand = original_subcommand
+        end
       end
 
       def help

--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -8,17 +8,15 @@ module Rails
     module Helpers
       module Editor
         private
-          def ensure_editor_available(command:)
+          def display_hint_if_system_editor_not_specified
             if ENV["EDITOR"].to_s.empty?
               say "No $EDITOR to open file in. Assign one like this:"
               say ""
-              say %(EDITOR="mate --wait" #{command})
+              say %(EDITOR="mate --wait" #{executable(current_subcommand)})
               say ""
-              say "For editors that fork and exit immediately, it's important to pass a wait flag,"
-              say "otherwise the credentials will be saved immediately with no chance to edit."
+              say "For editors that fork and exit immediately, it's important to pass a wait flag;"
+              say "otherwise, the file will be saved immediately with no chance to edit."
 
-              false
-            else
               true
             end
           end
@@ -27,12 +25,10 @@ module Rails
             system(*Shellwords.split(ENV["EDITOR"]), file_path.to_s)
           end
 
-          def catch_editing_exceptions
-            yield
+          def using_system_editor
+            display_hint_if_system_editor_not_specified || yield
           rescue Interrupt
             say "Aborted changing file: nothing saved."
-          rescue ActiveSupport::EncryptedFile::MissingKeyError => error
-            say error.message
           end
       end
     end

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -23,7 +23,6 @@ module Rails
       def edit(*)
         require_application!
 
-        ensure_editor_available(command: executable(:edit)) || (return)
         ensure_encryption_key_has_been_added
         ensure_encrypted_configuration_has_been_added
 
@@ -60,11 +59,13 @@ module Rails
         end
 
         def change_encrypted_configuration_in_system_editor
-          catch_editing_exceptions do
+          using_system_editor do
             encrypted_configuration.change { |tmp_path| system_editor(tmp_path) }
             say "File encrypted and saved."
             warn_if_encrypted_configuration_is_invalid
           end
+        rescue ActiveSupport::EncryptedFile::MissingKeyError => error
+          say error.message
         rescue ActiveSupport::MessageEncryptor::InvalidMessage
           say "Couldn't decrypt #{content_path}. Perhaps you passed the wrong key?"
         end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -38,6 +38,25 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
     assert_equal "FOO custom_bin", Rails::Command::CustomBinCommand.executable
   end
 
+  test "#current_subcommand reflects current subcommand" do
+    class Rails::Command::LastSubcommandCommand < Rails::Command::Base
+      singleton_class.attr_accessor :last_subcommand
+
+      def set_last_subcommand
+        self.class.last_subcommand = current_subcommand
+      end
+
+      alias :foo :set_last_subcommand
+      alias :bar :set_last_subcommand
+    end
+
+    Rails::Command.invoke("last_subcommand:foo")
+    assert_equal "foo", Rails::Command::LastSubcommandCommand.last_subcommand
+
+    Rails::Command.invoke("last_subcommand:bar")
+    assert_equal "bar", Rails::Command::LastSubcommandCommand.last_subcommand
+  end
+
   test "ARGV is populated" do
     class Rails::Command::ArgvCommand < Rails::Command::Base
       def check_populated(*args)

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -12,7 +12,7 @@ class Rails::Command::SecretsCommandTest < ActiveSupport::TestCase
   teardown :teardown_app
 
   test "edit without editor gives hint" do
-    assert_match "No $EDITOR to open decrypted secrets in", run_edit_command(editor: "")
+    assert_match "No $EDITOR to open file in", run_edit_command(editor: "")
   end
 
   test "encrypted secrets are deprecated when using credentials" do


### PR DESCRIPTION
The `Editor` command helper module was originally extracted from `CredentialsCommand`, and still includes a help message mentioning "credentials" and a `rescue` that is specific to encrypted files.

This commit removes those remnants, fully generalizing the `Editor` module.  Additionally, this commit changes `SecretsCommand` to make use of the `Editor` module.
