### PR TITLE
Add ability to handle reconnects with the `connected()` callback

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -197,6 +197,9 @@
     isActive() {
       return this.isState("open", "connecting");
     }
+    reconnectAttempted() {
+      return this.monitor.reconnectAttempts > 0;
+    }
     isProtocolSupported() {
       return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
     }
@@ -248,7 +251,9 @@
 
        case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier);
-        return this.subscriptions.notify(identifier, "connected");
+        return this.subscriptions.notify(identifier, "connected", {
+          reconnected: this.reconnectAttempted()
+        });
 
        case message_types.rejection:
         return this.subscriptions.reject(identifier);

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -123,7 +123,8 @@ var INTERNAL = {
   disconnect_reasons: {
     unauthorized: "unauthorized",
     invalid_request: "invalid_request",
-    server_restart: "server_restart"
+    server_restart: "server_restart",
+    remote: "remote"
   },
   default_mount_path: "/cable",
   protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
@@ -202,6 +203,9 @@ class Connection {
   isActive() {
     return this.isState("open", "connecting");
   }
+  reconnectAttempted() {
+    return this.monitor.reconnectAttempts > 0;
+  }
   isProtocolSupported() {
     return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
   }
@@ -255,7 +259,9 @@ Connection.prototype.events = {
 
      case message_types.confirmation:
       this.subscriptions.confirmSubscription(identifier);
-      return this.subscriptions.notify(identifier, "connected");
+      return this.subscriptions.notify(identifier, "connected", {
+        reconnected: this.reconnectAttempted()
+      });
 
      case message_types.rejection:
       return this.subscriptions.reject(identifier);

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -121,7 +121,8 @@
     disconnect_reasons: {
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
-      server_restart: "server_restart"
+      server_restart: "server_restart",
+      remote: "remote"
     },
     default_mount_path: "/cable",
     protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
@@ -196,6 +197,9 @@
     isActive() {
       return this.isState("open", "connecting");
     }
+    reconnectAttempted() {
+      return this.monitor.reconnectAttempts > 0;
+    }
     isProtocolSupported() {
       return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
     }
@@ -247,7 +251,9 @@
 
        case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier);
-        return this.subscriptions.notify(identifier, "connected");
+        return this.subscriptions.notify(identifier, "connected", {
+          reconnected: this.reconnectAttempted()
+        });
 
        case message_types.rejection:
         return this.subscriptions.reject(identifier);

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -81,6 +81,10 @@ class Connection {
     return this.isState("open", "connecting")
   }
 
+  reconnectAttempted() {
+    return this.monitor.reconnectAttempts > 0
+  }
+
   // Private
 
   isProtocolSupported() {
@@ -134,7 +138,7 @@ Connection.prototype.events = {
         return this.monitor.recordPing()
       case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier)
-        return this.subscriptions.notify(identifier, "connected")
+        return this.subscriptions.notify(identifier, "connected", {reconnected: this.reconnectAttempted()})
       case message_types.rejection:
         return this.subscriptions.reject(identifier)
       default:

--- a/actioncable/test/javascript/src/test_helpers/consumer_test_helper.js
+++ b/actioncable/test/javascript/src/test_helpers/consumer_test_helper.js
@@ -17,6 +17,8 @@ export default function(name, options, callback) {
     ActionCable.adapters.WebSocket = MockWebSocket
     const server = new MockServer(options.url)
     const consumer = ActionCable.createConsumer(options.url)
+    const connection = consumer.connection
+    const monitor = connection.monitor
 
     server.on("connection", function() {
       const clients = server.clients()
@@ -43,7 +45,7 @@ export default function(name, options, callback) {
       doneAsync()
     }
 
-    const testData = {assert, consumer, server, done}
+    const testData = {assert, consumer, connection, monitor, server, done}
 
     if (options.connect === false) {
       callback(testData)

--- a/actioncable/test/javascript/src/unit/subscription_test.js
+++ b/actioncable/test/javascript/src/unit/subscription_test.js
@@ -23,6 +23,20 @@ module("ActionCable.Subscription", () => {
     server.broadcastTo(subscription, {message_type: "confirmation"})
   })
 
+  consumerTest("#connected callback (handling reconnects)", ({server, consumer, connection, monitor, assert, done}) => {
+    const subscription = consumer.subscriptions.create("chat", {
+      connected({reconnected}) {
+        assert.ok(true, reconnected)
+        done()
+      }
+    })
+
+    monitor.reconnectAttempts = 1
+    assert.ok(connection.reconnectAttempted())
+    server.broadcastTo(subscription, {message_type: "welcome"})
+    server.broadcastTo(subscription, {message_type: "confirmation"})
+  })
+
   consumerTest("#disconnected callback", ({server, consumer, assert, done}) => {
     const subscription = consumer.subscriptions.create("chat", {
       disconnected() {


### PR DESCRIPTION
### Summary

The purpose is to allow subscribers to handle reconnects with the `connected()` callback:
```js
import consumer from "./consumer"

consumer.subscriptions.create("ExampleChannel", {
  connected({reconnected}) {
    if (reconnected) {
      ...
    } else {
      ...
    }
  }
})
```
That's useful if a subscriber misses some messages when the connection is lost.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
