### PR TITLE
update ContentAttachment so that it works with "content" attributes

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update ContentAttachment so that it can encapsulate arbitrary HTML content in a document.
+
+    *Jamis Buck*
+
 *   Fix an issue that caused the content layout to render multiple times when a
     rich_text field was updated.
 

--- a/actiontext/app/views/action_text/attachables/_content_attachment.html.erb
+++ b/actiontext/app/views/action_text/attachables/_content_attachment.html.erb
@@ -1,0 +1,3 @@
+<figure class="attachment attachment--content">
+  <%= content_attachment.attachable %>
+</figure>

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -6,33 +6,35 @@ module ActionText
       include ActiveModel::Model
 
       def self.from_node(node)
-        if node["content-type"]
-          if matches = node["content-type"].match(/vnd\.rubyonrails\.(.+)\.html/)
-            attachment = new(name: matches[1])
-            attachment if attachment.valid?
-          end
-        end
+        attachment = new(content_type: node["content-type"], content: node["content"])
+        attachment if attachment.valid?
       end
 
-      attr_accessor :name
-      validates_inclusion_of :name, in: %w( horizontal-rule )
+      attr_accessor :content_type, :content
+
+      validates_format_of :content_type, with: /html/
+      validates_presence_of :content
 
       def attachable_plain_text_representation(caption)
-        case name
-        when "horizontal-rule"
-          " ┄ "
-        else
-          " "
-        end
+        content_instance.fragment.source
+      end
+
+      def to_html
+        @to_html ||= content_instance.render
+      end
+
+      def to_s
+        to_html
       end
 
       def to_partial_path
         "action_text/attachables/content_attachment"
       end
 
-      def to_trix_content_attachment_partial_path
-        "action_text/attachables/content_attachments/#{name.underscore}"
-      end
+      private
+        def content_instance
+          @content_instance ||= ActionText::Content.new(content)
+        end
     end
   end
 end

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -20,7 +20,7 @@ module ActionText
       end
 
       def to_html
-        @to_html ||= content_instance.render
+        @to_html ||= content_instance.render(content_instance)
       end
 
       def to_s

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -2,7 +2,7 @@
 
 module ActionText
   module Attachables
-    class ContentAttachment
+    class ContentAttachment # :nodoc:
       include ActiveModel::Model
 
       def self.from_node(node)

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -8,7 +8,7 @@ module ActionText
 
     mattr_accessor :tag_name, default: "action-text-attachment"
 
-    ATTRIBUTES = %w( sgid content-type url href filename filesize width height previewable presentation caption )
+    ATTRIBUTES = %w( sgid content-type url href filename filesize width height previewable presentation caption content )
 
     class << self
       def fragment_by_canonicalizing_attachments(content)

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -56,7 +56,7 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
   end
 
   test "converts HTML content attachment" do
-    attachment = attachment_from_html(%Q(<action-text-attachment content-type="text/html" content="abc"></action-text-attachment>))
+    attachment = attachment_from_html('<action-text-attachment content-type="text/html" content="abc"></action-text-attachment>')
     attachable = attachment.attachable
 
     assert_kind_of ActionText::Attachables::ContentAttachment, attachable

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -55,6 +55,20 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal "[racecar.jpg]", ActionText::Attachment.from_attachable(attachable).to_plain_text
   end
 
+  test "converts HTML content attachment" do
+    attachment = attachment_from_html(%Q(<action-text-attachment content-type="text/html" content="abc"></action-text-attachment>))
+    attachable = attachment.attachable
+
+    assert_kind_of ActionText::Attachables::ContentAttachment, attachable
+    assert_equal "text/html", attachable.content_type
+    assert_equal "abc", attachable.content
+
+    trix_attachment = attachment.to_trix_attachment
+    assert_kind_of ActionText::TrixAttachment, trix_attachment
+    assert_equal "text/html", trix_attachment.attributes["contentType"]
+    assert_equal "abc", trix_attachment.attributes["content"]
+  end
+
   test "defaults trix partial to model partial" do
     attachable = Page.create! title: "Homepage"
     assert_equal "pages/page", attachable.to_trix_content_attachment_partial_path

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -69,6 +69,16 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal "abc", trix_attachment.attributes["content"]
   end
 
+  test "renders content attachment" do
+    html = '<action-text-attachment content-type="text/html" content="&lt;p&gt;abc&lt;/p&gt;"></action-text-attachment>'
+    attachment = attachment_from_html(html)
+    attachable = attachment.attachable
+
+    ActionText::Content.with_renderer MessagesController.renderer do
+      assert_equal "<p>abc</p>", attachable.to_html.strip
+    end
+  end
+
   test "defaults trix partial to model partial" do
     attachable = Page.create! title: "Homepage"
     assert_equal "pages/page", attachable.to_trix_content_attachment_partial_path


### PR DESCRIPTION
### Summary

The existing `ContentAttachment` model is a fossil from when Action Text was first extracted from Basecamp. It is unused, and effectively broken (since the partials it references were apparently never ported from Basecamp with it). The model has no corresponding unit tests, and the file in general has not been touched almost since it was extracted from Basecamp.

However, the model has seen significant evolution in 37signals' HEY email app, where it became more versatile and useful. Instead of being restricted to simply representing a horizontal rule, it can represent arbitrary encapsulated content via a new `content` attribute. When the `ContentAttachment` is rendered, the `content` attribute is expanded as the body of the element.

This makes it possible for an application to embed markup in a document that would otherwise be undesirable or expensive to process. For example, an incoming email may quote a complicated bit of DOM, and while you don't want to have to process and rewrite it, you also don't want
to discard it; the `content` attribute of `ContentAttachment` allows you to make that work.

### Other Information

This change is intentionally not backward-compatible with the previous `ContentAttachment` implementation. However, I believe that the previous implementation was broken, and unused, and so I don't think there will be any user-facing visibility to this change.
