### PR TITLE
Support schemas in Postgresql `enum_types`

### DIFF
--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -12,11 +12,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def standard_dump
-    @@standard_dump ||= perform_schema_dump
-  end
-
-  def perform_schema_dump
-    dump_all_table_schema []
+    @@standard_dump ||= dump_all_table_schema
   end
 
   def test_dump_schema_information_with_empty_versions
@@ -354,13 +350,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
       connection = ActiveRecord::Base.connection
 
       connection.stub(:extensions, ["hstore"]) do
-        output = perform_schema_dump
+        output = dump_all_table_schema
         assert_match "# These are extensions that must be enabled", output
         assert_match %r{enable_extension "hstore"}, output
       end
 
       connection.stub(:extensions, []) do
-        output = perform_schema_dump
+        output = dump_all_table_schema
         assert_no_match "# These are extensions that must be enabled", output
         assert_no_match %r{enable_extension}, output
       end
@@ -370,13 +366,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
       connection = ActiveRecord::Base.connection
 
       connection.stub(:extensions, ["hstore", "uuid-ossp", "xml2"]) do
-        output = perform_schema_dump
+        output = dump_all_table_schema
         enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
         assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
       end
 
       connection.stub(:extensions, ["uuid-ossp", "xml2", "hstore"]) do
-        output = perform_schema_dump
+        output = dump_all_table_schema
         enabled_extensions = output.scan(%r{enable_extension "(.+)"}).flatten
         assert_equal ["hstore", "uuid-ossp", "xml2"], enabled_extensions
       end
@@ -427,7 +423,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
           }
         )
 
-        output = perform_schema_dump
+        output = dump_all_table_schema
         assert_no_match(/^\s+add_foreign_key "fk_test_has_fk"[^\n]+\n\s+add_foreign_key "lessons_students"/, output)
       ensure
         ActiveRecord::Base.establish_connection(:arunit)
@@ -461,7 +457,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     migration = CreateDogMigration.new
     migration.migrate(:up)
 
-    output = perform_schema_dump
+    output = dump_all_table_schema
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
@@ -486,7 +482,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     migration = CreateDogMigration.new
     migration.migrate(:up)
 
-    output = perform_schema_dump
+    output = dump_all_table_schema
     assert_no_match %r{create_table "foo\$.+\$bar"}, output
     assert_no_match %r{add_index "foo\$.+\$bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
@@ -554,7 +550,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "this_should_remain_datetime"')
       assert output.include?('t.datetime "this_is_an_alias_of_datetime"')
       assert output.include?('t.datetime "without_time_zone"')
@@ -583,7 +579,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         end
         migration.migrate(:up)
 
-        output = perform_schema_dump
+        output = dump_all_table_schema
         assert output.include?('t.datetime "this_should_remain_datetime"')
         assert output.include?('t.datetime "this_is_an_alias_of_datetime"')
         assert output.include?('t.timestamp "without_time_zone"')
@@ -611,7 +607,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "this_should_remain_datetime"')
       assert output.include?('t.datetime "this_is_an_alias_of_datetime"')
       assert output.include?('t.datetime "this_is_also_an_alias_of_datetime"')
@@ -638,7 +634,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         end
         migration.migrate(:up)
 
-        output = perform_schema_dump
+        output = dump_all_table_schema
         # Normally we'd write `t.datetime` here. But because you've changed the `datetime_type`
         # to something else, `t.datetime` now means `:timestamptz`. To ensure that old columns
         # are still created as a `:timestamp` we need to change what is written to the schema dump.
@@ -672,7 +668,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "default_format"')
       assert output.include?('t.datetime "without_time_zone"')
       assert output.include?('t.timestamptz "with_time_zone"')
@@ -680,7 +676,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       datetime_type_was = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type
       ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type = :timestamptz
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.timestamp "default_format"')
       assert output.include?('t.timestamp "without_time_zone"')
       assert output.include?('t.datetime "with_time_zone"')
@@ -708,7 +704,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "default_format"')
       assert output.include?('t.datetime "without_time_zone"')
       assert output.include?('t.datetime "also_without_time_zone"')
@@ -736,7 +732,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "default_format"')
       assert output.include?('t.datetime "without_time_zone"')
       assert output.include?('t.datetime "also_without_time_zone"')
@@ -763,7 +759,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       end
       migration.migrate(:up)
 
-      output = perform_schema_dump
+      output = dump_all_table_schema
       assert output.include?('t.datetime "default_format"')
       assert output.include?('t.datetime "without_time_zone"')
       assert output.include?('t.datetime "also_without_time_zone"')
@@ -789,7 +785,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         end
         migration.migrate(:up)
 
-        output = perform_schema_dump
+        output = dump_all_table_schema
         # Normally we'd write `t.datetime` here. But because you've changed the `datetime_type`
         # to something else, `t.datetime` now means `:timestamptz`. To ensure that old columns
         # are still created as a `:timestamp` we need to change what is written to the schema dump.
@@ -822,7 +818,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         end
         migration.migrate(:up)
 
-        output = perform_schema_dump
+        output = dump_all_table_schema
         # Normally we'd write `t.datetime` here. But because you've changed the `datetime_type`
         # to something else, `t.datetime` now means `:timestamptz`. To ensure that old columns
         # are still created as a `:timestamp` we need to change what is written to the schema dump.

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -11,7 +11,7 @@ module SchemaDumpingHelper
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
   end
 
-  def dump_all_table_schema(ignore_tables)
+  def dump_all_table_schema(ignore_tables = [])
     old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, ignore_tables
     stream = StringIO.new
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/44896 and https://github.com/rails/rails/pull/45707, which added support for schemas in `create_enum`. This adds the same support to `enum_types`, which is what the schema (as in `schema.rb`) dumper uses.

cc @philip-maina @fatkodima @yahonda 