### PR TITLE
Allow upgrade to rack 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ end
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 11.1"
 
+gem "rack", "~> 3.0", git: "https://github.com/rack/rack.git"
+
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.26"

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0", ">= 2.2.0"
+  s.add_dependency "rack",      ">= 2.2.0"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"


### PR DESCRIPTION
Should we add Rack 3 to the text matrix? It's not released yet but will be soon, in the mean time you can get it from `git: "https://github.com/rack/rack"`.