### PR TITLE
Refactor form_for tests to stop re-assigning @output_buffer

### DIFF
--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -156,36 +156,36 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def test_form_with_with_block_in_erb
-    output_buffer = render_erb("<%= form_with(url: 'http://www.example.com') do %>Hello world!<% end %>")
+    @rendered = render_erb("<%= form_with(url: 'http://www.example.com') do %>Hello world!<% end %>")
 
     expected = whole_form { "Hello world!" }
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_block_and_method_in_erb
-    output_buffer = render_erb("<%= form_with(url: 'http://www.example.com', method: :put) do %>Hello world!<% end %>")
+    @rendered = render_erb("<%= form_with(url: 'http://www.example.com', method: :put) do %>Hello world!<% end %>")
 
     expected = whole_form("http://www.example.com", method: "put") do
       "Hello world!"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_block_in_erb_and_local_true
-    output_buffer = render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
+    @rendered = render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
 
     expected = whole_form("http://www.example.com", local: true) do
       "Hello world!"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 end
 
 class FormWithActsLikeFormForTest < FormWithTest
   def form_with(*, **)
-    @output_buffer = super
+    @rendered = super
   end
 
   teardown do
@@ -379,7 +379,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_persisted_to_model
@@ -389,7 +389,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: :patch) { "" }
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_new_record_to_model
@@ -399,7 +399,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts", method: :post) { "" }
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_button_yields_translation
@@ -411,7 +411,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<button name='button' type='submit'><span>Update Post</span></button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_not_outputting_ids
@@ -437,7 +437,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Helpers::FormHelper.form_with_generates_ids = old_value
   end
@@ -453,7 +453,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input type="text" name="title" id="title">'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_only_url_on_update
@@ -467,7 +467,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input type="text" name="title" id="title">'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_general_attributes
@@ -479,7 +479,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input type="text" name="no_model_to_back_this_badboy" id="no_model_to_back_this_badboy" >'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_false_url
@@ -487,7 +487,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form(false)
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_model_and_false_url
@@ -495,7 +495,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form(false)
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_attribute_not_on_model
@@ -507,7 +507,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input type="text" name="post[this_dont_exist_on_post]" id="post_this_dont_exist_on_post" >'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_doesnt_call_private_or_protected_properties_on_form_object_skipping_value
@@ -543,7 +543,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "</select>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_radio_buttons
@@ -561,7 +561,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_active_false'>false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_radio_buttons_with_custom_builder_block
@@ -585,7 +585,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_radio_buttons_with_custom_builder_block_does_not_leak_the_template
@@ -612,7 +612,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_index_and_with_collection_radio_buttons
@@ -631,7 +631,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_1_active_false'>false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_check_boxes
@@ -652,7 +652,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_tag_ids_3'>Tag 3</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_check_boxes_with_custom_builder_block
@@ -679,7 +679,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "Tag 3</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_collection_check_boxes_with_custom_builder_block_does_not_leak_the_template
@@ -710,7 +710,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_index_and_with_collection_check_boxes
@@ -728,7 +728,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_file_field_generate_multipart
@@ -740,7 +740,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[file]' type='file' id='post_file' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_file_field_generate_multipart
@@ -754,7 +754,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[comment][file]' type='file' id='post_comment_file'/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_format
@@ -766,7 +766,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_title'>Title</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_format_and_url
@@ -778,7 +778,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_title'>Title</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_model_using_relative_model_naming
@@ -794,7 +794,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_symbol_scope
@@ -815,7 +815,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_method_as_part_of_html_options
@@ -832,7 +832,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_method
@@ -849,7 +849,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_search_field
@@ -863,7 +863,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[title]' type='search' id='post_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_enables_remote_by_default
@@ -880,7 +880,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_is_not_remote_by_default_if_form_with_generates_remote_forms_is_false
@@ -900,7 +900,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Helpers::FormHelper.form_with_generates_remote_forms = old_value
   end
@@ -914,7 +914,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_skip_enforcing_utf8_false
@@ -926,7 +926,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_default_enforce_utf8_true
@@ -939,7 +939,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -953,7 +953,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -971,7 +971,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_index
@@ -990,7 +990,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_nil_index_option_override
@@ -1007,7 +1007,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_passes_translation_to_block_version
@@ -1023,7 +1023,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       %(<label for="post_title"><span>Title</span></label>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_passes_label_tag_builder_to_block_version
@@ -1039,7 +1039,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       %(<label for="post_title"><span>Title</span></label>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_accesses_object_through_label_tag_builder
@@ -1055,7 +1055,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       %(<label for="post_title"><span class="new_record">Title</span></label>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_error_wrapping
@@ -1071,7 +1071,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_error_wrapping_without_conventional_instance_variable
@@ -1089,7 +1089,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_label_error_wrapping_block_and_non_block_versions
@@ -1103,7 +1103,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Name</label></div>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_submit_with_object_as_new_record_and_locale_strings
@@ -1118,7 +1118,7 @@ class FormWithActsLikeFormForTest < FormWithTest
           "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post' />"
         end
 
-        assert_dom_equal expected, output_buffer
+        assert_dom_equal expected, @rendered
       end
     end
   end
@@ -1133,7 +1133,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -1147,7 +1147,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -1161,7 +1161,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -1176,7 +1176,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -1191,7 +1191,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input type="text" name="post[comment][dont_exist_on_model]" id="post_comment_dont_exist_on_model" >'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_attributes_not_on_model_deep_nested
@@ -1211,7 +1211,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="posts[post][0][comment][1][dont_exist_on_model]" type="text" id="posts_post_0_comment_1_dont_exist_on_model" >'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields
@@ -1226,7 +1226,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[comment][body]' type='text' value='Hello World' id='post_comment_body' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_deep_nested_fields
@@ -1246,7 +1246,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='posts[post][0][comment][1][name]' type='text' value='comment #1' id='posts_post_0_comment_1_name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_nested_collections
@@ -1262,7 +1262,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[123][comment][][name]' type='text' value='new comment' id='post_123_comment__name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_index_and_parent_fields
@@ -1278,11 +1278,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[1][comment][1][name]' type='text' value='new comment' id='post_1_comment_1_name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_index_and_nested_fields
-    output_buffer = form_with(model: @post, index: 1) do |f|
+    form_with(model: @post, index: 1) do |f|
       concat f.fields(:comment, model: @post) { |c|
         concat c.text_field(:title)
       }
@@ -1292,7 +1292,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[1][comment][title]' type='text' value='Hello World' id='post_1_comment_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_index_on_both
@@ -1306,7 +1306,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[1][comment][5][title]' type='text' value='Hello World' id='post_1_comment_5_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_auto_index
@@ -1320,7 +1320,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[123][comment][title]' type='text' value='Hello World' id='post_123_comment_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_index_radio_button
@@ -1334,7 +1334,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[comment][5][title]' type='radio' value='hello' id='post_comment_5_title_hello' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_auto_index_on_both
@@ -1348,29 +1348,33 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[123][comment][123][title]' type='text' value='Hello World' id='post_123_comment_123_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_index_and_auto_index
-    output_buffer = form_with(model: @post, scope: "post[]") do |f|
+    form_with(model: @post, scope: "post[]") do |f|
       concat f.fields(:comment, model: @post, index: 5) { |c|
-        concat c.text_field(:title)
-      }
-    end
-
-    output_buffer << form_with(model: @post, index: 1) do |f|
-      concat f.fields("comment[]", model: @post) { |c|
         concat c.text_field(:title)
       }
     end
 
     expected = whole_form("/posts/123", method: "patch") do
       "<input name='post[123][comment][5][title]' type='text' value='Hello World' id='post_123_comment_5_title' />"
-    end + whole_form("/posts/123", method: "patch") do
+    end
+
+    assert_dom_equal expected, @rendered
+
+    form_with(model: @post, index: 1) do |f|
+      concat f.fields("comment[]", model: @post) { |c|
+        concat c.text_field(:title)
+      }
+    end
+
+    expected = whole_form("/posts/123", method: "patch") do
       "<input name='post[1][comment][123][title]' type='text' value='Hello World' id='post_1_comment_123_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_a_new_record_on_a_nested_attributes_one_to_one_association
@@ -1388,7 +1392,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         '<input name="post[author_attributes][name]" type="text" value="new author" id="post_author_attributes_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_explicitly_passed_object_on_a_nested_attributes_one_to_one_association
@@ -1416,7 +1420,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_an_existing_record_on_a_nested_attributes_one_to_one_association_using_erb_and_inline_block
@@ -1435,7 +1439,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id
@@ -1453,7 +1457,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id_inherited
@@ -1471,7 +1475,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id_override
@@ -1490,7 +1494,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_one_to_one_association_with_explicit_hidden_field_placement
@@ -1510,7 +1514,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association
@@ -1533,7 +1537,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id
@@ -1560,7 +1564,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id_inherited
@@ -1586,7 +1590,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id_override
@@ -1613,7 +1617,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association_using_erb_and_inline_block
@@ -1636,7 +1640,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_nested_attributes_collection_association_with_explicit_hidden_field_placement
@@ -1660,7 +1664,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_new_records_on_a_nested_attributes_collection_association
@@ -1681,7 +1685,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_and_new_records_on_a_nested_attributes_collection_association
@@ -1703,7 +1707,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_an_empty_supplied_attributes_collection
@@ -1718,7 +1722,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_existing_records_on_a_supplied_nested_attributes_collection
@@ -1739,7 +1743,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_arel_like
@@ -1760,7 +1764,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_label_translation_with_more_than_10_records
@@ -1801,7 +1805,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_on_a_nested_attributes_collection_association_yields_only_builder
@@ -1823,7 +1827,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
     assert_equal yielded_comments, @post.comments
   end
 
@@ -1841,7 +1845,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_child_index_as_lambda_option_override_on_a_nested_attributes_collection_association
@@ -1858,7 +1862,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   class FakeAssociationProxy
@@ -1881,7 +1885,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_index_method_with_existing_records_on_a_nested_attributes_collection_association
@@ -1977,7 +1981,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[tags_attributes][1][id]" type="hidden" value="456" id="post_tags_attributes_1_id" autocomplete="off"/>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_with_hash_like_model
@@ -1993,11 +1997,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields
-    output_buffer = fields(:post, model: @post) do |f|
+    @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2009,11 +2013,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_index
-    output_buffer = fields("post[]", model: @post) do |f|
+    @rendered = fields("post[]", model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2025,11 +2029,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_nil_index_option_override
-    output_buffer = fields("post[]", model: @post, index: nil) do |f|
+    @rendered = fields("post[]", model: @post, index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2041,11 +2045,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_index_option_override
-    output_buffer = fields("post[]", model: @post, index: "abc") do |f|
+    @rendered = fields("post[]", model: @post, index: "abc") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2057,11 +2061,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[abc][secret]' checked='checked' type='checkbox' value='1' id='post_abc_secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_without_object
-    output_buffer = fields(:post) do |f|
+    @rendered = fields(:post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2073,11 +2077,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_only_object
-    output_buffer = fields(model: @post) do |f|
+    @rendered = fields(model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2089,39 +2093,39 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_only_object_array
-    output_buffer = fields(model: [@post, @comment]) do |f|
+    @rendered = fields(model: [@post, @comment]) do |f|
       concat f.text_field(:name)
     end
 
     expected = %(<input type="text" value="new comment" name="comment[name]" id="comment_name" />)
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_object_with_bracketed_name
-    output_buffer = fields("author[post]", model: @post) do |f|
+    @rendered = fields("author[post]", model: @post) do |f|
       concat f.label(:title)
       concat f.text_field(:title)
     end
 
     assert_dom_equal "<label for=\"author_post_title\">Title</label>" \
     "<input name='author[post][title]' type='text' value='Hello World' id='author_post_title' id='author_post_1_title' />",
-      output_buffer
+      @rendered
   end
 
   def test_fields_object_with_bracketed_name_and_index
-    output_buffer = fields("author[post]", model: @post, index: 1) do |f|
+    @rendered = fields("author[post]", model: @post, index: 1) do |f|
       concat f.label(:title)
       concat f.text_field(:title)
     end
 
     assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" \
       "<input name='author[post][1][title]' type='text' value='Hello World' id='author_post_1_title' />",
-      output_buffer
+      @rendered
   end
 
   def test_form_builder_does_not_have_form_with_method
@@ -2145,7 +2149,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='parent_post[secret]' checked='checked' type='checkbox' value='1' id='parent_post_secret' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_and_fields_with_object
@@ -2164,7 +2168,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[comment][name]' type='text' value='new comment' id='post_comment_name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_and_fields_with_non_nested_association_and_without_object
@@ -2178,7 +2182,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[category][name]' type='text' id='post_category_name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   class LabelledFormBuilder < ActionView::Helpers::FormBuilder
@@ -2205,7 +2209,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_default_form_builder
@@ -2224,7 +2228,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Base.default_form_builder = old_default_form_builder
   end
@@ -2241,7 +2245,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Base.default_form_builder = old_default_form_builder
   end
@@ -2249,29 +2253,29 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_builder_override
     self.default_form_builder = LabelledFormBuilder
 
-    output_buffer = fields(:post, model: @post) do |f|
+    @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)
     end
 
     expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_lazy_loading_form_builder_override
     self.default_form_builder = "FormWithActsLikeFormForTest::LabelledFormBuilder"
 
-    output_buffer = fields(:post, model: @post) do |f|
+    @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)
     end
 
     expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_with_labelled_builder
-    output_buffer = fields(:post, model: @post, builder: LabelledFormBuilder) do |f|
+    @rendered = fields(:post, model: @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -2282,7 +2286,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_labelled_builder_with_nested_fields_without_options_hash
@@ -2341,13 +2345,13 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, html: { id: "some_form", class: "some_class", multipart: true }) do |f| end
     expected = whole_form("/posts/123", "some_form", "some_class", method: "patch", multipart: "multipart/form-data")
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_string_url_option
     form_with(model: @post, url: "http://www.otherdomain.com") do |f| end
 
-    assert_dom_equal whole_form("http://www.otherdomain.com", method: "patch"), output_buffer
+    assert_dom_equal whole_form("http://www.otherdomain.com", method: "patch"), @rendered
   end
 
   def test_form_with_with_hash_url_option
@@ -2361,14 +2365,14 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, url: @post) do |f| end
 
     expected = whole_form("/posts/123", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_existing_object
     form_with(model: @post) do |f| end
 
     expected = whole_form("/posts/123", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_new_object
@@ -2379,7 +2383,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: post) { }
 
     expected = whole_form("/posts")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_existing_object_in_list
@@ -2387,14 +2391,14 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: [@post, @comment]) { }
 
     expected = whole_form(post_comment_path(@post, @comment), method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_new_object_in_list
     form_with(model: [@post, @comment]) { }
 
     expected = whole_form(post_comments_path(@post))
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_existing_object_and_namespace_in_list
@@ -2402,33 +2406,33 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: [:admin, @post, @comment]) { }
 
     expected = whole_form(admin_post_comment_path(@post, @comment), method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_new_object_and_namespace_in_list
     form_with(model: [:admin, @post, @comment]) { }
 
     expected = whole_form(admin_post_comments_path(@post))
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_existing_object_and_custom_url
     form_with(model: @post, url: "/super_posts") do |f| end
 
     expected = whole_form("/super_posts", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_default_method_as_patch
     form_with(model: @post) { }
     expected = whole_form("/posts/123", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_with_data_attributes
     form_with(model: @post, data: { behavior: "stuff" }) { }
-    assert_match %r|data-behavior="stuff"|, output_buffer
-    assert_match %r|data-remote="true"|, output_buffer
+    assert_match %r|data-behavior="stuff"|, @rendered
+    assert_match %r|data-remote="true"|, @rendered
   end
 
   def test_fields_returns_block_result

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -19,7 +19,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def form_for(*)
-    @output_buffer = super
+    @rendered = super
   end
 
   teardown do
@@ -254,7 +254,7 @@ class FormHelperTest < ActionView::TestCase
         '<label for="post_comments_attributes_0_body">Write body here</label>'
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -270,7 +270,7 @@ class FormHelperTest < ActionView::TestCase
         '<label for="post_tags_attributes_0_value">Tag</label>'
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -283,7 +283,7 @@ class FormHelperTest < ActionView::TestCase
       '<label for="person_name">Name</label>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_label_with_for_attribute_as_symbol
@@ -454,7 +454,7 @@ class FormHelperTest < ActionView::TestCase
         '<input id="post_comments_attributes_0_body" name="post[comments_attributes][0][body]" placeholder="Write body here" type="text" />'
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -470,7 +470,7 @@ class FormHelperTest < ActionView::TestCase
         '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" placeholder="Tag" type="text" value="new tag" />'
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -954,7 +954,7 @@ class FormHelperTest < ActionView::TestCase
         %{<textarea id="post_comments_attributes_0_body" name="post[comments_attributes][0][body]" placeholder="Write body here">\n</textarea>}
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -970,7 +970,7 @@ class FormHelperTest < ActionView::TestCase
         %{<textarea id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" placeholder="Tag">\nnew tag</textarea>}
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -1603,7 +1603,7 @@ class FormHelperTest < ActionView::TestCase
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_is_not_affected_by_form_with_generates_ids
@@ -1633,7 +1633,7 @@ class FormHelperTest < ActionView::TestCase
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Helpers::FormHelper.form_with_generates_ids = old_value
   end
@@ -1647,7 +1647,7 @@ class FormHelperTest < ActionView::TestCase
       '<button name="button" type="submit" form="new_post">Create Post</button>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_false_url
@@ -1656,7 +1656,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form(false, "new_post", "new_post")
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_false_action
@@ -1665,7 +1665,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form(false, "new_post", "new_post")
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_field_id_with_model
@@ -1693,7 +1693,7 @@ class FormHelperTest < ActionView::TestCase
       '<span id="post_title_error">is blank</span>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_id_with_index
@@ -1707,7 +1707,7 @@ class FormHelperTest < ActionView::TestCase
       '<span id="post_1_title_error">is blank</span>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_blank_as
@@ -1719,7 +1719,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="title" name="title" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_id_with_namespace
@@ -1735,7 +1735,7 @@ class FormHelperTest < ActionView::TestCase
       '<span id="special_post_title_error">is blank</span>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_blank_as_and_multiple
@@ -1747,7 +1747,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="title" name="title[]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_without_method_names_or_multiple_or_index
@@ -1759,7 +1759,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_title" name="post[title]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_without_method_names_and_multiple
@@ -1771,7 +1771,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_title" name="post[title][]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_without_method_names_and_index
@@ -1783,7 +1783,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_1_title" name="post[1][title]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_without_method_names_and_index_and_multiple
@@ -1795,7 +1795,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_1_title" name="post[1][title][]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_method_names
@@ -1807,7 +1807,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_title" name="post[title][subtitle]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_method_names_and_index
@@ -1819,7 +1819,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_1_title" name="post[1][title][subtitle]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_method_names_and_multiple
@@ -1831,7 +1831,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_title" name="post[title][subtitle][]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_name_with_method_names_and_multiple_and_index
@@ -1843,7 +1843,7 @@ class FormHelperTest < ActionView::TestCase
       %(<input id="post_1_title" name="post[1][title][subtitle][]" type="text">)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_field_id_with_namespace_and_index
@@ -1857,7 +1857,7 @@ class FormHelperTest < ActionView::TestCase
       '<span id="special_post_1_title_error">is blank</span>'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_radio_buttons
@@ -1875,7 +1875,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_active_false'>false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_radio_buttons_with_custom_builder_block
@@ -1899,7 +1899,7 @@ class FormHelperTest < ActionView::TestCase
       "false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_radio_buttons_with_custom_builder_block_does_not_leak_the_template
@@ -1926,7 +1926,7 @@ class FormHelperTest < ActionView::TestCase
       "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_namespace_and_with_collection_radio_buttons
@@ -1945,7 +1945,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='foo_post_active_false'>false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_index_and_with_collection_radio_buttons
@@ -1964,7 +1964,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_1_active_false'>false</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_check_boxes
@@ -1985,7 +1985,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_tag_ids_3'>Tag 3</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_check_boxes_with_custom_builder_block
@@ -2012,7 +2012,7 @@ class FormHelperTest < ActionView::TestCase
       "Tag 3</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_collection_check_boxes_with_custom_builder_block_does_not_leak_the_template
@@ -2043,7 +2043,7 @@ class FormHelperTest < ActionView::TestCase
       "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_namespace_and_with_collection_check_boxes
@@ -2061,7 +2061,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='foo_post_tag_ids_1'>Tag 1</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_with_index_and_with_collection_check_boxes
@@ -2079,7 +2079,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_persisted_to_model
@@ -2089,7 +2089,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: :patch) { "" }
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_new_record_to_model
@@ -2099,7 +2099,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts", "new_post", "new_post", method: :post) { "" }
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_file_field_generate_multipart
@@ -2111,7 +2111,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[file]' type='file' id='post_file' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_with_file_field_generate_multipart
@@ -2125,7 +2125,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[comment][file]' type='file' id='post_comment_file' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_format
@@ -2137,7 +2137,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_title'>Title</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_new_form_for_without_format
@@ -2149,7 +2149,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_title'>Title</label>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_model_using_relative_model_naming
@@ -2165,7 +2165,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_symbol_as
@@ -2186,7 +2186,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_tags_do_not_call_private_properties_on_form_object
@@ -2216,7 +2216,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_method
@@ -2233,7 +2233,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_search_field
@@ -2247,7 +2247,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='search' id='post_title' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_remote
@@ -2264,7 +2264,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_enforce_utf8_true
@@ -2276,7 +2276,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_enforce_utf8_false
@@ -2288,7 +2288,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_default_enforce_utf8_false
@@ -2301,7 +2301,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2315,7 +2315,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2333,7 +2333,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_remote_without_html
@@ -2352,7 +2352,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2370,7 +2370,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_index
@@ -2389,7 +2389,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_nil_index_option_override
@@ -2406,7 +2406,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_label_error_wrapping
@@ -2422,7 +2422,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_label_error_wrapping_without_conventional_instance_variable
@@ -2440,7 +2440,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_label_error_wrapping_block_and_non_block_versions
@@ -2454,7 +2454,7 @@ class FormHelperTest < ActionView::TestCase
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Name</label></div>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_namespace
@@ -2471,7 +2471,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_namespace_with_date_select
@@ -2493,7 +2493,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_namespace_and_as_option
@@ -2505,7 +2505,7 @@ class FormHelperTest < ActionView::TestCase
       "<input id='namespace_custom_name_title' name='custom_name[title]' type='text' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_two_form_for_with_namespace
@@ -2519,7 +2519,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='text' id='namespace_1_post_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected_1, output_buffer
+    assert_dom_equal expected_1, @rendered
 
     form_for(@post, namespace: "namespace_2") do |f|
       concat f.label(:title)
@@ -2531,7 +2531,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[title]' type='text' id='namespace_2_post_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected_2, output_buffer
+    assert_dom_equal expected_2, @rendered
   end
 
   def test_fields_for_with_namespace
@@ -2550,7 +2550,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[comment][body]' type='text' id='namespace_post_comment_body' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_submit_with_object_as_new_record_and_locale_strings
@@ -2565,7 +2565,7 @@ class FormHelperTest < ActionView::TestCase
           "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post' />"
         end
 
-        assert_dom_equal expected, output_buffer
+        assert_dom_equal expected, @rendered
       end
     end
   end
@@ -2580,7 +2580,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2594,7 +2594,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2608,7 +2608,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2623,7 +2623,7 @@ class FormHelperTest < ActionView::TestCase
         "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
       end
 
-      assert_dom_equal expected, output_buffer
+      assert_dom_equal expected, @rendered
     end
   end
 
@@ -2636,7 +2636,7 @@ class FormHelperTest < ActionView::TestCase
       %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update Post</button>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_method_name_and_attributes
@@ -2648,7 +2648,7 @@ class FormHelperTest < ActionView::TestCase
       %(<button type="submit" id="not_generated" name="post[not_generated]" value="true">Update Post</button>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_method_name_and_block
@@ -2660,7 +2660,7 @@ class FormHelperTest < ActionView::TestCase
       %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update secret Post</button>)
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_get_formmethod_attribute
@@ -2672,7 +2672,7 @@ class FormHelperTest < ActionView::TestCase
       "<button type='submit' formmethod='get' name='button'>GET</button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_post_formmethod_attribute
@@ -2684,7 +2684,7 @@ class FormHelperTest < ActionView::TestCase
       "<button type='submit' formmethod='post' name='button'>POST</button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_other_formmethod_attribute
@@ -2696,7 +2696,7 @@ class FormHelperTest < ActionView::TestCase
       "<button type='submit' formmethod='post' name='_method' value='delete'>Delete</button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_other_formmethod_attribute_and_name
@@ -2708,7 +2708,7 @@ class FormHelperTest < ActionView::TestCase
       "<button type='submit' formmethod='delete' name='existing'>Delete</button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_button_with_other_formmethod_attribute_and_value
@@ -2720,7 +2720,7 @@ class FormHelperTest < ActionView::TestCase
       "<button type='submit' formmethod='delete' name='button' value='existing'>Delete</button>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for
@@ -2735,7 +2735,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[comment][body]' type='text' id='post_comment_body' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_field_id
@@ -2749,7 +2749,7 @@ class FormHelperTest < ActionView::TestCase
       "post_comment_attributes_body"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_field_id_with_index_override
@@ -2763,7 +2763,7 @@ class FormHelperTest < ActionView::TestCase
       "post_comment_attributes_1_body"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_deep_nested_fields_for
@@ -2783,7 +2783,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='posts[post][0][comment][1][name]' type='text' id='posts_post_0_comment_1_name' value='comment #1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_nested_collections
@@ -2801,7 +2801,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[123][body]' type='text' id='post_123_body' value='Back to the hill and over it again!' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_index_and_parent_fields
@@ -2817,11 +2817,11 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[1][comment][1][name]' type='text' id='post_1_comment_1_name' value='new comment' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_index_and_nested_fields_for
-    output_buffer = form_for(@post, index: 1) do |f|
+    @rendered = form_for(@post, index: 1) do |f|
       concat f.fields_for(:comment, @post) { |c|
         concat c.text_field(:title)
       }
@@ -2831,7 +2831,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[1][comment][title]' type='text' id='post_1_comment_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_index_on_both
@@ -2845,7 +2845,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[1][comment][5][title]' type='text' id='post_1_comment_5_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_auto_index
@@ -2859,7 +2859,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[123][comment][title]' type='text' id='post_123_comment_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_index_radio_button
@@ -2873,7 +2873,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_auto_index_on_both
@@ -2887,29 +2887,32 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[123][comment][123][title]' type='text' id='post_123_comment_123_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_index_and_auto_index
-    output_buffer = form_for(@post, as: "post[]") do |f|
+    form_for(@post, as: "post[]") do |f|
       concat f.fields_for(:comment, @post, index: 5) { |c|
-        concat c.text_field(:title)
-      }
-    end
-
-    output_buffer << form_for(@post, as: :post, index: 1) do |f|
-      concat f.fields_for("comment[]", @post) { |c|
         concat c.text_field(:title)
       }
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
       "<input name='post[123][comment][5][title]' type='text' id='post_123_comment_5_title' value='Hello World' />"
-    end + whole_form("/posts/123", "edit_post", "edit_post", method: "patch") do
+    end
+    assert_dom_equal expected, @rendered
+
+    form_for(@post, as: :post, index: 1) do |f|
+      concat f.fields_for("comment[]", @post) { |c|
+        concat c.text_field(:title)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post", "edit_post", method: "patch") do
       "<input name='post[1][comment][123][title]' type='text' id='post_1_comment_123_title' value='Hello World' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_a_new_record_on_a_nested_attributes_one_to_one_association
@@ -2927,7 +2930,7 @@ class FormHelperTest < ActionView::TestCase
         '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="new author" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_explicitly_passed_object_on_a_nested_attributes_one_to_one_association
@@ -2955,7 +2958,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_an_existing_record_on_a_nested_attributes_one_to_one_association_using_erb_and_inline_block
@@ -2974,7 +2977,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id
@@ -2992,7 +2995,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id_inherited
@@ -3010,7 +3013,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_an_existing_record_on_a_nested_attributes_one_to_one_association_with_disabled_hidden_id_override
@@ -3029,7 +3032,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_one_to_one_association_with_explicit_hidden_field_placement
@@ -3049,7 +3052,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association
@@ -3072,7 +3075,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id
@@ -3099,7 +3102,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id_inherited
@@ -3125,7 +3128,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_with_disabled_hidden_id_override
@@ -3152,7 +3155,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_using_erb_and_inline_block
@@ -3175,7 +3178,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_nested_attributes_collection_association_with_explicit_hidden_field_placement
@@ -3199,7 +3202,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_new_records_on_a_nested_attributes_collection_association
@@ -3220,7 +3223,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_and_new_records_on_a_nested_attributes_collection_association
@@ -3242,7 +3245,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_an_empty_supplied_attributes_collection
@@ -3257,7 +3260,7 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_existing_records_on_a_supplied_nested_attributes_collection
@@ -3278,7 +3281,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_arel_like
@@ -3299,7 +3302,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_label_translation_with_more_than_10_records
@@ -3340,7 +3343,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_on_a_nested_attributes_collection_association_yields_only_builder
@@ -3362,7 +3365,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
     assert_equal yielded_comments, @post.comments
   end
 
@@ -3380,7 +3383,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_child_index_as_lambda_option_override_on_a_nested_attributes_collection_association
@@ -3397,7 +3400,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   class FakeAssociationProxy
@@ -3420,7 +3423,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_index_method_with_existing_records_on_a_nested_attributes_collection_association
@@ -3516,7 +3519,7 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_nested_fields_for_with_hash_like_model
@@ -3532,11 +3535,11 @@ class FormHelperTest < ActionView::TestCase
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for
-    output_buffer = fields_for(:post, @post) do |f|
+    @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3548,7 +3551,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_field_id
@@ -3558,7 +3561,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_fields_for_with_index
-    output_buffer = fields_for("post[]", @post) do |f|
+    @rendered = fields_for("post[]", @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3570,7 +3573,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_field_id_with_index_option
@@ -3580,7 +3583,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_fields_for_with_nil_index_option_override
-    output_buffer = fields_for("post[]", @post, index: nil) do |f|
+    @rendered = fields_for("post[]", @post, index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3592,7 +3595,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_with_index_option_override_field_id
@@ -3602,7 +3605,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_fields_for_with_index_option_override
-    output_buffer = fields_for("post[]", @post, index: "abc") do |f|
+    @rendered = fields_for("post[]", @post, index: "abc") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3614,11 +3617,11 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_without_object
-    output_buffer = fields_for(:post) do |f|
+    @rendered = fields_for(:post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3630,11 +3633,11 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_with_only_object
-    output_buffer = fields_for(@post) do |f|
+    @rendered = fields_for(@post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3646,29 +3649,29 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_object_with_bracketed_name
-    output_buffer = fields_for("author[post]", @post) do |f|
+    @rendered = fields_for("author[post]", @post) do |f|
       concat f.label(:title)
       concat f.text_field(:title)
     end
 
     assert_dom_equal "<label for=\"author_post_title\">Title</label>" \
     "<input name='author[post][title]' type='text' id='author_post_title' value='Hello World' />",
-      output_buffer
+      @rendered
   end
 
   def test_fields_for_object_with_bracketed_name_and_index
-    output_buffer = fields_for("author[post]", @post, index: 1) do |f|
+    @rendered = fields_for("author[post]", @post, index: 1) do |f|
       concat f.label(:title)
       concat f.text_field(:title)
     end
 
     assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" \
       "<input name='author[post][1][title]' type='text' id='author_post_1_title' value='Hello World' />",
-      output_buffer
+      @rendered
   end
 
   def test_form_builder_does_not_have_form_for_method
@@ -3692,7 +3695,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_and_fields_for_with_object
@@ -3711,7 +3714,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_and_fields_for_with_non_nested_association_and_without_object
@@ -3725,7 +3728,7 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[category][name]' type='text' id='post_category_name' />"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   class LabelledFormBuilder < ActionView::Helpers::FormBuilder
@@ -3751,7 +3754,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_default_form_builder
@@ -3770,7 +3773,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Base.default_form_builder = old_default_form_builder
   end
@@ -3787,7 +3790,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   ensure
     ActionView::Base.default_form_builder = old_default_form_builder
   end
@@ -3795,29 +3798,29 @@ class FormHelperTest < ActionView::TestCase
   def test_form_builder_override
     self.default_form_builder = LabelledFormBuilder
 
-    output_buffer = fields_for(:post, @post) do |f|
+    @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)
     end
 
     expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_lazy_loading_form_builder_override
     self.default_form_builder = "FormHelperTest::LabelledFormBuilder"
 
-    output_buffer = fields_for(:post, @post) do |f|
+    @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)
     end
 
     expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_fields_for_with_labelled_builder
-    output_buffer = fields_for(:post, @post, builder: LabelledFormBuilder) do |f|
+    @rendered = fields_for(:post, @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
       concat f.check_box(:secret)
@@ -3828,7 +3831,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
       "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_labelled_builder_with_nested_fields_for_without_options_hash
@@ -3887,13 +3890,13 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, html: { id: "some_form", class: "some_class", multipart: true }) do |f| end
     expected = whole_form("/posts/123", "some_form", "some_class", method: "patch", multipart: "multipart/form-data")
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_string_url_option
     form_for(@post, url: "http://www.otherdomain.com") do |f| end
 
-    assert_dom_equal whole_form("http://www.otherdomain.com", "edit_post_123", "edit_post", method: "patch"), output_buffer
+    assert_dom_equal whole_form("http://www.otherdomain.com", "edit_post_123", "edit_post", method: "patch"), @rendered
   end
 
   def test_form_for_with_hash_url_option
@@ -3907,14 +3910,14 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: @post) do |f| end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_existing_object
     form_for(@post) do |f| end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_new_object
@@ -3925,7 +3928,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(post) do |f| end
 
     expected = whole_form("/posts", "new_post", "new_post")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_existing_object_in_list
@@ -3933,14 +3936,14 @@ class FormHelperTest < ActionView::TestCase
     form_for([@post, @comment]) { }
 
     expected = whole_form(post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_new_object_in_list
     form_for([@post, @comment]) { }
 
     expected = whole_form(post_comments_path(@post), "new_comment", "new_comment")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_existing_object_and_namespace_in_list
@@ -3948,33 +3951,33 @@ class FormHelperTest < ActionView::TestCase
     form_for([:admin, @post, @comment]) { }
 
     expected = whole_form(admin_post_comment_path(@post, @comment), "edit_comment_1", "edit_comment", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_new_object_and_namespace_in_list
     form_for([:admin, @post, @comment]) { }
 
     expected = whole_form(admin_post_comments_path(@post), "new_comment", "new_comment")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_existing_object_and_custom_url
     form_for(@post, url: "/super_posts") do |f| end
 
     expected = whole_form("/super_posts", "edit_post_123", "edit_post", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_default_method_as_patch
     form_for(@post) { }
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   def test_form_for_with_data_attributes
     form_for(@post, data: { behavior: "stuff" }, remote: true) { }
-    assert_match %r|data-behavior="stuff"|, output_buffer
-    assert_match %r|data-remote="true"|, output_buffer
+    assert_match %r|data-behavior="stuff"|, @rendered
+    assert_match %r|data-remote="true"|, @rendered
   end
 
   def test_fields_for_returns_block_result


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/45731

It's really not what it's meant for. `@renderer` is a better use for this as it's the variable used by the DOM testing helpers.

Shipping this independently, as I don't like changing tests as part of feature refactors if I can avoid it.

These tests are in the way of various followup after https://github.com/rails/rails/pull/45731.

FYI: @jhawthorn, @BlakeWilliams (I'll merge on green)