### PR TITLE
Add missing Versioning header in maintenance policy guide

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -9,6 +9,9 @@ follows, all versions, except for security releases, in `X.Y.Z`, format.
 
 --------------------------------------------------------------------------------
 
+Versioning 
+------------
+
 Rails follows a shifted version of [semver](https://semver.org/):
 
 **Patch `Z`**


### PR DESCRIPTION
### Summary
 
I added a missing header in the  [maintenance policy page](https://edguides.rubyonrails.org/maintenance_policy.html) for the versioning section. 

