### PR TITLE
Refactor Action View tests to stop re-assigning @output_buffer

### DIFF
--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -24,7 +24,7 @@ module ActionView
       @raw_buffer.encode!
     end
 
-    delegate :length, :blank?, :encoding, :encode!, :force_encoding, to: :@raw_buffer
+    delegate :length, :empty?, :blank?, :encoding, :encode!, :force_encoding, to: :@raw_buffer
 
     def to_s
       @raw_buffer.html_safe

--- a/actionview/lib/action_view/context.rb
+++ b/actionview/lib/action_view/context.rb
@@ -17,7 +17,7 @@ module ActionView
     # Prepares the context by setting the appropriate instance variables.
     def _prepare_context
       @view_flow     = OutputFlow.new
-      @output_buffer = nil
+      @output_buffer = ActionView::OutputBuffer.new
       @virtual_path  = nil
     end
 

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -8,7 +8,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   tests ActionView::Helpers::FormHelper
 
   def form_for(*)
-    @output_buffer = super
+    @rendered = super
   end
 
   def setup
@@ -54,7 +54,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
           '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
-    assert_dom_equal expected, output_buffer
+    assert_dom_equal expected, @rendered
   end
 
   private

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -10,12 +10,12 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_capture_captures_the_temporary_output_buffer_in_its_block
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
     string = @av.capture do
       @av.output_buffer << "foo"
       @av.output_buffer << "bar"
     end
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
     assert_equal "foobar", string
   end
 
@@ -178,22 +178,22 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_with_output_buffer_swaps_the_output_buffer_given_no_argument
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
     buffer = @av.with_output_buffer do
       @av.output_buffer << "."
     end
     assert_equal ".", buffer.to_s
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
   end
 
   def test_with_output_buffer_swaps_the_output_buffer_with_an_argument
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
     buffer = ActionView::OutputBuffer.new(".")
     @av.with_output_buffer(buffer) do
       @av.output_buffer << "."
     end
     assert_equal "..", buffer.to_s
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
   end
 
   def test_with_output_buffer_restores_the_output_buffer
@@ -218,7 +218,7 @@ class CaptureHelperTest < ActionView::TestCase
   end
 
   def test_with_output_buffer_does_not_assume_there_is_an_output_buffer
-    assert_nil @av.output_buffer
+    assert_predicate @av.output_buffer, :empty?
     assert_equal "", @av.with_output_buffer { }.to_s
   end
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -10,11 +10,11 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   def with_collection_radio_buttons(*args, &block)
-    @output_buffer = collection_radio_buttons(*args, &block)
+    @rendered = collection_radio_buttons(*args, &block)
   end
 
   def with_collection_check_boxes(*args, &block)
-    @output_buffer = collection_check_boxes(*args, &block)
+    @rendered = collection_check_boxes(*args, &block)
   end
 
   # COLLECTION RADIO BUTTONS
@@ -197,7 +197,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection radio buttons with fields for" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    @output_buffer = fields_for(:post) do |p|
+    @rendered = fields_for(:post) do |p|
       p.collection_radio_buttons :category_id, collection, :id, :name
     end
 
@@ -397,7 +397,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     user = Struct.new(:category_ids).new(2)
     collection = (1..3).map { |i| [i, "Category #{i}"] }
 
-    @output_buffer = fields_for(:user, user) do |p|
+    @rendered = fields_for(:user, user) do |p|
       p.collection_check_boxes :category_ids, collection, :first, :last, checked: [1, 3]
     end
 
@@ -470,7 +470,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes with fields for" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    @output_buffer = fields_for(:post) do |p|
+    @rendered = fields_for(:post) do |p|
       p.collection_check_boxes :category_ids, collection, :id, :name
     end
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -21,7 +21,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   class Context < ActionView::Base
     def initialize(*)
       super
-      @output_buffer = "original"
+      @output_buffer << "original"
       @virtual_path = nil
     end
 
@@ -53,7 +53,7 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
 
     def my_buffer
-      @output_buffer
+      @output_buffer.to_s
     end
   end
 


### PR DESCRIPTION
Followup on https://github.com/rails/rails/pull/45745

`@rendered` is a much better variable for this kind of intermediate result as that's what is used by DOM assertions.

FYI: @jhawthorn, @BlakeWilliams (I'll merge on green)