### PR TITLE
Action View: use a local variable to hold the template buffer

### DIFF
--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -42,7 +42,7 @@ module ActionView
       #
       def capture(*args)
         value = nil
-        buffer = with_output_buffer { value = yield(*args) }
+        buffer = output_buffer.capture { value = yield(*args) }
 
         case string = buffer.presence || value
         when OutputBuffer
@@ -200,22 +200,6 @@ module ActionView
       #   </html>
       def content_for?(name)
         @view_flow.get(name).present?
-      end
-
-      # Use an alternate output buffer for the duration of the block.
-      # Defaults to a new empty string.
-      def with_output_buffer(buf = nil) # :nodoc:
-        unless buf
-          buf = ActionView::OutputBuffer.new
-          if output_buffer && output_buffer.respond_to?(:encoding)
-            buf.force_encoding(output_buffer.encoding)
-          end
-        end
-        self.output_buffer, old_buffer = buf, output_buffer
-        yield
-        output_buffer
-      ensure
-        self.output_buffer = old_buffer
       end
     end
   end

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -14,7 +14,7 @@ module ActionView
             # Dup properties so that we don't modify argument
             properties = Hash[properties]
 
-            properties[:bufvar]     ||= "@output_buffer"
+            properties[:bufvar]     ||= "output_buffer"
             properties[:preamble]   ||= ""
             properties[:postamble]  ||= "#{properties[:bufvar]}.to_s"
 

--- a/actionview/lib/action_view/template/handlers/html.rb
+++ b/actionview/lib/action_view/template/handlers/html.rb
@@ -4,7 +4,7 @@ module ActionView
   module Template::Handlers
     class Html < Raw
       def call(template, source)
-        "ActionView::OutputBuffer.new #{super}"
+        "output_buffer << #{super}"
       end
     end
   end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -177,51 +177,6 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "hi<p>title</p>", content_for(:title)
   end
 
-  def test_with_output_buffer_swaps_the_output_buffer_given_no_argument
-    assert_predicate @av.output_buffer, :empty?
-    buffer = @av.with_output_buffer do
-      @av.output_buffer << "."
-    end
-    assert_equal ".", buffer.to_s
-    assert_predicate @av.output_buffer, :empty?
-  end
-
-  def test_with_output_buffer_swaps_the_output_buffer_with_an_argument
-    assert_predicate @av.output_buffer, :empty?
-    buffer = ActionView::OutputBuffer.new(".")
-    @av.with_output_buffer(buffer) do
-      @av.output_buffer << "."
-    end
-    assert_equal "..", buffer.to_s
-    assert_predicate @av.output_buffer, :empty?
-  end
-
-  def test_with_output_buffer_restores_the_output_buffer
-    buffer = ActionView::OutputBuffer.new
-    @av.output_buffer = buffer
-    @av.with_output_buffer do
-      @av.output_buffer << "."
-    end
-    assert buffer.equal?(@av.output_buffer)
-  end
-
-  def test_with_output_buffer_sets_proper_encoding
-    @av.output_buffer = ActionView::OutputBuffer.new
-
-    # Ensure we set the output buffer to an encoding different than the default one.
-    alt_encoding = alt_encoding(@av.output_buffer)
-    @av.output_buffer.force_encoding(alt_encoding)
-
-    @av.with_output_buffer do
-      assert_equal alt_encoding, @av.output_buffer.encoding
-    end
-  end
-
-  def test_with_output_buffer_does_not_assume_there_is_an_output_buffer
-    assert_predicate @av.output_buffer, :empty?
-    assert_equal "", @av.with_output_buffer { }.to_s
-  end
-
   def alt_encoding(output_buffer)
     output_buffer.encoding == Encoding::US_ASCII ? Encoding::UTF_8 : Encoding::US_ASCII
   end


### PR DESCRIPTION
This isn't quite working yet, there is a case failing with Builder. I'll get back to it tomorrow but opening a draft now in case someone may have early feedback or ideas. (cc @jhawthorn, @BlakeWilliams)

The one failing test is:

```ruby
# hello_world_container.builder
xml.test do
  render partial: "hello", locals: { xm: xml }
end
```

The above test rely on `render` concatenating directly into the buffer, while in most other cases we rely on the return value of `render`. The whole thing is quite confusing and I'm not quite sure still how it even work.

But the idea is that if we no longer swap the buffer in `@output_buffer` we can now reference it using the local variable instead of the instance variable.

If we manage to make this work, it would open the door to further optimizations such as Eruby's `chain_appends`.

