### PR TITLE
Define #build_change_column_definition for MySQL and PG

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -714,6 +714,15 @@ module ActiveRecord
         raise NotImplementedError, "change_column_default is not implemented"
       end
 
+      # Builds a ChangeColumnDefaultDefinition object.
+      #
+      # This definition object contains information about the column change that would occur
+      # if the same arguments were passed to #change_column_default. See #change_column_default for
+      # information about passing a +table_name+, +column_name+, +type+ and other options that can be passed.
+      def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
+        raise NotImplementedError, "build_change_column_default_definition is not implemented"
+      end
+
       # Sets or removes a <tt>NOT NULL</tt> constraint on a column. The +null+ flag
       # indicates whether the value can be +NULL+. For example
       #
@@ -1705,11 +1714,8 @@ module ActiveRecord
         end
 
         def change_column_default_for_alter(table_name, column_name, default_or_changes)
-          column = column_for(table_name, column_name)
-          return unless column
-
-          default = extract_new_default_value(default_or_changes)
-          schema_creation.accept(ChangeColumnDefaultDefinition.new(column, default))
+          cd = build_change_column_default_definition(table_name, column_name, default_or_changes)
+          cd.ddl
         end
 
         def rename_column_sql(table_name, column_name, new_column_name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -350,6 +350,17 @@ module ActiveRecord
         execute "ALTER TABLE #{quote_table_name(table_name)} #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
       end
 
+      def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
+        column = column_for(table_name, column_name)
+        return unless column
+
+        default = extract_new_default_value(default_or_changes)
+        change_column_default_definition = ChangeColumnDefaultDefinition.new(column, default)
+        schema_creation.accept(change_column_default_definition)
+
+        change_column_default_definition
+      end
+
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
         validate_change_column_null_argument!(null)
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -428,6 +428,17 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
         end
 
+        def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
+          column = column_for(table_name, column_name)
+          return unless column
+
+          default = extract_new_default_value(default_or_changes)
+          change_column_default_definition = ChangeColumnDefaultDefinition.new(column, default)
+          schema_creation.accept(change_column_default_definition)
+
+          change_column_default_definition
+        end
+
         def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
           validate_change_column_null_argument!(null)
 

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -100,6 +100,23 @@ module ActiveRecord
         ensure
           connection.drop_table(:test) if connection.table_exists?(:test)
         end
+
+        def test_build_change_column_default_definition
+          connection.create_table(:test) do |t|
+            t.column :foo, :string
+          end
+
+          change_default_cd = connection.build_change_column_default_definition(:test, :foo, "new")
+          assert_match "SET DEFAULT 'new'", change_default_cd.ddl
+          assert_equal "new", change_default_cd.default
+
+          change_col = change_default_cd.column
+          assert_equal "foo", change_col.name.to_s
+          assert change_col.type
+          assert change_col.sql_type
+        ensure
+          connection.drop_table(:test) if connection.table_exists?(:test)
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

Define APIs on the MySQL and PostgreSQL connection adapters for building
ChangeColumnDefaultDefinition objects. These provide information on what a
column default change would look like, when called with the same arguments as
would be passed to #change_column_default.

### Other Information

As with `#change_column`, we ignore SQLite because it recreates the table from scratch when performing `change_column` operations.