### PR TITLE
Revert "Allow passing hash on secure password validations"

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,13 +1,3 @@
-*   Support passing `Hash` with keys `:if / :unless / :on` to SecurePassword.
-    This provides more flexibility when you want to trigger or skip validations on
-    specific conditions
-
-    ```ruby
-    secure_password validations: {if: :requires_password?}`
-    ```
-
-    *Kevin Jacoby*
-
 *   `has_secure_password` now supports password challenges via a
     `password_challenge` accessor and validation.
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -35,11 +35,8 @@ module ActiveModel
       # ActiveModel::Dirty; if dirty tracking methods are not defined, this
       # validation will fail.
       #
-      # The password presence validation can be conditionally enforced by
-      # passing an options hash to +:validations+ with the standard +:if+ /
-      # +:unless+ / +:on+ keys. (See ActiveModel::Validations::ClassMethods#validates
-      # for more information.) Alternatively, all of the above validations can
-      # be omitted by passing <tt>validations: false</tt>. This allows complete
+      # All of the above validations can be omitted by passing
+      # <tt>validations: false</tt> as an argument. This allows complete
       # customizability of validation behavior.
       #
       # To use +has_secure_password+, add bcrypt (~> 3.1.7) to your Gemfile:
@@ -96,13 +93,11 @@ module ActiveModel
         if validations
           include ActiveModel::Validations
 
-          validation_options = validations.is_a?(Hash) ? validations : {}
-
           # This ensures the model has a password by checking whether the password_digest
           # is present, so that this works with both new and existing records. However,
           # when there is an error, the message is added to the password attribute instead
           # so that the error message will make sense to the end-user.
-          validate(validation_options) do |record|
+          validate do |record|
             record.errors.add(attribute, :blank) unless record.public_send("#{attribute}_digest").present?
           end
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -31,16 +31,6 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_not_respond_to @visitor, :valid?
   end
 
-  test "support conditional validation" do
-    user = Struct.new(:requires_password, :password_digest) do
-      include ActiveModel::SecurePassword
-      has_secure_password validations: { if: :requires_password }
-    end
-
-    assert_predicate user.new(false), :valid?
-    assert_predicate user.new(true), :invalid?
-  end
-
   test "create a new user with validations and valid password/confirmation" do
     @user.password = "password"
     @user.password_confirmation = "password"


### PR DESCRIPTION
This reverts #45487 (8804128ad4cfea228ce97005072b029d0379d80f) until a better API can be decided upon.

---

/cc @liljack
