### PR TITLE
Factor out `validates_secure_password`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add `validates_secure_password`.
+
+    This method, in conjunction with `has_secure_password`, provides an API for
+    conditionally requiring a password.  For example:
+
+    ```ruby
+    class Account
+      include ActiveModel::SecurePassword
+
+      attr_accessor :is_guest, :password_digest
+
+      has_secure_password validations: false
+      validates_secure_password unless: :is_guest
+    end
+
+    account = Account.new
+    account.valid? # => false, password required
+
+    account.is_guest = true
+    account.valid? # => true
+    ```
+
+    *Jonathan Hefner* and *Kevin Jacoby*
+
 *   `has_secure_password` now supports password challenges via a
     `password_challenge` accessor and validation.
 

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -31,6 +31,29 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_not_respond_to @visitor, :valid?
   end
 
+  test "support presence validation options" do
+    class VisitorOrUser < Struct.new(:is_visitor, :password_digest)
+      include ActiveModel::SecurePassword
+      has_secure_password validations: false
+      validates_secure_password unless: :is_visitor
+    end
+
+    visitor = VisitorOrUser.new(true)
+    assert_predicate visitor, :valid?
+
+    visitor.password = "password"
+    assert_predicate visitor, :valid?
+
+    visitor.password_confirmation = "not password"
+    assert_predicate visitor, :invalid?
+
+    user = VisitorOrUser.new(false)
+    assert_predicate user, :invalid?
+
+    user.password = "password"
+    assert_predicate user, :valid?
+  end
+
   test "create a new user with validations and valid password/confirmation" do
     @user.password = "password"
     @user.password_confirmation = "password"


### PR DESCRIPTION
Follow-up to #45487, which was reverted by #45753.

This factors `validates_secure_password` out of `has_secure_password`, to provide an API for conditionally requiring a password.  For example:

  ```ruby
  class Account
    include ActiveModel::SecurePassword

    attr_accessor :is_guest, :password_digest

    has_secure_password validations: false
    validates_secure_password unless: :is_guest
  end

  account = Account.new
  account.valid? # => false, password required

  account.is_guest = true
  account.valid? # => true
  ```

---

/cc @liljack, @dhh
