### PR TITLE
Avoid calling to_s at end of ERB

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -154,10 +154,15 @@ module ActionView
     # This method is instrumented as "!render_template.action_view". Notice that
     # we use a bang in this instrumentation because you don't want to
     # consume this in production. This is only slow if it's being listened to.
-    def render(view, locals, buffer = ActionView::OutputBuffer.new, add_to_stack: true, &block)
+    def render(view, locals, buffer = nil, add_to_stack: true, &block)
       instrument_render_template do
         compile!(view)
-        view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, has_strict_locals: @strict_locals.present?, &block)
+        if buffer
+          view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, has_strict_locals: @strict_locals.present?, &block)
+          nil
+        else
+          view._run(method_name, self, locals, OutputBuffer.new, add_to_stack: add_to_stack, has_strict_locals: @strict_locals.present?, &block).to_s
+        end
       end
     rescue => e
       handle_render_error(view, e)

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -58,7 +58,7 @@ module ActionView
 
           if ActionView::Base.annotate_rendered_view_with_filenames && template.format == :html
             options[:preamble] = "@output_buffer.safe_append='<!-- BEGIN #{template.short_identifier} -->';"
-            options[:postamble] = "@output_buffer.safe_append='<!-- END #{template.short_identifier} -->';@output_buffer.to_s"
+            options[:postamble] = "@output_buffer.safe_append='<!-- END #{template.short_identifier} -->';@output_buffer"
           end
 
           self.class.erb_implementation.new(erb, options).src

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -16,7 +16,7 @@ module ActionView
 
             properties[:bufvar]     ||= "@output_buffer"
             properties[:preamble]   ||= ""
-            properties[:postamble]  ||= "#{properties[:bufvar]}.to_s"
+            properties[:postamble]  ||= "#{properties[:bufvar]}"
 
             # Tell Eruby that whether template will be compiled with `frozen_string_literal: true`
             properties[:freeze_template_literals] = !Template.frozen_string_literal

--- a/actionview/test/template/erb/erbubi_test.rb
+++ b/actionview/test/template/erb/erbubi_test.rb
@@ -16,6 +16,6 @@ class ErubiTest < ActiveSupport::TestCase
     baseline = ActionView::Template::Handlers::ERB::Erubi.new(template)
     erubi = ActionView::Template::Handlers::ERB::Erubi.new(template, bufvar: "boofer")
 
-    assert_equal baseline.src.gsub("#{baseline.bufvar}.", "boofer."), erubi.src
+    assert_equal baseline.src.gsub(baseline.bufvar, "boofer"), erubi.src
   end
 end


### PR DESCRIPTION
With the recent changes to OutputBuffer, calling `to_s` is extremely  expensive if the buffer later is concatenated to (if the buffer never changes it should be relatively inexpensive, as Ruby will share memory).

This tries to avoid calling `to_s` where possible, and to explicitly return nil when a buffer is passed to `template.render`

``` ruby
# frozen_string_literal: true

require 'rails'
require 'action_view'
require 'benchmark/ips'

class BenchView < ActionView::Base
  def compiled_method_container
    self.class
  end

  def self.compiled_method_container
    self
  end
end

view = BenchView.new(
  ActionView::LookupContext,
  {},
  nil,
)
locals = { message: "There aren’t any open alerts.!" }
erb_template = <<~ERB
    Hello! #{"a"*1000}
ERB
template = ActionView::Template.new(
  erb_template,
  "hello template",
  ActionView::Template::Handlers::ERB.new,
  virtual_path: "hello",
  locals: locals.keys,
)

def render_many(view, locals, template)
  buffer = ActionView::OutputBuffer.new
  1000.times do
    template.render(view, locals, buffer)
  end
end

Benchmark.ips do |x|
  x.report("render_many") { render_many(view, locals, template) }
end
```

**Before**

```
$ be ruby benchmark_output_buffer.rb
Warming up --------------------------------------
         render_many     1.000  i/100ms
Calculating -------------------------------------
         render_many     13.724  (± 7.3%) i/s -     69.000  in   5.071279s
```

**After**

```
$ be ruby benchmark_output_buffer.rb
Warming up --------------------------------------
         render_many    89.000  i/100ms
Calculating -------------------------------------
         render_many    929.182  (± 2.4%) i/s -      4.717k in   5.080056s
```