### PR TITLE
Improve failure safety for `RedisCacheStore#delete_multi`

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -388,7 +388,9 @@ module ActiveSupport
 
         # Deletes multiple entries in the cache. Returns the number of entries deleted.
         def delete_multi_entries(entries, **_options)
-          redis.then { |c| c.del(entries) }
+          failsafe :delete_multi_entries, returning: 0 do
+            redis.then { |c| c.del(entries) }
+          end
         end
 
         # Nonstandard store provider API to write multiple values at once.

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -91,6 +91,19 @@ module FailureSafetyBehavior
     end
   end
 
+  def test_delete_multi_failure_returns_zero
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write_multi(
+      key => SecureRandom.alphanumeric,
+      other_key => SecureRandom.alphanumeric
+    )
+
+    emulating_unavailability do |cache|
+      assert_equal 0, cache.delete_multi([key, other_key])
+    end
+  end
+
   def test_exist_failure_returns_false
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)


### PR DESCRIPTION
For redis cache store, running `Rails.cache.delete_multi(["foo", "bar"])`
will lead to an error when redis is down. Other existing cache store methods
already implement failure safety.