### PR TITLE
Add `:save_history` option to `stream_from`

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -116,7 +116,8 @@
       disconnect: "disconnect",
       ping: "ping",
       confirmation: "confirm_subscription",
-      rejection: "reject_subscription"
+      rejection: "reject_subscription",
+      history: "history"
     },
     disconnect_reasons: {
       unauthorized: "unauthorized",
@@ -256,9 +257,7 @@
         this.subscriptions.confirmSubscription(identifier);
         if (this.reconnectAttempted) {
           this.reconnectAttempted = false;
-          return this.subscriptions.notify(identifier, "connected", {
-            reconnected: true
-          });
+          return this.subscriptions.handleReconnect(identifier);
         } else {
           return this.subscriptions.notify(identifier, "connected", {
             reconnected: false
@@ -268,8 +267,11 @@
        case message_types.rejection:
         return this.subscriptions.reject(identifier);
 
+       case message_types.history:
+        return this.subscriptions.subscribeToHistory(identifier);
+
        default:
-        return this.subscriptions.notify(identifier, "received", message);
+        return this.subscriptions.handleReceive(identifier, message);
       }
     },
     open() {
@@ -368,6 +370,7 @@
       this.consumer = consumer;
       this.guarantor = new SubscriptionGuarantor(this);
       this.subscriptions = [];
+      this.historySubscriptions = {};
     }
     create(channelName, mixin) {
       const channel = channelName;
@@ -436,6 +439,34 @@
         command: command,
         identifier: identifier
       });
+    }
+    handleReceive(identifier, message) {
+      this.lastReceivedAt = Date.now();
+      return this.notify(identifier, "received", message);
+    }
+    handleReconnect(identifier) {
+      if (this.subscribedToHistory(identifier)) {
+        this.requestHistory(identifier);
+      }
+      return this.notify(identifier, "connected", {
+        reconnected: true
+      });
+    }
+    subscribedToHistory(identifier) {
+      return this.historySubscriptions[identifier];
+    }
+    subscribeToHistory(identifier) {
+      this.historySubscriptions[identifier] = true;
+      return this.historySubscriptions[identifier];
+    }
+    requestHistory(identifier) {
+      return this.findAll(identifier).map((subscription => {
+        this.consumer.send({
+          command: "history",
+          identifier: subscription.identifier,
+          since: this.lastReceivedAt
+        });
+      }));
     }
   }
   class Consumer {

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -118,7 +118,8 @@ var INTERNAL = {
     disconnect: "disconnect",
     ping: "ping",
     confirmation: "confirm_subscription",
-    rejection: "reject_subscription"
+    rejection: "reject_subscription",
+    history: "history"
   },
   disconnect_reasons: {
     unauthorized: "unauthorized",
@@ -264,9 +265,7 @@ Connection.prototype.events = {
       this.subscriptions.confirmSubscription(identifier);
       if (this.reconnectAttempted) {
         this.reconnectAttempted = false;
-        return this.subscriptions.notify(identifier, "connected", {
-          reconnected: true
-        });
+        return this.subscriptions.handleReconnect(identifier);
       } else {
         return this.subscriptions.notify(identifier, "connected", {
           reconnected: false
@@ -276,8 +275,11 @@ Connection.prototype.events = {
      case message_types.rejection:
       return this.subscriptions.reject(identifier);
 
+     case message_types.history:
+      return this.subscriptions.subscribeToHistory(identifier);
+
      default:
-      return this.subscriptions.notify(identifier, "received", message);
+      return this.subscriptions.handleReceive(identifier, message);
     }
   },
   open() {
@@ -380,6 +382,7 @@ class Subscriptions {
     this.consumer = consumer;
     this.guarantor = new SubscriptionGuarantor(this);
     this.subscriptions = [];
+    this.historySubscriptions = {};
   }
   create(channelName, mixin) {
     const channel = channelName;
@@ -448,6 +451,34 @@ class Subscriptions {
       command: command,
       identifier: identifier
     });
+  }
+  handleReceive(identifier, message) {
+    this.lastReceivedAt = Date.now();
+    return this.notify(identifier, "received", message);
+  }
+  handleReconnect(identifier) {
+    if (this.subscribedToHistory(identifier)) {
+      this.requestHistory(identifier);
+    }
+    return this.notify(identifier, "connected", {
+      reconnected: true
+    });
+  }
+  subscribedToHistory(identifier) {
+    return this.historySubscriptions[identifier];
+  }
+  subscribeToHistory(identifier) {
+    this.historySubscriptions[identifier] = true;
+    return this.historySubscriptions[identifier];
+  }
+  requestHistory(identifier) {
+    return this.findAll(identifier).map((subscription => {
+      this.consumer.send({
+        command: "history",
+        identifier: subscription.identifier,
+        since: this.lastReceivedAt
+      });
+    }));
   }
 }
 

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -116,7 +116,8 @@
       disconnect: "disconnect",
       ping: "ping",
       confirmation: "confirm_subscription",
-      rejection: "reject_subscription"
+      rejection: "reject_subscription",
+      history: "history"
     },
     disconnect_reasons: {
       unauthorized: "unauthorized",
@@ -256,9 +257,7 @@
         this.subscriptions.confirmSubscription(identifier);
         if (this.reconnectAttempted) {
           this.reconnectAttempted = false;
-          return this.subscriptions.notify(identifier, "connected", {
-            reconnected: true
-          });
+          return this.subscriptions.handleReconnect(identifier);
         } else {
           return this.subscriptions.notify(identifier, "connected", {
             reconnected: false
@@ -268,8 +267,11 @@
        case message_types.rejection:
         return this.subscriptions.reject(identifier);
 
+       case message_types.history:
+        return this.subscriptions.subscribeToHistory(identifier);
+
        default:
-        return this.subscriptions.notify(identifier, "received", message);
+        return this.subscriptions.handleReceive(identifier, message);
       }
     },
     open() {
@@ -368,6 +370,7 @@
       this.consumer = consumer;
       this.guarantor = new SubscriptionGuarantor(this);
       this.subscriptions = [];
+      this.historySubscriptions = {};
     }
     create(channelName, mixin) {
       const channel = channelName;
@@ -436,6 +439,34 @@
         command: command,
         identifier: identifier
       });
+    }
+    handleReceive(identifier, message) {
+      this.lastReceivedAt = Date.now();
+      return this.notify(identifier, "received", message);
+    }
+    handleReconnect(identifier) {
+      if (this.subscribedToHistory(identifier)) {
+        this.requestHistory(identifier);
+      }
+      return this.notify(identifier, "connected", {
+        reconnected: true
+      });
+    }
+    subscribedToHistory(identifier) {
+      return this.historySubscriptions[identifier];
+    }
+    subscribeToHistory(identifier) {
+      this.historySubscriptions[identifier] = true;
+      return this.historySubscriptions[identifier];
+    }
+    requestHistory(identifier) {
+      return this.findAll(identifier).map((subscription => {
+        this.consumer.send({
+          command: "history",
+          identifier: subscription.identifier,
+          since: this.lastReceivedAt
+        });
+      }));
     }
   }
   class Consumer {

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -143,14 +143,16 @@ Connection.prototype.events = {
         this.subscriptions.confirmSubscription(identifier)
         if (this.reconnectAttempted) {
           this.reconnectAttempted = false
-          return this.subscriptions.notify(identifier, "connected", {reconnected: true})
+          return this.subscriptions.handleReconnect(identifier)
         } else {
           return this.subscriptions.notify(identifier, "connected", {reconnected: false})
         }
       case message_types.rejection:
         return this.subscriptions.reject(identifier)
+      case message_types.history:
+        return this.subscriptions.subscribeToHistory(identifier)
       default:
-        return this.subscriptions.notify(identifier, "received", message)
+        return this.subscriptions.handleReceive(identifier, message)
     }
   },
 

--- a/actioncable/app/javascript/action_cable/internal.js
+++ b/actioncable/app/javascript/action_cable/internal.js
@@ -4,7 +4,8 @@ export default {
     "disconnect": "disconnect",
     "ping": "ping",
     "confirmation": "confirm_subscription",
-    "rejection": "reject_subscription"
+    "rejection": "reject_subscription",
+    "history": "history"
   },
   "disconnect_reasons": {
     "unauthorized": "unauthorized",

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -51,7 +51,8 @@ module ActionCable
       disconnect: "disconnect",
       ping: "ping",
       confirmation: "confirm_subscription",
-      rejection: "reject_subscription"
+      rejection: "reject_subscription",
+      history: "history"
     },
     disconnect_reasons: {
       unauthorized: "unauthorized",

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -183,6 +183,10 @@ module ActionCable
 
         reject_subscription if subscription_rejected?
         ensure_confirmation_sent
+
+        ActiveSupport::Notifications.subscribe("transmit_subscription_confirmation.action_cable") do
+          transmit_history_subscription if subscribed_to_streams_history?
+        end
       end
 
       # Called by the cable connection when it's cut, so the channel has a chance to cleanup with callbacks.
@@ -303,6 +307,18 @@ module ActionCable
           ActiveSupport::Notifications.instrument("transmit_subscription_rejection.action_cable", channel_class: self.class.name) do
             connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:rejection]
           end
+        end
+
+        def transmit_history_subscription
+          logger.debug "#{self.class.name} is transmitting the history subscription"
+
+          ActiveSupport::Notifications.instrument("transmit_history_subscription.action_cable", channel_class: self.class.name) do
+            connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:history]
+          end
+        end
+
+        def subscribed_to_streams_history?
+          streams_history.present?
         end
     end
   end

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -67,17 +67,27 @@ module ActionCable
 
       included do
         on_unsubscribe :stop_all_streams
+
+        prepend History
       end
 
       # Start streaming from the named <tt>broadcasting</tt> pubsub queue. Optionally, you can pass a <tt>callback</tt> that'll be used
       # instead of the default of just transmitting the updates straight to the subscriber.
       # Pass <tt>coder: ActiveSupport::JSON</tt> to decode messages as JSON before passing to the callback.
       # Defaults to <tt>coder: nil</tt> which does no decoding, passes raw messages.
-      def stream_from(broadcasting, callback = nil, coder: nil, &block)
+      def stream_from(broadcasting, callback = nil, coder: nil, save_history: false, &block)
         broadcasting = String(broadcasting)
 
         # Don't send the confirmation until pubsub#subscribe is successful
         defer_subscription_confirmation!
+
+        # Specify if the history of this stream should be saved
+        if save_history
+          save_history = {} if save_history == true
+          save_history[:key] ||= "#{broadcasting}:history"
+
+          streams_history[broadcasting] = save_history
+        end
 
         # Build a stream handler by wrapping the user-provided callback with
         # a decoder or defaulting to a JSON-decoding retransmitter.
@@ -139,6 +149,10 @@ module ActionCable
 
         def streams
           @_streams ||= {}
+        end
+
+        def streams_history
+          @_streams_history ||= {}
         end
 
         # Always wrap the outermost handler to invoke the user handler on the

--- a/actioncable/lib/action_cable/channel/streams/history.rb
+++ b/actioncable/lib/action_cable/channel/streams/history.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ActionCable
+  module Channel
+    module Streams
+      module History
+        extend ActiveSupport::Concern
+
+        prepended do
+          def stream_handler(broadcasting, user_handler, coder: nil)
+            -> message do
+              super.(message)
+              stream_history_saver(broadcasting).(message) if streams_history[broadcasting]
+            end
+          end
+
+          def stream_history_saver(broadcasting)
+            -> message do
+              key = streams_history[broadcasting][:key]
+              pubsub.save_history key, message
+              logger.info "#{self.class.name} saved message #{message} streamed from #{broadcasting}"
+            end
+          end
+
+          def stream_history_transmitter
+            -> since do
+              streams_history.each do |broadcasting, options|
+                stream_history = pubsub
+                  .read_history(options[:key], since: since)
+                  .values
+                  .first
+
+                stream_history.each do |_timestamp, entry|
+                  message = ActiveSupport::JSON.decode entry["message"]
+                  stream_transmitter(broadcasting: broadcasting).(message)
+                end
+
+                stream_history_cleaner.(options[:key], since)
+              end
+            end
+          end
+
+          def stream_history_cleaner
+            -> (key, since) do
+              pubsub.delete_history key, since: since
+              logger.info "#{key} cleared"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -17,6 +17,7 @@ module ActionCable
         when "subscribe"   then add data
         when "unsubscribe" then remove data
         when "message"     then perform_action data
+        when "history"     then transmit_history data
         else
           logger.error "Received unrecognized command in #{data.inspect}"
         end
@@ -54,6 +55,13 @@ module ActionCable
 
       def perform_action(data)
         find(data).perform_action ActiveSupport::JSON.decode(data["data"])
+      end
+
+      def transmit_history(data)
+        subscription = find data
+        since        = data["since"]
+
+        subscription.stream_history_transmitter.(since)
       end
 
       def identifiers

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -26,6 +26,18 @@ module ActionCable
         redis_connection_for_broadcasts.publish(channel, payload)
       end
 
+      def save_history(stream_history, payload)
+        redis_connection_for_broadcasts.xadd(stream_history, { message: payload })
+      end
+
+      def read_history(stream_history, since: "0")
+        redis_connection_for_broadcasts.xread(stream_history, since)
+      end
+
+      def delete_history(stream_history, since: "0")
+        redis_connection_for_broadcasts.del(stream_history, since)
+      end
+
       def subscribe(channel, callback, success_callback = nil)
         listener.add_subscriber(channel, callback, success_callback)
       end


### PR DESCRIPTION
## Summary
This PR is motivated by this [RailsConf talk](https://youtu.be/TgpSs2ffJL0) from @palkan, where he discusses message delivery guarantees in real-time Rails applications.

Since the beginning, ActionCable rely on [Redis PubSub](https://redis.io/docs/manual/pubsub/) to create channels of communication between the server and the client. The purpose of a PubSub is solely to broadcast messages to multiple subscribers, not to make sure that they receive them. It means that if the network connection is lost for some reason, the subscriber will not be able to receive messages sent during their absence. If the subscriber is able to reconnect, they will have an inconsistent state if they don't refresh the page, thus killing the real-time experience.

To solve this problem we can use Redis PubSub in combination with [Redis Streams](https://redis.io/docs/manual/data-types/streams/). With Redis Streams, we can keep track of the messages sent by the server and retrieve the history when needed, using a timestamp that corresponds to the last time the subscriber received a message from the server. This is easily achievable because Redis Streams uses timestamps as [IDs](https://redis.io/docs/manual/data-types/streams/#entry-ids).

The approach taken in this PR is to add a `:save_history` option to `stream_from`. This option takes a boolean or a hash with the `:key`  attribute to set a custom Redis key for the stream history (I'm also considering adding an `:expires_in` option).

If this option is enabled, subscribers will request the history of messages sent in their absence, after each reconnect:
![streams_history](https://user-images.githubusercontent.com/47113995/182995620-9a26ef4c-427e-4ac8-a455-060c2aabe90e.gif)

## Tasks
- [ ] Write tests
- [ ] Write documentation

<!-- If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
