### PR TITLE
[ci skip] Add basic create_enum and drop_enum in CommandRecorder documentations

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -18,9 +18,11 @@ module ActiveRecord
     # * change_column_null
     # * change_column_comment (must supply a +:from+ and +:to+ option)
     # * change_table_comment (must supply a +:from+ and +:to+ option)
+    # * create_enum
     # * create_join_table
     # * create_table
     # * disable_extension
+    # * drop_enum (must supply a list of values)
     # * drop_join_table
     # * drop_table (must supply a block)
     # * enable_extension


### PR DESCRIPTION
Add `create_enum` and `drop_enum` in `CommandRecorder` documentations

https://github.com/rails/rails/pull/45735