### PR TITLE
Define `#build_change_column_null_definition` for MySQL and PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -718,7 +718,7 @@ module ActiveRecord
       #
       # This definition object contains information about the column change that would occur
       # if the same arguments were passed to #change_column_default. See #change_column_default for
-      # information about passing a +table_name+, +column_name+, +type+ and other options that can be passed.
+      # information about passing a +table_name+, +column_name+, and +default+.
       def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
         raise NotImplementedError, "build_change_column_default_definition is not implemented"
       end
@@ -741,6 +741,10 @@ module ActiveRecord
       # Please note the fourth argument does not set a column's default.
       def change_column_null(table_name, column_name, null, default = nil)
         raise NotImplementedError, "change_column_null is not implemented"
+      end
+
+      def build_change_column_null_definition(table_name, column_name, null, default = nil) # :nodoc:
+        raise NotImplementedError, "build_change_column_null_definition is not implemented"
       end
 
       # Renames a column.

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -34,6 +34,11 @@ module ActiveRecord
             o.ddl = sql
           end
 
+          def visit_ChangeColumnNullDefinition(o)
+            sql = +"CHANGE #{quote_column_name(o.column.name)} #{accept(o.column)}"
+            o.ddl = sql
+          end
+
           def visit_CreateIndexDefinition(o)
             sql = visit_IndexDefinition(o.index, true)
             sql << " #{o.algorithm}" if o.algorithm

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -97,6 +97,11 @@ module ActiveRecord
             o.ddl = sql
           end
 
+          def visit_ChangeColumnNullDefinition(o)
+            sql = +"ALTER COLUMN #{quote_column_name(o.column.name)} #{o.null ? "DROP" : "SET"} NOT NULL"
+            o.ddl = sql
+          end
+
           def add_column_options!(sql, options)
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -294,6 +294,8 @@ module ActiveRecord
           @exclusion_constraint_drops << constraint_name
         end
       end
+
+      ChangeColumnNullDefinition = Struct.new(:column, :null, :ddl) # :nodoc:
     end
   end
 end


### PR DESCRIPTION
### Summary

Defines API on the MySQL and PostgreSQL connection adapters for returning
schema definition objects that describe a column's `NOT NULL` constraint
being added or removed. This method should be called with the same arguments
as would be passed to #change_column_null`.

Note that MySQL and PostgreSQL return different definition objects, due
to differences in their SQL needs. PG will return a `ChangeColumnNullDefinition`
object, whereas MySQL will return a `ChangeColumnDefinition`.

### Other Information

It would've been ideal for the schema definitions to match between adapters, but this was tricky to accomplish due to the nature of the SQL that must be produced for each adapter. PostgreSQL performs an `ALTER COLUMN` that only needs to know about the column name and the value of `null`, whereas MySQL needs to reconstruct the entire column query (`CHANGE foo <type> <type> <collation> <default> <null>`). For PG, we can introduce a new schema definition object that only needs a bit of information to generate the required SQL. For MySQL, however, we should reuse the existing logic around changing a column's definition, since this handles adding all of the column options back to the definition object to be turned into DDL.

The two definition objects are similar, so I don't think this is problematic.