### PR TITLE
Update docs for `.unscoped` to be explicit about associations

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -24,14 +24,22 @@ module ActiveRecord
         # Returns a scope for the model without the previously set scopes.
         #
         #   class Post < ActiveRecord::Base
+        #     belongs_to :user
+        #
         #     def self.default_scope
         #       where(published: true)
         #     end
         #   end
         #
+        #   class User < ActiveRecord::Base
+        #     has_many :posts
+        #   end
+        #
         #   Post.all                                  # Fires "SELECT * FROM posts WHERE published = true"
         #   Post.unscoped.all                         # Fires "SELECT * FROM posts"
         #   Post.where(published: false).unscoped.all # Fires "SELECT * FROM posts"
+        #   User.find(1).posts                        # Fires "SELECT * FROM posts WHERE published = true AND posts.user_id = 1"
+        #   User.find(1).posts.unscoped               # Fires "SELECT * FROM posts"
         #
         # This method also accepts a block. All queries inside the block will
         # not use the previously set scopes.


### PR DESCRIPTION
### Summary

We recently ran into an issue where we used `.unscoped` as part of a
method chain without realising that it would also unset the scoping of
the association. It feels like this would be useful information to
surface in the documentation so that there's a clear source of truth on
how the method behaves.