### PR TITLE
Type cast #attribute_changed? :from and :to options

### DIFF
--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -43,8 +43,8 @@ module ActiveModel
 
     def changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
       attribute_changed?(attr_name) &&
-        (OPTION_NOT_GIVEN == from || original_value(attr_name) == from) &&
-        (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == to)
+        (OPTION_NOT_GIVEN == from || original_value(attr_name) == type_cast(attr_name, from)) &&
+        (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == type_cast(attr_name, to))
     end
 
     def changed_in_place?(attr_name)
@@ -81,6 +81,10 @@ module ActiveModel
 
       def fetch_value(attr_name)
         attributes.fetch_value(attr_name)
+      end
+
+      def type_cast(attr_name, value)
+        attributes[attr_name].type_cast(value)
       end
   end
 
@@ -141,6 +145,10 @@ module ActiveModel
         value = fetch_value(attr_name)
         value.duplicable? ? value.clone : value
       rescue TypeError, NoMethodError
+        value
+      end
+
+      def type_cast(attr_name, value)
         value
       end
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -971,6 +971,16 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
+  test "attribute_changed? properly type casts enum values" do
+    parrot = LiveParrot.create!(name: "Scipio", breed: :african)
+
+    parrot.breed = :australian
+
+    assert parrot.breed_changed?(from: "african", to: "australian")
+    assert parrot.breed_changed?(from: :african, to: :australian)
+    assert parrot.breed_changed?(from: 0, to: 1)
+  end
+
   private
     def with_partial_writes(klass, on = true)
       old_inserts = klass.partial_inserts?


### PR DESCRIPTION
Fix https://github.com/rails/rails/issues/45766

### Summary

This change fixes a defect in `ActiveModel::Dirty#attribute_changed?` where the `:from` and `:to` options are not being type cast. For example, for an enum attribute, `:from` and `:to` should handle `String`, `Symbol` or `Integer`, which was broken. The relevant code is in `AttributeMutationTracker#changed?`. To fix the issue I get the relevant attribute of `@attributes` and pass the `:from` and `:to` values into `#type_cast` before comparing them to original / previous value of the attribute.

### Other Information

It was not clear to me if / how it's possible to typecast values in the `ForcedMutationTracker` (which is a subclass of `AttributeMutationTracker`), since in that case there are no `@attributes`. However, I was also not able to find a way reproduce the defect going down this code path, so I'm not sure there is an issue to solve. So, this is simply a refactoring for `ForcedMutationTracker`.

For tests, although this code lives in `ActiveModel`, it seemed to make more sense to test the enum case in the `ActiveRecord` tests. Let me know if there is an obvious test case I could add to the `ActiveModel` tests.
