### PR TITLE
Don't store `ddl` on schema definitions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -26,7 +26,6 @@ module ActiveRecord
           sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
           sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
           sql << o.check_constraint_drops.map { |con| visit_DropCheckConstraint con }.join(" ")
-          o.ddl = sql
         end
 
         def visit_ColumnDefinition(o)
@@ -67,7 +66,7 @@ module ActiveRecord
           create_sql << "(#{statements.join(', ')})" if statements.present?
           add_table_options!(create_sql, o)
           create_sql << " AS #{to_sql(o.as)}" if o.as
-          o.ddl = create_sql
+          create_sql
         end
 
         def visit_PrimaryKeyDefinition(o)
@@ -107,8 +106,7 @@ module ActiveRecord
           sql << "(#{quoted_columns(index)})"
           sql << "WHERE #{index.where}" if supports_partial_index? && index.where
 
-          sql = sql.join(" ")
-          o.ddl = sql
+          sql.join(" ")
         end
 
         def visit_CheckConstraintDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -92,11 +92,11 @@ module ActiveRecord
 
     AddColumnDefinition = Struct.new(:column) # :nodoc:
 
-    ChangeColumnDefinition = Struct.new(:column, :name, :ddl) # :nodoc:
+    ChangeColumnDefinition = Struct.new(:column, :name) # :nodoc:
 
-    ChangeColumnDefaultDefinition = Struct.new(:column, :default, :ddl) # :nodoc:
+    ChangeColumnDefaultDefinition = Struct.new(:column, :default) # :nodoc:
 
-    CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists, :ddl) # :nodoc:
+    CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists) # :nodoc:
 
     PrimaryKeyDefinition = Struct.new(:name) # :nodoc:
 
@@ -335,7 +335,6 @@ module ActiveRecord
       include ColumnMethods
 
       attr_reader :name, :temporary, :if_not_exists, :options, :as, :comment, :indexes, :foreign_keys, :check_constraints
-      attr_accessor :ddl
 
       def initialize(
         conn,
@@ -582,7 +581,6 @@ module ActiveRecord
       attr_reader :adds
       attr_reader :foreign_key_adds, :foreign_key_drops
       attr_reader :check_constraint_adds, :check_constraint_drops
-      attr_accessor :ddl
 
       def initialize(td)
         @td   = td

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -355,10 +355,7 @@ module ActiveRecord
         return unless column
 
         default = extract_new_default_value(default_or_changes)
-        change_column_default_definition = ChangeColumnDefaultDefinition.new(column, default)
-        schema_creation.accept(change_column_default_definition)
-
-        change_column_default_definition
+        ChangeColumnDefaultDefinition.new(column, default)
       end
 
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
@@ -411,10 +408,7 @@ module ActiveRecord
 
         td = create_table_definition(table_name)
         cd = td.new_column_definition(column.name, type, **options)
-        change_column_def = ChangeColumnDefinition.new(cd, column.name)
-        schema_creation.accept(change_column_def)
-
-        change_column_def
+        ChangeColumnDefinition.new(cd, column.name)
       end
 
       def rename_column(table_name, column_name, new_column_name) # :nodoc:
@@ -426,7 +420,7 @@ module ActiveRecord
         create_index = build_create_index_definition(table_name, column_name, **options)
         return unless create_index
 
-        execute(create_index.ddl)
+        execute schema_creation.accept(create_index)
       end
 
       def build_create_index_definition(table_name, column_name, **options) # :nodoc:
@@ -434,9 +428,7 @@ module ActiveRecord
 
         return if if_not_exists && index_exists?(table_name, column_name, name: index.name)
 
-        create_index = CreateIndexDefinition.new(index, algorithm)
-        schema_creation.accept(create_index)
-        create_index
+        CreateIndexDefinition.new(index, algorithm)
       end
 
       def add_sql_comment!(sql, comment) # :nodoc:
@@ -782,7 +774,7 @@ module ActiveRecord
 
         def change_column_for_alter(table_name, column_name, type, **options)
           cd = build_change_column_definition(table_name, column_name, type, **options)
-          cd.ddl
+          schema_creation.accept(cd)
         end
 
         def rename_column_for_alter(table_name, column_name, new_column_name)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -21,7 +21,7 @@ module ActiveRecord
 
           def visit_ChangeColumnDefinition(o)
             change_column_sql = +"CHANGE #{quote_column_name(o.name)} #{accept(o.column)}"
-            o.ddl = add_column_position!(change_column_sql, column_options(o.column))
+            add_column_position!(change_column_sql, column_options(o.column))
           end
 
           def visit_ChangeColumnDefaultDefinition(o)
@@ -31,13 +31,12 @@ module ActiveRecord
             else
               sql << quote_default_expression(o.default, o.column)
             end
-            o.ddl = sql
           end
 
           def visit_CreateIndexDefinition(o)
             sql = visit_IndexDefinition(o.index, true)
             sql << " #{o.algorithm}" if o.algorithm
-            o.ddl = sql
+            sql
           end
 
           def visit_IndexDefinition(o, create = false)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -10,7 +10,6 @@ module ActiveRecord
             sql << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
             sql << o.exclusion_constraint_adds.map { |con| visit_AddExclusionConstraint con }.join(" ")
             sql << o.exclusion_constraint_drops.map { |con| visit_DropExclusionConstraint con }.join(" ")
-            o.ddl = sql
           end
 
           def visit_AddForeignKey(o)
@@ -84,7 +83,7 @@ module ActiveRecord
               change_column_sql << ", ALTER COLUMN #{quoted_column_name} #{options[:null] ? 'DROP' : 'SET'} NOT NULL"
             end
 
-            o.ddl = change_column_sql
+            change_column_sql
           end
 
           def visit_ChangeColumnDefaultDefinition(o)
@@ -94,7 +93,6 @@ module ActiveRecord
             else
               sql << "SET DEFAULT #{quote_default_expression(o.default, o.column)}"
             end
-            o.ddl = sql
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -18,13 +18,9 @@ module ActiveRecord
 
         id_column = td.columns.find { |col| col.name == "id" }
         assert_predicate id_column, :present?
-        assert id_column.type
-        assert id_column.sql_type
 
         foo_column = td.columns.find { |col| col.name == "foo" }
         assert_predicate foo_column, :present?
-        assert foo_column.type
-        assert foo_column.sql_type
       end
 
       def test_build_create_table_definition_without_block
@@ -32,8 +28,6 @@ module ActiveRecord
 
         id_column = td.columns.find { |col| col.name == "id" }
         assert_predicate id_column, :present?
-        assert id_column.type
-        assert id_column.sql_type
       end
 
       def test_build_create_join_table_definition_with_block
@@ -64,7 +58,6 @@ module ActiveRecord
         end
         create_index = connection.build_create_index_definition(:test, :foo)
 
-        assert_match "CREATE INDEX", create_index.ddl
         assert_equal "index_test_on_foo", create_index.index.name
       ensure
         connection.drop_table(:test) if connection.table_exists?(:test)
@@ -91,12 +84,8 @@ module ActiveRecord
           end
 
           change_cd = connection.build_change_column_definition(:test, :foo, :integer)
-          assert change_cd.ddl
-
           change_col = change_cd.column
           assert_equal "foo", change_col.name.to_s
-          assert change_col.type
-          assert change_col.sql_type
         ensure
           connection.drop_table(:test) if connection.table_exists?(:test)
         end
@@ -107,13 +96,10 @@ module ActiveRecord
           end
 
           change_default_cd = connection.build_change_column_default_definition(:test, :foo, "new")
-          assert_match "SET DEFAULT 'new'", change_default_cd.ddl
           assert_equal "new", change_default_cd.default
 
           change_col = change_default_cd.column
           assert_equal "foo", change_col.name.to_s
-          assert change_col.type
-          assert change_col.sql_type
         ensure
           connection.drop_table(:test) if connection.table_exists?(:test)
         end


### PR DESCRIPTION
### Summary

We'll ensure that any consumers that require `ddl` obtain it by visiting
the schema definition. Consequently, we should also stop visiting the
schema definition in the "schema definition builder" methods -- callers
will need to both build a schema definition, and then visit it using a
`SchemaCreation` object. This means schema definitions will not be populated
with SQL type information, or any other information that is set when
the definition is visited.

This PR removes the `ddl` attribute from various schema definitions we'd added it to, and makes it so we're no longer visiting the definitions in the builder methods, but back in the schema statement methods where this was originally taking place.

### Other Information

This change is being made because storing `ddl` on schema definitions subverts the intention of the Visitor pattern in its original form. We shouldn't be storing `ddl` on an object and allowing it to leak out to consumers -- instead, callers interacting with schema definition objects should be responsible for visiting the object themselves to produce ddl.

cc @matthewd @eileencodes 