### PR TITLE
Ensure `drop_enum` is always reversible

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -465,7 +465,7 @@ module ActiveRecord
       end
 
       # Given a name and an array of values, creates an enum type.
-      def create_enum(name, values)
+      def create_enum(name, values, **options)
         sql_values = values.map { |s| quote(s) }.join(", ")
         scope = quoted_scope(name)
         query = <<~SQL
@@ -487,10 +487,15 @@ module ActiveRecord
       end
 
       # Drops an enum type.
-      # If the `if_exists: true` option is provided, the enum is only dropped if it exists.
-      # Otherwise, if the enum doesn't exist, an error is raised.
-      def drop_enum(name, *args)
-        options = args.extract_options!
+      #
+      # If the <tt>if_exists: true</tt> option is provided, the enum is dropped
+      # only if it exists. Otherwise, if the enum doesn't exist, an error is
+      # raised.
+      #
+      # The +values+ parameter will be ignored if present. It can be helpful
+      # to provide this in a migration's +change+ method so it can be reverted.
+      # In that case, +values+ will be used by #create_enum.
+      def drop_enum(name, values = nil, **options)
         query = <<~SQL
           DROP TYPE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(name)};
         SQL

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -46,7 +46,7 @@ module ActiveRecord
         :change_column_comment, :change_table_comment,
         :add_check_constraint, :remove_check_constraint,
         :add_exclusion_constraint, :remove_exclusion_constraint,
-        :create_enum, :drop_enum
+        :create_enum, :drop_enum,
       ]
       include JoinTable
 
@@ -282,6 +282,12 @@ module ActiveRecord
 
         def invert_remove_exclusion_constraint(args)
           raise ActiveRecord::IrreversibleMigration, "remove_exclusion_constraint is only reversible if given an expression." if args.size < 2
+          super
+        end
+
+        def invert_drop_enum(args)
+          _enum, values = args.dup.tap(&:extract_options!)
+          raise ActiveRecord::IrreversibleMigration, "drop_enum is only reversible if given a list of enum values." unless values
           super
         end
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -432,6 +432,26 @@ module ActiveRecord
           @recorder.inverse_of :remove_check_constraint, [:dogs]
         end
       end
+
+      def test_invert_create_enum
+        drop = @recorder.inverse_of :create_enum, [:color, ["blue", "green"]]
+        assert_equal [:drop_enum, [:color, ["blue", "green"]], nil], drop
+      end
+
+      def test_invert_drop_enum
+        create = @recorder.inverse_of :drop_enum, [:color, ["blue", "green"]]
+        assert_equal [:create_enum, [:color, ["blue", "green"]], nil], create
+      end
+
+      def test_invert_drop_enum_without_values
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_enum, [:color]
+        end
+
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_enum, [:color, if_exists: true]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Follow-up to #45735.

Prior to this commit, `drop_enum` could not be reversed when called with the `if_exists: true` option, because `create_enum` could not accept options.

This commit fixes that and adds test coverage.

This commit also ensures that reversing `drop_enum` will raise an `ActiveRecord::IrreversibleMigration` error if no enum values are specified.
