### PR TITLE
Add support for managing collations in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -539,6 +539,18 @@ module ActiveRecord
       def drop_enum(*) # :nodoc:
       end
 
+      # This is meant to be implemented by the adapters that support defining collations
+      def collations # :nodoc:
+      end
+
+      # This is meant to be implemented by the adapters that support defining collations
+      def create_collation(name, **) # :nodoc:
+      end
+
+      # This is meant to be implemented by the adapters that support defining collations
+      def drop_collation(name, **) # :nodoc:
+      end
+
       def advisory_locks_enabled? # :nodoc:
         supports_advisory_locks? && @advisory_locks_enabled
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -294,6 +294,20 @@ module ActiveRecord
           @exclusion_constraint_drops << constraint_name
         end
       end
+
+      class CollationDefinition
+        PROVIDER_MAP = { "i" => "icu", "c" => "libc" }
+
+        attr_reader :name, :provider, :lc_collate, :lc_ctype, :deterministic
+
+        def initialize(collname:, collprovider:, collcollate:, collctype:, collisdeterministic:)
+          @name = collname
+          @provider = PROVIDER_MAP.fetch(collprovider, "default")
+          @lc_collate = collcollate
+          @lc_ctype = collctype
+          @deterministic = collisdeterministic
+        end
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -28,6 +28,23 @@ module ActiveRecord
             end
           end
 
+          def collations(stream)
+            collations = @connection.collation_definitions
+            if collations.any?
+              stream.puts "  # Custom collations defined in this database."
+              collations.sort_by(&:name).each do |collation|
+                create_collation = "  create_collation #{collation.name.inspect}"
+                create_collation << ", provider: #{collation.provider.inspect}"
+                create_collation << ", lc_collate: #{collation.lc_collate.inspect}"
+                create_collation << ", lc_ctype: #{collation.lc_ctype.inspect}"
+                create_collation << ", deterministic: #{collation.deterministic.inspect}"
+
+                stream.puts create_collation
+              end
+              stream.puts
+            end
+          end
+
           def exclusion_constraints_in_create(table, stream)
             if (exclusion_constraints = @connection.exclusion_constraints(table)).any?
               add_exclusion_constraint_statements = exclusion_constraints.map do |exclusion_constraint|

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -934,7 +934,7 @@ module ActiveRecord
 
       say_with_time "#{method}(#{arg_list})" do
         unless connection.respond_to? :revert
-          unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
+          unless arguments.empty? || non_table_name_methods.include?(method)
             arguments[0] = proper_table_name(arguments.first, table_name_options)
             if method == :rename_table ||
               (method == :remove_foreign_key && !arguments.second.is_a?(Hash))
@@ -1042,6 +1042,10 @@ module ActiveRecord
 
       def command_recorder
         CommandRecorder.new(connection)
+      end
+
+      def non_table_name_methods
+        [:execute, :enable_extension, :disable_extension, :create_collation, :drop_collation]
       end
   end
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -18,10 +18,12 @@ module ActiveRecord
     # * change_column_null
     # * change_column_comment (must supply a +:from+ and +:to+ option)
     # * change_table_comment (must supply a +:from+ and +:to+ option)
+    # * create_collation
     # * create_enum
     # * create_join_table
     # * create_table
     # * disable_extension
+    # * drop_collation
     # * drop_enum (must supply a list of values)
     # * drop_join_table
     # * drop_table (must supply a block)
@@ -48,7 +50,8 @@ module ActiveRecord
         :change_column_comment, :change_table_comment,
         :add_check_constraint, :remove_check_constraint,
         :add_exclusion_constraint, :remove_exclusion_constraint,
-        :create_enum, :drop_enum
+        :create_enum, :drop_enum,
+        :create_collation, :drop_collation
       ]
       include JoinTable
 
@@ -148,7 +151,8 @@ module ActiveRecord
               add_check_constraint: :remove_check_constraint,
               add_exclusion_constraint: :remove_exclusion_constraint,
               enable_extension:  :disable_extension,
-              create_enum:       :drop_enum
+              create_enum:       :drop_enum,
+              create_collation:  :drop_collation
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -52,6 +52,7 @@ module ActiveRecord
     def dump(stream)
       header(stream)
       extensions(stream)
+      collations(stream)
       types(stream)
       tables(stream)
       trailer(stream)
@@ -102,6 +103,10 @@ module ActiveRecord
 
       # extensions are only supported by PostgreSQL
       def extensions(stream)
+      end
+
+      # collations are only supported by PostgreSQL
+      def collations(stream)
       end
 
       # (enum) types are only supported by PostgreSQL

--- a/activerecord/test/cases/adapters/postgresql/collation_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_adapter_test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgresqlCollationAdapterTest < ActiveRecord::PostgreSQLTestCase
+  LOCALE_ERROR_MESSAGE = "Either `locale' or both `lc_collate' and `lc_ctype' must be specified"
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def test_collations_with_postgresql_specific_schema
+    assert_equal ["german"], @connection.collations
+  end
+
+  def test_collations_with_no_collations
+    @connection.execute "DROP COLLATION german"
+    assert_equal [], @connection.collations
+  end
+
+  def test_collations_with_multiple_collations
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+    @connection.execute <<~SQL
+      CREATE COLLATION case_insensitive
+        (provider = icu, locale = 'und-u-ks-level2', deterministic = false)
+    SQL
+
+    assert_equal ["case_insensitive", "german", "japanese"], @connection.collations.sort
+  end
+
+  def test_collation_definitions_with_postgresql_specific_schema
+    assert_equal 1, @connection.collation_definitions.length
+    assert collation = @connection.collation_definitions.find { |c| c.name == "german" }
+
+    assert_equal "libc", collation.provider
+    assert_equal "de_DE", collation.lc_collate
+    assert_equal "de_DE", collation.lc_ctype
+    assert_equal true, collation.deterministic
+  end
+
+  def test_collation_definitions_with_no_collations
+    @connection.execute "DROP COLLATION german"
+    assert_equal [], @connection.collation_definitions
+  end
+
+  def test_collation_definitions_with_case_insensitive
+    @connection.execute <<~SQL
+      CREATE COLLATION case_insensitive
+        (provider = icu, locale = 'und-u-ks-level2', deterministic = false)
+    SQL
+
+    assert_equal 2, @connection.collation_definitions.length
+    assert collation = @connection.collation_definitions.find { |c| c.name == "case_insensitive" }
+
+    assert_equal "icu", collation.provider
+    assert_equal "und-u-ks-level2", collation.lc_collate
+    assert_equal "und-u-ks-level2", collation.lc_ctype
+    assert_equal false, collation.deterministic
+  end
+
+  def test_create_collation_for_japanese
+    assert_difference -> { @connection.collations.length } do
+      @connection.create_collation "japanese", provider: "libc", locale: "ja_JP"
+    end
+
+    assert collation = @connection.collation_definitions.find { |c| c.name == "japanese" }
+
+    assert_equal "libc", collation.provider
+    assert_equal "ja_JP", collation.lc_collate
+    assert_equal "ja_JP", collation.lc_ctype
+    assert_equal true, collation.deterministic
+  end
+
+  def test_create_collation_for_case_insensitive
+    assert_difference -> { @connection.collations.length } do
+      @connection.create_collation "case_insensitive",
+        provider: "icu", locale: "und-u-ks-level2", deterministic: false
+    end
+
+    assert collation = @connection.collation_definitions.find { |c| c.name == "case_insensitive" }
+
+    assert_equal "icu", collation.provider
+    assert_equal "und-u-ks-level2", collation.lc_collate
+    assert_equal "und-u-ks-level2", collation.lc_ctype
+    assert_equal false, collation.deterministic
+  end
+
+  def test_create_collation_when_collation_already_exists
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+
+    assert_no_difference -> { @connection.collations.length } do
+      @connection.create_collation "japanese", provider: "libc", locale: "ja_JP"
+    end
+  end
+
+  def test_create_collation_with_lc_collate_and_lc_ctype_params
+    assert_difference -> { @connection.collations.length } do
+      @connection.create_collation "japanese",
+        provider: "libc", lc_collate: "ja_JP", lc_ctype: "ja_JP"
+    end
+
+    assert collation = @connection.collation_definitions.find { |c| c.name == "japanese" }
+
+    assert_equal "libc", collation.provider
+    assert_equal "ja_JP", collation.lc_collate
+    assert_equal "ja_JP", collation.lc_ctype
+    assert_equal true, collation.deterministic
+  end
+
+  def test_create_collation_with_duplicate_locale_params
+    error = assert_raises ArgumentError do
+      @connection.create_collation "japanese",
+        provider: "libc", locale: "ja_JP", lc_collate: "ja_JP", lc_ctype: "ja_JP"
+    end
+
+    assert_equal LOCALE_ERROR_MESSAGE, error.message
+  end
+
+  def test_create_collation_with_no_locale_params
+    error = assert_raises ArgumentError do
+      @connection.create_collation "japanese", provider: "libc"
+    end
+
+    assert_equal LOCALE_ERROR_MESSAGE, error.message
+  end
+
+  def test_drop_collation_for_japanese
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+
+    assert_difference -> { @connection.collations.length }, -1 do
+      @connection.drop_collation "japanese", provider: "libc", locale: "ja_JP"
+    end
+
+    assert_not @connection.collation_definitions.find { |c| c.name == "japanese" }
+  end
+
+  def test_drop_collation_when_collation_does_not_exist
+    assert_no_difference -> { @connection.collations.length } do
+      @connection.drop_collation "japanese", provider: "libc", locale: "ja_JP"
+    end
+  end
+
+  def test_drop_collation_with_lc_collate_and_lc_ctype_params
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+
+    assert_difference -> { @connection.collations.length }, -1 do
+      @connection.drop_collation "japanese",
+        provider: "libc", lc_collate: "ja_JP", lc_ctype: "ja_JP"
+    end
+
+    assert_not @connection.collation_definitions.find { |c| c.name == "japanese" }
+  end
+
+  def test_drop_collation_ignores_param_values
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+
+    assert_difference -> { @connection.collations.length }, -1 do
+      @connection.drop_collation "japanese", provider: "foo", locale: "foo_BAR"
+    end
+
+    assert_not @connection.collation_definitions.find { |c| c.name == "japanese" }
+  end
+
+  def test_drop_collation_with_duplicate_locale_params
+    error = assert_raises ArgumentError do
+      @connection.drop_collation "japanese",
+        provider: "libc", locale: "ja_JP", lc_collate: "ja_JP", lc_ctype: "ja_JP"
+    end
+
+    assert_equal LOCALE_ERROR_MESSAGE, error.message
+  end
+
+  def test_drop_collation_with_no_locale_params
+    error = assert_raises ArgumentError do
+      @connection.drop_collation "japanese", provider: "libc"
+    end
+
+    assert_equal LOCALE_ERROR_MESSAGE, error.message
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/collation_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_migration_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "support/schema_dumping_helper"
 
 class PostgresqlCollationMigrationTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+
   class SilentMigration < ActiveRecord::Migration::Current
     def write(*); end
   end
@@ -56,5 +59,29 @@ class PostgresqlCollationMigrationTest < ActiveRecord::PostgreSQLTestCase
     assert_not_includes @connection.collations, "case_insensitive"
     DropCollation.new.migrate(:down)
     assert_includes @connection.collations, "case_insensitive"
+  end
+
+  def test_schema_dump_includes_collations_in_alphabetical_order
+    @connection.execute "CREATE COLLATION japanese (provider = libc, locale = 'ja_JP')"
+    @connection.execute <<~SQL
+      CREATE COLLATION case_insensitive
+        (provider = icu, locale = 'und-u-ks-level2', deterministic = false)
+    SQL
+
+    output = dump_all_table_schema([])
+
+    assert_includes output, <<-COLL
+  # Custom collations defined in this database.
+  create_collation "case_insensitive", provider: "icu", lc_collate: "und-u-ks-level2", lc_ctype: "und-u-ks-level2", deterministic: false
+  create_collation "german", provider: "libc", lc_collate: "de_DE", lc_ctype: "de_DE", deterministic: true
+  create_collation "japanese", provider: "libc", lc_collate: "ja_JP", lc_ctype: "ja_JP", deterministic: true
+    COLL
+  end
+
+  def test_schema_dump_without_collations_defined
+    @connection.execute "DROP COLLATION german"
+
+    output = dump_all_table_schema([])
+    assert_not_includes output, "# Custom collations defined in this database."
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/collation_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_migration_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgresqlCollationMigrationTest < ActiveRecord::PostgreSQLTestCase
+  class SilentMigration < ActiveRecord::Migration::Current
+    def write(*); end
+  end
+
+  class CreateCollation < SilentMigration
+    def change
+      create_collation "case_insensitive",
+        provider: "icu",
+        locale: "und-u-ks-level2",
+        deterministic: false
+    end
+  end
+
+  class DropCollation < SilentMigration
+    def change
+      drop_collation "case_insensitive",
+        provider: "icu",
+        locale: "und-u-ks-level2",
+        deterministic: false
+    end
+  end
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def test_create_collation_and_drop_collation
+    assert_not_includes @connection.collations, "case_insensitive"
+    CreateCollation.new.migrate(:up)
+    assert_includes @connection.collations, "case_insensitive"
+    DropCollation.new.migrate(:up)
+    assert_not_includes @connection.collations, "case_insensitive"
+  end
+
+  def test_migrate_and_revert_create_collation
+    assert_not_includes @connection.collations, "case_insensitive"
+    CreateCollation.new.migrate(:up)
+    assert_includes @connection.collations, "case_insensitive"
+    CreateCollation.new.migrate(:down)
+    assert_not_includes @connection.collations, "case_insensitive"
+  end
+
+  def test_migrate_and_revert_drop_collation
+    @connection.execute <<~SQL
+      CREATE COLLATION case_insensitive
+        (provider = icu, locale = 'und-u-ks-level2', deterministic = false)
+    SQL
+
+    assert_includes @connection.collations, "case_insensitive"
+    DropCollation.new.migrate(:up)
+    assert_not_includes @connection.collations, "case_insensitive"
+    DropCollation.new.migrate(:down)
+    assert_includes @connection.collations, "case_insensitive"
+  end
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -4,6 +4,8 @@ ActiveRecord::Schema.define do
   enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
   enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
 
+  create_collation "german", provider: "libc", locale: "de_DE"
+
   uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
 
   create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -615,9 +615,11 @@ actions automatically. Below are some of the actions that `change` supports:
 * [`change_column_default`][] (must supply a `:from` and `:to` option)
 * [`change_column_null`][]
 * [`change_table_comment`][] (must supply a `:from` and `:to` option)
+* `create_collation`
 * [`create_join_table`][]
 * [`create_table`][]
 * `disable_extension`
+* `drop_collation`
 * [`drop_join_table`][]
 * [`drop_table`][] (must supply a block)
 * `enable_extension`


### PR DESCRIPTION
### Summary

Add support for managing collations in PostgreSQL.

https://www.postgresql.org/docs/current/collation.html

Add `collations`, `create_collation`, and `drop_collation` to
`PostgreSQLAdapter`, and `AbstractAdapter` as empty methods. There is
existing support for collations but only as a column modifier. A simple use
case is adding a case-insensitive string field. In the past, we might have
downcased on save, but then you'd need to remember to make your uniqueness
constraint case-insensitive and to downcase on find, search, etc. We might
have used `citext`, a module that must be installed. Current PostgreSQL
documentation tells us to "Consider using nondeterministic collations".

```ruby
class CreateUsers < ActiveRecord::Migration[7.1]
  def change
    create_collation "case_insensitive",
      provider: "icu",
      locale: "und-u-ks-level2",
      deterministic: false

    create_collation "ignore_accents",
      provider: "icu",
      locale: "und-u-ks-level1-kc-true",
      deterministic: false

    create_table :users do |t|
      t.string :email, collation: "case_insensitive"
      t.string :name, collation: "ignore_accents"
      t.timestamps
    end
    add_index :users, :email, unique: true
  end
end

ActiveRecord::Base.connection.collations
# ["case_insensitive", "ignore_accents"]

User.create!(email: "dan@example.com", name: "dan")
# works

User.create!(email: "DAN@example.com", name: "dan")
# raises ActiveRecord::RecordNotUnique

class User < ApplicationRecord
  validates :email, uniqueness: true
end
# uniqueness validations just work

User.create!(email: "DAN@example.com", name: "dan")
# raises ActiveRecord::RecordInvalid

ActiveRecord::Base.connection.drop_collation "case_insensitive",
  provider: "icu", locale: "und-u-ks-level2", deterministic: false
# raises ActiveRecord::StatementInvalid because of the email column
```

### Other Information

Prevents needing `structure.sql` just for collations.
I wrote `drop_collation` to always be rollback safe.
To keep things simple, I chose not to add 2 things:
- a `:from` option on `create_collation` - I think this is less likely to be used
- a `:force` option on `drop_collation` - dangerous and less likely to be used
