### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -3,7 +3,7 @@
     Example:
 
     ```
-    > bin/rails rails --unused
+    > bin/rails routes --unused
 
     Found 2 unused routes:
 


### PR DESCRIPTION
### Summary

Fixed a typo in the Railties `CHANGELOG.md` introduced during #45701 
