### PR TITLE
Fix `EtagWithFlash` when there is no Flash middleware available

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_flash.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_flash.rb
@@ -12,7 +12,7 @@ module ActionController
     include ActionController::ConditionalGet
 
     included do
-      etag { flash unless flash.empty? }
+      etag { flash if request.respond_to?(:flash) && !flash.empty? }
     end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -632,6 +632,23 @@ module ApplicationTests
       assert last_response.ok?
     end
 
+    test "EtagWithFlash module doesn't break for API apps" do
+      make_basic_app do |application|
+        application.config.api_only = true
+      end
+
+      class ::OmgController < ActionController::Base
+        def index
+          stale?(weak_etag: "something")
+          render plain: "else"
+        end
+      end
+
+      get "/"
+
+      assert last_response.ok?
+    end
+
     test "Use key_generator when secret_key_base is set" do
       make_basic_app do |application|
         application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"


### PR DESCRIPTION
Fixes #45781.

We need to call `respond_to?(:flash)` on `request`, because flash is delegated https://github.com/rails/rails/blob/46c7420ebfd94314cef1606baf044230007bacfe/actionpack/lib/action_controller/metal/flash.rb#L10