### PR TITLE
[AR] Fix result with anonymous PG columns of different type from json

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -71,7 +71,7 @@ module ActiveRecord
             fields.each_with_index do |fname, i|
               ftype = result.ftype i
               fmod  = result.fmod i
-              types[fname] = get_oid_type(ftype, fmod, fname)
+              types[fname] = types[i] = get_oid_type(ftype, fmod, fname)
             end
             build_result(columns: fields, rows: result.values, column_types: types)
           end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -109,7 +109,7 @@ module ActiveRecord
         type = if type_overrides.is_a?(Array)
           type_overrides.first
         else
-          column_type(columns.first, type_overrides)
+          column_type(columns.first, 0, type_overrides)
         end
 
         rows.map do |(value)|
@@ -119,7 +119,7 @@ module ActiveRecord
         types = if type_overrides.is_a?(Array)
           type_overrides
         else
-          columns.map { |name| column_type(name, type_overrides) }
+          columns.map.with_index { |name, i| column_type(name, i, type_overrides) }
         end
 
         rows.map do |values|
@@ -141,9 +141,11 @@ module ActiveRecord
     end
 
     private
-      def column_type(name, type_overrides = {})
+      def column_type(name, index, type_overrides)
         type_overrides.fetch(name) do
-          column_types.fetch(name, Type.default_value)
+          column_types.fetch(index) do
+            column_types.fetch(name, Type.default_value)
+          end
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -33,6 +33,11 @@ module PostgresqlJSONSharedTestCases
     x.reload
     assert_equal ["foo" => "bar"], x.objects
   end
+
+  def test_noname_columns_of_different_types
+    @connection.execute(insert_statement_per_database('{"a":{},"b":"b"}'))
+    assert_equal [[{}, "b"]], klass.pluck(Arel.sql("payload->'a', payload->>'b'"))
+  end
 end
 
 class PostgresqlJSONTest < ActiveRecord::PostgreSQLTestCase


### PR DESCRIPTION
Fix #45758 

Updates ActiveRecord PostgreSQL adapter and ActiveRecord::Result to handle DB result with no-name columns (`?column?`) of different type.

cc @fatkodima @skipkayhil 