### PR TITLE
Remove incorrect 7.0 framework default

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -263,7 +263,6 @@ module Rails
           end
 
           if respond_to?(:action_controller)
-            action_controller.raise_on_missing_callback_actions = false
             action_controller.raise_on_open_redirects = true
             action_controller.wrap_parameters_by_default = true
           end


### PR DESCRIPTION
### Summary

This was added in 60f7d49, which didn't quite make the cutoff for the
7.0 release, so it doesn't belong under `7.0`.

In addition, the value being set is the same as the underlying
configuration's default. This is likely an oversight because the
`load_default` value was changed during review from `true` to be
`Rails.env` dependent, and later to `false`.

### Other Information

Ref: #45784