### PR TITLE
Correct the description for reject_unauthorized_connection

### DIFF
--- a/actioncable/lib/action_cable/connection/authorization.rb
+++ b/actioncable/lib/action_cable/connection/authorization.rb
@@ -5,7 +5,7 @@ module ActionCable
     module Authorization
       class UnauthorizedError < StandardError; end
 
-      # Closes the WebSocket connection if it is open and returns a 404 "File not Found" response.
+      # Closes the WebSocket connection if it is open and returns an "unauthorized" reason.
       def reject_unauthorized_connection
         logger.error "An unauthorized connection attempt was rejected"
         raise UnauthorizedError


### PR DESCRIPTION
### Summary

The description for `reject_unauthorized_connection` says:

> Closes the WebSocket connection if it is open and returns a 404 "File not Found" response.

I believe this should be:

> Closes the WebSocket connection if it is open and returns an "unauthorized" reason.