### PR TITLE
Add ActionView::OutputBuffer#concat back

### DIFF
--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -50,6 +50,7 @@ module ActionView
       end
       self
     end
+    alias :concat, :<<
     alias :append= :<<
 
     def safe_concat(value)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/45777

The method is being used by HAML, it's easy to add it back.
