### PR TITLE
[AR] Fix uniqueness validation on association not using overridden PK

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -45,7 +45,7 @@ module ActiveRecord
     def bind_attribute(name, value) # :nodoc:
       if reflection = klass._reflect_on_association(name)
         name = reflection.foreign_key
-        value = value.read_attribute(reflection.klass.primary_key) unless value.nil?
+        value = value.read_attribute(reflection.association_primary_key) unless value.nil?
       end
 
       attr = table[name]

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -11,6 +11,7 @@ require "models/uuid_item"
 require "models/author"
 require "models/person"
 require "models/essay"
+require "models/keyboard"
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -68,6 +69,14 @@ class TopicWithAfterCreate < Topic
   def set_author
     update!(author_name: "#{title} #{id}")
   end
+end
+
+class LessonWithUniqKeyboard < ActiveRecord::Base
+  self.table_name = "lessons"
+
+  belongs_to :keyboard, primary_key: :name, foreign_key: :name
+
+  validates_uniqueness_of :keyboard
 end
 
 class UniquenessValidationTest < ActiveRecord::TestCase
@@ -764,6 +773,15 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
   ensure
     TopicWithEvent.clear_validators!
     Event.delete_all
+  end
+
+  def test_uniqueness_on_custom_relation_primary_key
+    Keyboard.create!(name: "Keyboard #1")
+    LessonWithUniqKeyboard.create!(name: "Keyboard #1")
+
+    another = LessonWithUniqKeyboard.new(name: "Keyboard #1")
+    assert_not_predicate another, :valid?
+    assert_equal ["has already been taken"], another.errors[:keyboard]
   end
 
   def test_index_of_sublist_of_columns


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Resolves #45775 

Fixes what I believe is a bug where a uniqueness validation on a belongs_to association was not using the correct value in the query for existing records. The ID of the associated model was being used instead of the overridden `primary_key` column value.

### Other Information

From some quick grepping, it doesn't look like this `bind_attribute` method is used anywhere other this uniqueness validation. 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
