### PR TITLE
Ensure collation is set to database default when changing column to binary

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -398,7 +398,7 @@ module ActiveRecord
           options[:comment] = column.comment
         end
 
-        unless options.key?(:collation)
+        unless options.key?(:collation) || type == :binary
           options[:collation] = column.collation
         end
 

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -48,6 +48,16 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     assert_equal "utf8mb4_general_ci", column.collation
   end
 
+  test "change column ensures binary column type are set to nil" do
+    @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
+    @connection.change_column :charset_collations, :description, :binary
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+
+    assert_equal :binary, column.type
+    assert_nil column.collation
+  end
+
   test "change column preserves collation" do
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :text


### PR DESCRIPTION
Binary types are not being set to an incompatible collation type when the column is changed. See this comment for details: https://github.com/rails/rails/pull/45744#issuecomment-1208823797


This PR adds a failing test  which demonstrates a problem introduced in https://github.com/rails/rails/issues/45742, and a fix to the implementation to pass the test.



