### PR TITLE
Optimize AS::LogSubscriber

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -19,6 +19,7 @@ module ActionMailer
 
       debug { event.payload[:mail] }
     end
+    subscribe_log_level :deliver, :debug
 
     # An email was generated.
     def process(event)
@@ -28,6 +29,7 @@ module ActionMailer
         "#{mailer}##{action}: processed outbound mail in #{event.duration.round(1)}ms"
       end
     end
+    subscribe_log_level :process, :debug
 
     # Use the logger configured for ActionMailer::Base.
     def logger

--- a/actionpack/lib/action_dispatch/log_subscriber.rb
+++ b/actionpack/lib/action_dispatch/log_subscriber.rb
@@ -16,6 +16,7 @@ module ActionDispatch
         message
       end
     end
+    subscribe_log_level :redirect, :info
   end
 end
 

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -21,6 +21,7 @@ module ActionView
         message << " (Duration: #{event.duration.round(1)}ms | Allocations: #{event.allocations})"
       end
     end
+    subscribe_log_level :render_template, :debug
 
     def render_partial(event)
       debug do
@@ -31,6 +32,7 @@ module ActionView
         message
       end
     end
+    subscribe_log_level :render_partial, :debug
 
     def render_layout(event)
       info do
@@ -38,6 +40,7 @@ module ActionView
         message << " (Duration: #{event.duration.round(1)}ms | Allocations: #{event.allocations})"
       end
     end
+    subscribe_log_level :render_layout, :info
 
     def render_collection(event)
       identifier = event.payload[:identifier] || "templates"
@@ -49,6 +52,7 @@ module ActionView
         message
       end
     end
+    subscribe_log_level :render_collection, :debug
 
     module Utils # :nodoc:
       def logger

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -23,6 +23,7 @@ module ActiveJob
         end
       end
     end
+    subscribe_log_level :enqueue, :info
 
     def enqueue_at(event)
       job = event.payload[:job]
@@ -42,6 +43,7 @@ module ActiveJob
         end
       end
     end
+    subscribe_log_level :enqueue_at, :info
 
     def perform_start(event)
       info do
@@ -49,6 +51,7 @@ module ActiveJob
         "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} enqueued at #{job.enqueued_at}" + args_info(job)
       end
     end
+    subscribe_log_level :perform_start, :info
 
     def perform(event)
       job = event.payload[:job]
@@ -67,6 +70,7 @@ module ActiveJob
         end
       end
     end
+    subscribe_log_level :perform, :info
 
     def enqueue_retry(event)
       job = event.payload[:job]
@@ -81,6 +85,7 @@ module ActiveJob
         end
       end
     end
+    subscribe_log_level :enqueue_retry, :info
 
     def retry_stopped(event)
       job = event.payload[:job]
@@ -90,6 +95,7 @@ module ActiveJob
         "Stopped retrying #{job.class} (Job ID: #{job.job_id}) due to a #{ex.class} (#{ex.message}), which reoccurred on #{job.executions} attempts."
       end
     end
+    subscribe_log_level :enqueue_retry, :error
 
     def discard(event)
       job = event.payload[:job]
@@ -99,6 +105,7 @@ module ActiveJob
         "Discarded #{job.class} (Job ID: #{job.job_id}) due to a #{ex.class} (#{ex.message})."
       end
     end
+    subscribe_log_level :discard, :error
 
     private
       def queue_name(event)

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -26,10 +26,10 @@ module ActiveRecord
         color(reflection.strict_loading_violation_message(owner), RED)
       end
     end
+    subscribe_log_level :strict_loading_violation, :debug
 
     def sql(event)
       self.class.runtime += event.duration
-      return unless logger.debug?
 
       payload = event.payload
 
@@ -70,6 +70,7 @@ module ActiveRecord
 
       debug "  #{name}  #{sql}#{binds}"
     end
+    subscribe_log_level :sql, :debug
 
     private
       def type_casted_binds(casted_binds)

--- a/activestorage/lib/active_storage/log_subscriber.rb
+++ b/activestorage/lib/active_storage/log_subscriber.rb
@@ -9,34 +9,41 @@ module ActiveStorage
       message += " (checksum: #{event.payload[:checksum]})" if event.payload[:checksum]
       info event, color(message, GREEN)
     end
+    subscribe_log_level :service_upload, :info
 
     def service_download(event)
       info event, color("Downloaded file from key: #{key_in(event)}", BLUE)
     end
+    subscribe_log_level :service_download, :info
 
     alias_method :service_streaming_download, :service_download
 
     def service_delete(event)
       info event, color("Deleted file from key: #{key_in(event)}", RED)
     end
+    subscribe_log_level :service_delete, :info
 
     def service_delete_prefixed(event)
       info event, color("Deleted files by key prefix: #{event.payload[:prefix]}", RED)
     end
+    subscribe_log_level :service_delete_prefixed, :info
 
     def service_exist(event)
       debug event, color("Checked if file exists at key: #{key_in(event)} (#{event.payload[:exist] ? "yes" : "no"})", BLUE)
     end
+    subscribe_log_level :service_exist, :debug
 
     def service_url(event)
       debug event, color("Generated URL for file at key: #{key_in(event)} (#{event.payload[:url]})", BLUE)
     end
+    subscribe_log_level :service_url, :debug
 
     def service_mirror(event)
       message = "Mirrored file at key: #{key_in(event)}"
       message += " (checksum: #{event.payload[:checksum]})" if event.payload[:checksum]
       debug event, color(message, GREEN)
     end
+    subscribe_log_level :service_mirror, :debug
 
     def logger
       ActiveStorage.logger

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -50,8 +50,9 @@ module ActiveSupport
       def initialize
         @string_subscribers = Hash.new { |h, k| h[k] = [] }
         @other_subscribers = []
-        @listeners_for = Concurrent::Map.new
+        @all_listeners_for = Concurrent::Map.new
         @groups_for = Concurrent::Map.new
+        @silenceable_groups_for = Concurrent::Map.new
         super
       end
 
@@ -99,11 +100,13 @@ module ActiveSupport
 
       def clear_cache(key = nil) # :nodoc:
         if key
-          @listeners_for.delete(key)
+          @all_listeners_for.delete(key)
           @groups_for.delete(key)
+          @silenceable_groups_for.delete(key)
         else
-          @listeners_for.clear
+          @all_listeners_for.clear
           @groups_for.clear
+          @silenceable_groups_for.clear
         end
       end
 
@@ -182,11 +185,29 @@ module ActiveSupport
       end
 
       def groups_for(name) # :nodoc:
-        @groups_for.compute_if_absent(name) do
-          listeners_for(name).group_by(&:group_class).transform_values do |s|
+        groups = @groups_for.compute_if_absent(name) do
+          all_listeners_for(name).reject(&:silenceable).group_by(&:group_class).transform_values do |s|
             s.map(&:delegate)
           end
         end
+
+        silenceable_groups = @silenceable_groups_for.compute_if_absent(name) do
+          all_listeners_for(name).select(&:silenceable).group_by(&:group_class).transform_values do |s|
+            s.map(&:delegate)
+          end
+        end
+
+        unless silenceable_groups.empty?
+          groups = groups.dup
+          silenceable_groups.each do |group_class, subscriptions|
+            active_subscriptions = subscriptions.reject { |s| s.silenced?(name) }
+            unless active_subscriptions.empty?
+              groups[group_class] = (groups[group_class] || []) + active_subscriptions
+            end
+          end
+        end
+
+        groups
       end
 
       # A Handle is used to record the start and finish time of event
@@ -271,17 +292,21 @@ module ActiveSupport
         iterate_guarding_exceptions(listeners_for(event.name)) { |s| s.publish_event(event) }
       end
 
-      def listeners_for(name)
+      def all_listeners_for(name)
         # this is correctly done double-checked locking (Concurrent::Map's lookups have volatile semantics)
-        @listeners_for[name] || synchronize do
+        @all_listeners_for[name] || synchronize do
           # use synchronisation when accessing @subscribers
-          @listeners_for[name] ||=
+          @all_listeners_for[name] ||=
             @string_subscribers[name] + @other_subscribers.select { |s| s.subscribed_to?(name) }
         end
       end
 
+      def listeners_for(name)
+        all_listeners_for(name).reject { |s| s.silenced?(name) }
+      end
+
       def listening?(name)
-        listeners_for(name).any?
+        all_listeners_for(name).any? { |s| !s.silenced?(name) }
       end
 
       # This is a sync queue, so there is no waiting.
@@ -346,11 +371,12 @@ module ActiveSupport
         end
 
         class Evented # :nodoc:
-          attr_reader :pattern, :delegate
+          attr_reader :pattern, :delegate, :silenceable
 
           def initialize(pattern, delegate)
             @pattern = Matcher.wrap(pattern)
             @delegate = delegate
+            @silenceable = delegate.respond_to?(:silenced?)
             @can_publish = delegate.respond_to?(:publish)
             @can_publish_event = delegate.respond_to?(:publish_event)
           end
@@ -371,6 +397,10 @@ module ActiveSupport
             else
               publish(event.name, event.time, event.end, event.transaction_id, event.payload)
             end
+          end
+
+          def silenced?(name)
+            @silenceable && @delegate.silenced?(name)
           end
 
           def subscribed_to?(name)


### PR DESCRIPTION
The various `LogSubscriber` subclasses tend to subscribe to events but then end up doing nothing if the log level is high enough.

But even if we end up not logging, we have to go through the entire notification path, record timing etc.

By allowing subscribers to dynamically bail out early, we can save a lot of work if all subscribers are silenced.
