### PR TITLE
[ci-skip] Docs: Update belongs_to [:default] option section

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1768,6 +1768,7 @@ module ActiveRecord
         # [:default]
         #   Provide a callable (i.e. proc or lambda) to specify that the association should
         #   be initialized with a particular record before validation.
+        #   Please note that callable won't be executed if the record exists.
         # [:strict_loading]
         #   Enforces strict loading every time the associated record is loaded through this association.
         # [:ensuring_owner_was]


### PR DESCRIPTION
Just added some more details about how `belongs_to` behaves when using
this option based on what I found here:

- https://github.com/rails/rails/blob/main/activerecord/lib/active_record/associations/builder/belongs_to.rb#L102-L106
- https://github.com/rails/rails/blob/main/activerecord/lib/active_record/associations/belongs_to_association.rb#L35-L37