### PR TITLE
Expose `#schema_creation` methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1448,6 +1448,12 @@ module ActiveRecord
         supports_foreign_keys? && foreign_keys_enabled?
       end
 
+      # Returns an instance of SchemaCreation, which can be used to visit a schema definition
+      # object and return DDL.
+      def schema_creation # :nodoc:
+        SchemaCreation.new(self)
+      end
+
       private
         def check_constraint_exists?(table_name, **options)
           check_constraint_for(table_name, **options).present?
@@ -1540,10 +1546,6 @@ module ActiveRecord
               rename_index table_name, generated_index_name, index_name(table_name, column: index.columns)
             end
           end
-        end
-
-        def schema_creation
-          SchemaCreation.new(self)
         end
 
         def create_table_definition(name, **options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -125,6 +125,10 @@ module ActiveRecord
           256 # https://dev.mysql.com/doc/refman/en/identifiers.html
         end
 
+        def schema_creation # :nodoc:
+          MySQL::SchemaCreation.new(self)
+        end
+
         private
           CHARSETS_OF_4BYTES_MAXLEN = ["utf8mb4", "utf16", "utf16le", "utf32"]
 
@@ -148,10 +152,6 @@ module ActiveRecord
             end
 
             @default_row_format
-          end
-
-          def schema_creation
-            MySQL::SchemaCreation.new(self)
           end
 
           def create_table_definition(name, **options)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -759,11 +759,11 @@ module ActiveRecord
           super
         end
 
-        private
-          def schema_creation
-            PostgreSQL::SchemaCreation.new(self)
-          end
+        def schema_creation  # :nodoc:
+          PostgreSQL::SchemaCreation.new(self)
+        end
 
+        private
           def create_table_definition(name, **options)
             PostgreSQL::TableDefinition.new(self, name, **options)
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -115,11 +115,11 @@ module ActiveRecord
           SQLite3::SchemaDumper.create(self, options)
         end
 
-        private
-          def schema_creation
-            SQLite3::SchemaCreation.new(self)
-          end
+        def schema_creation # :nodoc
+          SQLite3::SchemaCreation.new(self)
+        end
 
+        private
           def create_table_definition(name, **options)
             SQLite3::TableDefinition.new(self, name, **options)
           end


### PR DESCRIPTION
### Summary

Follow up to: https://github.com/rails/rails/pull/45772

Accessing SchemaCreation instances allows consumers to visit schema definitions
and produce DDL / populate the definitions with DDL type information.

Consumers can use the `build_*` schema definition methods together with the `SchemaCreation` object returned here to produce definitions and their respective SQL.