### PR TITLE
Make `check_constraint_exists?` public

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -163,6 +163,11 @@ module ActiveRecord
       def export_name_on_schema_dump?
         !ActiveRecord::SchemaDumper.chk_ignore_pattern.match?(name) if name
       end
+
+      def defined_for?(name:, expression: nil, **options)
+        self.name == name.to_s &&
+          options.all? { |k, v| self.options[k].to_s == v.to_s }
+      end
     end
 
     class ReferenceDefinition # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1257,6 +1257,18 @@ module ActiveRecord
         execute schema_creation.accept(at)
       end
 
+
+      # Checks to see if a check constraint exists on a table for a given check constraint definition.
+      #
+      #   check_constraint_exists?(:products, name: "price_check")
+      #
+      def check_constraint_exists?(table_name, **options)
+        if !options.key?(:name) && !options.key?(:expression)
+          raise ArgumentError, "At least one of :name or :expression must be supplied"
+        end
+        check_constraint_for(table_name, **options).present?
+      end
+
       def dump_schema_information # :nodoc:
         versions = schema_migration.all_versions
         insert_versions_sql(versions) if versions.any?
@@ -1449,10 +1461,6 @@ module ActiveRecord
       end
 
       private
-        def check_constraint_exists?(table_name, **options)
-          check_constraint_for(table_name, **options).present?
-        end
-
         def validate_change_column_null_argument!(value)
           unless value == true || value == false
             raise ArgumentError, "change_column_null expects a boolean value (true for NULL, false for NOT NULL). Got: #{value.inspect}"
@@ -1640,7 +1648,7 @@ module ActiveRecord
         def check_constraint_for(table_name, **options)
           return unless supports_check_constraints?
           chk_name = check_constraint_name(table_name, **options)
-          check_constraints(table_name).detect { |chk| chk.name == chk_name.to_s }
+          check_constraints(table_name).detect { |chk| chk.defined_for?(name: chk_name, **options) }
         end
 
         def check_constraint_for!(table_name, expression: nil, **options)

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -311,6 +311,13 @@ module ActiveRecord
         end
       end
 
+      def test_check_constraint_exists
+        with_change_table do |t|
+          expect :check_constraint_exists?, nil, [:delete_me], name: "price_check"
+          assert_not t.check_constraint_exists?(name: "price_check")
+        end
+      end
+
       def test_remove_check_constraint_removes_check_constraint
         with_change_table do |t|
           expect :remove_check_constraint, nil, [:delete_me], name: "price_check"


### PR DESCRIPTION
This example raises because `check_constraint_exists?` method is private:

https://github.com/rails/rails/blob/e8f189b1cb85e080525553ebf6544fecc918d87c/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L890-L899