### PR TITLE
rails dbconsole defaults to include_password

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make `rails dbconsole` `include_password` the default behavior
+    This option will use credentials for database console connections, if they are provided.  This
+    behavior can be disabled via `rails dbconsole --no-include-password`.
+
+    *Winfield Peterson*
+
 *   Delegate application record generator description to orm hooked generator.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -167,7 +167,7 @@ module Rails
     class DbconsoleCommand < Base # :nodoc:
       include EnvironmentArgument
 
-      class_option :include_password, aliases: "-p", type: :boolean,
+      class_option :include_password, aliases: "-p", type: :boolean, default: true,
         desc: "Automatically provide the password from database.yml"
 
       class_option :mode, enum: %w( html list line column ), type: :string,

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -115,7 +115,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_mysql_full
     start(adapter: "mysql2", database: "db", host: "localhost", port: 1234, socket: "socket", username: "user", password: "qwerty", encoding: "UTF-8")
     assert_not aborted
-    assert_equal [%w[mysql mysql5], "--host=localhost", "--port=1234", "--socket=socket", "--user=user", "--default-character-set=UTF-8", "-p", "db"], dbconsole.find_cmd_and_exec_args
+    assert_equal [%w[mysql mysql5], "--host=localhost", "--port=1234", "--socket=socket", "--user=user", "--default-character-set=UTF-8", "--password=qwerty", "db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_mysql_include_password
@@ -137,7 +137,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_equal "user", ENV["PGUSER"]
     assert_equal "host", ENV["PGHOST"]
     assert_equal "5432", ENV["PGPORT"]
-    assert_not_equal "q1w2e3", ENV["PGPASSWORD"]
+    assert_equal "q1w2e3", ENV["PGPASSWORD"]
   end
 
   def test_postgresql_with_ssl
@@ -198,7 +198,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_oracle
     start(adapter: "oracle", database: "db", username: "user", password: "secret")
     assert_not aborted
-    assert_equal ["sqlplus", "user@db"], dbconsole.find_cmd_and_exec_args
+    assert_equal ["sqlplus", "user/secret@db"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_oracle_include_password


### PR DESCRIPTION
### Summary

`rails dbconsole` should default to `include_password`

rails dbconsole will inject the password into the DB console if one is configured and the `include_password` flag is enabled.  Let’s enable this flag by default.

For years, developers have been running `rails dbconsole` in staging or production and pasting in a password, not even knowing that `rails dbconsole -p` would do what they actually wanted and apply the credentials already configured in their `config/database.yml`.  Let's apply the principle of least surprise and change the default behavior to what most folks would expect and improve the user experience.

### Other Information

* fixes https://github.com/rails/rails/issues/45901
