### PR TITLE
Fix shared state from memoization of virtual attribute default procs

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix memoization causing shared state of attributes with default procs
+
+    When a model has an attribute with a default proc and no specified type,
+    `dup`ing and checking for changes no longer causes the value of the default
+    proc to be memoized in the original attribute definition, creating shared
+    state between instances of the model.
+
+    Falsy values are now also memoized like other values were when
+    `value_before_type_cast` is called on an attribute with a proc default.
+
+    *Milo Winningham*
+
 *   `has_secure_password` now supports password challenges via a
     `password_challenge` accessor and validation.
 

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -15,8 +15,10 @@ module ActiveModel
       end
 
       def value_before_type_cast
-        if user_provided_value.is_a?(Proc)
-          @memoized_value_before_type_cast ||= user_provided_value.call
+        if defined?(@memoized_value_before_type_cast)
+          @memoized_value_before_type_cast
+        elsif user_provided_value.is_a?(Proc)
+          @memoized_value_before_type_cast = user_provided_value.call
         else
           @user_provided_value
         end

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -24,6 +24,15 @@ module ActiveModel
         end
       end
 
+      def with_value_from_user(value)
+        type.assert_valid_value(value)
+        if defined?(@memoized_value_before_type_cast) || !user_provided_value.is_a?(Proc)
+          self.class.from_user(name, value, type, original_attribute || self)
+        else
+          self.class.from_user(name, value, type, original_attribute)
+        end
+      end
+
       def with_type(type)
         self.class.new(name, user_provided_value, type, original_attribute)
       end

--- a/activemodel/test/cases/attributes_dirty_test.rb
+++ b/activemodel/test/cases/attributes_dirty_test.rb
@@ -8,8 +8,9 @@ class AttributesDirtyTest < ActiveModel::TestCase
     include ActiveModel::Attributes
     include ActiveModel::Dirty
     attribute :name, :string
-    attribute :color, :string
+    attribute :color, :string, default: "unknown"
     attribute :size, :integer
+    attribute :thing, default: -> { Object.new }
 
     def save
       changes_applied
@@ -18,6 +19,10 @@ class AttributesDirtyTest < ActiveModel::TestCase
 
   setup do
     @model = DirtyModel.new
+  end
+
+  test "dup will not result in changes" do
+    assert_not_predicate @model.dup, :changed?
   end
 
   test "setting attribute will result in change" do

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -348,6 +348,16 @@ module ActiveRecord
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
 
+    test "attributes have independent default values" do
+      klass = Class.new(OverloadedType) do
+        attribute :sounds, default: -> { [] }
+      end
+      klass.new.dup.save!
+      klass.last.sounds << "meow"
+
+      assert_not_same klass.new.sounds, klass.new.sounds
+    end
+
     test "attributes do not require a connection is established" do
       assert_not_called(ActiveRecord::Base, :connection) do
         Class.new(OverloadedType) do

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -100,6 +100,15 @@ module ActiveRecord
       assert_equal "meow", duped.author_name
     end
 
+    def test_dup_default_attributes_are_unchanged
+      klass = Class.new(Topic) do
+        attribute :numbers, default: -> { [Object.new.object_id] }
+      end
+
+      assert_not_predicate klass.new, :numbers_changed?
+      assert_not_predicate klass.new.dup, :numbers_changed?
+    end
+
     def test_dup_timestamps_are_cleared
       topic = Topic.first
       assert_not_nil topic.updated_at


### PR DESCRIPTION
### Summary

This is a fix for #45817 with some additional test coverage for proc defaults for both Active Model and Active Record.

**Context:** When a class with both `ActiveModel::Attributes` and `ActiveModel::Dirty` has an attribute with a proc default, a new instance of the model won't have a value for the attribute until it is first accessed and the default proc is called. The default value of an attribute is also not considered to be `changed?`, whether or not the default proc has been called to determine the value.

**Bug:** When a model instance is `dup`ed, [`ActiveModel::Dirty` calls `with_value_from_user` for each attribute](https://github.com/rails/rails/blob/63d4f99e2bca562110d2597ba02541c400fd5b74/activemodel/lib/active_model/dirty.rb#L133-L141), wrapping the original `UserProvidedDefault` attribute instance in a new `FromUser` attribute. If a default value is still unknown at this point, it should not be passed as the original attribute because accessing it will memoize the proc value in both attribute instances and cause them to share state.

**Fix:** Override `ActiveModel::Attribute::UserProvidedDefault#with_value_from_user` so an unknown default is not passed as the original attribute.

**Bonus:** Fixing this also revealed that falsy return values of default procs are not memoized like others in `value_before_type_cast`. This appears to be unintentional and undocumented so I fixed it as well.

### Other Information

This seems to be a long standing bug and the fix should apply to versions going back to 5.1.