### PR TITLE
Fix plugin generation inside applications

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,7 +1,7 @@
 require "bundler/setup"
-<% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
+<% if engine? && !options[:skip_active_record] && (with_dummy_app? || inside_application?) -%>
 
-APP_RAKEFILE = File.expand_path("<%= dummy_path -%>/Rakefile", __dir__)
+APP_RAKEFILE = File.expand_path("<%= test_app_path -%>/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
 <% end -%>
 <% if engine? -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -3,12 +3,13 @@
 
 ENGINE_ROOT = File.expand_path("..", __dir__)
 ENGINE_PATH = File.expand_path("../lib/<%= namespaced_name -%>/engine", __dir__)
-<% if with_dummy_app? -%>
-APP_PATH = File.expand_path("../<%= dummy_path -%>/config/application", __dir__)
+<% if with_dummy_app? || inside_application? -%>
+APP_PATH = File.expand_path("../<%= test_app_path -%>/config/application", __dir__)
 <% end -%>
 
 # Set up gems listed in the Gemfile.
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+<%- gemfile_path = File.join("..", *relative_app_path, "Gemfile") %>
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("<%= gemfile_path %>", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 <% if include_all_railties? -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
@@ -1,9 +1,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require_relative "<%= File.join("..", options[:dummy_path], "config/environment") -%>"
+require_relative "<%= File.join("..", test_app_path, "config/environment") -%>"
 <% unless options[:skip_active_record] -%>
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= test_app_path -%>/db/migrate", __dir__)]
 <% if options[:mountable] -%>
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 <% end -%>

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -32,7 +32,12 @@ module ApplicationTests
 
     test "allow running plugin new generator inside Rails app directory" do
       rails "plugin", "new", "vendor/plugins/bukkits"
-      assert File.exist?(File.join(rails_root, "vendor/plugins/bukkits/test/dummy/config/application.rb"))
+      assert File.exist?(File.join(rails_root, "vendor/plugins/bukkits/bukkits.gemspec"))
+    end
+
+    test "allow generating plugin inside Rails app directory" do
+      output = rails "generate", "plugin", "components/bukkits", "--full"
+      assert_no_match(/Invalid application name/, output)
     end
 
     test "generators default values" do


### PR DESCRIPTION
### Summary

Previously, generating a plugin inside an application would create many
files that assume it should be able to run in isolation. The extraneous
generation also led to an error when using `rails generate plugin`
instead of `rails plugin new` where the dummy app created for tests
would try to use the same name as the parent application.

This commit fixes those issues by not generating the following when
inside a rails application:
- Gemfile
- .gitignore and `git init`
- a dummy application in test/

It also fixes the paths in the generated bin/rails and test_helper to
use the parent Rails application as a host.

### Other Information

Fixes #18073
