### PR TITLE
Remove NULL default check

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -26,7 +26,7 @@ module ActiveRecord
 
           def visit_ChangeColumnDefaultDefinition(o)
             sql = +"ALTER COLUMN #{quote_column_name(o.column.name)} "
-            if o.default.nil? && !o.column.null
+            if !o.column.null
               sql << "DROP DEFAULT"
             else
               sql << "SET DEFAULT #{quote_default_expression(o.default, o.column)}"


### PR DESCRIPTION
I found the SET DEFAULT NULL can be run when the column is nullable,
so we can safely remove this condition.
