### PR TITLE
Add String#downcase_first method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `String#downcase_first` method.
+
+    This method is the corollary of `String#upcase_first`.
+
+    *Mark Schneider*
+
 *   `thread_mattr_accessor` will call `.dup.freeze` on non-frozen default values.
 
     This provides a basic level of protection against different threads trying

--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -244,7 +244,7 @@ class String
     ActiveSupport::Inflector.classify(self)
   end
 
-  # Capitalizes the first word, turns underscores into spaces, and (by default)strips a
+  # Capitalizes the first word, turns underscores into spaces, and (by default) strips a
   # trailing '_id' if present.
   # Like +titleize+, this is meant for creating pretty output.
   #
@@ -267,7 +267,7 @@ class String
     ActiveSupport::Inflector.humanize(self, capitalize: capitalize, keep_id_suffix: keep_id_suffix)
   end
 
-  # Converts just the first character to uppercase.
+  # Converts the first character to uppercase.
   #
   #   'what a Lovely Day'.upcase_first # => "What a Lovely Day"
   #   'w'.upcase_first                 # => "W"
@@ -276,6 +276,17 @@ class String
   # See ActiveSupport::Inflector.upcase_first.
   def upcase_first
     ActiveSupport::Inflector.upcase_first(self)
+  end
+
+  # Converts the first character to lowercase.
+  #
+  #   'If they enjoyed The Matrix'.downcase_first # => "if they enjoyed The Matrix"
+  #   'I'.downcase_first                          # => "i"
+  #   ''.downcase_first                           # => ""
+  #
+  # See ActiveSupport::Inflector.downcase_first.
+  def downcase_first
+    ActiveSupport::Inflector.downcase_first(self)
   end
 
   # Creates a foreign key name from a class name.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -154,13 +154,22 @@ module ActiveSupport
       result
     end
 
-    # Converts just the first character to uppercase.
+    # Converts the first character in the string to uppercase.
     #
     #   upcase_first('what a Lovely Day') # => "What a Lovely Day"
     #   upcase_first('w')                 # => "W"
     #   upcase_first('')                  # => ""
     def upcase_first(string)
       string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
+    end
+
+    # Converts the first character in the string to lowercase.
+    #
+    #   downcase_first('If they enjoyed The Matrix') # => "if they enjoyed The Matrix"
+    #   downcase_first('I')                          # => "i"
+    #   downcase_first('')                           # => ""
+    def downcase_first(string)
+      string.length > 0 ? string[0].downcase.concat(string[1..-1]) : ""
     end
 
     # Capitalizes all the words and replaces some characters in the string to

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -90,6 +90,18 @@ class StringInflectionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_downcase_first
+    assert_equal "try again", "Try again".downcase_first
+  end
+
+  def test_downcase_first_with_one_char
+    assert_equal "t", "T".downcase_first
+  end
+
+  def test_downcase_first_with_empty_string
+    assert_equal "", "".downcase_first
+  end
+
   def test_upcase_first
     assert_equal "What a Lovely Day", "what a Lovely Day".upcase_first
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1859,6 +1859,32 @@ NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
 
 [String#foreign_key]: https://api.rubyonrails.org/classes/String.html#method-i-foreign_key
 
+#### `upcase_first`
+
+The method [`upcase_first`][String#upcase_first] capitalizes the first letter of the receiver:
+
+```ruby
+"employee salary".upcase_first # => "Employee salary"
+"".upcase_first                # => ""
+```
+
+NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+
+[String#upcase_first]: https://api.rubyonrails.org/classes/String.html#method-i-upcase_first
+
+#### `downcase_first`
+
+The method [`downcase_first`][String#downcase_first] converts the first letter of the receiver to lowercase:
+
+```ruby
+"If I had read Alice in Wonderland".downcase_first # => "if I had read Alice in Wonderland"
+"".downcase_first                                  # => ""
+```
+
+NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
+
+[String#downcase_first]: https://api.rubyonrails.org/classes/String.html#method-i-downcase_first
+
 ### Conversions
 
 #### `to_date`, `to_time`, `to_datetime`


### PR DESCRIPTION
Rails 5 added String#upcase_first, which converts the first letter of a
string to uppercase (returning a duplicate).  This commit adds the
corollary method, converting the first letter to lowercase.

### Summary

This adds `String#downcasecase_first` method via `ActiveSupport::Inflector`, which
is how `String#upcase_first` was added.


