### PR TITLE
Speed up no-op nested attributes save

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -491,6 +491,8 @@ module ActiveRecord
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 
+        existing_records = existing_records.index_by { |record| record.id.to_s }
+
         attributes_collection.each do |attributes|
           if attributes.respond_to?(:permitted?)
             attributes = attributes.to_h
@@ -501,7 +503,7 @@ module ActiveRecord
             unless reject_new_record?(association_name, attributes)
               association.reader.build(attributes.except(*UNASSIGNABLE_KEYS))
             end
-          elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes["id"].to_s }
+          elsif existing_record = existing_records[attributes["id"].to_s]
             unless call_reject_if(association_name, attributes)
               # Make sure we are operating on the actual object which is in the association's
               # proxy_target array (either by finding it, or adding it if not found)


### PR DESCRIPTION
### Summary

When we have two large collections, traversing one for each item in the other has a complexity of O(n^2). This makes Active Record do a lot of work in case when no record data has changed.

To speed it up, we create a map of existing recrods by record ID, and use that inside the loop. This speeds up the no-op case (when no records have changed) **by 2x**.

### Other Information

Here is the script to measure performance:

```rb
require "bundler/setup"
require "active_record"
require "benchmark"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.connection.create_table(:orders) { |t| }
ActiveRecord::Base.connection.create_table(:items) { |t| t.references :order, null: false }

class Order < ActiveRecord::Base
  has_many :items
  accepts_nested_attributes_for :items
end

class Item < ActiveRecord::Base
end

order = Order.create
Item.insert_all Array.new(2000, { order_id: order.id })

order = Order.first
items_attributes = order.items.map { |item| { id: item.id } }

puts Benchmark.realtime {
  order.update(items_attributes: items_attributes)
}
```

Additional speedup could be achieved by doing a similar thing for `association.target.detect`, but I found that trickier to do, since `association.target` changes through the loop, and couldn't guarantee equivalent behaviour, so I left it out of the PR.