### PR TITLE
Nested attribute docs improvements

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -280,6 +280,26 @@ module ActiveRecord
     #   member = Member.new
     #   member.avatar_attributes = {icon: 'sad'}
     #   member.avatar.width # => 200
+    #
+    # === Forms
+    #
+    # Use ActionView::Helpers::FormHelper#fields_for to create form elements
+    # for updating or destroying nested attributes.
+    #
+    # === Testing
+    #
+    # If you are using ActionView::Helpers::FormHelper#fields_for, your integration
+    # tests should replicate the HTML structure it provides. For example;
+    #
+    #   post members_path, params: {
+    #     member: {
+    #       name: 'joe',
+    #       posts_attributes: {
+    #         '0' => { title: 'Foo' },
+    #         '1' => { title: 'Bar' }
+    #       }
+    #     }
+    #   }
     module ClassMethods
       REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
 
@@ -375,11 +395,11 @@ module ActiveRecord
         end
     end
 
-    # Returns ActiveRecord::AutosaveAssociation::marked_for_destruction? It's
+    # Returns ActiveRecord::AutosaveAssociation#marked_for_destruction? It's
     # used in conjunction with fields_for to build a form element for the
     # destruction of this association.
     #
-    # See ActionView::Helpers::FormHelper::fields_for for more info.
+    # See ActionView::Helpers::FormHelper#fields_for for more info.
     def _destroy
       marked_for_destruction?
     end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -281,7 +281,7 @@ module ActiveRecord
     #   member.avatar_attributes = {icon: 'sad'}
     #   member.avatar.width # => 200
     #
-    # === Forms
+    # === Creating forms with nested attributes
     #
     # Use ActionView::Helpers::FormHelper#fields_for to create form elements
     # for updating or destroying nested attributes.


### PR DESCRIPTION
2 small improvemennts to the docs for `ActiveRecord::NestedAttributes`.

- Include a link to `ActionView::Helpers::FormHelper::fields_for`, since you would typically use these tools in tandem I think it makes sense to point you to it.
- Show an example of how to write an integration test when using `ActionView::Helpers::FormHelper::fields_for`. You could argue that this example should also go in Action View, but I think it makes more sense here as the "parent" doc for the Nested Attributes feature.
