### PR TITLE
Rescue EOFError error from rack on a multipart request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rescue `EOFError` exception from `rack` on a multipart request.
+
+    *Nikita Vasilevsky*
+
 *   Log redirects from routes the same way as redirects from controllers.
 
     *Dennis Paagman*

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -406,7 +406,7 @@ module ActionDispatch
         Request::Utils.check_param_encoding(pr)
         self.request_parameters = Request::Utils.normalize_encode_params(pr)
       end
-    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
+    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError, EOFError => e
       raise ActionController::BadRequest.new("Invalid request parameters: #{e.message}")
     end
     alias :request_parameters :POST


### PR DESCRIPTION
There are several variations of a multipart request that can cause  `request_parameters` method to fail with the `EOFError` exception raised by rack in the following places:
https://github.com/rack/rack/blob/c9c32b70f9ac98d903ab6361cdba3abbf4fa60ac/lib/rack/multipart/parser.rb#L42
https://github.com/rack/rack/blob/c9c32b70f9ac98d903ab6361cdba3abbf4fa60ac/lib/rack/multipart/parser.rb#L224
https://github.com/rack/rack/blob/c9c32b70f9ac98d903ab6361cdba3abbf4fa60ac/lib/rack/multipart/parser.rb#L359

So I added `EOFError` to the rescue list to raise `BadRequest` exception and render a "bad request" page instead of rendering http 500

`rack` 3.0 introduces a new `EmptyContentError ` exception for one of the cases but it's a child exception of `EOFError` so I'm not explicitly rescuing it even though I tested the code against rack `3.0.0.beta1`
https://github.com/rack/rack/commit/249dd785625f0cbe617d3144401de90ecf77025a

cc @rafaelfranca 