### PR TITLE
Reduce String allocations in `xml_name_escape`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -134,13 +134,15 @@ class ERB
       name = name.to_s
       return "" if name.blank?
 
-      starting_char = name[0].gsub(TAG_NAME_START_REGEXP, TAG_NAME_REPLACEMENT_CHAR)
+      starting_char = name[0]
+      starting_char.gsub!(TAG_NAME_START_REGEXP, TAG_NAME_REPLACEMENT_CHAR)
 
       return starting_char if name.size == 1
 
-      following_chars = name[1..-1].gsub(TAG_NAME_FOLLOWING_REGEXP, TAG_NAME_REPLACEMENT_CHAR)
+      following_chars = name[1..-1]
+      following_chars.gsub!(TAG_NAME_FOLLOWING_REGEXP, TAG_NAME_REPLACEMENT_CHAR)
 
-      starting_char + following_chars
+      starting_char << following_chars
     end
     module_function :xml_name_escape
   end


### PR DESCRIPTION
### Summary

When working in a large rails app, I noticed in a flamegraph of a particular request that ~68ms was spent in the `xml_name_escape` method. I also ran an allocation tracer, which showed this method at the top of the list for String allocations.

This patch updates this method to avoid 3 String allocations:
- 2 allocations saved by using gsub! instead of gsub
- 1 allocation saved by concatenating to an existing string instead of allocating a new output string

### Other Information

Relevant method was added in this commit: https://github.com/rails/rails/commit/649516ce0feb699ae06a8c5e81df75d460cc9a85

For a rough benchmark in our rails app, I wrote a test with an allocation tracer around rendering a small view component.
- 244 String allocations before this change
- 228 String allocations from switching to gsub!
- 220 String allocations with this full patch

A ~10% reduction in String allocations in a real-world example seemed like a good justification for this small change.