### PR TITLE
FFmpeg (5.0+) has updated the tag where rotation info is retrieved from

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix retrieving rotation value from FFmpeg on version 5.0+.
+
+    In FFmpeg version 5.0+ the rotation value has been removed from tags.
+    Instead the value can be found in side_data_list. Along with
+    this update it's possible to have values of -90, -270 to denote the video
+    has been rotated.
+
+    *Haroon Ahmed*
+
 *   Touch all corresponding model records after ActiveStorage::Blob is analyzed
 
     This fixes a race condition where a record can be requested and have a cache entry built, before

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -16,7 +16,7 @@ module ActiveStorage
   #   ActiveStorage::Analyzer::VideoAnalyzer.new(blob).metadata
   #   # => { width: 640.0, height: 480.0, duration: 5.0, angle: 0, display_aspect_ratio: [4, 3], audio: true, video: true }
   #
-  # When a video's angle is 90 or 270 degrees, its width and height are automatically swapped for convenience.
+  # When a video's angle is 90, -90, 270 or -270 degrees, its width and height are automatically swapped for convenience.
   #
   # This analyzer requires the {FFmpeg}[https://www.ffmpeg.org] system library, which is not provided by Rails.
   class Analyzer::VideoAnalyzer < Analyzer
@@ -51,7 +51,11 @@ module ActiveStorage
       end
 
       def angle
-        Integer(tags["rotate"]) if tags["rotate"]
+        if tags["rotate"]
+          Integer(tags["rotate"])
+        elsif side_data && side_data[0] && side_data[0]["rotation"]
+          Integer(side_data[0]["rotation"])
+        end
       end
 
       def display_aspect_ratio
@@ -66,7 +70,7 @@ module ActiveStorage
       end
 
       def rotated?
-        angle == 90 || angle == 270
+        angle == 90 || angle == 270 || angle == -90 || angle == -270
       end
 
       def audio?
@@ -95,9 +99,12 @@ module ActiveStorage
         @display_height_scale ||= Float(display_aspect_ratio.last) / display_aspect_ratio.first if display_aspect_ratio
       end
 
-
       def tags
         @tags ||= video_stream["tags"] || {}
+      end
+
+      def side_data
+        @side_data ||= video_stream["side_data_list"] || {}
       end
 
       def video_stream

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -26,7 +26,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 480, metadata[:width]
     assert_equal 640, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal 90, metadata[:angle]
+    assert_includes [90, -90], metadata[:angle]
   end
 
   test "analyzing a video with rectangular samples" do


### PR DESCRIPTION
### Summary

When running the test locally `bin/test test/analyzer/video_analyzer_test.rb:22`
(analyzing a rotated video).

I'm seeing it failing for FFmpeg in versions 5.0+ this is due to a change upstream.

The original code which pulls the rotation from tags is still left for
older ffmpeg versions whilst the newer ffmpeg version 5.0+ will use the
side_data to retrieve the rotation info.

Example output for side_data_list (when adding puts here https://github.com/rails/rails/pull/45837/files#diff-e69a5f7b5e4a55a776812dcc33b529c549984a5692048b0ec2683596abd999b4R107)

```
[{"side_data_type"=>"Display Matrix",   
  "displaymatrix"=>                     
   "\n00000000:            0       65536           0\n00000001:       -65536           0           0\n00000002:            0           0  1073741824\n",
  "rotation"=>-90}] 
```

Run the command below to see the full output for the rotated_video file.
> ffprobe -print_format json -show_streams -show_format activestorage/test/fixtures/files/rotated_video.mp4

### Other Information

It's unclear why on CI everything is green but this line https://github.com/rails/buildkite-config/blob/b44bcf075b8683283ee4ab06391c895e608f162e/Dockerfile#L91 looks like
we are using the latest version, I have no idea why upstream is not failing 🤷‍♂️

Commits where "rotate" was removed;
- https://github.com/FFmpeg/FFmpeg/commit/9dd104f6e263dce770541074d99b5286524f2a8b
- https://github.com/FFmpeg/FFmpeg/commit/7b6012efaae549b8e624876dba9550cb003f98b1
- Nothing mentioned on release notes that I could see https://www.ffmpeg.org
- https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/9dd104f6e263dce770541074d99b5286524f2a8b
- http://git.ffmpeg.org/gitweb/ffmpeg.git/commit/ddef3d902f0e4cbd6be6b3e5df7ec158ce51488b (this is also relevant for context)

cc/ @eileencodes 
