### PR TITLE
Reference consistency check correction

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -125,7 +125,7 @@ end
 When used alone, `belongs_to` produces a one-directional one-to-one connection. Therefore each book in the above example "knows" its author, but the authors don't know about their books.
 To setup a [bi-directional association](#bi-directional-associations) - use `belongs_to` in combination with a `has_one` or `has_many` on the other model.
 
-`belongs_to` does not ensure reference consistency if the optional option is set to true, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
+`belongs_to` does not ensure reference consistency if `optional` is set to true, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
 
 ```ruby
 create_table :books do |t|

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -125,7 +125,7 @@ end
 When used alone, `belongs_to` produces a one-directional one-to-one connection. Therefore each book in the above example "knows" its author, but the authors don't know about their books.
 To setup a [bi-directional association](#bi-directional-associations) - use `belongs_to` in combination with a `has_one` or `has_many` on the other model.
 
-`belongs_to` does not ensure reference consistency, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
+`belongs_to` does not ensure reference consistency if the optional option is set to true, so depending on the use case, you might also need to add a database-level foreign key constraint on the reference column, like this:
 
 ```ruby
 create_table :books do |t|


### PR DESCRIPTION


### Summary
By default all belongs_to relations are set to required, and required means Rails checks the reference consistency. That sentence is correct only if the optional is set to true, then in this case Rails not only allows this field to be null but also it does not check the reference consistency. But this is not the default behavior.

### Other Information
[Related discussion when this change introduced](https://github.com/rails/rails/issues/18233)
