### PR TITLE
Log a warning if ActiveSupport::Cache is given an expiration in the past

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Log a warning if `ActiveSupport::Cache` is given an expiration in the past.
+
+    *Trevor Turk*
+
 *   Add `skip_nil:` support to `ActiveSupport::Cache::Store#fetch_multi`.
 
     *Daniel Alfaro*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -718,6 +718,10 @@ module ActiveSupport
             expires_at = call_options.delete(:expires_at)
             call_options[:expires_in] = (expires_at - Time.now) if expires_at
 
+            if call_options[:expires_in]&.negative?
+              ActiveSupport::Cache::Store.logger&.warn("Cache expiration is in the past")
+            end
+
             if options.empty?
               call_options
             else

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -566,6 +566,14 @@ module CacheStoreBehavior
     assert_equal "Either :expires_in or :expires_at can be supplied, but not both", error.message
   end
 
+  def test_expires_at_logs_a_warning_if_in_the_past
+    buffer = StringIO.new
+    @cache.logger = ActiveSupport::Logger.new(buffer)
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_at: 1.minute.ago)
+    assert_match %r{Cache expiration is in the past}, buffer.string
+  end
+
   def test_race_condition_protection_skipped_if_not_defined
     key = SecureRandom.alphanumeric
     @cache.write(key, "bar")


### PR DESCRIPTION
### Summary

This change logs a warning if `ActiveSupport::Cache` is given an expiration in the past via `Rails.cache#fetch/write`. 

```ruby
# Before: silently fails to write to the cache because expires_at is in the past
Rails.cache.write(key, value, expires_at: Time.now.beginning_of_day)

# After: logs a warning
Rails.cache.write(key, value, expires_at: Time.now.beginning_of_day)
```

### Other Information

Note the `expires_at` option was introduced in #41831, and this PR references prior art in #45047. 

I ran into an issue that took me a while to debug, even though it was just a typo on my part. If you provide an `expires_at` time in the past, your cache fetch/write will fail without warning. (The cache entry is already expired by the time it's written. I'm not sure if the write is skipped, or if it'd be written and just not be accessible.)

I ran into this because I was using `expires_at: Time.now.beginning_of_day` when I meant `expires_at: Time.now.tomorrow.beginning_of_day`. 

Obviously this is a typo on my part, but it took me a while to figure out what went wrong before I realized my mistake, so I thought this might be helpful for future debuggers. 

Note this change should log a warning when using `expires_at` or `expires_in`, since it invokes the logger after `expires_at` has been converted into an `expires_in`. 