### PR TITLE
Fix "unmarshalable" test for minitest 5.16.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.1)
+    minitest (5.16.3)
     minitest-bisect (1.5.1)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -740,7 +740,7 @@ module ApplicationTests
       assert_no_match "create_table(:users)", output
     end
 
-    def test_run_in_parallel_with_unmarshable_exception
+    def test_run_in_parallel_with_unmarshalable_exception
       exercise_parallelization_regardless_of_machine_core_count(with: :processes)
 
       file = app_file "test/fail_test.rb", <<-RUBY
@@ -762,7 +762,7 @@ module ApplicationTests
 
       output = run_test_command(file)
 
-      assert_match(/RuntimeError: (Wrapped undumpable exception|result not reported)/, output)
+      assert_match(/RuntimeError: (Wrapped undumpable exception|result not reported|Neutered Exception)/, output)
       assert_match "1 runs, 0 assertions, 0 failures, 1 errors", output
     end
 


### PR DESCRIPTION
Minitest now contains its own logic for sanitizing exceptions.

https://github.com/minitest/minitest/blob/d24fba6c4d35d983c66944c460a0b37d11d2fff7/lib/minitest/test.rb#L204-L234

As long as they are reported (more-or-less) correctly we should consider this test to pass.