### PR TITLE
Reuse strict locals templates for any locals

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -120,7 +120,7 @@ module ActionView
     @frozen_string_literal = false
 
     attr_reader :identifier, :handler
-    attr_reader :variable, :format, :variant, :locals, :virtual_path
+    attr_reader :variable, :format, :variant, :virtual_path
 
     def initialize(source, identifier, handler, locals:, format: nil, variant: nil, virtual_path: nil)
       @source            = source.dup
@@ -129,7 +129,6 @@ module ActionView
       @compiled          = false
       @locals            = locals
       @virtual_path      = virtual_path
-      @strict_locals   = nil
 
       @variable = if @virtual_path
         base = @virtual_path.end_with?("/") ? "" : ::File.basename(@virtual_path)
@@ -140,6 +139,16 @@ module ActionView
       @format            = format
       @variant           = variant
       @compile_mutex     = Mutex.new
+    end
+
+    # The locals this template has been or will be compiled for, or nil if this
+    # is a strict locals template.
+    def locals
+      if strict_locals?
+        nil
+      else
+        @locals
+      end
     end
 
     # Returns whether the underlying handler supports streaming. If so,
@@ -177,7 +186,7 @@ module ActionView
     end
 
     def inspect
-      "#<#{self.class.name} #{short_identifier} locals=#{@locals.inspect}>"
+      "#<#{self.class.name} #{short_identifier} locals=#{locals.inspect}>"
     end
 
     def source
@@ -240,6 +249,14 @@ module ActionView
       return if @strict_locals.nil? # Magic comment not found
 
       @strict_locals = "**nil" if @strict_locals.blank?
+    end
+
+    def strict_locals?
+      if defined?(@strict_locals)
+        @strict_locals
+      else
+        STRICT_LOCALS_REGEX === self.source
+      end
     end
 
     # Exceptions are marshalled when using the parallel test runner with DRb, so we need

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -167,10 +167,10 @@ module ActionView
       instrument_render_template do
         compile!(view)
         if buffer
-          view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, has_strict_locals: @strict_locals.present?, &block)
+          view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, has_strict_locals: @strict_locals, &block)
           nil
         else
-          view._run(method_name, self, locals, OutputBuffer.new, add_to_stack: add_to_stack, has_strict_locals: @strict_locals.present?, &block).to_s
+          view._run(method_name, self, locals, OutputBuffer.new, add_to_stack: add_to_stack, has_strict_locals: @strict_locals, &block).to_s
         end
       end
     rescue => e
@@ -314,7 +314,7 @@ module ActionView
         code = @handler.call(self, source)
 
         method_arguments =
-          if @strict_locals.present?
+          if @strict_locals
             "output_buffer, #{@strict_locals}"
           else
             "local_assigns, output_buffer"
@@ -356,7 +356,7 @@ module ActionView
           raise SyntaxErrorInTemplate.new(self, original_source)
         end
 
-        return unless @strict_locals.present?
+        return unless @strict_locals
 
         # Check compiled method parameters to ensure that only kwargs
         # were provided as strict locals, preventing `locals: (foo, *foo)` etc
@@ -387,7 +387,7 @@ module ActionView
       end
 
       def locals_code
-        return "" if @strict_locals.present?
+        return "" if @strict_locals
 
         # Only locals with valid variable names get set directly. Others will
         # still be available in local_assigns.

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -18,21 +18,27 @@ module ActionView
     end
 
     def bind_locals(locals)
-      if template = @templates[locals]
-        template
-      else
+      unless template = @templates[locals]
         @write_lock.synchronize do
           normalized_locals = normalize_locals(locals)
 
           # We need ||=, both to dedup on the normalized locals and to check
           # while holding the lock.
-          @templates[normalized_locals] ||= build_template(normalized_locals)
+          template = (@templates[normalized_locals] ||= build_template(normalized_locals))
 
           # This may have already been assigned, but we've already de-dup'd so
           # reassignment is fine.
-          @templates[locals.dup] = @templates[normalized_locals]
+          @templates[locals.dup] = template
+
+          if template.strict_locals?
+            # Under strict locals, we only need one template.
+            # This replaces the @templates Concurrent::Map with a hash which
+            # returns this template for every key.
+            @templates = Hash.new(template).freeze
+          end
         end
       end
+      template
     end
 
     private

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -254,4 +254,16 @@ module ResolverSharedTests
   ensure
     I18n.reload!
   end
+
+  def test_strict_locals_reuses_same_template
+    with_file "test/hello_world.html.erb", %q{<%# locals: (message: "hello")%>\n<%= message %>}
+
+    template = context.find_all("hello_world", "test", false, [:message], {})[0]
+    template2 = context.find_all("hello_world", "test", false, [], {})[0]
+
+    assert_same template, template2
+
+    assert_predicate template, :strict_locals?
+    assert_nil template.locals
+  end
 end


### PR DESCRIPTION
This commit allows template lookups and render calls which find a "strict local" template to reuse that template even when provided with different locals.

This also makes `Template#locals` return nil for strict local templates, to avoid leaking the details of the first lookup. Almost nothing calls this method, so this should not be a significant change.

The second commit also avoids calling `present?` on `@strict_locals`, which should be slightly faster and arguably (see commit) more consistent.

cc @joelhawksley 