### PR TITLE
Fix assoc_hash handling in ripper tracker

### DIFF
--- a/actionview/lib/action_view/ripper_ast_parser.rb
+++ b/actionview/lib/action_view/ripper_ast_parser.rb
@@ -63,7 +63,7 @@ module ActionView
         end
 
         def call_method_name
-          self.last.first
+          self[2].first
         end
 
         def to_string

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -197,6 +197,18 @@ module SharedTrackerTests
     ], tracker.dependencies
   end
 
+  def test_finds_dependencies_with_bare_assoc_hash_on_constant
+    template = FakeTemplate.new(%{
+      <%= render SomeConstant.message(this: "that") %>
+    }, :erb)
+
+    tracker = make_tracker("assoc_hash/const", template)
+
+    assert_equal [
+      "messages/message",
+    ], tracker.dependencies
+  end
+
   def test_dependencies_with_interpolation
     template = FakeTemplate.new(%q{
       <%= render "double/#{quote}" %>


### PR DESCRIPTION
Previously ripper tracker would misidentify the method name when called with a constant and assoc_hash.

This correctly finds the method name in those cases.