### PR TITLE
Install specific version of codespell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install codespell
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install codespell==2.1.0
       - name: Check spelling with codespell
         run: codespell --ignore-words=codespell.txt || exit 1
   misspell:


### PR DESCRIPTION
As the codespell dictionary changes between versions, we should declare explicitly the version we are ready for so that this CI doesn't break every time there is a new version.

Ideally this would be upgraded periodically to catch new errors, but I don't think the need is urgent enough for us to fail CI on PRs. I think this is better than the alternative (letting it fail until someone gets around to fixing it) because it's likely we'll accidentally merge new typos while it fails.
