### PR TITLE
Redis 5.0.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
 gemspec
 
 if RUBY_VERSION < "3"

--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,7 @@ end
 group :cable do
   gem "puma", require: false
 
-  gem "hiredis", require: false
-  gem "redis", "~> 4.0", require: false
+  gem "redis", ">= 4.0.1", require: false
 
   gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,6 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
-    hiredis (0.6.3)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
     i18n (1.8.11)
@@ -400,7 +399,7 @@ GEM
     rbtree (0.4.5)
     rdoc (6.3.3)
     redcarpet (3.2.3)
-    redis (4.5.1)
+    redis (4.7.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
     regexp_parser (2.2.1)
@@ -574,7 +573,6 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   google-cloud-storage (~> 1.11)
-  hiredis
   image_processing (~> 1.2)
   importmap-rails
   jsbundling-rails
@@ -598,7 +596,7 @@ DEPENDENCIES
   rails!
   rake (>= 11.1)
   redcarpet (~> 3.2.3)
-  redis (~> 4.0)
+  redis (>= 4.0.1)
   redis-namespace
   resque
   resque-scheduler

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The Redis adapter is now compatible with redis-rb 5.0
+
+    Compatibility with redis-rb 3.x was dropped.
+
+    *Jean Boussier*
+
 *   The Action Cable server is now mounted with `anchor: true`.
 
     This means that routes that also start with `/cable` will no longer clash with Action Cable.

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "redis", ">= 3", "< 5"
+gem "redis", ">= 4", "< 6"
 require "redis"
 
 require "active_support/core_ext/hash/except"
@@ -76,7 +76,7 @@ module ActionCable
 
           def listen(conn)
             conn.without_reconnect do
-              original_client = conn.respond_to?(:_client) ? conn._client : conn.client
+              original_client = conn._client
 
               conn.subscribe("_action_cable_internal") do |on|
                 on.subscribe do |chan, count|

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -17,12 +17,6 @@ class RedisAdapterTest < ActionCable::TestCase
   end
 end
 
-class RedisAdapterTest::Hiredis < RedisAdapterTest
-  def cable_config
-    super.merge(driver: "hiredis")
-  end
-end
-
 class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
   def cable_config
     alt_cable_config = super.dup

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -48,7 +48,7 @@ class RedisAdapterTest::ConnectorDefaultID < ActionCable::TestCase
   end
 
   test "sets connection id for connection" do
-    assert_called_with ::Redis, :new, [ expected_connection.stringify_keys ] do
+    assert_called_with ::Redis, :new, [ expected_connection.symbolize_keys ] do
       @adapter.send(:redis_connection)
     end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Redis cache store is now compatible with redis-rb 5.0.
+
+    *Jean Boussier*
+
 *   Log a warning if `ActiveSupport::Cache` is given an expiration in the past.
 
     *Trevor Turk*

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -13,29 +13,10 @@ Rake::TestTask.new do |t|
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task["test:cache_stores:redis:ruby"].invoke
-end
-
 namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", file)
     end || raise("Failures")
-  end
-
-  namespace :cache_stores do
-    namespace :redis do
-      %w[ ruby hiredis ].each do |driver|
-        task("env:#{driver}") { ENV["REDIS_DRIVER"] = driver }
-
-        Rake::TestTask.new(driver => "env:#{driver}") do |t|
-          t.test_files = ["test/cache/stores/redis_cache_store_test.rb"]
-          t.warning = true
-          t.verbose = true
-          t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
-        end
-      end
-    end
   end
 end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -5,14 +5,8 @@ begin
   require "redis"
   require "redis/distributed"
 rescue LoadError
-  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \"~> 4.0\"`"
+  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \">= 4.0.1\"`"
   raise
-end
-
-# Prefer the hiredis driver but don't require it.
-begin
-  require "redis/connection/hiredis"
-rescue LoadError
 end
 
 require "connection_pool"

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -84,9 +84,11 @@ module ActiveSupport
           elsif redis
             redis
           elsif urls.size > 1
-            build_redis_distributed_client urls: urls, **redis_options
+            build_redis_distributed_client(urls: urls, **redis_options)
+          elsif urls.empty?
+            build_redis_client(**redis_options)
           else
-            build_redis_client url: urls.first, **redis_options
+            build_redis_client(url: urls.first, **redis_options)
           end
         end
 
@@ -97,8 +99,8 @@ module ActiveSupport
             end
           end
 
-          def build_redis_client(url:, **redis_options)
-            ::Redis.new DEFAULT_REDIS_OPTIONS.merge(redis_options.merge(url: url))
+          def build_redis_client(**redis_options)
+            ::Redis.new(DEFAULT_REDIS_OPTIONS.merge(redis_options))
           end
       end
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -323,13 +323,13 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   end
 
   class UnavailableRedisClient < Redis::Client
-    def ensure_connected
+    def ensure_connected(...)
       raise Redis::BaseConnectionError
     end
   end
 
   class MaxClientsReachedRedisClient < Redis::Client
-    def ensure_connected
+    def ensure_connected(...)
       raise Redis::CommandError
     end
   end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -46,7 +46,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class InitializationTest < ActiveSupport::TestCase
     test "omitted URL uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        url: nil,
         connect_timeout: 20, read_timeout: 1, write_timeout: 1,
         reconnect_attempts: 0
       ] do
@@ -56,7 +55,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     test "no URLs uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        url: nil,
         connect_timeout: 20, read_timeout: 1, write_timeout: 1,
         reconnect_attempts: 0
       ] do

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -517,16 +517,6 @@ To get started, add the redis gem to your Gemfile:
 gem 'redis'
 ```
 
-You can enable support for the faster [hiredis](https://github.com/redis/hiredis)
-connection library by additionally adding its ruby wrapper to your Gemfile:
-
-```ruby
-gem 'hiredis'
-```
-
-Redis cache store will automatically require and use hiredis if available. No further
-configuration is needed.
-
 Finally, add the configuration in the relevant `config/environments/*.rb` file:
 
 ```ruby


### PR DESCRIPTION
This requires very little actual code change. Most of the fixes are for the test suite itself.

The detailed explanation is in each individual commit, but a few key points:

  - We stop testing `hiredis`, mostly because it's very different in 5.0, so it would be lots of complexity, but also because it's supposed to be abstracted away, we shouldn't have to test our dependencies like this. cc @matthewd since git blame showed you cared about this.
  - `RedisCacheStore` basically no actual code change, just updated the stubs.
  - `ActionCable`, I plan to merge https://github.com/redis/redis-rb/pull/1131 for redis 5.0, with this we don't need to mess with the client internals anymore. So if anything the code is greatly simplified.
  - Also `ActionCable` initialize the redis client with symbol keys. 5.0 no longer accept string keys in its config.

I locally tested with https://github.com/redis/redis-rb/pull/1131, `activesupport/test/cache/stores/redis_cache_store_test.rb` and `actioncable/test/subscription_adapter/redis_test.rb` both pass.