### PR TITLE
Replace MutexHook by MonitorHook to allow reentrancy

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `config.allow_concurrency = false` now use a `Monitor` instead of a `Mutex`
+
+    This allows to enable `config.active_support.executor_around_test_case` even
+    when `config.allow_concurrency` is disabled.
+
+    *Jean Boussier*
+
 *   Add `routes --unused` option to detect extraneous routes.
 
     Example:

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -87,21 +87,21 @@ module Rails
         ActiveSupport.run_load_hooks(:after_initialize, self)
       end
 
-      class MutexHook
-        def initialize(mutex = Mutex.new)
-          @mutex = mutex
+      class MonitorHook # :nodoc:
+        def initialize(monitor = Monitor.new)
+          @monitor = monitor
         end
 
         def run
-          @mutex.lock
+          @monitor.enter
         end
 
         def complete(_state)
-          @mutex.unlock
+          @monitor.exit
         end
       end
 
-      module InterlockHook
+      module InterlockHook # :nodoc:
         def self.run
           ActiveSupport::Dependencies.interlock.start_running
         end
@@ -116,7 +116,7 @@ module Rails
           # User has explicitly opted out of concurrent request
           # handling: presumably their code is not threadsafe
 
-          app.executor.register_hook(MutexHook.new, outer: true)
+          app.executor.register_hook(MonitorHook.new, outer: true)
 
         elsif config.allow_concurrency == :unsafe
           # Do nothing, even if we know this is dangerous. This is the


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/45852
Ref: https://github.com/rails/rails/pull/43550

If `executor_around_test_case` is enabled, all hooks must be reentrant. However `allow_concurrency = false` register a `MutexHook` that isn't reentrant.

So this commit replace it by a `Monitor` which does allow reentrancy.

cc @JiaboHou, @skipkayhil 