### PR TITLE
Do not return CSP headers for 304 Not Modified responses

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -33,7 +33,11 @@ module ActionDispatch # :nodoc:
 
       def call(env)
         request = ActionDispatch::Request.new env
-        _, headers, _ = response = @app.call(env)
+        status, headers, _ = response = @app.call(env)
+
+        # Returning CSP headers with a 304 Not Modified is harmful, since nonces in the new
+        # CSP headers might not match nonces in the cached HTML.
+        return response if status == 304
 
         return response if policy_present?(headers)
 

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -440,6 +440,10 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       render json: {}
     end
 
+    def not_modified
+      head :not_modified
+    end
+
     private
       def condition?
         params[:condition] == "true"
@@ -457,6 +461,7 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       get "/style-src", to: "policy#style_src"
       get "/no-policy", to: "policy#no_policy"
       get "/api", to: "policy#api"
+      get "/not-modified", to: "policy#not_modified"
     end
   end
 
@@ -531,6 +536,13 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
   def test_generates_api_security_policy
     get "/api"
     assert_policy "default-src 'none'; frame-ancestors 'none'"
+  end
+
+  def test_generates_no_content_security_policy_for_not_modified
+    get "/not-modified"
+
+    assert_nil response.headers["Content-Security-Policy"]
+    assert_nil response.headers["Content-Security-Policy-Report-Only"]
   end
 
   private


### PR DESCRIPTION
### Summary

After the fix for CVE-2022-22577, Rails sends CSP headers for every response, even if the response contains no HTML.

However, there is one case where this is harmful: When we return a 304 Not Modified without any HTML, browsers will update the CSP header, but otherwise reuse the cached HTML. If that HTML contains a script tag with a nonce, this nonce may no longer match a new nonce from the CSP header.

Note that this is usually not an issue when using `request.session.id.to_s` as a nonce generator, but it will matter for people still using the old `SecureRandom.hex(16)` variant.

The PR simply skips returning the CSP headers for 304s. This should be fine, browsers will keep using the CSP from the original response.
