### PR TITLE
Add binary column default value support to sqlite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -430,6 +430,9 @@ module ActiveRecord
           # Numeric types
           when /\A-?\d+(\.\d*)?\z/
             $&
+          # Binary columns
+          when /x'(.*)'/
+            [ $1 ].pack("H*")
           else
             # Anything else is blank or some function
             # and we can't know the value of that, so return nil.

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -83,6 +83,39 @@ class DefaultStringsTest < ActiveRecord::TestCase
   end
 end
 
+if current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
+  class DefaultBinaryTest < ActiveRecord::TestCase
+    class DefaultBinary < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table :default_binaries do |t|
+        t.binary :varbinary_col, null: false, limit: 64, default: "varbinary_default"
+        t.binary :varbinary_col_hex_looking, null: false, limit: 64, default: "0xDEADBEEF"
+      end
+      DefaultBinary.reset_column_information
+    end
+
+    def test_default_varbinary_string
+      assert_equal "varbinary_default", DefaultBinary.new.varbinary_col
+    end
+
+    if current_adapter?(:Mysql2Adapter) && !ActiveRecord::Base.connection.mariadb?
+      def test_default_binary_string
+        assert_equal "binary_default", DefaultBinary.new.binary_col
+      end
+    end
+
+    def test_default_varbinary_string_that_looks_like_hex
+      assert_equal "0xDEADBEEF", DefaultBinary.new.varbinary_col_hex_looking
+    end
+
+    teardown do
+      @connection.drop_table :default_binaries
+    end
+  end
+end
+
 if supports_text_column_with_default?
   class DefaultTextTest < ActiveRecord::TestCase
     class DefaultText < ActiveRecord::Base; end


### PR DESCRIPTION
This adds support for reading binary column default values before the column data is read from the database.
This makes binary columns behave more like other column types with default values.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", path: "../code/rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.text :some_text, null: false, default: "hello-world"
    t.binary :some_binary, null: false, limit: 1024, default: "hello-world"
  end
end

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_association_stuff

    post = Post.create!

    assert_equal "hello-world", post.some_binary # this passes after this change

    reloaded_post = Post.first
    assert_equal "hello-world", reloaded_post.some_binary # This passes before and after this change
  end
end
```

similar to https://github.com/rails/rails/issues/45832, but for sqlite.
