### PR TITLE
Move InternalMetadata to migration context

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -187,7 +187,7 @@ module ActiveRecord
       end
 
       def truncate_tables(*table_names) # :nodoc:
-        table_names -= [schema_migration.table_name, InternalMetadata.table_name]
+        table_names -= [schema_migration.table_name, internal_metadata.table_name]
 
         return if table_names.empty?
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -189,7 +189,7 @@ module ActiveRecord
       end
 
       def migration_context # :nodoc:
-        MigrationContext.new(migrations_paths, schema_migration)
+        MigrationContext.new(migrations_paths, schema_migration, internal_metadata)
       end
 
       def schema_migration # :nodoc:
@@ -204,6 +204,24 @@ module ActiveRecord
                                 Class.new(ActiveRecord::SchemaMigration) do
                                   define_singleton_method(:name) { schema_migration_name }
                                   define_singleton_method(:to_s) { schema_migration_name }
+
+                                  self.connection_specification_name = connection_name
+                                end
+                              end
+      end
+
+      def internal_metadata # :nodoc:
+        @internal_metadata ||= begin
+                                conn = self
+                                connection_name = conn.pool.pool_config.connection_name
+
+                                return ActiveRecord::InternalMetadata if connection_name == "ActiveRecord::Base"
+
+                                internal_metadata_name = "#{connection_name}::InternalMetadata"
+
+                                Class.new(ActiveRecord::InternalMetadata) do
+                                  define_singleton_method(:name) { internal_metadata_name }
+                                  define_singleton_method(:to_s) { internal_metadata_name }
 
                                   self.connection_specification_name = connection_name
                                 end

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
     class << self
       def enabled?
-        ActiveRecord::Base.connection.use_metadata_table?
+        connection.use_metadata_table?
       end
 
       def primary_key
@@ -35,6 +35,12 @@ module ActiveRecord
         return unless enabled?
 
         where(key: key).pick(:value)
+      end
+
+      def create_table_and_set_flags(environment, schema_sha1 = nil)
+        create_table
+        self[:environment] = environment
+        self[:schema_sha1] = schema_sha1 if schema_sha1
       end
 
       # Creates an internal metadata table with columns +key+ and +value+

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -9,9 +9,10 @@ databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
 db_namespace = namespace :db do
   desc "Set the environment value for the database"
   task "environment:set" => :load_config do
-    raise ActiveRecord::EnvironmentStorageError unless ActiveRecord::InternalMetadata.enabled?
-    ActiveRecord::InternalMetadata.create_table
-    ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
+    connection = ActiveRecord::Base.connection
+    raise ActiveRecord::EnvironmentStorageError unless connection.internal_metadata.enabled?
+
+    connection.internal_metadata.create_table_and_set_flags(connection.migration_context.current_environment)
   end
 
   task check_protected_environments: :load_config do

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -59,8 +59,7 @@ module ActiveRecord
           connection.assume_migrated_upto_version(info[:version])
         end
 
-        ActiveRecord::InternalMetadata.create_table
-        ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+        connection.internal_metadata.create_table_and_set_flags(connection.migration_context.current_environment)
       end
     end
 

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -11,6 +11,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
     @schema_migration = @connection.schema_migration
     @schema_migration.drop_table
+    @internal_metadata = @connection.internal_metadata
   end
 
   teardown do
@@ -69,7 +70,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     old_table_name_prefix = ActiveRecord::Base.table_name_prefix
     ActiveRecord::Base.table_name_prefix = "nep_"
     @schema_migration.reset_table_name
-    ActiveRecord::InternalMetadata.reset_table_name
+    @internal_metadata.reset_table_name
     ActiveRecord::Schema.define(version: 7) do
       create_table :fruits do |t|
         t.column :color, :string
@@ -82,7 +83,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.table_name_prefix = old_table_name_prefix
     @schema_migration.reset_table_name
-    ActiveRecord::InternalMetadata.reset_table_name
+    @internal_metadata.reset_table_name
   end
 
   def test_schema_raises_an_error_for_invalid_column_type

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -28,15 +28,16 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
   def test_initializes_internal_metadata_for_encoding_utf8mb4
     with_encoding_utf8mb4 do
-      table_name = ActiveRecord::InternalMetadata.table_name
+      internal_metadata = connection.internal_metadata
+      table_name = internal_metadata.table_name
       connection.drop_table table_name, if_exists: true
 
-      ActiveRecord::InternalMetadata.create_table
+      internal_metadata.create_table
 
       assert connection.column_exists?(table_name, :key, :string)
     end
   ensure
-    ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+    connection.internal_metadata[:environment] = connection.migration_context.current_environment
   end
 
   private

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -114,7 +114,8 @@ class Mysql2DefaultEngineOptionTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
+    connection = ActiveRecord::Base.connection
+    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
 
     assert_match %r{ENGINE=InnoDB}, @log.string
 

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -28,7 +28,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::Base.table_name_prefix = "p_"
     ActiveRecord::Base.table_name_suffix = "_s"
     @connection.schema_migration.reset_table_name
-    ActiveRecord::InternalMetadata.reset_table_name
+    @connection.internal_metadata.reset_table_name
 
     @connection.schema_migration.delete_all rescue nil
     ActiveRecord::Migration.verbose = false
@@ -41,7 +41,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::Base.table_name_prefix = @old_table_name_prefix
     ActiveRecord::Base.table_name_suffix = @old_table_name_suffix
     @connection.schema_migration.reset_table_name
-    ActiveRecord::InternalMetadata.reset_table_name
+    @connection.internal_metadata.reset_table_name
 
     super
   end
@@ -50,7 +50,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.disable_extension("hstore")
 
     migrations = [EnableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::Base.connection.schema_migration).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @connection.schema_migration, @connection.internal_metadata).migrate
     assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
   end
 
@@ -58,7 +58,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.enable_extension("hstore")
 
     migrations = [DisableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::Base.connection.schema_migration).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @connection.schema_migration, @connection.internal_metadata).migrate
     assert_not @connection.extension_enabled?("hstore"), "extension hstore should not be enabled"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -299,7 +299,9 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
         create_table("pg_uuids_4", id: :uuid)
       end
     end.new
-    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
+
+    connection = ActiveRecord::Base.connection
+    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
@@ -349,7 +351,9 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
         create_table("pg_uuids_4", id: :uuid, default: nil)
       end
     end.new
-    ActiveRecord::Migrator.new(:up, [migration], ActiveRecord::Base.connection.schema_migration).migrate
+
+    connection = ActiveRecord::Base.connection
+    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: nil/, schema)

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -20,6 +20,7 @@ module ActiveRecord
         @schema_migration = ActiveRecord::Base.connection.schema_migration
         @schema_migration.create_table
         @schema_migration.delete_all
+        @internal_metadata = ActiveRecord::Base.connection.internal_metadata
       end
 
       teardown do
@@ -30,7 +31,7 @@ module ActiveRecord
         previous_logger = ActiveRecord::Base.logger
         ActiveRecord::Base.logger = nil
         migrations = [Migration.new("a", 1), Migration.new("b", 2), Migration.new("c", 3)]
-        ActiveRecord::Migrator.new(:up, migrations, @schema_migration).migrate
+        ActiveRecord::Migrator.new(:up, migrations, @schema_migration, @internal_metadata).migrate
       ensure
         ActiveRecord::Base.logger = previous_logger
       end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -45,6 +45,7 @@ class MigrationTest < ActiveRecord::TestCase
     Reminder.reset_column_information
     @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
     @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @internal_metadata = ActiveRecord::Base.connection.internal_metadata
     ActiveRecord::Base.connection.schema_cache.clear!
   end
 
@@ -100,7 +101,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_migrator_versions
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
     migrator.up
     assert_equal 3, migrator.current_version
@@ -126,23 +127,23 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
 
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
     assert_equal true, migrator.needs_migration?
   end
 
   def test_any_migrations
-    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", @schema_migration, @internal_metadata)
 
     assert_predicate migrator.migrations, :any?
 
-    migrator_empty = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/empty", @schema_migration)
+    migrator_empty = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/empty", @schema_migration, @internal_metadata)
 
     assert_not_predicate migrator_empty.migrations, :any?
   end
 
   def test_migration_version
-    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/version_check", @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/version_check", @schema_migration, @internal_metadata)
     assert_equal 0, migrator.current_version
     migrator.up(20131219224947)
     assert_equal 20131219224947, migrator.current_version
@@ -248,13 +249,13 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have added the last_name column on people"
 
-    ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+    ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     assert_no_column Person, :last_name, "migration_b should have dropped the last_name column on people"
 
-    migrator = ActiveRecord::Migrator.new(:up, [migration_c], @schema_migration, 102)
+    migrator = ActiveRecord::Migrator.new(:up, [migration_c], @schema_migration, @internal_metadata, 102)
 
     if current_adapter?(:SQLite3Adapter)
       assert_nothing_raised do
@@ -301,13 +302,13 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have added the last_name column on people"
 
-    ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+    ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     assert_no_column Person, :last_name, "migration_b should have dropped the last_name column on people"
 
-    migrator = ActiveRecord::Migrator.new(:up, [migration_c], @schema_migration, 102)
+    migrator = ActiveRecord::Migrator.new(:up, [migration_c], @schema_migration, @internal_metadata, 102)
 
     assert_nothing_raised do
       migrator.migrate
@@ -331,11 +332,11 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have created the last_name column on people"
 
     assert_raises do
-      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     end
   ensure
     Person.reset_column_information
@@ -359,11 +360,11 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have created the last_name column on people"
 
     assert_nothing_raised do
-      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     end
   ensure
     Person.reset_column_information
@@ -389,11 +390,11 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have created the last_name column on people"
 
     assert_nothing_raised do
-      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     end
   ensure
     Person.reset_column_information
@@ -417,11 +418,11 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, @internal_metadata, 100).migrate
     assert_column Person, :last_name, "migration_a should have created the last_name column on people"
 
     assert_nothing_raised do
-      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, @internal_metadata, 101).migrate
     end
   ensure
     Person.reset_column_information
@@ -511,7 +512,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert_not_predicate Reminder, :table_exists?
 
     name_filter = lambda { |migration| migration.name == "ValidPeopleHaveLastNames" }
-    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", @schema_migration, @internal_metadata)
     migrator.up(&name_filter)
 
     assert_column Person, :last_name
@@ -573,7 +574,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       }.new
 
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       e = assert_raise(StandardError) { migrator.migrate }
 
@@ -594,7 +595,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       }.new
 
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       e = assert_raise(StandardError) { migrator.run }
 
@@ -617,7 +618,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       }.new
 
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 101)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 101)
       e = assert_raise(StandardError) { migrator.migrate }
       assert_equal "An error has occurred, all later migrations canceled:\n\nSomething broke", e.message
 
@@ -676,10 +677,10 @@ class MigrationTest < ActiveRecord::TestCase
   def test_internal_metadata_stores_environment
     current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
     migrator.up
-    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
+    assert_equal current_env, @internal_metadata[:environment]
 
     original_rails_env  = ENV["RAILS_ENV"]
     original_rack_env   = ENV["RACK_ENV"]
@@ -690,7 +691,7 @@ class MigrationTest < ActiveRecord::TestCase
 
     sleep 1 # mysql by default does not store fractional seconds in the database
     migrator.up
-    assert_equal new_env, ActiveRecord::InternalMetadata[:environment]
+    assert_equal new_env, @internal_metadata[:environment]
   ensure
     ENV["RAILS_ENV"] = original_rails_env
     ENV["RACK_ENV"]  = original_rack_env
@@ -698,7 +699,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment_when_migration_fails
-    ActiveRecord::InternalMetadata.delete_all
+    @internal_metadata.delete_all
     current_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
 
     migration = Class.new(ActiveRecord::Migration::Current) {
@@ -708,70 +709,68 @@ class MigrationTest < ActiveRecord::TestCase
       end
     }.new
 
-    migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 101)
+    migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 101)
     assert_raise(StandardError) { migrator.migrate }
-    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
+    assert_equal current_env, @internal_metadata[:environment]
   end
 
   def test_internal_metadata_stores_environment_when_other_data_exists
-    ActiveRecord::InternalMetadata.delete_all
-    ActiveRecord::InternalMetadata[:foo] = "bar"
+    @internal_metadata.delete_all
+    @internal_metadata[:foo] = "bar"
 
     current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
     migrations_path = MIGRATIONS_ROOT + "/valid"
 
-    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
     migrator.up
-    assert_equal current_env, ActiveRecord::InternalMetadata[:environment]
-    assert_equal "bar", ActiveRecord::InternalMetadata[:foo]
+    assert_equal current_env, @internal_metadata[:environment]
+    assert_equal "bar", @internal_metadata[:foo]
   end
 
   def test_internal_metadata_not_used_when_not_enabled
-    ActiveRecord::InternalMetadata.drop_table
+    @internal_metadata.drop_table
     original_config = ActiveRecord::Base.connection.instance_variable_get("@config")
-
     modified_config = original_config.dup.merge(use_metadata_table: false)
 
-    ActiveRecord::Base.connection
-      .instance_variable_set("@config", modified_config)
+    ActiveRecord::Base.connection.instance_variable_set("@config", modified_config)
 
-    assert_not ActiveRecord::InternalMetadata.enabled?
-    assert_not ActiveRecord::InternalMetadata.table_exists?
+    assert_not @internal_metadata.enabled?
+    assert_not @internal_metadata.table_exists?
 
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
     migrator.up
 
-    assert_not ActiveRecord::InternalMetadata[:environment]
-    assert_not ActiveRecord::InternalMetadata.table_exists?
+    assert_not @internal_metadata[:environment]
+    assert_not @internal_metadata.table_exists?
   ensure
     ActiveRecord::Base.connection.instance_variable_set("@config", original_config)
-    ActiveRecord::InternalMetadata.create_table
+    @internal_metadata.create_table
   end
 
   def test_internal_metadata_create_table_wont_be_affected_by_schema_cache
-    ActiveRecord::InternalMetadata.drop_table
-    assert_not_predicate ActiveRecord::InternalMetadata, :table_exists?
+    @internal_metadata.drop_table
+    assert_not_predicate @internal_metadata, :table_exists?
 
-    ActiveRecord::InternalMetadata.connection.transaction do
-      ActiveRecord::InternalMetadata.create_table
-      assert_predicate ActiveRecord::InternalMetadata, :table_exists?
+    @internal_metadata.connection.transaction do
+      @internal_metadata.create_table
+      assert_predicate @internal_metadata, :table_exists?
 
-      ActiveRecord::InternalMetadata[:version] = "foo"
-      assert_equal "foo", ActiveRecord::InternalMetadata[:version]
+      @internal_metadata[:version] = "foo"
+      assert_equal "foo", @internal_metadata[:version]
       raise ActiveRecord::Rollback
     end
 
-    ActiveRecord::InternalMetadata.connection.transaction do
-      ActiveRecord::InternalMetadata.create_table
-      assert_predicate ActiveRecord::InternalMetadata, :table_exists?
+    @internal_metadata.connection.transaction do
+      @internal_metadata.create_table
+      assert_predicate @internal_metadata, :table_exists?
 
-      ActiveRecord::InternalMetadata[:version] = "bar"
-      assert_equal "bar", ActiveRecord::InternalMetadata[:version]
+      @internal_metadata[:version] = "bar"
+      assert_equal "bar", @internal_metadata[:version]
       raise ActiveRecord::Rollback
     end
   ensure
-    ActiveRecord::InternalMetadata.create_table
+    @internal_metadata.create_table
   end
 
   def test_schema_migration_create_table_wont_be_affected_by_schema_cache
@@ -990,7 +989,7 @@ class MigrationTest < ActiveRecord::TestCase
   if ActiveRecord::Base.connection.supports_advisory_locks?
     def test_migrator_generates_valid_lock_id
       migration = Class.new(ActiveRecord::Migration::Current).new
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
@@ -1004,7 +1003,7 @@ class MigrationTest < ActiveRecord::TestCase
       # It is important we are consistent with how we generate this so that
       # exclusive locking works across migrator versions
       migration = Class.new(ActiveRecord::Migration::Current).new
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
@@ -1026,7 +1025,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       }.new
 
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
       with_another_process_holding_lock(lock_id) do
@@ -1047,7 +1046,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       }.new
 
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
       with_another_process_holding_lock(lock_id) do
@@ -1060,7 +1059,7 @@ class MigrationTest < ActiveRecord::TestCase
 
     def test_with_advisory_lock_doesnt_release_closed_connections
       migration = Class.new(ActiveRecord::Migration::Current).new
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       silence_stream($stderr) do
         migrator.send(:with_advisory_lock) do
@@ -1077,7 +1076,7 @@ class MigrationTest < ActiveRecord::TestCase
           end
         }.new
 
-        migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+        migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
         lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
         query = <<~SQL
@@ -1096,7 +1095,7 @@ class MigrationTest < ActiveRecord::TestCase
 
     def test_with_advisory_lock_raises_the_right_error_when_it_fails_to_release_lock
       migration = Class.new(ActiveRecord::Migration::Current).new
-      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+      migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
       e = assert_raises(ActiveRecord::ConcurrentMigrationError) do

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Base.connection.migration_context.current_environment
 
-      InternalMetadata[:environment] = current_env
+      ActiveRecord::Base.connection.internal_metadata[:environment] = current_env
 
       assert_called_on_instance_of(
         ActiveRecord::MigrationContext,
@@ -86,7 +86,7 @@ module ActiveRecord
       protected_environments = ActiveRecord::Base.protected_environments
       current_env            = ActiveRecord::Base.connection.migration_context.current_environment
 
-      InternalMetadata[:environment] = current_env
+      ActiveRecord::Base.connection.internal_metadata[:environment] = current_env
 
       assert_called_on_instance_of(
         ActiveRecord::MigrationContext,
@@ -108,7 +108,7 @@ module ActiveRecord
     end
 
     def test_raises_an_error_if_no_migrations_have_been_made
-      ActiveRecord::InternalMetadata.stub(:table_exists?, false) do
+      ActiveRecord::Base.connection.internal_metadata.stub(:table_exists?, false) do
         assert_called_on_instance_of(
           ActiveRecord::MigrationContext,
           :current_version,


### PR DESCRIPTION
This PR is similar to #36439 which moved schema migrations to the
connection and migration context. This PR does the same thing for the
internal metadata class.

Previously the metadata class was only accessible on Base which makes it
a little weird when switching connections. This didn't really cause any
issues but I noticed it when working on a PR to change how connections
work in the database rake tasks.

In a multiple database environment it makes sense to access the
`ar_internal_metadata` on the existing connection rather than on
`Base.connection`. I previously didn't implement this because I felt we
wanted only one place to ask for the metadata information but recently
realized that we were still recording metadata on all the databases, so
we might as well record it correctly.

Applications should notice no change in behavior because this is only
accessed through the rake tasks. Additionally behavior between schema
migrations and internal metadata are now more similar. Eventually I'd
like neither of these to inherit from or rely on Base, but we have a
lot more work to do before that's possible.