### PR TITLE
Remove unnecessary class_eval from log_subscriber.rb

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -115,13 +115,9 @@ module ActiveSupport
           end
         end
 
-        %w(info debug warn error fatal unknown).each do |level|
-          class_eval <<-METHOD, __FILE__, __LINE__ + 1
-            private def subscribe_log_level(method, level)
-              self.log_levels = log_levels.merge(method => ::Logger.const_get(level.upcase))
-              set_event_levels
-            end
-          METHOD
+        def subscribe_log_level(method, level)
+          self.log_levels = log_levels.merge(method => ::Logger.const_get(level.upcase))
+          set_event_levels
         end
     end
 


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/45796 added the `subscribe_log_level` method by looping over log levels and re-defining the method for each log level, but here iterator value is not being used in the method definition, hence we can drop the whole `class_eval`.
