### PR TITLE
Fixes #45868 by Using #to_hash to serialize `AS::HWIA` for stored attributes

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -288,14 +288,7 @@ module ActiveRecord
 
         private
           def as_regular_hash(obj)
-            case obj
-            when ActiveSupport::HashWithIndifferentAccess
-              obj.to_h
-            when Hash
-              obj
-            else
-              {}
-            end
+            obj.respond_to?(:to_hash) ? obj.to_hash : {}
           end
       end
   end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -180,6 +180,15 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "heavy", @john.json_data["weight"]
   end
 
+  test "serialize stored nested attributes" do
+    user = Admin::User.find_by_name("Jamis")
+    user.update(settings: { "color" => { "jenny" => "blue" }, homepage: "rails" })
+
+    assert_equal true, user.settings.instance_of?(ActiveSupport::HashWithIndifferentAccess)
+    assert_equal "blue", user.settings[:color][:jenny]
+    assert_equal "blue", user.color[:jenny]
+  end
+
   def test_convert_store_attributes_from_Hash_to_HashWithIndifferentAccess_saving_the_data_and_access_attributes_indifferently
     user = Admin::User.find_by_name("Jamis")
     assert_equal "symbol",  user.settings[:symbol]


### PR DESCRIPTION
### Summary

Fixes #45868

Originally we were calling `#to_h` to serialize `ActiveSupport::HashWithIndifferentAccess` but it was serializing only top-level hash keys. 
By Using `#to_hash` to serialize `ActiveSupport::HashWithIndifferentAccess` it will also handle/convert nested objects.
