### PR TITLE
Backport Redis 5.0 compatibility (7-0-stable)

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The Redis adapter is now compatible with redis-rb 5.0
+
+    Compatibility with redis-rb 3.x was dropped.
+
+    *Jean Boussier*
+
 *   The Action Cable server is now mounted with `anchor: true`.
 
     This means that routes that also start with `/cable` will no longer clash with Action Cable.

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -2,7 +2,7 @@
 
 require "thread"
 
-gem "redis", ">= 3", "< 5"
+gem "redis", ">= 3", "< 6"
 require "redis"
 
 require "active_support/core_ext/hash/except"
@@ -56,7 +56,7 @@ module ActionCable
         end
 
         def redis_connection
-          self.class.redis_connector.call(@server.config.cable.merge(id: identifier))
+          self.class.redis_connector.call(@server.config.cable.symbolize_keys.merge(id: identifier))
         end
 
         class Listener < SubscriberMap
@@ -69,7 +69,7 @@ module ActionCable
             @subscribe_callbacks = Hash.new { |h, k| h[k] = [] }
             @subscription_lock = Mutex.new
 
-            @raw_client = nil
+            @subscribed_client = nil
 
             @when_connected = []
 
@@ -78,13 +78,13 @@ module ActionCable
 
           def listen(conn)
             conn.without_reconnect do
-              original_client = conn.respond_to?(:_client) ? conn._client : conn.client
+              original_client = extract_subscribed_client(conn)
 
               conn.subscribe("_action_cable_internal") do |on|
                 on.subscribe do |chan, count|
                   @subscription_lock.synchronize do
                     if count == 1
-                      @raw_client = original_client
+                      @subscribed_client = original_client
 
                       until @when_connected.empty?
                         @when_connected.shift.call
@@ -106,7 +106,7 @@ module ActionCable
                 on.unsubscribe do |chan, count|
                   if count == 0
                     @subscription_lock.synchronize do
-                      @raw_client = nil
+                      @subscribed_client = nil
                     end
                   end
                 end
@@ -119,8 +119,8 @@ module ActionCable
               return if @thread.nil?
 
               when_connected do
-                send_command("unsubscribe")
-                @raw_client = nil
+                @subscribed_client.unsubscribe
+                @subscribed_client = nil
               end
             end
 
@@ -131,13 +131,13 @@ module ActionCable
             @subscription_lock.synchronize do
               ensure_listener_running
               @subscribe_callbacks[channel] << on_success
-              when_connected { send_command("subscribe", channel) }
+              when_connected { @subscribed_client.subscribe(channel) }
             end
           end
 
           def remove_channel(channel)
             @subscription_lock.synchronize do
-              when_connected { send_command("unsubscribe", channel) }
+              when_connected { @subscribed_client.unsubscribe(channel) }
             end
           end
 
@@ -156,22 +156,49 @@ module ActionCable
             end
 
             def when_connected(&block)
-              if @raw_client
+              if @subscribed_client
                 block.call
               else
                 @when_connected << block
               end
             end
 
-            def send_command(*command)
-              @raw_client.write(command)
+            if ::Redis::VERSION < "5"
+              class SubscribedClient
+                def initialize(raw_client)
+                  @raw_client = raw_client
+                end
 
-              very_raw_connection =
-                @raw_client.connection.instance_variable_defined?(:@connection) &&
-                @raw_client.connection.instance_variable_get(:@connection)
+                def subscribe(*channel)
+                  send_command("subscribe", *channel)
+                end
 
-              if very_raw_connection && very_raw_connection.respond_to?(:flush)
-                very_raw_connection.flush
+                def unsubscribe(*channel)
+                  send_command("unsubscribe", *channel)
+                end
+
+                private
+                  def send_command(*command)
+                    @raw_client.write(command)
+
+                    very_raw_connection =
+                      @raw_client.connection.instance_variable_defined?(:@connection) &&
+                      @raw_client.connection.instance_variable_get(:@connection)
+
+                    if very_raw_connection && very_raw_connection.respond_to?(:flush)
+                      very_raw_connection.flush
+                    end
+                    nil
+                  end
+              end
+
+              def extract_subscribed_client(conn)
+                raw_client = conn.respond_to?(:_client) ? conn._client : conn.client
+                SubscribedClient.new(raw_client)
+              end
+            else
+              def extract_subscribed_client(conn)
+                conn
               end
             end
         end

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -19,12 +19,6 @@ class RedisAdapterTest < ActionCable::TestCase
   end
 end
 
-class RedisAdapterTest::Hiredis < RedisAdapterTest
-  def cable_config
-    super.merge(driver: "hiredis")
-  end
-end
-
 class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
   def cable_config
     alt_cable_config = super.dup
@@ -56,7 +50,7 @@ class RedisAdapterTest::ConnectorDefaultID < ActionCable::TestCase
   end
 
   test "sets connection id for connection" do
-    assert_called_with ::Redis, :new, [ expected_connection.stringify_keys ] do
+    assert_called_with ::Redis, :new, [ expected_connection.symbolize_keys ] do
       @adapter.send(:redis_connection)
     end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Redis cache store is now compatible with redis-rb 5.0.
+
+    *Jean Boussier*
+
 *   Fix `NoMethodError` on custom `ActiveSupport::Deprecation` behavior.
 
     `ActiveSupport::Deprecation.behavior=` was supposed to accept any object

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -13,29 +13,10 @@ Rake::TestTask.new do |t|
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task["test:cache_stores:redis:ruby"].invoke
-end
-
 namespace :test do
   task :isolated do
     Dir.glob("test/**/*_test.rb").all? do |file|
       sh(Gem.ruby, "-w", file)
     end || raise("Failures")
-  end
-
-  namespace :cache_stores do
-    namespace :redis do
-      %w[ ruby hiredis ].each do |driver|
-        task("env:#{driver}") { ENV["REDIS_DRIVER"] = driver }
-
-        Rake::TestTask.new(driver => "env:#{driver}") do |t|
-          t.test_files = ["test/cache/stores/redis_cache_store_test.rb"]
-          t.warning = true
-          t.verbose = true
-          t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
-        end
-      end
-    end
   end
 end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -5,13 +5,17 @@ begin
   require "redis"
   require "redis/distributed"
 rescue LoadError
-  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \"~> 4.0\"`"
+  warn "The Redis cache store requires the redis gem, version 4.0.1 or later. Please add it to your Gemfile: `gem \"redis\", \">= 4.0.1\"`"
   raise
 end
 
 # Prefer the hiredis driver but don't require it.
 begin
-  require "redis/connection/hiredis"
+  if ::Redis::VERSION < "5"
+    require "redis/connection/hiredis"
+  else
+    require "hiredis-client"
+  end
 rescue LoadError
 end
 
@@ -92,9 +96,11 @@ module ActiveSupport
           elsif redis
             redis
           elsif urls.size > 1
-            build_redis_distributed_client urls: urls, **redis_options
+            build_redis_distributed_client(urls: urls, **redis_options)
+          elsif urls.empty?
+            build_redis_client(**redis_options)
           else
-            build_redis_client url: urls.first, **redis_options
+            build_redis_client(url: urls.first, **redis_options)
           end
         end
 
@@ -105,8 +111,8 @@ module ActiveSupport
             end
           end
 
-          def build_redis_client(url:, **redis_options)
-            ::Redis.new DEFAULT_REDIS_OPTIONS.merge(redis_options.merge(url: url))
+          def build_redis_client(**redis_options)
+            ::Redis.new(DEFAULT_REDIS_OPTIONS.merge(redis_options))
           end
       end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -129,9 +129,9 @@ module CacheStoreBehavior
   end
 
   def test_read_multi_with_empty_keys_and_a_logger_and_no_namespace
-    @cache.options[:namespace] = nil
-    @cache.logger = ActiveSupport::Logger.new(nil)
-    assert_equal({}, @cache.read_multi)
+    cache = lookup_store(namespace: nil)
+    cache.logger = ActiveSupport::Logger.new(nil)
+    assert_equal({}, cache.read_multi)
   end
 
   def test_fetch_multi

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -358,7 +358,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, MaxClientsReachedRedisClient)
 
-        yield ActiveSupport::Cache::RedisCacheStore.new
+        yield ActiveSupport::Cache::RedisCacheStore.new(namespace: @namespace)
       ensure
         Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, old_client)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -51,7 +51,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class InitializationTest < ActiveSupport::TestCase
     test "omitted URL uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        url: nil,
         connect_timeout: 20, read_timeout: 1, write_timeout: 1,
         reconnect_attempts: 0, driver: DRIVER
       ] do
@@ -61,7 +60,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     test "no URLs uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        url: nil,
         connect_timeout: 20, read_timeout: 1, write_timeout: 1,
         reconnect_attempts: 0, driver: DRIVER
       ] do


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/45856

Redis 3.0 compatiblity is preserved in Action Cable

Redis 4.0 compatiblity is preserved in Active Support

