### PR TITLE
Extend `routes --grep` to also filter routes by matching against path

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Extend `routes --grep` to also filter routes by matching against path.
+
+    Example:
+
+    ```
+    > bin/rails routes --grep /cats/1
+    Prefix Verb   URI Pattern         Controller#Action
+       cat GET    /cats/:id(.:format) cats#show
+           PATCH  /cats/:id(.:format) cats#update
+           PUT    /cats/:id(.:format) cats#update
+           DELETE /cats/:id(.:format) cats#destroy
+    ```
+
+    *Orhan Toy*
+
 *   Improve `rails runner` output when given a file path that doesn't exist.
 
     *Tekin Suleyman*

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3375,6 +3375,7 @@ module ApplicationTests
       output = rails("routes", "-g", "active_storage")
       assert_equal <<~MESSAGE, output
                                Prefix Verb URI Pattern                                                                        Controller#Action
+                                           /:controller(/:action(/:id))(.:format)                                             :controller#:action
                    rails_service_blob GET  /files/blobs/redirect/:signed_id/*filename(.:format)                               active_storage/blobs/redirect#show
              rails_service_blob_proxy GET  /files/blobs/proxy/:signed_id/*filename(.:format)                                  active_storage/blobs/proxy#show
                                       GET  /files/blobs/:signed_id/*filename(.:format)                                        active_storage/blobs/redirect#show

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -84,6 +84,41 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
     MESSAGE
   end
 
+  test "rails routes with matching path" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resources :photos
+        get '/cart', to: 'cart#show'
+        post '/cart', to: 'cart#create'
+        get '/basketballs', to: 'basketball#index'
+      end
+    RUBY
+
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "/cart" ])
+    Prefix Verb URI Pattern     Controller#Action
+      cart GET  /cart(.:format) cart#show
+           POST /cart(.:format) cart#create
+    MESSAGE
+
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
+           Prefix Verb URI Pattern            Controller#Action
+      basketballs GET  /basketballs(.:format) basketball#index
+    MESSAGE
+
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "/photos/7" ])
+    Prefix Verb   URI Pattern           Controller#Action
+     photo GET    /photos/:id(.:format) photos#show
+           PATCH  /photos/:id(.:format) photos#update
+           PUT    /photos/:id(.:format) photos#update
+           DELETE /photos/:id(.:format) photos#destroy
+    MESSAGE
+
+    assert_equal <<~MESSAGE, run_routes_command([ "-g", "/cats" ])
+    No routes were found for this grep pattern.
+    For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
+    MESSAGE
+  end
+
   test "rails routes with controller search key" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do


### PR DESCRIPTION
### Summary

When looking at a path like `/users/orhantoy/settings` it's not always obvious which controller-action corresponds to this route. So, I thought it would be useful to be able to look up what controller-action matches a given path. Turns out this is actually possible via `/rails/info/routes` (news to me!) but I thought it would also come in handy to have the same functionality in `rails routes`.

#### Example

Revised after https://github.com/rails/rails/pull/45874#issuecomment-1224174649 (I originally introduced a separate `--path` option):

```
$ bin/rails routes -g /cats/1
Prefix Verb   URI Pattern         Controller#Action
   cat GET    /cats/:id(.:format) cats#show
       PATCH  /cats/:id(.:format) cats#update
       PUT    /cats/:id(.:format) cats#update
       DELETE /cats/:id(.:format) cats#destroy
```