### PR TITLE
Better rails runner output for missing files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Improve `rails runner` output when given a file path that doesn't exist.
+
+    *Tekin Suleyman*
+
 *   `config.allow_concurrency = false` now use a `Monitor` instead of a `Mutex`
 
     This allows to enable `config.active_support.executor_around_test_case` even

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -51,13 +51,23 @@ module Rails
               eval(code_or_file, TOPLEVEL_BINDING, __FILE__, __LINE__)
             end
           rescue SyntaxError, NameError => e
-            error "Please specify a valid ruby command or the path of a script to run."
-            error "Run '#{executable} -h' for help."
-            error ""
-            error e
+            if looks_like_a_file_path?(code_or_file)
+              error "The file #{code_or_file} could not be found, please check and try again."
+              error "Run '#{self.class.executable} -h' for help."
+            else
+              error "Please specify a valid ruby command or the path of a script to run."
+              error "Run '#{self.class.executable} -h' for help."
+              error ""
+              error e
+            end
+
             exit 1
           end
         end
+      end
+
+      def looks_like_a_file_path?(code_or_file)
+        code_or_file.ends_with?(".rb")
       end
     end
   end

--- a/railties/test/commands/runner_test.rb
+++ b/railties/test/commands/runner_test.rb
@@ -32,6 +32,13 @@ class Rails::RunnerTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  def test_rails_runner_with_file_path_that_does_not_exist
+    command_output = run_runner_command("no-file-here.rb", allow_failure: true)
+
+    assert_match(/The file no-file-here.rb could not be found/, command_output)
+    assert_equal 1, $?.exitstatus
+  end
+
   def test_rails_runner_with_ruby_code
     assert_equal <<~OUTPUT, run_runner_command('puts "Hello world"')
       Hello world


### PR DESCRIPTION
### Summary 

This updates The Rails runner command to give a more helpful error message when given a path as input to a file that doesn't exist.

### Before this change:

```
$ rails runner foo.rb   
Please specify a valid ruby command or the path of a script to run.
Run 'rails runner -h' for help.

undefined local variable or method `foo' for main:Object
```

### After this change:

```
$ rails runner foo.rb   
The file foo.rb could not be found, please check and try again.
Run 'rails runner -h' for help.
```

### Other Information

Distinguishing a valid file path from valid Ruby syntax is hard, if not impossible, so I've gone with the simplest approach I could think of that will catch a file path most of the time: the input ends with `".rb"`. This isn't a perfect approach – there's nothing stopping someone passing a script without an extension, and it's also possible to have valid Ruby syntax that ends in `".rb" – but it does feel "good enough" and will make the Rails runner slightly more user-friendly for those working with file paths without negatively impacting those that are passing in Ruby code.

I considered more sophisticated approaches to identifying potential file paths like looking for the presence of slashes and the lack of unescaped white space, but these come with their own drawbacks that make them not worth the cost in complexity and potential false-positives.  