### PR TITLE
Prevent leaking PII when broadcast payload in production

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -262,7 +262,7 @@ module ActionCable
         end
 
         def dispatch_action(action, data)
-          logger.info action_signature(action, data)
+          logger.debug action_signature(action, data)
 
           if method(action).arity == 1
             public_send action, data


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Payload that's being logged could contain PII/sensitive information.

To align with the rest of logging level in this channel/base.rb, for simplicity, this PR is to update the logging level from info to debug.

This also address long opening issue https://github.com/rails/rails/issues/25088 where many folks have to monkey patch actioncable cable to prevent logging PII

Alternatively, ideally, it should be slightly smarter, if we want to keep info level for production "debugging" purpose, we should consider dropping data when it's set to info level or adding some sort of verbose setting per channel or per action per channel configuration

### Other Information
~Lazy load debug log and only evaluate debug log when it matches the output level 
https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance~
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
