### PR TITLE
Remove `Rails::Application` `assets` accessor

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -94,7 +94,7 @@ module Rails
       public :new
     end
 
-    attr_accessor :assets, :sandbox
+    attr_accessor :sandbox
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders, :reloader, :executor, :autoloaders
 


### PR DESCRIPTION
It was used to store a `Sprockets::Environment` in 3e7985c9c1a6899ac06857bd8e6f29b48ad87cea but then it ended up being monkey-patched from sprockets-rails in https://github.com/rails/sprockets-rails/commit/78519dca00c4dcce5646fbd787db4f01947eb664
