### PR TITLE
Stop gap solution for long output on test cases

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -149,5 +149,9 @@ module ActiveSupport
     alias :assert_not_same :refute_same
 
     ActiveSupport.run_load_hooks(:active_support_test_case, self)
+
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % object_id}>"
+    end
   end
 end

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -151,7 +151,7 @@ module ActiveSupport
     ActiveSupport.run_load_hooks(:active_support_test_case, self)
 
     def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % object_id}>"
+      Object.instance_method(:to_s).bind_call(self)
     end
   end
 end


### PR DESCRIPTION
This patch just changes the inspect method on test case instances.
Seeing test instance internals probably isn't helpful when an exception
is raised (for example a `NoMethodError`).

This isn't as good as #45122, but should fix #45121

I don't think this is great, but should fix the immediate pain.  This does make me think we should have an API in Ruby for telling `inspect` what instance variables we would like it to use.

The implementation of `inspect` [simply loops over all instance variables](https://github.com/ruby/ruby/blob/0ad9cc16966c2e56f0fe7e5992edf76033d3a83f/object.c#L649), but interestingly it doesn't call the `instance_variables` method to determine what IVs to inspect.

To me, it feels like these two objects should have different inspect output, but they don't:

```ruby
class Foo
  def initialize
    @foo = 1
    @bar = 1
  end
end

class Bar < Foo
  def instance_variables
    [:@foo]
  end
end

p Foo.new
p Bar.new
```

Anyone have any thoughts on this PR or the above thing?  I'm happy to file a redmine ticket wrt the inspect feature.