### PR TITLE
Extend dangerous attribute methods with dangerous methods from Object

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -33,7 +33,8 @@ module ActiveRecord
           Base.instance_methods +
           Base.private_instance_methods -
           Base.superclass.instance_methods -
-          Base.superclass.private_instance_methods
+          Base.superclass.private_instance_methods +
+          %i[__id__ dup freeze hash object_id class clone]
         ).map { |m| -m.to_s }.to_set.freeze
       end
     end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -651,8 +651,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_predicate topic, :is_test?
   end
 
-  test "raises ActiveRecord::DangerousAttributeError when defining an AR method in a model" do
-    %w(save create_or_update).each do |method|
+  test "raises ActiveRecord::DangerousAttributeError when defining an AR method or dangerous Object method in a model" do
+    %w(save create_or_update hash dup).each do |method|
       klass = Class.new(ActiveRecord::Base)
       klass.class_eval "def #{method}() 'defined #{method}' end"
       assert_raise ActiveRecord::DangerousAttributeError do


### PR DESCRIPTION
Fixes #45879 (see there for more details).

> Another option would be not to exclude the methods that were inherited, but then have a small exclusion list for Object methods that are unlikely to be a problem and are common names (e.g. Object#display).

I do not like this approach, because this list can possibly be incomplete for some concrete apps. For example, some gem can monkey patch `Object` with some popular name and with this approach this name now will be dangerous.

Another reason, this approach (besides properties) also makes methods with arguments as dangerous. But this is not needed, because when the user will pass arguments, then this will blow up, showing that he is doing something wrong.

So I propose to add a small explicit list of the most likely used dangerous methods. I did not add `__send__`/`send`/`method_missing`/etc (as mentioned in https://github.com/rails/rails/issues/45879#issuecomment-1226293544), because they require arguments and this will already blow up and won't go unnoticed.

cc @byroot 