### PR TITLE
Fix RedisCacheStore#delete_entry interface

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -376,7 +376,7 @@ module ActiveSupport
         end
 
         # Delete an entry from the cache.
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           failsafe :delete_entry, returning: false do
             redis.then { |c| c.del key }
           end


### PR DESCRIPTION
### Summary

`RedisCacheStore#delete_entry` should implement the same interface as the parent class [Cache#delete_entry](https://github.com/rails/rails/blob/fd9308a2925e862435859e1803e720e6eebe4bb6/activesupport/lib/active_support/cache.rb#L700-L702).

