### PR TITLE
Add missing status code in the destroy method generated by the scaffold generator

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def destroy
     @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>
+    redirect_to <%= index_helper %>_url, status: :see_other, notice: <%= %("#{human_name} was successfully destroyed.") %>
   end
 
   private


### PR DESCRIPTION
### Summary

When scaffolding a model (`rails g scaffold ModelName`), the `destroy` method in the generated controller is missing a 302 status code. Adding this status code is recommended in the [Getting Started guide](https://guides.rubyonrails.org/getting_started.html#deleting-an-article), so it makes sense to add it to the generated controller as well (especially since the not having the status code can cause issues when using a turbo link with `data-turbo-method='delete`)
