### PR TITLE
Add exclude? method to ActionController::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `exclude?` method to `ActionController::Parameters`.
+
+    *Ian Neubert*
+
 *   Rescue `EOFError` exception from `rack` on a multipart request.
 
     *Nikita Vasilevsky*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -167,6 +167,14 @@ module ActionController
     # Returns true if the parameters have no key/value pairs.
 
     ##
+    # :method: exclude?
+    #
+    # :call-seq:
+    #   exclude?(key)
+    #
+    # Returns true if the given key is not present in the parameters.
+
+    ##
     # :method: has_key?
     #
     # :call-seq:
@@ -214,7 +222,7 @@ module ActionController
     #
     # Returns the content of the parameters as a string.
 
-    delegate :keys, :key?, :has_key?, :member?, :empty?, :include?,
+    delegate :keys, :key?, :has_key?, :member?, :empty?, :exclude?, :include?,
       :as_json, :to_s, :each_key, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -149,6 +149,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params[:person].except(:name), :permitted?
   end
 
+  test "exclude? returns true if the given key is not present in the params" do
+    assert @params.exclude?(:address)
+  end
+
+  test "exclude? returns false if the given key is present in the params" do
+    assert_not @params.exclude?(:person)
+  end
+
   test "fetch retains permitted status" do
     @params.permit!
     assert_predicate @params.fetch(:person), :permitted?


### PR DESCRIPTION
### Summary

This pull request adds the `exclude?` method in `ActionController::Parameters`. This method is delegated to the hash that backs the parameter data. It is the inverse of `include?`.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Adding this method keeps things a little more consistent with a `Hash`.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
