### PR TITLE
Raise or Rails.error.report if ActiveSupport::Cache is given an invalid expiration time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `raise_on_invalid_cache_expiration_time` config to `ActiveSupport::Cache::Store`
+
+    Specifies if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
+    `write` are given an invalid `expires_at` or `expires_in` time.
+
+    Options are `true`, and `false`. If `false`, the exception will be reported
+    as `handled` and logged instead. Defaults to `true` if `config.load_defaults >= 7.1`.
+
+     *Trevor Turk*
+
 *   `ActiveSupport::Cache:Store#fetch` now passes an options accessor to the block.
 
     It makes possible to override cache options:

--- a/activesupport/lib/active_support/error_reporter/test_helper.rb
+++ b/activesupport/lib/active_support/error_reporter/test_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveSupport::ErrorReporter::TestHelper # :nodoc:
+  class ErrorSubscriber
+    attr_reader :events
+
+    def initialize
+      @events = []
+    end
+
+    def report(error, handled:, severity:, source:, context:)
+      @events << [error, handled, severity, source, context]
+    end
+  end
+end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -18,6 +18,14 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.raise_on_invalid_cache_expiration_time" do |app|
+      config.after_initialize do
+        if app.config.active_support.raise_on_invalid_cache_expiration_time
+          ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = true
+        end
+      end
+    end
+
     initializer "active_support.remove_deprecated_time_with_zone_name" do |app|
       config.after_initialize do
         if app.config.active_support.remove_deprecated_time_with_zone_name

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -594,6 +594,28 @@ module CacheStoreBehavior
     assert_equal "Either :expires_in or :expires_at can be supplied, but not both", error.message
   end
 
+  def test_invalid_expiration_time_raises_an_error_when_raise_on_invalid_cache_expiration_time_is_true
+    with_raise_on_invalid_cache_expiration_time(true) do
+      key = SecureRandom.uuid
+      error = assert_raises(ArgumentError) do
+        @cache.write(key, "bar", expires_in: -60)
+      end
+      assert_equal "Cache expiration time is invalid, cannot be negative: -60", error.message
+    end
+  end
+
+  def test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false
+    with_raise_on_invalid_cache_expiration_time(false) do
+      with_error_subscriber_and_log do |error_subscriber, log|
+        key = SecureRandom.uuid
+        @cache.write(key, "bar", expires_in: -60)
+        error = ArgumentError.new("Cache expiration time is invalid, cannot be negative: -60")
+        assert_equal [[error, true, :warning, "application", {}]], error_subscriber.events
+        assert_equal "#{error.class}: #{error.message}", log.string.lines.first.chomp
+      end
+    end
+  end
+
   def test_race_condition_protection_skipped_if_not_defined
     key = SecureRandom.alphanumeric
     @cache.write(key, "bar")
@@ -761,5 +783,31 @@ module CacheStoreBehavior
       else
         assert_equal uncompressed_size, actual_size, "value should not be compressed"
       end
+    end
+
+    def with_raise_on_invalid_cache_expiration_time(new_value, &block)
+      old_value = ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
+      ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = new_value
+
+      yield
+    ensure
+      ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time = old_value
+    end
+
+    def with_error_subscriber_and_log(&block)
+      old_error_reporter = ActiveSupport.error_reporter
+      old_logger = ActiveSupport::Cache::Store.logger
+
+      ActiveSupport.error_reporter = ActiveSupport::ErrorReporter.new
+      error_subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+      ActiveSupport.error_reporter.subscribe(error_subscriber)
+
+      log = StringIO.new
+      ActiveSupport::Cache::Store.logger = ActiveSupport::Logger.new(log)
+
+      yield(error_subscriber, log)
+    ensure
+      ActiveSupport.error_reporter = old_error_reporter
+      ActiveSupport::Cache::Store.logger = old_logger
     end
 end

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -2,27 +2,17 @@
 
 require_relative "abstract_unit"
 require "active_support/execution_context/test_helper"
+require "active_support/error_reporter/test_helper"
 
 class ErrorReporterTest < ActiveSupport::TestCase
   # ExecutionContext is automatically reset in Rails app via executor hooks set in railtie
   # But not in Active Support's own test suite.
   include ActiveSupport::ExecutionContext::TestHelper
-
-  class ErrorSubscriber
-    attr_reader :events
-
-    def initialize
-      @events = []
-    end
-
-    def report(error, handled:, severity:, source:, context:)
-      @events << [error, handled, severity, source, context]
-    end
-  end
+  include ActiveSupport::ErrorReporter::TestHelper
 
   setup do
     @reporter = ActiveSupport::ErrorReporter.new
-    @subscriber = ErrorSubscriber.new
+    @subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
     @reporter.subscribe(@subscriber)
     @error = ArgumentError.new("Oops")
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -68,6 +68,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.sqlite3_adapter_strict_strings_by_default`](#config-active-record-sqlite3-adapter-strict-strings-by-default): `true`
 - [`config.active_support.default_message_encryptor_serializer`](#config-active-support-default-message-encryptor-serializer): `:json`
 - [`config.active_support.default_message_verifier_serializer`](#config-active-support-default-message-verifier-serializer): `:json`
+- [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
 
@@ -2172,6 +2173,21 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `:marshal`           |
 | 7.1                   | `:json`              |
+
+#### `config.active_support.raise_on_invalid_cache_expiration_time`
+
+Specifies if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
+`write` are given an invalid `expires_at` or `expires_in` time.
+
+Options are `true`, and `false`. If `false`, the exception will be reported
+as `handled` and logged instead.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| 7.0                   | `false`              |
+| 7.1                   | `true`               |
 
 ### Configuring Active Job
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -298,6 +298,7 @@ module Rails
           if respond_to?(:active_support)
             active_support.default_message_encryptor_serializer = :json
             active_support.default_message_verifier_serializer = :json
+            active_support.raise_on_invalid_cache_expiration_time = true
           end
 
           if respond_to?(:action_controller)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -57,3 +57,9 @@
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
 # Rails.application.config.active_job.use_big_decimal_serializer = true
+
+# Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
+# `write` are given an invalid `expires_at` or `expires_in` time.
+# Options are `true`, and `false`. If `false`, the exception will be reported
+# as `handled` and logged instead.
+# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4063,6 +4063,33 @@ module ApplicationTests
       assert_equal ActiveSupport::Cache::Coders::Rails61Coder, Rails.cache.instance_variable_get(:@coder)
     end
 
+    test "raise_on_invalid_cache_expiration_time is false with 7.0 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app "development"
+
+      assert_equal false, ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
+    end
+
+    test "raise_on_invalid_cache_expiration_time is true with 7.1 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.1"'
+      app "development"
+
+      assert_equal true, ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
+    end
+
+    test "raise_on_invalid_cache_expiration_time can be set via new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
+        Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+      RUBY
+      app "development"
+
+      assert_equal true, ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
+    end
+
     test "adds a time zone aware type if using PostgreSQL" do
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "postgresql" } } }


### PR DESCRIPTION
### Summary

Note this is a work in progress and should not be merged -- feedback needed, and the CI failures are expected (explained below...)

This is a followup from #45842 where @byroot suggested we might use the new `Rails.error.report` system (#43472) to report a `handled` error instead of just logging, and perhaps put raising an exception behind a new config flag, which could be the new default for 7.1. 

While working on this new PR, I tested using the `assert_called` helper and found that the `#merged_options` method appears to be called multiple times (in the Rails tests, and when running this Rails branch against a real app.) 

With this in mind, I propose we revert #45842, as it will currently log multiple times if an invalid expiration time is found. Because of this issue, I also propose that we alter our approach for this PR to only introduce the new config flag which will raise an exception (no logging or `Rails.error.report`ing) since this will avoid the multiple logging/reporting issue for now. 

Separately, this might highlight an area to explore for possible optimizations. I'm not sure if attempting to memoize `#merged_options` or something along those lines would make sense, but it may be worth considering. 

The relevant Rails test failure:

```
Failure:
MemoryStoreTest#test_invalid_expiration_time_reports_handled_error_when_raise_on_invalid_cache_expiration_time_is_false [rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:588]:
[#<ArgumentError: Cache expiration time is invalid>, {:handled=>true}].
Expected report to be called 1 times, but was called 4 times.
Expected: 1
  Actual: 4
```

Example from me debugging using a Rails app of mine running against this PR:

```ruby
Rails.cache.fetch(cache_key, expires_at: 1.hour.ago) do
  # expensive thing...
end

#<ArgumentError: Cache expiration time is invalid>, {:expires_in=>-3600.000023}
#<ArgumentError: Cache expiration time is invalid>, {:compress=>false, :compress_threshold=>1024, :expires_in=>-3600.000023}
# expensive thing...
#<ArgumentError: Cache expiration time is invalid>, {:compress=>false, :compress_threshold=>1024, :expires_in=>-3600.000023}
#<ArgumentError: Cache expiration time is invalid>, {:compress=>false, :compress_threshold=>1024, :expires_in=>-3600.000023}
#<ArgumentError: Cache expiration time is invalid>, {:compress=>false, :compress_threshold=>1024, :expires_in=>-3600.000023}
```

A few other loose ends:

* I think we should add the invalid expiration time to the error message (any feedback on the message is welcome)
* Any feedback on the config name is welcome (also, I'm not 100% sure I implemented this correctly, but I followed the docs/guide and prior art around adding new framework defaults)
* If we decide to keep the logging and/or `error.report`ing, I have an open question if we should follow the pattern from #43712, where we use both `ActiveSupport.error_reporter` and also `logger.error`. 

I'll happily work up any changes requested, thanks for your consideration!