### PR TITLE
Add `redirect.action_dispatch` to Action Dispatch

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -269,6 +269,13 @@ INFO. Additional keys may be added by the caller.
 | ------------- | ---------------------- |
 | `:middleware` | Name of the middleware |
 
+#### redirect.action_dispatch
+
+| Key         | Value               |
+| ----------- | ------------------- |
+| `:status`   | HTTP response code  |
+| `:location` | URL to redirect to  |
+
 ### Action View
 
 #### render_template.action_view


### PR DESCRIPTION
`redirect.action_dispatch` was introduced in the following pull request.

https://github.com/rails/rails/pull/43755

This patch added the hook description to Action Dispatch.
