### PR TITLE
Fix reverting the addition of invalid foreign keys and check constraints

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -140,7 +140,7 @@ module ActiveRecord
 
       def defined_for?(to_table: nil, validate: nil, **options)
         (to_table.nil? || to_table.to_s == self.to_table) &&
-          (validate.nil? || validate == options.fetch(:validate, validate)) &&
+          (validate.nil? || validate == self.options.fetch(:validate, validate)) &&
           options.all? { |k, v| self.options[k].to_s == v.to_s }
       end
 
@@ -164,8 +164,9 @@ module ActiveRecord
         !ActiveRecord::SchemaDumper.chk_ignore_pattern.match?(name) if name
       end
 
-      def defined_for?(name:, expression: nil, **options)
+      def defined_for?(name:, expression: nil, validate: nil, **options)
         self.name == name.to_s &&
+          (validate.nil? || validate == self.options.fetch(:validate, validate)) &&
           options.all? { |k, v| self.options[k].to_s == v.to_s }
       end
     end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -243,6 +243,11 @@ module ActiveRecord
           [:change_column_null, args]
         end
 
+        def invert_add_foreign_key(args)
+          args.last.delete(:validate) if args.last.is_a?(Hash)
+          super
+        end
+
         def invert_remove_foreign_key(args)
           options = args.extract_options!
           from_table, to_table = args
@@ -275,6 +280,11 @@ module ActiveRecord
           end
 
           [:change_table_comment, [table, from: options[:to], to: options[:from]]]
+        end
+
+        def invert_add_check_constraint(args)
+          args.last.delete(:validate) if args.last.is_a?(Hash)
+          super
         end
 
         def invert_remove_check_constraint(args)

--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -35,6 +35,20 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  class AddAndValidateCheckConstraint < SilentMigration
+    def change
+      add_check_constraint :settings, "value >= 0", name: "positive_value", validate: false
+      validate_check_constraint :settings, name: "positive_value"
+    end
+  end
+
+  class AddAndValidateForeignKey < SilentMigration
+    def change
+      add_foreign_key :bars, :foos, validate: false
+      validate_foreign_key :bars, :foos
+    end
+  end
+
   self.use_transactional_tests = false
 
   setup do
@@ -44,6 +58,8 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
   teardown do
     @connection.drop_table "settings", if_exists: true
     @connection.drop_table "enums", if_exists: true
+    @connection.drop_table "bars", if_exists: true
+    @connection.drop_table "foos", if_exists: true
   end
 
   def test_migrate_revert_add_index_with_expression
@@ -80,5 +96,28 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
 
     DropEnumMigration.new.migrate(:down)
     assert_equal [["color", "blue,green"]], @connection.enum_types
+  end
+
+  def test_migrate_revert_add_and_validate_check_constraint
+    @connection.create_table(:settings) do |t|
+      t.integer :value
+    end
+
+    AddAndValidateCheckConstraint.new.migrate(:up)
+    assert @connection.check_constraint_exists?(:settings, name: "positive_value")
+    AddAndValidateCheckConstraint.new.migrate(:down)
+    assert_not @connection.check_constraint_exists?(:settings, name: "positive_value")
+  end
+
+  def test_migrate_revert_add_and_validate_foreign_key
+    @connection.create_table(:foos)
+    @connection.create_table(:bars) do |t|
+      t.integer :foo_id
+    end
+
+    AddAndValidateForeignKey.new.migrate(:up)
+    assert @connection.foreign_key_exists?(:bars, :foos)
+    AddAndValidateForeignKey.new.migrate(:down)
+    assert_not @connection.foreign_key_exists?(:bars, :foos)
   end
 end


### PR DESCRIPTION
Adding foreign keys and check constraints to an existing (large) table is dangerous in PostgreSQL, because they need to be checked (validated) and while they are validated, the table stays exclusively locked. So, usually, they are added as invalid and then validated in a separate transaction.

Something like:
```ruby
class AddForeignKeyFromRepositoriesToUsers < ActiveRecord::Migration[7.1]
  disable_ddl_transaction!

  def change
    add_foreign_key :repositories, :users, validate: false
    validate_foreign_key :repositories, :users
  end
end
``` 

This migration is reversible, because of the bug in https://github.com/rails/rails/blob/a2fc96a80cf26c11df3e86e86c1b2b61736af80c/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L143

Note the missing `self` in `options.fetch...`.

Similar migration was also always reversible before https://github.com/rails/rails/pull/45808 (because before that PR, only name was checked for check constraints to match the searched one).

So, this PR fixes `defined_for?` for both foreign keys and check constraints to work correctly with validity and makes adding them them as invalid a reversible operation.