### PR TITLE
Revert "Remove `Rails::Application` `assets` accessor"

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -94,7 +94,7 @@ module Rails
       public :new
     end
 
-    attr_accessor :sandbox
+    attr_accessor :assets, :sandbox
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders, :reloader, :executor, :autoloaders
 


### PR DESCRIPTION
Reverts rails/rails#45878

if both assets pipeline needs to define this method it means it is an valid extension point of the framework. The fact that sprockets-rails monkey patches rails is historical and can be removed now, so it isn’t really a good reason to remove this accessor. 

Closes #45888