### PR TITLE
Lock que version to v1 until #45899 is resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :job do
   gem "delayed_job", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby
   gem "sneakers", require: false
-  gem "que", require: false
+  gem "que", "< 2", require: false
   gem "backburner", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,7 +591,7 @@ DEPENDENCIES
   propshaft (>= 0.1.7)
   psych (~> 3.0)
   puma
-  que
+  que (< 2)
   queue_classic (>= 4.0.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)


### PR DESCRIPTION
### Summary

This pull request locks que version to v1 until #45899 is resolved
Refer to https://github.com/rails/rails/issues/45899 for the background.
