### PR TITLE
Validate option keys passed to #change()

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -28,6 +28,11 @@
 
     *Andrii Gladkyi*, *Jean Boussier*
 
+*   Validate option keys passed to `Time#change`, `Date#change`, `DateTime#change`,
+    and `TimeWithZone#change`.
+
+    *Vlad Pisanov*
+
 *   `default` option of `thread_mattr_accessor` now applies through inheritance and
     also across new threads.
 

--- a/activesupport/lib/active_support/core_ext/date/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date/calculations.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/object/acts_like"
 require "active_support/core_ext/date/zones"
 require "active_support/core_ext/time/zones"
 require "active_support/core_ext/date_and_time/calculations"
+require "active_support/core_ext/hash/keys"
 
 class Date
   include DateAndTime::Calculations
@@ -126,6 +127,8 @@ class Date
   #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
   #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
   def change(options)
+    options.assert_valid_keys(:year, :month, :day)
+
     ::Date.new(
       options.fetch(:year, year),
       options.fetch(:month, month),

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -368,7 +368,11 @@ module DateAndTime
       end
 
       def copy_time_to(other)
-        other.change(hour: hour, min: min, sec: sec, nsec: try(:nsec))
+        if other.acts_like?(:time)
+          other.change(hour: hour, min: min, sec: sec, nsec: try(:nsec))
+        else
+          other
+        end
       end
   end
 end

--- a/activesupport/lib/active_support/core_ext/date_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/calculations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "date"
+require "active_support/core_ext/hash/keys"
 
 class DateTime
   class << self
@@ -43,12 +44,15 @@ class DateTime
   # passed, then minute and sec is set to 0. If the hour and minute is passed,
   # then sec is set to 0. The +options+ parameter takes a hash with any of these
   # keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>,
-  # <tt>:min</tt>, <tt>:sec</tt>, <tt>:offset</tt>, <tt>:start</tt>.
+  # <tt>:min</tt>, <tt>:sec</tt>, <tt>:nsec</tt>, <tt>:usec</tt>,
+  # <tt>:offset</tt>, <tt>:start</tt>.
   #
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => DateTime.new(2012, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => DateTime.new(1981, 8, 1, 22, 35, 0)
   #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
   def change(options)
+    options.assert_valid_keys(:year, :month, :day, :hour, :min, :sec, :usec, :nsec, :offset, :start)
+
     if new_nsec = options[:nsec]
       raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{options.inspect}" if options[:usec]
       new_fraction = Rational(new_nsec, 1000000000)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -7,6 +7,7 @@ require "active_support/core_ext/time/zones"
 require "active_support/core_ext/date_and_time/calculations"
 require "active_support/core_ext/date/calculations"
 require "active_support/core_ext/module/remove_method"
+require "active_support/core_ext/hash/keys"
 
 class Time
   include DateAndTime::Calculations
@@ -136,6 +137,8 @@ class Time
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
   #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => Time.new(1981, 8, 29, 0, 0, 0)
   def change(options)
+    options.assert_valid_keys(:year, :month, :day, :hour, :min, :sec, :usec, :nsec, :offset)
+
     new_year   = options.fetch(:year, year)
     new_month  = options.fetch(:month, month)
     new_day    = options.fetch(:day, day)

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -6,6 +6,7 @@ require "active_support/duration"
 require "active_support/values/time_zone"
 require "active_support/core_ext/object/acts_like"
 require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/core_ext/hash/keys"
 
 module ActiveSupport
   # A Time-like class that can represent a time in any time zone. Necessary
@@ -409,11 +410,13 @@ module ActiveSupport
     #   t.change(offset: "-10:00") # => Fri, 14 Apr 2017 11:45:15.116992711 HST -10:00
     #   t.change(zone: "Hawaii")   # => Fri, 14 Apr 2017 11:45:15.116992711 HST -10:00
     def change(options)
+      options.assert_valid_keys(:year, :month, :day, :hour, :min, :sec, :usec, :nsec, :offset, :zone)
+
       if options[:zone] && options[:offset]
         raise ArgumentError, "Can't change both :offset and :zone at the same time: #{options.inspect}"
       end
 
-      new_time = time.change(options)
+      new_time = time.change(options.without(:zone))
 
       if options[:zone]
         new_zone = ::Time.find_zone(options[:zone])

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -146,6 +146,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Date.new(2007, 5, 11), Date.new(2005, 2, 11).change(year: 2007, month: 5)
     assert_equal Date.new(2006, 2, 22), Date.new(2005, 2, 22).change(year: 2006)
     assert_equal Date.new(2005, 6, 22), Date.new(2005, 2, 22).change(month: 6)
+    assert_raise(ArgumentError) { Date.new(2005, 6, 22).change(badarg: 42) }
   end
 
   def test_sunday

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -231,6 +231,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { DateTime.civil(2005, 1, 2, 11, 22, 0).change(nsec: 1000000000) }
     assert_nothing_raised { DateTime.civil(2005, 1, 2, 11, 22, 0).change(usec: 999999) }
     assert_nothing_raised { DateTime.civil(2005, 1, 2, 11, 22, 0).change(nsec: 999999999) }
+
+    # invalid option key
+    assert_raise(ArgumentError) { DateTime.civil(2005, 1, 2, 11, 22, 0).change(badarg: 42) }
   end
 
   def test_advance

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -430,6 +430,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(2005, 1, 2, 11, 22, 33, 8), Time.local(2005, 1, 2, 11, 22, 33, 2).change(nsec: 8000)
     assert_raise(ArgumentError) { Time.local(2005, 1, 2, 11, 22, 33, 8).change(usec: 1, nsec: 1) }
     assert_nothing_raised { Time.new(2015, 5, 9, 10, 00, 00, "+03:00").change(nsec: 999999999) }
+    assert_raise(ArgumentError) { Time.local(2005, 1, 2, 11, 22, 33, 8).change(badarg: 42) }
   end
 
   def test_utc_change

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -734,6 +734,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "Fri, 31 Dec 1999 19:00:00.000000000 HST -10:00", @twz.change(zone: -10).inspect
     assert_equal "Fri, 31 Dec 1999 19:00:00.000000000 HST -10:00", @twz.change(zone: -36000).inspect
     assert_equal "Fri, 31 Dec 1999 19:00:00.000000000 HST -10:00", @twz.change(zone: "Pacific/Honolulu").inspect
+    assert_raise(ArgumentError) { @twz.change(badarg: 42) }
   end
 
   def test_change_at_dst_boundary


### PR DESCRIPTION
### Summary

`DateTime#change` and `Time#change` receive nearly identical keyword arguments, with one subtle difference: `DateTime#change` also supports `start:`.

The `change` method silently ignores invalid/unsupported keyword arguments, which makes it error-prone to typos and makes transitioning legacy codebases from `DateTime` to `Time` difficult.

The same problem affects related classes `Date` and `TimeWithZone`.

This PR enforces that all arguments passed to `change` are actually supported, and updates a stale comment to include `:nsec` and `:usec` as supported arguments to `DateTime#change`.