### PR TITLE
Replace `method_source` gem with stdlib equivalent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ PATH
     railties (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
-      method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.6)
@@ -315,7 +314,6 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
-    method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0"
-  s.add_dependency "method_source"
   s.add_dependency "zeitwerk", "~> 2.6"
 
   s.add_development_dependency "actionview", version

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -376,7 +376,7 @@ module ApplicationTests
       end
     end
 
-    def test_more_than_one_line_filter
+    def test_more_than_one_line_filter_macro_syntax
       app_file "test/models/post_test.rb", <<-RUBY
         require "test_helper"
 
@@ -392,6 +392,34 @@ module ApplicationTests
           end
 
           test "line filter does not run this" do
+            assert true
+          end
+        end
+      RUBY
+
+      run_test_command("test/models/post_test.rb:4:9").tap do |output|
+        assert_match "PostTest:FirstFilter", output
+        assert_match "PostTest:SecondFilter", output
+        assert_match "2 runs, 2 assertions", output
+      end
+    end
+
+    def test_more_than_one_line_filter_test_method_syntax
+      app_file "test/models/post_test.rb", <<-RUBY
+        require "test_helper"
+
+        class PostTest < ActiveSupport::TestCase
+          def test_first_filter
+            puts 'PostTest:FirstFilter'
+            assert true
+          end
+
+          def test_second_filter
+            puts 'PostTest:SecondFilter'
+            assert true
+          end
+
+          def test_line_filter_does_not_run_this
             assert true
           end
         end


### PR DESCRIPTION
The `method_source` gem was added to railties in https://github.com/rails/rails/pull/19216. It was used to determine the last line number of a given test method to support running tests by line number. But this is not something that requires an external dependency: Ripper can do this easily, and it has the added advantage of not using [repeated calls to `eval`](https://github.com/banister/method_source/blob/81d039c966ffd95d26e12eb2e205c0eb8377f49d/lib/method_source/code_helpers.rb#L66-L80) to do it.

Drop `method_source` and replace it with a simple handler for Ripper's `on_def` parser event.

I don't believe that there are any mainstream rubies at this point that can run Rails and don't support Ripper but correct me if I'm mistaken.