### PR TITLE
Pass options accessor to Cache#fetch block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `ActiveSupport::Cache:Store#fetch` now passes an options accessor to the block.
+
+    It makes possible to override cache options:
+
+        Rails.cache.fetch("3rd-party-token") do |name, options|
+          token = fetch_token_from_remote
+          # set cache's TTL to match token's TTL
+          options.expires_in = token.expires_in
+          token
+        end
+
+    *Andrii Gladkyi*, *Jean Boussier*
+
 *   `default` option of `thread_mattr_accessor` now applies through inheritance and
     also across new threads.
 


### PR DESCRIPTION
Closes: https://github.com/rails/rails/pull/45080

This is a surprisingly common use case when dealing with APIs with short lived authentication tokens.

This implementation is very much the same as the original one by @arg, except that we yield an object with a restricted interface  instead of yielding the options hash.

The reason is that not all options can be changed between the read and the write, so by restricting the interface we avoid surprising users.

Co-Authored-By: @arg 
