### PR TITLE
Fix typo in "Configuring Rails Applications" guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1209,11 +1209,11 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_record.yaml_column_permitted_classes`
 
-Defaults to `[Symbol]`. Allows applications to include additional permitted classes to `safe_load()` on the `ActiveStorage::Coders::YamlColumn`.
+Defaults to `[Symbol]`. Allows applications to include additional permitted classes to `safe_load()` on the `ActiveRecord::Coders::YAMLColumn`.
 
 #### `config.active_record.use_yaml_unsafe_load`
 
-Defaults to `false`. Allows applications to opt into using `unsafe_load` on the `ActiveStorage::Coders::YamlColumn`.
+Defaults to `false`. Allows applications to opt into using `unsafe_load` on the `ActiveRecord::Coders::YAMLColumn`.
 
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans`
 


### PR DESCRIPTION
### Summary

This pull request fixes typos in "Configuring Rails Applications" guide. Somehow, they have been there since 611990f1a6c137c2d56b1ba06b27e5d2434dcd6a.