### PR TITLE
Move SchemaMigration to an independent object

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Move `ActiveRecord::SchemaMigration` to an independent object.
+
+    `ActiveRecord::SchemaMigration` no longer inherits from `ActiveRecord::Base` and is now an independent object that should be instantiated with a `connection`. This class is private and should not be used by applications directly. If you want to interact with the schema migrations table, please access it on the connection directly, for example: `ActiveRecord::Base.connection.schema_migration`.
+
+    *Eileen M. Uchitelle*
+
 *   Deprecate `all_connection_pools` and make `connection_pool_list` more explicit.
 
     Following on #45924 `all_connection_pools` is now deprecated. `connection_pool_list` will either take an explicit role or applications can opt into the new behavior by passing `:all`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1270,7 +1270,7 @@ module ActiveRecord
       end
 
       def dump_schema_information # :nodoc:
-        versions = schema_migration.all_versions
+        versions = schema_migration.versions
         insert_versions_sql(versions) if versions.any?
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -193,21 +193,7 @@ module ActiveRecord
       end
 
       def schema_migration # :nodoc:
-        @schema_migration ||= begin
-                                conn = self
-                                connection_name = conn.pool.pool_config.connection_name
-
-                                return ActiveRecord::SchemaMigration if connection_name == "ActiveRecord::Base"
-
-                                schema_migration_name = "#{connection_name}::SchemaMigration"
-
-                                Class.new(ActiveRecord::SchemaMigration) do
-                                  define_singleton_method(:name) { schema_migration_name }
-                                  define_singleton_method(:to_s) { schema_migration_name }
-
-                                  self.connection_specification_name = connection_name
-                                end
-                              end
+        SchemaMigration.new(self)
       end
 
       def internal_metadata # :nodoc:

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -1,54 +1,87 @@
 # frozen_string_literal: true
 
-require "active_record/scoping/default"
-require "active_record/scoping/named"
-
 module ActiveRecord
   # This class is used to create a table that keeps track of which migrations
   # have been applied to a given database. When a migration is run, its schema
-  # number is inserted in to the `SchemaMigration.table_name` so it doesn't need
+  # number is inserted in to the schema migrations table so it doesn't need
   # to be executed the next time.
-  class SchemaMigration < ActiveRecord::Base # :nodoc:
-    class << self
-      def primary_key
-        "version"
-      end
+  class SchemaMigration # :nodoc:
+    attr_reader :connection, :arel_table
 
-      def table_name
-        "#{table_name_prefix}#{schema_migrations_table_name}#{table_name_suffix}"
-      end
+    def initialize(connection)
+      @connection = connection
+      @arel_table = Arel::Table.new(table_name)
+    end
 
-      def create_table
-        unless connection.table_exists?(table_name)
-          connection.create_table(table_name, id: false) do |t|
-            t.string :version, **connection.internal_string_options_for_primary_key
-          end
-        end
-      end
+    def create_version(version)
+      im = Arel::InsertManager.new(arel_table)
+      im.insert(arel_table[primary_key] => version)
+      connection.insert(im, "#{self} Create", primary_key, version)
+    end
 
-      def drop_table
-        connection.drop_table table_name, if_exists: true
-      end
+    def delete_version(version)
+      dm = Arel::DeleteManager.new(arel_table)
+      dm.wheres = [arel_table[primary_key].eq(version)]
 
-      def normalize_migration_number(number)
-        "%.3d" % number.to_i
-      end
+      connection.delete(dm, "#{self} Destroy")
+    end
 
-      def normalized_versions
-        all_versions.map { |v| normalize_migration_number v }
-      end
-
-      def all_versions
-        order(:version).pluck(:version)
-      end
-
-      def table_exists?
-        connection.data_source_exists?(table_name)
+    def delete_all_versions
+      versions.each do |version|
+        delete_version(version)
       end
     end
 
-    def version
-      super.to_i
+    def primary_key
+      "version"
+    end
+
+    def table_name
+      "#{ActiveRecord::Base.table_name_prefix}#{ActiveRecord::Base.schema_migrations_table_name}#{ActiveRecord::Base.table_name_suffix}"
+    end
+
+    def create_table
+      unless connection.table_exists?(table_name)
+        connection.create_table(table_name, id: false) do |t|
+          t.string :version, **connection.internal_string_options_for_primary_key
+        end
+      end
+    end
+
+    def drop_table
+      connection.drop_table table_name, if_exists: true
+    end
+
+    def normalize_migration_number(number)
+      "%.3d" % number.to_i
+    end
+
+    def normalized_versions
+      versions.map { |v| normalize_migration_number v }
+    end
+
+    def versions
+      sm = Arel::SelectManager.new(arel_table)
+      sm.project(arel_table[primary_key])
+      sm.order(arel_table[primary_key].asc)
+      connection.select_values(sm)
+    end
+
+    def integer_versions
+      versions.map(&:to_i)
+    end
+
+    def count
+      sm = Arel::SelectManager.new(arel_table)
+      sm.project(*Arel::Nodes::Count.new([Arel.star]))
+      connection.select_values(sm).first
+    end
+
+    def table_exists?
+      connection.data_source_exists?(table_name)
+    end
+
+    class NullSchemaMigration
     end
   end
 end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -192,7 +192,7 @@ module ActiveRecord
           ActiveRecord::Base.establish_connection(db_config)
 
           begin
-            database_initialized = ActiveRecord::SchemaMigration.table_exists?
+            database_initialized = ActiveRecord::Base.connection.schema_migration.table_exists?
           rescue ActiveRecord::NoDatabaseError
             create(db_config)
             retry

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -20,7 +20,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     @connection.drop_table :nep_schema_migrations rescue nil
     @connection.drop_table :has_timestamps rescue nil
     @connection.drop_table :multiple_indexes rescue nil
-    @schema_migration.delete_all rescue nil
+    @schema_migration.delete_all_versions rescue nil
     ActiveRecord::Migration.verbose = @original_verbose
   end
 
@@ -31,7 +31,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
     @schema_migration.create_table
     assert_difference "@schema_migration.count", 1 do
-      @schema_migration.create version: 12
+      @schema_migration.create_version(12)
     end
   ensure
     @schema_migration.drop_table
@@ -69,7 +69,6 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
   def test_schema_define_with_table_name_prefix
     old_table_name_prefix = ActiveRecord::Base.table_name_prefix
     ActiveRecord::Base.table_name_prefix = "nep_"
-    @schema_migration.reset_table_name
     @internal_metadata.reset_table_name
     ActiveRecord::Schema.define(version: 7) do
       create_table :fruits do |t|
@@ -82,7 +81,6 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     assert_equal 7, @connection.migration_context.current_version
   ensure
     ActiveRecord::Base.table_name_prefix = old_table_name_prefix
-    @schema_migration.reset_table_name
     @internal_metadata.reset_table_name
   end
 

--- a/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_migrations_test.rb
@@ -5,6 +5,10 @@ require "cases/helper"
 class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
   self.use_transactional_tests = false
 
+  def setup
+    @schema_migration = ActiveRecord::Base.connection.schema_migration
+  end
+
   def test_renaming_index_on_foreign_key
     connection.add_index "engines", "car_id"
     connection.add_foreign_key :engines, :cars, name: "fk_engines_cars"
@@ -17,10 +21,10 @@ class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
 
   def test_initializes_schema_migrations_for_encoding_utf8mb4
     with_encoding_utf8mb4 do
-      table_name = ActiveRecord::SchemaMigration.table_name
+      table_name = @schema_migration.table_name
       connection.drop_table table_name, if_exists: true
 
-      ActiveRecord::SchemaMigration.create_table
+      @schema_migration.create_table
 
       assert connection.column_exists?(table_name, :version, :string)
     end

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -94,7 +94,7 @@ class Mysql2DefaultEngineOptionTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Base.logger       = @logger_was
     ActiveRecord::Migration.verbose = @verbose_was
     ActiveRecord::Base.connection.drop_table "mysql_table_options", if_exists: true
-    ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Base.connection.schema_migration.delete_all_versions rescue nil
   end
 
   test "new migrations do not contain default ENGINE=InnoDB option" do

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -27,20 +27,18 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
 
     ActiveRecord::Base.table_name_prefix = "p_"
     ActiveRecord::Base.table_name_suffix = "_s"
-    @connection.schema_migration.reset_table_name
     @connection.internal_metadata.reset_table_name
 
-    @connection.schema_migration.delete_all rescue nil
+    @connection.schema_migration.delete_all_versions rescue nil
     ActiveRecord::Migration.verbose = false
   end
 
   def teardown
-    @connection.schema_migration.delete_all rescue nil
+    @connection.schema_migration.delete_all_versions rescue nil
     ActiveRecord::Migration.verbose = true
 
     ActiveRecord::Base.table_name_prefix = @old_table_name_prefix
     ActiveRecord::Base.table_name_suffix = @old_table_name_suffix
-    @connection.schema_migration.reset_table_name
     @connection.internal_metadata.reset_table_name
 
     super

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -308,7 +308,7 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::Base.connection.schema_migration.delete_all
+    ActiveRecord::Base.connection.schema_migration.delete_all_versions
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
 end
@@ -360,7 +360,7 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::Base.connection.schema_migration.delete_all
+    ActiveRecord::Base.connection.schema_migration.delete_all_versions
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_with_default_nil_in_legacy_migration
 end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       teardown do
         connection.drop_table :testings rescue nil
         ActiveRecord::Migration.verbose = @verbose_was
-        @schema_migration.delete_all rescue nil
+        @schema_migration.delete_all_versions rescue nil
       end
 
       def test_migration_doesnt_remove_named_index
@@ -685,7 +685,7 @@ module LegacyPolymorphicReferenceIndexTestCases
 
   def teardown
     ActiveRecord::Migration.verbose = @verbose_was
-    @schema_migration.delete_all rescue nil
+    @schema_migration.delete_all_versions rescue nil
     connection.drop_table :testings rescue nil
   end
 
@@ -812,7 +812,7 @@ module LegacyPrimaryKeyTestCases
   def teardown
     @migration.migrate(:down) if @migration
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::SchemaMigration.delete_all rescue nil
+    ActiveRecord::Base.connection.schema_migration.delete_all_versions rescue nil
     LegacyPrimaryKey.reset_column_information
   end
 

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         super
         @schema_migration = ActiveRecord::Base.connection.schema_migration
         @schema_migration.create_table
-        @schema_migration.delete_all
+        @schema_migration.delete_all_versions
         @internal_metadata = ActiveRecord::Base.connection.internal_metadata
       end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -8,7 +8,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   setup do
-    ActiveRecord::SchemaMigration.create_table
+    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @schema_migration.create_table
   end
 
   def standard_dump
@@ -16,7 +17,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_dump_schema_information_with_empty_versions
-    ActiveRecord::SchemaMigration.delete_all
+    @schema_migration.delete_all_versions
     schema_info = ActiveRecord::Base.connection.dump_schema_information
     assert_no_match(/INSERT INTO/, schema_info)
   end
@@ -24,7 +25,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   def test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order
     versions = %w{ 20100101010101 20100201010101 20100301010101 }
     versions.shuffle.each do |v|
-      ActiveRecord::SchemaMigration.create!(version: v)
+      @schema_migration.create_version(v)
     end
 
     schema_info = ActiveRecord::Base.connection.dump_schema_information
@@ -37,7 +38,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     STR
     assert_equal expected, schema_info
   ensure
-    ActiveRecord::SchemaMigration.delete_all
+    @schema_migration.delete_all_versions
   end
 
   def test_schema_dump_include_migration_version

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -135,14 +135,14 @@ class LoadingTest < ActiveSupport::TestCase
 
     initial = [
       ActiveStorage::Record, ActiveStorage::Blob, ActiveStorage::Attachment,
-      ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord
+      ActiveRecord::InternalMetadata, ApplicationRecord
     ].collect(&:to_s).sort
 
     assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
     get "/load"
     assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial
     get "/unload"
-    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
+    assert_equal ["ActiveRecord::InternalMetadata"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
   end
 
   test "initialize can't be called twice" do

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -34,7 +34,7 @@ module RailtiesTest
 
     def migrations
       migration_root = File.expand_path(ActiveRecord::Migrator.migrations_paths.first, app_path)
-      ActiveRecord::MigrationContext.new(migration_root, ActiveRecord::SchemaMigration).migrations
+      ActiveRecord::MigrationContext.new(migration_root, ActiveRecord::SchemaMigration::NullSchemaMigration.new).migrations
     end
 
     test "serving sprocket's assets" do


### PR DESCRIPTION
Previously, SchemaMigration inherited from ActiveRecord::Base. This is
problematic for multiple databases and resulted in building the code in
AbstractAdapter that was previously there. Rather than hacking around
the fact that SchemaMigration inherits from Base, this PR makes
SchemaMigration an independent object. Then each connection can get it's
own SchemaMigration object. This change required defining the methods
that SchemaMigration was depending on ActiveRecord::Base for (ex
create!). I reimplemented only the methods called by the framework as
this class is no-doc's so it doesn't need to implement anything beyond
that. Now each connection gets it's own SchemaMigration object which
stores the connection. I also decided to update the method names (create
-> create_version, delete_by -> delete_version, delete_all ->
delete_all_versions) to be more explicit.

This change also required adding a NullSchemaMigraiton class for cases
when we don't have a connection yet but still need to copy migrations
from the MigrationContext. Ultimately I think this is a little weird -
we need to do so much work to pick up a set of files? Maybe something to
explore in the future.

Aside from removing the hack we added back in #36439 this change will
enable my work to stop clobbering and depending directly on
Base.connection in the rake tasks. While working on this I discovered
that we always have a `ActiveRecord::SchemaMigration` because the
connection is always on `Base` in the rake tasks. This will free us up
to do less hacky stuff in the migrations and tasks.

Note: once this is merged I'm going to do the same thing with InternalMetadata.