### PR TITLE
Lock redis version to v4 until #45913 is resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ end
 group :cable do
   gem "puma", require: false
 
-  gem "redis", ">= 4.0.1", require: false
+  gem "redis", ">= 4.0.1", "< 5", require: false
 
   gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,7 +596,7 @@ DEPENDENCIES
   rails!
   rake (>= 11.1)
   redcarpet (~> 3.2.3)
-  redis (>= 4.0.1)
+  redis (>= 4.0.1, < 5)
   redis-namespace
   resque
   resque-scheduler


### PR DESCRIPTION
### Summary

This pull request locks redis version to v4 until #45913 is resolved.

Refer to https://github.com/rails/rails/issues/45913
https://github.com/redis/redis-rb/issues/1142

### Other Information
