### PR TITLE
Address `NameError: uninitialized constant ActiveSupport::ErrorReporter::TestHelper`

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/numeric/time"
+require "active_support/error_reporter/test_helper"
 
 # Tests the base functionality that should be identical across all cache stores.
 module CacheStoreBehavior


### PR DESCRIPTION
### Summary

This pull request addresses the isolated test failure at https://buildkite.com/rails/rails/builds/89113#0182ef62-c513-4f55-bbca-459385762ec4

Follow up #45892

```ruby
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
$ ruby -w test/cache/stores/file_store_test.rb
Running 230 tests in parallel using 8 processes
Run options: --seed 12562

......................................................................E

Error:
FileStoreTest#test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false:
NameError: uninitialized constant ActiveSupport::ErrorReporter::TestHelper
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:802:in `with_error_subscriber_and_log'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:609:in `block in test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:792:in `with_raise_on_invalid_cache_expiration_time'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:608:in `test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false'

rails test home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:607

...................................................................................................E

Error:
OptimizedFileStoreTest#test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false:
NameError: uninitialized constant ActiveSupport::ErrorReporter::TestHelper
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:802:in `with_error_subscriber_and_log'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:609:in `block in test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:792:in `with_raise_on_invalid_cache_expiration_time'
    /home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:608:in `test_invalid_expiration_time_reports_and_logs_when_raise_on_invalid_cache_expiration_time_is_false'

rails test home/yahonda/src/github.com/rails/rails/activesupport/test/cache/behaviors/cache_store_behavior.rb:607

...........................................................

Finished in 0.303590s, 757.6008 runs/s, 2048.8161 assertions/s.
230 runs, 622 assertions, 0 failures, 2 errors, 0 skips
$
```


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
