### PR TITLE
Reduce calls to pool_configs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/pool_manager.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_manager.rb
@@ -23,6 +23,16 @@ module ActiveRecord
         end
       end
 
+      def each_pool_config(role = nil, &block)
+        if role
+          @role_to_shard_mapping[role].each_value(&block)
+        else
+          @role_to_shard_mapping.each_value do |shard_map|
+            shard_map.each_value(&block)
+          end
+        end
+      end
+
       def remove_role(role)
         @role_to_shard_mapping.delete(role)
       end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -242,7 +242,7 @@ module ActiveRecord
 
     # Clears the query cache for all connections associated with the current thread.
     def clear_query_caches_for_current_thread
-      connection_handler.connection_pool_list(:all).each do |pool|
+      connection_handler.each_connection_pool do |pool|
         pool.connection.clear_query_cache if pool.active_connection?
       end
     end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -26,15 +26,13 @@ module ActiveRecord
     end
 
     def self.run
-      pools = []
-      pools.concat(ActiveRecord::Base.connection_handler.connection_pool_list(:all).reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
-      pools
+      ActiveRecord::Base.connection_handler.each_connection_pool.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
     end
 
     def self.complete(pools)
       pools.each { |pool| pool.disable_query_cache! }
 
-      ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
+      ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
       end
     end


### PR DESCRIPTION
Updated commit message:

This is a partial fix for https://github.com/rails/rails/issues/45906 to allocate less objects when iterating
through pool configs. My original attempt to fix this wasn't feasible
due to how the query cache works. The idea to use a dedicated `each_*`
came from jonathanhefner and I incorporated it here.

Using the following script:

```
Benchmark.memory do |x|
  x.report("all") do
    ActiveRecord::Base.connection_handler.all_connection_pools.each { }
  end

  x.report("each") do
    ActiveRecord::Base.connection_handler.each_connection_pool { }
  end

  x.compare!
end
```

We can see that less objects are allocated with the each method. This is
even more important now that we are calling `all_connection_pools` in
more placed since https://github.com/rails/rails/pull/45924 and https://github.com/rails/rails/pull/45961.

```
Calculating -------------------------------------
                 all   408.000  memsize (     0.000  retained)
                         7.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
                each   328.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
                each:        328 allocated
                 all:        408 allocated - 1.24x more
```

Note that if this is run again on this branch `all_connection_pools`
will have even more allocations due to the deprecation warning that was
introduced. However removing that shows similar numbers to the benchmark
here.

Co-authored-by: Jonathan Hefner <jonathan@hefner.pro>

~~We already have the pools that had the query cache enabled so while
looping through the pools to disable the query cache we can also release
the connection at the same time.~~

~~This should reduce calls to `pool_configs` from `complete`. There's no
performance difference in the benchmark-ips, but I can see that we no
longer hit `pool_configs` from this path.~~

~~This is related to #45906. We can't memoize the `pool_configs`
object easily (at least a ton of tests fail), but this will at least
reduce allocations. I'll continue investingating improvements.~~