### PR TITLE
Add `:request` to `redirect.action_dispatch` payload

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -19,10 +19,12 @@ module ActionDispatch
 
       def call(env)
         ActiveSupport::Notifications.instrument("redirect.action_dispatch") do |payload|
-          response = build_response(Request.new(env))
+          request = Request.new(env)
+          response = build_response(request)
 
           payload[:status] = @status
           payload[:location] = response.headers["Location"]
+          payload[:request] = request
 
           response.to_a
         end

--- a/actionpack/test/dispatch/routing/instrumentation_test.rb
+++ b/actionpack/test/dispatch/routing/instrumentation_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
+  test "redirect is instrumented" do
+    draw do
+      get "redirect", to: redirect("/login")
+    end
+
+    event = subscribed("redirect.action_dispatch") { get "/redirect" }
+
+    assert_equal 301, event.payload[:status]
+    assert_equal "http://www.example.com/login", event.payload[:location]
+    assert_kind_of ActionDispatch::Request, event.payload[:request]
+  end
+
+  private
+    def draw(&block)
+      self.class.stub_controllers do |routes|
+        routes.default_url_options = { host: "www.example.com" }
+        routes.draw(&block)
+        @app = RoutedRackApp.new routes
+      end
+    end
+
+    def subscribed(event_pattern, &block)
+      event = nil
+      subscriber = -> (_event) { event = _event }
+      ActiveSupport::Notifications.subscribed(subscriber, event_pattern, &block)
+      event
+    end
+end

--- a/actionpack/test/dispatch/routing/log_subscriber_test.rb
+++ b/actionpack/test/dispatch/routing/log_subscriber_test.rb
@@ -4,7 +4,7 @@ require "abstract_unit"
 require "active_support/log_subscriber/test_helper"
 require "action_dispatch/log_subscriber"
 
-class TestLogSubscriber < ActionDispatch::IntegrationTest
+class RoutingLogSubscriberTest < ActionDispatch::IntegrationTest
   include ActiveSupport::LogSubscriber::TestHelper
 
   def setup
@@ -12,28 +12,29 @@ class TestLogSubscriber < ActionDispatch::IntegrationTest
     ActionDispatch::LogSubscriber.attach_to :action_dispatch
   end
 
-  def test_redirect_logging
+  test "redirect is logged" do
     draw do
       get "redirect", to: redirect("/login")
     end
 
     get "/redirect"
     wait
+
     assert_equal 2, logs.size
     assert_equal "Redirected to http://www.example.com/login", logs.first
     assert_match(/Completed 301/, logs.last)
   end
 
-private
-  def draw(&block)
-    self.class.stub_controllers do |routes|
-      routes.default_url_options = { host: "www.example.com" }
-      routes.draw(&block)
-      @app = RoutedRackApp.new routes
+  private
+    def draw(&block)
+      self.class.stub_controllers do |routes|
+        routes.default_url_options = { host: "www.example.com" }
+        routes.draw(&block)
+        @app = RoutedRackApp.new routes
+      end
     end
-  end
 
-  def logs
-    @logs ||= @logger.logged(:info)
-  end
+    def logs
+      @logs ||= @logger.logged(:info)
+    end
 end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -271,10 +271,11 @@ INFO. Additional keys may be added by the caller.
 
 #### redirect.action_dispatch
 
-| Key         | Value               |
-| ----------- | ------------------- |
-| `:status`   | HTTP response code  |
-| `:location` | URL to redirect to  |
+| Key         | Value                         |
+| ----------- | ----------------------------- |
+| `:status`   | HTTP response code            |
+| `:location` | URL to redirect to            |
+| `:request`  | The `ActionDispatch::Request` |
 
 ### Action View
 


### PR DESCRIPTION
Follow-up to #43755.

This adds the request object to the `redirect.action_dispatch` payload, for parity with `redirect_to.action_controller`.

---

It appears that, in general, we don't test instrumentation or payloads.  I'm not sure whether that's intentional.  We do [document them](https://guides.rubyonrails.org/v7.0/active_support_instrumentation.html#rails-framework-hooks) though, so I thought it would be good to include a test in this PR.
