### PR TITLE
Freeze `thread_mattr_accessor` default values

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `thread_mattr_accessor` will call `.dup.freeze` on non-frozen default values.
+
+    This provides a basic level of protection against different threads trying
+    to mutate a shared default object.
+
+    *Jonathan Hefner*
+
 *   Add `raise_on_invalid_cache_expiration_time` config to `ActiveSupport::Cache::Store`
 
     Specifies if an `ArgumentError` should be raised if `Rails.cache` `fetch` or

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -52,6 +52,7 @@ class Module
           end
         EOS
       else
+        default = default.dup.freeze unless default.frozen?
         singleton_class.define_method("#{sym}_default_value") { default }
 
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
@@ -162,6 +163,10 @@ class Module
   #
   #   Current.new.user = "DHH"  # => NoMethodError
   #   Current.new.user          # => NoMethodError
+  #
+  # A default value may be specified using the +:default+ option. Because
+  # multiple threads can access the default value, non-frozen default values
+  # will be <tt>dup</tt>ed and frozen.
   def thread_mattr_accessor(*syms, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil)
     thread_mattr_reader(*syms, instance_reader: instance_reader, instance_accessor: instance_accessor, default: default)
     thread_mattr_writer(*syms, instance_writer: instance_writer, instance_accessor: instance_accessor)

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -62,15 +62,20 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
     end.join
   end
 
-  def test_default_value_is_the_same_object
-    default = Object.new
+  def test_nonfrozen_default_value_is_duped_and_frozen
+    default = []
+    @class.thread_mattr_accessor :baz, default: default
+
+    assert_equal default, @class.baz
+    assert_predicate @class.baz, :frozen?
+    assert_not_predicate default, :frozen?
+  end
+
+  def test_frozen_default_value_is_not_duped
+    default = [].freeze
     @class.thread_mattr_accessor :baz, default: default
 
     assert_same default, @class.baz
-
-    Thread.new do
-      assert_same default, @class.baz
-    end.join
   end
 
   def test_should_use_mattr_default


### PR DESCRIPTION
This provides a basic level of protection against different threads trying to mutate a shared default object.  It is not a bulletproof solution, because the default may contain nested non-frozen objects, but it should cover common cases.

---

Because the default might contain nested mutable objects, this could mask concurrency errors.  Another alternative would be to raise `ArgumentError` for any non-frozen default, so that the user is made aware of the constraints.

Or, another alternative would be to `dup` or `deep_dup` default values whenever they are first read by a thread, such that each thread gets its own copy.  That would be more convenient, but might also mask errors.
