### PR TITLE
Change ActiveStorage migration version from 5.2 to 7.0

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -1,4 +1,4 @@
-class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
   def change
     # Use Active Record's configured type for primary and foreign keys
     primary_key_type, foreign_key_type = primary_and_foreign_key_types


### PR DESCRIPTION
### Summary

This changes the migration version of `CreateActiveStorageTables` from `5.2` to `7.0` to fix #45922.

