### PR TITLE
Fix bug in connection handler methods using all pools

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix connection handler methods to operate on all pools.
+
+    `active_connections?`, `clear_active_connections!`, `clear_reloadable_connections!`, `clear_all_connections!`, and `flush_idle_connections!` now operate on all pools by default. Previously they would default to using the `current_role` or `:writing` role unless specified.
+
+    *Eileen M. Uchitelle*
+
 *   Allow ActiveRecord::QueryMethods#select to receive hash values.
 
     Currently, `select` might receive only raw sql and symbols to define columns and aliases to select.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -295,7 +295,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
         ActiveSupport::Reloader.before_class_unload do
           if ActiveRecord::Base.connected?
             ActiveRecord::Base.clear_cache!
-            ActiveRecord::Base.clear_reloadable_connections!
+            ActiveRecord::Base.clear_reloadable_connections!(:all)
           end
         end
       end
@@ -322,8 +322,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
           # this connection is trivial: the rest of the pool would need to be
           # populated anyway.
 
-          clear_active_connections!
-          flush_idle_connections!
+          clear_active_connections!(:all)
+          flush_idle_connections!(:all)
         end
       end
     end

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -162,7 +162,7 @@ module ActiveRecord
         ActiveRecord::FixtureSet.reset_cache
       end
 
-      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.clear_active_connections!(:all)
     end
 
     def enlist_fixture_connections

--- a/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
     end
 
     teardown do
-      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.clear_active_connections!(:all)
       ActiveRecord::Base.connection.drop_table "samples", if_exists: true
 
       Thread.abort_on_exception = @abort

--- a/activerecord/test/cases/adapters/postgresql/transaction_nested_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_nested_test.rb
@@ -217,7 +217,7 @@ module ActiveRecord
         ActiveRecord::Base.connection.client_min_messages = "error"
         yield
       ensure
-        ActiveRecord::Base.clear_active_connections!
+        ActiveRecord::Base.clear_active_connections!(:all)
         ActiveRecord::Base.connection.client_min_messages = log_level
       end
 

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -205,7 +205,7 @@ module ActiveRecord
         ActiveRecord::Base.connection.client_min_messages = "error"
         yield
       ensure
-        ActiveRecord::Base.clear_active_connections!
+        ActiveRecord::Base.clear_active_connections!(:all)
         ActiveRecord::Base.connection.client_min_messages = log_level
       end
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1350,7 +1350,7 @@ class BasicsTest < ActiveRecord::TestCase
       rd.binmode
       wr.binmode
 
-      ActiveRecord::Base.connection_handler.clear_all_connections!
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
 
       fork do
         rd.close

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -330,15 +330,22 @@ module ActiveRecord
       end
 
       def test_active_connections?
-        assert_not_predicate @handler, :active_connections?
+        assert_deprecated do
+          assert_not_predicate @handler, :active_connections?
+        end
 
         assert @handler.retrieve_connection(@connection_name)
         assert @handler.retrieve_connection(@connection_name, role: :reading)
 
-        assert_predicate @handler, :active_connections?
+        assert_deprecated do
+          assert_predicate @handler, :active_connections?
+        end
 
-        @handler.clear_active_connections!
-        assert_not_predicate @handler, :active_connections?
+        @handler.clear_active_connections!(:all)
+
+        assert_deprecated do
+          assert_not_predicate @handler, :active_connections?
+        end
       end
 
       def test_retrieve_connection_pool

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
         # make sure we have an active connection
         assert ActiveRecord::Base.connection
-        assert_predicate ActiveRecord::Base.connection_handler, :active_connections?
+        assert ActiveRecord::Base.connection_handler.active_connections?(:all)
       end
 
       def test_app_delegation

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -136,7 +136,7 @@ class HotCompatibilityTest < ActiveRecord::TestCase
             ActiveRecord::Base.connection_pool.checkin ddl_connection
           end
         ensure
-          ActiveRecord::Base.clear_all_connections!
+          ActiveRecord::Base.clear_all_connections!(:all)
         end
       end
     end

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -13,7 +13,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
   end
 
   teardown do
-    ActiveRecord::Base.clear_all_connections!
+    ActiveRecord::Base.clear_all_connections!(:all)
     ActiveRecord::Base.establish_connection(@connection)
     @per_test_teardown.each(&:call)
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -178,7 +178,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         assert_cache :dirty
 
         thread_1_connection = ActiveRecord::Base.connection
-        ActiveRecord::Base.clear_active_connections!
+        ActiveRecord::Base.clear_active_connections!(:all)
         assert_cache :off, thread_1_connection
 
         started = Concurrent::Event.new
@@ -200,7 +200,7 @@ class QueryCacheTest < ActiveRecord::TestCase
             started.set
             checked.wait
 
-            ActiveRecord::Base.clear_active_connections!
+            ActiveRecord::Base.clear_active_connections!(:all)
           }.call({})
         }
 
@@ -522,19 +522,19 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_query_cache_does_not_establish_connection_if_unconnected
-    ActiveRecord::Base.clear_active_connections!
-    assert_not ActiveRecord::Base.connection_handler.active_connections? # Double check they are cleared
+    ActiveRecord::Base.clear_active_connections!(:all)
+    assert_not ActiveRecord::Base.connection_handler.active_connections?(:all) # Double check they are cleared
 
     middleware {
-      assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in setup"
+      assert_not ActiveRecord::Base.connection_handler.active_connections?(:all), "QueryCache forced ActiveRecord::Base to establish a connection in setup"
     }.call({})
 
-    assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in cleanup"
+    assert_not ActiveRecord::Base.connection_handler.active_connections?(:all), "QueryCache forced ActiveRecord::Base to establish a connection in cleanup"
   end
 
   def test_query_cache_is_enabled_on_connections_established_after_middleware_runs
-    ActiveRecord::Base.clear_active_connections!
-    assert_not ActiveRecord::Base.connection_handler.active_connections? # Double check they are cleared
+    ActiveRecord::Base.clear_active_connections!(:all)
+    assert_not ActiveRecord::Base.connection_handler.active_connections?(:all) # Double check they are cleared
 
     middleware {
       assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
@@ -543,7 +543,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_query_caching_is_local_to_the_current_thread
-    ActiveRecord::Base.clear_active_connections!
+    ActiveRecord::Base.clear_active_connections!(:all)
 
     middleware {
       assert ActiveRecord::Base.connection_pool.query_cache_enabled

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -51,7 +51,7 @@ class TransactionTest < ActiveRecord::TestCase
       assert_not connection.active?
       assert_not Topic.connection_pool.connections.include?(connection)
     ensure
-      ActiveRecord::Base.clear_all_connections!
+      ActiveRecord::Base.clear_all_connections!(:all)
     end
 
     def test_rollback_dirty_changes_even_with_raise_during_rollback_doesnt_commit_transaction
@@ -77,7 +77,7 @@ class TransactionTest < ActiveRecord::TestCase
 
       assert_equal "The Fifth Topic of the day", topic.reload.title
     ensure
-      ActiveRecord::Base.clear_all_connections!
+      ActiveRecord::Base.clear_all_connections!(:all)
     end
   end
 


### PR DESCRIPTION
Previously when I implemented multiple database roles in Rails there
were two handlers so it made sense for the methods
`active_connections?`, `clear_active_connections!`,
`clear_reloadable_connections!`, `clear_all_connections!`, and
`flush_idle_connections!` to only operate on the current (or passed)
role and not all pools regardless of role. When I removed this and moved
all the pools to the handler maintained by a pool manager, I left these
methods as-is to preserve the original behavior.

This made sense because I thought these methods were only called by
applications and not called by Rails. I realized yesterday that some of
these methods (`flush_idle_connections!`, `clear_active_connections!`,
and `clear_reloadable_connections!` are all called on boot by the
Active Record railtie.

Unfortunately this means that applications using multiple databases
aren't getting connections flushed or cleared on boot for any connection
but the writing ones.

The change here continues existing behavior if a role like reading is
passed in directly. Otherwise if the role is `nil` (which is the new
default` we fall back to all connections and issue a deprecation
warning. This will be the new default behavior in the future. In order
to easily allow turning off the deprecation warning I've added an `:all`
argument that will use all pools but no warning. The deprecation warning
will only fire if there is more than one role in the pool manager,
otherwise we assume prior behavior.

This bug would have only affected applications with more than one role
and only when these methods are called outside the context of a
`connected_to` block. These methods no longer consider the set
`current_role` and applications need to be explicit if they don't want
these methods to operate on all pools.

cc/ @matthewd as we discussed this morning