### PR TITLE
Avoid using Module#<= in value_for

### DIFF
--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -119,11 +119,12 @@ module ActiveRecord
           return scope_type[model.name] if skip_inherited_scope
           klass = model
           base = model.base_class
-          while klass <= base
+          while klass != base
             value = scope_type[klass.name]
             return value if value
             klass = klass.superclass
           end
+          scope_type[klass.name]
         end
 
         # Sets the +value+ for a given +scope_type+ and +model+.


### PR DESCRIPTION
During where clause generation we search for scope type for the model. We can do this with Module#!= instead as long as we grab the final scope type after the loop.

This is a small, but significant performance improvement.

script:
<details>

```
require "active_record"
require "logger"
require "stackprof"
require "benchmark/ips"

ActiveRecord.allow_deprecated_singular_associations_name = false

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
  create_table :comments, force: true do |t|
    t.belongs_to :post
    t.string :title
    t.text :body
    t.integer :likes
    t.datetime :posted_at
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

Benchmark.ips do |x|
  x.report "Comment.where" do
    Comment.where(title: "something", post: 5)
  end
end
```

</details>


before:

```
-- create_table(:posts, {:force=>true})
   -> 0.0188s
-- create_table(:comments, {:force=>true})
   -> 0.0006s
Warming up --------------------------------------
       Comment.where     2.784k i/100ms
Calculating -------------------------------------
       Comment.where     26.948k (± 9.0%) i/s -    133.632k in   5.005965s
```

after:

```
-- create_table(:posts, {:force=>true})
   -> 0.0200s
-- create_table(:comments, {:force=>true})
   -> 0.0005s
Warming up --------------------------------------
       Comment.where     2.791k i/100ms
Calculating -------------------------------------
       Comment.where     27.672k (± 2.7%) i/s -    139.550k in   5.046750s
```