### PR TITLE
Add missing documentation for Rails.error

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -80,6 +80,13 @@ module Rails
       @_env = ActiveSupport::EnvironmentInquirer.new(environment)
     end
 
+    # Returns the ActiveSupport::ErrorReporter of the current Rails project,
+    # otherwise it returns +nil+ if there is no project.
+    #
+    #   Rails.error.handle(IOError) do
+    #     # ...
+    #   end
+    #   Rails.error.report(error)
     def error
       application && application.executor.error_reporter
     end


### PR DESCRIPTION
The functionality itself is documented, but not the accessor.

FYI @rafaelfranca 