### PR TITLE
Add supporting of SQL functions to AR#select

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1864,7 +1864,11 @@ module ActiveRecord
             end
           when String, Symbol
             arel_column(key.to_s) do
-              predicate_builder.resolve_arel_attribute(klass.table_name, key.to_s)
+              if (/(\w+)\s*\(/).match?(key.to_s)
+                Arel.sql(key.to_s)
+              else
+                predicate_builder.resolve_arel_attribute(klass.table_name, key.to_s)
+              end
             end.as(columns_aliases.to_s)
           end
         end

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -33,6 +33,12 @@ module ActiveRecord
       end
     end
 
+    def test_with_sql_function
+      expected = Post.joins(:comments).select("COUNT(comments.id)" => :comment_count).take
+
+      assert_not_nil(expected.comment_count)
+    end
+
     def test_select_with_hash_with_not_exists_field
       assert_raises(ActiveRecord::StatementInvalid) do
         Post.select(posts: { boo: :post_title }).take


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Add support of SQL functions to ActiveRecord::QueryMethods#select with
hashes:
```ruby
Post.joins(:comments).select('COUNT(comments.id)' => :comment_count)
```

### Other Information

Regarding to discussion on this PR: https://github.com/rails/rails/pull/45612

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
