### PR TITLE
Speed up arel visitor dispatch

### DIFF
--- a/activerecord/lib/arel/visitors/visitor.rb
+++ b/activerecord/lib/arel/visitors/visitor.rb
@@ -16,8 +16,8 @@ module Arel # :nodoc: all
 
         def self.dispatch_cache
           @dispatch_cache ||= Hash.new do |hash, klass|
-            hash[klass] = "visit_#{(klass.name || '').gsub('::', '_')}"
-          end
+            hash[klass] = :"visit_#{(klass.name || "").gsub("::", "_")}"
+          end.compare_by_identity
         end
 
         def get_dispatch_cache


### PR DESCRIPTION
This commit makes two performance tweaks to the dispatch_cache in Arel::Visitors::Visitor.

First, it interns the method name into a symbol rather than a string. send expects a symbol, so this avoids Ruby needing to intern that string itself.

Second, it changes the dispatch cache to an identity hash. Classes are already compared by identity, but Ruby is able to perform the lookup more quickly if it is explicit on the hash.

The performance difference is relatively small, but is of no cost to readability IMO. I found this by doing an audit of common string interns while running railsbench.

``` ruby
require "active_record"
require "logger"
require "stackprof"
require "benchmark/ips"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
  create_table :comments, force: true do |t|
    t.belongs_to :post
    t.string :title
    t.text :body
    t.integer :likes
    t.datetime :posted_at
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

scope = Comment.joins(:post).where(title: "something", likes: (1..), post: {id: 5})
arel = scope.arel
connection = Comment.connection
Benchmark.ips do |x|
  x.report "to_sql" do
    connection.to_sql(arel)
  end
end
```

**Before**
```
Warming up --------------------------------------
              to_sql     3.933k i/100ms
Calculating -------------------------------------
              to_sql     39.511k (± 0.2%) i/s -    200.583k in   5.076686s
```

**After**
```
Warming up --------------------------------------
              to_sql     4.587k i/100ms
Calculating -------------------------------------
              to_sql     45.634k (± 0.4%) i/s -    229.350k in   5.025906s
```