### PR TITLE
The description of `force_plural` doesn't make sense

### DIFF
--- a/railties/lib/rails/generators/model_helpers.rb
+++ b/railties/lib/rails/generators/model_helpers.rb
@@ -19,7 +19,8 @@ module Rails
       mattr_accessor :skip_warn
 
       def self.included(base) # :nodoc:
-        base.class_option :force_plural, type: :boolean, default: false, desc: "Forces the use of the given model name"
+        base.class_option :force_plural, type: :boolean, default: false,
+          desc: "Do not singularize the model name, even if it appears plural"
       end
 
       def initialize(args, *_options)


### PR DESCRIPTION
I couldn't understand the meaning of this description.

```
$ bin/rails g model | grep force-plural
      [--force-plural], [--no-force-plural]                  # Forces the use of the given model name
```
