### PR TITLE
The description of `--api` option doesn't make sense

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -8,7 +8,8 @@ module Rails
       remove_hook_for :resource_controller
       remove_class_option :actions
 
-      class_option :api, type: :boolean
+      class_option :api, type: :boolean,
+        desc: "Generate API-only controller and tests, with no view templates"
       class_option :resource_route, type: :boolean
 
       hook_for :scaffold_controller, required: true


### PR DESCRIPTION
"Indicates when to generate api" doesn't make sense

```
$ bin/rails g scaffold | grep api
      [--api], [--no-api]                                    # Indicates when to generate api
```
