### PR TITLE
Added `blob_url` to the response of direct uploads API

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,11 +1,11 @@
- * Added `blob_url` to the response of direct uploads API
+ *  Added `blob_url` to the response of direct uploads API
 
-   Add `blob_url` to the response of the `create` action of the 
-   `ActiveStorage::DirectUploadsController`. This will remove the need for 
-   another API to fetch the URL of the uploaded blob to be rendered in the 
-   frontend.
+    Add `blob_url` to the response of the `create` action of the 
+    `ActiveStorage::DirectUploadsController`. This will remove the need for 
+    another API to fetch the URL of the uploaded blob to be rendered in the 
+    frontend.
 
-   *Abhay V Ashokan*
+    *Abhay V Ashokan*
 
 *   Touch all corresponding model records after ActiveStorage::Blob is analyzed
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,8 +1,8 @@
- *  Added `blob_url` to the response of direct uploads API
+*   Added `blob_url` to the response of direct uploads API
 
-    Add `blob_url` to the response of the `create` action of the 
-    `ActiveStorage::DirectUploadsController`. This will remove the need for 
-    another API to fetch the URL of the uploaded blob to be rendered in the 
+    Add `blob_url` to the response of the `create` action of the
+    `ActiveStorage::DirectUploadsController`. This will remove the need for
+    another API to fetch the URL of the uploaded blob to be rendered in the
     frontend.
 
     *Abhay V Ashokan*

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+ * Added `blob_url` to the response of direct uploads API
+
+   Add `blob_url` to the response of the `create` action of the 
+   `ActiveStorage::DirectUploadsController`. This will remove the need for 
+   another API to fetch the URL of the uploaded blob to be rendered in the 
+   frontend.
+
+   *Abhay V Ashokan*
+
 *   Touch all corresponding model records after ActiveStorage::Blob is analyzed
 
     This fixes a race condition where a record can be requested and have a cache entry built, before

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -4,6 +4,8 @@
 # When the client-side upload is completed, the signed_blob_id can be submitted as part of the form to reference
 # the blob that was created up front.
 class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
+  include Rails.application.routes.url_helpers
+
   def create
     blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
     render json: direct_upload_json(blob)
@@ -15,7 +17,9 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
     end
 
     def direct_upload_json(blob)
-      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
+      blob.as_json(root: false, methods: :signed_id).merge(
+      blob_url: rails_blob_url(blob),
+      direct_upload: {
         url: blob.service_url_for_direct_upload,
         headers: blob.service_headers_for_direct_upload
       })

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -31,7 +31,10 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
       response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
+        blob = ActiveStorage::Blob.find(details["id"])
+
+        assert_equal blob, ActiveStorage::Blob.find_signed!(details["signed_id"])
+        assert_equal blob.url, details["blob_url"]
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -77,7 +80,10 @@ if SERVICE_CONFIGURATIONS[:gcs]
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
       @response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
+        blob = ActiveStorage::Blob.find(details["id"])
+
+        assert_equal blob, ActiveStorage::Blob.find_signed!(details["signed_id"])
+        assert_equal blob.url, details["blob_url"]
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -119,7 +125,10 @@ if SERVICE_CONFIGURATIONS[:azure]
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
       @response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
+        blob = ActiveStorage::Blob.find(details["id"])
+
+        assert_equal blob, ActiveStorage::Blob.find_signed!(details["signed_id"])
+        assert_equal blob.url, details["blob_url"]
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -149,7 +158,10 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
     @response.parsed_body.tap do |details|
-      assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
+      blob = ActiveStorage::Blob.find(details["id"])
+
+      assert_equal blob, ActiveStorage::Blob.find_signed!(details["signed_id"])
+      assert_equal url_for(blob), details["blob_url"]
       assert_equal "hello.txt", details["filename"]
       assert_equal 6, details["byte_size"]
       assert_equal checksum, details["checksum"]


### PR DESCRIPTION
### Summary

- Added `blob_url` to the response of the `create` action of the  `ActiveStorage::DirectUploadsController`. 
- This will be very useful for API-only applications where the uploaded files (usually images/videos) need to be immediately rendered in the frontend. Once the file upload is complete, the client need not send another API to the backend to fetch the blob URL.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
