### PR TITLE
Reset AR::Relation in bulk insert and upsert methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Reset relations after `insert_all`/`upsert_all`.
+
+    Bulk insert/upsert methods will now call `reset` if used on a relation, matching the behavior of `update_all`.
+
+    *Milo Winningham*
+
 *   Use `_N` as a parallel tests databases suffixes
 
     Peviously, `-N` was used as a suffix. This can cause problems for RDBMSes

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
     %w(insert insert_all insert! insert_all! upsert upsert_all).each do |method|
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
-        def #{method}(attributes, **kwargs)
+        def #{method}(...)
           if @association.reflection.through_reflection?
             raise ArgumentError, "Bulk insert or upsert is currently not supported for has_many through association"
           end

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1125,14 +1125,20 @@ module ActiveRecord
         super
       end
 
+      %w(insert insert_all insert! insert_all! upsert upsert_all).each do |method|
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{method}(...)
+            scope.#{method}(...).tap { reset }
+          end
+        RUBY
+      end
+
       delegate_methods = [
         QueryMethods,
         SpawnMethods,
       ].flat_map { |klass|
         klass.public_instance_methods(false)
-      } - self.public_instance_methods(false) - [:select] + [
-        :scoping, :values, :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all, :load_async
-      ]
+      } - self.public_instance_methods(false) - [ :select ] + [ :scoping, :values, :load_async ]
 
       delegate(*delegate_methods, to: :scope)
 

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       def execute(relation, ...)
         relation.model.with_connection do |c|
           new(relation, c, ...).execute
-        end
+        end.tap { relation.reset }
       end
     end
 

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -96,6 +96,24 @@ module ActiveRecord
       assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)\z/, comments.cache_key)
     end
 
+    test "insert_all will update cache_key" do
+      developers = Developer.all
+      cache_key = developers.cache_key
+
+      developers.insert_all([{ name: "Alice" }, { name: "Bob" }])
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
+    test "upsert_all will update cache_key" do
+      developers = Developer.all
+      cache_key = developers.cache_key
+
+      developers.upsert_all([{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }])
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
     test "update_all will update cache_key" do
       developers = Developer.where(name: "David")
       cache_key = developers.cache_key

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -729,6 +729,14 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_resets_relation
+    audit_logs = Developer.create!(name: "Alice").audit_logs.load
+
+    assert_changes "audit_logs.loaded?", from: true, to: false do
+      audit_logs.insert_all!([{ message: "event" }])
+    end
+  end
+
   def test_insert_all_create_with
     assert_difference "Book.where(format: 'X').count", +2 do
       Book.create_with(format: "X").insert_all!([ { name: "A" }, { name: "B" } ])
@@ -758,6 +766,14 @@ class InsertAllTest < ActiveRecord::TestCase
 
     assert_difference "author.books.count", +1 do
       author.books.upsert_all([{ name: "My little book", isbn: "1974522598", author_id: second_author.id }])
+    end
+  end
+
+  def test_upsert_all_resets_relation
+    audit_logs = Developer.create!(name: "Alice").audit_logs.load
+
+    assert_changes "audit_logs.loaded?", from: true, to: false do
+      audit_logs.upsert_all([{ id: 1, message: "event" }])
     end
   end
 


### PR DESCRIPTION
This adds a call to `reset` when `insert_all` or `upsert_all` are used on a relation object, matching the behavior of `update_all` added in #41789.