### PR TITLE
Disable prepared_statements by default for mysql2 adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Disable `prepared_statements` for mysql2 adapter
+
+    A recent change [#44591](https://github.com/rails/rails/pull/44591) enabled `prepared_statements` by default for mysql2 adapter
+    although this is only supposed to happen in Rails 7.2 as the deprecation warning indicates.
+
+    The default value of `prepared_statements` for mysql2 adapter is set back to `false`.
+
+    *Iliana Hadzhiatanasova*
+
 *   Move `ActiveRecord::SchemaMigration` to an independent object.
 
     `ActiveRecord::SchemaMigration` no longer inherits from `ActiveRecord::Base` and is now an independent object that should be instantiated with a `connection`. This class is private and should not be used by applications directly. If you want to interact with the schema migrations table, please access it on the connection directly, for example: `ActiveRecord::Base.connection.schema_migration`.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -125,7 +125,7 @@ module ActiveRecord
         @lock = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
 
         @prepared_statements = self.class.type_cast_config_to_boolean(
-          @config.fetch(:prepared_statements, true)
+          @config.fetch(:prepared_statements) { default_prepared_statements }
         )
 
         @advisory_locks_enabled = self.class.type_cast_config_to_boolean(
@@ -1124,6 +1124,10 @@ module ActiveRecord
         # Implementations may assume this method will only be called while
         # holding @lock (or from #initialize).
         def configure_connection
+        end
+
+        def default_prepared_statements
+          true
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -52,13 +52,6 @@ module ActiveRecord
           @config[:flags] |= Mysql2::Client::FOUND_ROWS
         end
 
-        unless @config.key?(:prepared_statements)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            The default value of `prepared_statements` for the mysql2 adapter will be changed from +false+ to +true+ in Rails 7.2.
-          MSG
-          @config[:prepared_statements] = false
-        end
-
         @connection_parameters ||= @config
       end
 
@@ -171,6 +164,13 @@ module ActiveRecord
           else
             super
           end
+        end
+
+        def default_prepared_statements
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            The default value of `prepared_statements` for the mysql2 adapter will be changed from +false+ to +true+ in Rails 7.2.
+          MSG
+          false
         end
     end
   end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -71,6 +71,31 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_mysql2_default_prepared_statements
+    fake_connection = Class.new do
+      def query_options
+        {}
+      end
+
+      def query(*)
+      end
+
+      def close
+      end
+    end.new
+
+    adapter = ActiveSupport::Deprecation.silence do
+      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
+        fake_connection,
+        ActiveRecord::Base.logger,
+        nil,
+        { socket: File::NULL }
+      )
+    end
+
+    assert_equal false, adapter.prepared_statements
+  end
+
   def test_exec_query_nothing_raises_with_no_result_queries
     assert_nothing_raised do
       with_example_table do


### PR DESCRIPTION
### Summary

This PR fixes a bug with defaulting `prepared_statements` to `true` for the mysql2 adapter prior to Rails 7.2 when this change should take effect (https://github.com/rails/rails/issues/42975)

As part of a [recent change](https://github.com/rails/rails/pull/44591), when initialising the mysql2 adapter [the abstract adapter constructor](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L45) is called first. The constructor [sets](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L112) the value of `connection_parameters` and as part of this, the value of `prepared_statements`. In this case the default value for `prepared_statements` is `true` ([code](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L127-L129)). 

Because the value of `connection_parameters` is set in the parent class, the [lines of code](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L59-L62) which used to set the default value to `false` for mysql2 adapter are no longer doing this.

Before this change, this value was set and passed down to the super constructor ([code](https://github.com/rails/rails/pull/44591/files#diff-538a9bf3450c3aed556a0d2eacc26839a60becd744cda8c0a247dcb06aa0f02fL59-L61))