### PR TITLE
Improve `word_wrap` performance

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -262,9 +262,17 @@ module ActionView
       #   word_wrap('Once upon a time', line_width: 1, break_sequence: "\r\n")
       #   # => Once\r\nupon\r\na\r\ntime
       def word_wrap(text, line_width: 80, break_sequence: "\n")
-        text.split("\n").collect! do |line|
-          line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").chomp!(break_sequence) : line
-        end * break_sequence
+        # Match up to `line_width` characters, followed by one of
+        #   (1) non-newline whitespace plus an optional newline
+        #   (2) the end of the string, ignoring any trailing newlines
+        #   (3) a newline
+        #
+        # -OR-
+        #
+        # Match an empty line
+        pattern = /(.{1,#{line_width}})(?:[^\S\n]+\n?|\n*\Z|\n)|\n/
+
+        text.gsub(pattern, "\\1#{break_sequence}").chomp!(break_sequence)
       end
 
       # Returns +text+ transformed into HTML using simple formatting rules.


### PR DESCRIPTION
This improves `word_wrap` performance and reduces allocations.

<details>
  <summary><strong>Benchmark</strong></summary>

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "benchmark/memory"

  def before(text, line_width: 80, break_sequence: "\n")
    text.split("\n").collect! do |line|
      line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").chomp!(break_sequence) : line
    end * break_sequence
  end

  def after(text, line_width: 80, break_sequence: "\n")
    pattern = /(.{1,#{line_width}})(?:[^\S\n]+\n?|\n*\Z|\n)|\n/
    text.gsub(pattern, "\\1#{break_sequence}").chomp!(break_sequence)
  end

  TEXT = <<~LOREM
    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
    minim veniam, quis nostrud exercitation ullamco laboris nisi ut
    aliquip ex ea commodo consequat. Duis aute irure dolor in
    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
    pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
    culpa qui officia deserunt mollit anim id est laborum.
  LOREM

  Benchmark.ips do |x|
    x.report("before") { before(TEXT, line_width: 50) }
    x.report("after") { after(TEXT, line_width: 50) }
    x.compare!
  end

  Benchmark.memory do |x|
    x.report("before") { before(TEXT, line_width: 50) }
    x.report("after") { after(TEXT, line_width: 50) }
    x.compare!
  end
  ```
</details>

<strong>Results</strong>

  ```
  Warming up --------------------------------------
                before   858.000  i/100ms
                 after     2.215k i/100ms
  Calculating -------------------------------------
                before      8.540k (± 1.3%) i/s -     42.900k in   5.024157s
                 after     22.370k (± 1.1%) i/s -    112.965k in   5.050565s

  Comparison:
                 after:    22369.8 i/s
                before:     8540.2 i/s - 2.62x  (± 0.00) slower
  ```

  ```
  Calculating -------------------------------------
                before    13.993k memsize (     0.000  retained)
                         122.000  objects (     0.000  retained)
                          34.000  strings (     0.000  retained)
                 after     5.423k memsize (     0.000  retained)
                          41.000  objects (     0.000  retained)
                          20.000  strings (     0.000  retained)

  Comparison:
                 after:       5423 allocated
                before:      13993 allocated - 2.58x more
  ```
