### PR TITLE
Fix ActiveSupport::CurrentAttributes for Ruby 3

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -164,6 +164,7 @@ module ActiveSupport
 
           send(name, *args, &block)
         end
+        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
 
     attr_accessor :attributes

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -31,6 +31,17 @@ class CurrentAttributesTest < ActiveSupport::TestCase
       Session.current = person&.id
     end
 
+    def set_world_and_account(world:, account:)
+      self.world = world
+      self.account = account
+    end
+
+    def get_world_and_account(hash)
+      hash[:world] = world
+      hash[:account] = account
+      hash
+    end
+
     def request
       "#{super} something"
     end
@@ -124,6 +135,18 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     assert_equal "world/1", Current.world
     assert_equal "account/1", Current.account
+  end
+
+  test "using keyword arguments" do
+    Current.set_world_and_account(world: "world/1", account: "account/1")
+
+    assert_equal "world/1", Current.world
+    assert_equal "account/1", Current.account
+
+    hash = {}
+    assert_same hash, Current.get_world_and_account(hash)
+    assert_equal "world/1", hash[:world]
+    assert_equal "account/1", hash[:account]
   end
 
   setup { @testing_teardown = false }


### PR DESCRIPTION
`ActiveSupport::CurrentAttributes.method_missing` is missing `ruby2_keywords(:method_missing)`. `ArgumentError` is raised on Ruby 3 when method with keyword arguments is called.

I've added `ruby2_keywords(:method_missing)` and tests for keyword arguments (copy&pasted them from `master`).

CC @byroot 