### PR TITLE
Extract h1 headings from ActionText content

### DIFF
--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -30,6 +30,10 @@ module ActionText
       @links ||= fragment.find_all("a[href]").map { |a| a["href"] }.uniq
     end
 
+    def headings
+      @headings ||= fragment.find_all("h1").map(&:text)
+    end
+
     def attachments
       @attachments ||= attachment_nodes.map do |node|
         attachment_for_node(node)

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -27,6 +27,12 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_equal ["http://example.com/1"], content.links
   end
 
+  test "extracts headings" do
+    html = "<h1>Hello world</h1><br><h1>Hello Rails</h1>"
+    content = content_from_html(html)
+    assert_equal ["Hello world", "Hello Rails"], content.headings
+  end
+
   test "extracts attachables" do
     attachable = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{attachable.attachable_sgid}" caption="Captioned"></action-text-attachment>)


### PR DESCRIPTION
### Summary

similar way how it's possible to extract ActionText Content links:

```
class Post < ApplicationRecord
  has_rich_text :content
end

 Post.last.content.body.links
# => ["http://localhost:3000/whatever"] 
``` 

... it would be awesome if we could extract h1 headings:

```
Post.last.content.body.headings
# => ["Hello Rails"] 
``` 

My use-case is that I want to extract title for post from the wysiwyg content

```
class Post < ApplicationRecord
  has_rich_text :content

  def title
    content.body.headings.first
  end
end
```
 


