### PR TITLE
Fix grammatical issue

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -11,9 +11,10 @@ Rails.application.configure do
   # Turn true under Spring and add config.action_view.cache_template_loading = true.
   config.enable_reloading = false
 
-  # Eager loading loads your whole application. When running a single test locally,
-  # this probably isn't necessary. It's a good idea to do in a continuous integration
-  # system, or in some way before deploying your code.
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's 
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.


### PR DESCRIPTION
This fixes a grammatical issue in the generated `config/environments/test.rb` file. The original text, `It's a good idea to do in a continuous integration system`, does not really make sense. 