### PR TITLE
ActionDispatch::Cookies json deserializer discards marshal dumps

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Rescue `JSON::ParserError` in Cookies json deserializer to discards marshal dumps:
+
+    Without this change, if `action_dispatch.cookies_serializer` is set to `:json` and the app tries to read a `:marshal` serialized cookie, it would error out which wouldn't clear the cookie and force app users to manually clear it in their browser.
+
+    (See #45127 for original bug discussion)
+
+    *Nathan Bardoux*
+
 *   Rescue `EOFError` exception from `rack` on a multipart request.
 
     *Nikita Vasilevsky*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -677,7 +677,7 @@ module ActionDispatch
           deserialize(name) do |rotate|
             @encryptor.decrypt_and_verify(encrypted_message, on_rotation: rotate, purpose: purpose)
           end
-        rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature, JSON::ParserError
           nil
         end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -810,6 +810,24 @@ class CookiesTest < ActionController::TestCase
     assert_nil @response.cookies["foo"]
   end
 
+  def test_encrypted_cookie_using_json_serializer_will_drop_marshal_dumped_value
+    @request.env["action_dispatch.cookies_serializer"] = :json
+
+    key_generator = @request.env["action_dispatch.key_generator"]
+    secret = key_generator.generate_key(@request.env["action_dispatch.authenticated_encrypted_cookie_salt"], 32)
+
+    encryptor = ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm", serializer: Marshal)
+    marshal_value = encryptor.encrypt_and_sign("bar")
+    @request.headers["Cookie"] = "foo=#{::Rack::Utils.escape marshal_value}"
+
+    get :get_encrypted_cookie
+
+    cookies = @controller.send :cookies
+    assert_not_equal "bar", cookies[:foo]
+    assert_nil cookies.encrypted[:foo] # #parse rescues JSON::ParserError and returns nil
+    assert_nil @response.cookies["foo"]
+  end
+
   def test_accessing_nonexistent_encrypted_cookie_should_not_raise_invalid_message
     get :set_encrypted_cookie
     assert_nil @controller.send(:cookies).encrypted[:non_existent_attribute]


### PR DESCRIPTION
### Summary

Without this change, if `action_dispatch.cookies_serializer` is set to `:json` and the app tries to read a `:marshal` serialized cookie, it will raise a `JSON::ParserError` which won't clear the cookie and force app user to manually clear the cookie in their browser.
- See https://github.com/rails/rails/pull/45127 for original bug discussion.
- Main reason to support this change (Copied from [comment](https://github.com/rails/rails/pull/45127#issuecomment-1132278942)):
  * For `cookies_serializer: :hybrid` to convert all existing Marshal cookies to JSON, all those cookies need to be loaded once during the timeframe between using `new_framework_defaults_7_0` fully un-commented and moving over to `config.load_defaults 7.0` (which uses `:json` by default)
      * We all know that sometimes some users might not use your app for long periods of time.
      * Switching over to `config.load_defaults 7.0` before all users have visited, means the app will be broken for those casual users next time they come by, and the only fix will be to manually clear their cookies themselves.
- @skipkayhil suggested this change [here](https://github.com/rails/rails/pull/45127#issuecomment-1135396802):
  > Would it be possible to rescue `JSON::ParserError` in the `:json` deserializer and clear the cookie? That may be a more forgiving approach than errors requiring manually cookie clearing

Thanks for your time and for considering this :pray:

<!-- ### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

cc @rafaelfranca @ghiculescu @p8

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
