### PR TITLE
Make ActionView::PathSet immutable

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -152,7 +152,11 @@ module ActionView
       # Whenever setting view paths, makes a copy so that we can manipulate them in
       # instance objects as we wish.
       def build_view_paths(paths)
-        ActionView::PathSet.new(Array(paths))
+        if ActionView::PathSet === paths
+          paths
+        else
+          ActionView::PathSet.new(Array(paths))
+        end
       end
 
       # Compute details hash and key according to user options (e.g. passed from #render).

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -148,6 +148,14 @@ module ActionView
       end
       alias :any_templates? :any?
 
+      def append_view_paths(paths)
+        @view_paths = build_view_paths(@view_paths.to_a + paths)
+      end
+
+      def prepend_view_paths(paths)
+        @view_paths = build_view_paths(paths + @view_paths.to_a)
+      end
+
     private
       # Whenever setting view paths, makes a copy so that we can manipulate them in
       # instance objects as we wish.

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -76,8 +76,10 @@ module ActionView # :nodoc:
           case path
           when Pathname, String
             FileSystemResolver.new path.to_s
-          else
+          when Resolver
             path
+          else
+            raise TypeError, "#{path.inspect} is not a valid path: must be a String, Pathname, or Resolver"
           end
         end
       end

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -13,14 +13,14 @@ module ActionView # :nodoc:
 
     attr_reader :paths
 
-    delegate :[], :include?, :pop, :size, :each, to: :paths
+    delegate :[], :include?, :size, :each, to: :paths
 
     def initialize(paths = [])
-      @paths = typecast paths
+      @paths = typecast(paths).freeze
     end
 
     def initialize_copy(other)
-      @paths = other.paths.dup
+      @paths = other.paths.dup.freeze
       self
     end
 
@@ -34,14 +34,6 @@ module ActionView # :nodoc:
 
     def +(array)
       PathSet.new(paths + array)
-    end
-
-    %w(<< concat push insert unshift).each do |method|
-      class_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{method}(*args)
-          paths.#{method}(*typecast(args))
-        end
-      METHOD
     end
 
     def find(path, prefixes, partial, details, details_key, locals)

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -35,7 +35,7 @@ module ActionView
       #   the default view path. You may also provide a custom view path
       #   (see ActionView::PathSet for more information)
       def append_view_path(path)
-        self._view_paths = view_paths + Array(path)
+        self._view_paths = ActionView::PathSet.new(view_paths.to_a + Array(path))
       end
 
       # Prepend a path to the list of view paths for this controller.
@@ -45,7 +45,7 @@ module ActionView
       #   the default view path. You may also provide a custom view path
       #   (see ActionView::PathSet for more information)
       def prepend_view_path(path)
-        self._view_paths = ActionView::PathSet.new(Array(path) + view_paths)
+        self._view_paths = ActionView::PathSet.new(Array(path) + view_paths.to_a)
       end
 
       # A list of all of the default view paths for this controller.
@@ -110,7 +110,7 @@ module ActionView
     #   the default view path. You may also provide a custom view path
     #   (see ActionView::PathSet for more information)
     def append_view_path(path)
-      lookup_context.view_paths.push(*path)
+      lookup_context.append_view_paths(Array(path))
     end
 
     # Prepend a path to the list of view paths for the current LookupContext.
@@ -120,7 +120,7 @@ module ActionView
     #   the default view path. You may also provide a custom view path
     #   (see ActionView::PathSet for more information)
     def prepend_view_path(path)
-      lookup_context.view_paths.unshift(*path)
+      lookup_context.prepend_view_paths(Array(path))
     end
   end
 end

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -155,7 +155,7 @@ class ViewLoadPathsTest < ActionController::TestCase
     end
 
     decorator = decorator_class.new(TestController.view_paths)
-    TestController.view_paths = ActionView::PathSet.new.push(decorator)
+    TestController.view_paths = ActionView::PathSet.new([decorator])
 
     get :hello_world
     assert_response :success


### PR DESCRIPTION
Previously we would mutate the `PathSet` in order to implement `{append,prepend}_view_path`.

This removes the mutation methods we had and instead constructs a new `PathSet` whenever we are modifying it. This should allow flexibility in the classes holding a view_path to know that their view paths isn't modified. I want to add a per-request partial cache to `LookupContext` and this could be useful if we want to have extra behaviour on controller for `{append,prepend}_view_path` in the future.

I also made the "typecast" within `PathSet` more strict, and avoided duplicating it on assignment to `LookupContext`.

`PathSet` is a private API so I believe this is safe to change without deprecation.