### PR TITLE
Make connection_pool_list take an explicit argument

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `all_connection_pools` and make `connection_pool_list` more explicit.
+
+    Following on #45924 `all_connection_pools` is now deprecated. `connection_pool_list` will either take an explicit role or applications can opt into the new behavior by passing `:all`.
+
+    *Eileen M. Uchitelle*
+
 *   Fix connection handler methods to operate on all pools.
 
     `active_connections?`, `clear_active_connections!`, `clear_reloadable_connections!`, `clear_all_connections!`, and `flush_idle_connections!` now operate on all pools by default. Previously they would default to using the `current_role` or `:writing` role unless specified.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -242,7 +242,7 @@ module ActiveRecord
 
     # Clears the query cache for all connections associated with the current thread.
     def clear_query_caches_for_current_thread
-      connection_handler.all_connection_pools.each do |pool|
+      connection_handler.connection_pool_list(:all).each do |pool|
         pool.connection.clear_query_cache if pool.active_connection?
       end
     end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -27,14 +27,14 @@ module ActiveRecord
 
     def self.run
       pools = []
-      pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
+      pools.concat(ActiveRecord::Base.connection_handler.connection_pool_list(:all).reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
       pools
     end
 
     def self.complete(pools)
       pools.each { |pool| pool.disable_query_cache! }
 
-      ActiveRecord::Base.connection_handler.all_connection_pools.each do |pool|
+      ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
       end
     end

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -168,7 +168,7 @@ module ActiveRecord
     def enlist_fixture_connections
       setup_shared_connection_pool
 
-      ActiveRecord::Base.connection_handler.connection_pool_list.map(&:connection)
+      ActiveRecord::Base.connection_handler.connection_pool_list(:writing).map(&:connection)
     end
 
     private

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -158,7 +158,7 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_nil async_pool1
     assert_nil async_pool2
 
-    assert_equal 2, handler.all_connection_pools.count
+    assert_equal 2, handler.connection_pool_list(:all).count
   ensure
     clean_up_connection_handler
     ActiveRecord.async_query_executor = old_value
@@ -190,7 +190,7 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 16, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy
 
-    assert_equal 2, handler.all_connection_pools.count
+    assert_equal 2, handler.connection_pool_list(:all).count
     assert_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
@@ -227,7 +227,7 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 32, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy
 
-    assert_equal 2, handler.all_connection_pools.count
+    assert_equal 2, handler.connection_pool_list(:all).count
     assert_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
@@ -281,7 +281,7 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 20, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy
 
-    assert_equal 2, handler.all_connection_pools.count
+    assert_equal 2, handler.connection_pool_list(:all).count
     assert_not_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
@@ -316,7 +316,7 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 40, async_pool1.max_queue
     assert_equal :caller_runs, async_pool1.fallback_policy
 
-    assert_equal 2, handler.all_connection_pools.count
+    assert_equal 2, handler.connection_pool_list(:all).count
     assert_not_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -319,9 +319,19 @@ module ActiveRecord
         end
       end
 
-      def test_connection_pools
-        assert_equal([@rw_pool], @handler.connection_pools(:writing))
-        assert_equal([@ro_pool], @handler.connection_pools(:reading))
+      def test_connection_pool_list
+        assert_equal([@rw_pool], @handler.connection_pool_list(:writing))
+        assert_equal([@ro_pool], @handler.connection_pool_list(:reading))
+
+        assert_deprecated do
+          @handler.connection_pool_list
+        end
+      end
+
+      def test_all_connection_pools
+        assert_deprecated do
+          assert_equal([@rw_pool, @ro_pool], @handler.all_connection_pools)
+        end
       end
 
       def test_retrieve_connection

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       fixtures :people
 
       def setup
-        @writing_handler = ConnectionHandler.new
+        @handler = ConnectionHandler.new
       end
 
       def teardown
@@ -30,17 +30,17 @@ module ActiveRecord
 
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
-          @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
+          @handler.establish_connection(:primary)
+          @handler.establish_connection(:primary, shard: :pool_config_two)
 
-          default_pool = @writing_handler.retrieve_connection_pool("primary", shard: :default)
-          other_pool = @writing_handler.retrieve_connection_pool("primary", shard: :pool_config_two)
+          default_pool = @handler.retrieve_connection_pool("primary", shard: :default)
+          other_pool = @handler.retrieve_connection_pool("primary", shard: :pool_config_two)
 
           assert_not_nil default_pool
           assert_not_equal default_pool, other_pool
 
           # :default if passed with no key
-          assert_equal default_pool, @writing_handler.retrieve_connection_pool("primary")
+          assert_equal default_pool, @handler.retrieve_connection_pool("primary")
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -58,14 +58,14 @@ module ActiveRecord
 
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
-          @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
+          @handler.establish_connection(:primary)
+          @handler.establish_connection(:primary, shard: :pool_config_two)
 
           # remove default
-          @writing_handler.remove_connection_pool("primary")
+          @handler.remove_connection_pool("primary")
 
-          assert_nil @writing_handler.retrieve_connection_pool("primary")
-          assert_not_nil @writing_handler.retrieve_connection_pool("primary", shard: :pool_config_two)
+          assert_nil @handler.retrieve_connection_pool("primary")
+          assert_not_nil @handler.retrieve_connection_pool("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -83,15 +83,15 @@ module ActiveRecord
 
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
-          @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
+          @handler.establish_connection(:primary)
+          @handler.establish_connection(:primary, shard: :pool_config_two)
 
           # connect to default
-          @writing_handler.connection_pool_list.first.checkout
+          @handler.connection_pool_list(:writing).first.checkout
 
-          assert @writing_handler.connected?("primary")
-          assert @writing_handler.connected?("primary", shard: :default)
-          assert_not @writing_handler.connected?("primary", shard: :pool_config_two)
+          assert @handler.connected?("primary")
+          assert @handler.connected?("primary", shard: :default)
+          assert_not @handler.connected?("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -81,7 +81,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
 
     mw = middleware { |env|
-      ActiveRecord::Base.connection_handler.all_connection_pools.each do |pool|
+      ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
         assert_predicate pool.connection, :query_cache_enabled
       end
     }
@@ -558,7 +558,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_query_cache_is_enabled_on_all_connection_pools
     middleware {
-      ActiveRecord::Base.connection_handler.all_connection_pools.each do |pool|
+      ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
         assert pool.query_cache_enabled
         assert pool.connection.query_cache_enabled
       end


### PR DESCRIPTION
Following on #45924 I realized that `all_connection_pools` and `connection_pool_list` don't make much sense as separate methods and should follow the same deprecation as the other methods on the handler here. So this PR deprecates `all_connection_pools` in favor of `connection_pool_list` with an explicit argument of the role or `:all`. Passing `nil` will throw a deprecation warning to get applications to be explicit about behavior they expect.