### PR TITLE
Fix ServerTiming in Threads, use single subscriber 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -6,21 +6,60 @@ module ActionDispatch
   class ServerTiming
     SERVER_TIMING_HEADER = "Server-Timing"
 
+    class Subscriber # :nodoc:
+      include Singleton
+      KEY = :action_dispatch_server_timing_events
+
+      def initialize
+        @mutex = Mutex.new
+      end
+
+      def call(event)
+        if events = ActiveSupport::IsolatedExecutionState[KEY]
+          events << event
+        end
+      end
+
+      def collect_events
+        events = []
+        ActiveSupport::IsolatedExecutionState[KEY] = events
+        yield
+        events
+      ensure
+        ActiveSupport::IsolatedExecutionState.delete(KEY)
+      end
+
+      def ensure_subscribed
+        @mutex.synchronize do
+          @subscriber ||= ActiveSupport::Notifications.subscribe(/.*/, self)
+        end
+      end
+
+      def unsubscribe
+        @mutex.synchronize do
+          ActiveSupport::Notifications.unsubscribe @subscriber
+          @subscriber = nil
+        end
+      end
+    end
+
+    def self.unsubscribe # :nodoc:
+      Subscriber.instance.unsubscribe
+    end
+
     def initialize(app)
       @app = app
+      @subscriber = Subscriber.instance
+      @subscriber.ensure_subscribed
     end
 
     def call(env)
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe(/.*/) do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
+      response = nil
+      events = @subscriber.collect_events do
+        response = @app.call(env)
       end
 
-      status, headers, body = begin
-        @app.call(env)
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
+      headers = response[1]
 
       header_info = events.group_by(&:name).map do |event_name, events_collection|
         "#{event_name};dur=#{events_collection.sum(&:duration)}"
@@ -29,7 +68,7 @@ module ActionDispatch
       header_info.prepend(headers[SERVER_TIMING_HEADER]) if headers[SERVER_TIMING_HEADER].present?
       headers[SERVER_TIMING_HEADER] = header_info.join(", ")
 
-      [ status, headers, body ]
+      response
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -31,7 +31,9 @@ module ActionDispatch
 
       def ensure_subscribed
         @mutex.synchronize do
-          @subscriber ||= ActiveSupport::Notifications.subscribe(/.*/, self)
+          # Subscribe to all events, except those beginning with "!"
+          # Ideally we would be more selective of what is being measured
+          @subscriber ||= ActiveSupport::Notifications.subscribe(/\A[^!]/, self)
         end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -64,7 +64,7 @@ module ActionDispatch
       headers = response[1]
 
       header_info = events.group_by(&:name).map do |event_name, events_collection|
-        "#{event_name};dur=#{events_collection.sum(&:duration)}"
+        "%s;dur=%.2f" % [event_name, events_collection.sum(&:duration)]
       end
 
       header_info.prepend(headers[SERVER_TIMING_HEADER]) if headers[SERVER_TIMING_HEADER].present?

--- a/actionpack/test/dispatch/server_timing_test.rb
+++ b/actionpack/test/dispatch/server_timing_test.rb
@@ -26,6 +26,13 @@ class ServerTimingTest < ActionDispatch::IntegrationTest
     @middlewares = [ActionDispatch::ServerTiming]
   end
 
+  teardown do
+    # Avoid leaking subscription into other tests
+    # This will break any active instance of the middleware, but we don't
+    # expect there to be any outside of this file.
+    ActionDispatch::ServerTiming.unsubscribe
+  end
+
   test "server timing header is included in the response" do
     with_test_route_set do
       get "/"
@@ -48,6 +55,43 @@ class ServerTimingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "events are tracked by thread" do
+    barrier = Concurrent::CyclicBarrier.new(2)
+
+    stub_app = -> (env) {
+      env["proc"].call
+      [200, {}, "ok"]
+    }
+    app = ActionDispatch::ServerTiming.new(stub_app)
+
+    t1 = Thread.new do
+      app.call({ "proc" => -> {
+        barrier.wait
+        barrier.wait
+      } })
+    end
+
+    t2 = Thread.new do
+      barrier.wait
+
+      response = app.call({ "proc" => -> {
+        ActiveSupport::Notifications.instrument("custom.event") do
+          true
+        end
+      } })
+
+      barrier.wait
+
+      response
+    end
+
+    headers1 = t1.value[1]
+    headers2 = t2.value[1]
+
+    assert_match(/custom.event;dur=\w+/, headers2["Server-Timing"])
+    assert_no_match(/custom.event;dur=\w+/, headers1["Server-Timing"])
+  end
+
   test "does not overwrite existing header values" do
     @middlewares << Class.new do
       def initialize(app)
@@ -65,13 +109,6 @@ class ServerTimingTest < ActionDispatch::IntegrationTest
       get "/"
       assert_match(/entry;desc="description"/, @response.headers["Server-Timing"])
       assert_match(/start_processing.action_controller;dur=\w+/, @response.headers["Server-Timing"])
-    end
-  end
-
-  test "ensures it doesn't leak subscriptions when the app crashes" do
-    with_test_route_set do
-      post "/"
-      assert_not ActiveSupport::Notifications.notifier.listening?("custom.event")
     end
   end
 


### PR DESCRIPTION
Previously ActionDispatch::ServerTiming would subscribe and unsubscribe on each request. This could cause issues with the internal stacks of ActiveSupport::Notifications, particlularly under the previous AS::N implementation which used thread-local stacks for every subscriber (the new implementation has mostly mitigated this).

Additionally, the previous ServerTiming implementation did not report metrics correctly in a multi-threaded environment.

This commit works around both of these issues by using a single global subscription, which collects events into a per-thread Array.

Thanks to lots of advice from @matthewd 