### PR TITLE
Enable `Minitest/AssertRaisesWithRegexpArgument` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -324,5 +324,8 @@ Performance/RedundantStringChars:
 Performance/StringInclude:
   Enabled: true
 
+Minitest/AssertRaisesWithRegexpArgument:
+  Enabled: true
+
 Minitest/UnreachableAssertion:
   Enabled: true


### PR DESCRIPTION
Follow up #45965.

It’s my fault. The commit to enable `Minitest/AssertRaisesWithRegexpArgument` cop was forgotten...
