### PR TITLE
Fix typo in :active_record_suppressor_registry symbol

### DIFF
--- a/activerecord/lib/active_record/suppressor.rb
+++ b/activerecord/lib/active_record/suppressor.rb
@@ -32,7 +32,7 @@ module ActiveRecord
 
     class << self
       def registry # :nodoc:
-        ActiveSupport::IsolatedExecutionState[:active_record_suppresor_registry] ||= {}
+        ActiveSupport::IsolatedExecutionState[:active_record_suppressor_registry] ||= {}
       end
     end
 


### PR DESCRIPTION
### Summary

Simple typo fix on a symbol, found while debugging one application.