### PR TITLE
Update documentation to prevent confusion on the stub going back automatically

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -96,7 +96,8 @@ module ActiveSupport
 
       # Changes current time to the given time by stubbing +Time.now+,
       # +Date.today+, and +DateTime.now+ to return the time or date passed into this method.
-      # The stubs are automatically removed at the end of the test.
+      # The stubs are automatically removed at the end of the test when a block
+      # is passed in.
       #
       #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)


### PR DESCRIPTION
### Motivation / Background

During lead review, someone pointed me to the [documentation](https://apidock.com/rails/ActiveSupport/Testing/TimeHelpers/travel_to) and mentioned that the stub gets automatically removed.  We weren't using it in a block:

```
before { freeze_time }
```

To prevent confusion, I updated the documentation to mention that the stub is only automatically removed when a block is passed in.
