### PR TITLE
Add RDoc for ActiveRecord::Result#cast_values

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -102,7 +102,11 @@ module ActiveRecord
       self
     end
 
-    def cast_values(type_overrides = {}) # :nodoc:
+    # Returns the array of deserialized result object(s).
+    #
+    #   result = ActiveRecord::Base.connection.exec_query("SELECT array_agg(id) FROM users;")
+    #   result.cast_values # => [[1, 2, 3]]
+    def cast_values(type_overrides = {})
       if columns.one?
         # Separated to avoid allocating an array per row
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is no docs for `ActiveRecord::Result#cast_values` method

### Detail

This Pull Request adds `ActiveRecord::Result#cast_values` docs