### PR TITLE
improve "in_order_of" to allow string column name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow `QueryMethods#in_order_of` to order by a string column name.
+
+    ```ruby
+    Post.in_order_of("id", [4,2,3,1]).to_a
+    Post.joins(:author).in_order_of("authors.name", ["Bob", "Anna", "John"]).to_a
+    ```
+
+    *Igor Kasyanchuk*
+
 *   Disable `prepared_statements` for mysql2 adapter
 
     A recent change [#44591](https://github.com/rails/rails/pull/44591) enabled `prepared_statements` by default for mysql2 adapter

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -527,7 +527,7 @@ module ActiveRecord
       self.references_values |= references unless references.empty?
 
       values = values.map { |value| type_caster.type_cast_for_database(column, value) }
-      arel_column = column.is_a?(Symbol) ? order_column(column.to_s) : column
+      arel_column = column.is_a?(Arel::Nodes::SqlLiteral) ? column : order_column(column.to_s)
 
       where_clause =
         if values.include?(nil)

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -28,7 +28,9 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     order = %w[written published proposed]
     books = Book.in_order_of(:status, order)
+    assert_equal(order, books.map(&:status))
 
+    books = Book.in_order_of("status", order)
     assert_equal(order, books.map(&:status))
   end
 
@@ -59,14 +61,18 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     order = %w[hardcover paperback ebook]
     books = Book.in_order_of(:format, order)
+    assert_equal(order, books.map(&:format))
 
+    books = Book.in_order_of("format", order)
     assert_equal(order, books.map(&:format))
   end
 
   def test_in_order_of_after_regular_order
     order = [3, 4, 1]
     posts = Post.where(type: "Post").order(:type).in_order_of(:id, order)
+    assert_equal(order, posts.map(&:id))
 
+    posts = Post.where(type: "Post").order(:type).in_order_of("id", order)
     assert_equal(order, posts.map(&:id))
   end
 
@@ -78,7 +84,28 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     order = ["ebook", nil, "paperback"]
     books = Book.in_order_of(:format, order)
-
     assert_equal(order, books.map(&:format))
+
+    books = Book.in_order_of("format", order)
+    assert_equal(order, books.map(&:format))
+  end
+
+  def test_in_order_of_with_associations
+    Author.destroy_all
+    Book.destroy_all
+    john = Author.create(name: "John")
+    bob = Author.create(name: "Bob")
+    anna = Author.create(name: "Anna")
+
+    john.books.create
+    bob.books.create
+    anna.books.create
+
+    order = ["Bob", "Anna", "John"]
+    books = Book.joins(:author).in_order_of("authors.name", order)
+    assert_equal(order, books.map { |book| book.author.name })
+
+    books = Book.joins(:author).in_order_of(:"authors.name", order)
+    assert_equal(order, books.map { |book| book.author.name })
   end
 end


### PR DESCRIPTION
### Motivation / Background

Right now `in_order_of` doesn't work with the column when it's a string. 

```
[1] pry(main)> User.in_order_of(:id, [1,2,3]).count
  User Count (7.2ms)  SELECT COUNT(*) FROM "users" WHERE "users"."id" IN (1, 2, 3)
=> 3
[2] pry(main)> User.in_order_of('id', [1,2,3]).count
NoMethodError: undefined method `in' for "id":String

        .where!(arel_column.in(values))
                           ^^^
Did you mean?  in?
from /Users/admin/.rvm/gems/ruby-3.1.2/gems/activerecord-7.0.3.1/lib/active_record/relation/query_methods.rb:459:in `in_order_of'
```
 
Examples:

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/11101/189219872-99e933dd-86f1-4476-88a5-2c696563b99f.png">


<img width="1351" alt="image" src="https://user-images.githubusercontent.com/11101/189221702-a593a7f6-398c-4efc-9ff3-63bd1e2fd268.png">




### Detail

- checking the class of the column.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
