### PR TITLE
Revert "Replace `method_source` gem with stdlib equivalent"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ PATH
     railties (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
+      method_source
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.6)
@@ -314,6 +315,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
+    method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require "method_source"
 require "rake/file_list"
 require "active_support"
 require "active_support/core_ext/module/attribute_accessors"
-require "ripper"
 
 module Rails
   module TestUnit
@@ -169,32 +169,9 @@ module Rails
       private
         def definition_for(method)
           file, start_line = method.source_location
-          end_line = MethodEndFinder.call(source: File.read(file), target: method.name)
+          end_line = method.source.count("\n") + start_line - 1
 
           return file, start_line..end_line
-        end
-
-        # Finds the line number where the definition of method named +target+ ends.
-        module MethodEndFinder # :nodoc:
-          def self.call(source:, target:)
-            catch(:line_number_is) do
-              DefParser.new(source: source, target: target).parse
-              return nil
-            end
-          end
-
-          class DefParser < Ripper # :nodoc:
-            def initialize(source:, target:)
-              @target = String(target)
-              super(source)
-            end
-
-            def on_def(method_name, *)
-              if method_name == @target
-                throw(:line_number_is, lineno)
-              end
-            end
-          end
         end
     end
   end

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0"
+  s.add_dependency "method_source"
   s.add_dependency "zeitwerk", "~> 2.6"
 
   s.add_development_dependency "actionview", version

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -376,7 +376,7 @@ module ApplicationTests
       end
     end
 
-    def test_more_than_one_line_filter_macro_syntax
+    def test_more_than_one_line_filter
       app_file "test/models/post_test.rb", <<-RUBY
         require "test_helper"
 
@@ -392,34 +392,6 @@ module ApplicationTests
           end
 
           test "line filter does not run this" do
-            assert true
-          end
-        end
-      RUBY
-
-      run_test_command("test/models/post_test.rb:4:9").tap do |output|
-        assert_match "PostTest:FirstFilter", output
-        assert_match "PostTest:SecondFilter", output
-        assert_match "2 runs, 2 assertions", output
-      end
-    end
-
-    def test_more_than_one_line_filter_test_method_syntax
-      app_file "test/models/post_test.rb", <<-RUBY
-        require "test_helper"
-
-        class PostTest < ActiveSupport::TestCase
-          def test_first_filter
-            puts 'PostTest:FirstFilter'
-            assert true
-          end
-
-          def test_second_filter
-            puts 'PostTest:SecondFilter'
-            assert true
-          end
-
-          def test_line_filter_does_not_run_this
             assert true
           end
         end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -386,18 +386,18 @@ module ApplicationTests
             assert true
           end
 
-          test "second filter" do
-            puts 'PostTest:SecondFilter'
+          test "line filter does not run this" do
             assert true
           end
 
-          test "line filter does not run this" do
+          test "second filter" do
+            puts 'PostTest:SecondFilter'
             assert true
           end
         end
       RUBY
 
-      run_test_command("test/models/post_test.rb:4:9").tap do |output|
+      run_test_command("test/models/post_test.rb:4:13").tap do |output|
         assert_match "PostTest:FirstFilter", output
         assert_match "PostTest:SecondFilter", output
         assert_match "2 runs, 2 assertions", output


### PR DESCRIPTION
Reverts rails/rails#45904

`on_def` doesn't work with the declarative test definition since it will not trigger for those methods. We might make this work by hooking to method calls nodes using `Ripper` but since this broke the filtering I'm reverting. I'm ok with a new PR that doesn't break it. I'll also make sure this doesn't regress by making sure a test fails when we forget to filter the declarative definition.