### PR TITLE
Improve plugin generator docs

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/USAGE
+++ b/railties/lib/rails/generators/rails/plugin/USAGE
@@ -1,10 +1,21 @@
 Description:
-    The 'rails plugin new' command creates a skeleton for developing any
-    kind of Rails extension with ability to run tests using dummy Rails
-    application.
+    The `rails plugin new` command creates a Rails plugin with ability
+    to run tests using dummy Rails application. A plugin is a gem with
+    either a railtie or an engine.
 
-Example:
-    rails plugin new ~/Code/Ruby/blog
+Examples:
+    `rails plugin new ~/Code/Ruby/blog`
 
-    This generates a skeletal Rails plugin in ~/Code/Ruby/blog.
+    This generates a Rails railtie gem in ~/Code/Ruby/blog.
     See the README in the newly created plugin to get going.
+
+    `rails plugin new blog --full`
+
+    This generates a full Rails engine gem in ./blog. The `--mountable`
+    option may also be used to generate mountable, namespaced isolated
+    engine with assets and layouts.
+
+    `rails plugin new blog --mountable --skip-asset-pipeline`
+
+    This generates a mountable Rails engine gem at ./blog without an asset
+    pipeline. Any part of Rails can be skipped during plugin generation.


### PR DESCRIPTION
### Motivation / Background

Improves the documentation for the plugin generator. Similar to https://github.com/rails/rails/pull/45973

### Detail

Before:
```
% bin/rails plugin -h
Usage:
  rails plugin new APP_PATH [options]

Options:
          [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
          [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
  -r, [--ruby=PATH]                                              # Path to the Ruby binary of your choice
                                                                 # Default: /opt/rubies/3.1.0/bin/ruby
  -n, [--name=NAME]                                              # Name of the app
  -m, [--template=TEMPLATE]                                      # Path to some plugin template (can be a filesystem path or URL)
  -d, [--database=DATABASE]                                      # Preconfigure for selected database (options: mysql/postgresql/sqlite3/oracle/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)
                                                                 # Default: sqlite3
  -G, [--skip-git], [--no-skip-git]                              # Skip git init, .gitignore and .gitattributes
          [--skip-keeps], [--no-skip-keeps]                      # Skip source control .keep files
  -M, [--skip-action-mailer], [--no-skip-action-mailer]          # Skip Action Mailer files
          [--skip-action-mailbox], [--no-skip-action-mailbox]    # Skip Action Mailbox gem
          [--skip-action-text], [--no-skip-action-text]          # Skip Action Text gem
  -O, [--skip-active-record], [--no-skip-active-record]          # Skip Active Record files
          [--skip-active-job], [--no-skip-active-job]            # Skip Active Job
          [--skip-active-storage], [--no-skip-active-storage]    # Skip Active Storage files
  -C, [--skip-action-cable], [--no-skip-action-cable]            # Skip Action Cable files
  -A, [--skip-asset-pipeline], [--no-skip-asset-pipeline]        # Indicates when to generate skip asset pipeline
  -a, [--asset-pipeline=ASSET_PIPELINE]                          # Choose your asset pipeline [options: sprockets (default), propshaft]
                                                                 # Default: sprockets
  -J, --skip-js, [--skip-javascript], [--no-skip-javascript]     # Skip JavaScript files
                                                                 # Default: true
          [--skip-hotwire], [--no-skip-hotwire]                  # Skip Hotwire integration
          [--skip-jbuilder], [--no-skip-jbuilder]                # Skip jbuilder gem
  -T, [--skip-test], [--no-skip-test]                            # Skip test files
          [--skip-system-test], [--no-skip-system-test]          # Skip system test files
          [--skip-bootsnap], [--no-skip-bootsnap]                # Skip bootsnap gem
          [--skip-dev-gems], [--no-skip-dev-gems]                # Skip development gems (e.g., web-console)
          [--dev], [--no-dev]                                    # Set up the plugin with Gemfile pointing to your Rails checkout
          [--edge], [--no-edge]                                  # Set up the plugin with Gemfile pointing to Rails repository
  --master, [--main], [--no-main]                                # Set up the plugin with Gemfile pointing to Rails repository main branch
          [--rc=RC]                                              # Path to file containing extra configuration options for rails command
          [--no-rc], [--no-no-rc]                                # Skip loading of extra configuration options from .railsrc file
          [--dummy-path=DUMMY_PATH]                              # Create dummy application at given path
                                                                 # Default: test/dummy
          [--full], [--no-full]                                  # Generate a rails engine with bundled Rails application for testing
          [--mountable], [--no-mountable]                        # Generate mountable isolated engine
          [--skip-gemspec], [--no-skip-gemspec]                  # Skip gemspec file
          [--skip-gemfile-entry], [--no-skip-gemfile-entry]      # If creating plugin in application's directory skip adding entry to Gemfile
          [--api], [--no-api]                                    # Generate a smaller stack for API application plugins

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Rails options:
  -h, [--help], [--no-help]  # Show this help message and quit

Description:
    The 'rails plugin new' command creates a skeleton for developing any
    kind of Rails extension with ability to run tests using dummy Rails
    application.

Example:
    rails plugin new ~/Code/Ruby/blog

    This generates a skeletal Rails plugin in ~/Code/Ruby/blog.
    See the README in the newly created plugin to get going.
```

After:
```
% bin/rails plugin -h
Usage:
  rails plugin new APP_PATH [options]

Options:
          [--skip-namespace], [--no-skip-namespace]              # Skip namespace (affects only isolated engines)
          [--skip-collision-check], [--no-skip-collision-check]  # Skip collision check
  -r, [--ruby=PATH]                                              # Path to the Ruby binary of your choice
                                                                 # Default: /opt/rubies/3.1.0/bin/ruby
  -n, [--name=NAME]                                              # Name of the app
  -m, [--template=TEMPLATE]                                      # Path to some plugin template (can be a filesystem path or URL)
  -d, [--database=DATABASE]                                      # Preconfigure for selected database (options: mysql/postgresql/sqlite3/oracle/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)
                                                                 # Default: sqlite3
  -G, [--skip-git], [--no-skip-git]                              # Skip git init, .gitignore and .gitattributes
          [--skip-keeps], [--no-skip-keeps]                      # Skip source control .keep files
  -M, [--skip-action-mailer], [--no-skip-action-mailer]          # Skip Action Mailer files
          [--skip-action-mailbox], [--no-skip-action-mailbox]    # Skip Action Mailbox gem
          [--skip-action-text], [--no-skip-action-text]          # Skip Action Text gem
  -O, [--skip-active-record], [--no-skip-active-record]          # Skip Active Record files
          [--skip-active-job], [--no-skip-active-job]            # Skip Active Job
          [--skip-active-storage], [--no-skip-active-storage]    # Skip Active Storage files
  -C, [--skip-action-cable], [--no-skip-action-cable]            # Skip Action Cable files
  -A, [--skip-asset-pipeline], [--no-skip-asset-pipeline]        # Indicates when to generate skip asset pipeline
  -a, [--asset-pipeline=ASSET_PIPELINE]                          # Choose your asset pipeline [options: sprockets (default), propshaft]
                                                                 # Default: sprockets
  -J, --skip-js, [--skip-javascript], [--no-skip-javascript]     # Skip JavaScript files
                                                                 # Default: true
          [--skip-hotwire], [--no-skip-hotwire]                  # Skip Hotwire integration
          [--skip-jbuilder], [--no-skip-jbuilder]                # Skip jbuilder gem
  -T, [--skip-test], [--no-skip-test]                            # Skip test files
          [--skip-system-test], [--no-skip-system-test]          # Skip system test files
          [--skip-bootsnap], [--no-skip-bootsnap]                # Skip bootsnap gem
          [--skip-dev-gems], [--no-skip-dev-gems]                # Skip development gems (e.g., web-console)
          [--dev], [--no-dev]                                    # Set up the plugin with Gemfile pointing to your Rails checkout
          [--edge], [--no-edge]                                  # Set up the plugin with Gemfile pointing to Rails repository
  --master, [--main], [--no-main]                                # Set up the plugin with Gemfile pointing to Rails repository main branch
          [--rc=RC]                                              # Path to file containing extra configuration options for rails command
          [--no-rc], [--no-no-rc]                                # Skip loading of extra configuration options from .railsrc file
          [--dummy-path=DUMMY_PATH]                              # Create dummy application at given path
                                                                 # Default: test/dummy
          [--full], [--no-full]                                  # Generate a rails engine with bundled Rails application for testing
          [--mountable], [--no-mountable]                        # Generate mountable isolated engine
          [--skip-gemspec], [--no-skip-gemspec]                  # Skip gemspec file
          [--skip-gemfile-entry], [--no-skip-gemfile-entry]      # If creating plugin in application's directory skip adding entry to Gemfile
          [--api], [--no-api]                                    # Generate a smaller stack for API application plugins

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Rails options:
  -h, [--help], [--no-help]  # Show this help message and quit

Description:
    The `rails plugin new` command creates a Rails plugin with ability
    to run tests using dummy Rails application. A plugin is a gem with
    either a railtie or an engine.

Examples:
    `rails plugin new ~/Code/Ruby/blog`

    This generates a Rails railtie gem in ~/Code/Ruby/blog.
    See the README in the newly created plugin to get going.

    `rails plugin new blog --full`

    This generates a full Rails engine gem in ./blog. The `--mountable`
    option may also be used to generate mountable, namespaced isolated
    engine with assets and layouts.

    `rails plugin new blog --mountable --skip-asset-pipeline`

    This generates a mountable Rails engine gem at ./blog without an asset
    pipeline. Any part of Rails can be skipped during plugin generation.
```

### Additional information

Mainly the two big edits are:

- Minor formatting changes
- Adds more examples with common options

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] PR is not in a draft state.
* [ ] CI is passing.
