### PR TITLE
Add italic and underline support to `ActiveSupport::LogSubscriber#color`

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       end
 
       name = colorize_payload_name(name, payload[:name])
-      sql  = color(sql, sql_color(sql), true) if colorize_logging
+      sql  = color(sql, sql_color(sql), bold: true) if colorize_logging
 
       debug "  #{name}  #{sql}#{binds}"
     end
@@ -94,9 +94,9 @@ module ActiveRecord
 
       def colorize_payload_name(name, payload_name)
         if payload_name.blank? || payload_name == "SQL" # SQL vs Model Load/Exists
-          color(name, MAGENTA, true)
+          color(name, MAGENTA, bold: true)
         else
-          color(name, CYAN, true)
+          color(name, CYAN, bold: true)
         end
       end
 

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -9,8 +9,8 @@ require "active_support/log_subscriber/test_helper"
 class LogSubscriberTest < ActiveRecord::TestCase
   include ActiveSupport::LogSubscriber::TestHelper
   include ActiveSupport::Logger::Severity
-  REGEXP_CLEAR = Regexp.escape(ActiveRecord::LogSubscriber::CLEAR)
-  REGEXP_BOLD = Regexp.escape(ActiveRecord::LogSubscriber::BOLD)
+  REGEXP_CLEAR = Regexp.escape("\e[#{ActiveRecord::LogSubscriber::MODES[:clear]}m")
+  REGEXP_BOLD = Regexp.escape("\e[#{ActiveRecord::LogSubscriber::MODES[:bold]}m")
   REGEXP_MAGENTA = Regexp.escape(ActiveRecord::LogSubscriber::MAGENTA)
   REGEXP_CYAN = Regexp.escape(ActiveRecord::LogSubscriber::CYAN)
   SQL_COLORINGS = {

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add italic and underline support to `ActiveSupport::LogSubscriber#color`
+
+    Previously, only bold text was supported via a positional argument.
+    This allows for bold, italic, and underline options to be specified
+    for colored logs.
+
+    ```ruby
+    info color("Hello world!", :red, bold: true, underline: true)
+    ```
+
+    *Gannon McGibbon*
+
 *   Add `String#downcase_first` method.
 
     This method is the corollary of `String#upcase_first`.

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -18,7 +18,15 @@ class MyLogSubscriber < ActiveSupport::LogSubscriber
   end
 
   def bar(event)
-    info "#{color("cool", :red)}, #{color("isn't it?", :blue, true)}"
+    info "#{color("cool", :red)}, #{color("isn't it?", :blue, bold: true)}"
+  end
+
+  def baz(event)
+    info "#{color("rad", :green, bold: true, underline: true)}, #{color("isn't it?", :yellow, italic: true)}"
+  end
+
+  def deprecated(event)
+    info "#{color("bogus", :red, true)}"
   end
 
   def puke(event)
@@ -54,6 +62,19 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     ActiveSupport::LogSubscriber.colorize_logging = true
     @log_subscriber.bar(nil)
     assert_equal "\e[31mcool\e[0m, \e[1m\e[34misn't it?\e[0m", @logger.logged(:info).last
+  end
+
+  def test_set_mode_for_messages
+    ActiveSupport::LogSubscriber.colorize_logging = true
+    @log_subscriber.baz(nil)
+    assert_equal "\e[1;4m\e[32mrad\e[0m, \e[3m\e[33misn't it?\e[0m", @logger.logged(:info).last
+  end
+
+  def test_deprecated_bold_format_for_messages
+    ActiveSupport::LogSubscriber.colorize_logging = true
+    assert_deprecated do
+      @log_subscriber.deprecated(nil)
+    end
   end
 
   def test_does_not_set_color_if_colorize_logging_is_set_to_false


### PR DESCRIPTION
### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

I recently tried underlining something using a log subscriber and it didn't support that level of formatting. I think it should, and the API for ANSI format modes should be passed as keywords / a hash instead of one positional boolean for bolding.

### Detail

Previously, only bold text was supported via a positional argument. This allows for bold, italic, and underline options to be specified for colored logs.

```ruby
info color("Hello world!", :red, bold: true, underline: true)
```

### Additional information

This also safely deprecates usage of bolding with positional arguments in old log subscriber code.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] PR is not in a draft state.
* [ ] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
