### PR TITLE
Add `:locals` to ActionView rendering instrumentation

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Report `:locals` as part of the data returned by ActionView render instrumentation.
+
+    Before:
+    ```ruby
+    {
+    identifier: "/Users/adam/projects/notifications/app/views/posts/index.html.erb",
+    layout: "layouts/application"
+    }
+    ```
+
+    After:
+    ```ruby
+    {
+    identifier: "/Users/adam/projects/notifications/app/views/posts/index.html.erb",
+    layout: "layouts/application",
+    locals: {foo: "bar"}
+    }
+    ```
+
+    *Aaron Gough*
+
 *   Strip `break_sequence` at the end of `word_wrap`.
 
     This fixes a bug where `word_wrap` didn't properly strip off break sequences that had printable characters.

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -246,7 +246,8 @@ module ActionView
         ActiveSupport::Notifications.instrument(
           "render_partial.action_view",
           identifier: template.identifier,
-          layout: layout && layout.virtual_path
+          layout: layout && layout.virtual_path,
+          locals: locals
         ) do |payload|
           content = template.render(view, locals, add_to_stack: !block) do |*name|
             view._layout_for(*name, &block)

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -65,7 +65,8 @@ module ActionView
         ActiveSupport::Notifications.instrument(
           "render_template.action_view",
           identifier: template.identifier,
-          layout: layout && layout.virtual_path
+          layout: layout && layout.virtual_path,
+          locals: locals
         ) do
           outer_config = I18n.config
           fiber = Fiber.new do

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -60,7 +60,8 @@ module ActionView
           ActiveSupport::Notifications.instrument(
             "render_template.action_view",
             identifier: template.identifier,
-            layout: layout && layout.virtual_path
+            layout: layout && layout.virtual_path,
+            locals: locals
           ) do
             template.render(view, locals) { |*name| view._layout_for(*name) }
           end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -281,27 +281,31 @@ INFO. Additional keys may be added by the caller.
 
 #### render_template.action_view
 
-| Key           | Value                 |
-| ------------- | --------------------- |
-| `:identifier` | Full path to template |
-| `:layout`     | Applicable layout     |
+| Key           | Value                              |
+| ------------- | ---------------------------------- |
+| `:identifier` | Full path to template              |
+| `:layout`     | Applicable layout                  |
+| `:locals`     | Local variables passed to template |
 
 ```ruby
 {
   identifier: "/Users/adam/projects/notifications/app/views/posts/index.html.erb",
-  layout: "layouts/application"
+  layout: "layouts/application",
+  locals: {foo: "bar"}
 }
 ```
 
 #### render_partial.action_view
 
-| Key           | Value                 |
-| ------------- | --------------------- |
-| `:identifier` | Full path to template |
+| Key           | Value                              |
+| ------------- | ---------------------------------- |
+| `:identifier` | Full path to template              |
+| `:locals`     | Local variables passed to template |
 
 ```ruby
 {
-  identifier: "/Users/adam/projects/notifications/app/views/posts/_form.html.erb"
+  identifier: "/Users/adam/projects/notifications/app/views/posts/_form.html.erb",
+  locals: {foo: "bar"}
 }
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created in order to expand the data that `ActiveSupport::Notifications` captures during the rendering process. This change is motivated by the need for additional insight into the rendering process in order to make assertions about it during testing, but will potentially also be useful for APM use.

### Detail

This Pull Request changes:
  * `ActionView::TemplateRenderer.render_template`
  * `ActionView::PartialRenderer.render_partial_template`
  * `ActionView::StreamingTemplateRenderer.render_template`
  
  in all cases simply adding `locals: locals` to the hash that is sent to `ActiveSupport::Notifications.instrument`.
  
  There are also small additions to the documentation (`active_support_instrumentation.md`) and to the `CHANGELOG` in order to keep them up to date. 

### Additional information

NOTE: There are no existing tests for the instrumentation or the data that is reported by it, nor is there a terribly obvious place to add it. I am very happy to add tests, just let me know the best place for them.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
