### PR TITLE
Mysql2Adapter remove reference to closed connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -141,6 +141,7 @@ module ActiveRecord
 
         def reconnect
           @raw_connection&.close
+          @raw_connection = nil
           connect
         end
 


### PR DESCRIPTION
If `connect` fails, we'd stick with a closed `Mysql2` connection which means on the next try we'll try to ping it without any chance of success.
