### PR TITLE
Add Enumerable#find_by

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1092,7 +1092,7 @@ module ActiveRecord
           @type_map_for_results.add_coder(MoneyDecoder.new(oid: 790, name: "money"))
 
           # extract timestamp decoder for use in update_typemap_for_default_timezone
-          @timestamp_decoder = coders.find { |coder| coder.name == "timestamp" }
+          @timestamp_decoder = coders.find_by(name: "timestamp")
           update_typemap_for_default_timezone
         end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -981,7 +981,7 @@ module ActiveRecord
 
           source = "#{magic_comments}#{inserted_comment}#{source}"
 
-          if duplicate = destination_migrations.detect { |m| m.name == migration.name }
+          if duplicate = destination_migrations.find_by(name: migration.name)
             if options[:on_skip] && duplicate.scope != scope.to_s
               options[:on_skip].call(scope, migration)
             end
@@ -1308,7 +1308,7 @@ module ActiveRecord
     end
 
     def current_migration
-      migrations.detect { |m| m.version == current_version }
+      migrations.find_by(version: current_version)
     end
     alias :current :current_migration
 
@@ -1359,7 +1359,7 @@ module ActiveRecord
     private
       # Used for running a specific migration.
       def run_without_lock
-        migration = migrations.detect { |m| m.version == @target_version }
+        migration = migrations.find_by(version: @target_version)
         raise UnknownMigrationVersionError.new(@target_version) if migration.nil?
 
         record_environment
@@ -1410,7 +1410,7 @@ module ActiveRecord
       end
 
       def target
-        migrations.detect { |m| m.version == @target_version }
+        migrations.find_by(version: @target_version)
       end
 
       def finish

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -88,11 +88,11 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
   end
 
   def boolean_column
-    BooleanType.columns.find { |c| c.name == "archived" }
+    BooleanType.columns.find_by(name: "archived")
   end
 
   def string_column
-    BooleanType.columns.find { |c| c.name == "published" }
+    BooleanType.columns.find_by(name: "published")
   end
 
   def emulate_booleans(value)

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -20,13 +20,13 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   end
 
   test "string column with charset and collation" do
-    column = @connection.columns(:charset_collations).find { |c| c.name == "string_ascii_bin" }
+    column = @connection.columns(:charset_collations).find_by(name: "string_ascii_bin")
     assert_equal :string, column.type
     assert_equal "ascii_bin", column.collation
   end
 
   test "text column with charset and collation" do
-    column = @connection.columns(:charset_collations).find { |c| c.name == "text_ucs2_unicode_ci" }
+    column = @connection.columns(:charset_collations).find_by(name: "text_ucs2_unicode_ci")
     assert_equal :text, column.type
     assert_equal "ucs2_unicode_ci", column.collation
   end
@@ -34,7 +34,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
   test "add column with charset and collation" do
     @connection.add_column :charset_collations, :title, :string, charset: "utf8mb4", collation: "utf8mb4_bin"
 
-    column = @connection.columns(:charset_collations).find { |c| c.name == "title" }
+    column = @connection.columns(:charset_collations).find_by(name: "title")
     assert_equal :string, column.type
     assert_equal "utf8mb4_bin", column.collation
   end
@@ -43,7 +43,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :text, charset: "utf8mb4", collation: "utf8mb4_general_ci"
 
-    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+    column = @connection.columns(:charset_collations).find_by(name: "description")
     assert_equal :text, column.type
     assert_equal "utf8mb4_general_ci", column.collation
   end
@@ -52,7 +52,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :binary
 
-    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+    column = @connection.columns(:charset_collations).find_by(name: "description")
 
     assert_equal :binary, column.type
     assert_nil column.collation
@@ -62,7 +62,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :int
 
-    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+    column = @connection.columns(:charset_collations).find_by(name: "description")
 
     assert_equal :integer, column.type
     assert_nil column.collation
@@ -72,7 +72,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :text
 
-    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+    column = @connection.columns(:charset_collations).find_by(name: "description")
     assert_equal :text, column.type
     assert_equal "utf8mb4_unicode_ci", column.collation
   end

--- a/activerecord/test/cases/adapters/mysql2/schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/schema_test.rb
@@ -33,13 +33,13 @@ module ActiveRecord
           t.float :float_25, limit: 25
         end
 
-        column_no_limit = @connection.columns(:mysql_doubles).find { |c| c.name == "float_no_limit" }
-        column_short = @connection.columns(:mysql_doubles).find { |c| c.name == "float_short" }
-        column_long = @connection.columns(:mysql_doubles).find { |c| c.name == "float_long" }
+        column_no_limit = @connection.columns(:mysql_doubles).find_by(name: "float_no_limit")
+        column_short = @connection.columns(:mysql_doubles).find_by(name: "float_short")
+        column_long = @connection.columns(:mysql_doubles).find_by(name: "float_long")
 
-        column_23 = @connection.columns(:mysql_doubles).find { |c| c.name == "float_23" }
-        column_24 = @connection.columns(:mysql_doubles).find { |c| c.name == "float_24" }
-        column_25 = @connection.columns(:mysql_doubles).find { |c| c.name == "float_25" }
+        column_23 = @connection.columns(:mysql_doubles).find_by(name: "float_23")
+        column_24 = @connection.columns(:mysql_doubles).find_by(name: "float_24")
+        column_25 = @connection.columns(:mysql_doubles).find_by(name: "float_25")
 
         # MySQL floats are precision 0..24, MySQL doubles are precision 25..53
         assert_equal 24, column_no_limit.limit

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -21,48 +21,48 @@ module ActiveRecord
 
       def test_change_string_to_date
         connection.change_column :strings, :somedate, :timestamp, using: 'CAST("somedate" AS timestamp)'
-        assert_equal :datetime, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+        assert_equal :datetime, connection.columns(:strings).find_by(name: "somedate").type
       end
 
       def test_change_type_with_symbol
         connection.change_column :strings, :somedate, :timestamp, cast_as: :timestamp
-        assert_equal :datetime, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+        assert_equal :datetime, connection.columns(:strings).find_by(name: "somedate").type
       end
 
       def test_change_type_with_symbol_with_timestamptz
         connection.change_column :strings, :somedate, :timestamptz, cast_as: :timestamptz
-        assert_equal :timestamptz, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+        assert_equal :timestamptz, connection.columns(:strings).find_by(name: "somedate").type
       end
 
       def test_change_type_with_symbol_using_datetime
         connection.change_column :strings, :somedate, :datetime, cast_as: :datetime
-        assert_equal :datetime, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+        assert_equal :datetime, connection.columns(:strings).find_by(name: "somedate").type
       end
 
       def test_change_type_with_symbol_using_timestamp_with_timestamptz_as_default
         with_postgresql_datetime_type(:timestamptz) do
           connection.change_column :strings, :somedate, :timestamp, cast_as: :timestamp
-          assert_equal :timestamp, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+          assert_equal :timestamp, connection.columns(:strings).find_by(name: "somedate").type
         end
       end
 
       def test_change_type_with_symbol_with_timestamptz_as_default
         with_postgresql_datetime_type(:timestamptz) do
           connection.change_column :strings, :somedate, :timestamptz, cast_as: :timestamptz
-          assert_equal :datetime, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+          assert_equal :datetime, connection.columns(:strings).find_by(name: "somedate").type
         end
       end
 
       def test_change_type_with_symbol_using_datetime_with_timestamptz_as_default
         with_postgresql_datetime_type(:timestamptz) do
           connection.change_column :strings, :somedate, :datetime, cast_as: :datetime
-          assert_equal :datetime, connection.columns(:strings).find { |c| c.name == "somedate" }.type
+          assert_equal :datetime, connection.columns(:strings).find_by(name: "somedate").type
         end
       end
 
       def test_change_type_with_array
         connection.change_column :strings, :somedate, :timestamp, array: true, cast_as: :timestamp
-        column = connection.columns(:strings).find { |c| c.name == "somedate" }
+        column = connection.columns(:strings).find_by(name: "somedate")
         assert_equal :datetime, column.type
         assert_predicate column, :array?
       end

--- a/activerecord/test/cases/adapters/postgresql/collation_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_test.rb
@@ -19,13 +19,13 @@ class PostgresqlCollationTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "string column with collation" do
-    column = @connection.columns(:postgresql_collations).find { |c| c.name == "string_c" }
+    column = @connection.columns(:postgresql_collations).find_by(name: "string_c")
     assert_equal :string, column.type
     assert_equal "C", column.collation
   end
 
   test "text column with collation" do
-    column = @connection.columns(:postgresql_collations).find { |c| c.name == "text_posix" }
+    column = @connection.columns(:postgresql_collations).find_by(name: "text_posix")
     assert_equal :text, column.type
     assert_equal "POSIX", column.collation
   end
@@ -33,7 +33,7 @@ class PostgresqlCollationTest < ActiveRecord::PostgreSQLTestCase
   test "add column with collation" do
     @connection.add_column :postgresql_collations, :title, :string, collation: "C"
 
-    column = @connection.columns(:postgresql_collations).find { |c| c.name == "title" }
+    column = @connection.columns(:postgresql_collations).find_by(name: "title")
     assert_equal :string, column.type
     assert_equal "C", column.collation
   end
@@ -42,7 +42,7 @@ class PostgresqlCollationTest < ActiveRecord::PostgreSQLTestCase
     @connection.add_column :postgresql_collations, :description, :string
     @connection.change_column :postgresql_collations, :description, :text, collation: "POSIX"
 
-    column = @connection.columns(:postgresql_collations).find { |c| c.name == "description" }
+    column = @connection.columns(:postgresql_collations).find_by(name: "description")
     assert_equal :text, column.type
     assert_equal "POSIX", column.collation
   end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -75,14 +75,14 @@ class PostgresqlInternalDataTypeTest < ActiveRecord::PostgreSQLTestCase
 
   def test_name_column_type
     with_example_table @connection, "ex", "data name" do
-      column = @connection.columns("ex").find { |col| col.name == "data" }
+      column = @connection.columns("ex").find_by(name: "data")
       assert_equal :string, column.type
     end
   end
 
   def test_char_column_type
     with_example_table @connection, "ex", 'data "char"' do
-      column = @connection.columns("ex").find { |col| col.name == "data" }
+      column = @connection.columns("ex").find_by(name: "data")
       assert_equal :string, column.type
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -366,7 +366,7 @@ class PostgreSQLGeometricTypesTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def assert_type_correct(column_name, type)
-      column = connection.columns(table_name).find { |c| c.name == column_name.to_s }
+      column = connection.columns(table_name).find_by(name: column_name.to_s)
       assert_equal type, column.type
     end
 end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -295,7 +295,7 @@ module ActiveRecord
       def test_partial_index
         with_example_table do
           @connection.add_index "ex", %w{ id number }, name: "partial", where: "number > 100"
-          index = @connection.indexes("ex").find { |idx| idx.name == "partial" }
+          index = @connection.indexes("ex").find_by(name: "partial")
           assert_equal "(number > 100)", index.where
         end
       end
@@ -304,7 +304,7 @@ module ActiveRecord
         with_example_table do
           expr = "mod(id, 10), abs(number)"
           @connection.add_index "ex", expr, name: "expression"
-          index = @connection.indexes("ex").find { |idx| idx.name == "expression" }
+          index = @connection.indexes("ex").find_by(name: "expression")
           assert_equal expr, index.columns
           assert_equal true, @connection.index_exists?("ex", expr, name: "expression")
         end
@@ -313,11 +313,11 @@ module ActiveRecord
       def test_index_with_opclass
         with_example_table do
           @connection.add_index "ex", "data", opclass: "varchar_pattern_ops"
-          index = @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data" }
+          index = @connection.indexes("ex").find_by(name: "index_ex_on_data")
           assert_equal ["data"], index.columns
 
           @connection.remove_index "ex", "data"
-          assert_not @connection.indexes("ex").find { |idx| idx.name == "index_ex_on_data" }
+          assert_not @connection.indexes("ex").find_by(name: "index_ex_on_data")
         end
       end
 

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -23,18 +23,18 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
   end
 
   test "string column with collation" do
-    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "string_nocase" }
+    column = @connection.columns(:collation_table_sqlite3).find_by(name: "string_nocase")
     assert_equal :string, column.type
     assert_equal "NOCASE", column.collation
 
     # Verify collation of a column behind the decimal column as well.
-    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "string_after_decimal_nocase" }
+    column = @connection.columns(:collation_table_sqlite3).find_by(name: "string_after_decimal_nocase")
     assert_equal :string, column.type
     assert_equal "NOCASE", column.collation
   end
 
   test "text column with collation" do
-    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "text_rtrim" }
+    column = @connection.columns(:collation_table_sqlite3).find_by(name: "text_rtrim")
     assert_equal :text, column.type
     assert_equal "RTRIM", column.collation
   end
@@ -42,7 +42,7 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
   test "add column with collation" do
     @connection.add_column :collation_table_sqlite3, :title, :string, collation: "RTRIM"
 
-    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "title" }
+    column = @connection.columns(:collation_table_sqlite3).find_by(name: "title")
     assert_equal :string, column.type
     assert_equal "RTRIM", column.collation
   end
@@ -51,7 +51,7 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
     @connection.add_column :collation_table_sqlite3, :description, :string
     @connection.change_column :collation_table_sqlite3, :description, :text, collation: "RTRIM"
 
-    column = @connection.columns(:collation_table_sqlite3).find { |c| c.name == "description" }
+    column = @connection.columns(:collation_table_sqlite3).find_by(name: "description")
     assert_equal :text, column.type
     assert_equal "RTRIM", column.collation
   end

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -29,7 +29,7 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
     test_copy_table("comments", "comments_with_default") do
       @connection.add_column("comments_with_default", "options", "json", default: {})
       test_copy_table("comments_with_default", "comments_with_default2") do
-        column = @connection.columns("comments_with_default2").find { |col| col.name == "options" }
+        column = @connection.columns("comments_with_default2").find_by(name: "options")
         assert_equal "{}", column.default
       end
     end
@@ -67,8 +67,8 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
 
   def test_copy_table_with_id_col_that_is_not_primary_key
     test_copy_table("goofy_string_id", "goofy_string_id2") do
-      original_id = @connection.columns("goofy_string_id").detect { |col| col.name == "id" }
-      copied_id = @connection.columns("goofy_string_id2").detect { |col| col.name == "id" }
+      original_id = @connection.columns("goofy_string_id").find_by(name: "id")
+      copied_id = @connection.columns("goofy_string_id2").find_by(name: "id")
       assert_equal original_id.type, copied_id.type
       assert_equal original_id.sql_type, copied_id.sql_type
       assert_nil original_id.limit

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -320,7 +320,7 @@ module ActiveRecord
 
       def test_columns_with_not_null
         with_example_table "id integer PRIMARY KEY AUTOINCREMENT, number integer not null" do
-          column = @conn.columns("ex").find { |x| x.name == "number" }
+          column = @conn.columns("ex").find_by(name: "number")
           assert_not column.null, "column should not be null"
         end
       end
@@ -328,7 +328,7 @@ module ActiveRecord
       def test_add_column_with_not_null
         with_example_table "id integer PRIMARY KEY AUTOINCREMENT, number integer not null" do
           assert_nothing_raised { @conn.add_column :ex, :name, :string, null: false }
-          column = @conn.columns("ex").find { |x| x.name == "name" }
+          column = @conn.columns("ex").find_by(name: "name")
           assert_not column.null, "column should not be null"
         end
       end
@@ -348,7 +348,7 @@ module ActiveRecord
       def test_index
         with_example_table do
           @conn.add_index "ex", "id", unique: true, name: "fun"
-          index = @conn.indexes("ex").find { |idx| idx.name == "fun" }
+          index = @conn.indexes("ex").find_by(name: "fun")
 
           assert_equal "ex", index.table
           assert index.unique, "index is unique"
@@ -369,7 +369,7 @@ module ActiveRecord
       def test_non_unique_index
         with_example_table do
           @conn.add_index "ex", "id", name: "fun"
-          index = @conn.indexes("ex").find { |idx| idx.name == "fun" }
+          index = @conn.indexes("ex").find_by(name: "fun")
           assert_not index.unique, "index is not unique"
         end
       end
@@ -377,7 +377,7 @@ module ActiveRecord
       def test_compound_index
         with_example_table do
           @conn.add_index "ex", %w{ id number }, name: "fun"
-          index = @conn.indexes("ex").find { |idx| idx.name == "fun" }
+          index = @conn.indexes("ex").find_by(name: "fun")
           assert_equal %w{ id number }.sort, index.columns.sort
         end
       end
@@ -386,7 +386,7 @@ module ActiveRecord
         def test_expression_index
           with_example_table do
             @conn.add_index "ex", "max(id, number)", name: "expression"
-            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            index = @conn.indexes("ex").find_by(name: "expression")
             assert_equal "max(id, number)", index.columns
           end
         end
@@ -394,7 +394,7 @@ module ActiveRecord
         def test_expression_index_with_trailing_comment
           with_example_table do
             @conn.execute "CREATE INDEX expression on ex (number % 10) /* comment */"
-            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            index = @conn.indexes("ex").find_by(name: "expression")
             assert_equal "number % 10", index.columns
           end
         end
@@ -402,7 +402,7 @@ module ActiveRecord
         def test_expression_index_with_where
           with_example_table do
             @conn.add_index "ex", "id % 10, max(id, number)", name: "expression", where: "id > 1000"
-            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            index = @conn.indexes("ex").find_by(name: "expression")
             assert_equal "id % 10, max(id, number)", index.columns
             assert_equal "id > 1000", index.where
           end
@@ -411,7 +411,7 @@ module ActiveRecord
         def test_complicated_expression
           with_example_table do
             @conn.execute "CREATE INDEX expression ON ex (id % 10, (CASE WHEN number > 0 THEN max(id, number) END))WHERE(id > 1000)"
-            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            index = @conn.indexes("ex").find_by(name: "expression")
             assert_equal "id % 10, (CASE WHEN number > 0 THEN max(id, number) END)", index.columns
             assert_equal "(id > 1000)", index.where
           end
@@ -420,7 +420,7 @@ module ActiveRecord
         def test_not_everything_an_expression
           with_example_table do
             @conn.add_index "ex", "id, max(id, number)", name: "expression"
-            index = @conn.indexes("ex").find { |idx| idx.name == "expression" }
+            index = @conn.indexes("ex").find_by(name: "expression")
             assert_equal "id, max(id, number)", index.columns
           end
         end
@@ -549,13 +549,13 @@ module ActiveRecord
 
         indexes = connection.indexes("barcodes")
 
-        partial_index = indexes.find { |idx| idx.name == "partial" }
+        partial_index = indexes.find_by(name: "partial")
         assert_equal "bool_attr", partial_index.where
 
-        unique_index = indexes.find { |idx| idx.name == "unique" }
+        unique_index = indexes.find_by(name: "unique")
         assert unique_index.unique
 
-        ordered_index = indexes.find { |idx| idx.name == "ordered" }
+        ordered_index = indexes.find_by(name: "ordered")
         assert_equal :desc, ordered_index.orders
       ensure
         Barcode.reset_column_information

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -66,7 +66,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_loading_with_one_association
     posts = Post.all.merge!(includes: :comments).to_a
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal 2, post.comments.size
     assert_includes post.comments, comments(:greetings)
 
@@ -75,13 +75,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_includes post.comments, comments(:greetings)
 
     posts = Post.all.merge!(includes: :last_comment).to_a
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 
   def test_loading_with_one_association_with_non_preload
     posts = Post.all.merge!(includes: :last_comment, order: "comments.id DESC").to_a
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 
@@ -1309,7 +1309,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_include_has_one_using_primary_key
     expected = accounts(:signals37)
-    firm = Firm.all.merge!(includes: :account_using_primary_key, order: "accounts.id").to_a.detect { |f| f.id == 1 }
+    firm = Firm.all.merge!(includes: :account_using_primary_key, order: "accounts.id").to_a.find_by(id: 1)
     assert_no_queries do
       assert_equal expected, firm.account_using_primary_key
     end

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -89,7 +89,7 @@ if ActiveRecord::Base.connection.supports_comments?
     def test_add_index_with_comment_later
       unless current_adapter?(:OracleAdapter)
         @connection.add_index :commenteds, :obvious, name: "idx_obvious", comment: "We need to see obvious comments"
-        index = @connection.indexes("commenteds").find { |idef| idef.name == "idx_obvious" }
+        index = @connection.indexes("commenteds").find_by(name: "idx_obvious")
         assert_equal "We need to see obvious comments", index.comment
       end
     end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -325,7 +325,7 @@ class FixturesTest < ActiveRecord::TestCase
   def test_create_fixtures
     fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "organizations")
     assert Organization.find_by_name("No Such Agency"), "'No Such Agency' is not in the database"
-    assert fixtures.detect { |f| f.name == "organizations" }, "no fixtures named 'organizations' in #{fixtures.map(&:name).inspect}"
+    assert fixtures.find_by(name: "organizations"), "no fixtures named 'organizations' in #{fixtures.map(&:name).inspect}"
   end
 
   def test_multiple_clean_fixtures
@@ -339,7 +339,7 @@ class FixturesTest < ActiveRecord::TestCase
     fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :collections, collections: Course) { Course.connection }
 
     assert Course.find_by_name("Collection"), "course is not in the database"
-    assert fixtures.detect { |f| f.name == "collections" }, "no fixtures named 'collections' in #{fixtures.map(&:name).inspect}"
+    assert fixtures.find_by(name: "collections"), "no fixtures named 'collections' in #{fixtures.map(&:name).inspect}"
   end
 
   def test_attributes

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -63,11 +63,11 @@ module ActiveRecord
         end
 
         columns = connection.columns(:testings)
-        one = columns.detect { |c| c.name == "one" }
-        two = columns.detect { |c| c.name == "two" }
-        three = columns.detect { |c| c.name == "three" }
-        four = columns.detect { |c| c.name == "four" }
-        five = columns.detect { |c| c.name == "five" } unless mysql
+        one = columns.find_by(name: "one")
+        two = columns.find_by(name: "two")
+        three = columns.find_by(name: "three")
+        four = columns.find_by(name: "four")
+        five = columns.find_by(name: "five") unless mysql
 
         assert_equal "hello", one.default
         assert_equal true, connection.lookup_cast_type_from_column(two).deserialize(two.default)
@@ -82,7 +82,7 @@ module ActiveRecord
           connection.add_column :testings, :foo, :string, array: true
 
           columns = connection.columns(:testings)
-          array_column = columns.detect { |c| c.name == "foo" }
+          array_column = columns.find_by(name: "foo")
 
           assert_predicate array_column, :array?
         end
@@ -93,7 +93,7 @@ module ActiveRecord
           end
 
           columns = connection.columns(:testings)
-          array_column = columns.detect { |c| c.name == "foo" }
+          array_column = columns.find_by(name: "foo")
 
           assert_predicate array_column, :array?
         end
@@ -104,7 +104,7 @@ module ActiveRecord
           t.bigint :eight_int
         end
         columns = connection.columns(:testings)
-        eight   = columns.detect { |c| c.name == "eight_int"   }
+        eight   = columns.find_by(name: "eight_int")
 
         if current_adapter?(:OracleAdapter)
           assert_equal "NUMBER(19)", eight.sql_type
@@ -130,13 +130,13 @@ module ActiveRecord
         end
 
         columns = connection.columns(:testings)
-        foo = columns.detect { |c| c.name == "foo" }
+        foo = columns.find_by(name: "foo")
         assert_equal 255, foo.limit
 
-        default = columns.detect { |c| c.name == "default_int" }
-        one     = columns.detect { |c| c.name == "one_int"     }
-        four    = columns.detect { |c| c.name == "four_int"    }
-        eight   = columns.detect { |c| c.name == "eight_int"   }
+        default = columns.find_by(name: "default_int")
+        one     = columns.find_by(name: "one_int")
+        four    = columns.find_by(name: "four_int")
+        eight   = columns.find_by(name: "eight_int")
 
         if current_adapter?(:PostgreSQLAdapter)
           assert_equal "integer", default.sql_type
@@ -213,8 +213,8 @@ module ActiveRecord
         end
         created_columns = connection.columns(table_name)
 
-        created_at_column = created_columns.detect { |c| c.name == "created_at" }
-        updated_at_column = created_columns.detect { |c| c.name == "updated_at" }
+        created_at_column = created_columns.find_by(name: "created_at")
+        updated_at_column = created_columns.find_by(name: "updated_at")
 
         assert_not created_at_column.null
         assert_not updated_at_column.null
@@ -226,8 +226,8 @@ module ActiveRecord
         end
         created_columns = connection.columns(table_name)
 
-        created_at_column = created_columns.detect { |c| c.name == "created_at" }
-        updated_at_column = created_columns.detect { |c| c.name == "updated_at" }
+        created_at_column = created_columns.find_by(name: "created_at")
+        updated_at_column = created_columns.find_by(name: "updated_at")
 
         assert created_at_column.null
         assert updated_at_column.null
@@ -275,7 +275,7 @@ module ActiveRecord
           t.column :foo, :timestamp
         end
 
-        column = connection.columns(:testings).find { |c| c.name == "foo" }
+        column = connection.columns(:testings).find_by(name: "foo")
 
         assert_equal :datetime, column.type
 
@@ -295,7 +295,7 @@ module ActiveRecord
           t.column :foo, :datetime
         end
 
-        column = connection.columns(:testings).find { |c| c.name == "foo" }
+        column = connection.columns(:testings).find_by(name: "foo")
 
         assert_equal :datetime, column.type
 
@@ -316,7 +316,7 @@ module ActiveRecord
               t.column :foo, :datetime
             end
 
-            column = connection.columns(:testings).find { |c| c.name == "foo" }
+            column = connection.columns(:testings).find_by(name: "foo")
 
             assert_equal :datetime, column.type
             assert_equal "timestamp(6) with time zone", column.sql_type
@@ -331,7 +331,7 @@ module ActiveRecord
 
         connection.change_column :testings, :foo, :timestamp
 
-        column = connection.columns(:testings).find { |c| c.name == "foo" }
+        column = connection.columns(:testings).find_by(name: "foo")
 
         assert_equal :datetime, column.type
 
@@ -422,9 +422,9 @@ module ActiveRecord
           end
           notnull_migration.new.suppress_messages do
             notnull_migration.migrate(:up)
-            assert_equal false, connection.columns(:testings).find { |c| c.name == "foo" }.null
+            assert_equal false, connection.columns(:testings).find_by(name: "foo").null
             notnull_migration.migrate(:down)
-            assert connection.columns(:testings).find { |c| c.name == "foo" }.null
+            assert connection.columns(:testings).find_by(name: "foo").null
           end
         end
       end

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -50,7 +50,7 @@ if ActiveRecord::Base.connection.supports_check_constraints?
               @connection.add_check_constraint(:trades,
                 "CASE WHEN price IS NOT NULL THEN true ELSE false END", name: "price_is_required")
 
-              constraint = @connection.check_constraints("trades").find { |c| c.name == "price_is_required" }
+              constraint = @connection.check_constraints("trades").find_by(name: "price_is_required")
               assert_includes constraint.expression, "WHEN price IS NOT NULL"
             ensure
               @connection.remove_check_constraint(:trades, name: "price_is_required")

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -54,20 +54,20 @@ module ActiveRecord
       def test_rename_column_preserves_default_value_not_null
         add_column "test_models", "salary", :integer, default: 70000
 
-        default_before = connection.columns("test_models").find { |c| c.name == "salary" }.default
+        default_before = connection.columns("test_models").find_by(name: "salary").default
         assert_equal "70000", default_before
 
         rename_column "test_models", "salary", "annual_salary"
 
         assert_includes TestModel.column_names, "annual_salary"
-        default_after = connection.columns("test_models").find { |c| c.name == "annual_salary" }.default
+        default_after = connection.columns("test_models").find_by(name: "annual_salary").default
         assert_equal "70000", default_after
       end
 
       if current_adapter?(:Mysql2Adapter)
         def test_mysql_rename_column_preserves_auto_increment
           rename_column "test_models", "id", "id_test"
-          assert_predicate connection.columns("test_models").find { |c| c.name == "id_test" }, :auto_increment?
+          assert_predicate connection.columns("test_models").find_by(name: "id_test"), :auto_increment?
           TestModel.reset_column_information
         ensure
           rename_column "test_models", "id_test", "id"

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -495,7 +495,7 @@ module ActiveRecord
 
         ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
 
-        column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
+        column = connection.columns(:more_testings).find_by(name: "testings_id")
 
         if current_adapter?(:SQLite3Adapter)
           assert_match(/integer/i, column.sql_type)
@@ -525,7 +525,7 @@ module ActiveRecord
 
         ActiveRecord::Migrator.new(:up, [create_migration, migration], @schema_migration, @internal_metadata).migrate
 
-        column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
+        column = connection.columns(:more_testings).find_by(name: "testings_id")
 
         if current_adapter?(:SQLite3Adapter)
           assert_match(/integer/i, column.sql_type)

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -50,7 +50,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
 
-          fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
+          fk = @connection.foreign_keys("testings").find_by(to_table: "testing_parents")
           assert_equal "other_id", fk.primary_key
         end
 
@@ -116,7 +116,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             t.references :testing_parent, foreign_key: { primary_key: :other_id }
           end
 
-          fk = @connection.foreign_keys("testings").find { |k| k.to_table == "testing_parents" }
+          fk = @connection.foreign_keys("testings").find_by(to_table: "testing_parents")
           assert_equal "other_id", fk.primary_key
         end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -911,7 +911,7 @@ class MigrationTest < ActiveRecord::TestCase
     }
 
     columns = Person.connection.columns(:binary_testings)
-    data_column = columns.detect { |c| c.name == "data" }
+    data_column = columns.find_by(name: "data")
 
     assert_nil data_column.default
   ensure
@@ -1545,7 +1545,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       end
 
       def column(name)
-        columns.detect { |c| c.name == name.to_s }
+        columns.find_by(name: name.to_s)
       end
 
       def columns
@@ -1553,7 +1553,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       end
 
       def index(name)
-        indexes.detect { |i| i.name == name.to_s }
+        indexes.find_by(name: name.to_s)
       end
 
       def indexes

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -656,7 +656,7 @@ module NestedAttributesOnACollectionAssociationTests
   def test_should_not_overwrite_unsaved_updates_when_loading_association
     @pirate.reload
     @pirate.public_send(association_setter, [{ id: @child_1.id, name: "Grace OMalley" }])
-    assert_equal "Grace OMalley", @pirate.public_send(@association_name).load_target.find { |r| r.id == @child_1.id }.name
+    assert_equal "Grace OMalley", @pirate.public_send(@association_name).load_target.find_by(id: @child_1.id).name
   end
 
   def test_should_preserve_order_when_not_overwriting_unsaved_updates
@@ -677,7 +677,7 @@ module NestedAttributesOnACollectionAssociationTests
   def test_should_not_remove_scheduled_destroys_when_loading_association
     @pirate.reload
     @pirate.public_send(association_setter, [{ id: @child_1.id, _destroy: "1" }])
-    assert_predicate @pirate.public_send(@association_name).load_target.find { |r| r.id == @child_1.id }, :marked_for_destruction?
+    assert_predicate @pirate.public_send(@association_name).load_target.find_by(id: @child_1.id), :marked_for_destruction?
   end
 
   def test_should_take_a_hash_with_composite_id_keys_and_assign_the_attributes_to_the_associated_models

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -436,7 +436,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
 
     test "primary key column type with serial/integer" do
       @connection.create_table(:widgets, id: @pk_type, force: true)
-      column = @connection.columns(:widgets).find { |c| c.name == "id" }
+      column = @connection.columns(:widgets).find_by(name: "id")
       assert_equal :integer, column.type
       assert_not_predicate column, :bigint?
     end
@@ -456,7 +456,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
     if current_adapter?(:Mysql2Adapter)
       test "primary key column type with options" do
         @connection.create_table(:widgets, id: :primary_key, limit: 4, unsigned: true, force: true)
-        column = @connection.columns(:widgets).find { |c| c.name == "id" }
+        column = @connection.columns(:widgets).find_by(name: "id")
         assert_predicate column, :auto_increment?
         assert_equal :integer, column.type
         assert_not_predicate column, :bigint?
@@ -468,7 +468,7 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
 
       test "bigint primary key with unsigned" do
         @connection.create_table(:widgets, id: :bigint, unsigned: true, force: true)
-        column = @connection.columns(:widgets).find { |c| c.name == "id" }
+        column = @connection.columns(:widgets).find_by(name: "id")
         assert_predicate column, :auto_increment?
         assert_equal :integer, column.type
         assert_predicate column, :bigint?

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -234,7 +234,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     relations << Post.eager_load(:last_comment).merge(Post.order("comments.id DESC")).merge(Post.all)
 
     relations.each do |posts|
-      post = posts.find { |p| p.id == 1 }
+      post = posts.find_by(id: 1)
       assert_equal Post.find(1).last_comment, post.last_comment
     end
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -722,7 +722,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_loading_with_one_association
     posts = Post.preload(:comments)
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal 2, post.comments.size
     assert_includes post.comments, comments(:greetings)
 
@@ -731,7 +731,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_includes post.comments, comments(:greetings)
 
     posts = Post.preload(:last_comment)
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 
@@ -751,7 +751,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_loading_with_one_association_with_non_preload
     posts = Post.eager_load(:last_comment).order("comments.id DESC")
-    post = posts.find { |p| p.id == 1 }
+    post = posts.find_by(id: 1)
     assert_equal Post.find(1).last_comment, post.last_comment
   end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `Enumerable#find_by`, per `ActiveRecord::FinderMethods#find_by`.
+
+    Finds the first element matching the specified attributes.
+
+    *Américo Duarte*
+
 *   Add italic and underline support to `ActiveSupport::LogSubscriber#color`
 
     Previously, only bold text was supported via a positional argument.

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -110,6 +110,30 @@ module Enumerable
     end
   end
 
+  # Finds the first element matching the specified attributes.
+  #
+  #   people = [
+  #     Person.new(first_name: "Jane", last_name: "Doe", age: 23),
+  #     Person.new(first_name: "John", last_name: "Doe", age: 42),
+  #     Person.new(first_name: "John", last_name: "Doe", age: 32)
+  #   ]
+  #
+  #   people.find_by(first_name: 'John', last_name: 'Doe')
+  #   # => #<Person first_name: "John", last_name: "Doe", age: 42>
+  #
+  #   people.find_by(last_name: 'Doe')
+  #   # => #<Person first_name: "Jane", last_name: "Doe", age: 23>
+  #
+  #   people.find_by(age: 32)
+  #   # => #<Person first_name: "John", last_name: "Doe", age: 32>
+  def find_by(attrs)
+    find do |elem|
+      attrs.all? do |attr_name, value|
+        elem.public_send(attr_name) == value
+      end
+    end
+  end
+
   # Convert an enumerable to a hash, using the element as the key and the block
   # result as the value.
   #

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2255,6 +2255,23 @@ NOTE: Defined in `active_support/core_ext/enumerable.rb`.
 
 [Enumerable#index_by]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-index_by
 
+### `find_by`
+
+The method [`find_by`][Enumerable#find_by] returns the first element which has all the specified attributes.
+
+It iterates the collection and returns the first element which has all the attributes from a given Hash.
+
+So instead of this `posts.find { |p| p.author_name == 'DHH' && p.category == 'Ruby on Rails' }` you can do this:
+
+```ruby
+posts.find_by(author_name: 'DHH', category: 'Ruby on Rails')
+# => #<Post author_name: 'DHH', category: 'Ruby On Rails'>
+```
+
+NOTE: Defined in `active_support/core_ext/enumerable.rb`.
+
+[Enumerable#find_by]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-find_by
+
 ### `index_with`
 
 The method [`index_with`][Enumerable#index_with] generates a hash with the elements of an enumerable as keys. The value


### PR DESCRIPTION
Add `Enumerable#find_by` that mimic  `ActiveRecord::FinderMethods#find_by`, as other methods do, like [`minimum`](https://github.com/rails/rails/blob/25396b1/activesupport/lib/active_support/core_ext/enumerable.rb#L40-L46), [`maximum`](https://github.com/rails/rails/blob/25396b1/activesupport/lib/active_support/core_ext/enumerable.rb#L48-L54), [`pluck`](https://github.com/rails/rails/blob/25396b1/activesupport/lib/active_support/core_ext/enumerable.rb#L189-L203), [`pick`](https://github.com/rails/rails/blob/25396b1/activesupport/lib/active_support/core_ext/enumerable.rb#L205-L220) and others.

### Motivation / Background

Would be nice if instead of this

```ruby
people.find do |person|
  person.name == 'John' && person.age == 42
end
```

We could do this

```ruby
people.find_by(name: 'John', age: 42)
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
