### PR TITLE
allow direct uploads to work within engines

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1013,9 +1013,14 @@ module ActionView
         end
 
         def convert_direct_upload_option_to_url(options)
-          if options.delete(:direct_upload) && respond_to?(:rails_direct_uploads_url)
+          return options unless options.delete(:direct_upload)
+
+          if respond_to?(:rails_direct_uploads_url)
             options["data-direct-upload-url"] = rails_direct_uploads_url
+          elsif respond_to?(:main_app) && main_app.respond_to?(:rails_direct_uploads_url)
+            options["data-direct-upload-url"] = main_app.rails_direct_uploads_url
           end
+
           options
         end
     end

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -118,6 +118,7 @@ module ApplicationTests
           get '/application_route_in_view', to: 'posts#application_route_in_view'
           get '/engine_polymorphic_path', to: 'posts#engine_polymorphic_path'
           get '/engine_asset_path', to: 'posts#engine_asset_path'
+          get '/file_field_with_direct_upload_path', to: 'posts#file_field_with_direct_upload_path'
         end
       RUBY
 
@@ -149,6 +150,10 @@ module ApplicationTests
 
             def engine_asset_path
               render inline: "<%= asset_path 'images/foo.png', skip_pipeline: true %>"
+            end
+
+            def file_field_with_direct_upload_path
+              render inline: "<%= file_field_tag :image, direct_upload: true %>"
             end
           end
         end
@@ -268,6 +273,10 @@ module ApplicationTests
       # test that asset path will not get script_name when generated in the engine
       get "/someone/blog/engine_asset_path"
       assert_equal "/images/foo.png", last_response.body
+
+      # test that the active storage direct upload URL is added to a file field that explicitly requires it within en engine's view code
+      get "/someone/blog/file_field_with_direct_upload_path"
+      assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\" />", last_response.body
     end
 
     test "route path for controller action when engine is mounted at root" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because direct uploads don't work when attempting to call them from inside a Rails Engine.

### Detail

This Pull Request changes the `convert_direct_upload_option_to_url` conditionals that determine wether it should add an upload URL as a data attribute or not. It now uses the `main_app` helper to verify if the `rails_direct_uploads_url` exists. Before this change, calling this method inside of a template in an engine would result in it being looked up in the engine's routes instead of the main app's one which it wouldn't find.

The test is there to prevent a regression.

### Additional information

No additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
