### PR TITLE
Ruby 3.2 `FileUtils.rm_f` raises `Errno::EISDIR` to remove directories

### DIFF
--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -251,7 +251,7 @@ module ApplicationTests
         directory ||= suite
         create_fixture_test directory
         assert_match "3 users", run_test_command("test/#{suite}")
-        Dir.chdir(app_path) { FileUtils.rm_f "test/#{directory}" }
+        Dir.chdir(app_path) { FileUtils.rm_r "test/#{directory}" }
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

This pull request addresses the following error reported at #45983


### Detail

This pull request addresses the following error.

```ruby
% cd rails/railties
% rm ../Gemfile.lock
% bundle install
$ bin/test test/application/test_runner_test.rb -n test_load_fixtures_when_running_test_suites

E

Error:
ApplicationTests::TestRunnerTest#test_load_fixtures_when_running_test_suites:
Errno::EISDIR: Is a directory @ apply2files - test/models
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2300:in `unlink'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2300:in `block in remove_file'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2305:in `platform_support'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2299:in `remove_file'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1449:in `remove_file'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1189:in `block in rm'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1188:in `each'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1188:in `rm'
    /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1211:in `rm_f'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/test_runner_test.rb:254:in `block (2 levels) in test_load_fixtures_when_running_test_suites'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/test_runner_test.rb:254:in `chdir'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/test_runner_test.rb:254:in `block in test_load_fixtures_when_running_test_suites'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/test_runner_test.rb:250:in `each'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/test_runner_test.rb:250:in `test_load_fixtures_when_running_test_suites'

bin/test test/application/test_runner_test.rb:246

Finished in 2.319535s, 0.4311 runs/s, 0.8622 assertions/s.
1 runs, 2 assertions, 0 failures, 1 errors, 0 skips
$ ruby -v
ruby 3.2.0preview2 (2022-09-09 master 35cfc9a3bb) [x86_64-linux]
```

Fix #45983

### Additional information

* Ruby 3.2.0.preview2 raises `Errno::EISDIR` if `FileUtils.rm_f` fails to remove directories

```ruby
$ ruby -v
ruby 3.2.0preview2 (2022-09-09 master 35cfc9a3bb) [x86_64-linux]
$ mkdir foo
$ ruby -rfileutils -e 'FileUtils.rm_f("foo")'
/home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2300:in `unlink': Is a directory @ apply2files - foo (Errno::EISDIR)
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2300:in `block in remove_file'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2305:in `platform_support'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:2299:in `remove_file'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1449:in `remove_file'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1189:in `block in rm'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1188:in `each'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1188:in `rm'
	from /home/yahonda/.rbenv/versions/3.2.0-preview2/lib/ruby/3.2.0+2/fileutils.rb:1211:in `rm_f'
	from -e:1:in `<main>'
$ ls -ld foo/
drwxrwxr-x 2 yahonda yahonda 4096 Sep 10 23:00 foo/
```

* Ruby 3.1 does not raise any exceptions even if `FileUtils.rm_f` fails to remove directories

```ruby
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
$ mkdir foo
$ ruby -rfileutils -e 'FileUtils.rm_f("foo")'
$ ls -ld foo/
drwxrwxr-x 2 yahonda yahonda 4096 Sep 10 23:01 foo/
$
```

* Ruby 3.2.0.preview2 `FileUtils.rm_r` successfuly removes directories

```ruby
$ ruby -v
ruby 3.2.0preview2 (2022-09-09 master 35cfc9a3bb) [x86_64-linux]
$ mkdir foo
$ ruby -rfileutils -e 'FileUtils.rm_r("foo")'
$ ls -ld foo
ls: cannot access 'foo': No such file or directory
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
