### PR TITLE
Clarify --edge points to latest stable branch of rails

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -92,7 +92,7 @@ module Rails
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
         class_option :edge,                type: :boolean, default: nil,
-                                           desc: "Set up the #{name} with Gemfile pointing to Rails repository"
+                                           desc: "Set up the #{name} with a Gemfile pointing to the #{edge_branch} branch on the Rails repository"
 
         class_option :main,                type: :boolean, default: nil, aliases: "--master",
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository main branch"
@@ -105,6 +105,10 @@ module Rails
 
         class_option :help,                type: :boolean, aliases: "-h", group: :rails,
                                            desc: "Show this help message and quit"
+      end
+
+      def self.edge_branch # :nodoc:
+        Rails.gem_version.prerelease? ? "main" : [*Rails.gem_version.segments.first(2), "stable"].join("-")
       end
 
       def initialize(positional_argv, option_argv, *)
@@ -357,7 +361,6 @@ module Rails
         if options.dev?
           GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH, "Use local checkout of Rails")
         elsif options.edge?
-          edge_branch = Rails.gem_version.prerelease? ? "main" : [*Rails.gem_version.segments.first(2), "stable"].join("-")
           GemfileEntry.github("rails", "rails/rails", edge_branch, "Use specific branch of Rails")
         elsif options.main?
           GemfileEntry.github("rails", "rails/rails", "main", "Use main development branch of Rails")
@@ -564,6 +567,10 @@ module Rails
         else
           "git init && git symbolic-ref HEAD refs/heads/main"
         end
+      end
+
+      def edge_branch
+        self.class.edge_branch
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

I thought the `--edge` and `--main` options for app generation were redundant based on the descriptions, but edge points to the stable branch (unless you're using a prerelease, where it uses main) where main always points the generated app to the main branch.

### Detail

Be more specific in the description that this option points to the stable branch for a given version.

The --edge option points or the latest stable branch of a release of rails (eg. rails _7.0.4_ new my_app --edge would point to 7-0-stable).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.
