### PR TITLE
Allow empty callstack in `AS::Deprecation#warn`

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -125,6 +125,7 @@ module ActiveSupport
         end
 
         def extract_callstack(callstack)
+          return [] if callstack.empty?
           return _extract_callstack(callstack) if callstack.first.is_a? String
 
           offending_line = callstack.find { |frame|

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -501,6 +501,15 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_deprecated(/g is deprecated/) { @dtc.g(1) }
   end
 
+  test "warn with empty callstack" do
+    @deprecator.behavior = :silence
+
+    assert_nothing_raised do
+      @deprecator.warn("message", [])
+      Thread.new { @deprecator.warn("message") }.join
+    end
+  end
+
   def test_config_disallows_no_deprecations_by_default
     assert_equal @deprecator.disallowed_warnings, []
   end
@@ -803,7 +812,7 @@ class DeprecationTest < ActiveSupport::TestCase
       # barrier.wait
       @deprecator.allow "fubar" do
         th2 = Thread.new do
-          @deprecator.warn("using fubar is deprecated", ["call stack"])
+          @deprecator.warn("using fubar is deprecated")
         end
         th2.join
       end


### PR DESCRIPTION
This fixes an "undefined method 'path' for nil:NilClass" error in `Deprecation::Reporting#extract_callstack` when the callstack is empty, either because it was specified as such or because the `warn` call was not sufficiently deep in a call tree (e.g. at the top level of a new thread).
