### PR TITLE
ErrorReporter: allow to unsubscribe

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -123,6 +123,18 @@ module ActiveSupport
       @subscribers << subscriber
     end
 
+    # Unregister an error subscriber. Accepts either a subscriber or a class.
+    #
+    #  subscriber = MyErrorSubscriber.new
+    #  Rails.error.subscribe(subscriber)
+    #
+    #  Rails.error.unsubscribe(subscriber)
+    #  # or
+    #  Rails.error.unsubscribe(MyErrorSubscriber)
+    def unsubscribe(subscriber)
+      @subscribers.delete_if { |s| subscriber === s }
+    end
+
     # Prevent a subscriber from being notified of errors for the
     # duration of the block. You may pass in the subscriber itself, or its class.
     #

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -143,6 +143,31 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal 1, second_subscriber.events.size
   end
 
+  test "can unsubscribe" do
+    second_subscriber = ErrorSubscriber.new
+    @reporter.subscribe(second_subscriber)
+
+    error = ArgumentError.new("Oops")
+    @reporter.report(error, handled: true)
+
+    @reporter.unsubscribe(second_subscriber)
+
+    error = ArgumentError.new("Oops 2")
+    @reporter.report(error, handled: true)
+
+    assert_equal 2, @subscriber.events.size
+    assert_equal 1, second_subscriber.events.size
+
+    @reporter.subscribe(second_subscriber)
+    @reporter.unsubscribe(ErrorSubscriber)
+
+    error = ArgumentError.new("Oops 3")
+    @reporter.report(error, handled: true)
+
+    assert_equal 2, @subscriber.events.size
+    assert_equal 1, second_subscriber.events.size
+  end
+
   test "handled errors default to :warning severity" do
     @reporter.report(@error, handled: true)
     assert_equal :warning, @subscriber.events.dig(0, 2)


### PR DESCRIPTION
This may be useful if you'd like to replace or remove a subscriber added by one of your dependencies.

~~I'm in the process of migrating our app to use `Rails.error`, and this came up because I'd like to implement a `assert_error_reported(criterias)` test helper. So naturally this would subscribe for the duration of the block.~~

FYI @st0012 