### PR TITLE
Bundler should use platform :windows instead of :mingw, etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ group :test do
   gem "benchmark-ips"
 end
 
-platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
+platforms :ruby, :windows do
   gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
 
   # Needed for compiling the ActionDispatch::Journey parser.
@@ -174,8 +174,8 @@ if ENV["ORACLE_ENHANCED"]
   gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
 end
 
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
+gem "tzinfo-data", platforms: [:windows, :jruby]
+gem "wdm", ">= 0.1.0", platforms: [:windows]
 
 # The error_highlight gem only works on CRuby 3.1 or later.
 # Also, Rails depends on a new API available since error_highlight 0.4.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,4 +633,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.3.17
+   2.3.22

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -476,6 +476,10 @@ module Rails
         !(options[:skip_bundle] || options[:pretend])
       end
 
+      def bundler_windows_platforms
+        Gem.rubygems_version >= Gem::Version.new("3.3.22") ? "windows" : "mswin mswin64 mingw x64_mingw"
+      end
+
       def depends_on_system_test?
         !(options[:skip_system_test] || options[:skip_test] || options[:api])
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -16,7 +16,7 @@ ruby <%= "\"#{Gem.ruby_version}\"" -%>
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
@@ -41,7 +41,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
 end
 <% end -%>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -13,7 +13,7 @@ gemspec
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 <% end -%>
-<% if RUBY_PLATFORM.match?(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
+<% if RUBY_PLATFORM.match?(/mingw|mswin|java/) -%>
 
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
 <% end -%>

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -92,6 +92,7 @@ module GeneratorsTestHelper
         depends_on_system_test: false,
         options: ActiveSupport::OrderedOptions.new,
         skip_sprockets: false,
+        bundler_windows_platforms: "windows",
       }
     end
 end


### PR DESCRIPTION
Bundler should use platform `:windows` instead of `:mingw, :mswin, :x64_mingw, :mswin64` (the former is an alias for the latter).

This is a recently added feature to bundler/rubygems released in v3.3.22. It will not work on older bundler/rubygems versions.

I've updated both Rails' own Gemfile, as well as the Gemfile templates in the app/plugin generators.