### PR TITLE
Minor refactoring to schema migration and internal metadata

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1085,15 +1085,25 @@ module ActiveRecord
 
     def initialize(migrations_paths, schema_migration = nil, internal_metadata = nil)
       if schema_migration == SchemaMigration
-        schema_migration = SchemaMigration.new(ActiveRecord::Base.connection)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          SchemaMigration no longer inherits from ActiveRecord::Base. If you want
+          to use the default connection, remove this argument. If you want to use a
+          specific connection, instaniate MigrationContext with the connection's schema
+          migration, for example `MigrationContext.new(path, Dog.connection.schema_migration)`.
+        MSG
 
-        ActiveSupport::Deprecation.warn("SchemaMigration no longer inherits from ActiveRecord::Base. Please instaniate a new SchemaMigration object with the desired connection, ie `ActiveRecord::SchemaMigration.new(ActiveRecord::Base.connection)`.")
+        schema_migration = nil
       end
 
       if internal_metadata == InternalMetadata
-        internal_metadata = InternalMetadata.new(ActiveRecord::Base.connection)
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          SchemaMigration no longer inherits from ActiveRecord::Base. If you want
+          to use the default connection, remove this argument. If you want to use a
+          specific connection, instaniate MigrationContext with the connection's internal
+          metadata, for example `MigrationContext.new(path, nil, Dog.connection.internal_metadata)`.
+        MSG
 
-        ActiveSupport::Deprecation.warn("InternalMetadata no longer inherits from ActiveRecord::Base. Please instaniate a new InternalMetadata object with the desired connection, ie `ActiveRecord::InternalMetadata.new(ActiveRecord::Base.connection)`.")
+        internal_metadata = nil
       end
 
       @migrations_paths = migrations_paths

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -6,6 +6,9 @@ module ActiveRecord
   # number is inserted in to the schema migrations table so it doesn't need
   # to be executed the next time.
   class SchemaMigration # :nodoc:
+    class NullSchemaMigration
+    end
+
     attr_reader :connection, :arel_table
 
     def initialize(connection)
@@ -79,9 +82,6 @@ module ActiveRecord
 
     def table_exists?
       connection.data_source_exists?(table_name)
-    end
-
-    class NullSchemaMigration
     end
   end
 end


### PR DESCRIPTION
This clean up wraps the messages at 80 characters and clarifies the changes needed. 99% of apps won't see this warning as they aren't accessing MigrationContext directly. This is only for libraries or apps that are passing a custom `SchemaMigration` or `InternalMetadata` class so they get a more helpful error.

In addition I moved the `NullSchemaMigration` up to the top of the class to match InternalMetadata.
