### PR TITLE
Fix bug in internal metadata

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -96,7 +96,11 @@ module ActiveRecord
         entry = select_entry(key)
 
         if entry
-          update_entry(key, value)
+          if entry[value_key] != value
+            update_entry(key, value)
+          else
+            entry[value_key]
+          end
         else
           create_entry(key, value)
         end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -762,6 +762,31 @@ class MigrationTest < ActiveRecord::TestCase
     @internal_metadata.create_table
   end
 
+  def test_inserting_a_new_entry_into_internal_metadata
+    @internal_metadata[:version] = "foo"
+    assert_equal "foo", @internal_metadata[:version]
+  ensure
+    @internal_metadata.delete_all_entries
+  end
+
+  def test_updating_an_existing_entry_into_internal_metadata
+    @internal_metadata[:version] = "foo"
+    updated_at = @internal_metadata.send(:select_entry, :version)["updated_at"]
+    assert_equal "foo", @internal_metadata[:version]
+
+    # same version doesn't update timestamps
+    @internal_metadata[:version] = "foo"
+    assert_equal "foo", @internal_metadata[:version]
+    assert_equal updated_at, @internal_metadata.send(:select_entry, :version)["updated_at"]
+
+    # updated version updates timestamps
+    @internal_metadata[:version] = "not_foo"
+    assert_equal "not_foo", @internal_metadata[:version]
+    assert_not_equal updated_at, @internal_metadata.send(:select_entry, :version)["updated_at"]
+  ensure
+    @internal_metadata.delete_all_entries
+  end
+
   def test_internal_metadata_create_table_wont_be_affected_by_schema_cache
     @internal_metadata.drop_table
     assert_not_predicate @internal_metadata, :table_exists?


### PR DESCRIPTION
Since changing internal metadata to no longer inherit from Base in #45982 I accidentally changed the behavior when a key's value is the same. Prior to this change the record would not be updated if the environment key was found an the value had not changed. So instead of just checking whether we have an entry here we also need to check if the value should actually be updated, otherwise we should return the entry.
