### PR TITLE
Fix disallowed deprecations with default warning

### DIFF
--- a/activesupport/lib/active_support/deprecation/disallowed.rb
+++ b/activesupport/lib/active_support/deprecation/disallowed.rb
@@ -27,7 +27,7 @@ module ActiveSupport
           disallowed = ActiveSupport::Deprecation.disallowed_warnings
           return false if explicitly_allowed?(message)
           return true if disallowed == :all
-          disallowed.any? do |rule|
+          message && disallowed.any? do |rule|
             case rule
             when String, Symbol
               message.include?(rule.to_s)
@@ -41,8 +41,7 @@ module ActiveSupport
           allowances = @explicitly_allowed_warnings.value
           return false unless allowances
           return true if allowances == :all
-          allowances = [allowances] unless allowances.kind_of?(Array)
-          allowances.any? do |rule|
+          message && Array(allowances).any? do |rule|
             case rule
             when String, Symbol
               message.include?(rule.to_s)

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -19,11 +19,11 @@ module ActiveSupport
         return if silenced
 
         callstack ||= caller_locations(2)
-        deprecation_message(callstack, message).tap do |m|
+        deprecation_message(callstack, message).tap do |full_message|
           if deprecation_disallowed?(message)
-            disallowed_behavior.each { |b| b.call(m, callstack, deprecation_horizon, gem_name) }
+            disallowed_behavior.each { |b| b.call(full_message, callstack, deprecation_horizon, gem_name) }
           else
-            behavior.each { |b| b.call(m, callstack, deprecation_horizon, gem_name) }
+            behavior.each { |b| b.call(full_message, callstack, deprecation_horizon, gem_name) }
           end
         end
       end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -584,6 +584,14 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_match(/fubar/, @c)
   end
 
+  test "disallowed_warnings with the default warning message" do
+    @deprecator.disallowed_warnings = :all
+    assert_disallowed(/./, @deprecator) { @deprecator.warn }
+
+    @deprecator.disallowed_warnings = ["fubar"]
+    assert_deprecated(/./, @deprecator) { @deprecator.warn }
+  end
+
   def test_allow
     @deprecator.disallowed_warnings = :all
 
@@ -675,6 +683,18 @@ class DeprecationTest < ActiveSupport::TestCase
 
     @deprecator.allow("fubar", if: -> { false }) do
       assert_disallowed(/fubar/, @deprecator) { @deprecator.warn("fubar") }
+    end
+  end
+
+  test "allow with the default warning message" do
+    @deprecator.disallowed_warnings = :all
+
+    @deprecator.allow(:all) do
+      assert_deprecated(/./, @deprecator) { @deprecator.warn }
+    end
+
+    @deprecator.allow(["fubar"]) do
+      assert_disallowed(/./, @deprecator) { @deprecator.warn }
     end
   end
 


### PR DESCRIPTION
This fixes "undefined method 'include?' for nil:NilClass" errors in both `deprecation_disallowed?` and `explicitly_allowed?` when using any string or symbol filter with the default (`nil`) warning message.
