### PR TITLE
Fix `disallowed_warnings` for non-global deprecators

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,39 @@
+*   `ActiveSupport::Deprecation#disallowed_warnings` now affects the instance on
+    which it is configured.
+
+    This means that individual `ActiveSupport::Deprecation` instances can be
+    configured with their own disallowed warnings, and the global
+    `ActiveSupport::Deprecation.disallowed_warnings` now only affects the global
+    `ActiveSupport::Deprecation.warn`.
+
+    **Before**
+
+    ```ruby
+    ActiveSupport::Deprecation.disallowed_warnings = ["foo"]
+    deprecator = ActiveSupport::Deprecation.new("2.0", "MyCoolGem")
+    deprecator.disallowed_warnings = ["bar"]
+
+    ActiveSupport::Deprecation.warn("foo") # => raise ActiveSupport::DeprecationException
+    ActiveSupport::Deprecation.warn("bar") # => print "DEPRECATION WARNING: bar"
+    deprecator.warn("foo")                 # => raise ActiveSupport::DeprecationException
+    deprecator.warn("bar")                 # => print "DEPRECATION WARNING: bar"
+    ```
+
+    **After**
+
+    ```ruby
+    ActiveSupport::Deprecation.disallowed_warnings = ["foo"]
+    deprecator = ActiveSupport::Deprecation.new("2.0", "MyCoolGem")
+    deprecator.disallowed_warnings = ["bar"]
+
+    ActiveSupport::Deprecation.warn("foo") # => raise ActiveSupport::DeprecationException
+    ActiveSupport::Deprecation.warn("bar") # => print "DEPRECATION WARNING: bar"
+    deprecator.warn("foo")                 # => print "DEPRECATION WARNING: foo"
+    deprecator.warn("bar")                 # => raise ActiveSupport::DeprecationException
+    ```
+
+    *Jonathan Hefner*
+
 *   Add italic and underline support to `ActiveSupport::LogSubscriber#color`
 
     Previously, only bold text was supported via a positional argument.

--- a/activesupport/lib/active_support/deprecation/disallowed.rb
+++ b/activesupport/lib/active_support/deprecation/disallowed.rb
@@ -24,10 +24,9 @@ module ActiveSupport
 
       private
         def deprecation_disallowed?(message)
-          disallowed = ActiveSupport::Deprecation.disallowed_warnings
           return false if explicitly_allowed?(message)
-          return true if disallowed == :all
-          message && disallowed.any? do |rule|
+          return true if disallowed_warnings == :all
+          message && disallowed_warnings.any? do |rule|
             case rule
             when String, Symbol
               message.include?(rule.to_s)

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -26,12 +26,7 @@ class DeprecationTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 
   def setup
-    @original_configuration = get_configuration(ActiveSupport::Deprecation)
-    @deprecator = ActiveSupport::Deprecation
-  end
-
-  def teardown
-    set_configuration(ActiveSupport::Deprecation, @original_configuration)
+    @deprecator = ActiveSupport::Deprecation.new
   end
 
   test "assert_deprecated" do
@@ -693,24 +688,6 @@ class DeprecationTest < ActiveSupport::TestCase
         @messages ||= []
       end
       deprecator
-    end
-
-    def get_configuration(deprecator)
-      %i[
-        debug
-        silenced
-        behavior
-        disallowed_behavior
-        disallowed_warnings
-      ].index_with do |attribute|
-        deprecator.public_send(attribute)
-      end
-    end
-
-    def set_configuration(deprecator, configuration)
-      configuration.each do |attribute, value|
-        deprecator.public_send("#{attribute}=", value)
-      end
     end
 
     module ::Rails; end


### PR DESCRIPTION
Prior to this commit, the globally configured `ActiveSupport::Deprecation.disallowed_warnings` affected all deprecators, and each deprecator's `#disallowed_warnings` had no effect. (Though the same was not true for `ActiveSupport::Deprecation.allow`, which would only affect warnings from `ActiveSupport::Deprecation.warn`, not warnings from non-global deprecators.)

This commit fixes `disallowed_warnings` to only affect the deprecator on which it is configured.
