### PR TITLE
Update guides on secuity page for sql injection sample code [ci-skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -614,10 +614,10 @@ SQL injection attacks aim at influencing database queries by manipulating web ap
 Project.where("name = '#{params[:name]}'")
 ```
 
-This could be in a search action and the user may enter a project's name that they want to find. If a malicious user enters `' OR 1 --`, the resulting SQL query will be:
+This could be in a search action and the user may enter a project's name that they want to find. If a malicious user enters `' OR 1) --`, the resulting SQL query will be:
 
 ```sql
-SELECT * FROM projects WHERE name = '' OR 1 --'
+SELECT * FROM projects WHERE (name = '' OR 1) --')
 ```
 
 The two dashes start a comment ignoring everything after it. So the query returns all records from the projects table including those blind to the user. This is because the condition is true for all records.


### PR DESCRIPTION
The SQL injection sample code in the Rails guide has been modified so that the attack succeeds with SQL generated by ActiveRecord in Rails 7.0.

It seems that `()` has been added to where method since some version.

## Before (attack failure)

`' OR 1 --`

```
irb> input_string = "' OR 1 --"
irb> Project.where("name = '#{input_string}'")
Project Load (0.2ms)  SELECT "projects".* FROM "projects" WHERE (name = '' OR 1 --')
=>
```

`WHERE (name = '' OR 1 --')`

`--` and after that are comments, but attack fails because `()` does not match.

## After (attack succeed)

`' OR 1) --`

```
irb> input_string = "' OR 1) --"
irb> Project.where("name = '#{input_string}'")
  Project Load (0.4ms)  SELECT "projects".* FROM "projects" WHERE (name = '' OR 1) --')
=>
[#<Project:0x000000010907eec8
  id: 1,
  name: "1",
  created_at: Wed, 14 Sep 2022 01:09:28.649529000 UTC +00:00,
  updated_at: Wed, 14 Sep 2022 01:09:28.649529000 UTC +00:00>,
 #<Project:0x00000001092b6498
  id: 2,
  name: "2",
  created_at: Wed, 14 Sep 2022 01:09:30.614712000 UTC +00:00,
  updated_at: Wed, 14 Sep 2022 01:09:30.614712000 UTC +00:00>]
```

`WHERE (name = '' OR 1) --')`

`--` and after that are comments, attack succeeds because `()` matches.

## sample code

- https://github.com/igaiga/rails704_ruby312_projects_app
- Rails 7.0.4
- Ruby 3.1.2
