### PR TITLE
Add `assert_error_reported` and `assert_no_error_reported`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `assert_error_reported` and `assert_no_error_reported`
+
+    Allows to easily asserts an error happened but was handled
+
+    ```ruby
+    report = assert_error_reported(IOError) do
+      # ...
+    end
+    assert_equal "Oops", report.error.message
+    assert_equal "admin", report.context[:section]
+    assert_equal :warning, report.severity
+    assert_predicate report, :handled?
+    ```
+
+    *Jean Boussier*
+
 *   `ActiveSupport::Deprecation` behavior callbacks can now receive the
     deprecator instance as an argument.  This makes it easier for such callbacks
     to change their behavior based on the deprecator's state.  For example,

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -95,6 +95,7 @@ module ActiveSupport
   cattr_accessor :test_order # :nodoc:
   cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
 
+  @error_reporter = ActiveSupport::ErrorReporter.new
   singleton_class.attr_accessor :error_reporter # :nodoc:
 
   def self.cache_format_version

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -109,7 +109,7 @@ module ActiveSupport
     end
 
     def self.error_reporter
-      @error_reporter ||= ActiveSupport::ErrorReporter.new
+      ActiveSupport.error_reporter
     end
 
     def self.active_key # :nodoc:

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -121,10 +121,6 @@ module ActiveSupport
       end
     end
 
-    initializer "active_support.set_error_reporter" do |app|
-      ActiveSupport.error_reporter = app.executor.error_reporter
-    end
-
     initializer "active_support.set_configs" do |app|
       app.config.active_support.each do |k, v|
         k = "#{k}="

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -5,6 +5,7 @@ require "minitest"
 require "active_support/testing/tagged_logging"
 require "active_support/testing/setup_and_teardown"
 require "active_support/testing/assertions"
+require "active_support/testing/error_reporter_assertions"
 require "active_support/testing/deprecation"
 require "active_support/testing/declarative"
 require "active_support/testing/isolation"
@@ -126,6 +127,7 @@ module ActiveSupport
     include ActiveSupport::Testing::TaggedLogging
     prepend ActiveSupport::Testing::SetupAndTeardown
     include ActiveSupport::Testing::Assertions
+    include ActiveSupport::Testing::ErrorReporterAssertions
     include ActiveSupport::Testing::Deprecation
     include ActiveSupport::Testing::ConstantStubbing
     include ActiveSupport::Testing::TimeHelpers

--- a/activesupport/lib/active_support/testing/error_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/error_reporter_assertions.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Testing
+    module ErrorReporterAssertions
+      module ErrorCollector
+        @subscribed = false
+        @mutex = Mutex.new
+
+        Report = Struct.new(:error, :handled, :severity, :context, :source, keyword_init: true)
+        class Report
+          alias_method :handled?, :handled
+        end
+
+        class << self
+          def record
+            subscribe
+            recorders = ActiveSupport::IsolatedExecutionState[:active_support_error_reporter_assertions] ||= []
+            reports = []
+            recorders << reports
+            begin
+              yield
+              reports
+            ensure
+              recorders.delete_if { |r| reports.equal?(r) }
+            end
+          end
+
+          def report(error, **kwargs)
+            report = Report.new(error: error, **kwargs)
+            ActiveSupport::IsolatedExecutionState[:active_support_error_reporter_assertions]&.each do |reports|
+              reports << report
+            end
+            true
+          end
+
+          private
+            def subscribe
+              return if @subscribed
+              @mutex.synchronize do
+                return if @subscribed
+
+                if ActiveSupport.error_reporter
+                  ActiveSupport.error_reporter.subscribe(self)
+                else
+                  raise Minitest::Assertion, "No error reporter is configured"
+                end
+              end
+            end
+        end
+      end
+
+      private
+        # Assertion that the block should not cause an exception to be reported
+        # to +Rails.error+.
+        #
+        # Passes if evaluated code in the yielded block reports no exception.
+        #
+        #   assert_no_error_reported do
+        #     perform_service(param: 'no_exception')
+        #   end
+        def assert_no_error_reported(&block)
+          reports = ErrorCollector.record do
+            _assert_nothing_raised_or_warn("assert_no_error_reported", &block)
+          end
+          assert_predicate(reports, :empty?)
+        end
+
+        # Assertion that the block should cause at least one exception to be reported
+        # to +Rails.error+.
+        #
+        # Passes if the evaluated code in the yielded block reports a matching exception.
+        #
+        #   assert_error_reported(IOError) do
+        #     Rails.error.report(IOError.new("Oops"))
+        #   end
+        #
+        # To test further details about the reported exception, you can use the return
+        # value.
+        #
+        #   report = assert_error_reported(IOError) do
+        #     # ...
+        #   end
+        #   assert_equal "Oops", report.error.message
+        #   assert_equal "admin", report.context[:section]
+        #   assert_equal :warning, report.severity
+        #   assert_predicate report, :handled?
+        def assert_error_reported(error_class = StandardError, &block)
+          reports = ErrorCollector.record do
+            _assert_nothing_raised_or_warn("assert_error_reported", &block)
+          end
+
+          if reports.empty?
+            assert(false, "Expected a #{error_class.name} to be reported, but there were no errors reported.")
+          elsif (report = reports.find { |r| error_class === r.error })
+            self.assertions += 1
+            report
+          else
+            message = "Expected a #{error_class.name} to be reported, but none of the " \
+              "#{reports.size} reported errors matched:  \n" \
+              "#{reports.map { |r| r.error.class.name }.join("\n  ")}"
+            assert(false, message)
+          end
+        end
+    end
+  end
+end

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -12,6 +12,7 @@ end
 
 require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"
+require "active_support/testing/error_reporter_assertions"
 
 ENV["NO_RELOAD"] = "1"
 require "active_support"
@@ -37,6 +38,7 @@ class ActiveSupport::TestCase
   end
 
   include ActiveSupport::Testing::MethodCallAssertions
+  include ActiveSupport::Testing::ErrorReporterAssertions
 
   private
     # Skips the current run on JRuby using Minitest::Assertions#skip

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -88,7 +88,7 @@ module Rails
     #   end
     #   Rails.error.report(error)
     def error
-      application && application.executor.error_reporter
+      ActiveSupport.error_reporter
     end
 
     # Returns all Rails groups for loading based on:


### PR DESCRIPTION
Allows to easily asserts an error happened but was handled

```ruby
report = assert_error_reported(IOError) do
  # ...
end
assert_equal "Oops", report.error.message
assert_equal "admin", report.context[:section]
assert_equal :warning, report.severity
assert_predicate report, :handled?
```

The matching is on purpose limited to a single class matching, at least in the documentation, as I don't think it would be a good idea to add more complex matchers, as they would get unwidly.

That being said, I use `===` for matching, so you could pass a proc to do more complex matching, it would be not handle nothing matching properly.

