### PR TITLE
[ci skip] Fix form_with documentation

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -496,7 +496,7 @@ module ActionView
       #     <%= form.text_field :title %>
       #   <% end %>
       #   # =>
-      #   <form method="post" data-remote="true">
+      #   <form method="post">
       #     <input type="text" name="title">
       #   </form>
       #


### PR DESCRIPTION
Remote forms are no longer the default with the `form_with` helper.