### PR TITLE
Remove redundant `ELSE` branch from the `ActiveRecord::Base.in_order_of` SQL query

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1785,7 +1785,7 @@ module ActiveRecord
           node.when(column.eq(value)).then(order)
         end
 
-        Arel::Nodes::Ascending.new(node.else(values.length + 1))
+        Arel::Nodes::Ascending.new(node)
       end
 
       def resolve_arel_attributes(attrs)


### PR DESCRIPTION
`ActiveRecord::Base.in_order_of` mimics the behavior of [`Enumerable.in_order_of`](https://api.rubyonrails.org/classes/Enumerable.html#method-i-in_order_of) by ignoring all the records having column values not specified in the order list.

Generated queries are something like:
```
User.in_order_of(:id, [1, 5, 3])

SELECT * FROM users 
WHERE id IN (1, 5, 3)
ORDER BY CASE id WHEN 1 THEN 1 WHEN 5 THEN 2 WHEN 3 THEN 3 ELSE 4 END ASC  
```

Because of the `IN`, the `ELSE` clause will be never executed and thus redundant.