### PR TITLE
Fix flaky PostgreSQL enum migration reversibility test

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -60,6 +60,7 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_table "enums", if_exists: true
     @connection.drop_table "bars", if_exists: true
     @connection.drop_table "foos", if_exists: true
+    @connection.drop_enum "color", if_exists: true
   end
 
   def test_migrate_revert_add_index_with_expression


### PR DESCRIPTION
This flaky test annoyed me for quite some time, but I was unable to reproduce it.
When I ran tests for PostgreSQL, *sometimes* I got 
```
Failure:
PostgresqlInvertibleMigrationTest#test_migrate_revert_drop_enum [/Users/fatkodima/Desktop/oss/rails/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb:96]:
Expected: []
  Actual: [["color", "blue,green"]]
```

When I tried to replicate the test failure with the same `--seed`, it was not reproducible 😞

Finally, I was able to reproduce:
```
bin/test --verbose -a postgresql test/cases/adapters/postgresql/invertible_migration_test.rb -n "test_migrate_revert_drop_enum"
```

The problem was: when `test_migrate_revert_drop_enum` run after `test_migrate_revert_create_enum`, the `color` enum was left in the database. On the next run, if `test_migrate_revert_drop_enum` is called before `test_migrate_revert_create_enum`, it fails.

If `test_migrate_revert_create_enum` was called after `test_migrate_revert_drop_enum`, the enum was properly deleted from the db and on the next run `test_migrate_revert_drop_enum` will succeed no matter the ordering.