### PR TITLE
Derive arity of `AS::Deprecation` behavior callbacks

### DIFF
--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -114,7 +114,9 @@ module ActiveSupport
             raise ArgumentError, "#{behavior.inspect} is not a valid deprecation behavior."
           end
 
-          if behavior.respond_to?(:arity) && behavior.arity == 2
+          arity = behavior.respond_to?(:arity) ? behavior.arity : behavior.method(:call).arity
+
+          if arity == 2
             -> message, callstack, _, _ { behavior.call(message, callstack) }
           else
             behavior


### PR DESCRIPTION
This changes `arity_coerce` to always derive the arity of the callback, even when it does not respond to `arity`.  Thus, callable objects that don't respond to `arity` can now implement either a 2-arity or 4-arity `call` method, the same as lambda callbacks.
