### PR TITLE
Pass deprecator to `AS::Deprecation` callbacks

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   `ActiveSupport::Deprecation` behavior callbacks can now receive the
+    deprecator instance as an argument.  This makes it easier for such callbacks
+    to change their behavior based on the deprecator's state.  For example,
+    based on the deprecator's `debug` flag.
+
+    3-arity and splat-args callbacks such as the following will now be passed
+    the deprecator instance as their third argument:
+
+    * `->(message, callstack, deprecator) { ... }`
+    * `->(*args) { ... }`
+    * `->(message, *other_args) { ... }`
+
+    2-arity and 4-arity callbacks such as the following will continue to behave
+    the same as before:
+
+    * `->(message, callstack) { ... }`
+    * `->(message, callstack, deprecation_horizon, gem_name) { ... }`
+    * `->(message, callstack, *deprecation_details) { ... }`
+
+    *Jonathan Hefner*
+
 *   `ActiveSupport::Deprecation#disallowed_warnings` now affects the instance on
     which it is configured.
 

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -11,18 +11,18 @@ module ActiveSupport
   class Deprecation
     # Default warning behaviors per Rails.env.
     DEFAULT_BEHAVIORS = {
-      raise: ->(message, callstack, deprecation_horizon, gem_name) {
+      raise: ->(message, callstack, deprecator) do
         e = DeprecationException.new(message)
         e.set_backtrace(callstack.map(&:to_s))
         raise e
-      },
+      end,
 
-      stderr: ->(message, callstack, deprecation_horizon, gem_name) {
+      stderr: ->(message, callstack, deprecator) do
         $stderr.puts(message)
-        $stderr.puts callstack.join("\n  ") if debug
-      },
+        $stderr.puts callstack.join("\n  ") if deprecator.debug
+      end,
 
-      log: ->(message, callstack, deprecation_horizon, gem_name) {
+      log: ->(message, callstack, deprecator) do
         logger =
             if defined?(Rails.logger) && Rails.logger
               Rails.logger
@@ -31,19 +31,20 @@ module ActiveSupport
               ActiveSupport::Logger.new($stderr)
             end
         logger.warn message
-        logger.debug callstack.join("\n  ") if debug
-      },
+        logger.debug callstack.join("\n  ") if deprecator.debug
+      end,
 
-      notify: ->(message, callstack, deprecation_horizon, gem_name) {
-        notification_name = "deprecation.#{gem_name.underscore.tr('/', '_')}"
-        ActiveSupport::Notifications.instrument(notification_name,
-                                                message: message,
-                                                callstack: callstack,
-                                                gem_name: gem_name,
-                                                deprecation_horizon: deprecation_horizon)
-      },
+      notify: ->(message, callstack, deprecator) do
+        ActiveSupport::Notifications.instrument(
+          "deprecation.#{deprecator.gem_name.underscore.tr("/", "_")}",
+          message: message,
+          callstack: callstack,
+          gem_name: deprecator.gem_name,
+          deprecation_horizon: deprecator.deprecation_horizon,
+        )
+      end,
 
-      silence: ->(message, callstack, deprecation_horizon, gem_name) { },
+      silence: ->(message, callstack, deprecator) { },
     }
 
     # Behavior module allows to determine how to display deprecation messages.
@@ -114,13 +115,22 @@ module ActiveSupport
             raise ArgumentError, "#{behavior.inspect} is not a valid deprecation behavior."
           end
 
-          arity = behavior.respond_to?(:arity) ? behavior.arity : behavior.method(:call).arity
-
-          if arity == 2
-            -> message, callstack, _, _ { behavior.call(message, callstack) }
-          else
+          case arity_of_callable(behavior)
+          when 2
+            ->(message, callstack, deprecator) do
+              behavior.call(message, callstack)
+            end
+          when -2..3
             behavior
+          else
+            ->(message, callstack, deprecator) do
+              behavior.call(message, callstack, deprecator.deprecation_horizon, deprecator.gem_name)
+            end
           end
+        end
+
+        def arity_of_callable(callable)
+          callable.respond_to?(:arity) ? callable.arity : callable.method(:call).arity
         end
     end
   end

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -21,9 +21,9 @@ module ActiveSupport
         callstack ||= caller_locations(2)
         deprecation_message(callstack, message).tap do |full_message|
           if deprecation_disallowed?(message)
-            disallowed_behavior.each { |b| b.call(full_message, callstack, deprecation_horizon, gem_name) }
+            disallowed_behavior.each { |b| b.call(full_message, callstack, self) }
           else
-            behavior.each { |b| b.call(full_message, callstack, deprecation_horizon, gem_name) }
+            behavior.each { |b| b.call(full_message, callstack, self) }
           end
         end
       end


### PR DESCRIPTION
This commit adds support for 3-arity `ActiveSupport::Deprecation` behavior callbacks, which receive the deprecator instance as their third argument.  This allows such callbacks to change their behavior based on the deprecator's state.  For example, based on the deprecator's `debug` flag.

This commit also fixes the `:stderr` and `:log` behaviors to check the given deprecator's `debug` flag, instead of the global `ActiveSupport::Deprecation.debug` flag.

Note that 2-arity and 4-arity callbacks will continue to behave the same as before.  However, callbacks with -1 and -2 arity (i.e. with splat args) will now receive the deprecator as their third argument, instead of the deprecation horizon and gem name.

---

Do we want to preserve the behavior of negative-1-arity and negative-2-arity callbacks instead?

Passing the deprecator as the third argument seems like the "right" behavior, but perhaps backwards compatibility is more important.  Or perhaps splat-args callbacks are such a corner case that it does not particularly matter.
