### PR TITLE
Fix typo in ActiveRecord ChangeLog

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -102,7 +102,7 @@
     This adds two new configuration options The configuration options are as
     follows:
     
-    * `config.active_storage.use_yaml_unsafe_load`
+    * `config.active_record.use_yaml_unsafe_load`
     
     When set to true, this configuration option tells Rails to use the old
     "unsafe" YAML loading strategy, maintaining the existing behavior but leaving


### PR DESCRIPTION
# Summary

This pull request fixes typo in ActiveRecord's `CHANGELOG.md` on 7-0-stable. The same fix should be applied to `6-1-stable`, `6-0-stable`, and `5-2-stable`