### PR TITLE
Fix ActionText::ModelTest#test_eager_loading_all_rich_text

### DIFF
--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -106,7 +106,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "eager loading all rich text" do
     Message.create!(subject: "Subject", content: "<h1>Content</h1>", body: "<h2>Body</h2>")
 
-    message = assert_queries(1) { Message.with_all_rich_text.last }
+    message = assert_queries(2) { Message.with_all_rich_text.last }
     assert_no_queries do
       assert_equal "Content", message.content.to_plain_text
       assert_equal "Body", message.body.to_plain_text


### PR DESCRIPTION
I'm getting:

```
/usr/share/gems/gems/actiontext-7.0.3.1/test/unit/model_test.rb:109]:
2 instead of 1 queries were executed. ["UPDATE \"active_storage_blobs\" SET \"metadata\" = ? WHERE \"active_storage_blobs\".\"id\" = ?", "SELECT \"messages\".\"id\" AS t0_r0, \"messages\".\"subject\" AS t0_r1, \"messages\".\"created_at\" AS t0_r2, \"messages\".\"updated_at\" AS t0_r3, \"action_text_rich_texts\".\"id\" AS t1_r0, \"action_text_rich_texts\".\"name\" AS t1_r1, \"action_text_rich_texts\".\"body\" AS t1_r2, \"action_text_rich_texts\".\"record_type\" AS t1_r3, \"action_text_rich_texts\".\"record_id\" AS t1_r4, \"action_text_rich_texts\".\"created_at\" AS t1_r5, \"action_text_rich_texts\".\"updated_at\" AS t1_r6, \"rich_text_bodies_messages\".\"id\" AS t2_r0, \"rich_text_bodies_messages\".\"name\" AS t2_r1, \"rich_text_bodies_messages\".\"body\" AS t2_r2, \"rich_text_bodies_messages\".\"record_type\" AS t2_r3, \"rich_text_bodies_messages\".\"record_id\" AS t2_r4, \"rich_text_bodies_messages\".\"created_at\" AS t2_r5, \"rich_text_bodies_messages\".\"updated_at\" AS t2_r6 FROM \"messages\" LEFT OUTER JOIN \"action_text_rich_texts\" ON \"action_text_rich_texts\".\"record_type\" = ? AND \"action_text_rich_texts\".\"name\" = ? AND \"action_text_rich_texts\".\"record_id\" = \"messages\".\"id\" LEFT OUTER JOIN \"action_text_rich_texts\" \"rich_text_bodies_messages\" ON \"rich_text_bodies_messages\".\"record_type\" = ? AND \"rich_text_bodies_messages\".\"name\" = ? AND \"rich_text_bodies_messages\".\"record_id\" = \"messages\".\"id\" ORDER BY \"messages\".\"id\" DESC LIMIT ?"].
Expected: 1
  Actual: 2
```

<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

This Pull Request could have probably been an issue. I'm not sure if I should get 1 or 2.

### Detail

Is the response correct? We run the tests as part of package building in Fedora, like so:

```
$ ruby -rselenium-webdriver -Ilib:test -e 'Dir.glob "./test/**/*_test.rb",
&method(:require)'
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] PR is not in a draft state.
* [ ] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
