### PR TITLE
Drop Rubinius code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,12 +159,6 @@ platforms :jruby do
   end
 end
 
-platforms :rbx do
-  # The rubysl-yaml gem doesn't ship with Psych by default as it needs
-  # libyaml that isn't always available.
-  gem "psych", "~> 3.0"
-end
-
 # Gems that are necessary for Active Record tests with Oracle.
 if ENV["ORACLE_ENHANCED"]
   platforms :ruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,7 +371,6 @@ GEM
       activesupport (>= 7.0.0.alpha2)
       rack
       railties (>= 7.0.0.alpha2)
-    psych (3.3.2)
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
@@ -588,7 +587,6 @@ DEPENDENCIES
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
   propshaft (>= 0.1.7)
-  psych (~> 3.0)
   puma
   queue_classic (>= 4.0.0)
   racc (>= 1.4.6)

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -39,11 +39,6 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -359,11 +359,6 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -369,8 +369,6 @@ module ActionController
     end
 
     def test_async_stream
-      rubinius_skip "https://github.com/rubinius/rubinius/issues/2934"
-
       @controller.latch = Concurrent::CountDownLatch.new
       parts             = ["hello", "world"]
 

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -186,11 +186,6 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -144,7 +144,6 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_distance_in_words_doesnt_use_the_quotient_operator
-    rubinius_skip "Date is written in Ruby and relies on Integer#/"
     jruby_skip "Date is written in Ruby and relies on Integer#/"
 
     # Make sure that we avoid Integer#/ (redefined by mathn)

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -16,11 +16,6 @@ class ActiveModel::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -22,43 +22,15 @@ module ActiveSupport
         codepoints.pack("U*").unicode_normalize(:nfc).codepoints
       end
 
-      # Rubinius' String#scrub, however, doesn't support ASCII-incompatible chars.
-      if !defined?(Rubinius)
-        # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
-        # resulting in a valid UTF-8 string.
-        #
-        # Passing +true+ will forcibly tidy all bytes, assuming that the string's
-        # encoding is entirely CP1252 or ISO-8859-1.
-        def tidy_bytes(string, force = false)
-          return string if string.empty? || string.ascii_only?
-          return recode_windows1252_chars(string) if force
-          string.scrub { |bad| recode_windows1252_chars(bad) }
-        end
-      else
-        def tidy_bytes(string, force = false)
-          return string if string.empty?
-          return recode_windows1252_chars(string) if force
-
-          # We can't transcode to the same format, so we choose a nearly-identical encoding.
-          # We're going to 'transcode' bytes from UTF-8 when possible, then fall back to
-          # CP1252 when we get errors. The final string will be 'converted' back to UTF-8
-          # before returning.
-          reader = Encoding::Converter.new(Encoding::UTF_8, Encoding::UTF_16LE)
-
-          source = string.dup
-          out = "".force_encoding(Encoding::UTF_16LE)
-
-          loop do
-            reader.primitive_convert(source, out)
-            _, _, _, error_bytes, _ = reader.primitive_errinfo
-            break if error_bytes.nil?
-            out << error_bytes.encode(Encoding::UTF_16LE, Encoding::Windows_1252, invalid: :replace, undef: :replace)
-          end
-
-          reader.finish
-
-          out.encode!(Encoding::UTF_8)
-        end
+      # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
+      # resulting in a valid UTF-8 string.
+      #
+      # Passing +true+ will forcibly tidy all bytes, assuming that the string's
+      # encoding is entirely CP1252 or ISO-8859-1.
+      def tidy_bytes(string, force = false)
+        return string if string.empty? || string.ascii_only?
+        return recode_windows1252_chars(string) if force
+        string.scrub { |bad| recode_windows1252_chars(bad) }
       end
 
       private

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -39,11 +39,6 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -82,9 +82,6 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_eql
-    rubinius_skip "Rubinius' #eql? definition relies on #instance_of? " \
-                  "which behaves oddly for the sake of backward-compatibility."
-
     assert 1.minute.eql?(1.minute)
     assert 1.minute.eql?(60.seconds)
     assert 2.days.eql?(48.hours)

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -10,9 +10,6 @@ class DuplicableTest < ActiveSupport::TestCase
   ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
 
   def test_duplicable
-    rubinius_skip "* Method#dup is allowed at the moment on Rubinius\n" \
-                  "* https://github.com/rubinius/rubinius/issues/3089"
-
     RAISE_DUP.each do |v|
       assert_not v.duplicable?, "#{ v.inspect } should not be duplicable"
       assert_raises(TypeError, v.class.name) { v.dup }

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1092,8 +1092,6 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_no_method_error_has_proper_context
-    rubinius_skip "Error message inconsistency"
-
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -37,8 +37,6 @@ class TestJSONEncoding < ActiveSupport::TestCase
   end
 
   def test_process_status
-    rubinius_skip "https://github.com/rubinius/rubinius/issues/3334"
-
     # There doesn't seem to be a good way to get a handle on a Process::Status object without actually
     # creating a child process, hence this to populate $?
     system("not_a_real_program_#{SecureRandom.hex}")

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -128,7 +128,6 @@ module Rails
           hotwire_gemfile_entry,
           css_gemfile_entry,
           jbuilder_gemfile_entry,
-          psych_gemfile_entry,
           cable_gemfile_entry,
         ].flatten.compact.select(&@gem_filter)
       end
@@ -432,14 +431,6 @@ module Rails
         else
           GemfileEntry.floats "cssbundling-rails", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]"
         end
-      end
-
-      def psych_gemfile_entry
-        return unless defined?(Rubinius)
-
-        comment = "Use Psych as the YAML engine, instead of Syck, so serialized " \
-                  "data can be read safely from different rubies"
-        GemfileEntry.new("psych", "~> 2.0", comment, platforms: :rbx)
       end
 
       def cable_gemfile_entry

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -22,11 +22,6 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 
   private
-    # Skips the current run on Rubinius using Minitest::Assertions#skip
-    def rubinius_skip(message = "")
-      skip message if RUBY_ENGINE == "rbx"
-    end
-
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")
       skip message if defined?(JRUBY_VERSION)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -647,7 +647,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_inclusion_of_a_debugger
     run_generator
-    if defined?(JRUBY_VERSION) || RUBY_ENGINE == "rbx"
+    if defined?(JRUBY_VERSION)
       assert_no_gem "debug"
     else
       assert_gem "debug"
@@ -1030,19 +1030,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     )
     folders_with_keep.each do |folder|
       assert_file("#{folder}/.keep")
-    end
-  end
-
-  def test_psych_gem
-    run_generator
-    gem_regex = /gem 'psych',\s+'~> 2\.0',\s+platforms: :rbx/
-
-    assert_file "Gemfile" do |content|
-      if defined?(Rubinius)
-        assert_match(gem_regex, content)
-      else
-        assert_no_match(gem_regex, content)
-      end
     end
   end
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -145,7 +145,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_inclusion_of_a_debugger
     run_generator [destination_root, "--full"]
-    if defined?(JRUBY_VERSION) || RUBY_ENGINE == "rbx"
+    if defined?(JRUBY_VERSION)
       assert_file "Gemfile" do |content|
         assert_no_match(/debug/, content)
       end


### PR DESCRIPTION
### Motivation / Background

Rubinius has not been maintained since May 2020 and based on the discussion at https://github.com/rails/rails/pull/44984 , I think we can remove Rubinius specific code from Rails.

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request removes Rubinius specific code from Rails.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
