### PR TITLE
Warn if frameworks are loaded too early

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -79,6 +79,12 @@ module ActiveRecord
       app.deprecators[:active_record] = ActiveRecord.deprecator
     end
 
+    initializer "active_record.warn_if_prematurely_loaded" do
+      ActiveSupport.on_load(:active_record) do
+        ActiveSupport.warn_if_prematurely_loaded(:active_record, before: :after_initialize)
+      end
+    end
+
     initializer "active_record.initialize_timezone" do
       ActiveSupport.on_load(:active_record) do
         self.time_zone_aware_attributes = true

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,39 @@
+*   Warn if frameworks are loaded to early.
+
+    Prematurely loading frameworks in a Rails application may slow down boot
+    time and could cause conflicts with load order and boot of the
+    application.
+
+    By calling `warn_if_prematurely_loaded` in an `on_load` hook we can define a
+    dependency that needs to be loaded before the load hook has run.
+
+    ```ruby
+    initializer "active_record.warn_if_prematurely_loaded" do
+      ActiveSupport.on_load(:active_record) do
+        ActiveSupport.warn_if_prematurely_loaded(:active_record, before: :after_initialize)
+      end
+    end
+    ```
+
+    If the framework gets loaded to early we show a warning with a backtrace:
+
+    ```
+    Load hook :active_record was called before load hook :after_initialize.
+    Prematurely loading frameworks may slow down your boot time and could
+    cause conflicts with load order and boot of your application.
+
+    Consider wrapping your code with an on_load hook:
+
+        ActiveSupport.on_load(:active_record) do
+          # your code
+        end
+
+    Called from:
+    config/initializers/some_initializer.rb:1:in `<main>'
+    ```
+
+    *Petrik de Heus*
+
 *   `HashWithIndifferentAccess#transform_keys` now takes a Hash argument, just
     as Ruby's `Hash#transform_keys` does.
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -14,6 +14,14 @@ module ActiveSupport
       app.deprecators[:active_support] = ActiveSupport.deprecator
     end
 
+    initializer "active_support.silence_prematurely_loading_warnings" do |app|
+      config.before_configuration do
+        if app.config.eager_load
+          ActiveSupport.silence_prematurely_loading_warnings
+        end
+      end
+    end
+
     initializer "active_support.isolation_level" do |app|
       config.after_initialize do
         if level = app.config.active_support.delete(:isolation_level)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -384,6 +384,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define(version: 1) do
@@ -405,6 +406,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define(version: 1) do
@@ -431,6 +433,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define(version: 1) do
@@ -446,6 +449,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/schema_cache.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.connection.schema_cache.add("posts")
       RUBY
 
@@ -461,6 +465,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define(version: 1) do
@@ -2610,6 +2615,7 @@ module ApplicationTests
 
     test "SQLite3Adapter.strict_strings_by_default is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
 
@@ -2626,6 +2632,7 @@ module ApplicationTests
 
       remove_from_config '.*config\.load_defaults.*\n'
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
 
@@ -2644,6 +2651,7 @@ module ApplicationTests
       add_to_config "config.active_record.sqlite3_adapter_strict_strings_by_default = true"
 
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
 
@@ -2663,6 +2671,7 @@ module ApplicationTests
         Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
       RUBY
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
 
@@ -3471,6 +3480,7 @@ module ApplicationTests
         Rails.application.config.filter_parameters += [ :password, :credit_card_number ]
       RUBY
       app "development"
+
       assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
       assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
     end
@@ -3843,6 +3853,7 @@ module ApplicationTests
     test "logs a warning when running SQLite3 in production" do
       restore_sqlite3_warning
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
       add_to_config "config.logger = MyLogRecorder.new"
@@ -3854,6 +3865,7 @@ module ApplicationTests
 
     test "doesn't log a warning when running SQLite3 in production and sqlite3_production_warning=false" do
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
       add_to_config "config.logger = MyLogRecorder.new"
@@ -3868,6 +3880,7 @@ module ApplicationTests
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "mysql2" } } }
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "mysql2")
       RUBY
       add_to_config "config.logger = MyLogRecorder.new"
@@ -3882,6 +3895,7 @@ module ApplicationTests
     test "doesn't log a warning when running SQLite3 in development" do
       restore_sqlite3_warning
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
       RUBY
       add_to_config "config.logger = MyLogRecorder.new"
@@ -4266,6 +4280,7 @@ module ApplicationTests
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "postgresql" } } }
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "postgresql")
       RUBY
 
@@ -4280,6 +4295,7 @@ module ApplicationTests
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "mysql2" } } }
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "mysql2")
       RUBY
 
@@ -4294,6 +4310,7 @@ module ApplicationTests
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "postgresql" } } }
       app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.establish_connection(adapter: "postgresql")
       RUBY
       app_file "config/initializers/tz_aware_types.rb", <<~RUBY

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -335,6 +335,7 @@ module ApplicationTests
 
     test "connections checked out during initialization are returned to the pool" do
       app_file "config/initializers/active_record.rb", <<-RUBY
+        ActiveSupport.silence_prematurely_loading_warnings
         ActiveRecord::Base.connection
       RUBY
       require "#{app_path}/config/environment"

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -560,6 +560,7 @@ module ApplicationTests
           end
         RUBY
         app_file "config/initializers/primary_key_table_name.rb", <<-RUBY
+          ActiveSupport.silence_prematurely_loading_warnings
           ActiveRecord::Base.primary_key_prefix_type = :table_name
         RUBY
         app_file "db/schema.rb", <<-RUBY


### PR DESCRIPTION
Fixes #50133

Prematurely loading frameworks in a Rails application may slow down boot time and could cause conflicts with load order and boot of the application. It is a common problem in gems:
- https://github.com/ViewComponent/view_component/issues/1507
- https://github.com/collectiveidea/delayed_job_active_record/issues/185

This change allows showing a warning in a load hook if a required
framework or load hook hasn't been loaded yet:

```ruby
  initializer "active_record.premature_loading_check" do
    ActiveSupport.on_load(:active_record) do
      ActiveSupport.warn_if_prematurely_loaded(:active_record, before: :after_initialize)
    end
  end
```

In this case if `:active_record` is loaded before `:after_initialize`
has run we show a warning:

      Load hook :active_record was called before load hook :after_initialize.
      Prematurely loading frameworks may slow down your boot time and could
      cause conflicts with load order and boot of your application.

      Consider wrapping your code with an on_load hook:

          ActiveSupport.on_load(:active_record) do
            # your code
          end
      Called from:
      config/initializers/some_initializer.rb:1:in `<main>'
      ...

In production `eager_load` gets called to load add frameworks and we
should silence the warning. A `silence_prematurely_loading_warnings` has
been added to silence all load hook order warnings. This
`silence_prematurely_loading_warnings` is called before `eager_load`
gets called.

The hook has been implemented for ActiveRecord but other frameworks,
like ActionView for example, could use it as well.

Some tests include initializers that call ActiveRecord::Base. To not
show the warning `silence_prematurely_loading_warnings` has been added
to the initializers.

### Additional information

`ActiveRecord` should be loaded after `:after_initialize` has run, so I've added an initializer to add the load_hook order in the railtie. For other frameworks like ActionView and ActionPack it should probably be added as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.