### PR TITLE
Fix logger tags for SchemaMigration and InternalMetadata

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -53,13 +53,14 @@ module ActiveRecord
     def delete_all_entries
       dm = Arel::DeleteManager.new(arel_table)
 
-      connection.delete(dm, "#{self} Destroy")
+      connection.delete(dm, "#{self.class} Destroy")
     end
 
     def count
       sm = Arel::SelectManager.new(arel_table)
       sm.project(*Arel::Nodes::Count.new([Arel.star]))
-      connection.select_values(sm).first
+
+      connection.select_values(sm, "#{self.class} Count").first
     end
 
     def create_table_and_set_flags(environment, schema_sha1 = nil)
@@ -119,7 +120,7 @@ module ActiveRecord
           [arel_table[:updated_at], current_time]
         ]
 
-        connection.insert(im, "#{self} Create", primary_key, key)
+        connection.insert(im, "#{self.class} Create", primary_key, key)
       end
 
       def update_entry(key, new_value)
@@ -131,7 +132,7 @@ module ActiveRecord
 
         um.where(arel_table[primary_key].eq(key))
 
-        connection.update(um, "#{self} Update")
+        connection.update(um, "#{self.class} Update")
       end
 
       def select_entry(key)
@@ -141,7 +142,7 @@ module ActiveRecord
         sm.order(arel_table[primary_key].asc)
         sm.limit = 1
 
-        connection.select_all(sm).first
+        connection.select_all(sm, "#{self.class} Load").first
       end
   end
 end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -19,14 +19,14 @@ module ActiveRecord
     def create_version(version)
       im = Arel::InsertManager.new(arel_table)
       im.insert(arel_table[primary_key] => version)
-      connection.insert(im, "#{self} Create", primary_key, version)
+      connection.insert(im, "#{self.class} Create", primary_key, version)
     end
 
     def delete_version(version)
       dm = Arel::DeleteManager.new(arel_table)
       dm.wheres = [arel_table[primary_key].eq(version)]
 
-      connection.delete(dm, "#{self} Destroy")
+      connection.delete(dm, "#{self.class} Destroy")
     end
 
     def delete_all_versions
@@ -67,7 +67,8 @@ module ActiveRecord
       sm = Arel::SelectManager.new(arel_table)
       sm.project(arel_table[primary_key])
       sm.order(arel_table[primary_key].asc)
-      connection.select_values(sm)
+
+      connection.select_values(sm, "#{self.class} Load")
     end
 
     def integer_versions
@@ -77,7 +78,8 @@ module ActiveRecord
     def count
       sm = Arel::SelectManager.new(arel_table)
       sm.project(*Arel::Nodes::Count.new([Arel.star]))
-      connection.select_values(sm).first
+
+      connection.select_values(sm, "#{self.class} Count").first
     end
 
     def table_exists?


### PR DESCRIPTION
When I moved `SchemaMigration` and `InternalMetadata` away from inheriting from `ActiveRecord::Base` I accidentally set the logger tags to `self` rather than `self.class` which meant they were accidentally logging the instance rather than the class name. While fixing these I realized I missed a few tags for other queries and have fixed those as well.