### PR TITLE
Use `sslmode` option instead of `ssl_mode` for MySQL command connections

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -95,7 +95,7 @@ module ActiveRecord
             sslcapath: "--ssl-capath",
             sslcipher: "--ssl-cipher",
             sslkey:    "--ssl-key",
-            sslmode:   "--ssl-mode"
+            ssl_mode:  "--ssl-mode"
           }.filter_map { |opt, arg| "#{arg}=#{configuration_hash[opt]}" if configuration_hash[opt] }
 
           args

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -31,7 +31,7 @@ module Rails
           sslcapath: "--ssl-capath",
           sslcipher: "--ssl-cipher",
           sslkey: "--ssl-key",
-          sslmode: "--ssl-mode"
+          ssl_mode: "--ssl-mode"
         }.filter_map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }
 
         if config[:password] && @options[:include_password]

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -127,7 +127,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       sslcapath: "/path/to/cacerts",
       sslcipher: "DHE-RSA-AES256-SHA",
       sslkey:    "/path/to/client-key.pem",
-      sslmode:   "VERIFY_IDENTITY"
+      ssl_mode:  "VERIFY_IDENTITY"
     )
     assert_not aborted
     assert_equal [


### PR DESCRIPTION
In ed3b92b38f6db2a487b10b68d5320ab6b118521f support for the ssl-mode option was added for MySQL when using the dbconsole command and MySQLDatabaseTasks. However, the mysql2 gem uses `ssl_mode` instead of `sslmode`:

https://github.com/brianmario/mysql2/blob/ba4d46551d132492b34205cdb8fa224c92765bef/lib/mysql2/client.rb#L51

As `ssl_mode` is what should be used in the database.yml configuration for MySQL we should use it as well for the dbconsole command and MySQLDatabaseTasks.

Trilogy uses `ssl_mode` as well:
https://github.com/github/trilogy/blob/a80c404ba0fa515e5b1bbe2fb1390c351f3fe336/contrib/ruby/test/ssl_test.rb#L142

Thanks to @cgunther for [pointing out the issue](https://github.com/rails/rails/pull/46008#issuecomment-1249861134).