### PR TITLE
Fix word case

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -63,7 +63,7 @@ module ActiveSupport
       module Subprocess
         ORIG_ARGV = ARGV.dup unless defined?(ORIG_ARGV)
 
-        # Complicated H4X to get this working in windows / jruby with
+        # Complicated H4X to get this working in Windows / JRuby with
         # no forking.
         def run_in_isolation(&blk)
           require "tempfile"


### PR DESCRIPTION
`windows` -> `Windows`
`jruby` -> `JRuby`
