### PR TITLE
Don't delegate tasks to ActiveRecord::Base

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -5,8 +5,6 @@ module ActiveRecord
     class MySQLDatabaseTasks # :nodoc:
       ER_DB_CREATE_EXISTS = 1007
 
-      delegate :connection, :establish_connection, to: ActiveRecord::Base
-
       def self.using_database_configurations?
         true
       end
@@ -19,11 +17,11 @@ module ActiveRecord
       def create
         establish_connection(configuration_hash_without_database)
         connection.create_database(db_config.database, creation_options)
-        establish_connection(db_config)
+        establish_connection
       end
 
       def drop
-        establish_connection(db_config)
+        establish_connection
         connection.drop_database(db_config.database)
       end
 
@@ -70,6 +68,14 @@ module ActiveRecord
 
       private
         attr_reader :db_config, :configuration_hash
+
+        def connection
+          ActiveRecord::Base.connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
 
         def configuration_hash_without_database
           configuration_hash.merge(database: nil)

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -9,9 +9,6 @@ module ActiveRecord
       ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
       SQL_COMMENT_BEGIN = "--"
 
-      delegate :connection, :establish_connection, :clear_active_connections!,
-        to: ActiveRecord::Base
-
       def self.using_database_configurations?
         true
       end
@@ -21,14 +18,14 @@ module ActiveRecord
         @configuration_hash = db_config.configuration_hash
       end
 
-      def create(master_established = false)
-        establish_master_connection unless master_established
+      def create(connection_already_established = false)
+        establish_connection(public_schema_config) unless connection_already_established
         connection.create_database(db_config.database, configuration_hash.merge(encoding: encoding))
-        establish_connection(db_config)
+        establish_connection
       end
 
       def drop
-        establish_master_connection
+        establish_connection(public_schema_config)
         connection.drop_database(db_config.database)
       end
 
@@ -41,7 +38,7 @@ module ActiveRecord
       end
 
       def purge
-        clear_active_connections!
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
         drop
         create true
       end
@@ -90,15 +87,20 @@ module ActiveRecord
       private
         attr_reader :db_config, :configuration_hash
 
+        def connection
+          ActiveRecord::Base.connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
+
         def encoding
           configuration_hash[:encoding] || DEFAULT_ENCODING
         end
 
-        def establish_master_connection
-          establish_connection configuration_hash.merge(
-            database: "postgres",
-            schema_search_path: "public"
-          )
+        def public_schema_config
+          configuration_hash.merge(database: "postgres", schema_search_path: "public")
         end
 
         def psql_env

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -3,8 +3,6 @@
 module ActiveRecord
   module Tasks # :nodoc:
     class SQLiteDatabaseTasks # :nodoc:
-      delegate :connection, :establish_connection, to: ActiveRecord::Base
-
       def self.using_database_configurations?
         true
       end
@@ -17,7 +15,7 @@ module ActiveRecord
       def create
         raise DatabaseAlreadyExists if File.exist?(db_config.database)
 
-        establish_connection(db_config)
+        establish_connection
         connection
       end
 
@@ -67,6 +65,14 @@ module ActiveRecord
 
       private
         attr_reader :db_config, :root
+
+        def connection
+          ActiveRecord::Base.connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
 
         def run_cmd(cmd, args, out)
           fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -208,8 +208,8 @@ if current_adapter?(:PostgreSQLAdapter)
 
       def test_clears_active_connections
         with_stubbed_connection do
-          ActiveRecord::Base.stub(:establish_connection, nil) do
-            assert_called(ActiveRecord::Base, :clear_active_connections!) do
+          ActiveRecord::Base.connection_handler.stub(:establish_connection, nil) do
+            assert_called(ActiveRecord::Base.connection_handler, :clear_active_connections!) do
               ActiveRecord::Tasks::DatabaseTasks.purge @configuration
             end
           end


### PR DESCRIPTION
This PR calls `ActiveRecord::Base` directly on `establish_connection` and `connection` rather than delegating. While this doesn't have much effect right now, I'm working on moving the database tasks away from their reliance on Base and eventually we'll need to pass a class through to these adapter tasks. This change prepares these adapter tasks for that change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
