### PR TITLE
[FIX #46021] Allow passing classes to dom_id

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Allow passing a class to `dom_id`.
+    You no longer need to call `new` when passing a class to `dom_id`.
+    This makes `dom_id` behave like `dom_class` in this regard.
+    Apart from saving a few keystrokes, it prevents Ruby from needing
+    to instantiate a whole new object just to generate a string.
+
+    Before:
+    ```ruby
+    dom_id(Post) # => NoMethodError: undefined method `to_key' for Post:Class
+    ```
+
+    After:
+    ```ruby
+    dom_id(Post) # => "new_post"
+    ```
+
+    *Goulven Champenois*
+
 *   Report `:locals` as part of the data returned by ActionView render instrumentation.
 
     Before:

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -31,6 +31,8 @@ module ActionView
   # automatically generated, following naming conventions encapsulated by the
   # RecordIdentifier methods #dom_id and #dom_class:
   #
+  #   dom_id(Post)             # => "new_post"
+  #   dom_class(Post)          # => "post"
   #   dom_id(Post.new)         # => "new_post"
   #   dom_class(Post.new)      # => "post"
   #   dom_id(Post.find 42)     # => "post_42"
@@ -79,18 +81,19 @@ module ActionView
     # The DOM id convention is to use the singular form of an object or class with the id following an underscore.
     # If no id is found, prefix with "new_" instead.
     #
-    #   dom_id(Post.find(45))       # => "post_45"
-    #   dom_id(Post.new)            # => "new_post"
+    #   dom_id(Post.find(45)) # => "post_45"
+    #   dom_id(Post)          # => "new_post"
     #
     # If you need to address multiple instances of the same class in the same view, you can prefix the dom_id:
     #
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
-    #   dom_id(Post.new, :custom)    # => "custom_post"
-    def dom_id(record, prefix = nil)
-      if record_id = record_key_for_dom_id(record)
-        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
+    #   dom_id(Post, :custom)        # => "custom_post"
+    def dom_id(record_or_class, prefix = nil)
+      record_id = record_key_for_dom_id(record_or_class) unless record_or_class.is_a?(Class)
+      if record_id
+        "#{dom_class(record_or_class, prefix)}#{JOIN}#{record_id}"
       else
-        dom_class(record, prefix || NEW)
+        dom_class(record_or_class, prefix || NEW)
       end
     end
 

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -193,9 +193,12 @@ Car = Struct.new(:color)
 
 class Plane
   attr_reader :to_key
+  delegate :model_name, to: :class
 
-  def model_name
-    OpenStruct.new param_key: "airplane"
+  class << self
+    def model_name
+      OpenStruct.new param_key: "airplane"
+    end
   end
 
   def save

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -13,6 +13,10 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     @plural = "comments"
   end
 
+  def test_dom_id_with_class
+    assert_equal "new_#{@singular}", dom_id(@klass)
+  end
+
   def test_dom_id_with_new_record
     assert_equal "new_#{@singular}", dom_id(@record)
   end
@@ -53,7 +57,12 @@ class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
   include ActionView::RecordIdentifier
 
   def setup
-    @record = Plane.new
+    @klass = Plane
+    @record = @klass.new
+  end
+
+  def test_dom_id_with_new_class
+    assert_equal "new_airplane", dom_id(@klass)
   end
 
   def test_dom_id_with_new_record


### PR DESCRIPTION
### Motivation / Background

As mentioned in #46021, allowing `dom_id` to receive a class makes it behave like `dom_class`, saves a few keystrokes, and saves memory because Ruby doesn't need to instantiate an entire object (which could have `after_initialize` callbacks, etc).

The last commit allows receiving non-ActiveModel classes, in case this change is deemed unnecessary. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive. (see comment above regarding non-ActiveModel)
* [X] Tests are added if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [X] CI is passing. (extra whitespace in the changelog, I'm on it)