### PR TITLE
Fix plugin generation inside applications

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -21,6 +21,7 @@ module Rails
       private
         def generator_options
           options = { api: !!Rails.application.config.api_only, update: true }
+          options[:name]                = Rails.application.class.name.chomp("::Application").underscore
           options[:skip_active_job]     = !defined?(ActiveJob::Railtie)
           options[:skip_active_record]  = !defined?(ActiveRecord::Railtie)
           options[:skip_active_storage] = !defined?(ActiveStorage::Engine)

--- a/railties/lib/rails/generators/app_name.rb
+++ b/railties/lib/rails/generators/app_name.rb
@@ -11,22 +11,11 @@ module Rails
         end
 
         def original_app_name
-          @original_app_name ||= defined_app_const_base? ? defined_app_name : (options[:name] || File.basename(destination_root))
+          @original_app_name ||= (options[:name] || File.basename(destination_root))
         end
-
-        def defined_app_name
-          defined_app_const_base.underscore
-        end
-
-        def defined_app_const_base
-          Rails.respond_to?(:application) && defined?(Rails::Application) &&
-            Rails.application.is_a?(Rails::Application) && Rails.application.class.name.chomp("::Application")
-        end
-
-        alias :defined_app_const_base? :defined_app_const_base
 
         def app_const_base
-          @app_const_base ||= defined_app_const_base || app_name.gsub(/\W/, "_").squeeze("_").camelize
+          @app_const_base ||= app_name.gsub(/\W/, "_").squeeze("_").camelize
         end
         alias :camelized :app_const_base
 

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -35,6 +35,11 @@ module ApplicationTests
       assert File.exist?(File.join(rails_root, "vendor/plugins/bukkits/test/dummy/config/application.rb"))
     end
 
+    test "allow generating plugin inside Rails app directory" do
+      rails "generate", "plugin", "vendor/plugins/bukkits"
+      assert File.exist?(File.join(rails_root, "vendor/plugins/bukkits/test/dummy/config/application.rb"))
+    end
+
     test "generators default values" do
       with_bare_config do |c|
         assert_equal(true, c.generators.colorize_logging)

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -36,7 +36,7 @@ module Rails
 
             assert_file("config/database.yml") do |content|
               assert_match "adapter: postgresql", content
-              assert_match "database: test_app", content
+              assert_match "database: tmp_production", content
             end
 
             assert_file("Gemfile") do |content|
@@ -50,7 +50,7 @@ module Rails
 
             assert_file("config/database.yml") do |content|
               assert_match "adapter: mysql2", content
-              assert_match "database: test_app", content
+              assert_match "database: tmp_production", content
             end
 
             assert_file("Gemfile") do |content|
@@ -79,7 +79,7 @@ module Rails
 
             assert_file("config/database.yml") do |content|
               assert_match "adapter: mysql2", content
-              assert_match "database: test_app", content
+              assert_match "database: tmp_production", content
             end
 
             assert_file("Gemfile") do |content|


### PR DESCRIPTION
### Motivation / Background

Previously, generating a plugin inside an application would throw an error when trying to create a dummy_app due to the generator trying to reuse the application's name.

### Detail

This is fixed by extracting the logic used to determine the source of an application's name, and then only using the existing name as the source for the app:update and db:change tasks.

### Additional information

Closes #45824
Fixes #18073

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
