### PR TITLE
Add `expires_at` option to `signed_id`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `expires_in` option to `signed_id`.
+
+    *Shouichi Kamiya*
+
 *   Fix a case where the query cache can return wrong values. See #46044
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -109,8 +109,8 @@ module ActiveRecord
     #
     # And you then change your +find_signed+ calls to require this new purpose. Any old signed ids that were not
     # created with the purpose will no longer find the record.
-    def signed_id(expires_in: nil, purpose: nil)
-      self.class.signed_id_verifier.generate id, expires_in: expires_in, purpose: self.class.combine_signed_id_purposes(purpose)
+    def signed_id(expires_in: nil, expires_at: nil, purpose: nil)
+      self.class.signed_id_verifier.generate id, expires_in: expires_in, expires_at: expires_at, purpose: self.class.combine_signed_id_purposes(purpose)
     end
   end
 end

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -67,11 +67,11 @@ class SignedIdTest < ActiveRecord::TestCase
     assert_nil Account.find_signed("this won't find anything")
   end
 
-  test "find signed record within expiration date" do
+  test "find signed record within expiration duration" do
     assert_equal @account, Account.find_signed(@account.signed_id(expires_in: 1.minute))
   end
 
-  test "fail to find signed record within expiration date" do
+  test "fail to find signed record within expiration duration" do
     signed_id = @account.signed_id(expires_in: 1.minute)
     travel 2.minutes
     assert_nil Account.find_signed(signed_id)
@@ -81,6 +81,16 @@ class SignedIdTest < ActiveRecord::TestCase
     signed_id = @account.signed_id(expires_in: 1.minute)
     @account.destroy
     assert_nil Account.find_signed signed_id
+  end
+
+  test "find signed record within expiration time" do
+    assert_equal @account, Account.find_signed(@account.signed_id(expires_at: 1.minute.from_now))
+  end
+
+  test "fail to find signed record within expiration time" do
+    signed_id = @account.signed_id(expires_at: 1.minute.from_now)
+    travel 2.minutes
+    assert_nil Account.find_signed(signed_id)
   end
 
   test "find signed record with purpose" do
@@ -99,11 +109,11 @@ class SignedIdTest < ActiveRecord::TestCase
     end
   end
 
-  test "find signed record with a bang within expiration date" do
+  test "find signed record with a bang within expiration duration" do
     assert_equal @account, Account.find_signed!(@account.signed_id(expires_in: 1.minute))
   end
 
-  test "finding signed record outside expiration date raises on the bang" do
+  test "finding signed record outside expiration duration raises on the bang" do
     signed_id = @account.signed_id(expires_in: 1.minute)
     travel 2.minutes
 


### PR DESCRIPTION
Problem:

Though, the `MessageVerifier` that powers `signed_id` supports both `expires_in` and `expires_at`, `signed_id` only supports `expires_in`. Because of this, generating signed_id that expires at a certain time is somewhat tedious. Imagine issuing a coupon that is valid only for a day.

Solution:

Add `expires_at` option to `signed_id` to generate signed ids that expire at the given time.