### PR TITLE
Use a higher-level Sidekiq API for ActiveJob

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for Sidekiq's transaction-aware client
+
+    *Jonathan del Strother*
+
 *   Remove QueAdapter from Active Job.
 
     After maintaining Active Job QueAdapter by Rails and Que side

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -18,21 +18,17 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :sidekiq
     class SidekiqAdapter
       def enqueue(job) # :nodoc:
-        # Sidekiq::Client does not support symbols as keys
-        job.provider_job_id = Sidekiq::Client.push \
-          "class"   => JobWrapper,
-          "wrapped" => job.class,
-          "queue"   => job.queue_name,
-          "args"    => [ job.serialize ]
+        job.provider_job_id = JobWrapper.set(
+          wrapped: job.class,
+          queue: job.queue_name
+        ).perform_async(job.serialize)
       end
 
       def enqueue_at(job, timestamp) # :nodoc:
-        job.provider_job_id = Sidekiq::Client.push \
-          "class"   => JobWrapper,
-          "wrapped" => job.class,
-          "queue"   => job.queue_name,
-          "args"    => [ job.serialize ],
-          "at"      => timestamp
+        job.provider_job_id = JobWrapper.set(
+          wrapped: job.class,
+          queue: job.queue_name,
+        ).perform_at(timestamp, job.serialize)
       end
 
       class JobWrapper # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This allows Sidekiq to use a custom client_class, which is necessary for the new transaction-aware client in 6.5 (https://github.com/mperham/sidekiq/blob/main/Changes.md#650)

### Detail

This Pull Request replaces use of `Sidekiq::Client.push` with the higher-level `JobWrapper.perform_async`. Sidekiq can then dynamically look up the necessary client (which might be Sidekiq::Client, or might be Sidekiq::TransactionAwareClient).

### Additional information

https://github.com/mperham/sidekiq/issues/5526

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
