### PR TITLE
Fix being able to pass --force to db:system:change

### DIFF
--- a/railties/lib/rails/commands/db/system/change/change_command.rb
+++ b/railties/lib/rails/commands/db/system/change/change_command.rb
@@ -15,7 +15,7 @@ module Rails
             super
           end
 
-          def perform
+          def perform(*)
             Rails::Generators::Db::System::ChangeGenerator.start(@argv)
           end
         end

--- a/railties/test/commands/db_system_change_test.rb
+++ b/railties/test/commands/db_system_change_test.rb
@@ -54,6 +54,13 @@ class Rails::Command::Db::System::ChangeCommandTest < ActiveSupport::TestCase
     assert_match "gsub  Gemfile", output
   end
 
+  test "change can be forced" do
+    output = `cd #{app_path}; bin/rails db:system:change --to=postgresql --force`
+
+    assert_match "force  config/database.yml", output
+    assert_match "gsub  Gemfile", output
+  end
+
   private
     def change_database(to:, **options)
       args = ["--to", to]


### PR DESCRIPTION
### Motivation / Background

Running db:system:change will always prompt to overwrite database.yml, so being able to --force it seems expected

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
