### PR TITLE
Allow manipulating namespaced indices on postgresql with the migration DSL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -67,8 +67,10 @@ module ActiveRecord
         # * <tt>"schema_name".table_name</tt>
         # * <tt>"schema.name"."table name"</tt>
         def extract_schema_qualified_name(string)
-          schema, table = string.scan(/[^".]+|"[^"]*"/)
-          if table.nil?
+          schema, *table = string.scan(/[^".]+|"[^"]*"/)
+          table = table.join('.')
+
+          if table.empty?
             table = schema
             schema = nil
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         # * <tt>"schema.name"."table name"</tt>
         def extract_schema_qualified_name(string)
           schema, *table = string.scan(/[^".]+|"[^"]*"/)
-          table = table.join('.')
+          table = table.join(".")
 
           if table.empty?
             table = schema

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -378,6 +378,12 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
     assert_nothing_raised { @connection.remove_index "#{SCHEMA_NAME}.things", name: "#{SCHEMA_NAME}.things_Index" }
 
+    @connection.execute "CREATE INDEX \"namespace.things_Index\" ON #{SCHEMA_NAME}.things (name)"
+    assert_nothing_raised { @connection.remove_index "things", name: "#{SCHEMA_NAME}.namespace.things_Index" }
+
+    @connection.execute "CREATE INDEX \"namespace.things_Index\" ON #{SCHEMA_NAME}.things (moment)"
+    assert_nothing_raised { @connection.remove_index "#{SCHEMA_NAME}.things", :moment }
+
     @connection.execute "CREATE INDEX \"things_Index\" ON #{SCHEMA_NAME}.things (name)"
     assert_raises(ArgumentError) { @connection.remove_index "#{SCHEMA2_NAME}.things", name: "#{SCHEMA_NAME}.things_Index" }
 

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -16,7 +16,8 @@ class PostgreSQLUtilsTest < ActiveRecord::PostgreSQLTestCase
       %(schema."table_name")   => %w{schema table_name},
       %("schema"."table_name") => %w{schema table_name},
       %("even spaces".table)   => ["even spaces", "table"],
-      %(schema."table.name")   => ["schema", "table.name"]
+      %(schema."table.name")   => ["schema", "table.name"],
+      %(schema.table.name)   => ["schema", "table.name"]
     }.each do |given, expect|
       assert_equal Name.new(*expect), extract_schema_qualified_name(given)
     end

--- a/activerecord/test/cases/adapters/postgresql/utils_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/utils_test.rb
@@ -17,7 +17,7 @@ class PostgreSQLUtilsTest < ActiveRecord::PostgreSQLTestCase
       %("schema"."table_name") => %w{schema table_name},
       %("even spaces".table)   => ["even spaces", "table"],
       %(schema."table.name")   => ["schema", "table.name"],
-      %(schema.table.name)   => ["schema", "table.name"]
+      %(schema.table.name)     => ["schema", "table.name"],
     }.each do |given, expect|
       assert_equal Name.new(*expect), extract_schema_qualified_name(given)
     end


### PR DESCRIPTION
### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

This Pull Request has been created because we use namespaced indices in our database, resulting in indices looking like this:

`namespace.index_table_on_column`

Trying to use the ActiveRecord migration DSL to remove such an index fails because the `Utils.extract_schema_qualified_name` method returns only `namespace` and not `namespace.index_table_on_column`.

### Detail

This Pull Request changes `Utils.extract_schema_qualified_name` to handle this case.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
