### PR TITLE
Do not write unchanged value to ActiveRecord::Store

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -225,7 +225,7 @@ module ActiveRecord
 
         def self.write(object, attribute, key, value)
           prepare(object, attribute)
-          object.public_send(attribute)[key] = value
+          object.public_send(attribute)[key] = value if value != read(object, attribute, key)
         end
 
         def self.prepare(object, attribute)

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -31,6 +31,12 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "37signals.com", @john.homepage
   end
 
+  test "writing store attributes does not update unchanged value" do
+    admin_user = Admin::User.new(homepage: nil)
+    admin_user.homepage = nil
+    assert_equal({}, admin_user.settings)
+  end
+
   test "reading store attributes through accessors with prefix" do
     assert_equal "Quinn", @john.parent_name
     assert_nil @john.parent_birthday


### PR DESCRIPTION
### Motivation / Background

Partially reverts https://github.com/rails/rails/pull/45645/files

### Detail

The PR mentioned above introduced a behind-the-scenes behavior change which may not be anticipated
Prior the PR mentioned above, `nil` values were not explicitly set on a newly initialized store because of the `value != read(object, attribute, key)` check. However after the change store started to explicitly initializing keys with `nil`s.
I don't think it's critical for applications as the reader will still return `nil`. However it's a behavior change and I'd like to prevent it until we explicitly state that we are doing it intentionally. There is also a real-world downside of explicitly initializing keys with `nil` and that is the serialization of the store. Every explicit `nil` value gets unnecessarily serialized and stored in the database.

### Alternative

This PR is basically the same as:

- Revert (https://github.com/rails/rails/pull/45645/files) 
- Add `writing store attributes does not update unchanged value` test from the current PR to cover the behavior
- Re-introduce https://github.com/rails/rails/pull/45645/files with either explicit behavior change or with keeping the inequality check before writing to the store

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.
