### PR TITLE
Move dbconsole logic to Active Record connection adapter.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -89,6 +89,39 @@ module ActiveRecord
         @quoted_table_names ||= {}
       end
 
+      def self.find_cmd_and_exec(commands, *args) # :doc:
+        commands = Array(commands)
+
+        dirs_on_path = ENV["PATH"].to_s.split(File::PATH_SEPARATOR)
+        unless (ext = RbConfig::CONFIG["EXEEXT"]).empty?
+          commands = commands.map { |cmd| "#{cmd}#{ext}" }
+        end
+
+        full_path_command = nil
+        found = commands.detect do |cmd|
+          dirs_on_path.detect do |path|
+            full_path_command = File.join(path, cmd)
+            begin
+              stat = File.stat(full_path_command)
+            rescue SystemCallError
+            else
+              stat.file? && stat.executable?
+            end
+          end
+        end
+
+        if found
+          exec full_path_command, *args
+        else
+          abort("Couldn't find database client: #{commands.join(', ')}. Check your $PATH and try again.")
+        end
+      end
+
+      # Opens a database console session.
+      def self.dbconsole(config, options = {})
+        raise NotImplementedError
+      end
+
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:
         super()
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -51,6 +51,36 @@ module ActiveRecord
           end
       end
 
+      class << self
+        def dbconsole(config, options = {})
+          mysql_config = config.configuration_hash
+
+          args = {
+            host: "--host",
+            port: "--port",
+            socket: "--socket",
+            username: "--user",
+            encoding: "--default-character-set",
+            sslca: "--ssl-ca",
+            sslcert: "--ssl-cert",
+            sslcapath: "--ssl-capath",
+            sslcipher: "--ssl-cipher",
+            sslkey: "--ssl-key",
+            ssl_mode: "--ssl-mode"
+          }.filter_map { |opt, arg| "#{arg}=#{mysql_config[opt]}" if mysql_config[opt] }
+
+          if mysql_config[:password] && options[:include_password]
+            args << "--password=#{mysql_config[:password]}"
+          elsif mysql_config[:password] && !mysql_config[:password].to_s.empty?
+            args << "-p"
+          end
+
+          args << config.database
+
+          find_cmd_and_exec(["mysql", "mysql5"], *args)
+        end
+      end
+
       def get_database_version # :nodoc:
         full_version_string = get_full_version
         version_string = version_string(full_version_string)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -8,9 +8,13 @@ require "mysql2"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
+    def mysql2_connection_class
+      ConnectionAdapters::Mysql2Adapter
+    end
+
     # Establishes a connection to the database that's used by all Active Record objects.
     def mysql2_connection(config)
-      ConnectionAdapters::Mysql2Adapter.new(config)
+      mysql2_connection_class.new(config)
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -15,8 +15,12 @@ require "sqlite3"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
+    def sqlite3_connection_class
+      ConnectionAdapters::SQLite3Adapter
+    end
+
     def sqlite3_connection(config)
-      ConnectionAdapters::SQLite3Adapter.new(config)
+      sqlite3_connection_class.new(config)
     end
   end
 
@@ -39,6 +43,16 @@ module ActiveRecord
           else
             raise
           end
+        end
+
+        def dbconsole(config, options = {})
+          args = []
+
+          args << "-#{options[:mode]}" if options[:mode]
+          args << "-header" if options[:header]
+          args << File.expand_path(config.database, Rails.respond_to?(:root) ? Rails.root : nil)
+
+          find_cmd_and_exec("sqlite3", *args)
         end
       end
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -17,6 +17,10 @@ module ActiveRecord
         "#{adapter}_connection"
       end
 
+      def adapter_class_method
+        "#{adapter}_connection_class"
+      end
+
       def host
         raise NotImplementedError
       end

--- a/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/testing/method_call_assertions"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class Mysql2DbConsoleTest < ActiveRecord::Mysql2TestCase
+      include ActiveSupport::Testing::MethodCallAssertions
+
+      def test_mysql
+        config = make_db_config(adapter: "mysql2", database: "db")
+
+        assert_find_cmd_and_exec_called_with([%w[mysql mysql5], "db"]) do
+          Mysql2Adapter.dbconsole(config)
+        end
+      end
+
+      def test_mysql_full
+        config = make_db_config(
+          adapter:   "mysql2",
+          database:  "db",
+          host:      "localhost",
+          port:      1234,
+          socket:    "socket",
+          username:  "user",
+          password:  "qwerty",
+          encoding:  "UTF-8",
+          sslca:     "/path/to/ca-cert.pem",
+          sslcert:   "/path/to/client-cert.pem",
+          sslcapath: "/path/to/cacerts",
+          sslcipher: "DHE-RSA-AES256-SHA",
+          sslkey:    "/path/to/client-key.pem",
+          ssl_mode:  "VERIFY_IDENTITY"
+        )
+
+        args = [
+          %w[mysql mysql5],
+          "--host=localhost",
+          "--port=1234",
+          "--socket=socket",
+          "--user=user",
+          "--default-character-set=UTF-8",
+          "--ssl-ca=/path/to/ca-cert.pem",
+          "--ssl-cert=/path/to/client-cert.pem",
+          "--ssl-capath=/path/to/cacerts",
+          "--ssl-cipher=DHE-RSA-AES256-SHA",
+          "--ssl-key=/path/to/client-key.pem",
+          "--ssl-mode=VERIFY_IDENTITY",
+          "-p", "db"
+        ]
+
+        assert_find_cmd_and_exec_called_with(args) do
+          Mysql2Adapter.dbconsole(config)
+        end
+      end
+
+      def test_mysql_include_password
+        config = make_db_config(adapter: "mysql2", database: "db", username: "user", password: "qwerty")
+
+        assert_find_cmd_and_exec_called_with([%w[mysql mysql5], "--user=user", "--password=qwerty", "db"]) do
+          Mysql2Adapter.dbconsole(config, include_password: true)
+        end
+      end
+
+      private
+        def make_db_config(config)
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
+        end
+
+        def assert_find_cmd_and_exec_called_with(args, &block)
+          assert_called_with(Mysql2Adapter, :find_cmd_and_exec, args, &block)
+        end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/testing/method_call_assertions"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgresqlDbConsoleTest < ActiveRecord::PostgreSQLTestCase
+      include ActiveSupport::Testing::MethodCallAssertions
+
+      ENV_VARS = %w(PGUSER PGHOST PGPORT PGPASSWORD PGSSLMODE PGSSLCERT PGSSLKEY PGSSLROOTCERT PGOPTIONS)
+
+      def run(*)
+        preserve_pg_env do
+          super
+        end
+      end
+
+      def test_postgresql
+        config = make_db_config(adapter: "postgresql", database: "db")
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+      end
+
+      def test_postgresql_full
+        config = make_db_config(
+          adapter: "postgresql",
+          database: "db",
+          username: "user",
+          password: "q1w2e3",
+          host: "host",
+          port: 5432,
+        )
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "user", ENV["PGUSER"]
+        assert_equal "host", ENV["PGHOST"]
+        assert_equal "5432", ENV["PGPORT"]
+        assert_not_equal "q1w2e3", ENV["PGPASSWORD"]
+      end
+
+      def test_postgresql_with_ssl
+        config = make_db_config(adapter: "postgresql", database: "db", sslmode: "verify-full", sslcert: "client.crt", sslkey: "client.key", sslrootcert: "root.crt")
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "verify-full", ENV["PGSSLMODE"]
+        assert_equal "client.crt", ENV["PGSSLCERT"]
+        assert_equal "client.key", ENV["PGSSLKEY"]
+        assert_equal "root.crt", ENV["PGSSLROOTCERT"]
+      end
+
+      def test_postgresql_include_password
+        config = make_db_config(adapter: "postgresql", database: "db", username: "user", password: "q1w2e3")
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config, include_password: true)
+        end
+
+        assert_equal "user", ENV["PGUSER"]
+        assert_equal "q1w2e3", ENV["PGPASSWORD"]
+      end
+
+      def test_postgresql_include_variables
+        config = make_db_config(adapter: "postgresql", database: "db", variables: { search_path: "my_schema, default, \\my_schema", statement_timeout: 5000, lock_timeout: ":default" })
+
+        assert_find_cmd_and_exec_called_with(["psql", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+
+        assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema -c statement_timeout=5000", ENV["PGOPTIONS"]
+      end
+
+      private
+        def preserve_pg_env
+          old_values = ENV_VARS.map { |var| ENV[var] }
+          yield
+        ensure
+          ENV_VARS.zip(old_values).each { |var, value| ENV[var] = value }
+        end
+
+        def make_db_config(config)
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
+        end
+
+        def assert_find_cmd_and_exec_called_with(args, &block)
+          assert_called_with(PostgreSQLAdapter, :find_cmd_and_exec, args, &block)
+        end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/testing/method_call_assertions"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SQLite3DbConsoleTest < ActiveRecord::SQLite3TestCase
+      include ActiveSupport::Testing::MethodCallAssertions
+
+      def test_sqlite3
+        config = make_db_config(adapter: "sqlite3", database: "db.sqlite3")
+
+        assert_find_cmd_and_exec_called_with(["sqlite3", root.join("db.sqlite3").to_s]) do
+          SQLite3Adapter.dbconsole(config)
+        end
+      end
+
+      def test_sqlite3_mode
+        config = make_db_config(adapter: "sqlite3", database: "db.sqlite3")
+
+        assert_find_cmd_and_exec_called_with(["sqlite3", "-html", root.join("db.sqlite3").to_s]) do
+          SQLite3Adapter.dbconsole(config, mode: "html")
+        end
+      end
+
+      def test_sqlite3_header
+        config = make_db_config(adapter: "sqlite3", database: "db.sqlite3")
+
+        assert_find_cmd_and_exec_called_with(["sqlite3", "-header", root.join("db.sqlite3").to_s]) do
+          SQLite3Adapter.dbconsole(config, header: true)
+        end
+      end
+
+      def test_sqlite3_db_absolute_path
+        config = make_db_config(adapter: "sqlite3", database: "/tmp/db.sqlite3")
+
+        assert_find_cmd_and_exec_called_with(["sqlite3", "/tmp/db.sqlite3"]) do
+          SQLite3Adapter.dbconsole(config)
+        end
+      end
+
+      def test_sqlite3_db_with_defined_rails_root
+        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3")
+
+        Rails.define_singleton_method(:root, &method(:root))
+
+        assert_find_cmd_and_exec_called_with(["sqlite3", Rails.root.join("config/db.sqlite3").to_s]) do
+          SQLite3Adapter.dbconsole(config)
+        end
+      ensure
+        Rails.singleton_class.remove_method(:root)
+      end
+
+      private
+        def root
+          Pathname(__dir__).join("../../../..")
+        end
+
+        def make_db_config(config)
+          ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
+        end
+
+        def assert_find_cmd_and_exec_called_with(args, &block)
+          assert_called_with(SQLite3Adapter, :find_cmd_and_exec, args, &block)
+        end
+    end
+  end
+end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Move dbconsole logic to Active Record connection adapter.
+
+    Instead of hosting the connection logic in the command object, the
+    database adapter should be responsible for connecting to a console session.
+    This patch moves #find_cmd_and_exec to the adapter and exposes a new API to
+    lookup the adapter class without instantiating it.
+
+    *Gannon McGibbon, Paarth Madan*
+
 *   Add `Rails.application.message_verifiers` as a central point to configure
     and create message verifiers for an application.
 

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -5,15 +5,19 @@ require "minitest/mock"
 require "rails/command"
 require "rails/commands/dbconsole/dbconsole_command"
 require "active_record/database_configurations"
+require "active_support/testing/method_call_assertions"
+require "active_record/connection_adapters/sqlite3_adapter"
 
 class Rails::DBConsoleTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
   def setup
     Rails::DBConsole.const_set("APP_PATH", "rails/all")
   end
 
   def teardown
     Rails::DBConsole.send(:remove_const, "APP_PATH")
-    %w[PGUSER PGHOST PGPORT PGPASSWORD DATABASE_URL].each { |key| ENV.delete(key) }
+    %w[DATABASE_URL].each { |key| ENV.delete(key) }
   end
 
   def test_config_with_db_config_only
@@ -106,140 +110,11 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     end
   end
 
-  def test_mysql
-    start(adapter: "mysql2", database: "db")
-    assert_not aborted
-    assert_equal [%w[mysql mysql5], "db"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_mysql_full
-    start(
-      adapter:   "mysql2",
-      database:  "db",
-      host:      "localhost",
-      port:      1234,
-      socket:    "socket",
-      username:  "user",
-      password:  "qwerty",
-      encoding:  "UTF-8",
-      sslca:     "/path/to/ca-cert.pem",
-      sslcert:   "/path/to/client-cert.pem",
-      sslcapath: "/path/to/cacerts",
-      sslcipher: "DHE-RSA-AES256-SHA",
-      sslkey:    "/path/to/client-key.pem",
-      ssl_mode:  "VERIFY_IDENTITY"
-    )
-    assert_not aborted
-    assert_equal [
-      %w[mysql mysql5],
-      "--host=localhost",
-      "--port=1234",
-      "--socket=socket",
-      "--user=user",
-      "--default-character-set=UTF-8",
-      "--ssl-ca=/path/to/ca-cert.pem",
-      "--ssl-cert=/path/to/client-cert.pem",
-      "--ssl-capath=/path/to/cacerts",
-      "--ssl-cipher=DHE-RSA-AES256-SHA",
-      "--ssl-key=/path/to/client-key.pem",
-      "--ssl-mode=VERIFY_IDENTITY",
-      "-p", "db"
-    ], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_mysql_include_password
-    start({ adapter: "mysql2", database: "db", username: "user", password: "qwerty" }, ["-p"])
-    assert_not aborted
-    assert_equal [%w[mysql mysql5], "--user=user", "--password=qwerty", "db"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_postgresql
-    start(adapter: "postgresql", database: "db")
-    assert_not aborted
-    assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_postgresql_full
-    start(adapter: "postgresql", database: "db", username: "user", password: "q1w2e3", host: "host", port: 5432)
-    assert_not aborted
-    assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
-    assert_equal "user", ENV["PGUSER"]
-    assert_equal "host", ENV["PGHOST"]
-    assert_equal "5432", ENV["PGPORT"]
-    assert_not_equal "q1w2e3", ENV["PGPASSWORD"]
-  end
-
-  def test_postgresql_with_ssl
-    start(adapter: "postgresql", database: "db", sslmode: "verify-full", sslcert: "client.crt", sslkey: "client.key", sslrootcert: "root.crt")
-    assert_not aborted
-    assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
-    assert_equal "verify-full", ENV["PGSSLMODE"]
-    assert_equal "client.crt", ENV["PGSSLCERT"]
-    assert_equal "client.key", ENV["PGSSLKEY"]
-    assert_equal "root.crt", ENV["PGSSLROOTCERT"]
-  end
-
-  def test_postgresql_include_password
-    start({ adapter: "postgresql", database: "db", username: "user", password: "q1w2e3" }, ["-p"])
-    assert_not aborted
-    assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
-    assert_equal "user", ENV["PGUSER"]
-    assert_equal "q1w2e3", ENV["PGPASSWORD"]
-  end
-
-  def test_postgresql_include_variables
-    start(adapter: "postgresql", database: "db", variables: { search_path: "my_schema, default, \\my_schema", statement_timeout: 5000, lock_timeout: ":default" })
-    assert_not aborted
-    assert_equal "-c search_path=my_schema,\\ default,\\ \\\\my_schema -c statement_timeout=5000", ENV["PGOPTIONS"]
-  end
-
-  def test_sqlite3
-    start(adapter: "sqlite3", database: "db.sqlite3")
-    assert_not aborted
-    assert_equal ["sqlite3", Rails.root.join("db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_sqlite3_mode
-    start({ adapter: "sqlite3", database: "db.sqlite3" }, ["--mode", "html"])
-    assert_not aborted
-    assert_equal ["sqlite3", "-html", Rails.root.join("db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_sqlite3_header
-    start({ adapter: "sqlite3", database: "db.sqlite3" }, ["--header"])
-    assert_equal ["sqlite3", "-header", Rails.root.join("db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_sqlite3_db_absolute_path
-    start(adapter: "sqlite3", database: "/tmp/db.sqlite3")
-    assert_not aborted
-    assert_equal ["sqlite3", "/tmp/db.sqlite3"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_sqlite3_db_without_defined_rails_root
-    Rails.stub(:respond_to?, false) do
-      start(adapter: "sqlite3", database: "config/db.sqlite3")
-      assert_not aborted
-      assert_equal ["sqlite3", Rails.root.join("../config/db.sqlite3").to_s], dbconsole.find_cmd_and_exec_args
+  def test_start
+    assert_called_with(ActiveRecord::ConnectionAdapters::SQLite3Adapter, :exec, [/sqlite3/, /db\.sqlite3/]) do
+      start(adapter: "sqlite3", database: "db.sqlite3")
     end
-  end
-
-  def test_oracle
-    start(adapter: "oracle", database: "db", username: "user", password: "secret")
     assert_not aborted
-    assert_equal ["sqlplus", "user@db"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_oracle_include_password
-    start({ adapter: "oracle", database: "db", username: "user", password: "secret" }, ["-p"])
-    assert_not aborted
-    assert_equal ["sqlplus", "user/secret@db"], dbconsole.find_cmd_and_exec_args
-  end
-
-  def test_sqlserver
-    start(adapter: "sqlserver", database: "db", username: "user", password: "secret", host: "localhost", port: 1433)
-    assert_not aborted
-    assert_equal ["sqlcmd", "-d", "db", "-U", "user", "-P", "secret", "-S", "tcp:localhost,1433"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_unknown_command_line_client
@@ -332,22 +207,12 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
       Rails.application.config.stub(:database_configuration, results || {}, &block)
     end
 
-    def make_dbconsole
-      Class.new(Rails::DBConsole) do
-        attr_reader :find_cmd_and_exec_args
-
-        def find_cmd_and_exec(*args)
-          @find_cmd_and_exec_args = args
-        end
-      end
-    end
-
     attr_reader :dbconsole
 
     def start(config = {}, argv = [])
       hash_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
 
-      @dbconsole = make_dbconsole.new(parse_arguments(argv))
+      @dbconsole = Rails::DBConsole.new(parse_arguments(argv))
       @dbconsole.stub(:db_config, hash_config) do
         capture_abort { @dbconsole.start }
       end


### PR DESCRIPTION
This Pull Request has been created because the dbconsole command is doing too much. It makes it impossible for adapters to configure dbconsole behaviour without patching it in the command directly.

### Detail

Instead of hosting the connection logic in the command object, the database adapter should be responsible for connecting to a console session.

### Additional information

This patch moves `#find_cmd_and_exec` to the adapter and exposes a new API to lookup the adapter class without instantiating it.

Since we also are effectively dropping first party dbconsole support for oracle and sqlserver adapters, we will be submitting patches to implement and test this in those adapters. The jdbc mysql and postgis adapters are subclassed to inherit this behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
