### PR TITLE
Fix --skip-listen not persisting to app:update

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -30,6 +30,7 @@ module Rails
           options[:skip_puma]           = !defined?(Puma)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options[:skip_spring]         = !defined?(Spring)
+          options[:skip_listen]         = !defined?(Listen)
           options
         end
     end


### PR DESCRIPTION
### Motivation / Background

Previously, when upgrading from 6.0 to 6.1, the EventedFileWatcher
configuration is always uncommented because --skip-listen is never set
during app:update.

### Detail

This commit fixes that by setting --skip-listen based on the absence of
the Listen constant when upgrading, similarly to what is done for
Spring/Bootsnap/etc.

### Additional information

Fixes #46091 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.
