### PR TITLE
ActiveSupport::Reloader should not report exception

### DIFF
--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -91,7 +91,7 @@ module ActiveSupport
       begin
         yield
       rescue => error
-        error_reporter.report(error, handled: false, source: source)
+        error_reporter&.report(error, handled: false, source: source)
         raise
       ensure
         instance.complete!
@@ -108,7 +108,7 @@ module ActiveSupport
       end
     end
 
-    def self.error_reporter
+    def self.error_reporter # :nodoc:
       ActiveSupport.error_reporter
     end
 

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -68,8 +68,15 @@ module ActiveSupport
 
     # Run the supplied block as a work unit, reloading code as needed
     def self.wrap(**kwargs)
+      return yield if active?
+
       executor.wrap(**kwargs) do
-        super
+        instance = run!
+        begin
+          yield
+        ensure
+          instance.complete!
+        end
       end
     end
 

--- a/activesupport/lib/active_support/testing/error_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/error_reporter_assertions.rb
@@ -42,6 +42,7 @@ module ActiveSupport
 
                 if ActiveSupport.error_reporter
                   ActiveSupport.error_reporter.subscribe(self)
+                  @subscribed = true
                 else
                   raise Minitest::Assertion, "No error reporter is configured"
                 end

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -85,6 +85,17 @@ class ReloaderTest < ActiveSupport::TestCase
     assert_equal [:before_unload, :unload, :after_unload, :body], called
   end
 
+  def test_report_errors_once
+    reports = ErrorCollector.record do
+      assert_raises RuntimeError do
+        reloader.wrap do
+          raise "Oops"
+        end
+      end
+    end
+    assert_equal 1, reports.size
+  end
+
   private
     def new_reloader(&check)
       Class.new(ActiveSupport::Reloader).tap do |r|


### PR DESCRIPTION
Since it always delegate to an actual executor that does report them already, this cause exceptions to be reported twice.

Fix: https://github.com/rails/rails/issues/46100

cc @nvasilevski 