### PR TITLE
Don't re-establish connection for purge_current and create_current

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -182,7 +182,6 @@ module ActiveRecord
 
       def create_current(environment = env, name = nil)
         each_current_configuration(environment, name) { |db_config| create(db_config) }
-        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def prepare_all
@@ -345,7 +344,6 @@ module ActiveRecord
 
       def purge_current(environment = env)
         each_current_configuration(environment) { |db_config| purge(db_config) }
-        ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
       def structure_dump(configuration, *arguments)


### PR DESCRIPTION
These methods call `establish_connection` at the end of their adapter tasks code so  we shouldn't need to re-establihs a connection at the end.

---

Opening a PR to see if any tests fail due to this change. If they do I'll close.