### PR TITLE
Use explicit deprecator in wrappers tests

### DIFF
--- a/activesupport/test/deprecation/method_wrappers_test.rb
+++ b/activesupport/test/deprecation/method_wrappers_test.rb
@@ -17,46 +17,43 @@ class MethodWrappersTest < ActiveSupport::TestCase
         def new_private_method; "abc" end
         alias_method :old_private_method, :new_private_method
     end
+
+    @deprecator = ActiveSupport::Deprecation.new
   end
 
   def test_deprecate_methods_without_alternate_method
-    warning = /old_method is deprecated and will be removed from Rails \d.\d./
-    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method)
+    @deprecator.deprecate_methods(@klass, :old_method)
 
-    assert_deprecated(warning) { assert_equal "abc", @klass.new.old_method }
+    assert_deprecated("old_method", @deprecator) do
+      assert_equal @klass.new.new_method, @klass.new.old_method
+    end
   end
 
   def test_deprecate_methods_warning_default
-    warning = /old_method is deprecated and will be removed from Rails \d.\d \(use new_method instead\)/
-    ActiveSupport::Deprecation.deprecate_methods(@klass, old_method: :new_method)
+    @deprecator.deprecate_methods(@klass, old_method: :new_method)
 
-    assert_deprecated(warning) { assert_equal "abc", @klass.new.old_method }
+    assert_deprecated(/old_method .* \(use new_method instead\)/, @deprecator) do
+      assert_equal @klass.new.new_method, @klass.new.old_method
+    end
   end
 
   def test_deprecate_methods_warning_with_optional_deprecator
-    warning = /old_method is deprecated and will be removed from MyGem next-release \(use new_method instead\)/
-    deprecator = ActiveSupport::Deprecation.new("next-release", "MyGem")
-    ActiveSupport::Deprecation.deprecate_methods(@klass, old_method: :new_method, deprecator: deprecator)
+    @deprecator = ActiveSupport::Deprecation.new("next-release", "MyGem")
+    ActiveSupport::Deprecation.deprecate_methods(@klass, :old_method, deprecator: @deprecator)
 
-    assert_deprecated(warning, deprecator) { assert_equal "abc", @klass.new.old_method }
-  end
-
-  def test_deprecate_methods_warning_when_deprecated_with_custom_deprecator
-    warning = /old_method is deprecated and will be removed from MyGem next-release \(use new_method instead\)/
-    deprecator = ActiveSupport::Deprecation.new("next-release", "MyGem")
-    deprecator.deprecate_methods(@klass, old_method: :new_method)
-
-    assert_deprecated(warning, deprecator) { assert_equal "abc", @klass.new.old_method }
+    assert_deprecated(/old_method .* MyGem next-release/, @deprecator) do
+      assert_equal @klass.new.new_method, @klass.new.old_method
+    end
   end
 
   def test_deprecate_methods_protected_method
-    ActiveSupport::Deprecation.deprecate_methods(@klass, old_protected_method: :new_protected_method)
+    @deprecator.deprecate_methods(@klass, old_protected_method: :new_protected_method)
 
     assert(@klass.protected_method_defined?(:old_protected_method))
   end
 
   def test_deprecate_methods_private_method
-    ActiveSupport::Deprecation.deprecate_methods(@klass, old_private_method: :new_private_method)
+    @deprecator.deprecate_methods(@klass, old_private_method: :new_private_method)
 
     assert(@klass.private_method_defined?(:old_private_method))
   end
@@ -69,10 +66,11 @@ class MethodWrappersTest < ActiveSupport::TestCase
         "abc"
       end
     end
-    ActiveSupport::Deprecation.deprecate_methods(mod, old_method: :new_method)
+    @deprecator.deprecate_methods(mod, :old_method)
 
-    warning = /old_method is deprecated and will be removed from Rails \d.\d \(use new_method instead\)/
-    assert_deprecated(warning) { assert_equal "abc", mod.old_method }
+    assert_deprecated("old_method", @deprecator) do
+      assert_equal "abc", mod.old_method
+    end
   end
 
   def test_deprecate_method_when_class_extends_module
@@ -81,10 +79,11 @@ class MethodWrappersTest < ActiveSupport::TestCase
         "abc"
       end
     end
-    @klass.extend mod
-    ActiveSupport::Deprecation.deprecate_methods(mod, old_method: :new_method)
+    klass = Class.new { extend mod }
+    @deprecator.deprecate_methods(mod, :old_method)
 
-    warning = /old_method is deprecated and will be removed from Rails \d.\d \(use new_method instead\)/
-    assert_deprecated(warning) { assert_equal "abc", @klass.old_method }
+    assert_deprecated("old_method", @deprecator) do
+      assert_equal "abc", klass.old_method
+    end
   end
 end

--- a/activesupport/test/deprecation/proxy_wrappers_test.rb
+++ b/activesupport/test/deprecation/proxy_wrappers_test.rb
@@ -13,6 +13,10 @@ class ProxyWrappersTest < ActiveSupport::TestCase
     end
   end
 
+  def setup
+    @deprecator = ActiveSupport::Deprecation.new
+  end
+
   def test_deprecated_object_proxy_doesnt_wrap_falsy_objects
     proxy = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(nil, "message")
     assert_not proxy
@@ -29,31 +33,31 @@ class ProxyWrappersTest < ActiveSupport::TestCase
   end
 
   def test_including_proxy_module
-    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name, @deprecator)
     klass = Class.new
-    assert_deprecated do
+    assert_deprecated("OldWaffleModule", @deprecator) do
       klass.include proxy
     end
     assert klass.new.waffle?
   end
 
   def test_prepending_proxy_module
-    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name, @deprecator)
     klass = Class.new do
       def waffle?
         false
       end
     end
-    assert_deprecated do
+    assert_deprecated("OldWaffleModule", @deprecator) do
       klass.prepend proxy
     end
     assert klass.new.waffle?
   end
 
   def test_extending_proxy_module
-    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name)
+    proxy = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("OldWaffleModule", WaffleModule.name, @deprecator)
     obj = Object.new
-    assert_deprecated do
+    assert_deprecated("OldWaffleModule", @deprecator) do
       obj.extend proxy
     end
     assert obj.waffle?


### PR DESCRIPTION
This changes `MethodWrappersTest` and `ProxyWrappersTest` tests to use an explicit deprecator, similar to what was done for `DeprecationTest` in #46000 and its follow-ups.
