### PR TITLE
Use `#with_raw_connection` in `#quote_string` to retry connection errors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use connection from `#with_raw_connection` in `#quote_string`.
+
+    This ensures that the string quoting is wrapped in the reconnect and retry logic
+    that `#with_raw_connection` offers.
+
+    *Adrianna Chang*
+
 *   Add `expires_in` option to `signed_id`.
 
     *Shouichi Kamiya*

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -97,10 +97,11 @@ module ActiveRecord
       # QUOTING ==================================================
       #++
 
+      # Quotes strings for use in SQL input.
       def quote_string(string)
-        any_raw_connection.escape(string)
-      rescue Mysql2::Error => error
-        raise translate_exception(error, message: error.message, sql: "<escape>", binds: [])
+        with_raw_connection(allow_retry: true, uses_transaction: false) do |connection|
+          connection.escape(string)
+        end
       end
 
       #--

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -43,7 +43,9 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) # :nodoc:
-          valid_raw_connection.escape(s)
+          with_raw_connection(allow_retry: true, uses_transaction: false) do |connection|
+            connection.escape(s)
+          end
         end
 
         # Checks the following cases:


### PR DESCRIPTION
### Motivation / Background

Follow-up to the work done in #44576, #44591, #46046

MySQL and PostgreSQL both rely on a connection to perform string quoting. If the raw connection ends up being closed (network errors, server-side disconnect, etc.), instead of immediately raising a connection error, we can instead reconnect and retry the quoting by going through `#with_raw_connection`.

Shopify has historically patched `#quote_string` to rescue and retry connection-related exceptions. Often `#quote` is called before querying the db, so if we've lost connection to the db, we'll fail on `#quote_string` and raise without making it to the query to be retried. We were using the same logic in our patch for both `#quote_string` and `#execute`, so now that `#execute` will reconnect and retry upstream, we're motivated to have `#quote_string` reuse that logic so that our patch can go away completely.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [X] Tests are added if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [X] CI is passing.