### PR TITLE
Reloader: Use ErrorReporter from main Executor

### DIFF
--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -83,6 +83,10 @@ module ActiveSupport
     class_attribute :executor, default: Executor
     class_attribute :check, default: lambda { false }
 
+    class << self
+      delegate :error_reporter, to: :executor
+    end
+
     def self.check! # :nodoc:
       @should_reload ||= check.call
     end


### PR DESCRIPTION
This PR is related to the new Rails' error reporter. I noticed that, in development, unhandled exceptions were not being reported to my error subscribers, even though the `Executor` middleware [ostensibly does this](https://github.com/rails/rails/blob/93b2a2c05fb1211a92944add06ce85c380ee2b88/actionpack/lib/action_dispatch/middleware/executor.rb#L17). It turns out that, in development, the error is actually rescued in the `Reloader` middleware (which extends the `Executor`), and it uses its own executorwrapper ([`app.reloader` instead of `app.executor`](https://github.com/shalvah/rails/blob/d179383284eb19eab441563e9b5edd6053602463/railties/lib/rails/application/default_middleware_stack.rb#L58-L61)), which was creating a fresh ErrorReporter instance with no subscribers. 

The fix is to delegate the `error_reporter` method so it uses the base ExecutorWrapper's error reporter. 
