### PR TITLE
Fix erroneous nil default precision on virtual datetime columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix erroneous nil default precision on virtual datetime columns.
+
+    Prior to this change, virtual datetime columns did not have the same
+    default precision as regular datetime columns, resulting in the following
+    being erroneously equivalent:
+
+        t.virtual :name, type: datetime,                 as: "expression"
+        t.virtual :name, type: datetime, precision: nil, as: "expression"
+
+    This change fixes the default precision lookup, so virtual and regular
+    datetime column default precisions match.
+
+    *Sam Bostock*
+
 *   Use connection from `#with_raw_connection` in `#quote_string`.
 
     This ensures that the string quoting is wrapped in the reconnect and retry logic

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -475,12 +475,6 @@ module ActiveRecord
           end
         end
 
-        if @conn.supports_datetime_with_precision?
-          if type == :datetime && !options.key?(:precision)
-            options[:precision] = 6
-          end
-        end
-
         @columns_hash[name] = new_column_definition(name, type, **options)
 
         if index
@@ -547,6 +541,13 @@ module ActiveRecord
           type = integer_like_primary_key_type(type, options)
         end
         type = aliased_types(type.to_s, type)
+
+        if @conn.supports_datetime_with_precision?
+          if type == :datetime && !options.key?(:precision)
+            options[:precision] = 6
+          end
+        end
+
         options[:primary_key] ||= type == :primary_key
         options[:null] = false if options[:primary_key]
         create_column_definition(name, type, options)

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -15,12 +15,14 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
     def setup
       @connection = ActiveRecord::Base.connection
       @connection.create_table :virtual_columns, force: true do |t|
-        t.string  :name
-        t.virtual :upper_name,  type: :string,  as: "UPPER(`name`)"
-        t.virtual :name_length, type: :integer, as: "LENGTH(`name`)", stored: true
-        t.virtual :name_octet_length, type: :integer, as: "OCTET_LENGTH(`name`)", stored: true
-        t.json    :profile
-        t.virtual :profile_email, type: :string, as: "json_extract(`profile`,_utf8mb4'$.email')", stored: true
+        t.string   :name
+        t.virtual  :upper_name,  type: :string,  as: "UPPER(`name`)"
+        t.virtual  :name_length, type: :integer, as: "LENGTH(`name`)", stored: true
+        t.virtual  :name_octet_length, type: :integer, as: "OCTET_LENGTH(`name`)", stored: true
+        t.json     :profile
+        t.virtual  :profile_email, type: :string, as: "json_extract(`profile`,_utf8mb4'$.email')", stored: true
+        t.datetime :time
+        t.virtual  :time_mirror, type: :datetime, as: "`time`"
       end
       VirtualColumn.create(name: "Rails")
     end
@@ -61,6 +63,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`,\w*?'\$\.email'\)", stored: true$/i, output)
+      assert_match(/t\.virtual\s+"time_mirror",\s+type: :datetime,\s+precision: nil,\s+as: "`time`"$/i, output[/^.*time_mirror.*$/])
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -63,7 +63,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`,\w*?'\$\.email'\)", stored: true$/i, output)
-      assert_match(/t\.virtual\s+"time_mirror",\s+type: :datetime,\s+precision: nil,\s+as: "`time`"$/i, output[/^.*time_mirror.*$/])
+      assert_match(/t\.virtual\s+"time_mirror",\s+type: :datetime,\s+as: "`time`"$/i, output[/^.*time_mirror.*$/])
     end
   end
 end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -286,7 +286,7 @@ module ActiveRecord
         elsif current_adapter?(:OracleAdapter)
           assert_equal "TIMESTAMP(6)", column.sql_type
         else
-          assert_equal connection.type_to_sql("datetime"), column.sql_type
+          assert_equal connection.type_to_sql("datetime(6)"), column.sql_type
         end
       end
 


### PR DESCRIPTION
<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

Prior to this change, virtual datetime columns did not have the same default precision as regular datetime columns, resulting in the following being erroneously equivalent:

```ruby
t.virtual :name, type: datetime,                 as: "expression"
t.virtual :name, type: datetime, precision: nil, as: "expression"
```

This change fixes the default precision lookup, so virtual and regular datetime column default precisions match.

### Detail

The existing code paths look roughly like:

- `t.datetime` is delegated to the `column` method
  - `column` sees `type == :datetime` and sets a default `precision` is none was given
  - `column` calls `new_column_definition` to add the result to `@columns_hash`
- `t.virtual` is delegated to the `column` method
  - `column` sees `type == :virtual`, not `:datetime`, so skips the default lookup
  - `column` calls `new_column_definition` to add the result to `@columns_hash`
    - `new_column_definition` sees `type == :virtual`, so sets `type = options[:type]`

This PR moves the location of the default lookup, resulting in the following code paths:

- `t.datetime` is delegated to the `column` method
  - `column` calls `new_column_definition` to add the result to `@columns_hash`
    - `new_column_definition` sees `type == :datetime` and sets a default `precision` is none was given
- `t.virtual` is delegated to the `column` method
  - `column` calls `new_column_definition` to add the result to `@columns_hash`
    - `new_column_definition` sees `type == :virtual`, so sets `type = options[:type]`
    - `new_column_definition` sees `type == :datetime` and sets a default `precision` is none was given

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

In our application, we use [LHM](https://github.com/shopify/lhm) to make schema changes to **existing** tables. In LHM, migrations describe columns in SQL:

```ruby
change_table :things do |m|
  m.add_column(:my_column, "DATETIME(6) AS (expression)")
```

The above LHM results in the following schema entry, as expected:

```ruby
t.virtual "my_column", type: :datetime, as: "expression"
```

However, if a developer runs a command that loads the schema from `db/schema.rb` (e.g. `rails db:schema:load` or `rails db:reset`), the column is silently created with the incorrect precision. If they later run a command that dumps the schema (e.g. `rails db:schema:dump`, or `rails db:migrate`), the file is updated to reflect the corrupted precision:

```ruby
t.virtual "my_column", type: :datetime, precision: nil, as: "expression"
```

We only noticed this bug because migrations started causing unrelated changes to the schema file. It is possible that others have run into this bug with regular migrations, but may not have noticed the precision mismatch.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [ ] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
