### PR TITLE
Make app_name consistent between new and update

### DIFF
--- a/railties/lib/rails/generators/app_name.rb
+++ b/railties/lib/rails/generators/app_name.rb
@@ -7,7 +7,7 @@ module Rails
 
       private
         def app_name
-          @app_name ||= original_app_name.tr("\\", "").tr("-. ", "_")
+          @app_name ||= original_app_name.parameterize(preserve_case: true).underscore
         end
 
         def original_app_name

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -470,6 +470,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/
   end
 
+  def test_application_name_is_normalized_in_config
+    run_generator [File.join(destination_root, "MyWebSite"), "-d", "postgresql"]
+    assert_file "MyWebSite/app/views/layouts/application.html.erb", /<title>MyWebSite<\/title>/
+    assert_file "MyWebSite/config/database.yml", /my_web_site_production/
+  end
+
   def test_gemfile_has_no_whitespace_errors
     run_generator
     absolute = File.expand_path("Gemfile", destination_root)


### PR DESCRIPTION
### Motivation / Background

Previously, the app_name in the App Generator would behave differently when creating a new app and updating an existing app.

When updating an app, app_name is always the Rails::Application class name underscored. When creating a new app, app_name will use whatever the user passes in with a few characters replaced.

This isn't necessarily an issue, but it can lead to extra noise when running app:update. For example, an app generated with `rails new MyWebSite` will end up with a configuration line like:

```
config.active_job.queue_name_prefix = "MyWebSite_production"
```

and running app:update will change it to

```
config.active_job.queue_name_prefix = "my_web_site_production"
```

### Detail

By normalizing app_name when creating an application, the amount of changes when updating is reduced.

### Additional information

Ref #46091 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.