### PR TITLE
Use native `Element.matches` in UJS

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs.esm.js
+++ b/actionview/app/assets/javascripts/rails-ujs.esm.js
@@ -248,7 +248,7 @@ const toArray = e => Array.prototype.slice.call(e);
 
 const serializeElement = (element, additionalParam) => {
   let inputs = [ element ];
-  if (matches(element, "form")) {
+  if (element.matches("form")) {
     inputs = toArray(element.elements);
   }
   const params = [];
@@ -256,10 +256,10 @@ const serializeElement = (element, additionalParam) => {
     if (!input.name || input.disabled) {
       return;
     }
-    if (matches(input, "fieldset[disabled] *")) {
+    if (input.matches("fieldset[disabled] *")) {
       return;
     }
-    if (matches(input, "select")) {
+    if (input.matches("select")) {
       toArray(input.options).forEach((function(option) {
         if (option.selected) {
           params.push({
@@ -288,8 +288,8 @@ const serializeElement = (element, additionalParam) => {
 };
 
 const formElements = (form, selector) => {
-  if (matches(form, "form")) {
-    return toArray(form.elements).filter((el => matches(el, selector)));
+  if (form.matches("form")) {
+    return toArray(form.elements).filter((el => el.matches(selector)));
   } else {
     return toArray(form.querySelectorAll(selector));
   }
@@ -336,22 +336,22 @@ const enableElement = e => {
   } else {
     element = e;
   }
-  if (matches(element, linkDisableSelector)) {
+  if (element.matches(linkDisableSelector)) {
     return enableLinkElement(element);
-  } else if (matches(element, buttonDisableSelector) || matches(element, formEnableSelector)) {
+  } else if (element.matches(buttonDisableSelector) || element.matches(formEnableSelector)) {
     return enableFormElement(element);
-  } else if (matches(element, formSubmitSelector)) {
+  } else if (element.matches(formSubmitSelector)) {
     return enableFormElements(element);
   }
 };
 
 const disableElement = e => {
   const element = e instanceof Event ? e.target : e;
-  if (matches(element, linkDisableSelector)) {
+  if (element.matches(linkDisableSelector)) {
     return disableLinkElement(element);
-  } else if (matches(element, buttonDisableSelector) || matches(element, formDisableSelector)) {
+  } else if (element.matches(buttonDisableSelector) || element.matches(formDisableSelector)) {
     return disableFormElement(element);
-  } else if (matches(element, formSubmitSelector)) {
+  } else if (element.matches(formSubmitSelector)) {
     return disableFormElements(element);
   }
 };
@@ -387,7 +387,7 @@ var disableFormElement = function(element) {
   }
   const replacement = element.getAttribute("data-disable-with");
   if (replacement != null) {
-    if (matches(element, "button")) {
+    if (element.matches("button")) {
       setData(element, "ujs:enable-with", element.innerHTML);
       element.innerHTML = replacement;
     } else {
@@ -404,7 +404,7 @@ var enableFormElements = form => formElements(form, formEnableSelector).forEach(
 var enableFormElement = function(element) {
   const originalText = getData(element, "ujs:enable-with");
   if (originalText != null) {
-    if (matches(element, "button")) {
+    if (element.matches("button")) {
       element.innerHTML = originalText;
     } else {
       element.value = originalText;
@@ -462,7 +462,7 @@ const handleRemoteWithRails = rails => function(e) {
   }
   const withCredentials = element.getAttribute("data-with-credentials");
   const dataType = element.getAttribute("data-type") || "script";
-  if (matches(element, formSubmitSelector)) {
+  if (element.matches(formSubmitSelector)) {
     const button = getData(element, "ujs:submit-button");
     method = getData(element, "ujs:submit-button-formmethod") || element.getAttribute("method") || "get";
     url = getData(element, "ujs:submit-button-formaction") || element.getAttribute("action") || location.href;
@@ -480,7 +480,7 @@ const handleRemoteWithRails = rails => function(e) {
     setData(element, "ujs:submit-button", null);
     setData(element, "ujs:submit-button-formmethod", null);
     setData(element, "ujs:submit-button-formaction", null);
-  } else if (matches(element, buttonClickSelector) || matches(element, inputChangeSelector)) {
+  } else if (matches(element, buttonClickSelector) || element.matches(inputChangeSelector)) {
     method = element.getAttribute("data-method");
     url = element.getAttribute("data-url");
     data = serializeElement(element, element.getAttribute("data-params"));

--- a/actionview/app/assets/javascripts/rails-ujs.esm.js
+++ b/actionview/app/assets/javascripts/rails-ujs.esm.js
@@ -35,13 +35,11 @@ const loadCSPNonce = () => {
 
 const cspNonce = () => nonce || loadCSPNonce();
 
-const m = Element.prototype.matches || Element.prototype.matchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.msMatchesSelector || Element.prototype.oMatchesSelector || Element.prototype.webkitMatchesSelector;
-
 const matches = function(element, selector) {
   if (selector.exclude) {
-    return m.call(element, selector.selector) && !m.call(element, selector.exclude);
+    return element.matches(selector.selector) && !element.matches(selector.exclude);
   } else {
-    return m.call(element, selector);
+    return element.matches(selector);
   }
 };
 

--- a/actionview/app/assets/javascripts/rails-ujs.js
+++ b/actionview/app/assets/javascripts/rails-ujs.js
@@ -27,12 +27,11 @@ Released under the MIT license
     return nonce = metaTag && metaTag.content;
   };
   const cspNonce = () => nonce || loadCSPNonce();
-  const m = Element.prototype.matches || Element.prototype.matchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.msMatchesSelector || Element.prototype.oMatchesSelector || Element.prototype.webkitMatchesSelector;
   const matches = function(element, selector) {
     if (selector.exclude) {
-      return m.call(element, selector.selector) && !m.call(element, selector.exclude);
+      return element.matches(selector.selector) && !element.matches(selector.exclude);
     } else {
-      return m.call(element, selector);
+      return element.matches(selector);
     }
   };
   const EXPANDO = "_ujsData";

--- a/actionview/app/assets/javascripts/rails-ujs.js
+++ b/actionview/app/assets/javascripts/rails-ujs.js
@@ -216,7 +216,7 @@ Released under the MIT license
   const toArray = e => Array.prototype.slice.call(e);
   const serializeElement = (element, additionalParam) => {
     let inputs = [ element ];
-    if (matches(element, "form")) {
+    if (element.matches("form")) {
       inputs = toArray(element.elements);
     }
     const params = [];
@@ -224,10 +224,10 @@ Released under the MIT license
       if (!input.name || input.disabled) {
         return;
       }
-      if (matches(input, "fieldset[disabled] *")) {
+      if (input.matches("fieldset[disabled] *")) {
         return;
       }
-      if (matches(input, "select")) {
+      if (input.matches("select")) {
         toArray(input.options).forEach((function(option) {
           if (option.selected) {
             params.push({
@@ -255,8 +255,8 @@ Released under the MIT license
     })).join("&");
   };
   const formElements = (form, selector) => {
-    if (matches(form, "form")) {
-      return toArray(form.elements).filter((el => matches(el, selector)));
+    if (form.matches("form")) {
+      return toArray(form.elements).filter((el => el.matches(selector)));
     } else {
       return toArray(form.querySelectorAll(selector));
     }
@@ -298,21 +298,21 @@ Released under the MIT license
     } else {
       element = e;
     }
-    if (matches(element, linkDisableSelector)) {
+    if (element.matches(linkDisableSelector)) {
       return enableLinkElement(element);
-    } else if (matches(element, buttonDisableSelector) || matches(element, formEnableSelector)) {
+    } else if (element.matches(buttonDisableSelector) || element.matches(formEnableSelector)) {
       return enableFormElement(element);
-    } else if (matches(element, formSubmitSelector)) {
+    } else if (element.matches(formSubmitSelector)) {
       return enableFormElements(element);
     }
   };
   const disableElement = e => {
     const element = e instanceof Event ? e.target : e;
-    if (matches(element, linkDisableSelector)) {
+    if (element.matches(linkDisableSelector)) {
       return disableLinkElement(element);
-    } else if (matches(element, buttonDisableSelector) || matches(element, formDisableSelector)) {
+    } else if (element.matches(buttonDisableSelector) || element.matches(formDisableSelector)) {
       return disableFormElement(element);
-    } else if (matches(element, formSubmitSelector)) {
+    } else if (element.matches(formSubmitSelector)) {
       return disableFormElements(element);
     }
   };
@@ -344,7 +344,7 @@ Released under the MIT license
     }
     const replacement = element.getAttribute("data-disable-with");
     if (replacement != null) {
-      if (matches(element, "button")) {
+      if (element.matches("button")) {
         setData(element, "ujs:enable-with", element.innerHTML);
         element.innerHTML = replacement;
       } else {
@@ -359,7 +359,7 @@ Released under the MIT license
   var enableFormElement = function(element) {
     const originalText = getData(element, "ujs:enable-with");
     if (originalText != null) {
-      if (matches(element, "button")) {
+      if (element.matches("button")) {
         element.innerHTML = originalText;
       } else {
         element.value = originalText;
@@ -413,7 +413,7 @@ Released under the MIT license
     }
     const withCredentials = element.getAttribute("data-with-credentials");
     const dataType = element.getAttribute("data-type") || "script";
-    if (matches(element, formSubmitSelector)) {
+    if (element.matches(formSubmitSelector)) {
       const button = getData(element, "ujs:submit-button");
       method = getData(element, "ujs:submit-button-formmethod") || element.getAttribute("method") || "get";
       url = getData(element, "ujs:submit-button-formaction") || element.getAttribute("action") || location.href;
@@ -431,7 +431,7 @@ Released under the MIT license
       setData(element, "ujs:submit-button", null);
       setData(element, "ujs:submit-button-formmethod", null);
       setData(element, "ujs:submit-button-formaction", null);
-    } else if (matches(element, buttonClickSelector) || matches(element, inputChangeSelector)) {
+    } else if (matches(element, buttonClickSelector) || element.matches(inputChangeSelector)) {
       method = element.getAttribute("data-method");
       url = element.getAttribute("data-url");
       data = serializeElement(element, element.getAttribute("data-params"));

--- a/actionview/app/javascript/rails-ujs/features/disable.js
+++ b/actionview/app/javascript/rails-ujs/features/disable.js
@@ -5,7 +5,7 @@ import {
   formEnableSelector,
   formSubmitSelector
 } from "../utils/constants"
-import { matches, getData, setData } from "../utils/dom"
+import { getData, setData } from "../utils/dom"
 import { stopEverything } from "../utils/event"
 import { formElements } from "../utils/form"
 import { isContentEditable } from "../utils/dom"
@@ -29,11 +29,11 @@ const enableElement = (e) => {
     return
   }
 
-  if (matches(element, linkDisableSelector)) {
+  if (element.matches(linkDisableSelector)) {
     return enableLinkElement(element)
-  } else if (matches(element, buttonDisableSelector) || matches(element, formEnableSelector)) {
+  } else if (element.matches(buttonDisableSelector) || element.matches(formEnableSelector)) {
     return enableFormElement(element)
-  } else if (matches(element, formSubmitSelector)) {
+  } else if (element.matches(formSubmitSelector)) {
     return enableFormElements(element)
   }
 }
@@ -46,11 +46,11 @@ const disableElement = (e) => {
     return
   }
 
-  if (matches(element, linkDisableSelector)) {
+  if (element.matches(linkDisableSelector)) {
     return disableLinkElement(element)
-  } else if (matches(element, buttonDisableSelector) || matches(element, formDisableSelector)) {
+  } else if (element.matches(buttonDisableSelector) || element.matches(formDisableSelector)) {
     return disableFormElement(element)
-  } else if (matches(element, formSubmitSelector)) {
+  } else if (element.matches(formSubmitSelector)) {
     return disableFormElements(element)
   }
 }
@@ -89,7 +89,7 @@ var disableFormElement = function(element) {
   if (getData(element, "ujs:disabled")) { return }
   const replacement = element.getAttribute("data-disable-with")
   if (replacement != null) {
-    if (matches(element, "button")) {
+    if (element.matches("button")) {
       setData(element, "ujs:enable-with", element.innerHTML)
       element.innerHTML = replacement
     } else {
@@ -109,7 +109,7 @@ var enableFormElements = form => formElements(form, formEnableSelector).forEach(
 var enableFormElement = function(element) {
   const originalText = getData(element, "ujs:enable-with")
   if (originalText != null) {
-    if (matches(element, "button")) {
+    if (element.matches("button")) {
       element.innerHTML = originalText
     } else {
       element.value = originalText

--- a/actionview/app/javascript/rails-ujs/features/remote.js
+++ b/actionview/app/javascript/rails-ujs/features/remote.js
@@ -30,7 +30,7 @@ const handleRemoteWithRails = (rails) => function(e) {
   const withCredentials = element.getAttribute("data-with-credentials")
   const dataType = element.getAttribute("data-type") || "script"
 
-  if (matches(element, formSubmitSelector)) {
+  if (element.matches(formSubmitSelector)) {
     // memoized value from clicked submit button
     const button = getData(element, "ujs:submit-button")
     method = getData(element, "ujs:submit-button-formmethod") || element.getAttribute("method") || "get"
@@ -49,7 +49,7 @@ const handleRemoteWithRails = (rails) => function(e) {
     setData(element, "ujs:submit-button", null)
     setData(element, "ujs:submit-button-formmethod", null)
     setData(element, "ujs:submit-button-formaction", null)
-  } else if (matches(element, buttonClickSelector) || matches(element, inputChangeSelector)) {
+  } else if (matches(element, buttonClickSelector) || element.matches(inputChangeSelector)) {
     method = element.getAttribute("data-method")
     url = element.getAttribute("data-url")
     data = serializeElement(element, element.getAttribute("data-params"))

--- a/actionview/app/javascript/rails-ujs/utils/dom.js
+++ b/actionview/app/javascript/rails-ujs/utils/dom.js
@@ -1,10 +1,3 @@
-const m = Element.prototype.matches ||
-    Element.prototype.matchesSelector ||
-    Element.prototype.mozMatchesSelector ||
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.oMatchesSelector ||
-    Element.prototype.webkitMatchesSelector
-
 // Checks if the given native dom element matches the selector
 // element::
 //   native DOM element
@@ -14,9 +7,9 @@ const m = Element.prototype.matches ||
 //   Examples: "form", { selector: "form", exclude: "form[data-remote='true']"}
 const matches = function(element, selector) {
   if (selector.exclude) {
-    return m.call(element, selector.selector) && !m.call(element, selector.exclude)
+    return element.matches(selector.selector) && !element.matches(selector.exclude)
   } else {
-    return m.call(element, selector)
+    return element.matches(selector)
   }
 }
 

--- a/actionview/app/javascript/rails-ujs/utils/form.js
+++ b/actionview/app/javascript/rails-ujs/utils/form.js
@@ -1,16 +1,14 @@
-import { matches } from "./dom"
-
 const toArray = e => Array.prototype.slice.call(e)
 
 const serializeElement = (element, additionalParam) => {
   let inputs = [element]
-  if (matches(element, "form")) { inputs = toArray(element.elements) }
+  if (element.matches("form")) { inputs = toArray(element.elements) }
   const params = []
 
   inputs.forEach(function(input) {
     if (!input.name || input.disabled) { return }
-    if (matches(input, "fieldset[disabled] *")) { return }
-    if (matches(input, "select")) {
+    if (input.matches("fieldset[disabled] *")) { return }
+    if (input.matches("select")) {
       toArray(input.options).forEach(function(option) {
         if (option.selected) { params.push({name: input.name, value: option.value}) }
       })
@@ -33,8 +31,8 @@ const serializeElement = (element, additionalParam) => {
 // If form is actually a "form" element this will return associated elements outside the from that have
 // the HTML form attribute set
 const formElements = (form, selector) => {
-  if (matches(form, "form")) {
-    return toArray(form.elements).filter(el => matches(el, selector))
+  if (form.matches("form")) {
+    return toArray(form.elements).filter(el => el.matches(selector))
   } else {
     return toArray(form.querySelectorAll(selector))
   }


### PR DESCRIPTION
**Summary**

I've notice in https://github.com/rails/rails/pull/45546 that there is some unnecessary complexity in `Rails.matches` implementation. `Element.matches` is well supported by all browsers since several years ago, so I've simplified to just rely on `Element.matches`, and avoiding to import `Rails.matches` where is not necessary.

**Other Information**

https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#browser_compatibility
![Screen Shot 2022-09-23 at 13 03 04](https://user-images.githubusercontent.com/1860816/191947217-a85e3f06-3595-43a2-a37e-d01f044bc0f6.png)
