### PR TITLE
Add table name to error for duplicate column definitions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add table to error for duplicate column definitions.
+
+    If a migration defines duplicate columns for a table, the error message
+    shows which table it concerns.
+
+    *Petrik de Heus*
+
 *   Fix erroneous nil default precision on virtual datetime columns.
 
     Prior to this change, virtual datetime columns did not have the same

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -469,9 +469,9 @@ module ActiveRecord
 
         if @columns_hash[name]
           if @columns_hash[name].primary_key?
-            raise ArgumentError, "you can't redefine the primary key column '#{name}'. To define a custom primary key, pass { id: false } to create_table."
+            raise ArgumentError, "you can't redefine the primary key column '#{name}' on '#{@name}'. To define a custom primary key, pass { id: false } to create_table."
           else
-            raise ArgumentError, "you can't define an already defined column '#{name}'."
+            raise ArgumentError, "you can't define an already defined column '#{name}' on '#{@name}'."
           end
         end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -183,7 +183,7 @@ module ActiveRecord
           end
         end
 
-        assert_equal "you can't redefine the primary key column 'id'. To define a custom primary key, pass { id: false } to create_table.", error.message
+        assert_equal "you can't redefine the primary key column 'id' on 'testings'. To define a custom primary key, pass { id: false } to create_table.", error.message
       end
 
       def test_create_table_raises_when_redefining_custom_primary_key_column
@@ -193,7 +193,7 @@ module ActiveRecord
           end
         end
 
-        assert_equal "you can't redefine the primary key column 'testing_id'. To define a custom primary key, pass { id: false } to create_table.", error.message
+        assert_equal "you can't redefine the primary key column 'testing_id' on 'testings'. To define a custom primary key, pass { id: false } to create_table.", error.message
       end
 
       def test_create_table_raises_when_defining_existing_column
@@ -204,7 +204,7 @@ module ActiveRecord
           end
         end
 
-        assert_equal "you can't define an already defined column 'testing_column'.", error.message
+        assert_equal "you can't define an already defined column 'testing_column' on 'testings'.", error.message
       end
 
       def test_create_table_with_timestamps_should_create_datetime_columns


### PR DESCRIPTION
If a migration defines duplicate columns for a table the error message should show which table it concerns.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.