### PR TITLE
Always provide a fallback renderer for Action Text

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -59,12 +59,6 @@ module ActionText
     end
 
     initializer "action_text.renderer" do
-      ActiveSupport.on_load(:action_controller_base) do
-        ActiveSupport.on_load(:action_text_content) do
-          self.default_renderer = Class.new(ActionController::Base).renderer
-        end
-      end
-
       %i[action_controller_base action_mailer].each do |base|
         ActiveSupport.on_load(base) do
           around_action do |controller, action|

--- a/actiontext/lib/action_text/rendering.rb
+++ b/actiontext/lib/action_text/rendering.rb
@@ -8,12 +8,15 @@ module ActionText
     extend ActiveSupport::Concern
 
     included do
-      cattr_accessor :default_renderer, instance_accessor: false
       thread_cattr_accessor :renderer, instance_accessor: false
       delegate :render, to: :class
     end
 
     class_methods do
+      def action_controller_renderer
+        @action_controller_renderer ||= Class.new(ActionController::Base).renderer
+      end
+
       def with_renderer(renderer)
         previous_renderer = self.renderer
         self.renderer = renderer
@@ -23,7 +26,7 @@ module ActionText
       end
 
       def render(*args, &block)
-        (renderer || default_renderer).render_to_string(*args, &block)
+        (renderer || action_controller_renderer).render_to_string(*args, &block)
       end
     end
   end


### PR DESCRIPTION
Follow-up to #45144.

This ensures that a renderer is always available for Action Text, even when `ActionController::Base` was not previously loaded.

Fixes #46113.

As with #45144, this still avoids loading `ActionController::Base` unnecessarily when rendering mail after Action Text has been loaded.

**Before:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ MyBlankMailer.blank_email.body } }'
Calculating -------------------------------------
                load     4.466M memsize (     1.205M retained)
                        29.202k objects (    11.943k retained)
                        50.000  strings (    50.000  retained)
```

**After:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ MyBlankMailer.blank_email.body } }'
Calculating -------------------------------------
                load     4.462M memsize (     1.205M retained)
                        29.141k objects (    11.940k retained)
                        50.000  strings (    50.000  retained)
```

---

/cc @clouvet I've added you as a co-author since you were digging into #46113.
