### PR TITLE
Keep rescue template paths in an array

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -7,10 +7,10 @@ require "action_view/base"
 
 module ActionDispatch
   class DebugView < ActionView::Base # :nodoc:
-    RESCUES_TEMPLATE_PATH = File.expand_path("templates", __dir__)
+    RESCUES_TEMPLATE_PATHS = [File.expand_path("templates", __dir__)]
 
     def initialize(assigns)
-      paths = [RESCUES_TEMPLATE_PATH]
+      paths = RESCUES_TEMPLATE_PATHS.dup
       lookup_context = ActionView::LookupContext.new(paths)
       super(lookup_context, assigns, nil)
     end

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -4,7 +4,7 @@ require "rails/application_controller"
 require "action_dispatch/routing/inspector"
 
 class Rails::InfoController < Rails::ApplicationController # :nodoc:
-  prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATH
+  prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATHS
   layout -> { request.xhr? ? false : "application" }
 
   before_action :require_local!

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -3,7 +3,7 @@
 require "rails/application_controller"
 
 class Rails::MailersController < Rails::ApplicationController # :nodoc:
-  prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATH
+  prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATHS
 
   around_action :set_locale, only: [:preview, :download]
   before_action :find_preview, only: [:preview, :download]


### PR DESCRIPTION
Gotta be honest, this is so I can make some hacks.  Basically I would like an engine to specify where to find rescue templates, and currently there's no way to add search paths to the debug view lookup context. This commit turns the template path in to an array (that I plan to mutate, but nobody should do that besides me until we make an actual good API).

I added the `dup` in `initialize` so in case the array is accidentally mutated we don't leak memory.