### PR TITLE
Add upcase option for deterministically encrypted case insensitive unique constraints

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `upcase` option for deterministically encrypted case insensitive unique constraints
+
+    Unique constraints for case insensitive deterministically encrypted columns only had
+    the option to `downcase` the field (which works well for email columns). This change
+    adds the `upcase` option for columns that should be case insensitively unique but
+    naturally exist as upcased (like a license plate number or vin) while removing the
+    need to store the case information separately.
+
+    *Alex Taujenis*
+
 *   Add table to error for duplicate column definitions.
 
     If a migration defines duplicate columns for a table, the error message

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -32,7 +32,10 @@ module ActiveRecord
         #   data.
         # * <tt>:downcase</tt> - When true, it converts the encrypted content to downcase automatically. This allows to
         #   effectively ignore case when querying data. Notice that the case is lost. Use +:ignore_case+ if you are interested
-        #   in preserving it.
+        #   in preserving it. This cannot be used simultaneously with upcase.
+        # * <tt>:upcase</tt> - When true, it converts the encrypted content to upcase automatically. This allows to
+        #   effectively ignore case when querying data. Notice that the case is lost. Use +:ignore_case+ if you are interested
+        #   in preserving it. This cannot be used simultaneously with downcase.
         # * <tt>:ignore_case</tt> - When true, it behaves like +:downcase+ but, it also preserves the original case in a specially
         #   designated column +original_<name>+. When reading the encrypted content, the version with the original case is
         #   served. But you can still execute queries that will ignore the case. This option can only be used when +:deterministic+
@@ -42,10 +45,10 @@ module ActiveRecord
         # * <tt>:previous</tt> - List of previous encryption schemes. When provided, they will be used in order when trying to read
         #   the attribute. Each entry of the list can contain the properties supported by #encrypts. Also, when deterministic
         #   encryption is used, they will be used to generate additional ciphertexts to check in the queries.
-        def encrypts(*names, key_provider: nil, key: nil, deterministic: false, downcase: false, ignore_case: false, previous: [], **context_properties)
+        def encrypts(*names, key_provider: nil, key: nil, deterministic: false, downcase: false, upcase: false, ignore_case: false, previous: [], **context_properties)
           self.encrypted_attributes ||= Set.new # not using :default because the instance would be shared across classes
           scheme = scheme_for key_provider: key_provider, key: key, deterministic: deterministic, downcase: downcase, \
-              ignore_case: ignore_case, previous: previous, **context_properties
+              upcase: upcase, ignore_case: ignore_case, previous: previous, **context_properties
 
           names.each do |name|
             encrypt_attribute name, scheme
@@ -65,9 +68,9 @@ module ActiveRecord
         end
 
         private
-          def scheme_for(key_provider: nil, key: nil, deterministic: false, downcase: false, ignore_case: false, previous: [], **context_properties)
+          def scheme_for(key_provider: nil, key: nil, deterministic: false, downcase: false, upcase: false, ignore_case: false, previous: [], **context_properties)
             ActiveRecord::Encryption::Scheme.new(key_provider: key_provider, key: key, deterministic: deterministic,
-                                                 downcase: downcase, ignore_case: ignore_case, **context_properties).tap do |scheme|
+                                                 downcase: downcase, upcase: upcase, ignore_case: ignore_case, **context_properties).tap do |scheme|
               scheme.previous_schemes = global_previous_schemes_for(scheme) +
                 Array.wrap(previous).collect { |scheme_config| ActiveRecord::Encryption::Scheme.new(**scheme_config) }
             end

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       attr_reader :scheme, :cast_type
 
-      delegate :key_provider, :downcase?, :deterministic?, :previous_schemes, :with_context, :fixed?, to: :scheme
+      delegate :key_provider, :downcase?, :upcase?, :deterministic?, :previous_schemes, :with_context, :fixed?, to: :scheme
       delegate :accessor, to: :cast_type
 
       # === Options
@@ -115,7 +115,11 @@ module ActiveRecord
 
         def serialize_with_current(value)
           casted_value = cast_type.serialize(value)
-          casted_value = casted_value&.downcase if downcase?
+          if downcase?
+            casted_value = casted_value&.downcase
+          elsif upcase?
+            casted_value = casted_value&.upcase
+          end
           encrypt(casted_value.to_s) unless casted_value.nil?
         end
 
@@ -142,7 +146,7 @@ module ActiveRecord
         end
 
         def clean_text_scheme
-          @clean_text_scheme ||= ActiveRecord::Encryption::Scheme.new(downcase: downcase?, encryptor: ActiveRecord::Encryption::NullEncryptor.new)
+          @clean_text_scheme ||= ActiveRecord::Encryption::Scheme.new(downcase: downcase?, upcase: upcase?, encryptor: ActiveRecord::Encryption::NullEncryptor.new)
         end
     end
   end

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     class Scheme
       attr_accessor :previous_schemes
 
-      def initialize(key_provider: nil, key: nil, deterministic: nil, downcase: nil, ignore_case: nil,
+      def initialize(key_provider: nil, key: nil, deterministic: nil, downcase: nil, upcase: nil, ignore_case: nil,
                      previous_schemes: nil, **context_properties)
         # Initializing all attributes to +nil+ as we want to allow a "not set" semantics so that we
         # can merge schemes without overriding values with defaults. See +#merge+
@@ -18,8 +18,23 @@ module ActiveRecord
         @key_provider_param = key_provider
         @key = key
         @deterministic = deterministic
-        @downcase = downcase || ignore_case
+
+        # If ignore_case is true, then the downcase or upcase option needs to be set to true
+        # (to actually perform case insensitive matches). This selects downcase as the default
+        # method for case insensitivity.
+        @downcase = downcase
+        @upcase = upcase
         @ignore_case = ignore_case
+        if ignore_case
+          if upcase
+            @downcase = nil
+            @upcase = ignore_case
+          else
+            @downcase = ignore_case
+            @upcase = nil
+          end
+        end
+
         @previous_schemes_param = previous_schemes
         @previous_schemes = Array.wrap(previous_schemes)
         @context_properties = context_properties
@@ -33,6 +48,10 @@ module ActiveRecord
 
       def downcase?
         @downcase
+      end
+
+      def upcase?
+        @upcase
       end
 
       def deterministic?
@@ -53,7 +72,7 @@ module ActiveRecord
       end
 
       def to_h
-        { key_provider: @key_provider_param, key: @key, deterministic: @deterministic, downcase: @downcase, ignore_case: @ignore_case,
+        { key_provider: @key_provider_param, key: @key, deterministic: @deterministic, downcase: @downcase, upcase: @upcase, ignore_case: @ignore_case,
           previous_schemes: @previous_schemes_param, **@context_properties }.compact
       end
 
@@ -69,6 +88,7 @@ module ActiveRecord
         def validate_config!
           raise Errors::Configuration, "ignore_case: can only be used with deterministic encryption" if @ignore_case && !@deterministic
           raise Errors::Configuration, "key_provider: and key: can't be used simultaneously" if @key_provider_param && @key
+          raise Errors::Configuration, "downcase: and upcase: can't be used simultaneously" if @downcase && @upcase
         end
 
         def build_key_provider

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -183,6 +183,18 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert EncryptedBookWithDowncaseName.find_by_name("dune")
   end
 
+  test "when using upcase: true it ignores case since everything will be upcase" do
+    EncryptedBookWithUpcaseName.create!(name: "Dune")
+    assert EncryptedBookWithUpcaseName.find_by(name: "Dune")
+    assert EncryptedBookWithUpcaseName.find_by(name: "dune")
+    assert EncryptedBookWithUpcaseName.find_by(name: "DUNE")
+  end
+
+  test "when upcase: true it creates content upcased" do
+    EncryptedBookWithUpcaseName.create!(name: "Dune")
+    assert EncryptedBookWithUpcaseName.find_by_name("DUNE")
+  end
+
   test "when ignore_case: true, it ignores case in queries but keep it when reading the attribute" do
     EncryptedBookThatIgnoresCase.create!(name: "Dune")
     book = EncryptedBookThatIgnoresCase.find_by_name("dune")

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -25,6 +25,11 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
     assert EncryptedBookWithDowncaseName.find_by(name: "DUNE")
   end
 
+  test "Works well with upcased attributes" do
+    ActiveRecord::Encryption.without_encryption { EncryptedBookWithUpcaseName.create! name: "Dune" }
+    assert EncryptedBookWithUpcaseName.find_by(name: "dune")
+  end
+
   test "find_or_create works" do
     EncryptedBook.find_or_create_by!(name: "Dune")
     assert EncryptedBook.find_by(name: "Dune")

--- a/activerecord/test/cases/encryption/uniqueness_validations_test.rb
+++ b/activerecord/test/cases/encryption/uniqueness_validations_test.rb
@@ -5,20 +5,37 @@ require "models/book_encrypted"
 require "models/author_encrypted"
 
 class ActiveRecord::Encryption::UniquenessValidationsTest < ActiveRecord::EncryptionTestCase
-  test "uniqueness validations work" do
+  test "uniqueness validations work when using downcase" do
     EncryptedBookWithDowncaseName.create!(name: "dune")
     assert_raises ActiveRecord::RecordInvalid do
       EncryptedBookWithDowncaseName.create!(name: "dune")
     end
   end
 
-  test "uniqueness validations work when mixing encrypted an unencrypted data" do
+  test "uniqueness validations work when using upcase" do
+    EncryptedBookWithUpcaseName.create!(name: "dune")
+    assert_raises ActiveRecord::RecordInvalid do
+      EncryptedBookWithUpcaseName.create!(name: "dune")
+    end
+  end
+
+  test "uniqueness validations work when mixing encrypted an unencrypted data when using downcase" do
     ActiveRecord::Encryption.config.support_unencrypted_data = true
 
     ActiveRecord::Encryption.without_encryption { EncryptedBookWithDowncaseName.create! name: "dune" }
 
     assert_raises ActiveRecord::RecordInvalid do
       EncryptedBookWithDowncaseName.create!(name: "dune")
+    end
+  end
+
+  test "uniqueness validations work when mixing encrypted an unencrypted data when using upcase" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+
+    ActiveRecord::Encryption.without_encryption { EncryptedBookWithUpcaseName.create! name: "dune" }
+
+    assert_raises ActiveRecord::RecordInvalid do
+      EncryptedBookWithUpcaseName.create!(name: "dune")
     end
   end
 

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -17,6 +17,13 @@ class EncryptedBookWithDowncaseName < ActiveRecord::Base
   encrypts :name, deterministic: true, downcase: true
 end
 
+class EncryptedBookWithUpcaseName < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  validates :name, uniqueness: true
+  encrypts :name, deterministic: true, upcase: true
+end
+
 class EncryptedBookThatIgnoresCase < ActiveRecord::Base
   self.table_name = "encrypted_books"
 

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -242,7 +242,14 @@ end
 
 They will also work when combining encrypted and unencrypted data, and when configuring previous encryption schemes.
 
-NOTE: If you want to ignore case, make sure to use `downcase:` or `ignore_case:` in the `encrypts` declaration. Using the `case_sensitive:` option in the validation won't work.
+NOTE: If you want to ignore case, make sure to use `downcase:` or `ignore_case:` in the `encrypts` declaration. Using the `case_sensitive:` option in the validation won't work. This also applies to the use of `upcase`.
+
+```ruby
+class Vehicle
+  validates :vehicle_identification_number, uniqueness: true
+  encrypts :vehicle_identification_number, deterministic: true, upcase: true
+end
+```
 
 #### Unique Indexes
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I would like to add case insensitive unique constraints to deterministically encrypted columns with the option to store the values as `upcase` in the database without having to separately store the case information in another column (see https://guides.rubyonrails.org/active_record_encryption.html#ignoring-case). 

The current implementation only allows `downcase`, which is great for things like email columns, but there are other data types that naturally exist as `upcase`, such as a vehicle license plate, or vin number, that could benefit from this natural addition to the API.

### Detail

This Pull Request adds the `upcase` option to ActiveRecord `encrypts` when `deterministic: true`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
