### PR TITLE
Fix ActionText::Attachable#as_json

### DIFF
--- a/actiontext/lib/action_text/attachable.rb
+++ b/actiontext/lib/action_text/attachable.rb
@@ -64,7 +64,7 @@ module ActionText
     end
 
     def as_json(*)
-      super.merge(attachable_sgid: attachable_sgid)
+      super.merge("attachable_sgid" => persisted? ? attachable_sgid : nil)
     end
 
     def to_trix_content_attachment_partial_path

--- a/actiontext/test/unit/attachable_test.rb
+++ b/actiontext/test/unit/attachable_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::AttachableTest < ActiveSupport::TestCase
+  test "as_json is a hash when the attachable is persisted" do
+    freeze_time do
+      attachable = ActiveStorage::Blob.create_after_unfurling!(io: StringIO.new("test"), filename: "test.txt", key: 123)
+      attributes = {
+        id: attachable.id,
+        key: "123",
+        filename: "test.txt",
+        content_type: "text/plain",
+        metadata: { identified: true },
+        service_name: "test",
+        byte_size: 4,
+        checksum: "CY9rzUYh03PK3k6DJie09g==",
+        created_at: Time.zone.now.as_json,
+        attachable_sgid: attachable.attachable_sgid
+      }.deep_stringify_keys
+
+      assert_equal attributes, attachable.as_json
+    end
+  end
+
+  test "as_json is a hash when the attachable is a new record" do
+    attachable = ActiveStorage::Blob.build_after_unfurling(io: StringIO.new("test"), filename: "test.txt", key: 123)
+    attributes = {
+      id: nil,
+      key: "123",
+      filename: "test.txt",
+      content_type: "text/plain",
+      metadata: { identified: true },
+      service_name: "test",
+      byte_size: 4,
+      checksum: "CY9rzUYh03PK3k6DJie09g==",
+      created_at: nil,
+      attachable_sgid: nil
+    }.deep_stringify_keys
+
+    assert_equal attributes, attachable.as_json
+  end
+end


### PR DESCRIPTION
Closes #45949 

Before this commit, using ActionText and calling `#as_json` on a non-persisted `ActiveStorage::Blob` raised an error.

This is because `ActionText::Attachable` is included in `ActiveStorage::Blob` and overrides the `#as_json` method to expose a global signed id. However, a global signed id can only be generated on a persisted instance.

This commit fixes the issue by making sure the blob is persisted before exposing the global signed id.