### PR TITLE
Do not preserve original column collation in `change_column` for older migrations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -393,8 +393,10 @@ module ActiveRecord
           options[:comment] = column.comment
         end
 
-        unless options.key?(:collation)
-          options[:collation] = column.collation if text_type?(type)
+        if options[:collation] == :no_collation
+          options.delete(:collation)
+        else
+          options[:collation] ||= column.collation if text_type?(type)
         end
 
         unless options.key?(:auto_increment)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -61,6 +61,13 @@ module ActiveRecord
           super
         end
 
+        def change_column(table_name, column_name, type, **options)
+          if connection.adapter_name == "Mysql2"
+            options[:collation] = :no_collation
+          end
+          super
+        end
+
         def change_column_null(table_name, column_name, null, default = nil)
           super(table_name, column_name, !!null, default)
         end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -658,6 +658,20 @@ module ActiveRecord
         end
       end
 
+      if current_adapter?(:Mysql2Adapter)
+        def test_change_column_on_7_0
+          migration = Class.new(ActiveRecord::Migration[7.0]) do
+            def up
+              execute("ALTER TABLE testings CONVERT TO CHARACTER SET utf32")
+              change_column(:testings, :foo, "varchar(255) CHARACTER SET ascii")
+            end
+          end
+          assert_nothing_raised do
+            ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+          end
+        end
+      end
+
       private
         def precision_implicit_default
           if current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
Fixes #45823.

cc @byroot 