### PR TITLE
`Rails.error.report` now marks errors as reported to avoid reporting them twice

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `Rails.error.report` now marks errors as reported to avoid reporting them twice.
+
+    In some cases, users might want to report errors explicitly with some extra context
+    before letting it bubble up.
+
+    This also allows to safely catch and report errors outside of the execution context.
+
+    *Jean Boussier*
+
 *   Add `Rails.application.message_verifiers` as a central point to configure
     and create message verifiers for an application.
 

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -166,6 +166,8 @@ module ActiveSupport
     #   Rails.error.report(error)
     #
     def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: DEFAULT_SOURCE)
+      return if error.instance_variable_get(:@__rails_error_reported)
+
       unless SEVERITIES.include?(severity)
         raise ArgumentError, "severity must be one of #{SEVERITIES.map(&:inspect).join(", ")}, got: #{severity.inspect}"
       end
@@ -185,6 +187,10 @@ module ActiveSupport
         else
           raise
         end
+      end
+
+      unless error.frozen?
+        error.instance_variable_set(:@__rails_error_reported, true)
       end
 
       nil

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -178,6 +178,24 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal :error, @subscriber.events.dig(0, 2)
   end
 
+  test "report errors only once" do
+    assert_difference -> { @subscriber.events.size }, +1 do
+      @reporter.report(@error, handled: false)
+    end
+
+    assert_no_difference -> { @subscriber.events.size } do
+      3.times do
+        @reporter.report(@error, handled: false)
+      end
+    end
+  end
+
+  test "can report frozen exceptions" do
+    assert_difference -> { @subscriber.events.size }, +1 do
+      @reporter.report(@error.freeze, handled: false)
+    end
+  end
+
   class FailingErrorSubscriber
     Error = Class.new(StandardError)
 

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -29,6 +29,7 @@ class ExecutorTest < ActiveSupport::TestCase
     end
     assert_equal [error, false, :error, "application.active_support", {}], subscriber.events.last
 
+    error = DummyError.new("Oops")
     assert_raises DummyError do
       executor.wrap(source: "custom") do
         raise error


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/46094

This is done by setting a special instance variable on the exception.

Another implementation could be to use an `ObjectSpace::WeakMap` as a weak reference set, but I figured 3rd party error reporting libraries may want to inspect wether the error was reported.

FYI: @shalvah @st0012 (let me know if you have any concern or comments).