### PR TITLE
Keep backwards compatibility for `assert_redirected_to`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -55,7 +55,7 @@ module ActionDispatch
       #   # Permanently).
       #   assert_redirected_to "/some/path", status: :moved_permanently
       def assert_redirected_to(url_options = {}, options = {}, message = nil)
-        options, message = message, nil if message.is_a?(Hash) && options.empty?
+        options, message = {}, options unless options.is_a?(Hash)
 
         status = options[:status] || :redirect
         assert_response(status, message)

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -442,6 +442,14 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     }
   end
 
+  def test_assert_redirection_with_custom_message
+    error = assert_raise(ActiveSupport::TestCase::Assertion) do
+      assert_redirected_to "http://test.host/some/path", "wrong redirect"
+    end
+
+    assert_equal("wrong redirect", error.message)
+  end
+
   def test_assert_redirection_with_status
     process :redirect_to_path
     assert_redirected_to "http://test.host/some/path", status: :found


### PR DESCRIPTION
Tweak for https://github.com/rails/rails/pull/46057

### Problem
Current implementation is not backwards compatible for expectations with a custom message like `assert_redirected_to "url", "something went wrong"`

It fails with `TypeError: no implicit conversion of Symbol into Integer` when trying to access options status:
https://github.com/rails/rails/blob/021113927a5b6a119fda9ea15fd4d126d7e2163b/actionpack/lib/action_dispatch/testing/assertions/response.rb#L60


### Solution

I assume that the current backwards compatibility check got confused during review as I don't think `message.is_a?(Hash)` will ever be true unless we want to support a signature like  `assert_redirected_to("url", "error message", status: :redirect)`

So I'm simplifying the check to be  `unless options.is_a?(Hash)` which can be read as "if options is a hash, then we are using the new signature" or "if options is not a hash, we should treat arguments as it was prior the `status` introduction"

Also added a test that was passing before to confirm the compatibility.
I've verified this fix against a larger codebase on CI




