### PR TITLE
Fix incorrect error class for `config.action_controller.raise_on_open_redirects` in the configuring guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1355,7 +1355,7 @@ Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
 
 #### `config.action_controller.raise_on_open_redirects`
 
-Raises an `ArgumentError` when an unpermitted open redirect occurs.
+Raises an `ActionController::Redirecting::UnsafeRedirectError` when an unpermitted open redirect occurs.
 
 The default value depends on the `config.load_defaults` target version:
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because documentation regarding `config.action_controller.raise_on_open_redirects` was incorrect regarding the error type being raised.

### Detail

This Pull Request changes the "Configuring Rails Applications" guide.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.