### PR TITLE
Check for Existing but nil `:precision` Option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -514,6 +514,10 @@ module ActiveRecord
       def timestamps(**options)
         options[:null] = false if options[:null].nil?
 
+        if !options.key?(:precision) && @conn.supports_datetime_with_precision?
+          options[:precision] = 6
+        end
+
         column(:created_at, :datetime, **options)
         column(:updated_at, :datetime, **options)
       end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -274,6 +274,23 @@ module ActiveRecord
         end
       end
 
+      def test_timestamps_sets_default_precision_on_create_table
+        migration = Class.new(ActiveRecord::Migration[6.1]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.timestamps
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+
+        assert connection.column_exists?(:more_testings, :created_at, **{ precision: 6 })
+        assert connection.column_exists?(:more_testings, :updated_at, **{ precision: 6 })
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
       def test_datetime_doesnt_set_precision_on_create_table
         migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)


### PR DESCRIPTION
### Motivation / Background

The code to assign a default of precision to 6 in the timestamps method was removed in a [previous PR](https://github.com/rails/rails/pull/46112/files), but it had a side effect of causing certain timestamp fields to be changed from `datetime(6)` to `datetime` when performing a schema migration in the 6.1 version of the migration class. 

This is due to `options[:precision]` being set to `nil` [here](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration/compatibility.rb#L137-L140), and therefore not being set to the default of 6 later on in the code path.



[This comment](https://github.com/rails/rails/pull/46140#discussion_r982664557
) indicates that Rails 6.1 migrations _should_ be `precision: nil` by default although it seems that wasn't actually the case. It was getting set to `6` in the `timestamps` method and therefore not being set to `nil` in the compatibility class.

### Detail

This PR just adds back the precision assignment to the `timestamps` method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.
