### PR TITLE
Add style-src to default nonce_directives

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -16,9 +16,9 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap and inline scripts.
+#   # Generate session nonces for permitted importmap, inline scripts and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
+#   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because commenting in the suggested default CSP configuration in new Rails apps is partly broken with Turbo (the default), leading to confusion. (see https://github.com/hotwired/turbo/issues/704)

### Details

Turbo creates a <style> element for its loading bar with an appropriate nonce, but the suggested CSP configuration of a new app did not support nonces for <style> tags.