### PR TITLE
Remove syntax error exception mutations

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -48,8 +48,6 @@ module ActionDispatch
       @exception = exception
       @exception_class_name = @exception.class.name
       @wrapped_causes = wrapped_causes_for(exception, backtrace_cleaner)
-
-      expand_backtrace if exception.is_a?(SyntaxError) || exception.cause.is_a?(SyntaxError)
     end
 
     def unwrapped_exception
@@ -234,12 +232,6 @@ module ActionDispatch
         # Windows and Unix path styles.
         file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
         [file, line.to_i]
-      end
-
-      def expand_backtrace
-        @exception.backtrace.unshift(
-          @exception.to_s.split("\n")
-        ).flatten!
       end
   end
 end


### PR DESCRIPTION
I am trying to clean up error handling somewhat and this code is getting in the way.  It mutates the backtrace on exceptions, but only when the exceptions were SyntaxError instances.  I believe this codepath isn't used in real life, so I want to remove it.

In real life, the template compiler will catch `SyntaxError` instances and re-raise them as `SyntaxErrorInTemplate` instances:

  https://github.com/rails/rails/blob/08ef43ed5e01b42b2aec847a0424515f537ed427/actionview/lib/action_view/template.rb#L349-L360

If you have a syntax error in your controller, it's simply not caught by the DebugExceptions middleware, and you get the "We're sorry, but something went wrong" page.

I think we can do something good in the case of syntax errors inside of controllers, but this code isn't doing it.