### PR TITLE
Backport Assert sql_type disregarding case sensitiveness

### DIFF
--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -282,7 +282,7 @@ module ActiveRecord
           ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
           testings_id_column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
-          assert_equal "integer", testings_id_column.sql_type
+          assert_match(/integer/i, testings_id_column.sql_type)
         ensure
           connection.drop_table :more_testings rescue nil
         end
@@ -307,7 +307,7 @@ module ActiveRecord
           ActiveRecord::Migrator.new(:up, [create_migration, migration], @schema_migration).migrate
 
           testings_id_column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
-          assert_equal "integer", testings_id_column.sql_type
+          assert_match(/integer/i, testings_id_column.sql_type)
         ensure
           connection.drop_table :more_testings rescue nil
         end


### PR DESCRIPTION
Backport 1d769a139da71141604acd603356eea0cf0ae373 to fix the 6-1-stable build.