### PR TITLE
Pin Que gem to be less than 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :job do
   gem "delayed_job", require: false
   gem "queue_classic", github: "QueueClassic/queue_classic", require: false, platforms: :ruby
   gem "sneakers", require: false
-  gem "que", require: false
+  gem "que", "< 2.2.0", require: false
   gem "backburner", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ DEPENDENCIES
   pg (>= 1.3.0.rc1)
   psych (~> 3.0)
   puma
-  que
+  que (< 2.2.0)
   queue_classic!
   racc (>= 1.4.6)
   rack-cache (~> 1.2)


### PR DESCRIPTION
Active Job CI has been failing since que 2.2.0 is installed. On main we dropped support for Que in cb22eb2b3628de428171175063371155d70a136c For backwards compatibility we pin the gem version on 6-1-stable.