### PR TITLE
HostAuthorization: confusing error message when using multiple hostnames

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -1,8 +1,12 @@
 <header>
-  <h1>Blocked host: <%= @host %></h1>
+  <h1>Blocked host: <%= @hosts.join(', ') %></h1>
 </header>
 <main role="main" id="container">
   <h2>To allow requests to <%= @host %> make sure it is a valid hostname (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:</h2>
-  <pre>config.hosts &lt;&lt; "<%= @host %>"</pre>
+  <pre>
+  <% @hosts.each do |host| %>
+config.hosts &lt;&lt; "<%= host %>"
+  <% end %>
+  </pre>
   <p>For more details view: <a href="https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization">the Host Authorization guide</a></p>
 </main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
@@ -2,6 +2,8 @@ Blocked host: <%= @host %>
 
 To allow requests to <%= @host %> make sure it is a valid hostname (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:
 
-  config.hosts << "<%= @host %>"
+<% @hosts.each do |host| %>
+  config.hosts << "<%= host %>"
+<% end %>
 
 For more details on host authorization view: https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -284,7 +284,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: 127.0.0.1", response.body
+    assert_match "Blocked host: www.example.com, 127.0.0.1", response.body
   end
 
   test "blocks requests with spoofed relative X-FORWARDED-HOST" do
@@ -297,7 +297,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: //randomhost.com", response.body
+    assert_match "Blocked host: www.example.com, //randomhost.com", response.body
   end
 
   test "forwarded secondary hosts are allowed when permitted" do
@@ -322,7 +322,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: evil.com", response.body
+    assert_match "Blocked host: domain.com, evil.com", response.body
   end
 
   test "does not consider IP addresses in X-FORWARDED-HOST spoofed when disabled" do
@@ -347,7 +347,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: localhost", response.body
+    assert_match "Blocked host: www.example.com, localhost", response.body
   end
 
   test "forwarded hosts should be permitted" do
@@ -360,7 +360,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: sub.domain.com", response.body
+    assert_match "Blocked host: domain.com, sub.domain.com", response.body
   end
 
   test "sub-sub domains should not be permitted" do
@@ -420,7 +420,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
       }
 
       assert_response :forbidden
-      assert_match "Blocked host: #{host}", response.body
+      assert_match "Blocked host: example.com, #{host}", response.body
     end
   end
 


### PR DESCRIPTION
See #40230

### Feedback needed

This pull request tries to solve the mentioned issue by displaying all hosts that have been blocked by `HostAuthorization`.

**But** there are currently two test cases that are failing, that were fine before the commits of this pull request.

Failing Tests:

* `HostAuthorizationTest#test_detects_localhost_domain_spoofing`
* `HostAuthorizationTest#test_blocks_requests_with_spoofed_X-FORWARDED-HOST`

both located in `actionpack/test/dispatch/host_authorization_test.rb`.

From my understanding these test did **not fail** for the **wrong reasons**. It is in both cases expected that the **permitted, potentially spoofed hosts** are printed in the error message as `Blocked host:`. But they only were printed there, because the other host name within the test were **not permitted** and the bug described in #40230 lead to **always printing the X-FORWARDED-HOST** if any host name was not permitted.

Seeing the **security implications** of this is beyond my understanding, thus I would like to have someone have a look at it, before "fixing" the tests (by me or someone else).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] PR is not in a draft state.
* [ ] CI is passing.
