### PR TITLE
Fix `upsert_all` for PostgreSQL json columns when `record_timestamps: true`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -573,7 +573,11 @@ module ActiveRecord
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
           else
-            sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column} IS NOT DISTINCT FROM excluded.#{column}" }
+            sql << insert.touch_model_timestamps_unless do |column, type|
+              column = cast_column_for_comparison(column, type)
+              "#{insert.model.quoted_table_name}.#{column} IS NOT DISTINCT FROM excluded.#{column}"
+            end
+
             sql << insert.updatable_columns.map { |column| "#{column}=excluded.#{column}" }.join(",")
           end
         end
@@ -1055,6 +1059,10 @@ module ActiveRecord
               end
             end
           end
+        end
+
+        def cast_column_for_comparison(column, type)
+          type == :json ? "#{column}::jsonb" : column
         end
 
         def add_pg_encoders

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -277,7 +277,14 @@ module ActiveRecord
 
           model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if touch_timestamp_attribute?(column_name)
-              "#{column_name}=(CASE WHEN (#{updatable_columns.map(&block).join(" AND ")}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END),"
+              condition =
+                insert_all.updatable_columns.map do |column|
+                  type = model.columns_hash[column.to_s].type
+
+                  block.call(quote_column(column), type)
+                end.join(" AND ")
+
+              "#{column_name}=(CASE WHEN (#{condition}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END),"
             end
           end.join
         end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -754,3 +754,40 @@ class InsertAllTest < ActiveRecord::TestCase
       model.record_timestamps = original
     end
 end
+
+if ActiveRecord::Base.connection.supports_json?
+  class UpsertAllWithJSON < ActiveRecord::TestCase
+    self.use_transactional_tests = false
+
+    class Foo < ActiveRecord::Base
+    end
+
+    def setup
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table :foos do |t|
+        t.json :json_data
+        t.timestamps
+      end
+    end
+
+    def teardown
+      @connection.drop_table :foos, if_exists: true
+    end
+
+    def test_upsert_all_for_json_column_with_record_timestamps
+      skip unless supports_insert_on_duplicate_update?
+
+      foo = Foo.create(json_data: { "bar" => 1 })
+
+      Foo.upsert_all(
+        [{ id: foo.id, json_data: { "bar" => 2 } }],
+        record_timestamps: true
+      )
+
+      updated_foo = Foo.find(foo.id)
+
+      assert_equal({ "bar" => 2 }, updated_foo.json_data)
+      assert_not_equal(foo.updated_at, updated_foo.updated_at)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

`upsert_all` uses a SQL `CASE` statement to determine whether the record's `updated_at` timestamp should be touched (#37627).

However, the `CASE` condition does not support `json` columns on PostgreSQL, [since comparison operators are not supported for the `json` data type](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING).

> [...] the usual comparison operators shown in [Table 9.1](https://www.postgresql.org/docs/current/functions-comparison.html#FUNCTIONS-COMPARISON-OP-TABLE) are available for `jsonb`, though not for `json`.

Attempting to run an upsert with a `json` column would run into an error:

```
ERROR:  operator does not exist: json = json (PG::UndefinedFunction)
```

### Detail

This PR adds an explicit `jsonb` type cast on `json` columns within that `CASE` condition. This allows the query to succeed.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [X] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [X] CI is passing.
