### PR TITLE
Fix 6-1-stable tests for selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "minitest", "~> 5.15.0"
 gem "rake", ">= 11.1"
 
 gem "capybara", ">= 3.26"
-gem "selenium-webdriver", ">= 4.0.0.alpha7"
+gem "selenium-webdriver", "< 4.2"
 
 gem "rack-cache", "~> 1.2"
 gem "sass-rails"
@@ -68,7 +68,7 @@ group :job do
   gem "delayed_job", require: false
   gem "queue_classic", github: "QueueClassic/queue_classic", require: false, platforms: :ruby
   gem "sneakers", require: false
-  gem "que", "< 2.2.0", require: false
+  gem "que", "< 2", require: false
   gem "backburner", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ DEPENDENCIES
   pg (>= 1.3.0.rc1)
   psych (~> 3.0)
   puma
-  que (< 2.2.0)
+  que (< 2)
   queue_classic!
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
@@ -601,7 +601,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   sdoc (>= 2.3.0)
-  selenium-webdriver (>= 4.0.0.alpha7)
+  selenium-webdriver (< 4.2)
   sequel
   sidekiq
   sneakers


### PR DESCRIPTION
`selenium-webdriver` v4.5.0 adds more entries ("acceptInsecureCerts" and "moz:debuggerAddress") to the `as_json` output for `Selenium::WebDriver::Firefox::Options`, causing an exact comparison of the Hash to fail.

Pinning the version to less than 4.5.0 should fix the tests.

On main this was fixed by updating the tests in 6a0ec0e54e86c76a6164d2a73dec193644a63919

The que gem has been pinned to less than 2 (instead of just 2.2.0) as 2.0.0 dropped
support for ruby 2.7:
https://github.com/que-rb/que/blob/master/CHANGELOG.md#200beta1-2022-03-24