### PR TITLE
Use ActiveSupport::ConfigurationFile in load_database_yaml

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -384,26 +384,14 @@ module Rails
       def load_database_yaml # :nodoc:
         if path = paths["config/database"].existent.first
           require "rails/application/dummy_config"
-
           original_rails_config = Rails.application.config
-          dummy_config = DummyConfig.new(original_rails_config)
-          database_config = {}
 
           begin
-            Rails.application.config = dummy_config
-
-            yaml = ERB.new(Pathname.new(path).read).result
-
-            if YAML.respond_to?(:unsafe_load)
-              database_config = YAML.unsafe_load(yaml) || {}
-            else
-              database_config = YAML.load(yaml) || {}
-            end
+            Rails.application.config = DummyConfig.new(original_rails_config)
+            ActiveSupport::ConfigurationFile.parse(Pathname.new(path))
           ensure
             Rails.application.config = original_rails_config
           end
-
-          database_config
         else
           {}
         end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2012,6 +2012,12 @@ module ApplicationTests
       assert_equal({}, Rails.application.config.load_database_yaml)
     end
 
+    test "load_database_yaml returns blank hash if no database configuration is found" do
+      remove_file "config/database.yml"
+      app "development"
+      assert_equal({}, Rails.application.config.load_database_yaml)
+    end
+
     test "setup_initial_database_yaml does not print a warning if config.active_record.suppress_multiple_database_warning is true" do
       app_file "config/database.yml", <<-YAML
         <%= Rails.env %>:


### PR DESCRIPTION
This Pull Request has been created because the ERB and YAML combination used in `#load_database_yaml` is already implemented in the `ActiveSupport::ConfigurationFile` class and can be reused.