### PR TITLE
Add missing descriptions for additional commands in Rails help

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Show descriptions for all commands in Rails help
+
+    When calling `rails help` most commands missed their description. We now
+    show the same descriptions as shown in `rails -T`.
+
+    *Petrik de Heus*
+
 *   Always generate the storage/ directory with rails new to ensure there's a stable place to
     put permanent files, and a single mount point for containers to map. Then default sqlite3 databases
     to live there instead of db/, which is only meant for configuration, not data.

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -86,8 +86,10 @@ module Rails
         end
       end
 
-      def print_commands # :nodoc:
-        commands.each { |command| puts("  #{command}") }
+      def printing_commands # :nodoc:
+        lookup!
+
+        (subclasses - hidden_commands).flat_map(&:printing_commands)
       end
 
       private

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -92,7 +92,7 @@ module Rails
         end
 
         def printing_commands
-          namespaced_commands
+          namespaced_commands.map { |command| [command, ""] }
         end
 
         def executable(subcommand = nil)

--- a/railties/lib/rails/commands/help/help_command.rb
+++ b/railties/lib/rails/commands/help/help_command.rb
@@ -8,8 +8,19 @@ module Rails
       def help(*)
         say self.class.desc
 
-        Rails::Command.print_commands
+        other_commands = printing_commands_not_in_usage.sort_by(&:first)
+        print_table(other_commands, indent: 1, truncate: true)
       end
+
+      private
+        COMMANDS_IN_USAGE = %w(generate console server test test:system dbconsole new)
+        private_constant :COMMANDS_IN_USAGE
+
+        def printing_commands_not_in_usage # :nodoc:
+          Rails::Command.printing_commands.reject do |command, _|
+            command.in?(COMMANDS_IN_USAGE)
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -9,7 +9,7 @@ module Rails
 
       class << self
         def printing_commands
-          formatted_rake_tasks.map(&:first)
+          formatted_rake_tasks
         end
 
         def perform(task, args, config)

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -8,9 +8,9 @@ require "rails/commands/db/system/change/change_command"
 
 class Rails::Command::BaseTest < ActiveSupport::TestCase
   test "printing commands" do
-    assert_equal %w(generate), Rails::Command::GenerateCommand.printing_commands
-    assert_equal %w(secrets:setup secrets:edit secrets:show), Rails::Command::SecretsCommand.printing_commands
-    assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands
+    assert_equal [["generate", ""]], Rails::Command::GenerateCommand.printing_commands
+    assert_equal [["secrets:setup", ""], ["secrets:edit", ""], ["secrets:show", ""]], Rails::Command::SecretsCommand.printing_commands
+    assert_equal [["db:system:change", ""]], Rails::Command::Db::System::ChangeCommand.printing_commands
   end
 
   test "printing commands hides hidden commands" do


### PR DESCRIPTION
### Motivation / Background

When calling `rails help` most commands missed their description. We now
show the same descriptions as shown in `rails -T`.

### Before
Calling `rails help` shows most commands without the description. This is a bit confusing when `rails -T` does show the descriptions.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/28561/83968184-9d587600-a8c7-11ea-90db-62a8545ab9b8.png">

### After
We can show the description after the command name and use some padding to align the descriptions. Lines are truncated to the width of the terminal.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/28561/83968198-b9f4ae00-a8c7-11ea-9ba9-c19d3091a984.png">

### Detail

Rails::Command had logic for printing help commands not in 'usage': `print_commands`, `commands` and the `COMMANDS_IN_USAGE` constant. As these methods were only used by Rails::Command::HelpCommand, they have been moved HelpCommand.

This also changes the `printing_commands` methods on several classes. Instead of returning just the commands, they return the commands with the descriptions. As these are only used for printing help it does not affect any other code.

Some commands (routes, credentials:diff, etc) show no description yet, but these can be added later.

This was previously submitted in #39561 but that PR was stale and I can no longer access the branch.

<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
