### PR TITLE
Show common commands when calling `rails -h` outside a Rails dir

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Show relevant commands when calling help
+
+    When running `rails -h` or just `rails` outside a Rails application,
+    Rails outputs all options for running the `rails new` command. This can be
+    confusing to users when they probably want to see the common Rails commands.
+
+    Instead, we should always show the common commands when running `rails -h`
+    inside or outside a Rails application.
+
+    As the relevant commands inside a Rails application differ from the
+    commands outside an application, the help USAGE file has been split to
+    show the most relevant commands for the context.
+
+    *Petrik de Heus*
+
 *   Add Rails::HealthController#show and map it to /up for newly generated applications.
     Load balancers and uptime monitors all need a basic endpoint to tell whether the app is up.
     This is a good starting point that'll work in many situations.

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -10,8 +10,11 @@ require "rails/ruby_version_check"
 Signal.trap("INT") { puts; exit(1) }
 
 require "rails/command"
-
-if ARGV.first == "plugin"
+case ARGV.first
+when Rails::Command::HELP_MAPPINGS, "help", nil
+  ARGV.shift
+  Rails::Command.invoke :gem_help, ARGV
+when "plugin"
   ARGV.shift
   Rails::Command.invoke :plugin, ARGV
 else

--- a/railties/lib/rails/commands/gem_help/USAGE
+++ b/railties/lib/rails/commands/gem_help/USAGE
@@ -1,0 +1,13 @@
+You must specify a command:
+
+  new          Create a new Rails application. "rails new my_app" creates a
+               new application called MyApp in "./my_app"
+  plugin new   Create a new Rails railtie or engine
+
+All commands can be run with -h (or --help) for more information.
+
+Inside a Rails application directory, some common commands are:
+
+  console      Start the Rails console
+  server       Start the Rails server
+  test         Run tests except system tests

--- a/railties/lib/rails/commands/gem_help/gem_help_command.rb
+++ b/railties/lib/rails/commands/gem_help/gem_help_command.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Rails
+  module Command
+    class GemHelpCommand < Base # :nodoc:
+      hide_command!
+
+      def perform
+        say self.class.desc
+      end
+    end
+  end
+end

--- a/railties/lib/rails/commands/help/USAGE
+++ b/railties/lib/rails/commands/help/USAGE
@@ -1,17 +1,14 @@
-The most common rails commands are:
- generate     Generate new code (short-cut alias: "g")
- console      Start the Rails console (short-cut alias: "c")
- server       Start the Rails server (short-cut alias: "s")
- test         Run tests except system tests (short-cut alias: "t")
- test:system  Run system tests
- dbconsole    Start a console for the database specified in config/database.yml
-              (short-cut alias: "db")
+You must specify a command. The most common commands are:
+
+  generate     Generate new code (short-cut alias: "g")
+  console      Start the Rails console (short-cut alias: "c")
+  server       Start the Rails server (short-cut alias: "s")
+  test         Run tests except system tests (short-cut alias: "t")
+  test:system  Run system tests
+  dbconsole    Start a console for the database specified in config/database.yml
+               (short-cut alias: "db")
 <% unless engine? -%>
- new          Create a new Rails application. "rails new my_app" creates a
-              new application called MyApp in "./my_app"
- plugin new   Create a new Rails railtie or engine
+  plugin new   Create a new Rails railtie or engine
 <% end -%>
 
 All commands can be run with -h (or --help) for more information.
-In addition to those commands, there are:
-

--- a/railties/lib/rails/commands/help/help_command.rb
+++ b/railties/lib/rails/commands/help/help_command.rb
@@ -7,9 +7,17 @@ module Rails
 
       def help(*)
         say self.class.desc
+      end
 
-        other_commands = printing_commands_not_in_usage.sort_by(&:first)
-        print_table(other_commands, indent: 1, truncate: true)
+      def help_extended(*)
+        help
+
+        say ""
+        say "In addition to those commands, there are:"
+        say ""
+
+        extended_commands = printing_commands_not_in_usage.sort_by(&:first)
+        print_table(extended_commands, truncate: true)
       end
 
       private

--- a/railties/test/application/help_test.rb
+++ b/railties/test/application/help_test.rb
@@ -13,13 +13,40 @@ class HelpTest < ActiveSupport::TestCase
     teardown_app
   end
 
-  test "command works" do
+  test "lists common commands and extended commands" do
     output = rails("help")
-    assert_match "The most common rails commands are", output
+    assert_match "You must specify a command. The most common commands are:", output
+    assert_match "  generate     Generate new code (short-cut alias: \"g\")", output
+    assert_match "In addition to those commands", output
+    assert_no_match(/^generate/, output)
+    assert_no_match(/^console/, output)
+    assert_no_match(/^server/, output)
   end
 
   test "short-cut alias works" do
     output = rails("-h")
-    assert_match "The most common rails commands are", output
+    assert_match "You must specify a command. The most common commands are:", output
+    assert_match "  generate     Generate new code (short-cut alias: \"g\")", output
+    assert_match "In addition to those commands", output
   end
+
+  test "when no arguments are passed lists the common commands only" do
+    output = rails("")
+    assert_match "You must specify a command. The most common commands are:", output
+    assert_match "  generate     Generate new code (short-cut alias: \"g\")", output
+    assert_no_match "In addition to those commands", output
+  end
+
+  test "outside application root it lists gem commands" do
+    output = gem_rails("")
+    assert_match "You must specify a command:", output
+    assert_match "  new          Create a new Rails application.", output
+  end
+
+  private
+    def gem_rails(cmd)
+      capture(:stdout) do
+        system("#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}", exception: true)
+      end
+    end
 end


### PR DESCRIPTION
### Motivation

When running `rails -h` or just `rails` outside a Rails application, Rails outputs all options for running the `rails new` command. This can be confusing to users when they probably want to see the common Rails commands.

Instead, we should always show the common commands when running `rails -h` inside or outside a Rails application.

### Detail

With this change help works as follows...

Outside a Rails application we never show the extended commands: db:migrate, etc...
The extended commands require a Rails application. They also take up a lot screen space.

- `rails`        outputs the help for the gem commands
- `rails -h`     outputs the help for the gem commands.
- `rails new -h` outputs the help for the new command.

Inside a Rails application it works mostly as before. The only change is that calling plain `bin/rails` now only outputs the common commands and not the extended commands.

- `bin/rails`    outputs the help for the common commands
- `bin/rails -h` outputs the help for the common commands and the
  extended commands

### Additional information

This was previously submitted in https://github.com/rails/rails/pull/41425 but that PR was stale and I can no longer access the branch.

Fixes: #40823

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
