### PR TITLE
Allow resetting singular associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `has_one` and `belongs_to` associations now define a `reset_association` method
+    on the owner model (where `association` is the name of the association). This
+    method unloads the cached associate record, if any, and causes the next access
+    to query it from the database.
+
+    *George Claghorn*
+
 *   Allow per attribute setting of YAML permitted classes (safe load) and unsafe load.
 
     *Carlos Palhares*

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1500,6 +1500,8 @@ module ActiveRecord
         #   if the record is invalid.
         # [reload_association]
         #   Returns the associated object, forcing a database read.
+        # [reset_association]
+        #   Unloads the associated object. The next access will query it from the database.
         #
         # === Example
         #
@@ -1510,6 +1512,7 @@ module ActiveRecord
         # * <tt>Account#create_beneficiary</tt> (similar to <tt>b = Beneficiary.new(account_id: id); b.save; b</tt>)
         # * <tt>Account#create_beneficiary!</tt> (similar to <tt>b = Beneficiary.new(account_id: id); b.save!; b</tt>)
         # * <tt>Account#reload_beneficiary</tt>
+        # * <tt>Account#reset_beneficiary</tt>
         #
         # === Scopes
         #
@@ -1669,6 +1672,8 @@ module ActiveRecord
         #   if the record is invalid.
         # [reload_association]
         #   Returns the associated object, forcing a database read.
+        # [reset_association]
+        #   Unloads the associated object. The next access will query it from the database.
         # [association_changed?]
         #   Returns true if a new associate object has been assigned and the next save will update the foreign key.
         # [association_previously_changed?]
@@ -1683,9 +1688,9 @@ module ActiveRecord
         # * <tt>Post#create_author</tt> (similar to <tt>post.author = Author.new; post.author.save; post.author</tt>)
         # * <tt>Post#create_author!</tt> (similar to <tt>post.author = Author.new; post.author.save!; post.author</tt>)
         # * <tt>Post#reload_author</tt>
+        # * <tt>Post#reset_author</tt>
         # * <tt>Post#author_changed?</tt>
         # * <tt>Post#author_previously_changed?</tt>
-        # The declaration can also include an +options+ hash to specialize the behavior of the association.
         #
         # === Scopes
         #
@@ -1699,6 +1704,8 @@ module ActiveRecord
         #   belongs_to :level, ->(game) { where("game_level > ?", game.current_level) }
         #
         # === Options
+        #
+        # The declaration can also include an +options+ hash to specialize the behavior of the association.
         #
         # [:class_name]
         #   Specify the class name of the association. Use it only if that name can't be inferred

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -19,6 +19,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
         def reload_#{name}
           association(:#{name}).force_reload_reader
         end
+
+        def reset_#{name}
+          association(:#{name}).reset
+        end
       CODE
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -414,7 +414,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Company.where(id: odegy_account.firm_id).update_all(name: "ODEGY")
     assert_equal "Odegy", odegy_account.firm.name
 
-    assert_equal "ODEGY", odegy_account.reload_firm.name
+    assert_queries(1) { odegy_account.reload_firm }
+
+    assert_no_queries { odegy_account.firm }
+    assert_equal "ODEGY", odegy_account.firm.name
   end
 
   def test_reload_the_belonging_object_with_query_cache
@@ -439,6 +442,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_queries(1) { Account.find(odegy_account_id) }
   ensure
     ActiveRecord::Base.connection.disable_query_cache!
+  end
+
+  def test_resetting_the_association
+    odegy_account = accounts(:odegy_account)
+
+    assert_equal "Odegy", odegy_account.firm.name
+    Company.where(id: odegy_account.firm_id).update_all(name: "ODEGY")
+    assert_equal "Odegy", odegy_account.firm.name
+
+    assert_no_queries { odegy_account.reset_firm }
+    assert_queries(1) { odegy_account.firm }
+    assert_equal "ODEGY", odegy_account.firm.name
   end
 
   def test_natural_assignment_to_nil

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -364,7 +364,9 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     Account.where(id: odegy.account.id).update_all(credit_limit: 80)
     assert_equal 53, odegy.account.credit_limit
 
-    assert_equal 80, odegy.reload_account.credit_limit
+    assert_queries(1) { odegy.reload_account }
+    assert_no_queries { odegy.account }
+    assert_equal 80, odegy.account.credit_limit
   end
 
   def test_reload_association_with_query_cache
@@ -388,6 +390,19 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_queries(1) { Company.find(odegy_id) }
   ensure
     ActiveRecord::Base.connection.disable_query_cache!
+  end
+
+  def test_reset_assocation
+    odegy = companies(:odegy)
+
+    assert_equal 53, odegy.account.credit_limit
+    Account.where(id: odegy.account.id).update_all(credit_limit: 80)
+    assert_equal 53, odegy.account.credit_limit
+
+    assert_no_queries { odegy.reset_account }
+
+    assert_queries(1) { odegy.account }
+    assert_equal 80, odegy.account.credit_limit
   end
 
   def test_build

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -923,6 +923,7 @@ When you declare a `belongs_to` association, the declaring class automatically g
 * `create_association(attributes = {})`
 * `create_association!(attributes = {})`
 * `reload_association`
+* `reset_association`
 * `association_changed?`
 * `association_previously_changed?`
 
@@ -943,6 +944,7 @@ build_author
 create_author
 create_author!
 reload_author
+reset_author
 author_changed?
 author_previously_changed?
 ```
@@ -961,6 +963,12 @@ If the associated object has already been retrieved from the database for this o
 
 ```ruby
 @author = @book.reload_author
+```
+
+To unload the cached version of the associated object—causing the next access, if any, to query it from the database—call `#reset_association` on the parent object.
+
+```ruby
+@book.reset_author
 ```
 
 ##### `association=(associate)`
@@ -1320,6 +1328,7 @@ When you declare a `has_one` association, the declaring class automatically gain
 * `create_association(attributes = {})`
 * `create_association!(attributes = {})`
 * `reload_association`
+* `reset_assocation`
 
 In all of these methods, `association` is replaced with the symbol passed as the first argument to `has_one`. For example, given the declaration:
 
@@ -1338,6 +1347,7 @@ build_account
 create_account
 create_account!
 reload_account
+reset_account
 ```
 
 NOTE: When initializing a new `has_one` or `belongs_to` association you must use the `build_` prefix to build the association, rather than the `association.build` method that would be used for `has_many` or `has_and_belongs_to_many` associations. To create one, use the `create_` prefix.
@@ -1354,6 +1364,12 @@ If the associated object has already been retrieved from the database for this o
 
 ```ruby
 @account = @supplier.reload_account
+```
+
+To unload the cached version of the associated object—forcing the next access, if any, to query it from the database—call `#reset_association` on the parent object.
+
+```ruby
+@supplier.reset_account
 ```
 
 ##### `association=(associate)`


### PR DESCRIPTION
`has_one :author` and `belongs_to :author` each define a `reload_author` method on the owning model. `reload_author` clears the cached `author` associate-object and eagerly fetches a new one from the database.

In some cases, you know the cached associate is stale but not whether it will be needed again. If it isn’t, the database query from calling `reload_*` is wasted.

Consider the following models:

```ruby
class Account < ApplicationRecord
  has_many :trials
  has_one :active_trial, -> { active }, class_name: "Trial"
end

class Trial < ApplicationRecord
  belongs_to :account
  
  scope :active, -> { where active: true }

  def deactivate
    update! active: false
    # 📍
  end
end
```

At the 📍 in `Trial#deactivate`, we know we’ve potentially made `account`’s `active_trial` association stale. We don’t know if `account` will need to reference its `active_trial` again. It would be useful to be able to evict the cached `active_trial`, if any, and defer the database query until the next access.

For collection associations, [`ActiveRecord::Associations::CollectionProxy`](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html) provides a `#reset` method in addition to `#reload`. There’s not an equivalent way to reset a singular association, though. This PR adds one.