### PR TITLE
Use `adapter_class` instead of `connection_class` for adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -8,13 +8,13 @@ require "mysql2"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
-    def mysql2_connection_class
+    def mysql2_adapter_class
       ConnectionAdapters::Mysql2Adapter
     end
 
     # Establishes a connection to the database that's used by all Active Record objects.
     def mysql2_connection(config)
-      mysql2_connection_class.new(config)
+      mysql2_adapter_class.new(config)
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -21,13 +21,13 @@ require "active_record/connection_adapters/postgresql/utils"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
-    def postgresql_connection_class
+    def postgresql_adapter_class
       ConnectionAdapters::PostgreSQLAdapter
     end
 
     # Establishes a connection to the database that's used by all Active Record objects
     def postgresql_connection(config)
-      postgresql_connection_class.new(config)
+      postgresql_adapter_class.new(config)
     end
   end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -15,12 +15,12 @@ require "sqlite3"
 
 module ActiveRecord
   module ConnectionHandling # :nodoc:
-    def sqlite3_connection_class
+    def sqlite3_adapter_class
       ConnectionAdapters::SQLite3Adapter
     end
 
     def sqlite3_connection(config)
-      sqlite3_connection_class.new(config)
+      sqlite3_adapter_class.new(config)
     end
   end
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       end
 
       def adapter_class_method
-        "#{adapter}_connection_class"
+        "#{adapter}_adapter_class"
       end
 
       def host

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -16,7 +16,7 @@ module Rails
     end
 
     def start
-      connection_class.dbconsole(db_config, @options)
+      adapter_class.dbconsole(db_config, @options)
     rescue NotImplementedError
       abort "Unknown command-line client for #{db_config.database}."
     end
@@ -50,7 +50,7 @@ module Rails
     end
 
     private
-      def connection_class
+      def adapter_class
         if ActiveRecord::Base.respond_to?(db_config.adapter_class_method)
           ActiveRecord::Base.public_send(db_config.adapter_class_method)
         else


### PR DESCRIPTION
In Active Record `connection_class` already means "the class in your application that established the connection" so I would prefer it only have that one meaning. This change swaps `connection_class` for `adapter_class` where applicable.