### PR TITLE
Remove YARD docs and rename :legacy to :marginalia

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     It is now possible to opt into sqlcommenter-formatted query log tags with `config.active_record.query_log_tags_format = :sqlcommenter`.
 
-    *Modulitos and Iheanyi*
+    *Modulitos* and *Iheanyi*
 
 *   Allow any ERB in the database.yml when creating rake tasks.
 

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -90,8 +90,9 @@ module ActiveRecord
         self.cached_comment = nil
       end
 
-      # Updates the formatter to be what the passed in format is.
-      def update_formatter(format = :legacy)
+      # Updates the tag formatter based on the format passed in. Available
+      # formats are <tt>:marginalia</tt> and <tt>:sqlcommenter</tt>
+      def update_formatter(format = :marginalia)
         self.tags_formatter = QueryLogs::FormatterFactory.from_symbol(format)
       end
 
@@ -109,7 +110,7 @@ module ActiveRecord
         end
 
         def formatter
-          self.tags_formatter ||= QueryLogs::FormatterFactory.from_symbol(:legacy)
+          self.tags_formatter ||= QueryLogs::FormatterFactory.from_symbol(:marginalia)
         end
 
         def uncached_comment

--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -5,18 +5,10 @@ module ActiveRecord
     class Formatter # :nodoc:
       attr_reader :key_value_separator
 
-      # @param [String] key_value_separator: indicates the string used for
-      # separating keys and values.
-      #
-      # @param [Symbol] quote_values: indicates how values will be formatted (eg:
-      # in single quotes, not quoted at all, etc)
       def initialize(key_value_separator:)
         @key_value_separator = key_value_separator
       end
 
-      # @param [String-coercible] value
-      # @return [String] The formatted value that will be used in our key-value
-      # pairs.
       def format_value(value)
         value
       end
@@ -29,11 +21,9 @@ module ActiveRecord
     end
 
     class FormatterFactory # :nodoc:
-      # @param [Symbol] formatter: the kind of formatter we're building.
-      # @return [Formatter]
       def self.from_symbol(formatter)
         case formatter
-        when :legacy
+        when :marginalia
           Formatter.new(key_value_separator: ":")
         when :sqlcommenter
           QuotingFormatter.new(key_value_separator: "=")

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -34,7 +34,7 @@ module ActiveRecord
     config.active_record.sqlite3_production_warning = true
     config.active_record.query_log_tags_enabled = false
     config.active_record.query_log_tags = [ :application ]
-    config.active_record.query_log_tags_format = :legacy
+    config.active_record.query_log_tags_format = :marginalia
     config.active_record.cache_query_log_tags = false
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1127,7 +1127,7 @@ application name.
 
 #### `config.active_record.query_log_tags_format`
 
-A `Symbol` specifying the formatter to use for tags. Valid values are `:sqlcommenter` and `:legacy`.  Defaults to `:legacy`.
+A `Symbol` specifying the formatter to use for tags. Valid values are `:sqlcommenter` and `:marginalia`.  Defaults to `:marginalia`.
 
 #### `config.active_record.cache_query_log_tags`
 


### PR DESCRIPTION
Rails uses RDoc, so YARD is the incorrect format for docs. In addition,
the class is :nodoc: so documentation is not necessary.

cc @rafaelfranca 