### PR TITLE
Fix dev initializer logs not going to stdout

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -60,15 +60,10 @@ module ActiveRecord
 
     # When loading console, force ActiveRecord::Base to be loaded
     # to avoid cross references when loading a constant for the
-    # first time. Also, make it output to STDERR.
+    # first time.
     console do |app|
       require "active_record/railties/console_sandbox" if app.sandbox?
       require "active_record/base"
-      unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
-        console = ActiveSupport::Logger.new(STDERR)
-        console.level = Rails.logger.level
-        Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
-      end
       ActiveRecord.verbose_query_logs = false
     end
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -59,6 +59,14 @@ module Rails
         unless config.consider_all_requests_local
           Rails.error.logger = Rails.logger
         end
+
+        if config.log_to_stdout? && !ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDOUT, STDERR)
+          console = ActiveSupport::Logger.new(STDOUT)
+          console.formatter = Rails.logger.formatter
+          console.level = Rails.logger.level
+
+          Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
+        end
       end
 
       # Initialize cache early in the stack so railties can make use of it.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -83,6 +83,7 @@ module Rails
         @rake_eager_load                         = false
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
+        @log_to_stdout                           = false
       end
 
       # Loads default configuration values for a target version. This includes
@@ -551,6 +552,14 @@ module Rails
         else
           @permissions_policy
         end
+      end
+
+      def log_to_stdout! # :nodoc:
+        @log_to_stdout = true
+      end
+
+      def log_to_stdout? # :nodoc:
+        @log_to_stdout
       end
 
       def default_log_file

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -102,7 +102,9 @@ module Rails
 
       desc "console", "Start the Rails console"
       def perform
-        boot_application!
+        require_application!
+        Rails.configuration.log_to_stdout!
+        Rails.application.require_environment! if defined?(APP_PATH)
         Rails::Console.start(Rails.application, options)
       end
     end

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -33,7 +33,7 @@ module Rails
       trap(:INT) { exit }
       create_tmp_directories
       setup_dev_caching
-      log_to_stdout if options[:log_stdout]
+      Rails.configuration.log_to_stdout! if options[:log_stdout]
 
       super()
     ensure
@@ -69,18 +69,6 @@ module Rails
       def create_tmp_directories
         %w(cache pids sockets).each do |dir_to_make|
           FileUtils.mkdir_p(File.join(Rails.root, "tmp", dir_to_make))
-        end
-      end
-
-      def log_to_stdout
-        wrapped_app # touch the app so the logger is set up
-
-        console = ActiveSupport::Logger.new(STDOUT)
-        console.formatter = Rails.logger.formatter
-        console.level = Rails.logger.level
-
-        unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
-          Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

Previously, the Rails server and console commands would broadcast logs to STDOUT if the Rails.logger was not already logging to STDOUT/STDERR. However, the broadcast was setup after initialization had finished, so some logs may not have been broadcast. More specifically, anything logged during initialization after the :initialize_logger initializer would not be logged to STDOUT.

This is an issue especially because of how common it is for deprecation warnings to be logged during initialization. Very important deprecation warnings such as :warn_if_autoloaded in Rails 6/6.1 would not be logged to STDOUT even though application logs after initialization would.

This is very confusing because users most likely assumed that development logs were identical between STDOUT and log/development.log when they were actually not.

### Detail

This commit fixes the issue by broadcasting when the logger is set up, so that STDOUT and log/development.log will both log everything.

### Additional information

Ref #44800 as this also fixes the STDERR/STDOUT duplicate logs if Rails.logger is configured to output to STDERR

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.