### PR TITLE
Fixes sqlite -> SQLite [ci-skip] 

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -418,7 +418,7 @@ module ActiveRecord
       # something beyond a simple insert (e.g. Oracle).
       # Most of adapters should implement +insert_fixtures_set+ that leverages bulk SQL insert.
       # We keep this method to provide fallback
-      # for databases like sqlite that do not support bulk inserts.
+      # for databases like SQLite that do not support bulk inserts.
       def insert_fixture(fixture, table_name)
         execute(build_fixture_sql(Array.wrap(fixture), table_name), "Fixture Insert")
       end

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -156,7 +156,7 @@ if ActiveRecord::Base.connection.supports_views?
     end
   end
 
-  # sqlite dose not support CREATE, INSERT, and DELETE for VIEW
+  # SQLite dose not support CREATE, INSERT, and DELETE for VIEW
   if current_adapter?(:Mysql2Adapter, :SQLServerAdapter, :PostgreSQLAdapter)
 
     class UpdateableViewTest < ActiveRecord::TestCase

--- a/guides/source/5_2_release_notes.md
+++ b/guides/source/5_2_release_notes.md
@@ -526,7 +526,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
     ([Commit](https://github.com/rails/rails/commit/63cf15877bae859ff7b4ebaf05186f3ca79c1863))
 
 *   Fixed a bug where column orders for an index weren't written to
-    `db/schema.rb` when using the sqlite adapter.
+    `db/schema.rb` when using the SQLite adapter.
     ([Pull Request](https://github.com/rails/rails/pull/30970))
 
 *   Fix `bin/rails db:migrate` with specified `VERSION`.


### PR DESCRIPTION
Fixes typo, from sqlite to SQLite in RDoc comments and release notes.