### PR TITLE
Validate options when managing columns and tables in migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Validate options when managing columns and tables in migrations.
+
+    If an invalid option is passed to a migration method like `create_table` and `add_column`, an error will be raised
+    instead of the option being silently ignored. Validation of the options will only be applied for new migrations
+    that are created.
+
+    *Guo Xiang Tan*, *George Wambold*
+
 *   Add configurable formatter on query log tags to support sqlcommenter. See #45139
 
     It is now possible to opt into sqlcommenter-formatted query log tags with `config.active_record.query_log_tags_format = :sqlcommenter`.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -290,6 +290,7 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options, &block)
+        validate_create_table_options!(options)
         validate_table_length!(table_name) unless options[:_uses_legacy_table_name]
         td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
 
@@ -324,8 +325,8 @@ module ActiveRecord
       # if the same arguments were passed to #create_table. See #create_table for information about
       # passing a +table_name+, and other additional options that can be passed.
       def build_create_table_definition(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
-        table_definition = create_table_definition(table_name, **extract_table_options!(options))
-        table_definition.set_primary_key(table_name, id, primary_key, **options)
+        table_definition = create_table_definition(table_name, **options.extract!(*valid_table_definition_options, :_skip_validate_options))
+        table_definition.set_primary_key(table_name, id, primary_key, **options.extract!(*valid_primary_key_options, :_skip_validate_options))
 
         yield table_definition if block_given?
 
@@ -1558,8 +1559,20 @@ module ActiveRecord
           AlterTable.new create_table_definition(name)
         end
 
-        def extract_table_options!(options)
-          options.extract!(:temporary, :if_not_exists, :options, :as, :comment, :charset, :collation)
+        def valid_table_definition_options
+          [:temporary, :if_not_exists, :options, :as, :comment, :charset, :collation]
+        end
+
+        def valid_primary_key_options
+          [:limit, :default, :precision]
+        end
+
+        def validate_create_table_options!(options)
+          unless options[:_skip_validate_options]
+            options
+              .except(:_uses_legacy_table_name, :_skip_validate_options)
+              .assert_valid_keys(valid_table_definition_options, valid_primary_key_options)
+          end
         end
 
         def fetch_type_metadata(sql_type)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -85,6 +85,10 @@ module ActiveRecord
         end
 
         private
+          def valid_column_definition_options
+            super + [:auto_increment, :charset, :as, :size, :unsigned, :first, :after, :type, :stored]
+          end
+
           def aliased_types(name, fallback)
             fallback
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -154,6 +154,10 @@ module ActiveRecord
             @default_row_format
           end
 
+          def valid_primary_key_options
+            super + [:unsigned]
+          end
+
           def create_table_definition(name, **options)
             MySQL::TableDefinition.new(self, name, **options)
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -237,6 +237,10 @@ module ActiveRecord
         end
 
         private
+          def valid_column_definition_options
+            super + [:array, :using, :cast_as, :as, :type, :enum_type, :stored]
+          end
+
           def aliased_types(name, fallback)
             fallback
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -120,6 +120,10 @@ module ActiveRecord
         end
 
         private
+          def valid_table_definition_options
+            super + [:rename]
+          end
+
           def create_table_definition(name, **options)
             SQLite3::TableDefinition.new(self, name, **options)
           end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -34,13 +34,26 @@ module ActiveRecord
 
       class V7_0 < V7_1
         module TableDefinition
+          def new_column_definition(name, type, **options)
+            options[:_skip_validate_options] = true
+            super
+          end
+
           private
             def raise_on_if_exist_options(options)
             end
         end
 
+        def add_column(table_name, column_name, type, **options)
+          options[:_skip_validate_options] = true
+          super
+        end
+
+
         def create_table(table_name, **options)
           options[:_uses_legacy_table_name] = true
+          options[:_skip_validate_options] = true
+
           if block_given?
             super { |t| yield compatible_table_definition(t) }
           else

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -255,6 +255,26 @@ module ActiveRecord
         end
       end
 
+      def test_options_are_not_validated
+        migration = Class.new(ActiveRecord::Migration[7.0]) {
+          def migrate(x)
+            create_table :tests, wrong_id: false do |t|
+              t.references :some_table, wrong_primary_key: true
+              t.integer :some_id, wrong_unique: true
+              t.string :some_string_column, wrong_null: false
+            end
+
+            add_column :tests, "last_name", :string, wrong_precision: true
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+
+        assert connection.table_exists?(:tests)
+      ensure
+        connection.drop_table :tests, if_exists: true
+      end
+
       if current_adapter?(:PostgreSQLAdapter)
         class Testing < ActiveRecord::Base
         end

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "cases/migration/helper"
+
+module ActiveRecord
+  class Migration
+    class InvalidOptionsTest < ActiveRecord::TestCase
+      include ActiveRecord::Migration::TestHelper
+
+      def invalid_add_column_option_exception_message(key)
+        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":if_exists", ":if_not_exists"]
+
+        if current_adapter?(:Mysql2Adapter)
+          default_keys.concat([":auto_increment", ":charset", ":as", ":size", ":unsigned", ":first", ":after", ":type", ":stored"])
+        elsif current_adapter?(:PostgreSQLAdapter)
+          default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":enum_type", ":stored"])
+        end
+
+        "Unknown key: :#{key}. Valid keys are: #{default_keys.join(", ")}"
+      end
+
+      def invalid_add_index_option_exception_message(key)
+        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm"
+      end
+
+      def invalid_create_table_option_exception_message(key)
+        table_keys = [":temporary", ":if_not_exists", ":options", ":as", ":comment", ":charset", ":collation"]
+        primary_keys = [":limit", ":default", ":precision"]
+
+        if current_adapter?(:Mysql2Adapter)
+          primary_keys.concat([":unsigned"])
+        elsif current_adapter?(:SQLite3Adapter)
+          table_keys.concat([":rename"])
+        end
+
+        "Unknown key: :#{key}. Valid keys are: #{(table_keys + primary_keys).join(", ")}"
+      end
+
+      def test_add_reference_with_invalid_options
+        exception = assert_raises(ArgumentError) do
+          connection.create_table "my_table", force: true do |t|
+            t.references :some_table, boring_key: true
+          end
+        end
+
+        assert_equal(
+          invalid_add_column_option_exception_message(:boring_key),
+          exception.message
+        )
+
+        exception = assert_raises(ArgumentError) do
+          add_reference :some_table, :some_column, boring_key: true
+        end
+
+        assert_equal(
+          invalid_add_column_option_exception_message(:boring_key),
+          exception.message
+        )
+      ensure
+        connection.drop_table :my_table, if_exists: true
+      end
+
+      def test_add_column_with_invalid_options
+        exception = assert_raises(ArgumentError) do
+          add_column "test_models", "first_name", :string, preccision: true
+        end
+
+        assert_equal(
+          invalid_add_column_option_exception_message(:preccision),
+          exception.message
+        )
+
+        exception = assert_raises(ArgumentError) do
+          connection.create_table "my_table", force: true do |t|
+            t.string :first_name, index: { nema: "test" }
+          end
+        end
+
+        assert_equal(
+          invalid_add_index_option_exception_message(:nema),
+          exception.message
+        )
+      ensure
+        connection.drop_table :my_table, if_exists: true
+      end
+
+      def test_add_index_with_invalid_options
+        exception = assert_raises(ArgumentError) do
+          add_index "test_models", "first_name", nema: "my_index"
+        end
+
+        assert_equal(
+          invalid_add_index_option_exception_message(:nema),
+          exception.message
+        )
+      end
+
+      if current_adapter?(:Mysql2Adapter) || current_adapter?(:PostgreSQLAdapter)
+        def test_change_column_with_invalid_options
+          exception = assert_raises(ArgumentError) do
+            change_column "posts", "title", :text, liimit: true
+          end
+
+          assert_equal(
+            invalid_add_column_option_exception_message(:liimit),
+            exception.message
+          )
+        end
+      end
+
+      def test_create_table_with_invalid_options
+        exception = assert_raises(ArgumentError) do
+          connection.create_table "my_table", idd: false do |t|
+          end
+        end
+
+        assert_equal(
+          invalid_create_table_option_exception_message(:idd),
+          exception.message
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because invalid options used when managing columns and tables in migrations are silently ignored. 

Previous attempt in https://github.com/rails/rails/pull/33347
Resolves https://github.com/rails/rails/issues/33284
Resolves https://github.com/rails/rails/issues/39230

### Detail

This Pull Request adds a step to validate the options that are used when managing columns and tables in migrations. The intention is to only validate options for new migrations that are added. Invalid options used in old migrations are silently ignored like they always have been.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [X] CI is passing.
