### PR TITLE
Remove private `transaction(joinable:)` parameter from RDoc

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -306,6 +306,7 @@ module ActiveRecord
       #
       # The mysql2 and postgresql adapters support setting the transaction
       # isolation level.
+      #  :args: (requires_new: nil, isolation: nil, &block)
       def transaction(requires_new: nil, isolation: nil, joinable: true, &block)
         if !requires_new && current_transaction.joinable?
           if isolation


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/46182

This argument is only for internal use, like transactional fixtures or the `--sandbox` console flag.
