### PR TITLE
Namespace keys in EncodedKeyCacheBehavior test

### DIFF
--- a/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
@@ -6,7 +6,7 @@
 module EncodedKeyCacheBehavior
   Encoding.list.each do |encoding|
     define_method "test_#{encoding.name.underscore}_encoded_values" do
-      key = (+"foo").force_encoding(encoding)
+      key = (+"foo_#{encoding.name.underscore}").force_encoding(encoding)
       assert @cache.write(key, "1", raw: true)
       assert_equal "1", @cache.read(key, raw: true)
       assert_equal "1", @cache.fetch(key, raw: true)


### PR DESCRIPTION
It's a bit of a stab in the dark but I'm hoping it may fix the flaky failures such as:

```ruby
Failure:
OptimizedMemCacheStoreTest#test_iso_8859_6_encoded_values [/rails/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb:10]:
Expected false to be truthy.
```
