### PR TITLE
Add support for unique constraints (PostgreSQL-only).

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -16,7 +16,8 @@ module ActiveRecord
       delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
         :options_include_default?, :supports_indexes_in_create?, :use_foreign_keys?,
         :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?,
-        :supports_index_include?, :supports_exclusion_constraints?, to: :@conn, private: true
+        :supports_index_include?, :supports_exclusion_constraints?, :supports_unique_keys?,
+        to: :@conn, private: true
 
       private
         def visit_AlterTable(o)
@@ -61,6 +62,10 @@ module ActiveRecord
 
           if supports_exclusion_constraints?
             statements.concat(o.exclusion_constraints.map { |exc| accept exc })
+          end
+
+          if supports_unique_keys?
+            statements.concat(o.unique_keys.map { |exc| accept exc })
           end
 
           create_sql << "(#{statements.join(', ')})" if statements.present?

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -500,6 +500,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating unique constraints?
+      def supports_unique_keys?
+        false
+      end
+
       # Does this adapter support views?
       def supports_views?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -49,6 +49,26 @@ module ActiveRecord
             end
           end
 
+          def unique_keys_in_create(table, stream)
+            if (unique_keys = @connection.unique_keys(table)).any?
+              add_unique_key_statements = unique_keys.map do |unique_key|
+                parts = [
+                  "t.unique_key #{unique_key.columns.inspect}"
+                ]
+
+                parts << "deferrable: #{unique_key.deferrable.inspect}" if unique_key.deferrable
+
+                if unique_key.export_name_on_schema_dump?
+                  parts << "name: #{unique_key.name.inspect}"
+                end
+
+                "    #{parts.join(', ')}"
+              end
+
+              stream.puts add_unique_key_statements.sort.join("\n")
+            end
+          end
+
           def prepare_column_options(column)
             spec = super
             spec[:array] = "true" if column.array?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -614,6 +614,40 @@ module ActiveRecord
           end
         end
 
+        # Returns an array of unique constraints for the given table.
+        # The unique constraints are represented as UniqueKeyDefinition objects.
+        def unique_keys(table_name)
+          scope = quoted_scope(table_name)
+
+          unique_info = exec_query(<<~SQL, "SCHEMA", allow_retry: true, uses_transaction: false)
+            SELECT c.conname, c.conindid, c.condeferrable, c.condeferred
+            FROM pg_constraint c
+            JOIN pg_class t ON c.conrelid = t.oid
+            JOIN pg_namespace n ON n.oid = c.connamespace
+            WHERE c.contype = 'u'
+              AND t.relname = #{scope[:name]}
+              AND n.nspname = #{scope[:schema]}
+          SQL
+
+          unique_info.map do |row|
+            deferrable = extract_unique_key_deferrable(row["condeferrable"], row["condeferred"])
+
+            columns = query_values(<<~SQL, "SCHEMA")
+              SELECT a.attname
+              FROM pg_attribute a
+              WHERE a.attrelid = #{row['conindid']}
+              ORDER BY a.attnum
+            SQL
+
+            options = {
+              name: row["conname"],
+              deferrable: deferrable
+            }
+
+            UniqueKeyDefinition.new(table_name, columns, options)
+          end
+        end
+
         # Adds a new exclusion constraint to the table. +expression+ is a String
         # representation of a list of exclusion elements and operators.
         #
@@ -652,6 +686,57 @@ module ActiveRecord
 
           at = create_alter_table(table_name)
           at.drop_exclusion_constraint(excl_name_to_delete)
+
+          execute schema_creation.accept(at)
+        end
+
+        # Adds a new unique constraint to the table.
+        #
+        # PostgreSQL allows users to create a unique constraints on top of the unique index
+        # that cannot be deferred. In this case, even if users creates deferrable unique constraint,
+        # the existing unique index does not allow users to violate uniqueness within the transaction.
+        # If you want to change existing unique index to deferrable, you need execute `remove_index`
+        # before creating deferrable unique constraints.
+        #
+        #   add_unique_key :sections, [:position], deferrable: :deferred, name: "unique_position"
+        #
+        # generates:
+        #
+        #   ALTER TABLE "sections" ADD CONSTRAINT unique_position UNIQUE (position) DEFERRABLE INITIALLY DEFERRED
+        #
+        # The +options+ hash can include the following keys:
+        # [<tt>:name</tt>]
+        #   The constraint name. Defaults to <tt>uniq_rails_<identifier></tt>.
+        # [<tt>:deferrable</tt>]
+        #   Specify whether or not the unique constraint should be deferrable. Valid values are +false+ or +:immediate+ or +:deferred+ to specify the default behavior. Defaults to +false+.
+        def add_unique_key(table_name, column_name, **options)
+          options = unique_key_options(table_name, column_name, options)
+          at = create_alter_table(table_name)
+          at.add_unique_key(column_name, options)
+
+          execute schema_creation.accept(at)
+        end
+
+        def unique_key_options(table_name, column_name, options) # :nodoc:
+          assert_valid_deferrable(options[:deferrable])
+
+          options = options.dup
+          options[:name] ||= unique_key_name(table_name, column_name: column_name, **options)
+          options
+        end
+
+        # Removes the given unique constraint from the table.
+        #
+        #   remove_unique_key :sections, name: "unique_position"
+        #
+        # The +column_name+ parameter will be ignored if present. It can be helpful
+        # to provide this in a migration's +change+ method so it can be reverted.
+        # In that case, +column_name+ will be used by #add_unique_key.
+        def remove_unique_key(table_name, column_name = nil, **options)
+          unique_name_to_delete = unique_key_for!(table_name, column_name: column_name, **options).name
+
+          at = create_alter_table(table_name)
+          at.drop_unique_key(unique_name_to_delete)
 
           execute schema_creation.accept(at)
         end
@@ -854,6 +939,16 @@ module ActiveRecord
             deferrable && (deferred ? :deferred : true)
           end
 
+          def extract_unique_key_deferrable(deferrable, deferred)
+            deferrable && (deferred ? :deferred : :immediate)
+          end
+
+          def assert_valid_deferrable(deferrable) # :nodoc:
+            return if !deferrable || %i(immediate deferred).include?(deferrable)
+
+            raise ArgumentError, "deferrable must be `:immediate` or `:deferred`, got: `#{deferrable.inspect}`"
+          end
+
           def reference_name_for_table(table_name)
             _schema, table_name = extract_schema_qualified_name(table_name.to_s)
             table_name.singularize
@@ -909,6 +1004,26 @@ module ActiveRecord
           def exclusion_constraint_for!(table_name, expression: nil, **options)
             exclusion_constraint_for(table_name, expression: expression, **options) ||
               raise(ArgumentError, "Table '#{table_name}' has no exclusion constraint for #{expression || options}")
+          end
+
+          def unique_key_name(table_name, **options)
+            options.fetch(:name) do
+              column_name = options.fetch(:column_name)
+              identifier = "#{table_name}_#{column_name}_unique"
+              hashed_identifier = Digest::SHA256.hexdigest(identifier).first(10)
+
+              "uniq_rails_#{hashed_identifier}"
+            end
+          end
+
+          def unique_key_for(table_name, **options)
+            unique_key_name = unique_key_name(table_name, **options)
+            unique_keys(table_name).detect { |unique_key| unique_key.name == unique_key_name }
+          end
+
+          def unique_key_for!(table_name, column_name: nil, **options)
+            unique_key_for(table_name, column_name: column_name, **options) ||
+              raise(ArgumentError, "Table '#{table_name}' has no unique constraint for #{column_name || options}")
           end
 
           def data_source_sql(name = nil, type: nil)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -224,6 +224,10 @@ module ActiveRecord
         true
       end
 
+      def supports_unique_keys?
+        true
+      end
+
       def supports_validate_constraints?
         true
       end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -10,6 +10,7 @@ module ActiveRecord
     # * add_foreign_key
     # * add_check_constraint
     # * add_exclusion_constraint
+    # * add_unique_key
     # * add_index
     # * add_reference
     # * add_timestamps
@@ -30,6 +31,7 @@ module ActiveRecord
     # * remove_foreign_key (must supply a second table)
     # * remove_check_constraint
     # * remove_exclusion_constraint
+    # * remove_unique_key
     # * remove_index
     # * remove_reference
     # * remove_timestamps
@@ -47,6 +49,7 @@ module ActiveRecord
         :change_column_comment, :change_table_comment,
         :add_check_constraint, :remove_check_constraint,
         :add_exclusion_constraint, :remove_exclusion_constraint,
+        :add_unique_key, :remove_unique_key,
         :create_enum, :drop_enum,
       ]
       include JoinTable
@@ -154,6 +157,7 @@ module ActiveRecord
               add_foreign_key:   :remove_foreign_key,
               add_check_constraint: :remove_check_constraint,
               add_exclusion_constraint: :remove_exclusion_constraint,
+              add_unique_key: :remove_unique_key,
               enable_extension:  :disable_extension,
               create_enum:       :drop_enum
             }.each do |cmd, inv|
@@ -301,6 +305,13 @@ module ActiveRecord
 
         def invert_remove_exclusion_constraint(args)
           raise ActiveRecord::IrreversibleMigration, "remove_exclusion_constraint is only reversible if given an expression." if args.size < 2
+          super
+        end
+
+        def invert_remove_unique_key(args)
+          _table, columns = args.dup.tap(&:extract_options!)
+
+          raise ActiveRecord::IrreversibleMigration, "remove_unique_key is only reversible if given an column_name." if columns.blank?
           super
         end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -34,6 +34,12 @@ module ActiveRecord
     # should not be dumped to db/schema.rb.
     cattr_accessor :excl_ignore_pattern, default: /^excl_rails_[0-9a-f]{10}$/
 
+    ##
+    # :singleton-method:
+    # Specify a custom regular expression matching unique constraints which name
+    # should not be dumped to db/schema.rb.
+    cattr_accessor :unique_ignore_pattern, default: /^uniq_rails_[0-9a-f]{10}$/
+
     class << self
       def dump(connection = ActiveRecord::Base.connection, stream = STDOUT, config = ActiveRecord::Base)
         connection.create_schema_dumper(generate_options(config)).dump(stream)
@@ -182,6 +188,7 @@ module ActiveRecord
           indexes_in_create(table, tbl)
           check_constraints_in_create(table, tbl) if @connection.supports_check_constraints?
           exclusion_constraints_in_create(table, tbl) if @connection.supports_exclusion_constraints?
+          unique_keys_in_create(table, tbl) if @connection.supports_unique_keys?
 
           tbl.puts "  end"
           tbl.puts
@@ -215,6 +222,12 @@ module ActiveRecord
             exclusion_constraint_names = exclusion_constraints.collect(&:name)
 
             indexes = indexes.reject { |index| exclusion_constraint_names.include?(index.name) }
+          end
+
+          if @connection.supports_unique_keys? && (unique_keys = @connection.unique_keys(table)).any?
+            unique_key_names = unique_keys.collect(&:name)
+
+            indexes = indexes.reject { |index| unique_key_names.include?(index.name) }
           end
 
           index_statements = indexes.map do |index|

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -176,6 +176,20 @@ module ActiveRecord
             t.remove_exclusion_constraint name: "date_overlap"
           end
         end
+
+        def test_unique_key_creates_unique_key
+          with_change_table do |t|
+            expect :add_unique_key, nil, [:delete_me, :foo, deferrable: :deferred, name: "unique_key"]
+            t.unique_key :foo, deferrable: :deferred, name: "unique_key"
+          end
+        end
+
+        def test_remove_unique_key_removes_unique_key
+          with_change_table do |t|
+            expect :remove_unique_key, nil, [:delete_me, name: "unique_key"]
+            t.remove_unique_key name: "unique_key"
+          end
+        end
       end
 
       def test_column_creates_column

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -457,6 +457,22 @@ module ActiveRecord
         end
       end
 
+      def test_invert_remove_unique_key_constraint
+        enable = @recorder.inverse_of :remove_unique_key, [:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed"]
+        assert_equal [:add_unique_key, [:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed"], nil], enable
+      end
+
+      def test_invert_remove_unique_key_constraint_without_options
+        enable = @recorder.inverse_of :remove_unique_key, [:dogs, ["speed"]]
+        assert_equal [:add_unique_key, [:dogs, ["speed"]], nil], enable
+      end
+
+      def test_invert_remove_unique_key_constraint_without_columns
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :remove_unique_key, [:dogs, name: "uniq_speed"]
+        end
+      end
+
       def test_invert_create_enum
         drop = @recorder.inverse_of :create_enum, [:color, ["blue", "green"]]
         assert_equal [:drop_enum, [:color, ["blue", "green"]], nil], drop

--- a/activerecord/test/cases/migration/unique_key_test.rb
+++ b/activerecord/test/cases/migration/unique_key_test.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+if ActiveRecord::Base.connection.supports_unique_keys?
+  module ActiveRecord
+    class Migration
+      class UniqueKeyTest < ActiveRecord::TestCase
+        include SchemaDumpingHelper
+
+        class Section < ActiveRecord::Base
+        end
+
+        setup do
+          @connection = ActiveRecord::Base.connection
+          @connection.create_table "sections", force: true do |t|
+            t.integer "position", null: false
+          end
+        end
+
+        teardown do
+          @connection.drop_table "sections", if_exists: true
+        end
+
+        def test_unique_keys
+          unique_keys = @connection.unique_keys("test_unique_keys")
+
+          expected_constraints = [
+            {
+              name: "test_unique_keys_position_deferrable_false",
+              deferrable: false,
+              columns: ["position_1"]
+            }, {
+              name: "test_unique_keys_position_deferrable_immediate",
+              deferrable: :immediate,
+              columns: ["position_2"]
+            }, {
+              name: "test_unique_keys_position_deferrable_deferred",
+              deferrable: :deferred,
+              columns: ["position_3"]
+            }
+          ]
+
+          assert_equal expected_constraints.size, unique_keys.size
+
+          expected_constraints.each do |expected_constraint|
+            constraint = unique_keys.find { |constraint| constraint.name == expected_constraint[:name] }
+            assert_equal "test_unique_keys", constraint.table_name
+            assert_equal expected_constraint[:name], constraint.name
+            assert_equal expected_constraint[:columns], constraint.columns
+            assert_equal expected_constraint[:deferrable], constraint.deferrable
+          end
+        end
+
+        def test_unique_keys_scoped_to_schemas
+          @connection.add_unique_key :sections, [:position]
+
+          assert_no_changes -> { @connection.unique_keys("sections").size } do
+            @connection.create_schema "test_schema"
+            @connection.create_table "test_schema.sections" do |t|
+              t.integer :position
+            end
+            @connection.add_unique_key "test_schema.sections", [:position]
+          end
+        ensure
+          @connection.drop_schema "test_schema"
+        end
+
+        def test_add_unique_key_without_deferrable
+          @connection.add_unique_key :sections, [:position]
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "uniq_rails_3d89d7e853", constraint.name
+          assert_equal false, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_deferrable_false
+          @connection.add_unique_key :sections, [:position], deferrable: false
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "uniq_rails_3d89d7e853", constraint.name
+          assert_equal false, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_deferrable_immediate
+          @connection.add_unique_key :sections, [:position], deferrable: :immediate
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "uniq_rails_3d89d7e853", constraint.name
+          assert_equal :immediate, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_deferrable_deferred
+          @connection.add_unique_key :sections, [:position], deferrable: :deferred
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "uniq_rails_3d89d7e853", constraint.name
+          assert_equal :deferred, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_deferrable_invalid
+          error = assert_raises(ArgumentError) do
+            @connection.add_unique_key :sections, [:position], deferrable: true
+          end
+
+          assert_equal "deferrable must be `:immediate` or `:deferred`, got: `true`", error.message
+        end
+
+        def test_added_deferrable_initially_immediate_unique_key
+          @connection.add_unique_key :sections, [:position], deferrable: :immediate, name: "unique_section_position"
+
+          section = Section.create!(position: 1)
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            Section.transaction(requires_new: true) do
+              Section.create!(position: 1)
+              section.update!(position: 2)
+            end
+          end
+
+          assert_nothing_raised do
+            Section.transaction(requires_new: true) do
+              Section.connection.exec_query("SET CONSTRAINTS unique_section_position DEFERRED")
+              Section.create!(position: 1)
+              section.update!(position: 2)
+
+              # NOTE: Clear `SET CONSTRAINTS` statement at the end of transaction.
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+
+        def test_remove_unique_key
+          assert_equal 0, @connection.unique_keys("sections").size
+
+          @connection.add_unique_key :sections, [:position], name: "unique_section_position"
+          assert_equal 1, @connection.unique_keys("sections").size
+          @connection.remove_unique_key :sections, name: "unique_section_position"
+          assert_equal 0, @connection.unique_keys("sections").size
+        end
+
+        def test_remove_non_existing_unique_key
+          assert_raises(ArgumentError) do
+            @connection.remove_unique_key :sections, name: "nonexistent"
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -135,6 +135,16 @@ _SQL
     t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "test_exclusion_constraints_date_overlap"
   end
 
+  create_table :test_unique_keys, force: true do |t|
+    t.integer :position_1
+    t.integer :position_2
+    t.integer :position_3
+
+    t.unique_key :position_1, name: "test_unique_keys_position_deferrable_false"
+    t.unique_key :position_2, name: "test_unique_keys_position_deferrable_immediate", deferrable: :immediate
+    t.unique_key :position_3, name: "test_unique_keys_position_deferrable_deferred", deferrable: :deferred
+  end
+
   if supports_partitioned_indexes?
     create_table(:measurements, id: false, force: true, options: "PARTITION BY LIST (city_id)") do |t|
       t.string :city_id, null: false


### PR DESCRIPTION
### Motivation / Background

Add support for unique constraints (PostgreSQL-only).

```ruby
add_unique_key :sections, [:position], deferrable: :deferred, name: "unique_section_position"
remove_unique_key :sections, name: "unique_section_position"
```

See PostgreSQL's [Unique Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS) documentation for more on unique constraints.

By default, unique constraints in PostgreSQL are checked after each statement.
This works for most use cases, but becomes a major limitation when replacing
records with unique column by using multiple statements.

An example of swapping unique columns between records.

```ruby
# position is unique column
old_item = Item.create!(position: 1)
new_item = Item.create!(position: 2)

Item.transaction do
  old_item.update!(position: 2)
  new_item.update!(position: 1)
end
```

Using the default behavior, the transaction would fail when executing the
first `UPDATE` statement.

By passing the `:deferrable` option to the `add_unique_key` statement in
migrations, it's possible to defer this check.

```ruby
add_unique_key :items, [:position], deferrable: :immediate
```

Passing `deferrable: :immediate` does not change the behaviour of the previous example,
but allows manually deferring the check using `SET CONSTRAINTS ALL DEFERRED` within a transaction.
This will cause the unique constraints to be checked after the transaction.

It's also possible to adjust the default behavior from an immediate
check (after the statement), to a deferred check (after the transaction):

```ruby
add_unique_key :items, [:position], deferrable: :deferred
```

PostgreSQL allows users to create a unique constraints on top of the unique
index that cannot be deferred. In this case, even if users creates deferrable
unique constraint, the existing unique index does not allow users to violate uniqueness
within the transaction. If you want to change existing unique index to deferrable,
you need execute `remove_index` before creating deferrable unique constraints.


### Detail

Similar to https://github.com/rails/rails/pull/40224, this extends Active Record's migration/schema dumping to support [Unique Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS).

```ruby
add_unique_key :sections, [:position], deferrable: :deferred, name: "unique_section_position"
remove_unique_key :sections, name: "unique_section_position"
```

### Additional information

The unique constraint is supported by most DB, but its function is almost equivalent to unique index.
Perhaps only PostgreSQL and Oracle Database with deferrable features would benefit from supporting unique constraint syntax.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
