### PR TITLE
Always run `rails app:update` in app update tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem "rexml", require: false
 # for railties
 gem "bootsnap", ">= 1.4.4", require: false
 gem "webrick", require: false
+gem "jbuilder", require: false
+gem "web-console", require: false
 
 # Active Job
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     bcrypt (3.1.16)
     beaneater (1.1.1)
     benchmark-ips (2.9.2)
+    bindex (0.8.1)
     blade (0.7.3)
       activesupport (>= 3.0.0)
       blade-qunit_adapter (>= 2.0.1)
@@ -298,6 +299,9 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     jmespath (1.4.0)
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
@@ -531,6 +535,11 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
       rexml (~> 3.2)
+    web-console (4.2.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webdrivers (5.0.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -576,6 +585,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails
+  jbuilder
   jsbundling-rails
   json (>= 2.0.0)
   libxml-ruby
@@ -624,6 +634,7 @@ DEPENDENCIES
   tzinfo-data
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)
+  web-console
   webdrivers
   webmock
   webrick


### PR DESCRIPTION
Prior to this commit, several tests in `AppGeneratorTest` were testing app update behavior without actually running `rails app:update`.  This meant the logic in [`Rails::AppUpdater#generator_options`](https://github.com/rails/rails/blob/4328d0e16028a46bba79ab775e509a743ceaf18c/railties/lib/rails/app_updater.rb#L22-L37) that detects which frameworks and components are installed was not being tested.

Additionally, because `ENV["BUNDLE_GEMFILE"]` is set when tests are run (by [`require "bundler/setup"` in `tools/test.rb`](https://github.com/rails/rails/blob/4328d0e16028a46bba79ab775e509a743ceaf18c/tools/test.rb#L5)), any tests which did run `rails app:update` used the Rails repo Gemfile, instead of the generated app Gemfile.  The difference becomes obvious when running `rails app:update` after generating an app without Sprockets (as in `test_app_update_does_not_generate_manifest_config_when_propshaft_is_used`), because `rails app:update` will load the Sprockets railtie (due to [`Bundler.require`](https://github.com/rails/rails/blob/4328d0e16028a46bba79ab775e509a743ceaf18c/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt#L23) using the Rails repo Gemfile), and then exit with a `Sprockets::Railtie::ManifestNeededError`.  However, if `rails app:update` is run within a `quietly` block, such an error will be swallowed.

This commit changes all such tests to run `rails app:update` via a `run_app_update` helper that: (1) overrides the `BUNDLE_GEMFILE` environment variable to point to the generated app Gemfile, (2) points the `rails` gem in the generated app Gemfile to the Rails repo (otherwise the `rails` gem version cannot be resolved), and (3) sets `exception: true` so that the `system` call will raise an error if `rails app:update` exits with an error code.

This commit also adds `jbuilder` and `web-console` to the Rails repo Gemfile to ensure they are already installed when evaluating the generated app Gemfile.

These changes do add a couple dozen seconds to the test suite run time, but the thorough test coverage seems worth it.
