### PR TITLE
Don't trigger `after_commit :destroy` callback again on destroy if record previously was destroyed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Only trigger `after_commit :destroy` callbacks when a database row is deleted.
+
+    This prevents `after_commit :destroy` callbacks from being triggered again
+    when `destroy` is called multiple times on the same record.
+
+    *Ben Sheldon*
+
 *   Fix `ciphertext_for` for yet-to-be-encrypted values.
 
     Previously, `ciphertext_for` returned the cleartext of values that had not

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -676,11 +676,7 @@ module ActiveRecord
     def destroy
       _raise_readonly_record_error if readonly?
       destroy_associations
-      @_trigger_destroy_callback = if persisted?
-        destroy_row > 0
-      else
-        true
-      end
+      @_trigger_destroy_callback = persisted? && destroy_row > 0
       @destroyed = true
       freeze
     end


### PR DESCRIPTION
This change ensures that `after_commit :destroy` will only be triggered if a record in the database is destroyed. e.g.

```ruby
record = MyModel.find(42)
record.destroy # => triggers after_commit callbacks
record.destroy # => does NOT trigger after_commit callbacks
```

Previously in https://github.com/rails/rails/pull/27248 the `after_commit :destroy` behavior was updated so that if there are two instances of the same record, and one of them is destroyed, the 2nd record's destroy will not trigger after_commit callbacks... but the initial record's subsequent destroys still would. This is the current behavior as a result of that change:

```ruby
record = MyModel.find(42)
same_record = MyModel.find(42)

record.destroy # => triggers after_commit callbacks
record.destroy # => triggers after_commit callbacks, again
same_record.destroy # => does NOT trigger after_commit callbacks
```



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
