### PR TITLE
Deprecate obsolete permissions policy directives

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   The `speaker`, `vibrate`, and `vr` permissions policy directives are now
+    deprecated.
+
+    There is no browser support for these directives, and no plan for browser
+    support in the future. You can just remove these directives from your
+    application.
+
+    *Jonathan Hefner*
+
 *   Added the `:status` option to `assert_redirected_to` to specify the precise
     HTTP status of the redirect. Defaults to `:redirect` for backwards
     compatibility.

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -104,11 +104,8 @@ module ActionDispatch # :nodoc:
       picture_in_picture:   "picture-in-picture",
       screen_wake_lock:     "screen-wake-lock",
       serial:               "serial",
-      speaker:              "speaker",
       sync_xhr:             "sync-xhr",
       usb:                  "usb",
-      vibrate:              "vibrate",
-      vr:                   "vr",
       web_share:            "web-share",
     }.freeze
 
@@ -127,6 +124,25 @@ module ActionDispatch # :nodoc:
 
     DIRECTIVES.each do |name, directive|
       define_method(name) do |*sources|
+        if sources.first
+          @directives[directive] = apply_mappings(sources)
+        else
+          @directives.delete(directive)
+        end
+      end
+    end
+
+    %w[speaker vibrate vr].each do |directive|
+      define_method(directive) do |*sources|
+        ActiveSupport::Deprecation.warn(<<~MSG)
+          The `#{directive}` permissions policy directive is deprecated
+          and will be removed in Rails 7.2.
+
+          There is no browser support for this directive, and no plan
+          for browser support in the future. You can just remove this
+          directive from your application.
+        MSG
+
         if sources.first
           @directives[directive] = apply_mappings(sources)
         else

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -34,10 +34,20 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
 
   def test_invalid_directive_source
     exception = assert_raises(ArgumentError) do
-      @policy.vr [:non_existent]
+      @policy.geolocation [:non_existent]
     end
 
     assert_equal "Invalid HTTP permissions policy source: [:non_existent]", exception.message
+  end
+
+  def test_deprecated_directives
+    assert_deprecated { @policy.speaker :self }
+    assert_deprecated { @policy.vibrate :self }
+    assert_deprecated { @policy.vr :self }
+
+    assert_not_deprecated do
+      assert_equal "speaker 'self'; vibrate 'self'; vr 'self'", @policy.build
+    end
   end
 end
 


### PR DESCRIPTION
`speaker`, `vibrate`, and `vr` were [listed as policy-controlled features][1] around the time when #33439 was first written (2018-07-25).  However, `vibrate` was removed in w3c/webappsec-permissions-policy@b7271ac0f23c11d6d34ad27e7c837795f42c3caa, `vr` was changed to `xr` in w3c/webappsec-permissions-policy@bec5ce6547078b078ea4ced32f1453d83a736f4e, and `speaker` was removed in w3c/webappsec-permissions-policy@18707d396e1d3f0be3de348fc432383cc8866e0b. (And `xr` was later changed to `xr-spatial-tracking`, and still only has [experimental support][2].)

Therefore, this commit deprecates these permissions policy directives.

[1]: https://github.com/w3c/webappsec-permissions-policy/blob/6d8bbbe738368c317d280bb866c66cedaef3391c/features.md#policy-controlled-features
[2]: https://github.com/w3c/webappsec-permissions-policy/blob/432a1532c943a079351eecbc445ae4c6ed9b949c/features.md#standardized-features
