### PR TITLE
Add missing middleware methods to guide

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -173,6 +173,24 @@ You can swap an existing middleware in the middleware stack using `config.middle
 config.middleware.swap ActionDispatch::ShowExceptions, Lifo::ShowExceptions
 ```
 
+#### Moving a Middleware
+
+You can move an existing middleware in the middleware stack using `config.middleware.move_before` and `config.middleware.move_after`.
+
+```ruby
+# config/application.rb
+
+# Move ActionDispatch::ShowExceptions to before Lifo::ShowExceptions
+config.middleware.move_before Lifo::ShowExceptions, ActionDispatch::ShowExceptions
+```
+
+```ruby
+# config/application.rb
+
+# Move ActionDispatch::ShowExceptions to after Lifo::ShowExceptions
+config.middleware.move_after Lifo::ShowExceptions, ActionDispatch::ShowExceptions
+```
+
 #### Deleting a Middleware
 
 Add the following lines to your application configuration:


### PR DESCRIPTION
This adds the move_after and move_before methods to the rails_on_rack guide.

### Motivation / Background

This Pull Request has been created because I was looking for how to move a middleware around and the only info in the guide was about swapping.

### Detail

This Pull Request changes the `guides/source/rails_on_rack.md` to add a section on moving middlewares.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.