### PR TITLE
Fix typo, add missing "to"

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -509,7 +509,7 @@ add_reference :users, :role
 ```
 
 This migration will create a `role_id` column in the users table. It creates an
-index for this column as well, unless explicitly told not with the
+index for this column as well, unless explicitly told not to with the
 `index: false` option:
 
 ```ruby


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the word "to" is missing from this sentence:

> This migration will create a `role_id` column in the users table. It creates an
> index for this column as well, unless explicitly told not with the
> `index: false` option:

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [ ] CI is passing.