### PR TITLE
PoC: AbstractController::Base#renderer_for

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -68,6 +68,10 @@ module AbstractController
       end
     end
 
+    def renderer_for(object)
+      nil
+    end
+
   private
     # Normalize args by converting <tt>render "foo"</tt> to
     # <tt>render action: "foo"</tt> and <tt>render "foo/bar"</tt> to

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -37,9 +37,18 @@ module ActionView
               view_renderer.render(self, options)
             end
           end
+        when String, Array
+          view_renderer.render_partial(self, partial: options, locals: locals, &block)
         else
-          if options.respond_to?(:render_in)
-            options.render_in(self, &block)
+          object_renderer = controller.renderer_for(options) || options
+          if object_renderer.respond_to?(:render_in)
+            object_renderer.render_in(self, &block)
+          elsif object_renderer.is_a?(Hash)
+            if object_renderer.key?(:locals)
+              object_renderer = object_renderer.dup
+              object_renderer[:locals] = object_renderer[:locals].merge(locals)
+            end
+            view_renderer.render_partial(self, locals: locals, **object_renderer, &block)
           else
             view_renderer.render_partial(self, partial: options, locals: locals, &block)
           end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -726,6 +726,32 @@ module RenderTestCases
     )
   end
 
+  def test_renderer_for_returning_renderable
+    object_to_render = Object.new
+    @view.controller.singleton_class.define_method(:renderer_for) do |object|
+      if object_to_render.equal?(object)
+        TestRenderable.new
+      end
+    end
+    assert_equal(
+      %(Hello, World!),
+      @view.render(object_to_render)
+    )
+  end
+
+  def test_renderer_for_returning_partial_path
+    object_to_render = Struct.new(:name).new("George")
+    @view.controller.singleton_class.define_method(:renderer_for) do |object|
+      if object_to_render.equal?(object)
+        { partial: "test/customer", locals: { customer: object } }
+      end
+    end
+    assert_equal(
+      "Hello: George",
+      @view.render(object_to_render)
+    )
+  end
+
   def test_render_mutate_string_literal
     assert_equal "foobar", @view.render(inline: "'foo' << 'bar'", type: :ruby)
   end


### PR DESCRIPTION
### Context 

There has been some demands from view systems not based on paths, to offer some extension API that are better suited for them: https://discuss.rubyonrails.org/t/replace-to-partial-path-calls-with-a-more-abstract-to-renderable/81457

I'm in favor of the general idea, but not at all with the proposed solutions so far.

### Existing API

Currently you can customize the behavior of `render some_object` in two ways:

- The object can respond to `to_partial_path` and return a view path.
- The object can respond to `render_in` and return a string representation.

What I don't like with both of these APIs is that they ask the object how to render itself. Applications often have several different ways to represent the same object based on the context, e.g. frontend vs admin panel, or HTML vs JSON.

### Proposal

It would be way more powerful if the view or controller was in charge of selecting the proper renderer for a given object.

e.g. (pseudo code)

```ruby
module Admin
  class BaseController < ApplicationController
    def renderer_for(object)
      { partial: "admin/#{object.class.underscore}" }
    end
  end
```

On paper, you'd probably want to define this on thew view, but in practive Rails users very rarely interact with the view, hence why I do this on the controller. But I'm maybe missing something.

Another benefit of such API would be to allow view component systems to better integrate with Rails by implementing their own conventions, e.g. (pseudo code)

```ruby
module MyViewComponentExtension
  def renderer_for(object)
    component_name = "#{object.class.name}Component"
    "#{self.class.module_parent_name}#{component_name}".safe_constantize ||
      component_name.constantize
  end
end
```

It's somewhat similar to what Active Model Serializer used to do for its default serializer system:
https://github.com/rails-api/active_model_serializers/blob/0-9-stable/lib/action_controller/serialization.rb

It used to work quite well.

### Note

his is purely a proof of concept to demonstrate the general idea, what capabilities it brings to the table.

I'm absolutely not happy with that implementation and I'm not suggesting to merge it. If we chose to go with the idea, we
should carefully study what the API would look like.
