### PR TITLE
Fix `index_exists?` when column is an array

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -48,6 +48,7 @@ module ActiveRecord
       end
 
       def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, **options)
+        columns = options[:column] if columns.nil?
         (columns.nil? || Array(self.columns) == Array(columns).map(&:to_s)) &&
           (name.nil? || self.name == name.to_s) &&
           (unique.nil? || self.unique == unique) &&

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -127,6 +127,19 @@ module ActiveRecord
         assert_not connection.index_exists?(table_name, :foo, name: "foo")
       end
 
+      def test_remove_index_with_column_array_which_does_not_exist_doesnt_raise_with_option
+        connection.add_index(table_name, [:foo], name: "foo")
+
+        assert connection.index_exists?(table_name, :foo, name: "foo")
+
+        assert_nothing_raised do
+          connection.remove_index(table_name, column: [:foo, :bar], if_exists: true)
+        end
+
+        assert connection.index_exists?(table_name, :foo, name: "foo")
+        assert_not connection.index_exists?(table_name, nil, column: [:foo, :bar], name: "foo")
+      end
+
       def test_internal_index_with_name_matching_database_limit
         good_index_name = "x" * connection.index_name_length
         connection.add_index(table_name, "foo", name: good_index_name, internal: true)


### PR DESCRIPTION
When `column` is passed as an array and the column does not exist, then `index_exists?` check would fail to return early which would cause `index_name_for_remove` to raise an error instead of ignoring the missing column. This change ensures that `defined_for` checks the column options in addition to the column argument.

Fixes #46196

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ x Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.