### PR TITLE
remove redis reconnect_attempts

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -36,10 +36,9 @@ module ActiveSupport
       MAX_KEY_BYTESIZE = 1024
 
       DEFAULT_REDIS_OPTIONS = {
-        connect_timeout:    20,
+        connect_timeout:    1,
         read_timeout:       1,
         write_timeout:      1,
-        reconnect_attempts: 0,
       }
 
       DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) do

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -46,8 +46,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class InitializationTest < ActiveSupport::TestCase
     test "omitted URL uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        connect_timeout: 20, read_timeout: 1, write_timeout: 1,
-        reconnect_attempts: 0
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
       ] do
         build
       end
@@ -55,8 +54,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     test "no URLs uses Redis client with default settings" do
       assert_called_with Redis, :new, [
-        connect_timeout: 20, read_timeout: 1, write_timeout: 1,
-        reconnect_attempts: 0
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
       ] do
         build url: []
       end
@@ -65,8 +63,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     test "singular URL uses Redis client" do
       assert_called_with Redis, :new, [
         url: REDIS_URL,
-        connect_timeout: 20, read_timeout: 1, write_timeout: 1,
-        reconnect_attempts: 0
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
       ] do
         build url: REDIS_URL
       end
@@ -75,8 +72,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     test "one URL uses Redis client" do
       assert_called_with Redis, :new, [
         url: REDIS_URL,
-        connect_timeout: 20, read_timeout: 1, write_timeout: 1,
-        reconnect_attempts: 0
+        connect_timeout: 1, read_timeout: 1, write_timeout: 1
       ] do
         build url: [ REDIS_URL ]
       end
@@ -84,10 +80,9 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
     test "multiple URLs uses Redis::Distributed client" do
       default_args = {
-        connect_timeout: 20,
+        connect_timeout: 1,
         read_timeout: 1,
-        write_timeout: 1,
-        reconnect_attempts: 0,
+        write_timeout: 1
       }
 
       mock = Minitest::Mock.new


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/46149
<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

This Pull Request has been created because by default `RedisCacheStore` does not establish a connection. The cache store does not attempt to reconnect to Redis if the connection fails during a request, which causes it to return a `nil` value. 

### Detail

1. This Pull Request removes the override of `reconnect_attempts: 0` line from the redis_cache_store. The spec has been updated accordingly as well. 
2. This PR also reduces the `connect_timeout` from 20 seconds to 1 second because 20 seconds is massive when combined with 1 second on `read_timeout`. Thank you @byroot   
 
Relates to: #46149

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
