### PR TITLE
Delete variants from service only if variants are being tracked

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -319,7 +319,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # methods in most circumstances.
   def delete
     service.delete(key)
-    service.delete_prefixed("variants/#{key}/") if image?
+    service.delete_prefixed("variants/#{key}/") if image? && ActiveStorage.track_variants
   end
 
   # Destroys the blob record and then deletes the file on the service. This is the recommended way to dispose of unwanted


### PR DESCRIPTION
### Motivation / Background

When purging an `ActiveStorage::Blob` object, it makes two calls to the underlying file service. once to delete the actual file and then again to delete the variants. ActiveStorage makes tracking variants optional, and when not opted, the second delete call to the file service is redundant and can be avoided.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
