### PR TITLE
Fix #preview example code on active storage overview doc

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -446,7 +446,7 @@ You can use specific variants for previews as well:
 ```ruby
 class User < ApplicationRecord
   has_one_attached :video do |attachable|
-    attachable.variant :thumb, resize_to_limit: [100, 100]
+    attachable.preview :thumb, resize_to_limit: [100, 100]
   end
 end
 ```


### PR DESCRIPTION
### Detail

This PR fixes `#preview` example code on [guides/source/active_storage_overview.md](https://edgeguides.rubyonrails.org/active_storage_overview.html#has-one-attached) **has_one_attached** section.

**Before:**

![active-storage-preview-example](https://user-images.githubusercontent.com/17840/194762237-a41f2314-cf00-4f42-a6aa-4e8b2cfdccc1.png)

**After**

```ruby
class User < ApplicationRecord
  has_one_attached :video do |attachable|
    attachable.preview :thumb, resize_to_limit: [100, 100]
  end
end
```