### PR TITLE
before_validations example 1 ,changed .nil? to .blank?

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -38,7 +38,7 @@ class User < ApplicationRecord
 
   private
     def ensure_login_has_a_value
-      if login.nil?
+      if login.blank?
         self.login = email unless email.blank?
       end
     end


### PR DESCRIPTION
before_validation :ensure_login_has_a_value  does not work in the web browser but only in rails console as it is supposed to work.  This is because  "".nil? returns false while "".blank? returns true.  Changing .nil? to .blank? allows this example to work as it was intended IMO. :)

