### PR TITLE
Add `ActiveRecord::Persistence#exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Persistence#exists?`.
+
+    *Ryo Nakamura*
+
 *   Add configurable formatter on query log tags to support sqlcommenter. See #45139
 
     It is now possible to opt into sqlcommenter-formatted query log tags with `config.active_record.query_log_tags_format = :sqlcommenter`.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1035,6 +1035,11 @@ module ActiveRecord
       end
     end
 
+    # Returns true if this object exists in the database, otherwise returns false.
+    def exists?
+      self.class.exists?(id)
+    end
+
   private
     def strict_loaded_associations
       @association_cache.find_all do |_, assoc|

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1186,6 +1186,20 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal false, developer.persisted?
   end
 
+  def test_exists_returns_boolean
+    developer1 = Developer.new(name: "Jose")
+    assert_equal false, developer1.exists?
+
+    developer1.save!
+    developer2 = Developer.last
+    assert_equal true, developer1.exists?
+    assert_equal true, developer2.exists?
+
+    developer1.destroy
+    assert_equal false, developer1.exists?
+    assert_equal false, developer2.exists?
+  end
+
   def test_class_level_destroy
     should_be_destroyed_reply = Reply.create("title" => "hello", "content" => "world")
     Topic.find(1).replies << should_be_destroyed_reply


### PR DESCRIPTION
### Motivation / Background

When you want to check whether a record still exists in the database or not, there is already methods called `ActiveRecord::Persistence#destroyed?` and `ActiveRecord::Persistence#persisted?`, but they are not able to get accurate result unless you query the same instance that was used when the record was destroyed.

For example, this is often a problem when writing tests. Writing in the RSpec example commonly used in Rails app:

```ruby
RSpec.describe 'DELETE /articles/:id' do
  let(:article) do
    Article.create!
  end

  it 'destroys article' do
    delete "/articles/#{article.id}"
    expect(article).not_to be_persisted # WRONG CODE
    # or expect(article).to be_destroyed # WRONG CODE
  end
end
```

In such case, I have seen many codes written as a workaround like this, but none of them would be considered concise code:

```ruby
RSpec.describe 'DELETE /articles/:id' do
  let(:article) do
    Article.create!
  end

  it 'destroys article' do
    delete "/articles/#{article.id}"
    expect(article.class.exists?(article)).to be false
    # or expect { article.reload }.to raise_error(ActiveRecord::RecordNotFound)
    # or expect { article.class.find(article.id) }.to raise_error(ActiveRecord::RecordNotFound)
    # or expect { article.class.find_by(id: article.id) }.to be_nil
    # or expect { delete "/articles/#{article.id}" }.to change { article.class.count }.by(-1)
    # or so...
  end
end
```

This Pull Request has been created to provide a convenient API that can be used in such case. Of course, it could be used for many other cases as well.

### Detail

This Pull Request adds `ActiveRecord::Persistence#exists?` so that you can easily check with this whether the record exists in the database or not.

```ruby
RSpec.describe 'DELETE /articles/:id' do
  let(:article) do
    Article.create!
  end

  it 'destroys article' do
    delete "/articles/#{article.id}"
    expect(article.exists?).to be false
    # or expect(article).not_to exist
  end
end
```

### Additional information

I am not that familiar with the ActiveRecord API, so maybe there is already a method to achieve something similar that I am not aware of. If so, please let me know.

It might be debatable whether the method name `exists?` means `exists on the database`, and whether it wouldn't be confusing in the situation where a method called `persisted?` already exists.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.