### PR TITLE
remove deprecated purge and purge_later methods on association extension

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -162,29 +162,7 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
-          def purge
-            deprecate(:purge)
-            each(&:purge)
-            reset
-          end
-
-          def purge_later
-            deprecate(:purge_later)
-            each(&:purge_later)
-            reset
-          end
-
-          private
-          def deprecate(action)
-            reflection_name = proxy_association.reflection.name
-            attached_name = reflection_name.to_s.partition("_").first
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Calling `#{action}` from `#{reflection_name}` is deprecated and will be removed in Rails 7.1.
-              To migrate to Rails 7.1's behavior call `#{action}` from `#{attached_name}` instead: `#{attached_name}.#{action}`.
-            MSG
-          end
-        end
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
         has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> {

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -596,28 +596,6 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
-  test "purging from the attachments relation" do
-    [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
-      @user.highlights.attach blobs
-      assert @user.highlights.attached?
-
-      message = <<-MSG.squish
-        Calling `purge` from `highlights_attachments` is deprecated and will be removed in Rails 7.1.
-        To migrate to Rails 7.1's behavior call `purge` from `highlights` instead: `highlights.purge`.
-      MSG
-      assert_deprecated(message) do
-        assert_changes -> { @user.updated_at } do
-          @user.highlights_attachments.purge
-        end
-      end
-      assert_not @user.highlights.attached?
-      assert_not ActiveStorage::Blob.exists?(blobs.first.id)
-      assert_not ActiveStorage::Blob.exists?(blobs.second.id)
-      assert_not ActiveStorage::Blob.service.exist?(blobs.first.key)
-      assert_not ActiveStorage::Blob.service.exist?(blobs.second.key)
-    end
-  end
-
   test "purging attachment with shared blobs" do
     [
       create_blob(filename: "funky.jpg"),
@@ -680,31 +658,6 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
       perform_enqueued_jobs do
         assert_changes -> { @user.updated_at } do
           @user.highlights.purge_later
-        end
-      end
-
-      assert_not @user.highlights.attached?
-      assert_not ActiveStorage::Blob.exists?(blobs.first.id)
-      assert_not ActiveStorage::Blob.exists?(blobs.second.id)
-      assert_not ActiveStorage::Blob.service.exist?(blobs.first.key)
-      assert_not ActiveStorage::Blob.service.exist?(blobs.second.key)
-    end
-  end
-
-  test "purging later from the attachments relation" do
-    [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
-      @user.highlights.attach blobs
-      assert @user.highlights.attached?
-
-      message = <<-MSG.squish
-        Calling `purge_later` from `highlights_attachments` is deprecated and will be removed in Rails 7.1.
-        To migrate to Rails 7.1's behavior call `purge_later` from `highlights` instead: `highlights.purge_later`.
-      MSG
-      assert_deprecated(message) do
-        perform_enqueued_jobs do
-          assert_changes -> { @user.updated_at } do
-            @user.highlights_attachments.purge_later
-          end
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

Follow up of https://github.com/rails/rails/pull/42506

### Detail

Removed the deprecated methods and tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.