### PR TITLE
Remove all non word characters from screenshot filenames

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -62,7 +62,7 @@ module ActionDispatch
           end
 
           def image_name
-            sanitized_method_name = method_name.tr("/\\", "--")
+            sanitized_method_name = method_name.gsub(/[^\w]+/, "-")
             name = "#{unique}_#{sanitized_method_name}"
             name[0...225]
           end

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -158,12 +158,12 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     end
   end
 
-  test "slashes and backslashes are replaced with dashes in paths" do
-    slash_test = DrivenBySeleniumWithChrome.new("x/y\\z")
+  test "Non word characters are replaced with dashes in paths" do
+    non_word_chars_test = DrivenBySeleniumWithChrome.new("x/y\\z?<br>-span")
 
     Rails.stub :root, Pathname.getwd do
-      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z.png").to_s, slash_test.send(:image_path)
-      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z.html").to_s, slash_test.send(:html_path)
+      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z-br-span.png").to_s, non_word_chars_test.send(:image_path)
+      assert_equal Rails.root.join("tmp/screenshots/0_x-y-z-br-span.html").to_s, non_word_chars_test.send(:html_path)
     end
   end
 end


### PR DESCRIPTION
Screenshot filenames are derived from test names which can contain special characters. These special characters may not be supported by CI systems like Github Actions. Replacing all non word characters ensures compatibility.


### Motivation / Background

Special characters in failing tests causes Artifacts uploads to fail in Github actions with the following message.

```
Artifact path is not valid: /screenshots/failures_test_should_wrap_text_nodes_with_<span_->.png. Contains the following character:  Less than <
          
Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
          
The following characters are not allowed in files that are uploaded due to limitations with certain file systems such as NTFS. To maintain file system agnostic behavior, these characters are intentionally not allowed to prevent potential problems with downloads on different file systems.
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

