### PR TITLE
Remove extra advisory lock connection

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1466,29 +1466,18 @@ module ActiveRecord
 
       def with_advisory_lock
         lock_id = generate_migrator_advisory_lock_id
+        connection = ActiveRecord::Base.connection
 
-        with_advisory_lock_connection do |connection|
-          got_lock = connection.get_advisory_lock(lock_id)
-          raise ConcurrentMigrationError unless got_lock
-          load_migrated # reload schema_migrations to be sure it wasn't changed by another process before we got the lock
-          yield
-        ensure
-          if got_lock && !connection.release_advisory_lock(lock_id)
-            raise ConcurrentMigrationError.new(
-              ConcurrentMigrationError::RELEASE_LOCK_FAILED_MESSAGE
-            )
-          end
-        end
-      end
-
-      def with_advisory_lock_connection(&block)
-        pool = ActiveRecord::ConnectionAdapters::ConnectionHandler.new.establish_connection(
-          ActiveRecord::Base.connection_db_config
-        )
-
-        pool.with_connection(&block)
+        got_lock = connection.get_advisory_lock(lock_id)
+        raise ConcurrentMigrationError unless got_lock
+        load_migrated # reload schema_migrations to be sure it wasn't changed by another process before we got the lock
+        yield
       ensure
-        pool&.disconnect!
+        if got_lock && !connection.release_advisory_lock(lock_id)
+          raise ConcurrentMigrationError.new(
+            ConcurrentMigrationError::RELEASE_LOCK_FAILED_MESSAGE
+          )
+        end
       end
 
       MIGRATOR_SALT = 2053462845


### PR DESCRIPTION
In #38235 I moved advisory locks to their own named connections, then in #39758 the advisory lock was left on Base.connection but then moved it it's own connection handler. I believe with #45450 that this change was made obsolete and can be returned to the prior behavior without having to open an additional connection. The tests added pass and I also tested this in my local demo to ensure that this is working correctly.

When I originally changed the behavior here Matthew noted that this could be surprising for some setups that expect only one connection for a running migration. I thought there was an issue related to this but I can't find it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.