### PR TITLE
Add `ActiveRecord::Base.connection_pool.without_connection(&block)`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `ActiveRecord::Base.connection_pool.without_connection(&block)`
+
+    ```ruby
+    Thread.new do
+      Rails.application.executor.wrap do
+        user = User.first
+
+        ActiveRecord::Base.connection_pool.without_connection do
+          sleep(5)
+        end
+
+        user.touch
+      end
+    end
+    ```
+
+    *Teja Sophista*
+
 *   Validate options when managing columns and tables in migrations.
 
     If an invalid option is passed to a migration method like `create_table` and `add_column`, an error will be raised

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -220,6 +220,18 @@ module ActiveRecord
         release_connection if fresh_connection
       end
 
+      # Check-ins the connection if any, yield, and checkout a new connection when finished.
+      def without_connection
+        if @thread_cached_conns[connection_cache_key(ActiveSupport::IsolatedExecutionState.context)]
+          reconnect = true
+        end
+
+        release_connection
+        yield
+      ensure
+        connection if reconnect
+      end
+
       # Returns true if a connection has already been opened.
       def connected?
         synchronize { @connections.any? }


### PR DESCRIPTION
### Motivation / Background

The Rails [guide about threading](https://guides.rubyonrails.org/threading_and_code_execution.html#wrapping-application-code) mention that we should wrap the thread block with `Rails.application.executor.wrap`
which one of its functionality is to automatically check in and out a database connection using
`ActiveRecord::Base.connection_pool.with_connection`.

The guide says that we should immediately wrap the block 

```ruby
Thread.new do
  Rails.application.executor.wrap do
    # your code here
  end
end
```

One possible use case of needing to spawn a thread is because we're running a long task, such as calling an external
HTTP API call.

```ruby
Thread.new do
  Rails.application.executor.wrap do
    user = User.first
    response = Net::HTTP.get(URI("https://google.com/?user_id=#{@user.id}")) # Might take a while

    user.update(name: response)
  end
end
```

That `Net::HTTP` call might take a long time. In this case, the thread will be unnecessarily holding the connection
while waiting for the response from the network call.

To avoid this, we can wrap only the block that needs to connect to the database:

```ruby
Thread.new do
  Rails.application.executor.wrap do
    @user = User.first
  end

  @response = Net::HTTP.get(URI("https://google.com/?user_id=#{@user.id}"))

  Rails.application.executor.wrap do
    @user.update(name: @response)
  end
end
```

However, in a real-world case, it might not be practical to wrap each individual database call. In a typical Rails app, we're making more database calls compared to network calls.

Therefore, it would be more manageable if we can have a method to mark a block that is NOT using the database.

Yes, the easiest way is to check the connection back in to the pool before making a network call, but it would be great if this behavior is supported by the framework.

### Detail

This Pull Request added a new method `without_connection` to `ActiveRecord::ConnectionAdapters::ConnectionPool`, so we can use it like:

```ruby
Thread.new do
  Rails.application.executor.wrap do
    user = User.first

    ActiveRecord::Base.connection_pool.without_connection do
      @response = Net::HTTP.get(URI("https://google.com/?user_id=#{@user.id}"))
    end

    user.update(name: @response)
  end
end
```

### Additional information

There are a couple of behaviors that I'm not yet sure how should be handled.

1. Should the method automatically checkout a new connection from the pool at the end of the block?

	Currently, in this PR, it will check-out a new connection at the end of the block if there were a connection at the beginning of the block.
	I don't think we need this, the subsequent connection will be established lazily only when it's needed again anyway.

2. Should we raise an error when trying to establish a connection inside a `without_connection`?

	Currently, this PR allows doing so.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.
