### PR TITLE
Don't encrypt values twice when saving encrypted attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Don't encrypt values twice when saving encrypted attributes.
+
+    *Jorge Manrubia*
+
 *   Validate options when managing columns and tables in migrations.
 
     If an invalid option is passed to a migration method like `create_table` and `add_column`, an error will be raised

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     # model classes. Whenever you declare an attribute as encrypted, it configures an +EncryptedAttributeType+
     # for that attribute.
     class EncryptedAttributeType < ::ActiveRecord::Type::Text
-      include ActiveModel::Type::Helpers::Mutable
+      include ActiveModel::Type::Helpers::Mutable, ActiveModel::Type::SerializeCastValue
 
       attr_reader :scheme, :cast_type
 
@@ -33,6 +33,10 @@ module ActiveRecord
       end
 
       def serialize(value)
+        cast(value)
+      end
+
+      def cast(value)
         if serialize_with_oldest?
           serialize_with_oldest(value)
         else


### PR DESCRIPTION
ActiveRecord currently invokes the encryption logic twice for each encrypted attribute: once for determining if the attribute changed and another one to persist the encrypted payload.

This fix leverages the system introduced in https://github.com/rails/rails/pull/44625 to prevent double casting when serializing attributes.

Fixes #46195

cc @jonathanhefner 

