### PR TITLE
Remove invalid :size option from ActionText migration

### DIFF
--- a/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
@@ -5,7 +5,7 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
 
     create_table :action_text_rich_texts, id: primary_key_type do |t|
       t.string     :name, null: false
-      t.text       :body, size: :long
+      t.text       :body
       t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
 
       t.timestamps

--- a/actiontext/test/dummy/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/test/dummy/db/migrate/20180528164100_create_action_text_tables.rb
@@ -2,7 +2,7 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
   def change
     create_table :action_text_rich_texts do |t|
       t.string     :name, null: false
-      t.text       :body, size: :long
+      t.text       :body
       t.references :record, null: false, polymorphic: true, index: false
 
       t.timestamps


### PR DESCRIPTION
Resolves https://github.com/rails/rails/issues/46232

### Motivation / Background

Recently [a change was introduced on main](https://github.com/rails/rails/pull/46178) to raise an error if a migration is run with invalid column options. This is causing `CreateActionTextTables` to error because it is using an invalid `:size` option.

### Detail

I removed the invalid option from the migration.

### Additional information

To replicate the issue:

```
rails new test_app
# modify the Gemfile, set Rails to `gem "rails", github: 'rails/rails'`
rails action_text:install
rails db:mirgate
```

The issue is fixed if you run these steps but point the gemfile at this branch.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [ ] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
