### PR TITLE
Remove Calculations#count doc example with 0

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -30,8 +30,7 @@ module ActiveRecord
     # of each key would be the #count.
     #
     #   Article.group(:status, :category).count
-    #   # =>  {["draft", "business"]=>10, ["draft", "technology"]=>4,
-    #   #      ["published", "business"]=>0, ["published", "technology"]=>2}
+    #   # =>  {["draft", "business"]=>10, ["draft", "technology"]=>4, ["published", "technology"]=>2}
     #
     # If #count is used with {Relation#select}[rdoc-ref:QueryMethods#select], it will count the selected columns:
     #


### PR DESCRIPTION
A `Model.group(columns).count` won't return entries for combinations that don't occur, so there won't be any zeroes.