### PR TITLE
Skip `to_s` call when we're in a `without_encryption_context`

### DIFF
--- a/activerecord/lib/active_record/encryption/context.rb
+++ b/activerecord/lib/active_record/encryption/context.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     # * A cipher, the encryption algorithm
     # * A message serializer
     class Context
-      PROPERTIES = %i[ key_provider key_generator cipher message_serializer encryptor frozen_encryption ]
+      PROPERTIES = %i[ key_provider key_generator cipher message_serializer encryptor frozen_encryption skip_type_cast ]
 
       attr_accessor(*PROPERTIES)
 
@@ -32,6 +32,7 @@ module ActiveRecord
           self.cipher = ActiveRecord::Encryption::Cipher.new
           self.encryptor = ActiveRecord::Encryption::Encryptor.new
           self.message_serializer = ActiveRecord::Encryption::MessageSerializer.new
+          self.skip_type_cast = false
         end
 
         def build_default_key_provider

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         # * Reading encrypted content will return its ciphertexts.
         # * Writing encrypted content will write its clear text.
         def without_encryption(&block)
-          with_encryption_context encryptor: ActiveRecord::Encryption::NullEncryptor.new, &block
+          with_encryption_context skip_type_cast: true, encryptor: ActiveRecord::Encryption::NullEncryptor.new, &block
         end
 
         # Runs the provided block in an encryption context where:

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -116,7 +116,12 @@ module ActiveRecord
         def serialize_with_current(value)
           casted_value = cast_type.serialize(value)
           casted_value = casted_value&.downcase if downcase?
-          encrypt(casted_value.to_s) unless casted_value.nil?
+          final_casted_value = if ActiveRecord::Encryption.context.skip_type_cast
+            casted_value
+          else
+            casted_value.to_s
+          end
+          encrypt(final_casted_value) unless casted_value.nil?
         end
 
         def encrypt(value)

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -28,8 +28,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -66,8 +66,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -81,8 +81,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -132,7 +132,7 @@ module ActiveRecord
       end
 
       def test_columns_for_existent_table
-        assert_equal 12, @cache.columns("posts").size
+        assert_equal 13, @cache.columns("posts").size
       end
 
       def test_columns_for_non_existent_table
@@ -142,7 +142,7 @@ module ActiveRecord
       end
 
       def test_columns_hash_for_existent_table
-        assert_equal 12, @cache.columns_hash("posts").size
+        assert_equal 13, @cache.columns_hash("posts").size
       end
 
       def test_columns_hash_for_non_existent_table
@@ -195,8 +195,8 @@ module ActiveRecord
         cache = Marshal.load(Marshal.dump(cache))
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -217,8 +217,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -244,8 +244,8 @@ module ActiveRecord
 
         # Assert a table in the cache
         assert cache.data_sources("posts"), "expected posts to be in the cached data_sources"
-        assert_equal 12, cache.columns("posts").size
-        assert_equal 12, cache.columns_hash("posts").size
+        assert_equal 13, cache.columns("posts").size
+        assert_equal 13, cache.columns_hash("posts").size
         assert cache.data_sources("posts")
         assert_equal "id", cache.primary_keys("posts")
         assert_equal 1, cache.indexes("posts").size
@@ -278,8 +278,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size
@@ -291,8 +291,8 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -73,7 +73,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   end
 
   test "encrypted_attributes returns the list of encrypted attributes in a model (each record class holds their own list)" do
-    assert_equal Set.new([:title, :body]), EncryptedPost.encrypted_attributes
+    assert_equal Set.new([:title, :body, :raw_body]), EncryptedPost.encrypted_attributes
     assert_not_equal EncryptedAuthor.encrypted_attributes, EncryptedPost.encrypted_attributes
   end
 

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -128,7 +128,7 @@ module ActiveRecord
     def test_star_select_with_joins_and_includes
       posts = Post.select("posts.*").joins(:comments).includes(:comments)
       assert_equal %w(
-        id author_id title body type legacy_comments_count taggings_with_delete_all_count taggings_with_destroy_count
+        id author_id title body raw_body type legacy_comments_count taggings_with_delete_all_count taggings_with_destroy_count
         tags_count indestructible_tags_count tags_with_destroy_count tags_with_nullify_count
       ), posts.first.attributes.keys
     end

--- a/activerecord/test/models/post_encrypted.rb
+++ b/activerecord/test/models/post_encrypted.rb
@@ -12,4 +12,5 @@ class EncryptedPost < Post
 
   encrypts :title
   encrypts :body, key_provider: MutableDerivedSecretKeyProvider.new("my post body secret!")
+  encrypts :raw_body
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -862,6 +862,7 @@ ActiveRecord::Schema.define do
     else
       t.text    :body, null: false
     end
+    t.blob    :raw_body
     t.string  :type
     t.integer :legacy_comments_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because at our company we're trying to test that our previous encryption scheme (which was saved as binary data in the database) can be upgraded to rails encrypted columns. To test this we simulate some data from the previous encryption scheme using the `without_encryption` helper, and then validate that data can be read by an encrypted column. For example:

```ruby
class Post < Post
  encrypts :raw_body
end

class PostTest
  test "can read previous encryption scheme value" do
    ActiveRecord::Encryption.without_encryption do

      # The following line currently raises a query warning, but it's not valid UTF-8
      @post.update!(raw_body, expected_previous_encrypted_data)
    end

    assert_equal obj.reload.send(column), expected_previous_plaintext
  end
end
```

Currently the line `@post.update!(raw_body, expected_previous_encrypted_data)` raises a query warning similar to `Invalid utf8mb4 character string: '9F546D'` because rails column encryption seems to change the encoding used for the value being encrypted in the `without_encryption` context.

### Detail

This Pull Request changes how the `without_encryption` context works for tests so that the type that is passed is not converted to a string. It should be left up to the adopter of column encryption to provide a mechanism to ensure that in an encryption context a valid string is passed. Thus in the `without_encryption` context, no `to_s` should be enforced.

Here's the query that's generated when `to_s` is used (this generates the query warning):

```sql
UPDATE `table` SET `table`.`column` = 'Tm$����@     ��윮�R��,m0�ߪ��>�      ͗��V' WHERE `column`.`id` = 430
```

Here's what the query looks like after the change:

```sql
UPDATE `table` SET `table`.`column` = x'021b9f546d2483f6b3df4009ef1883ec9caec70752b1f32c6d30f2dfaab4a63ed8090ecd97f1f456' WHERE `table`.`id` = 421
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ bugfix
* [x] PR is not in a draft state.
* [ ] CI is passing.
