### PR TITLE
Fix some Migration versions not inheriting options

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -553,6 +553,9 @@ module ActiveRecord
 
     # This must be defined before the inherited hook, below
     class Current < Migration # :nodoc:
+      def compatible_table_definition(t)
+        t
+      end
     end
 
     def self.inherited(subclass) # :nodoc:

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -97,7 +97,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
       end
 
@@ -162,7 +162,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
       end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -256,7 +256,7 @@ module ActiveRecord
       end
 
       def test_options_are_not_validated
-        migration = Class.new(ActiveRecord::Migration[7.0]) {
+        migration = Class.new(ActiveRecord::Migration[4.2]) {
           def migrate(x)
             create_table :tests, wrong_id: false do |t|
               t.references :some_table, wrong_primary_key: true


### PR DESCRIPTION
### Motivation / Background

Previously, most version of the Migration class would call `super` in compatible_table_definition to ensure that they append all of the later Migration verion's TableDefinition modules. However, the latest Migration class did not do this and prepended its own TableDefinition because there was no super method for it to call.

This led to an issue where Action Text migrations started failing on Rails main, after migration option validation was added in e6da3eb. The new functionality was not supposed to affect V6_0 Migrations, but it was because both V6_1 and V7_0 were not calling super.

### Detail

This commit fixes the issue by correctly calling super in both classes. It also adds a compatible_table_definition method to Current that returns the value passed in so that all of the versioned Migrations can always return super.

### Additional information

Fixes #46232

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
