### PR TITLE
Combine predefined activestorage attachment variants

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add support for combining predefined variations
+
+    Sometimes you will want to combine predefined variants, like rotate a thumb:
+    `@user.avatar.variant(:thumb, rotate: 90)`
+
+    *Marek de Heus*
+
 *   Delegate `ActiveStorage::Filename#to_str` to `#to_s`
 
     Supports checking String equality:

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -75,11 +75,15 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   #
   #   avatar.variant(:thumb).processed.url
   #
+  # or use multiple pre-defined variants:
+  #
+  #   avatar.variant(:thumb, :rotate_90).processed.url
+  #
   # See ActiveStorage::Blob::Representable#variant for more information.
   #
-  # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
+  # Raises an +ArgumentError+ if +transformations+ includes a +Symbol+ which is an
   # unknown pre-defined variant of the attachment.
-  def variant(transformations)
+  def variant(*transformations)
     transformations = transformations_by_name(transformations)
     blob.variant(transformations)
   end
@@ -94,11 +98,15 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   #
   #   video.preview(:thumb).processed.url
   #
+  # or use multiple pre-defined variants:
+  #
+  #   avatar.preview(:thumb, :rotate_90).processed.url
+  #
   # See ActiveStorage::Blob::Representable#preview for more information.
   #
-  # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
+  # Raises an +ArgumentError+ if +transformations+ includes a +Symbol+ which is an
   # unknown pre-defined variant of the attachment.
-  def preview(transformations)
+  def preview(*transformations)
     transformations = transformations_by_name(transformations)
     blob.preview(transformations)
   end
@@ -113,11 +121,15 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   #
   #   avatar.representation(:thumb).processed.url
   #
+  # or use multiple pre-defined variants:
+  #
+  #   avatar.representation(:thumb, :rotate_90).processed.url
+  #
   # See ActiveStorage::Blob::Representable#representation for more information.
   #
-  # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
+  # Raises an +ArgumentError+ if +transformations+ includes a +Symbol+ which is an
   # unknown pre-defined variant of the attachment.
-  def representation(transformations)
+  def representation(*transformations)
     transformations = transformations_by_name(transformations)
     blob.representation(transformations)
   end
@@ -161,6 +173,8 @@ class ActiveStorage::Attachment < ActiveStorage::Record
 
     def transformations_by_name(transformations)
       case transformations
+      when Array
+        transformations.map { |variant_name| transformations_by_name(variant_name) }.reduce(&:merge)
       when Symbol
         variant_name = transformations
         named_variants.fetch(variant_name) do

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -866,6 +866,26 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
+  test "creating variation by combining multiple variation names" do
+    @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
+    variant = @user.highlights_with_variants.first.variant(:thumb, :rotate_90).processed
+
+    image = read_image(variant)
+    assert_equal "JPEG", image.type
+    assert_equal 67, image.width
+    assert_equal 100, image.height
+  end
+
+  test "creating variation with variation name and variation options" do
+    @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
+    variant = @user.highlights_with_variants.first.variant(:thumb, rotate: 90).processed
+
+    image = read_image(variant)
+    assert_equal "JPEG", image.type
+    assert_equal 67, image.width
+    assert_equal 100, image.height
+  end
+
   test "raises error when unknown variant name is used to generate variant" do
     @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
 

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -147,6 +147,7 @@ class User < ActiveRecord::Base
   has_many_attached :vlogs, dependent: false, service: :local
   has_many_attached :highlights_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
+    attachable.variant :rotate_90, rotate: 90
   end
   has_many_attached :highlights_with_preprocessed do |attachable|
     attachable.variant :bool, resize_to_limit: [1, 1], preprocessed: true


### PR DESCRIPTION
### Motivation / Background

Sometimes you will want to combine predefined-variants, like rotate and thumb:
```ruby
@user.avatar.variant(:thumb, :rotate_90)
```
Until now, you could only use 1 variant. If you would like to combine multiple variants, you would have to explicitly create all possible combinations, which becomes quite cluttered quick, e.g.:
```ruby
attachable.variant :thumb, ...
attachable.variant :thumb_rotate_90, ...
attachable.variant :thumb_rotate_180, ...
```

This PR adds support for combining multiple variants.

This Pull Request has been created because we use activestorage a lot and sometimes want to combine predefined-variants.

### Detail

This Pull Request changes the way that ActiveStorage::Attachment looks up transformations. It is backwards compatible, but allows users to define more than 1 predefined variant.

#### Before:
```ruby
has_one_attached :avatar do |attachable|
  attachable.variant :thumb,            resize_to_limit: [100, 100]
  attachable.variant :thumb_rotate_90,  resize_to_limit: [100, 100], rotate: 90
  attachable.variant :thumb_rotate_180, resize_to_limit: [100, 100], rotate: 180
end

@user.avatar.variant(:thumb_rotate_90)
```

#### After:
```ruby
has_one_attached :avatar do |attachable|
  attachable.variant :thumb, resize_to_limit: [100, 100]
end

@user.avatar.variant(:thumb, rotate: 90)
```

### Additional information

I chose to use some recursion in the lookup process, it works just fine, but might be hard to read for some. Could write this out in a more explicit way.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
