### PR TITLE
Add Proc as a type for ActiveJob retry_on attempts

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add Proc as a supported type for ActiveJob retry_on attempts:
+
+    Example:
+
+     ```ruby
+    class RetryJob < ActiveJob::Base
+      retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }
+      # ...
+    end
+    ```
+
+    *Rose Wiegley*
+
 *   Add support for Sidekiq's transaction-aware client
 
     *Jonathan del Strother*

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -307,6 +307,26 @@ class ExceptionsTest < ActiveSupport::TestCase
     assert_equal "Successfully completed job", JobBuffer.values[9]
   end
 
+  test "successfully retry job throwing ProcRetryError" do
+    RetryJob.perform_later "ProcRetryError", 2
+
+    assert_equal [
+      "Raised ProcRetryError for the 1st time",
+      "Successfully completed job"
+    ], JobBuffer.values
+  end
+
+  test "successfully throw an error when ProcRetryError returns false from its proc" do
+    assert_raises ProcRetryError do
+      RetryJob.perform_later "ProcRetryError", 3
+    end
+
+    assert_equal [
+      "Raised ProcRetryError for the 1st time",
+      "Raised ProcRetryError for the 2nd time"
+    ], JobBuffer.values
+  end
+
   test "running a job enqueued by AJ 5.2" do
     job = RetryJob.new("DefaultsError", 6)
     job.exception_executions = nil # This is how jobs from Rails 5.2 will look

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -18,6 +18,7 @@ class FirstDiscardableErrorOfTwo < StandardError; end
 class SecondDiscardableErrorOfTwo < StandardError; end
 class CustomDiscardableError < StandardError; end
 class UnlimitedRetryError < StandardError; end
+class ProcRetryError < StandardError; end
 
 class RetryJob < ActiveJob::Base
   retry_on DefaultsError
@@ -31,6 +32,7 @@ class RetryJob < ActiveJob::Base
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }
   retry_on UnlimitedRetryError, attempts: :unlimited
+  retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }
 
   discard_on DiscardableError
   discard_on FirstDiscardableErrorOfTwo, SecondDiscardableErrorOfTwo


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I needed `retry_on attempts:` to use more complex logic than an Integer.

In my specific case I was creating a concern for Jobs that would use `retry_on` to allow jobs to quietly fail and retry. The concern was going to use a method to allow attempts to be customized in individual jobs. 
```
    included do
      retry_on(QuietRetryError, wait: :exponentially_longer, attempts: quiet_retry_attempts) do
        # ...
      end
    end
```

However this ran into a state where the method needed to be defined and run when the concern was included instead of being available later in the job. It would be very fragile to have to define the method before including the concern. This lead to me to looking at if attempts accepted anything besides an integer. It did not but I saw there was already a pattern in place for wait to accept a Proc. I thought if that pattern was repeated for attempts than it would allow more flexibility for configuring attempts.

My original thought was to have the Proc for attempts return a number similar to what the Proc for wait does. However, on thinking about it I decided that still did not leave much flexibility because attempts would still be determined by a number. Instead I switched it to return true/false so if the next attempt occurred could be determined by whatever logic was implemented in the Proc.

### Detail

This Pull Request changes ActiveJob retry_on attempts so it will accept a Proc.

ActiveJob retry_on allowed the wait option to be set as a Proc that calculates the wait but did not give the same option for attempts. attempts could be set to only a number of times to attempt or unlimited. However, jobs sometimes need different logic than number of executions to determine if they should try again.

This PR adds support for setting attempts to a Proc that returns either true or false. On true the retry will occur.

As a an example:

    retry_on ProcRetryError, attempts: ->(executions) { executions < 2 }

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [ ] CI is passing.

