### PR TITLE
Fix changing time during fall daylight savings transition

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `Time#advance` and `Time#change` behavior during fall daylight savings time (DST)
+
+    Previously calling `advance` or `change` during the second repeated hour of DST would
+    change the hour to the first repeated hour.
+
+    Fixes #45055
+
+    *Kevin Hall*
+
 *   `Class#subclasses` and `Class#descendants` now automatically filter reloaded classes.
 
     Previously they could return old implementations of reloadable classes that have been

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -155,7 +155,7 @@ class Time
 
     new_sec += Rational(new_usec, 1000000)
 
-    if new_offset
+    new_time = if new_offset
       ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, new_offset)
     elsif utc?
       ::Time.utc(new_year, new_month, new_day, new_hour, new_min, new_sec)
@@ -166,6 +166,10 @@ class Time
     else
       ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, utc_offset)
     end
+
+    # if hour isn't changing on a daylight savings day, keep the original hour
+    second_repeated_dst_hour = options[:hour].nil? && (self - 1.hour).hour == hour
+    second_repeated_dst_hour ? new_time + 1.hour : new_time
   end
 
   # Uses Date to provide precise Time calculations for years, months, and days

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1421,4 +1421,33 @@ class TimeWithZoneMethodsForString < ActiveSupport::TestCase
       assert_equal Time.utc(2014, 10, 25, 22, 0, 0), "2014-10-26 01:00:00".in_time_zone
     end
   end
+
+  def test_fall_dst_changes
+    with_tz_default "Europe/Lisbon" do
+      time = Time.new(2021, 10, 31, 0, 0, 0, Time.zone).advance(hours: 2)
+      assert_equal 0, time.advance(seconds: 0) - time
+
+      time = Time.new(2021, 10, 31, 0, 0, 0, Time.zone).advance(hours: 2)
+      assert_equal 3600, time.advance(hours: 1) - time
+
+      time = Time.new(2021, 10, 31, 0, 0, 0, Time.zone).advance(hours: 2)
+      assert_equal 0, time.change(seconds: 0) - time
+    end
+  end
+
+  def test_spring_dst_changes
+    with_tz_default "Europe/Lisbon" do
+      time = Time.new(2021, 3, 28, 0, 0, 0, Time.zone).advance(hours: 2)
+      assert_equal 0, time.advance(seconds: 0) - time
+
+      time = Time.new(2021, 3, 28, 0, 0, 0, Time.zone).advance(hours: 1)
+      assert_equal 3600, time.advance(hours: 1) - time
+
+      time = Time.new(2021, 3, 28, 0, 0, 0, Time.zone).advance(hours: 1)
+      assert_equal 0, time.change(seconds: 0) - time
+
+      time = Time.new(2021, 3, 28, 0, 0, 0, Time.zone).advance(hours: 2)
+      assert_equal 0, time.change(seconds: 0) - time
+    end
+  end
 end


### PR DESCRIPTION
<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes #45055
<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

This Pull Request has been created because of an issue changing or advancing time during the autumn daylight savings time time change. The issue relates to how an hour repeats during the fall DST time change (there are two 1ams), but in Time#change we create a new time using just the integer hour. When creating the new time using the hour of 1, we always choose to use the first 1am. This change makes it so if the hour is being changed then the old behavior happens (the first 1am is used) but if the hour isn't being changed, and `self` is using the second 1am, then we use the second 1am.

### Detail

This Pull Request changes Time#change, but also affects Time#advance

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [X] Tests are added if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [X] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
