### PR TITLE
Focus editor after calling `fill_in_rich_text_area`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Focus rich-text editor after calling `fill_in_rich_text_area`
+
+    *Sean Doyle*
+
 *   Support `strict_loading:` option for `has_rich_text` declaration
 
     *Sean Doyle*

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -30,7 +30,11 @@ module ActionText
     #   # <trix-editor input="trix_input_1"></trix-editor>
     #   fill_in_rich_text_area "message[content]", with: "Hello <em>world!</em>"
     def fill_in_rich_text_area(locator = nil, with:)
-      find(:rich_text_area, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
+      javascript = <<~JS
+        this.editor.loadHTML(arguments[0])
+        this.editor.focus()
+      JS
+      find(:rich_text_area, locator).execute_script(javascript, with.to_s)
     end
   end
 end

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -3,6 +3,14 @@
 require "application_system_test_case"
 
 class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
+  test "filling in a rich-text area focuses the trix-editor" do
+    visit new_message_url
+
+    fill_in_rich_text_area "message_content", with: "Hello world!"
+
+    assert_selector(:rich_text_area, "message[content]", &:focused?)
+  end
+
   test "filling in a rich-text area by ID" do
     visit new_message_url
     assert_selector "trix-editor#message_content"


### PR DESCRIPTION
### Motivation / Background

When System Tests call `fill_in_rich_text_area`, they interact with `<trix-editor>` elements by changing the contents programmatically.

This is unlike how end-users will interact with the element. Overhauling the test helper to more accurately reflect Real World usage would require a sizable effort.

### Detail

With that being said, leaving the `<trix-editor>` with focus after populating its contents is a minor change that makes it a more genuine recreation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
