### PR TITLE
Fix `Time#change` and `#advance` around the end of DST

### DIFF
--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -463,6 +463,118 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_raise(ArgumentError) { Time.new(2005, 2, 22, 15, 15, 45, "+01:00").change(nsec: 1000000000, offset: -28800) }
   end
 
+  def test_change_preserves_offset_for_local_times_around_end_of_dst
+    with_env_tz "US/Eastern" do
+      # DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+      # were rolled back 1 hour.
+      midnight = Time.local(2005, 10, 30, 00, 00, 00)     # 2005-10-30 00:00:00 -0400
+      one_am_1 = Time.local(2005, 10, 30, 00, 59, 59) + 1 # 2005-10-30 01:00:00 -0400
+      one_am_2 = Time.local(2005, 10, 30, 01, 00, 00)     # 2005-10-30 01:00:00 -0500
+      two_am   = Time.local(2005, 10, 30, 02, 00, 00)     # 2005-10-30 02:00:00 -0500
+      assert_operator one_am_1, :<, one_am_2
+
+      assert_equal one_am_1, midnight.change(hour: 1)
+      assert_equal two_am, midnight.change(hour: 2)
+
+      assert_equal midnight, one_am_1.change(hour: 0)
+      assert_equal one_am_1, one_am_1.change(hour: 1)
+      assert_equal one_am_1 + 1, one_am_1.change(sec: 1)
+      assert_equal two_am, one_am_1.change(hour: 2)
+
+      assert_equal midnight, one_am_2.change(hour: 0)
+      assert_equal one_am_2, one_am_2.change(hour: 1)
+      assert_equal one_am_2 + 1, one_am_2.change(sec: 1)
+      assert_equal two_am, one_am_2.change(hour: 2)
+
+      assert_equal one_am_2, two_am.change(hour: 1)
+      assert_equal midnight, two_am.change(hour: 0)
+    end
+  end
+
+  def test_change_preserves_offset_for_zoned_times_around_end_of_dst
+    with_tz_default "US/Eastern" do
+      # DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+      # were rolled back 1 hour.
+      midnight = Time.new(2005, 10, 30, 00, 00, 00, Time.zone)        # 2005-10-30 00:00:00 -0400
+      one_am_1 = Time.new(2005, 10, 30, 01, 00, 00, Time.zone)        # 2005-10-30 01:00:00 -0400
+      one_am_2 = Time.new(2005, 10, 30, 02, 00, 00, Time.zone) - 3600 # 2005-10-30 01:00:00 -0500
+      two_am   = Time.new(2005, 10, 30, 02, 00, 00, Time.zone)        # 2005-10-30 02:00:00 -0500
+      assert_operator one_am_1, :<, one_am_2
+
+      assert_equal one_am_1, midnight.change(hour: 1)
+      assert_equal two_am, midnight.change(hour: 2)
+
+      assert_equal midnight, one_am_1.change(hour: 0)
+      assert_equal one_am_1, one_am_1.change(hour: 1)
+      assert_equal one_am_1 + 1, one_am_1.change(sec: 1)
+      assert_equal two_am, one_am_1.change(hour: 2)
+
+      assert_equal midnight, one_am_2.change(hour: 0)
+      assert_equal one_am_2, one_am_2.change(hour: 1)
+      assert_equal one_am_2 + 1, one_am_2.change(sec: 1)
+      assert_equal two_am, one_am_2.change(hour: 2)
+
+      assert_equal one_am_2, two_am.change(hour: 1)
+      assert_equal midnight, two_am.change(hour: 0)
+    end
+  end
+
+  def test_change_preserves_fractional_hour_offset_for_local_times_around_end_of_dst
+    with_env_tz "Australia/Lord_Howe" do
+      # DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and
+      # clocks were rolled back 30 minutes.
+      one_am     = Time.local(2005, 03, 27, 01, 00, 00)     # 2005-03-27 00:00:00 +1100
+      one30_am_1 = Time.local(2005, 03, 27, 01, 29, 59) + 1 # 2005-03-27 01:30:00 +1100
+      one30_am_2 = Time.local(2005, 03, 27, 01, 30, 00)     # 2005-03-27 01:30:00 +1030
+      two_am     = Time.local(2005, 03, 27, 02, 00, 00)     # 2005-03-27 02:00:00 +1030
+      assert_operator one30_am_1, :<, one30_am_2
+
+      assert_equal one30_am_1, one_am.change(min: 30)
+      assert_equal two_am, one_am.change(hour: 2)
+
+      assert_equal one_am, one30_am_1.change(min: 0)
+      assert_equal one30_am_1, one30_am_1.change(min: 30)
+      assert_equal one30_am_1 + 1, one30_am_1.change(min: 30, sec: 1)
+      assert_equal two_am, one30_am_1.change(hour: 2)
+
+      assert_equal one_am, one30_am_2.change(min: 0)
+      assert_equal one30_am_2, one30_am_2.change(min: 30)
+      assert_equal one30_am_2 + 1, one30_am_2.change(min: 30, sec: 1)
+      assert_equal two_am, one30_am_2.change(hour: 2)
+
+      assert_equal one30_am_2, two_am.change(hour: 1, min: 30)
+      assert_equal one_am, two_am.change(hour: 1)
+    end
+  end
+
+  def test_change_preserves_fractional_hour_offset_for_zoned_times_around_end_of_dst
+    with_tz_default "Australia/Lord_Howe" do
+      # DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and
+      # clocks were rolled back 30 minutes.
+      one_am     = Time.new(2005, 03, 27, 01, 00, 00, Time.zone)        # 2005-03-27 00:00:00 +1100
+      one30_am_1 = Time.new(2005, 03, 27, 01, 30, 00, Time.zone)        # 2005-03-27 01:30:00 +1100
+      one30_am_2 = Time.new(2005, 03, 27, 02, 00, 00, Time.zone) - 1800 # 2005-03-27 01:30:00 +1030
+      two_am     = Time.new(2005, 03, 27, 02, 00, 00, Time.zone)        # 2005-03-27 02:00:00 +1030
+      assert_operator one30_am_1, :<, one30_am_2
+
+      assert_equal one30_am_1, one_am.change(min: 30)
+      assert_equal two_am, one_am.change(hour: 2)
+
+      assert_equal one_am, one30_am_1.change(min: 0)
+      assert_equal one30_am_1, one30_am_1.change(min: 30)
+      assert_equal one30_am_1 + 1, one30_am_1.change(min: 30, sec: 1)
+      assert_equal two_am, one30_am_1.change(hour: 2)
+
+      assert_equal one_am, one30_am_2.change(min: 0)
+      assert_equal one30_am_2, one30_am_2.change(min: 30)
+      assert_equal one30_am_2 + 1, one30_am_2.change(min: 30, sec: 1)
+      assert_equal two_am, one30_am_2.change(hour: 2)
+
+      assert_equal one30_am_2, two_am.change(hour: 1, min: 30)
+      assert_equal one_am, two_am.change(hour: 1)
+    end
+  end
+
   def test_advance
     assert_equal Time.local(2006, 2, 28, 15, 15, 10), Time.local(2005, 2, 28, 15, 15, 10).advance(years: 1)
     assert_equal Time.local(2005, 6, 28, 15, 15, 10), Time.local(2005, 2, 28, 15, 15, 10).advance(months: 4)
@@ -549,6 +661,134 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.local(1582, 10, 4, 15, 15, 10), Time.local(1582, 10, 5, 15, 15, 10).advance(days: -1)
     assert_equal Time.local(999, 10, 4, 15, 15, 10), Time.local(1000, 10, 4, 15, 15, 10).advance(years: -1)
     assert_equal Time.local(1000, 10, 4, 15, 15, 10), Time.local(999, 10, 4, 15, 15, 10).advance(years: 1)
+  end
+
+  def test_advance_preserves_offset_for_local_times_around_end_of_dst
+    with_env_tz "US/Eastern" do
+      # DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+      # were rolled back 1 hour.
+      midnight = Time.local(2005, 10, 30, 00, 00, 00)     # 2005-10-30 00:00:00 -0400
+      one_am_1 = Time.local(2005, 10, 30, 00, 59, 59) + 1 # 2005-10-30 01:00:00 -0400
+      one_am_2 = Time.local(2005, 10, 30, 01, 00, 00)     # 2005-10-30 01:00:00 -0500
+      two_am   = Time.local(2005, 10, 30, 02, 00, 00)     # 2005-10-30 02:00:00 -0500
+      assert_operator one_am_1, :<, one_am_2
+
+      assert_equal one_am_1, midnight.advance(hours: 1)
+      assert_equal one_am_2, midnight.advance(hours: 2)
+      assert_equal two_am, midnight.advance(hours: 3)
+
+      assert_equal midnight, one_am_1.advance(hours: -1)
+      assert_equal one_am_1, one_am_1.advance(seconds: 0)
+      assert_equal one_am_1 + 1, one_am_1.advance(seconds: 1)
+      assert_equal one_am_2, one_am_1.advance(hours: 1)
+      assert_equal two_am, one_am_1.advance(hours: 2)
+
+      assert_equal midnight, one_am_2.advance(hours: -2)
+      assert_equal one_am_1, one_am_2.advance(hours: -1)
+      assert_equal one_am_2, one_am_2.advance(seconds: 0)
+      assert_equal one_am_2 + 1, one_am_2.advance(seconds: 1)
+      assert_equal two_am, one_am_2.advance(hours: 1)
+
+      assert_equal one_am_2, two_am.advance(hours: -1)
+      assert_equal one_am_1, two_am.advance(hours: -2)
+      assert_equal midnight, two_am.advance(hours: -3)
+    end
+  end
+
+  def test_advance_preserves_offset_for_zoned_times_around_end_of_dst
+    with_tz_default "US/Eastern" do
+      # DST ended just before 2005-10-30 2:00:00 AM in US/Eastern, and clocks
+      # were rolled back 1 hour.
+      midnight = Time.new(2005, 10, 30, 00, 00, 00, Time.zone)        # 2005-10-30 00:00:00 -0400
+      one_am_1 = Time.new(2005, 10, 30, 01, 00, 00, Time.zone)        # 2005-10-30 01:00:00 -0400
+      one_am_2 = Time.new(2005, 10, 30, 02, 00, 00, Time.zone) - 3600 # 2005-10-30 01:00:00 -0500
+      two_am   = Time.new(2005, 10, 30, 02, 00, 00, Time.zone)        # 2005-10-30 02:00:00 -0500
+      assert_operator one_am_1, :<, one_am_2
+
+      assert_equal one_am_1, midnight.advance(hours: 1)
+      assert_equal one_am_2, midnight.advance(hours: 2)
+      assert_equal two_am, midnight.advance(hours: 3)
+
+      assert_equal midnight, one_am_1.advance(hours: -1)
+      assert_equal one_am_1, one_am_1.advance(seconds: 0)
+      assert_equal one_am_1 + 1, one_am_1.advance(seconds: 1)
+      assert_equal one_am_2, one_am_1.advance(hours: 1)
+      assert_equal two_am, one_am_1.advance(hours: 2)
+
+      assert_equal midnight, one_am_2.advance(hours: -2)
+      assert_equal one_am_1, one_am_2.advance(hours: -1)
+      assert_equal one_am_2, one_am_2.advance(seconds: 0)
+      assert_equal one_am_2 + 1, one_am_2.advance(seconds: 1)
+      assert_equal two_am, one_am_2.advance(hours: 1)
+
+      assert_equal one_am_2, two_am.advance(hours: -1)
+      assert_equal one_am_1, two_am.advance(hours: -2)
+      assert_equal midnight, two_am.advance(hours: -3)
+    end
+  end
+
+  def test_advance_preserves_fractional_hour_offset_for_local_times_around_end_of_dst
+    with_env_tz "Australia/Lord_Howe" do
+      # DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and
+      # clocks were rolled back 30 minutes.
+      one_am     = Time.local(2005, 03, 27, 01, 00, 00)     # 2005-03-27 00:00:00 +1100
+      one30_am_1 = Time.local(2005, 03, 27, 01, 29, 59) + 1 # 2005-03-27 01:30:00 +1100
+      one30_am_2 = Time.local(2005, 03, 27, 01, 30, 00)     # 2005-03-27 01:30:00 +1030
+      two_am     = Time.local(2005, 03, 27, 02, 00, 00)     # 2005-03-27 02:00:00 +1030
+      assert_operator one30_am_1, :<, one30_am_2
+
+      assert_equal one30_am_1, one_am.advance(minutes: 30)
+      assert_equal one30_am_2, one_am.advance(minutes: 60)
+      assert_equal two_am, one_am.advance(minutes: 90)
+
+      assert_equal one_am, one30_am_1.advance(minutes: -30)
+      assert_equal one30_am_1, one30_am_1.advance(seconds: 0)
+      assert_equal one30_am_1 + 1, one30_am_1.advance(seconds: 1)
+      assert_equal one30_am_2, one30_am_1.advance(minutes: 30)
+      assert_equal two_am, one30_am_1.advance(minutes: 60)
+
+      assert_equal one_am, one30_am_2.advance(minutes: -60)
+      assert_equal one30_am_1, one30_am_2.advance(minutes: -30)
+      assert_equal one30_am_2, one30_am_2.advance(seconds: 0)
+      assert_equal one30_am_2 + 1, one30_am_2.advance(seconds: 1)
+      assert_equal two_am, one30_am_2.advance(minutes: 30)
+
+      assert_equal one30_am_2, two_am.advance(minutes: -30)
+      assert_equal one30_am_1, two_am.advance(minutes: -60)
+      assert_equal one_am, two_am.advance(minutes: -90)
+    end
+  end
+
+  def test_advance_preserves_fractional_hour_offset_for_zoned_times_around_end_of_dst
+    with_tz_default "Australia/Lord_Howe" do
+      # DST ended just before 2005-03-27 2:00:00 AM in Australia/Lord_Howe, and
+      # clocks were rolled back 30 minutes.
+      one_am     = Time.new(2005, 03, 27, 01, 00, 00, Time.zone)        # 2005-03-27 00:00:00 +1100
+      one30_am_1 = Time.new(2005, 03, 27, 01, 30, 00, Time.zone)        # 2005-03-27 01:30:00 +1100
+      one30_am_2 = Time.new(2005, 03, 27, 02, 00, 00, Time.zone) - 1800 # 2005-03-27 01:30:00 +1030
+      two_am     = Time.new(2005, 03, 27, 02, 00, 00, Time.zone)        # 2005-03-27 02:00:00 +1030
+      assert_operator one30_am_1, :<, one30_am_2
+
+      assert_equal one30_am_1, one_am.advance(minutes: 30)
+      assert_equal one30_am_2, one_am.advance(minutes: 60)
+      assert_equal two_am, one_am.advance(minutes: 90)
+
+      assert_equal one_am, one30_am_1.advance(minutes: -30)
+      assert_equal one30_am_1, one30_am_1.advance(seconds: 0)
+      assert_equal one30_am_1 + 1, one30_am_1.advance(seconds: 1)
+      assert_equal one30_am_2, one30_am_1.advance(minutes: 30)
+      assert_equal two_am, one30_am_1.advance(minutes: 60)
+
+      assert_equal one_am, one30_am_2.advance(minutes: -60)
+      assert_equal one30_am_1, one30_am_2.advance(minutes: -30)
+      assert_equal one30_am_2, one30_am_2.advance(seconds: 0)
+      assert_equal one30_am_2 + 1, one30_am_2.advance(seconds: 1)
+      assert_equal two_am, one30_am_2.advance(minutes: 30)
+
+      assert_equal one30_am_2, two_am.advance(minutes: -30)
+      assert_equal one30_am_1, two_am.advance(minutes: -60)
+      assert_equal one_am, two_am.advance(minutes: -90)
+    end
   end
 
   def test_last_week


### PR DESCRIPTION
Prior to this commit, when `Time#change` or `Time#advance` constructed a time inside the final stretch of Daylight Saving Time (DST), the non-DST offset would always be chosen for local times:

  ```ruby
  ENV["TZ"] = "US/Eastern"

  time = Time.local(2021, 11, 07, 00, 59, 59) + 1
  # => 2021-11-07 01:00:00 -0400
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0500
  time.advance(seconds: 0)
  # => 2021-11-07 01:00:00 -0500

  time = Time.local(2021, 11, 06, 01, 00, 00)
  # => 2021-11-06 01:00:00 -0400
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0500
  time.advance(days: 1)
  # => 2021-11-07 01:00:00 -0500
  ```

And the DST offset would always be chosen for times with a `TimeZone` object:

  ```ruby
  Time.zone = "US/Eastern"

  time = Time.new(2021, 11, 07, 02, 00, 00, Time.zone) - 3600
  # => 2021-11-07 01:00:00 -0500
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0400
  time.advance(seconds: 0)
  # => 2021-11-07 01:00:00 -0400

  time = Time.new(2021, 11, 8, 01, 00, 00, Time.zone)
  # => 2021-11-08 01:00:00 -0500
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0400
  time.advance(days: -1)
  # => 2021-11-07 01:00:00 -0400
  ```

This commit fixes `Time#change` and `Time#advance` to choose the offset that matches the original time's offset when possible:

  ```ruby
  ENV["TZ"] = "US/Eastern"

  time = Time.local(2021, 11, 07, 00, 59, 59) + 1
  # => 2021-11-07 01:00:00 -0400
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0400
  time.advance(seconds: 0)
  # => 2021-11-07 01:00:00 -0400

  time = Time.local(2021, 11, 06, 01, 00, 00)
  # => 2021-11-06 01:00:00 -0400
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0400
  time.advance(days: 1)
  # => 2021-11-07 01:00:00 -0400

  Time.zone = "US/Eastern"

  time = Time.new(2021, 11, 07, 02, 00, 00, Time.zone) - 3600
  # => 2021-11-07 01:00:00 -0500
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0500
  time.advance(seconds: 0)
  # => 2021-11-07 01:00:00 -0500

  time = Time.new(2021, 11, 8, 01, 00, 00, Time.zone)
  # => 2021-11-08 01:00:00 -0500
  time.change(day: 07)
  # => 2021-11-07 01:00:00 -0500
  time.advance(days: -1)
  # => 2021-11-07 01:00:00 -0500
  ```

Fixes #45055.
Closes #45556.
Closes #46248.

---

/cc @khall I've added you as co-author for your work on #46248.
/cc @takp I've added you as co-author for your work on #45556.
