### PR TITLE
Custom route formatters

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -77,17 +77,16 @@ module ActionDispatch
       def format(formatter, filter = {})
         routes_to_display = filter_routes(normalize_filter(filter))
         routes = collect_routes(routes_to_display)
+
         if routes.none?
           formatter.no_routes(collect_routes(@routes), filter)
           return formatter.result
         end
 
-        formatter.header routes
-        formatter.section routes
+        formatter.draw(routes)
 
         @engines.each do |name, engine_routes|
-          formatter.section_title "Routes for #{name}"
-          formatter.section engine_routes
+          formatter.draw engine_routes, "Routes for #{name}"
         end
 
         formatter.result
@@ -150,22 +149,30 @@ module ActionDispatch
     end
 
     module ConsoleFormatter
+      cattr_accessor :registered_formatters, default: {}
+
+      def self.register_formatter(formatter, name = nil)
+        formatter_name = name || formatter.name.split(/::/).last
+        registered_formatters[formatter_name] = formatter if valid_formatter?(formatter)
+      end
+
+      def self.valid_formatter?(formatter)
+        raise ArgumentError, "#{formatter} must implement #draw, #result, and #no_routes" unless [:draw, :result, :no_routes].all? { |method| formatter.instance_methods.include?(method) }
+        !registered_formatters.has_key?(formatter.name)
+      end
+      private_class_method :valid_formatter?
+
       class Base
         def initialize
           @buffer = []
         end
 
+        def draw(routes, title = nil)
+          raise NotImplementedError
+        end
+
         def result
           @buffer.join("\n")
-        end
-
-        def section_title(title)
-        end
-
-        def section(routes)
-        end
-
-        def header(routes)
         end
 
         def no_routes(routes, filter)
@@ -186,17 +193,11 @@ module ActionDispatch
         end
       end
 
-      class Sheet < Base
-        def section_title(title)
-          @buffer << "\n#{title}:"
-        end
-
-        def section(routes)
-          @buffer << draw_section(routes)
-        end
-
-        def header(routes)
+      class SheetFormatter < Base
+        def draw(routes, title = nil)
           @buffer << draw_header(routes)
+          @buffer << "\n#{"[ #{title} ]"}" if title.present?
+          @buffer << draw_section(routes)
         end
 
         private
@@ -221,18 +222,16 @@ module ActionDispatch
              routes.map { |r| r[:path].length }.max || 0]
           end
       end
+      ConsoleFormatter.register_formatter(SheetFormatter, "sheet")
 
-      class Expanded < Base
-        def initialize(width: IO.console_size[1])
-          @width = width
-          super()
+      class ExpandedFormatter < Base
+        def initialize
+          @width = IO.console_size[1]
+          super
         end
 
-        def section_title(title)
-          @buffer << "\n#{"[ #{title} ]"}"
-        end
-
-        def section(routes)
+        def draw(routes, title = "")
+          @buffer << "\n#{"[ #{title} ]"}" if title.present?
           @buffer << draw_expanded_section(routes)
         end
 
@@ -253,9 +252,10 @@ module ActionDispatch
             "--[ Route #{index} ]".ljust(@width, "-")
           end
       end
+      ConsoleFormatter.register_formatter(ExpandedFormatter, "expanded")
 
-      class Unused < Sheet
-        def header(routes)
+      class Unused < SheetFormatter
+        def draw(routes)
           @buffer << <<~MSG
             Found #{routes.count} unused #{"route".pluralize(routes.count)}:
           MSG

--- a/actionpack/test/routing/console_formatter_test.rb
+++ b/actionpack/test/routing/console_formatter_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module ActionDispatch
+  module Routing
+    class ConsoleFormatterTest < ActiveSupport::TestCase
+      class ::MockFormatter
+        def draw
+        end
+
+        def no_routes
+        end
+
+        def result
+        end
+      end
+
+      class ::BadFormatter
+      end
+
+      def setup
+        ActionDispatch::Routing::ConsoleFormatter.registered_formatters = {}
+      end
+
+      def test_route_formatter_registration
+        ActionDispatch::Routing::ConsoleFormatter.register_formatter(MockFormatter)
+
+        assert_includes ActionDispatch::Routing::ConsoleFormatter.registered_formatters.values, MockFormatter
+      end
+
+      def test_route_formatter_registration_with_custom_name
+        ActionDispatch::Routing::ConsoleFormatter.register_formatter(MockFormatter, "test-formatter")
+
+        assert_includes ActionDispatch::Routing::ConsoleFormatter.registered_formatters.keys, "test-formatter"
+      end
+
+      def test_route_formatter_registration_raises_if_not_given_valid_formatter
+        assert_raises(ArgumentError) {
+          ActionDispatch::Routing::ConsoleFormatter.register_formatter(BadFormatter)
+        }
+      end
+
+      def test_route_formatter_generates_formatter_name
+        ActionDispatch::Routing::ConsoleFormatter.register_formatter(MockFormatter)
+
+        assert_includes ActionDispatch::Routing::ConsoleFormatter.registered_formatters.keys, "MockFormatter"
+      end
+
+      def test_route_formatter_registration_doesnt_register_multiple_formatters
+        ActionDispatch::Routing::ConsoleFormatter.register_formatter(MockFormatter)
+
+        formatter_count = ActionDispatch::Routing::ConsoleFormatter.registered_formatters.keys.size
+
+        ActionDispatch::Routing::ConsoleFormatter.register_formatter(MockFormatter)
+        assert_equal formatter_count, ActionDispatch::Routing::ConsoleFormatter.registered_formatters.keys.size
+      end
+    end
+  end
+end

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -7,8 +7,8 @@ module Rails
     class RoutesCommand < Base # :nodoc:
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
-      class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
+      class_option :formatter, aliases: "-f", desc: "Specify the formatter to render the routes, e.g. sheet, expanded."
 
       def invoke_command(*)
         if options.key?("unused")
@@ -31,11 +31,9 @@ module Rails
         end
 
         def formatter
-          if options.key?("expanded")
-            ActionDispatch::Routing::ConsoleFormatter::Expanded.new
-          else
-            ActionDispatch::Routing::ConsoleFormatter::Sheet.new
-          end
+          ActionDispatch::Routing::ConsoleFormatter.registered_formatters.fetch(options["formatter"]).new
+        rescue KeyError
+          ActionDispatch::Routing::ConsoleFormatter::SheetFormatter.new
         end
 
         def routes_filter

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -232,7 +232,32 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     MESSAGE
   end
 
-  test "rails routes with expanded option" do
+  test "uses default route formatter if an invalid one is specified" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resource :post
+        resource :user_permission
+      end
+    RUBY
+
+    output = IO.stub(:console_size, [0, 27]) do
+      run_routes_command([ "-c", "PostController", "-f", "bad-formatter" ])
+    end
+
+    assert_equal <<~OUTPUT, output
+                             Prefix Verb   URI Pattern                                             Controller#Action
+                           new_post GET    /post/new(.:format)                                     posts#new
+                          edit_post GET    /post/edit(.:format)                                    posts#edit
+                               post GET    /post(.:format)                                         posts#show
+                                    PATCH  /post(.:format)                                         posts#update
+                                    PUT    /post(.:format)                                         posts#update
+                                    DELETE /post(.:format)                                         posts#destroy
+                                    POST   /post(.:format)                                         posts#create
+      rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format) action_mailbox/ingresses/postmark/inbound_emails#create
+    OUTPUT
+  end
+
+  test "rails routes with expanded formatter" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
         get '/cart', to: 'cart#show'
@@ -240,7 +265,7 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     RUBY
 
     output = IO.stub(:console_size, [0, 27]) do
-      run_routes_command([ "--expanded" ])
+      run_routes_command([ "-f", "expanded" ])
     end
 
     # rubocop:disable Layout/TrailingWhitespace
@@ -375,7 +400,7 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
       end
     RUBY
 
-    output = run_routes_command([ "--unused" ])
+    output = run_routes_command(["--unused"])
 
     assert_equal(output, "No unused routes found.\n")
   end


### PR DESCRIPTION
### Motivation / Background

To allow for easily customising the output of `rails routes` this PR implements the ability to register custom route formatters and adds a `--formatter` option to use the registered formatter(s). 

### Detail

Adds a `ActionDispatch::Routing::ConsoleFormatter.register_formatter()` method and a `registered_formatters` on the `ActionDispatch::Routing::ConsoleFormatter` module. 
Each registered formatter implements `#draw(routes, "title")` to output the application routes and any routes registered in engines. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
