### PR TITLE
Bump Puma to v6.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       rack
       railties (>= 7.0.0.alpha2)
     public_suffix (4.0.6)
-    puma (5.6.5)
+    puma (6.0.0)
       nio4r (~> 2.0)
     queue_classic (4.0.0)
       pg (>= 1.1, < 2.0)

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -243,7 +243,7 @@ module Rails
       end
 
       def web_server_gemfile_entry # :doc:
-        GemfileEntry.new "puma", "~> 5.0", "Use the Puma web server [https://github.com/puma/puma]"
+        GemfileEntry.new "puma", ">= 5.0", "Use the Puma web server [https://github.com/puma/puma]"
       end
 
       def asset_pipeline_gemfile_entry

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -498,7 +498,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_generator_defaults_to_puma_version
     run_generator [destination_root]
-    assert_gem "puma", '"~> 5.0"'
+    assert_gem "puma", /"\W+ \d/
   end
 
   def test_action_cable_redis_gems

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -417,7 +417,12 @@ module SharedGeneratorTests
     end
 
     def assert_gem(name, constraint = nil)
-      constraint_pattern = /, #{Regexp.escape constraint}/ if constraint
+      constraint_pattern =
+        if constraint.is_a?(String)
+          /, #{Regexp.escape constraint}/
+        elsif constraint
+          /, #{constraint}/
+        end
       assert_file "Gemfile", %r/^\s*gem ["']#{name}["']#{constraint_pattern}/
     end
 


### PR DESCRIPTION
The `Gemfile` was updated in #46106 to allow Puma 6.  Puma v6.0.0 was released on 2022-10-14.  This commit updates `Gemfile.lock` to reflect the new version.

This commit also updates the Puma version constraint used in generated apps to allow Puma 6.

---

This fixes current build failures such as: https://buildkite.com/rails/rails/builds/90327#0183e1f4-f708-4f01-896a-f5237c7b3efa/1212-1308
