### PR TITLE
Avoid encrypt + decrypt on attribute assignment

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -28,6 +28,10 @@ module ActiveRecord
         @default = default
       end
 
+      def cast(value)
+        cast_type.cast(value)
+      end
+
       def deserialize(value)
         cast_type.deserialize decrypt(value)
       end


### PR DESCRIPTION
Prior to this commit, `EncryptedAttributeType` inherited its `cast` method from `ActiveModel::Type::Helpers::Mutable`.  `Mutable#cast` is implemented as a `serialize` + `deserialize`.  For `EncryptedAttributeType`, this means `encrypt` + `decrypt`.  This overhead can be avoided by simply delegating `cast` to the `cast_type`.

**Before**

  ```console
  irb> Post.encrypts :body, encryptor: MyLoggingEncryptor.new

  irb> post = Post.create!(body: "Hello")
  ! encrypting "Hello"
  ! decrypted "Hello"
  ! encrypting "Hello"
    TRANSACTION (0.1ms)  begin transaction
    Post Create (1.0ms)  INSERT INTO "posts" ...
  ! encrypting "Hello"
    TRANSACTION (76.7ms)  commit transaction

  irb> post.update!(body: "World")
  ! decrypted "Hello"
  ! encrypting "World"
  ! decrypted "World"
  ! decrypted "Hello"
  ! encrypting "World"
    TRANSACTION (0.1ms)  begin transaction
    Post Update (0.6ms)  UPDATE "posts" ...
  ! encrypting "World"
    TRANSACTION (100.0ms)  commit transaction
  ```

**After**

  ```console
  irb> Post.encrypts :body, encryptor: MyLoggingEncryptor.new

  irb> post = Post.create!(body: "Hello")
  ! encrypting "Hello"
    TRANSACTION (0.1ms)  begin transaction
    Post Create (0.8ms)  INSERT INTO "posts" ...
  ! encrypting "Hello"
    TRANSACTION (97.0ms)  commit transaction

  irb> post.update!(body: "World")
  ! decrypted "Hello"
  ! decrypted "Hello"
  ! encrypting "World"
    TRANSACTION (0.1ms)  begin transaction
    Post Update (0.9ms)  UPDATE "posts" ...
  ! encrypting "World"
    TRANSACTION (85.4ms)  commit transaction
  ```
