### PR TITLE
fix: Ensure `ActiveJob::TestHelper` sets `scheduled_at` to a `Float`

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -710,7 +710,7 @@ module ActiveJob
 
       def instantiate_job(payload, skip_deserialize_arguments: false)
         job = payload[:job].deserialize(payload)
-        job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
+        job.scheduled_at = payload[:at].to_f if payload.key?(:at)
         job.send(:deserialize_arguments_if_needed) unless skip_deserialize_arguments
         job
       end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -515,7 +515,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_instance_of LoggingJob, job
-    assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
+    assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at, 1
     assert_equal "default", job.queue_name
     assert_equal [1, 2, 3, { keyword: true }], job.arguments
   end
@@ -525,7 +525,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     job = assert_enqueued_with(job: LoggingJob)
 
     assert_instance_of LoggingJob, job
-    assert_in_delta 5.minutes.from_now, job.scheduled_at, 1
+    assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at, 1
     assert_equal "default", job.queue_name
     assert_equal [1, 2, 3, { keyword: true }], job.arguments
   end


### PR DESCRIPTION
<!--
About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->

This Pull Request has been created because I noticed a difference in behavior when inspecting `ActiveJob::Core#scheduled_at` in non-test environments vs when inspecting in while executing tests.

### Detail

Prior to this change, `ActiveJob::TestHelper` would set `ActiveJob::Core#scheduled_at` to a `Time` object in tests, however this attribute was set to a `Float` objects in non-test environments:

<https://github.com/rails/rails/blob/d1aa6af5cc093164043641e99e30a9c8c60aa159/activejob/lib/active_job/core.rb#L161>

This change ensures parity in all runtime environments.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] There are no typos in commit messages and comments.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Feature branch is up-to-date with `main` (if not - rebase it).
* [x] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [x] Tests are added if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] PR is not in a draft state.
* [x] CI is passing.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
