### PR TITLE
Support proc and symbol for `NumericalityValidator`'s `:in` option

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Support proc and symbol for `NumericalityValidator`s `:in` option
+
+    ```ruby
+    validates_numericality_of :price, in: ->(o) { 0..o.max_price }
+    ```
+
+    or
+
+    ```ruby
+    validates_numericality_of :price, in: :price_range
+
+    def price_range
+      0..max_price
+    end
+    ```
+
+    *Thomas Sevestre*
+
 *   Combine `:if`, `:unless`, and `:on` options when specified at both the
     `validates` level and the per-validator level, instead of the per-validator
     options silently replacing the top-level ones.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -27,8 +27,8 @@ module ActiveModel
         end
 
         options.slice(*RANGE_CHECKS.keys).each do |option, value|
-          unless value.is_a?(Range)
-            raise ArgumentError, ":#{option} must be a range"
+          unless value.is_a?(Range) || value.is_a?(Proc) || value.is_a?(Symbol)
+            raise ArgumentError, ":#{option} must be a range, a symbol or a proc"
           end
         end
       end
@@ -52,6 +52,10 @@ module ActiveModel
               record.errors.add(attr_name, option, **filtered_options(value))
             end
           elsif RANGE_CHECKS.include?(option)
+            option_value = resolve_value(record, option_value)
+            unless option_value.is_a?(Range)
+              raise ArgumentError, ":#{option} must return a range"
+            end
             unless value.public_send(RANGE_CHECKS[option], option_value)
               record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
             end
@@ -207,6 +211,7 @@ module ActiveModel
       # * <tt>:less_than_or_equal_to</tt>
       # * <tt>:only_integer</tt>
       # * <tt>:other_than</tt>
+      # * <tt>:in</tt>
       #
       # For example:
       #

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -237,6 +237,34 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_valid_values([1, 2, 3])
   end
 
+  def test_validates_numericality_with_in_and_proc_as_value
+    Topic.validates_numericality_of :approved, in: ->(o) { 1..3 }
+
+    assert_invalid_values([0, 4])
+    assert_valid_values([1, 2, 3])
+  end
+
+  def test_validates_numericality_with_in_and_symbol_as_value
+    Topic.define_method(:dynamic_range) { 1..3 }
+    Topic.validates_numericality_of :approved, in: :dynamic_range
+
+    assert_invalid_values([0, 4])
+    assert_valid_values([1, 2, 3])
+  ensure
+    Topic.remove_method(:dynamic_range)
+  end
+
+  def test_validates_numericality_with_in_and_invalid_value
+    Topic.define_method(:dynamic_non_range) { "foo" }
+    Topic.validates_numericality_of :approved, in: :dynamic_non_range
+
+    assert_raises(ArgumentError, match: ":in must return a range") do
+      assert_invalid_values([0, 4])
+    end
+  ensure
+    Topic.remove_method(:dynamic_non_range)
+  end
+
   def test_validates_numericality_with_other_than_using_string_value
     Topic.validates_numericality_of :approved, other_than: 0
 


### PR DESCRIPTION
This PR adds support for proc and symbol parameters for `NumericalityValidator`'s `:in` option

For instance :
```ruby
validates_numericality_of :price, in: ->(o) { 0..o.max_price }
```

or :

```ruby
validates_numericality_of :price, in: :price_range
    
def price_range
  0..max_price
end
```
