### PR TITLE
Make TagBuilder#attributes documentation public [ci-skip]

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -52,6 +52,7 @@ module ActionView
           @view_context = view_context
         end
 
+        # :doc:
         # Transforms a Hash into HTML Attributes, ready to be interpolated into
         # ERB.
         #
@@ -60,6 +61,7 @@ module ActionView
         def attributes(attributes)
           tag_options(attributes.to_h).to_s.strip.html_safe
         end
+        # :nodoc:
 
         def p(*arguments, **options, &block)
           tag_string(:p, *arguments, **options, &block)


### PR DESCRIPTION
The `TagBuilder#attributes` seems to be [public AP](https://github.com/rails/rails/pull/40657)I but because TagBuilder is defined as `:nodoc` it doesn't show up in the API docs.

By adding `:doc:` for this method, it becomes visible in the API docs:
<img width="793" alt="image" src="https://user-images.githubusercontent.com/28561/196500130-67fb2c04-a472-4f17-beb6-6a7479e5349f.png">

This PR makes only `attributes` public, but since more methods of `TagBuilder` are [described in `tag`](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag) maybe we can make more public?