### PR TITLE
Allow adapter `#execute` methods  to take `allow_retry` option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Adapter `#execute` methods now accept an `allow_retry` option. When set to `true`, the SQL statement will be
+    retried, up to the database's configured `connection_retries` value, upon encountering connection-related errors.
+
+    *Adrianna Chang*
+
 *   Only trigger `after_commit :destroy` callbacks when a database row is deleted.
 
     This prevents `after_commit :destroy` callbacks from being triggered again

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -110,10 +110,15 @@ module ActiveRecord
 
       # Executes the SQL statement in the context of this connection and returns
       # the raw result from the connection adapter.
+      #
+      # Setting +allow_retry+ to true causes the db to reconnect and retry
+      # executing the SQL statement in case of a connection-related exception.
+      # This option should only be enabled for known idempotent queries.
+      #
       # Note: depending on your database connector, the result returned by this
       # method may be manually memory managed. Consider using the exec_query
       # wrapper instead.
-      def execute(sql, name = nil)
+      def execute(sql, name = nil, allow_retry: false)
         raise NotImplementedError
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -221,11 +221,15 @@ module ActiveRecord
       #++
 
       # Executes the SQL statement in the context of this connection.
-      def execute(sql, name = nil, async: false)
+      #
+      # Setting +allow_retry+ to true causes the db to reconnect and retry
+      # executing the SQL statement in case of a connection-related exception.
+      # This option should only be enabled for known idempotent queries.
+      def execute(sql, name = nil, async: false, allow_retry: false)
         sql = transform_query(sql)
         check_if_write_query(sql)
 
-        raw_execute(sql, name, async: async)
+        raw_execute(sql, name, async: async, allow_retry: allow_retry)
       end
 
       # Mysql2Adapter doesn't have to free a result after using it, but we use this method

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -20,14 +20,14 @@ module ActiveRecord
           SQLite3::ExplainPrettyPrinter.new.pp(exec_query(sql, "EXPLAIN", []))
         end
 
-        def execute(sql, name = nil) # :nodoc:
+        def execute(sql, name = nil, allow_retry: false) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
 
           mark_transaction_written_if_write(sql)
 
           log(sql, name) do
-            with_raw_connection do |conn|
+            with_raw_connection(allow_retry: allow_retry) do |conn|
               conn.execute(sql)
             end
           end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -690,6 +690,21 @@ module ActiveRecord
         end
       end
 
+      unless current_adapter?(:SQLite3Adapter)
+        test "#execute is retryable" do
+          conn_id = case @connection.class::ADAPTER_NAME
+                    when "Mysql2"
+                      @connection.execute("SELECT CONNECTION_ID()").to_a[0][0]
+                    when "PostgreSQL"
+                      @connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
+          end
+
+          kill_connection_from_server(conn_id)
+
+          @connection.execute("SELECT 1", allow_retry: true)
+        end
+      end
+
       private
         def raw_transaction_open?(connection)
           case connection.class::ADAPTER_NAME
@@ -730,6 +745,18 @@ module ActiveRecord
           else
             skip
           end
+        end
+
+        def kill_connection_from_server(connection_id)
+          conn = @connection.pool.checkout
+          case conn.class::ADAPTER_NAME
+          when "Mysql2"
+            conn.execute("KILL #{connection_id}")
+          when "PostgreSQL"
+            conn.execute("SELECT pg_cancel_backend(#{connection_id})")
+          end
+
+          conn.close
         end
     end
   end


### PR DESCRIPTION

### Motivation / Background

In order to opt-into retry behaviour, the entire `#execute` method needs to be reimplemented. If instead we allow `#execute` to take the `allow_retry` option, apps can patch `#execute` to call super with `allow_retry: true`.

### Additional information

We discussed adding a config to allow apps to turn on retries across all queries, but decided that this was too risky a config to introduce to Rails, despite the fact that Shopify and Github applications have historically retried all queries without much deliberation. Changing `#execute` seems like a good compromise -- apps still have to knowingly patch `#execute` in order to get retry behaviour, but this way our patches don't need to reimplement the entire method, which makes them less brittle.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] There are no typos in commit messages and comments.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Feature branch is up-to-date with `main` (if not - rebase it).
* [X] Pull request only contains one commit for bug fixes and small features. If it's a larger feature, multiple commits are permitted but must be descriptive.
* [X] Tests are added if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] PR is not in a draft state.
* [x] CI is passing.
