### PR TITLE
Expose the request.parameter_filter

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -41,6 +41,7 @@ module ActionDispatch
         @filtered_parameters = nil
         @filtered_env        = nil
         @filtered_path       = nil
+        @parameter_filter    = nil
       end
 
       # Returns a hash of parameters with all sensitive data replaced.
@@ -60,13 +61,16 @@ module ActionDispatch
         @filtered_path ||= query_string.empty? ? path : "#{path}?#{filtered_query_string}"
       end
 
-    private
-      def parameter_filter # :doc:
-        parameter_filter_for fetch_header("action_dispatch.parameter_filter") {
-          return NULL_PARAM_FILTER
-        }
+      # Returns the +ActiveSupport::ParameterFilter+ object used to filter in this request.
+      def parameter_filter
+        @parameter_filter ||= if has_header?("action_dispatch.parameter_filter")
+          parameter_filter_for get_header("action_dispatch.parameter_filter")
+        else
+          NULL_PARAM_FILTER
+        end
       end
 
+    private
       def env_filter # :doc:
         user_key = fetch_header("action_dispatch.parameter_filter") {
           return NULL_ENV_FILTER

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1286,6 +1286,18 @@ class RequestParameterFilter < BaseRequestTest
     path = request.filtered_path
     assert_equal request.script_name + "/authenticate?secret", path
   end
+
+  test "parameter_filter returns the same instance of ActiveSupport::ParameterFilter" do
+    request = stub_request(
+      "action_dispatch.parameter_filter" => [:secret]
+    )
+
+    filter = request.parameter_filter
+
+    assert_kind_of ActiveSupport::ParameterFilter, filter
+    assert_equal({ "secret" => "[FILTERED]", "something" => "bar" }, filter.filter("secret" => "foo", "something" => "bar"))
+    assert_same filter, request.parameter_filter
+  end
 end
 
 class RequestEtag < BaseRequestTest


### PR DESCRIPTION
This is useful when you want to filter your own hashes based on the same parameter filter as the request.

Examples of this are exception notification and logging, that needs to load headers or even custom values from the request, and want to keep filtering those.