### PR TITLE
Fix encryption of column default values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   Fix encryption of column default values.
+
+    Previously, encrypted attributes that used column default values appeared to
+    be encrypted on create, but were not:
+
+      ```ruby
+      Book.encrypts :name
+
+      book = Book.create!
+      book.name
+      # => "<untitled>"
+      book.name_before_type_cast
+      # => "{\"p\":\"abc..."
+      book.reload.name_before_type_cast
+      # => "<untitled>"
+      ```
+
+    Now, attributes with column default values are encrypted:
+
+      ```ruby
+      Book.encrypts :name
+
+      book = Book.create!
+      book.name
+      # => "<untitled>"
+      book.name_before_type_cast
+      # => "{\"p\":\"abc..."
+      book.reload.name_before_type_cast
+      # => "{\"p\":\"abc..."
+      ```
+
+    *Jonathan Hefner*
+
 *   Deprecate delegation from `Base` to `connection_handler`.
 
     Calling `Base.clear_all_connections!`, `Base.clear_active_connections!`, `Base.clear_reloadable_connections!` and `Base.flush_idle_connections!` is deprecated. Please call these methods on the connection handler directly. In future Rails versions, the delegation from `Base` to the `connection_handler` will be removed.

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -311,6 +311,7 @@ module ActiveRecord # :nodoc:
     include Attributes
     include Locking::Optimistic
     include Locking::Pessimistic
+    include Encryption::EncryptableRecord
     include AttributeMethods
     include Callbacks
     include Timestamp
@@ -328,7 +329,6 @@ module ActiveRecord # :nodoc:
     include TokenFor
     include SignedId
     include Suppressor
-    include Encryption::EncryptableRecord
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -161,6 +161,15 @@ module ActiveRecord
       private
         ORIGINAL_ATTRIBUTE_PREFIX = "original_"
 
+        def _create_record(attribute_names = self.attribute_names)
+          if has_encrypted_attributes?
+            # Always persist encrypted attributes, because an attribute might be
+            # encrypting a column default value.
+            attribute_names |= self.class.encrypted_attributes.map(&:to_s)
+          end
+          super
+        end
+
         def encrypt_attributes
           validate_encryption_allowed
 

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -10,10 +10,13 @@ end
 module ActiveRecord::Encryption
   module EncryptionHelpers
     def assert_encrypted_attribute(model, attribute_name, expected_value)
-      encrypted_content = model.ciphertext_for(attribute_name)
-      assert_not_equal expected_value, encrypted_content
+      assert_not_equal expected_value, model.ciphertext_for(attribute_name)
       assert_equal expected_value, model.public_send(attribute_name)
-      assert_equal expected_value, model.reload.public_send(attribute_name) unless model.new_record?
+      unless model.new_record?
+        model.reload
+        assert_not_equal expected_value, model.ciphertext_for(attribute_name)
+        assert_equal expected_value, model.public_send(attribute_name)
+      end
     end
 
     def assert_invalid_key_cant_read_attribute(model, attribute_name)


### PR DESCRIPTION
Prior to this commit, encrypted attributes that used column default values appeared to be encrypted on create, but were not:

  ```ruby
  Book.encrypts :name

  book = Book.create!
  book.name
  # => "<untitled>"
  book.name_before_type_cast
  # => "{\"p\":\"abc..."
  book.reload.name_before_type_cast
  # => "<untitled>"
  ```

This commit ensures attributes with column default values are encrypted:

  ```ruby
  Book.encrypts :name

  book = Book.create!
  book.name
  # => "<untitled>"
  book.name_before_type_cast
  # => "{\"p\":\"abc..."
  book.reload.name_before_type_cast
  # => "{\"p\":\"abc..."
  ```

The existing ["support encrypted attributes defined on columns with default values" test](https://github.com/rails/rails/blob/0eb42cae30e3b74d88771c971d2d2957084cf88a/activerecord/test/cases/encryption/encryptable_record_test.rb#L295-L298) in `encryptable_record_test.rb` shows the intended behavior, but it was not failing without a `reload`.
