### PR TITLE
Fix `ciphertext_for` for yet-to-be-encrypted values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   Fix `ciphertext_for` for yet-to-be-encrypted values.
+
+    Previously, `ciphertext_for` returned the cleartext of values that had not
+    yet been encrypted, such as with an unpersisted record:
+
+      ```ruby
+      Post.encrypts :body
+
+      post = Post.create!(body: "Hello")
+      post.ciphertext_for(:body)
+      # => "{\"p\":\"abc..."
+
+      post.body = "World"
+      post.ciphertext_for(:body)
+      # => "World"
+      ```
+
+    Now, `ciphertext_for` will always return the ciphertext of encrypted
+    attributes:
+
+      ```ruby
+      Post.encrypts :body
+
+      post = Post.create!(body: "Hello")
+      post.ciphertext_for(:body)
+      # => "{\"p\":\"abc..."
+
+      post.body = "World"
+      post.ciphertext_for(:body)
+      # => "{\"p\":\"xyz..."
+      ```
+
+    *Jonathan Hefner*
+
 *   Fix a bug where using groups and counts with long table names would return incorrect results.
 
     *Shota Toguchi*, *Yusaku Ono*

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -140,12 +140,16 @@ module ActiveRecord
 
       # Returns whether a given attribute is encrypted or not.
       def encrypted_attribute?(attribute_name)
-        ActiveRecord::Encryption.encryptor.encrypted? ciphertext_for(attribute_name)
+        ActiveRecord::Encryption.encryptor.encrypted? read_attribute_before_type_cast(attribute_name)
       end
 
       # Returns the ciphertext for +attribute_name+.
       def ciphertext_for(attribute_name)
-        read_attribute_before_type_cast(attribute_name)
+        if encrypted_attribute?(attribute_name)
+          read_attribute_before_type_cast(attribute_name)
+        else
+          read_attribute_for_database(attribute_name)
+        end
       end
 
       # Encrypts all the encryptable attributes and saves the changes.


### PR DESCRIPTION
Prior to this commit, `ciphertext_for` returned the cleartext of values that had not yet been encrypted, such as with an unpersisted record:

  ```ruby
  Post.encrypts :body

  post = Post.create!(body: "Hello")
  post.ciphertext_for(:body)
  # => "{\"p\":\"abc..."

  post.body = "World"
  post.ciphertext_for(:body)
  # => "World"
  ```

This commit fixes `ciphertext_for` to always return the ciphertext of encrypted attributes:

  ```ruby
  Post.encrypts :body

  post = Post.create!(body: "Hello")
  post.ciphertext_for(:body)
  # => "{\"p\":\"abc..."

  post.body = "World"
  post.ciphertext_for(:body)
  # => "{\"p\":\"xyz..."
  ```

---

@jorgemanrubia Does the behavior in this PR seem correct to you?
