### PR TITLE
Skip validation options for `change_table` in old migrations

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -34,7 +34,12 @@ module ActiveRecord
 
       class V7_0 < V7_1
         module TableDefinition
-          def new_column_definition(name, type, **options)
+          def column(name, type, **options)
+            options[:_skip_validate_options] = true
+            super
+          end
+
+          def change(name, type, **options)
             options[:_skip_validate_options] = true
             super
           end
@@ -75,6 +80,7 @@ module ActiveRecord
         end
 
         def change_column(table_name, column_name, type, **options)
+          options[:_skip_validate_options] = true
           if connection.adapter_name == "Mysql2"
             options[:collation] = :no_collation
           end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -265,6 +265,13 @@ module ActiveRecord
             end
 
             add_column :tests, "last_name", :string, wrong_precision: true
+
+            change_column :tests, :some_id, :float, wrong_index: true
+
+            change_table :tests do |t|
+              t.change :some_id, :float, null: false, wrong_index: true
+              t.integer :another_id, wrong_unique: true
+            end
           end
         }.new
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because while we were upgrading Rails version for Github, we saw an error for older migrations for `change_table`, ex:

```ruby
class SomeMigration < ActiveRecord::Migration[7.0]
  change_table :tests do |t|
    t.change :some_id, :float, null: false, index: true # <- `index` is not a valid option here
  end
end
```

It resulted in the following error message:

```
Unknown key: :index. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :auto_increment, :charset, :as, :size, :unsigned, :first, :after, :type, :stored
```

### Detail

This Pull Request revises the changes at https://github.com/rails/rails/pull/46178 to handle `change_table` in [compatibility.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration/compatibility.rb).

To better support both of `create_table` and `change_table`, we switched from overriding `#new_column_definition` to `#column` as that is called in both cases when adding a new column.

We also defined a similar `#change` override in order to skip validation options for `t.change` call.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

