### PR TITLE
Add missing `preview` event  to `ActiveStorage::LogSubscriber`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add missing preview event to `ActiveStorage::LogSubscriber`
+
+    A `preview` event is being instrumented in `ActiveStorage::Previewer`.
+    However it was not added inside ActiveStorage's LogSubscriber class.
+
+    This will allow to have logs for when a preview happens
+    in the same fashion as all other ActiveStorage events such as
+    `upload` and `download` inside `Rails.logger`.
+
+    *Chedli Bourguiba*
+
 *   Fix retrieving rotation value from FFmpeg on version 5.0+.
 
     In FFmpeg version 5.0+ the rotation value has been removed from tags.

--- a/activestorage/lib/active_storage/log_subscriber.rb
+++ b/activestorage/lib/active_storage/log_subscriber.rb
@@ -18,6 +18,11 @@ module ActiveStorage
 
     alias_method :service_streaming_download, :service_download
 
+    def preview(event)
+      info event, color("Previewed file from key: #{key_in(event)}", BLUE)
+    end
+    subscribe_log_level :preview, :info
+
     def service_delete(event)
       info event, color("Deleted file from key: #{key_in(event)}", RED)
     end

--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -65,7 +65,12 @@ module ActiveStorage
       end
 
       def instrument(operation, payload = {}, &block)
-        ActiveSupport::Notifications.instrument "#{operation}.active_storage", payload, &block
+        ActiveSupport::Notifications.instrument "#{operation}.active_storage", payload.merge(service: service_name), &block
+      end
+
+      def service_name
+        # ActiveStorage::Service::DiskService => Disk
+        blob.service.class.to_s.split("::").third.remove("Service")
       end
 
       def capture(*argv, to:)


### PR DESCRIPTION
A `preview` event is being [instrumented](https://github.com/rails/rails/blob/be0b5c65a175b6c92514375fc7044efb11cdbe90/activestorage/lib/active_storage/previewer.rb#L49) in `ActiveStorage::Previewer`. However it is not added inside ActiveStorage's `LogSubscriber` class.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

While making my custom ActiveStorage Previewer, I've realized that the `instrument` call for the `preview` method was not being displayed in the Rails logs. 

It would also be helpful to have logs for when a preview happens in the same fashion as all other ActiveStorage events such as `upload` and `download`, regardless of the previewer being used ( Default Rails ones, or custom ones)

### Detail

This Pull Request simply adds the missing `preview` method inside ActiveStorage's Log Subscriber, as well as merging the service name in the `ActiveStorage::Previewer`, deriving it from the `blob` reader already available, and mimicking a similar experience as all other ActiveStorage events. ( Although adding the previewer name as well can be a nice addition)

### Additional information
Here is a screenshot displaying the log when a preview happens.
<img width="725" alt="Screenshot 2022-10-20 at 21 51 35" src="https://user-images.githubusercontent.com/1371733/197047309-3a4a134f-e659-4af2-b592-84e1595948fa.png">

**I didn't add tests because LogSubscriber is not tested for the other methods.**
### Checklist



Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. ( **the file had no associated tests** )
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.