### PR TITLE
Fix Action View compatibility with jbuilder

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -142,7 +142,7 @@ module ActionView
       attr_reader :body, :template
 
       def initialize(body, template)
-        @body = body.to_s
+        @body = body
         @template = template
       end
 

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -180,7 +180,7 @@ module ActionView
           view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, has_strict_locals: @strict_locals, &block)
           nil
         else
-          view._run(method_name, self, locals, OutputBuffer.new, add_to_stack: add_to_stack, has_strict_locals: @strict_locals, &block).to_s
+          view._run(method_name, self, locals, OutputBuffer.new, add_to_stack: add_to_stack, has_strict_locals: @strict_locals, &block)&.to_s
         end
       end
     rescue => e


### PR DESCRIPTION
Fix: https://github.com/rails/jbuilder/issues/540

jbuilder is doing some weird things such as instantiatign RenderedTemplate with a `Hash` instance as a `body`.

So we can't forcibly cast to string in these places.
