### PR TITLE
Allow ErrorReporter to handle several error classes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `Rails.error.handle` and `Rails.error.record` filter now by multiple error classes.
+
+    ```ruby
+    Rails.error.handle(IOError, ArgumentError) do
+      1 + '1' # raises TypeError
+    end
+    1 + 1 # TypeErrors are not IOErrors or ArgumentError, so this will *not* be handled
+    ```
+
+    *Martin Spickermann*
+
 *   `Class#subclasses` and `Class#descendants` now automatically filter reloaded classes.
 
     Previously they could return old implementations of reloadable classes that have been

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -42,7 +42,7 @@ module ActiveSupport
     #     1 + '1'
     #   end
     #
-    # Can be restricted to handle only a specific error class:
+    # Can be restricted to handle only specific error classes:
     #
     #   maybe_tags = Rails.error.handle(Redis::BaseError) { redis.get("tags") }
     #
@@ -69,9 +69,10 @@ module ActiveSupport
     # * +:source+ - This value is passed along to subscribers to indicate the
     #   source of the error. Subscribers can use this value to ignore certain
     #   errors. Defaults to <tt>"application"</tt>.
-    def handle(error_class = StandardError, severity: :warning, context: {}, fallback: nil, source: DEFAULT_SOURCE)
+    def handle(*error_classes, severity: :warning, context: {}, fallback: nil, source: DEFAULT_SOURCE)
+      error_classes = [StandardError] if error_classes.blank?
       yield
-    rescue error_class => error
+    rescue *error_classes => error
       report(error, handled: true, severity: severity, context: context, source: source)
       fallback.call if fallback
     end
@@ -84,7 +85,7 @@ module ActiveSupport
     #     1 + '1'
     #   end
     #
-    # Can be restricted to handle only a specific error class:
+    # Can be restricted to handle only specific error classes:
     #
     #   tags = Rails.error.record(Redis::BaseError) { redis.get("tags") }
     #
@@ -104,9 +105,10 @@ module ActiveSupport
     # * +:source+ - This value is passed along to subscribers to indicate the
     #   source of the error. Subscribers can use this value to ignore certain
     #   errors. Defaults to <tt>"application"</tt>.
-    def record(error_class = StandardError, severity: :error, context: {}, source: DEFAULT_SOURCE)
+    def record(*error_classes, severity: :error, context: {}, source: DEFAULT_SOURCE)
+      error_classes = [StandardError] if error_classes.blank?
       yield
-    rescue error_class => error
+    rescue *error_classes => error
       report(error, handled: false, severity: severity, context: context, source: source)
       raise
     end

--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -131,9 +131,9 @@ Rails.error.handle(context: {user_id: user.id}, severity: :info) do
 end
 ```
 
-### Filtering by Error Class
+### Filtering by Error Classes
 
-With `Rails.error.handle` and `Rails.error.record`, you can also choose to only report errors of a certain class. For example:
+With `Rails.error.handle` and `Rails.error.record`, you can also choose to only report errors of certain classes. For example:
 
 ```ruby
 Rails.error.handle(IOError) do


### PR DESCRIPTION
### Motivation / Background

The error reporter aims to replace boilerplate error-handling code like this:

```ruby
begin
  do_something
rescue SomethingIsBroken => error
  MyErrorReportingService.notify(error)
end
```

with a consistent interface:

```ruby
Rails.error.handle(SomethingIsBroken) do
  do_something
end
```

But sometimes you want to be able to rescue from several error classes, for example:

```ruby
Rails.error.handle(ArgumentError, TypeError) do
  [1, 2, 3].first(x) # where `x` might be `-4` or `'4'` 
end
```

This PR adds the ability to pass a list of error classes to `Rails.error.handle` and `Rails.error.record`. And it is fully backwards compatible.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

