### PR TITLE
Use one-liner for destructive transform keys in object

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -129,11 +129,12 @@ class Hash
     def _deep_transform_keys_in_object!(object, &block)
       case object
       when Hash
-        object.keys.each do |key|
-          value = object.delete(key)
-          object[yield(key)] = _deep_transform_keys_in_object!(value, &block)
+        object.tap do |result|
+          result.keys.each do |key|
+            value = result.delete(key)
+            result[yield(key)] = _deep_transform_keys_in_object!(value, &block)
+          end
         end
-        object
       when Array
         object.map! { |e| _deep_transform_keys_in_object!(e, &block) }
       else


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because using a single-line method with `tap` is more of Ruby way than using an extra line

### Detail

This Pull Request changes `_deep_transform_keys_in_object!` method realization with `tap`. `case` that it touches will become more elegant and readable
