### PR TITLE
MemoryStore: preserve entry ttl when incrementing

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix MemoryStore to preserve entries TTL when incrementing or decrementing
+
+    This is to be more consistent with how MemCachedStore and RedisCacheStore behaves.
+
+    *Jean Boussier*
+
 *   `Rails.error.handle` and `Rails.error.record` filter now by multiple error classes.
 
     ```ruby


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/46301

When incrementing in Memcached or Redis, we use `raw` values, so only the backing store TTL counts, and is preserved.

So for consistency we need to emulate this in MemoryStore by re-using the existing entry's `expires_at`.
