### PR TITLE
Removes the Content-Length header in Blobs::Proxycontroller#show

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -16,7 +16,6 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     else
       http_cache_forever public: true do
         response.headers["Accept-Ranges"] = "bytes"
-        response.headers["Content-Length"] = @blob.byte_size.to_s
 
         send_blob_stream @blob, disposition: params[:disposition]
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I researched the cause for #46288. When investigating, I noticed we're setting the header but always remove it later in the code linked below.

### Detail

Even though the Content-Length header is set in the controller action, it will always be removed in https://github.com/rails/rails/blob/7fdcbe747f7ab5ef664b894f73c8e0ada04c5c50/actionpack/lib/action_controller/metal/live.rb#L154 We should not set it in the first place in this action.