### PR TITLE
PR template: note about auto-closing issues [ci skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,10 @@ Feel free to discard it if you need to (e.g. when you just fix a typo). -->
 
 ### Motivation / Background
 
-<!-- Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important? -->
+<!--
+Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
+If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to to this PR.
+-->
 
 This Pull Request has been created because [REPLACE ME]
 


### PR DESCRIPTION
I've noticed a few PRs made since the latest template update, that have said things like "this PR was created because of #ISSUE" or things along those lines. It seems like people are reading the template and following its advice!

But Github requires a specific syntax to auto-close an issue, so we may as well encourage people to use that to save everyone a bit of time. So in this PR I've added a comment to the template explaining that.
