### PR TITLE
Fix Action Mailer not skipped when Active Job is (7-0-stable)

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -438,7 +438,7 @@ module Rails
 
       def delete_app_views_if_api_option
         if options[:api]
-          if options[:skip_action_mailer]
+          if skip_action_mailer?
             remove_dir "app/views"
           else
             remove_file "app/views/layouts/application.html.erb"
@@ -483,7 +483,7 @@ module Rails
       end
 
       def delete_action_mailer_files_skipping_action_mailer
-        if options[:skip_action_mailer]
+        if skip_action_mailer?
           remove_file "app/views/layouts/mailer.html.erb"
           remove_file "app/views/layouts/mailer.text.erb"
           remove_dir "app/mailers"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -39,7 +39,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
   <%- end -%>
-  <%- unless options.skip_action_mailer? -%>
+  <%- unless skip_action_mailer? -%>
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -72,7 +72,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "<%= app_name %>_production"
 
   <%- end -%>
-  <%- unless options.skip_action_mailer? -%>
+  <%- unless skip_action_mailer? -%>
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.active_storage.service = :test
 
   <%- end -%>
-  <%- unless options.skip_action_mailer? -%>
+  <%- unless skip_action_mailer? -%>
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -28,14 +28,14 @@ module Rails
 
         empty_directory_with_keep_file "app/models/concerns"
         empty_directory_with_keep_file "app/controllers/concerns"
-        remove_dir "app/mailers" if options[:skip_action_mailer]
+        remove_dir "app/mailers" if skip_action_mailer?
         remove_dir "app/jobs" if options[:skip_active_job]
       elsif full?
         empty_directory_with_keep_file "app/models"
         empty_directory_with_keep_file "app/controllers"
         empty_directory_with_keep_file "app/models/concerns"
         empty_directory_with_keep_file "app/controllers/concerns"
-        empty_directory_with_keep_file "app/mailers" unless options[:skip_action_mailer]
+        empty_directory_with_keep_file "app/mailers" unless skip_action_mailer?
         empty_directory_with_keep_file "app/jobs" unless options[:skip_active_job]
 
         unless api?


### PR DESCRIPTION
### Motivation / Background

Previously, generating an app with `rails new jobless --skip-active-job` would error because it would still generate files and configuration for Action Mailer. The Action Mailer railtie would be commented in config/application because it correctly used the skip_action_mailer? method added in 9578865, so the app generation would fail when it tried to reload the app.

Fixes #46295

### Detail

This commit fixes the issue by using skip_action_mailer? everywhere instead of options[:skip_action_mailer], which isn't aware of the Active Job dependency.

### Additional information

This fix is only necessary for 7-0-stable because --skip-* option dependencies were completely reworked on main in 4c67975. This rework removed the need for the `skip_*?` methods and made the values in `options[:skip_*]` always correct.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

