### PR TITLE
Clarify activerecord changelog for sqlcommenter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -94,9 +94,9 @@
 
     *Guo Xiang Tan*, *George Wambold*
 
-*   Add configurable formatter on query log tags to support sqlcommenter. See #45139
+*   Update query log tags to use the [SQLCommenter](https://open-telemetry.github.io/opentelemetry-sqlcommenter/) format by default. See [#46179](https://github.com/rails/rails/issues/46179)
 
-    It is now possible to opt into sqlcommenter-formatted query log tags with `config.active_record.query_log_tags_format = :sqlcommenter`.
+    To opt out of SQLCommenter-formatted query log tags, set `config.active_record.query_log_tags_format = :legacy`. By default, this is set to `:sqlcommenter`.
 
     *Modulitos* and *Iheanyi*
 


### PR DESCRIPTION
### Motivation / Background

This is a minor fix to clarify a changelog entry I had made earlier. When we changed the default values for `config.active_record.query_log_tags_format` from `:legacy` to `:sqlcommenter` (in PR https://github.com/rails/rails/pull/46180), I should've updated the changelog entry to reflect that as well. Updating it now to avoid confusion.

This change is a followup to this issue: https://github.com/rails/rails/issues/46179.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

