### PR TITLE
Fix test where broadcaster doesn't define #silence

### DIFF
--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -74,6 +74,9 @@ module ActiveSupport
     test "#silence does not break custom loggers" do
       new_logger = FakeLogger.new
       custom_logger = CustomLogger.new
+      assert_respond_to new_logger, :silence
+      assert_not_respond_to custom_logger, :silence
+
       custom_logger.extend(Logger.broadcast(new_logger))
 
       custom_logger.silence do
@@ -115,8 +118,6 @@ module ActiveSupport
     end
 
     class CustomLogger
-      include ActiveSupport::LoggerSilence
-
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level
 
@@ -168,6 +169,11 @@ module ActiveSupport
     end
 
     class FakeLogger < CustomLogger
+      include ActiveSupport::LoggerSilence
+
+      # LoggerSilence includes LoggerThreadSafeLevel which defines these as
+      # methods, so we need to redefine them
+      attr_accessor :level, :local_level
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This test was added in 308e84e to ensure that calling #silence on a broadcasted logger works if the broadcastee implements #silence but the broadcaster does not.

However, `include ActiveSupport::LoggerSilence` was moved from the `FakeLogger` to the `CustomLogger` in 05ad44e. This resulted in both loggers in the above test implementing silence, so it no longer tested the behavior expected (that only one of them implements #silence).

### Detail

The inclusion of `LoggerSilence` was moved back to `FakeLogger` so that `CustomLogger` does not implement silence, and assertions were added so that this does not regress. In addition, methods transitively included by `LoggerSilence` are overriden so that they continue to behave like `CustomLogger`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

