### PR TITLE
Fix SQLCommenter value serialization

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -134,7 +134,7 @@ module ActiveRecord
         def tag_content
           context = ActiveSupport::ExecutionContext.to_h
 
-          tags.flat_map { |i| [*i] }.filter_map do |tag|
+          pairs = tags.flat_map { |i| [*i] }.filter_map do |tag|
             key, handler = tag
             handler ||= taggings[key]
 
@@ -149,9 +149,9 @@ module ActiveRecord
             else
               handler
             end
-
-            self.formatter.format(key, val) unless val.nil?
-          end.join(",")
+            [key, val] unless val.nil?
+          end
+          self.formatter.format(pairs)
         end
     end
   end

--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -8,8 +8,10 @@ module ActiveRecord
       end
 
       # Formats the key value pairs into a string.
-      def format(key, value)
-        "#{key}#{key_value_separator}#{format_value(value)}"
+      def format(pairs)
+        pairs.map! do |key, value|
+          "#{key}#{key_value_separator}#{format_value(value)}"
+        end.join(",")
       end
 
       private
@@ -25,9 +27,14 @@ module ActiveRecord
         @key_value_separator = "="
       end
 
+      def format(pairs)
+        pairs.sort_by!(&:first)
+        super
+      end
+
       private
         def format_value(value)
-          "'#{value.to_s.gsub("'", "\\\\'")}'"
+          "'#{ERB::Util.url_encode(value)}'"
         end
     end
   end

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -195,10 +195,10 @@ class QueryLogsTest < ActiveRecord::TestCase
 
     ActiveRecord::QueryLogs.tags = [
       :application,
-      { custom_proc: -> { "Joe's Crab Shack" } },
+      { tracestate: "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7", custom_proc: -> { "Joe's Shack" } },
     ]
 
-    assert_sql(%r{custom_proc='Joe\\'s Crab Shack'\*/}) do
+    assert_sql(%r{custom_proc='Joe%27s%20Shack',tracestate='congo%3Dt61rcWkgMzE%2Crojo%3D00f067aa0ba902b7'\*/}) do
       Dashboard.first
     end
   end


### PR DESCRIPTION
### Motivation / Background

Fix two issues with serialization from https://github.com/rails/rails/pull/45081
- Before escaping the `'` character during value serialization, URL encoding needs to be performed: https://google.github.io/sqlcommenter/spec/#value-serialization. Since Ruby already encodes `'`, it seems we can skip the second step to escape `'` completely.
- The serialized key-value pairs have to be sorted: https://google.github.io/sqlcommenter/spec/#sorting

There does seems to be some inconsistencies in the reference implementations upstream for which I filed an issue (https://github.com/google/sqlcommenter/issues/168) but this PR unambiguously fixes a couple of things that the specification prescribes.

cc @modulitos @iheanyi 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.