### PR TITLE
Fix content-type header with `send_stream`

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -321,7 +321,7 @@ module ActionController
     def send_stream(filename:, disposition: "attachment", type: nil)
       response.headers["Content-Type"] =
         (type.is_a?(Symbol) ? Mime[type].to_s : type) ||
-        Mime::Type.lookup_by_extension(File.extname(filename).downcase.delete(".")) ||
+        Mime::Type.lookup_by_extension(File.extname(filename).downcase.delete("."))&.to_s ||
         "application/octet-stream"
 
       response.headers["Content-Disposition"] =

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -168,6 +168,27 @@ module ActionController
         end
       end
 
+      def send_stream_with_inferred_content_type
+        send_stream(filename: "sample.csv") do |stream|
+          stream.writeln "fruit,quantity"
+          stream.writeln "apple,5"
+        end
+      end
+
+      def send_stream_with_implicit_content_type
+        send_stream(filename: "sample.csv", type: :csv) do |stream|
+          stream.writeln "fruit,quantity"
+          stream.writeln "apple,5"
+        end
+      end
+
+      def send_stream_with_explicit_content_type
+        send_stream(filename: "sample.csv", type: "text/csv") do |stream|
+          stream.writeln "fruit,quantity"
+          stream.writeln "apple,5"
+        end
+      end
+
       def blocking_stream
         response.headers["Content-Type"] = "text/event-stream"
         %w{ hello world }.each do |word|
@@ -358,6 +379,36 @@ module ActionController
       assert_equal "application/json", @response.headers["Content-Type"]
       assert_match "inline", @response.headers["Content-Disposition"]
       assert_match "export", @response.headers["Content-Disposition"]
+    end
+
+    def test_send_stream_with_explicit_content_type
+      get :send_stream_with_explicit_content_type
+
+      assert_equal "fruit,quantity\napple,5\n", @response.body
+
+      content_type = @response.headers.fetch("Content-Type")
+      assert_equal String, content_type.class
+      assert_equal "text/csv", content_type
+    end
+
+    def test_send_stream_with_implicit_content_type
+      get :send_stream_with_implicit_content_type
+
+      assert_equal "fruit,quantity\napple,5\n", @response.body
+
+      content_type = @response.headers.fetch("Content-Type")
+      assert_equal String, content_type.class
+      assert_equal "text/csv", content_type
+    end
+
+    def test_send_stream_with_inferred_content_type
+      get :send_stream_with_inferred_content_type
+
+      assert_equal "fruit,quantity\napple,5\n", @response.body
+
+      content_type = @response.headers.fetch("Content-Type")
+      assert_equal String, content_type.class
+      assert_equal "text/csv", content_type
     end
 
     def test_delayed_autoload_after_write_within_interlock_hook


### PR DESCRIPTION
[The Rack specification](https://github.com/rack/rack/blob/0a62f75eeee8fbf14e87a92d458a4428382e3504/SPEC.rdoc#label-The+Headers) states that header values must be a `String` instance (or array thereof).

When setting up the content-type header based on the file extension, `send_stream` assigns the whole
`Mime::Type` object, instead of its `String`
representation.

This change ensures that all three ways of setting the content-type header (implicit via extension,
implicit via a symbol, and explicit via a string)
all result in a `String` instance being assigned as the header's value.

### Motivation / Background

This Pull Request has been created because other libraries (in this case specifically https://github.com/DFE-Digital/dfe-analytics and its use of BigQuery) assume that header values will be strings per the rack spec.

### Detail

This Pull Request changes the behaviour of `send_stream` when it is inferring a content-type from the file extension, so that it assigns a `String` instance as the header value rather than a `Mime::Type` instance.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

