### PR TITLE
Apply config to `Rails.application.deprecators`

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -71,20 +71,22 @@ module ActiveSupport
 
     initializer "active_support.deprecation_behavior" do |app|
       if app.config.active_support.report_deprecations == false
-        ActiveSupport::Deprecation.silenced = true
-        ActiveSupport::Deprecation.behavior = :silence
-        ActiveSupport::Deprecation.disallowed_behavior = :silence
+        app.deprecators.silenced = true
+        app.deprecators.behavior = :silence
+        app.deprecators.disallowed_behavior = :silence
       else
         if deprecation = app.config.active_support.deprecation
-          ActiveSupport::Deprecation.behavior = deprecation
+          app.deprecators.behavior = deprecation
         end
 
         if disallowed_deprecation = app.config.active_support.disallowed_deprecation
-          ActiveSupport::Deprecation.disallowed_behavior = disallowed_deprecation
+          app.deprecators.disallowed_behavior = disallowed_deprecation
         end
 
         if disallowed_warnings = app.config.active_support.disallowed_deprecation_warnings
-          ActiveSupport::Deprecation.disallowed_warnings = disallowed_warnings
+          app.deprecators.each do |deprecator|
+            deprecator.disallowed_warnings = disallowed_warnings
+          end
         end
       end
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2030,15 +2030,15 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_support.deprecation`
 
-Configures the behavior of deprecation warnings. The options are `:raise`, `:stderr`, `:log`, `:notify`, or `:silence`. The default is `:stderr`. Alternatively, you can set `ActiveSupport::Deprecation.behavior`.
+Configures the behavior of deprecation warnings. The options are `:raise`, `:stderr`, `:log`, `:notify`, or `:silence`. The default is `:stderr`.
 
 #### `config.active_support.disallowed_deprecation`
 
-Configures the behavior of disallowed deprecation warnings. The options are `:raise`, `:stderr`, `:log`, `:notify`, or `:silence`. The default is `:raise`. Alternatively, you can set `ActiveSupport::Deprecation.disallowed_behavior`.
+Configures the behavior of disallowed deprecation warnings. The options are `:raise`, `:stderr`, `:log`, `:notify`, or `:silence`. The default is `:raise`.
 
 #### `config.active_support.disallowed_deprecation_warnings`
 
-Configures deprecation warnings that the Application considers disallowed. This allows, for example, specific deprecations to be treated as hard failures. Alternatively, you can set `ActiveSupport::Deprecation.disallowed_warnings`.
+Configures deprecation warnings that the Application considers disallowed. This allows, for example, specific deprecations to be treated as hard failures.
 
 #### `config.active_support.report_deprecations`
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3893,18 +3893,18 @@ module ApplicationTests
       assert_equal true, ActiveSupport::TimeWithZone.methods(false).include?(:name)
     end
 
-    test "can entirely opt out of ActiveSupport::Deprecations" do
+    test "can entirely opt out of deprecation warnings" do
       add_to_config "config.active_support.report_deprecations = false"
 
       app "production"
 
-      assert_equal true, ActiveSupport::Deprecation.silenced
-      assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], ActiveSupport::Deprecation.behavior
-      assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], ActiveSupport::Deprecation.disallowed_behavior
+      assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
 
-      assert_equal true, Rails.application.deprecators[:rails].silenced
-      assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], Rails.application.deprecators[:rails].behavior
-      assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], Rails.application.deprecators[:rails].disallowed_behavior
+      Rails.application.deprecators.each do |deprecator|
+        assert_equal true, deprecator.silenced
+        assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], deprecator.behavior
+        assert_equal [ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:silence]], deprecator.disallowed_behavior
+      end
     end
 
     test "ParamsWrapper is enabled in a new app and uses JSON as the format" do


### PR DESCRIPTION
This applies the following configs to `Rails.application.deprecators`, which then applies them to `ActiveSupport::Deprecation.instance`:

* `config.active_support.report_deprecations`
* `config.active_support.deprecation`
* `config.active_support.disallowed_deprecation`
* `config.active_support.disallowed_deprecation_warnings`
