### PR TITLE
Add `ActiveRecord.deprecator`

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -30,6 +30,7 @@ require "arel"
 require "yaml"
 
 require "active_record/version"
+require "active_record/deprecator"
 require "active_model/attribute_set"
 require "active_record/errors"
 
@@ -337,14 +338,14 @@ module ActiveRecord
   self.dump_schemas = :schema_search_path
 
   def self.suppress_multiple_database_warning
-    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+    ActiveRecord.deprecator.warn(<<-MSG.squish)
       config.active_record.suppress_multiple_database_warning is deprecated and will be removed in Rails 7.2.
       It no longer has any effect and should be removed from the configuration file.
     MSG
   end
 
   def self.suppress_multiple_database_warning=(value)
-    ActiveSupport::Deprecation.warn(<<-MSG.squish)
+    ActiveRecord.deprecator.warn(<<-MSG.squish)
       config.active_record.suppress_multiple_database_warning= is deprecated and will be removed in Rails 7.2.
       It no longer has any effect and should be removed from the configuration file.
     MSG

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -29,7 +29,7 @@ module ActiveRecord
 
       module ClassMethods
         def partial_writes
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             ActiveRecord::Base.partial_writes is deprecated and will be removed in Rails 7.1.
             Use `partial_updates` and `partial_inserts` instead.
           MSG
@@ -37,7 +37,7 @@ module ActiveRecord
         end
 
         def partial_writes?
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             `ActiveRecord::Base.partial_writes?` is deprecated and will be removed in Rails 7.1.
             Use `partial_updates?` and `partial_inserts?` instead.
           MSG
@@ -45,7 +45,7 @@ module ActiveRecord
         end
 
         def partial_writes=(value)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             `ActiveRecord::Base.partial_writes=` is deprecated and will be removed in Rails 7.1.
             Use `partial_updates=` and `partial_inserts=` instead.
           MSG

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -93,7 +93,7 @@ module ActiveRecord
       end
 
       def all_connection_pools
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
           The `all_connection_pools` method is deprecated in favor of `connection_pool_list`.
           Call `connection_pool_list(:all)` to get the same behavior as `all_connection_pools`.
         MSG
@@ -288,7 +288,7 @@ module ActiveRecord
           end
 
           if roles.flatten.uniq.count > 1
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
               `#{method}` currently only applies to connection pools in the current
               role (`#{ActiveRecord::Base.current_role}`). In Rails 7.1, this method
               will apply to all known pools, regardless of role. To affect only those

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         pool_config.connection_class
       end
       alias :connection_klass :connection_class
-      deprecate :connection_klass
+      deprecate :connection_klass, deprecator: ActiveRecord.deprecator
 
       # Returns true if there is an open connection being used for the current thread.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -221,7 +221,7 @@ module ActiveRecord
         end
 
         def warn_quote_duration_deprecated
-          ActiveSupport::Deprecation.warn(<<~MSG)
+          ActiveRecord.deprecator.warn(<<~MSG)
             Using ActiveSupport::Duration as an interpolated bind parameter in a SQL
             string template is deprecated. To avoid this warning, you should explicitly
             convert the duration to a more specific database type. For example, if you

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -487,7 +487,7 @@ module ActiveRecord
                 if !completed && transaction.written_indirectly
                   # This is the case that was missed in the 6.1 deprecation, so we have to
                   # do it now
-                  ActiveSupport::Deprecation.warn(<<~EOW)
+                  ActiveRecord.deprecator.warn(<<~EOW)
                     Using `return`, `break` or `throw` to exit a transaction block is
                     deprecated without replacement. If the `throw` came from
                     `Timeout.timeout(duration)`, pass an exception class as a second

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -172,7 +172,7 @@ module ActiveRecord
         end
 
         def default_prepared_statements
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             The default value of `prepared_statements` for the mysql2 adapter will be changed from +false+ to +true+ in Rails 7.2.
           MSG
           false

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -330,7 +330,7 @@ module ActiveRecord
 
     private
       def deprecation_for_delegation(method)
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
           Calling `ActiveRecord::Base.#{method} is deprecated. Please
           call the method directly on the connection handler; for
           example: `ActiveRecord::Base.connection_handler.#{method}`.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -309,7 +309,7 @@ module ActiveRecord
       ).each do |attr|
         module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def #{attr}
-            ActiveSupport::Deprecation.warn(<<~MSG)
+            ActiveRecord.deprecator.warn(<<~MSG)
               ActiveRecord::Base.#{attr} is deprecated and will be removed in Rails 7.1.
               Use `ActiveRecord.#{attr}` instead.
             MSG
@@ -317,7 +317,7 @@ module ActiveRecord
           end
 
           def #{attr}=(value)
-            ActiveSupport::Deprecation.warn(<<~MSG)
+            ActiveRecord.deprecator.warn(<<~MSG)
               ActiveRecord::Base.#{attr}= is deprecated and will be removed in Rails 7.1.
               Use `ActiveRecord.#{attr}=` instead.
             MSG

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -45,7 +45,7 @@ module ActiveRecord
     def configs_for(env_name: nil, name: nil, include_replicas: false, include_hidden: false)
       if include_replicas
         include_hidden = include_replicas
-        ActiveSupport::Deprecation.warn("The kwarg `include_replicas` is deprecated in favor of `include_hidden`. When `include_hidden` is passed, configurations with `replica: true` or `database_tasks: false` will be returned. `include_replicas` will be removed in Rails 7.1.")
+        ActiveRecord.deprecator.warn("The kwarg `include_replicas` is deprecated in favor of `include_hidden`. When `include_hidden` is passed, configurations with `replica: true` or `database_tasks: false` will be returned. `include_replicas` will be removed in Rails 7.1.")
       end
 
       env_name ||= default_env if name

--- a/activerecord/lib/active_record/deprecator.rb
+++ b/activerecord/lib/active_record/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -12,7 +12,8 @@ module ActiveRecord
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor
   DeprecatedActiveJobRequiredError = Class.new(ActiveRecordError) # :nodoc:
   deprecate_constant "ActiveJobRequiredError", "ActiveRecord::DeprecatedActiveJobRequiredError",
-    message: "ActiveRecord::ActiveJobRequiredError has been deprecated. If Active Job is not present, a NameError will be raised instead."
+    message: "ActiveRecord::ActiveJobRequiredError has been deprecated. If Active Job is not present, a NameError will be raised instead.",
+    deprecator: ActiveRecord.deprecator
 
   # Raised when the single-table inheritance mechanism fails to locate the subclass
   # (for example due to improper usage of column that

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -7,21 +7,21 @@ module ActiveRecord
     class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new
 
     def self.runtime=(value)
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveRecord.deprecator.warn(<<-MSG.squish)
         ActiveRecord::LogSubscriber.runtime= is deprecated and will be removed in Rails 7.2.
       MSG
       ActiveRecord::RuntimeRegistry.sql_runtime = value
     end
 
     def self.runtime
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveRecord.deprecator.warn(<<-MSG.squish)
         ActiveRecord::LogSubscriber.runtime is deprecated and will be removed in Rails 7.2.
       MSG
       ActiveRecord::RuntimeRegistry.sql_runtime
     end
 
     def self.reset_runtime
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveRecord.deprecator.warn(<<-MSG.squish)
         ActiveRecord::LogSubscriber.reset_runtime is deprecated and will be removed in Rails 7.2.
       MSG
       ActiveRecord::RuntimeRegistry.reset

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1097,7 +1097,7 @@ module ActiveRecord
 
     def initialize(migrations_paths, schema_migration = nil, internal_metadata = nil)
       if schema_migration == SchemaMigration
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
           SchemaMigration no longer inherits from ActiveRecord::Base. If you want
           to use the default connection, remove this argument. If you want to use a
           specific connection, instaniate MigrationContext with the connection's schema
@@ -1108,7 +1108,7 @@ module ActiveRecord
       end
 
       if internal_metadata == InternalMetadata
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
           SchemaMigration no longer inherits from ActiveRecord::Base. If you want
           to use the default connection, remove this argument. If you want to use a
           specific connection, instaniate MigrationContext with the connection's internal

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -73,6 +73,10 @@ module ActiveRecord
       require "active_record/base"
     end
 
+    initializer "active_record.deprecator" do |app|
+      app.deprecators[:active_record] = ActiveRecord.deprecator
+    end
+
     initializer "active_record.initialize_timezone" do
       ActiveSupport.on_load(:active_record) do
         self.time_zone_aware_attributes = true

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -151,7 +151,7 @@ module ActiveRecord
         end
 
         if identity_or_column.nil?
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4.
             Sum of non-numeric elements requires an initial argument.
           MSG

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       if reflection = klass&._reflect_on_association(table_name)
         reflection
       elsif ActiveRecord.allow_deprecated_singular_associations_name && reflection = klass&._reflect_on_association(table_name.singularize)
-        ActiveSupport::Deprecation.warn(<<~MSG)
+        ActiveRecord.deprecator.warn(<<~MSG)
           Referring to a singular association (e.g. `#{reflection.name}`) by its plural name (e.g. `#{reflection.plural_name}`) is deprecated.
 
           To convert this deprecation warning to an error and enable more performant behavior, set config.active_record.allow_deprecated_singular_associations_name = false.

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -443,7 +443,7 @@ module ActiveRecord
           "structure.sql"
         end
       end
-      deprecate :schema_file_type
+      deprecate :schema_file_type, deprecator: ActiveRecord.deprecator
 
       def schema_dump_path(db_config, format = ActiveRecord.schema_format)
         return ENV["SCHEMA"] if ENV["SCHEMA"]

--- a/activerecord/test/activejob/destroy_association_async_job_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_job_test.rb
@@ -40,7 +40,7 @@ class DestroyAssociationAsyncJobTest < ActiveRecord::TestCase
   end
 
   test "deprecation of rescuing ActiveJobRequiredError which has been replaced by a NameError" do
-    assert_deprecated { ActiveRecord::ActiveJobRequiredError }
+    assert_deprecated(ActiveRecord.deprecator) { ActiveRecord::ActiveJobRequiredError }
   end
 
   test "belong_to dependent destroy_async requires destroy_association_async_job" do

--- a/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
@@ -79,7 +79,7 @@ module ActiveRecord
         end
 
         def test_where_with_duration_for_string_column_using_bind_parameters
-          count = assert_deprecated { Post.where("title = ?", 0.seconds).count }
+          count = assert_deprecated(ActiveRecord.deprecator) { Post.where("title = ?", 0.seconds).count }
           assert_equal 0, count
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -52,7 +52,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
         fake_connection,
         ActiveRecord::Base.logger,
@@ -84,7 +84,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    adapter = ActiveSupport::Deprecation.silence do
+    adapter = ActiveRecord.deprecator.silence do
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
         fake_connection,
         ActiveRecord::Base.logger,

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -21,7 +21,7 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_quote_bound_duration
-    expected = assert_deprecated { @conn.quote_bound_value(42.seconds) }
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(42.seconds) }
     assert_equal "'42'", expected
   end
 

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -46,7 +46,7 @@ module ActiveRecord
 
         def test_where_with_duration_for_string_column_using_bind_parameters
           assert_raises ActiveRecord::StatementInvalid do
-            assert_deprecated { Post.where("title = ?", 0.seconds).count }
+            assert_deprecated(ActiveRecord.deprecator) { Post.where("title = ?", 0.seconds).count }
           end
         end
       end

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -40,7 +40,7 @@ module ActiveRecord
         end
 
         def test_where_with_duration_for_string_column_using_bind_parameters
-          count = assert_deprecated { Post.where("title = ?", 0.seconds).count }
+          count = assert_deprecated(ActiveRecord.deprecator) { Post.where("title = ?", 0.seconds).count }
           assert_equal 0, count
         end
       end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -764,12 +764,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       firm = companies(:first_firm)
       lifo = Developer.new(name: "lifo")
       assert_raises(ActiveRecord::RecordInvalid) do
-        assert_deprecated { firm.developers << lifo }
+        assert_deprecated(ActiveRecord.deprecator) { firm.developers << lifo }
       end
 
       lifo = Developer.create!(name: "lifo")
       assert_raises(ActiveRecord::RecordInvalid) do
-        assert_deprecated { firm.developers << lifo }
+        assert_deprecated(ActiveRecord.deprecator) { firm.developers << lifo }
       end
     end
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -525,7 +525,7 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 6, [1, 2, 3].sum(&:abs)
     assert_equal 15, some_companies.sum(&:id)
     assert_equal 25, some_companies.sum(10, &:id)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal "LeetsoftJadedpixel", some_companies.sum(&:name)
     end
     assert_equal "companies: LeetsoftJadedpixel", some_companies.sum("companies: ", &:name)

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -323,13 +323,13 @@ module ActiveRecord
         assert_equal([@rw_pool], @handler.connection_pool_list(:writing))
         assert_equal([@ro_pool], @handler.connection_pool_list(:reading))
 
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           @handler.connection_pool_list
         end
       end
 
       def test_all_connection_pools
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_equal([@rw_pool, @ro_pool], @handler.all_connection_pools)
         end
       end
@@ -340,20 +340,20 @@ module ActiveRecord
       end
 
       def test_active_connections?
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_not_predicate @handler, :active_connections?
         end
 
         assert @handler.retrieve_connection(@connection_name)
         assert @handler.retrieve_connection(@connection_name, role: :reading)
 
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_predicate @handler, :active_connections?
         end
 
         @handler.clear_active_connections!(:all)
 
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_not_predicate @handler, :active_connections?
         end
       end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -111,7 +111,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   end
 
   def test_include_replicas_is_deprecated
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary", include_replicas: true)
 
       assert_equal "primary", db_config.name

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -19,7 +19,7 @@ require "support/connection"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+ActiveRecord.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -81,7 +81,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_passing_a_schema_migration_class_to_migration_context_is_deprecated
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = assert_deprecated { ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata) }
+    migrator = assert_deprecated(ActiveRecord.deprecator) { ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata) }
     migrator.up
 
     assert_equal 3, migrator.current_version

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -191,7 +191,7 @@ module ActiveRecord
       end
 
       def test_quote_duration
-        expected = assert_deprecated { @quoter.quote(30.minutes) }
+        expected = assert_deprecated(ActiveRecord.deprecator) { @quoter.quote(30.minutes) }
         assert_equal "1800", expected
       end
     end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -211,7 +211,7 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       transaction_with_shallow_return
     end
     assert committed
@@ -226,7 +226,7 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   def test_deprecation_on_ruby_timeout_outside_inner_transaction
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       catch do |timeout|
         Topic.transaction do
           Topic.transaction(requires_new: true) do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1773,13 +1773,17 @@ module ApplicationTests
     test "config.active_record.suppress_multiple_database_warning getter is deprecated" do
       app "development"
 
-      assert_deprecated { ActiveRecord.suppress_multiple_database_warning }
+      assert_deprecated(Rails.application.deprecators[:active_record]) do
+        ActiveRecord.suppress_multiple_database_warning
+      end
     end
 
     test "config.active_record.suppress_multiple_database_warning setter is deprecated" do
       app "development"
 
-      assert_deprecated { ActiveRecord.suppress_multiple_database_warning = true }
+      assert_deprecated(Rails.application.deprecators[:active_record]) do
+        ActiveRecord.suppress_multiple_database_warning = true
+      end
     end
 
     test "config.active_record.use_yaml_unsafe_load is false by default" do
@@ -3893,12 +3897,19 @@ module ApplicationTests
       assert_equal true, ActiveSupport::TimeWithZone.methods(false).include?(:name)
     end
 
+    test "Rails.application.deprecators includes framework deprecators" do
+      app "production"
+
+      assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
+      assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
+    end
+
     test "can entirely opt out of deprecation warnings" do
       add_to_config "config.active_support.report_deprecations = false"
 
       app "production"
 
-      assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
+      assert_predicate Rails.application.deprecators.each, :any?
 
       Rails.application.deprecators.each do |deprecator|
         assert_equal true, deprecator.silenced


### PR DESCRIPTION
This commit adds `ActiveRecord.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `activerecord/lib` with `ActiveRecord.deprecator`.

Additionally, this commit adds `ActiveRecord.deprecator` to `Rails.application.deprecators` so that it can be configured using e.g. `config.active_support.report_deprecations`.
