### PR TITLE
Allow specifying columns to use in ActiveRecord::Base object queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow configuring columns list to be used in SQL queries issued by an `ActiveRecord::Base` object
+
+    It is now possible to configure columns list that will be used to build an SQL query clauses when
+    updating, deleting or reloading an `ActiveRecord::Base` object
+
+    ```ruby
+    class Developer < ActiveRecord::Base
+      query_constraints :company_id, :id
+    end
+    developer = Developer.first.update(name: "Bob")
+    # => UPDATE "developers" SET "name" = 'Bob' WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+    ```
+
+    *Nikita Vasilevsky*
+
 *   Adds `validate` to foreign keys and check constraints in schema.rb
 
     Previously, `schema.rb` would not record if `validate: false` had been used when adding a foreign key or check

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -60,6 +60,7 @@ module ActiveRecord
   autoload :Persistence
   autoload :QueryCache
   autoload :Querying
+  autoload :QueryConstraints
   autoload :QueryLogs
   autoload :ReadonlyAttributes
   autoload :RecordInvalid, "active_record/validations"

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -91,7 +91,7 @@ module ActiveRecord
             locking_column = self.class.locking_column
             lock_attribute_was = @attributes[locking_column]
 
-            update_constraints = _primary_key_constraints_hash
+            update_constraints = _query_constraints_hash
             update_constraints[locking_column] = _lock_value_for_database(locking_column)
 
             attribute_names = attribute_names.dup if attribute_names.frozen?
@@ -122,7 +122,7 @@ module ActiveRecord
 
           locking_column = self.class.locking_column
 
-          delete_constraints = _primary_key_constraints_hash
+          delete_constraints = _query_constraints_hash
           delete_constraints[locking_column] = _lock_value_for_database(locking_column)
 
           affected_rows = self.class._delete_record(delete_constraints)

--- a/activerecord/lib/active_record/query_constraints.rb
+++ b/activerecord/lib/active_record/query_constraints.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module QueryConstraints
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :query_constraints_list, instance_writer: false
+    end
+
+    module ClassMethods
+      # Accepts a list of attribute names to be used in the WHERE clause
+      # of SELECT / UPDATE / DELETE queries.
+      #
+      #   class Developer < ActiveRecord::Base
+      #     query_constraints :company_id, :id
+      #   end
+      #
+      #   developer = Developer.first
+      #   developer.inspect # => #<Developer id: 1, company_id: 1, ...>
+      #
+      #   developer.update!(name: "Nikita")
+      #   # => UPDATE "developers" SET "name" = 'Nikita' WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+      #
+      #   It is possible to update attribute used in the query_by clause:
+      #   developer.update!(company_id: 2)
+      #   # => UPDATE "developers" SET "company_id" = 2 WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+      #
+      #   developer.name = "Bob"
+      #   developer.save!
+      #   # => UPDATE "developers" SET "name" = 'Bob' WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+      #
+      #   developer.destroy!
+      #   # => DELETE FROM "developers" WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+      #
+      #   developer.delete
+      #   # => DELETE FROM "developers" WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
+      #
+      #   developer.reload
+      #   # => SELECT "developers".* FROM "developers" WHERE "developers"."company_id" = 1 AND "developers"."id" = 1 LIMIT 1
+      def query_constraints(*columns_list)
+        self.query_constraints_list = columns_list.map(&:to_s)
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/query_constraints_test.rb
+++ b/activerecord/test/cases/query_constraints_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/clothing_item"
+
+class QueryConstraintsTest < ActiveRecord::TestCase
+  def test_primary_key_stays_the_same
+    assert_equal("id", ClothingItem.primary_key)
+  end
+
+  def test_query_constraints_list_is_an_array_of_strings
+    assert_equal(["clothing_type", "color"], ClothingItem.query_constraints_list)
+  end
+end

--- a/activerecord/test/fixtures/clothing_items.yml
+++ b/activerecord/test/fixtures/clothing_items.yml
@@ -1,0 +1,14 @@
+green_pants:
+  color: green
+  clothing_type: pants
+  description: Cool green pants
+
+green_t_shirt:
+  color: green
+  clothing_type: t-shirt
+  description: Cool green t-shirt
+
+red_t_shirt:
+  color: red
+  clothing_type: t-shirt
+  description: Cool red t-shirt

--- a/activerecord/test/models/clothing_item.rb
+++ b/activerecord/test/models/clothing_item.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ClothingItem < ActiveRecord::Base
+  query_constraints :clothing_type, :color
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -232,6 +232,14 @@ ActiveRecord::Schema.define do
     t.references :citation
   end
 
+  create_table :clothing_items, force: true do |t|
+    t.string :clothing_type
+    t.string :color
+    t.text :description
+
+    t.index [:clothing_type, :color], unique: true
+  end
+
   create_table :clubs, force: true do |t|
     t.string :name
     t.integer :category_id


### PR DESCRIPTION
### Description
This PR is a continuation of the PR that made a small refactoring to prepare Rails to support composite primary keys in the future - https://github.com/rails/rails/pull/41427
This PR renames `_primary_key_constraints_hash` private method to be less specific and adds a capability to configure it using a public `ActiveRecord::Base.query_constraints` macro.

### Rationale
This proposed capability is fundamental for supporting composite primary keys in Rails and utilizing tenant based sharding. A Tenant based sharding design requires all queries to a SQL database to include the sharding key. For example tables sharded by user_id will always need to be queried by user_id value to make sure that the query reaches the correct shard. As a real-world example of a sharding solution we can name [Vitess](https://vitess.io/), however, we are building a solution that is generic in a similar way with `default_scope(all_queries: true)` and will enable applications to query by multiple default constraints regardless of underlying technology.
### Implementation details

Renames `_primary_key_constraints_hash` to `_query_constraints_hash` to avoid being too specific as the feature doesn’t necessarily have to represent a primary key.

Defines a new `QueryConstraints` module with the definition of the `query_constraints` macro and `query_constraints_list` class attribute which stores the configuration. At first class attribute and macro definition were placed in `ActiveRecord::Core` but a separate module was chosen mainly to avoid cluttering core with documentation for `query_constraints`
`QueryConstraints` module is included directly into `Persistence` as `Persistence` relies on the class attribute to be defined.
`_query_constraints_hash` uses `attribute_in_database` to fetch the value to unlock the ability to update parts of the composite primary key like
```ruby
developer.update!(company_id: 2)
# => UPDATE "developers" SET "company_id" = 2 WHERE "developers"."company_id" = 1 AND "developers"."id" = 1
```

### Naming

The main use-case of this capability is to define a “virtual” composite primary key like `[:shard_id, :id]` or `[:tenant_id, :id]` for an Active Record model. However we would like to avoid explicitly mentioning the term “primary key” as the capability in the current implementation is generic and only provides foundation to support composite primary keys.
At the same time, name `query_constraints` may be too generic but luckily it’s short enough for us to perhaps consider specializing it a little bit with an additional word like `query_by_attributes`
Please do not hesitate to provide your naming suggestions!

Isn’t it similar to  `default_scope(all_queries: true) {}`
Even though the proposed feature and `all_queries` capabilities share some similarities they are not quite the same. While `default_scope(all_queries: true)` applies to all queries, `query_constraints` changes behavior issued by a single Active Record object. It also gets column values directly from the object while `default_scope` needs either a hardcoded or globally accessible value like `default_scope { company_id: Current.company_id }` 

### Vision
I also wanted to briefly share a bigger picture for this foundational feature and upcoming additions we would like to propose soon:
Rails starts to implicitly configure `query_constraints` to match the `primary_key`
Add capability to build a “row-constructor” using an Active Record relation. For example `Model.where([:tenant_id, :id] => [[1,2], [1,3], [2,4]])` Similar to https://github.com/rails/rails/pull/36003
Associations should respect the `query_constraints` and by implication composite primary key configuration. For example given a blogging platform with models `Blog`, `BlogPost`, `Comment` sharded by `blog_id`, query like `comment.blog_post` should load blogpost using whole `query_constraints` clause

