### PR TITLE
Improve BelongsToAssociationsTest's `test_destroy_linked_models` by adding two assertions

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1660,5 +1660,8 @@ class BelongsToWithForeignKeyTest < ActiveRecord::TestCase
     author = Author.create! name: "Author", author_address_id: address.id
 
     author.destroy!
+
+    assert_not AuthorAddress.exists?(address.id)
+    assert_not Author.exists?(author.id)
   end
 end


### PR DESCRIPTION
Hi there,

This change makes sure that the `test_destroy_linked_models` test case has two reasonable assertions.

### Motivation / Background

This Pull Request has been created because the `test_destroy_linked_models` test case was written to assert that a linked associated is destroyed yet it doesn't assert this expectation. 

### Detail

This Pull Request changes the way we verify that linked models are indeed destroyed.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] CI is passing.

