### PR TITLE
Point 'Canberra' time zone mapping to Australia/Canberra'

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -159,7 +159,7 @@ module ActiveSupport
       "Yakutsk"                      => "Asia/Yakutsk",
       "Darwin"                       => "Australia/Darwin",
       "Adelaide"                     => "Australia/Adelaide",
-      "Canberra"                     => "Australia/Melbourne",
+      "Canberra"                     => "Australia/Canberra",
       "Melbourne"                    => "Australia/Melbourne",
       "Sydney"                       => "Australia/Sydney",
       "Brisbane"                     => "Australia/Brisbane",


### PR DESCRIPTION
### Motivation / Background

When building a timezone select, the options for Australia are:

```
<option value="Australia/Adelaide">(GMT+09:30) Adelaide</option>
  <option value="Australia/Darwin">(GMT+09:30) Darwin</option>
  <option value="Australia/Brisbane">(GMT+10:00) Brisbane</option>
  <option value="Australia/Melbourne">(GMT+10:00) Canberra</option>
  <option value="Pacific/Guam">(GMT+10:00) Guam</option>
  <option value="Australia/Hobart">(GMT+10:00) Hobart</option>
  <option value="Australia/Melbourne">(GMT+10:00) Melbourne</option>
  <option value="Pacific/Port_Moresby">(GMT+10:00) Port Moresby</option>
  <option value="Australia/Sydney">(GMT+10:00) Sydney</option>
```

Finding the local browser's timezone with this code:

```js
Intl.DateTimeFormat().resolvedOptions().timeZone 
```

Returns the value (for me) as: "Australia/Melbourne".

Given that the first `option` tag in this list that matches that is "Canberra", that option is the one that appears as selected... even though I am in the Melbourne timezone.

I'd like to suggest re-mapping this time zone to:

1. Prevent this option select bug from occurring
2. Update the mappings for Australian timezones to be consistently the same: town on the left, TZ designation on the right. Even if the timezones are (at the moment) the same. This is the case for Darwin, Adelaide, Melbourne, Sydney, Brisbane, and Hobart... so why not Canberra too?

It looks like it has been this way for a while and nobody has noticed: https://github.com/rails/rails/commit/1d4f4cdfe22cbe4962ae8953c96bc5c70d8d4e6a.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

