### PR TITLE
fix typo in pull request template [ci-skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ Feel free to discard it if you need to (e.g. when you just fix a typo). -->
 
 <!--
 Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
-If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to to this PR.
+If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
 -->
 
 This Pull Request has been created because [REPLACE ME]


### PR DESCRIPTION
This fixes the typo for the recently added change in this PR https://github.com/rails/rails/pull/46307
