### PR TITLE
Add `ActiveSupport.deprecator`

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -26,6 +26,7 @@
 require "securerandom"
 require "active_support/dependencies/autoload"
 require "active_support/version"
+require "active_support/deprecator"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
@@ -114,7 +115,7 @@ module ActiveSupport
 
   def self.to_time_preserves_timezone=(value)
     unless value
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Support for the pre-Ruby 2.4 behavior of to_time has been deprecated and will be removed in Rails 7.2."
       )
     end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -196,7 +196,7 @@ module ActiveSupport
             else
               {}.tap do |pool_options|
                 if options[:pool_size]
-                  ActiveSupport::Deprecation.warn(<<~MSG)
+                  ActiveSupport.deprecator.warn(<<~MSG)
                     Using :pool_size is deprecated and will be removed in Rails 7.2.
                     Use `pool: { size: #{options[:pool_size].inspect} }` instead.
                   MSG
@@ -204,7 +204,7 @@ module ActiveSupport
                 end
 
                 if options[:pool_timeout]
-                  ActiveSupport::Deprecation.warn(<<~MSG)
+                  ActiveSupport.deprecator.warn(<<~MSG)
                     Using :pool_timeout is deprecated and will be removed in Rails 7.2.
                     Use `pool: { timeout: #{options[:pool_timeout].inspect} }` instead.
                   MSG

--- a/activesupport/lib/active_support/core_ext/array/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/deprecated_conversions.rb
@@ -5,7 +5,7 @@ class Array
   def to_s(format = NOT_SET) # :nodoc:
     case format
     when :db
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_fs(#{format.inspect}) instead."
       )
       if empty?
@@ -16,7 +16,7 @@ class Array
     when NOT_SET
       to_default_s
     else
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_fs(#{format.inspect}) instead."
       )
       to_default_s

--- a/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
@@ -6,7 +6,7 @@ class Date
   NOT_SET = Object.new # :nodoc:
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = DATE_FORMATS[format]
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_fs(#{format.inspect}) instead."
       )
       if formatter.respond_to?(:call)
@@ -17,7 +17,7 @@ class Date
     elsif format == NOT_SET
       to_default_s
     else
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_fs(#{format.inspect}) instead."
       )
       to_default_s

--- a/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
@@ -6,14 +6,14 @@ class DateTime
   NOT_SET = Object.new # :nodoc:
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = ::Time::DATE_FORMATS[format]
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_fs(#{format.inspect}) instead."
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
       to_default_s
     else
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_fs(#{format.inspect}) instead."
       )
       to_default_s

--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -65,7 +65,7 @@ module Digest
 
         match_data.captures.map { |s| s.to_i(16) }.pack("NnnnnN")
       else
-        ActiveSupport::Deprecation.warn <<~WARNING.squish
+        ActiveSupport.deprecator.warn <<~WARNING.squish
           Providing a namespace ID that is not one of the constants defined on Digest::UUID generates an incorrect UUID value according to RFC 4122.
           To enable the correct behavior, set the Rails.application.config.active_support.use_rfc4122_namespaced_uuids configuration option to true.
         WARNING

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -84,7 +84,7 @@ module Enumerable
       identity ||= 0
       _original_sum_with_required_identity(identity, &block)
     else
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActiveSupport.deprecator.warn(<<-MSG.squish)
         Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4.
         Sum of non-numeric elements requires an initial argument.
       MSG

--- a/activesupport/lib/active_support/core_ext/numeric/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/deprecated_conversions.rb
@@ -9,42 +9,42 @@ module ActiveSupport
       when Integer, String
         super(format)
       when :phone
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_phone(self, options || {})
       when :currency
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_currency(self, options || {})
       when :percentage
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_percentage(self, options || {})
       when :delimited
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_delimited(self, options || {})
       when :rounded
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_rounded(self, options || {})
       when :human
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_human(self, options || {})
       when :human_size
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_human_size(self, options || {})
       when Symbol
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         super()

--- a/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
@@ -5,21 +5,21 @@ module ActiveSupport
     NOT_SET = Object.new # :nodoc:
     def to_s(format = NOT_SET)
       if formatter = RangeWithFormat::RANGE_FORMATS[format]
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_fs(#{format.inspect}) instead."
         )
         formatter.call(first, last)
       elsif format == NOT_SET
         super()
       else
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_fs(#{format.inspect}) instead."
         )
         super()
       end
     end
     alias_method :to_default_s, :to_s
-    deprecate :to_default_s
+    deprecate :to_default_s, deprecator: ActiveSupport.deprecator
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
+++ b/activesupport/lib/active_support/core_ext/range/include_time_with_zone.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-ActiveSupport::Deprecation.warn(<<-MSG.squish)
+ActiveSupport.deprecator.warn(<<-MSG.squish)
   `active_support/core_ext/range/include_time_with_zone` is deprecated and will be removed in Rails 7.1.
 MSG

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -192,7 +192,7 @@ module ActiveSupport # :nodoc:
           rescue NoMethodError => error
             if error.name == :to_str
               str = arg.to_s
-              ActiveSupport::Deprecation.warn <<~MSG.squish
+              ActiveSupport.deprecator.warn <<~MSG.squish
                 Implicit conversion of #{arg.class} into String by ActiveSupport::SafeBuffer
                 is deprecated and will be removed in Rails 7.1.
                 You must explicitly cast it to a String.

--- a/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
@@ -6,14 +6,14 @@ class Time
   NOT_SET = Object.new # :nodoc:
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = DATE_FORMATS[format]
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_fs(#{format.inspect}) instead."
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
       to_default_s
     else
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport.deprecator.warn(
         "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_fs(#{format.inspect}) instead."
       )
       to_default_s

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-ActiveSupport::Deprecation.warn(<<-MSG.squish)
+ActiveSupport.deprecator.warn(<<-MSG.squish)
   `active_support/core_ext/uri` is deprecated and will be removed in Rails 7.1.
 MSG

--- a/activesupport/lib/active_support/deprecator.rb
+++ b/activesupport/lib/active_support/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -65,8 +65,8 @@ module ActiveSupport
   # (via <tt>action_dispatch.callback</tt> notification) in a Rails environment.
   class LogSubscriber < Subscriber
     # Embed in a String to clear all previous ANSI sequences.
-    CLEAR = ActiveSupport::Deprecation::DeprecatedObjectProxy.new("\e[0m", "CLEAR is deprecated! Use MODES[:clear] instead.")
-    BOLD  = ActiveSupport::Deprecation::DeprecatedObjectProxy.new("\e[1m", "BOLD is deprecated! Use MODES[:bold] instead.")
+    CLEAR = ActiveSupport::Deprecation::DeprecatedObjectProxy.new("\e[0m", "CLEAR is deprecated! Use MODES[:clear] instead.", ActiveSupport.deprecator)
+    BOLD  = ActiveSupport::Deprecation::DeprecatedObjectProxy.new("\e[1m", "BOLD is deprecated! Use MODES[:bold] instead.", ActiveSupport.deprecator)
 
     # ANSI sequence modes
     MODES = {
@@ -179,7 +179,7 @@ module ActiveSupport
 
     def mode_from(options)
       if options.is_a?(TrueClass) || options.is_a?(FalseClass)
-        ActiveSupport::Deprecation.warn(<<~MSG.squish)
+        ActiveSupport.deprecator.warn(<<~MSG.squish)
           Bolding log text with a positional boolean is deprecated and will be removed
           in Rails 7.2. Use an option hash instead (eg. `color(:red, "my text", bold: true)`).
         MSG

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -165,7 +165,7 @@ module ActiveSupport
       end
 
       def children # :nodoc:
-        ActiveSupport::Deprecation.warn <<~EOM
+        ActiveSupport.deprecator.warn <<~EOM
           ActiveSupport::Notifications::Event#children is deprecated and will
           be removed in Rails 7.2.
         EOM
@@ -173,7 +173,7 @@ module ActiveSupport
       end
 
       def parent_of?(event) # :nodoc:
-        ActiveSupport::Deprecation.warn <<~EOM
+        ActiveSupport.deprecator.warn <<~EOM
           ActiveSupport::Notifications::Event#parent_of? is deprecated and will
           be removed in Rails 7.2.
         EOM

--- a/activesupport/lib/active_support/per_thread_registry.rb
+++ b/activesupport/lib/active_support/per_thread_registry.rb
@@ -40,7 +40,7 @@ module ActiveSupport
   # If the class has an initializer, it must accept no arguments.
   module PerThreadRegistry
     def self.extended(object)
-      ActiveSupport::Deprecation.warn(<<~MSG)
+      ActiveSupport.deprecator.warn(<<~MSG)
         ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1.
         Use `Module#thread_mattr_accessor` instead.
       MSG

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -10,6 +10,10 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
+    initializer "active_support.deprecator" do |app|
+      app.deprecators[:active_support] = ActiveSupport.deprecator
+    end
+
     initializer "active_support.isolation_level" do |app|
       config.after_initialize do
         if level = app.config.active_support.delete(:isolation_level)

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -42,7 +42,7 @@ module ActiveSupport
   class TimeWithZone
     # Report class name as 'Time' to thwart type checking.
     def self.name
-      ActiveSupport::Deprecation.warn(<<~EOM)
+      ActiveSupport.deprecator.warn(<<~EOM)
         ActiveSupport::TimeWithZone.name has been deprecated and
         from Rails 7.1 will use the default Ruby implementation.
         You can set `config.active_support.remove_deprecated_time_with_zone_name = true`
@@ -211,19 +211,19 @@ module ActiveSupport
     # Returns a string of the object's date and time.
     def to_s(format = NOT_SET)
       if format == :db
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead."
         )
         utc.to_fs(format)
       elsif formatter = ::Time::DATE_FORMATS[format]
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
         )
         formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
       elsif format == NOT_SET
         "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
       else
-        ActiveSupport::Deprecation.warn(
+        ActiveSupport.deprecator.warn(
           "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
         )
         "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -22,10 +22,10 @@ require "active_support"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+ActiveSupport.deprecator.debug = true
 
 # Default to Ruby 2.4+ to_time behavior but allow running tests with old behavior
-ActiveSupport::Deprecation.silence do
+ActiveSupport.deprecator.silence do
   ActiveSupport.to_time_preserves_timezone = ENV.fetch("PRESERVE_TIMEZONES", "1") == "1"
 end
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -359,7 +359,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def test_deprecated_connection_pool_works
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, pool_size: 2, pool_timeout: 1)
       pool = cache.instance_variable_get(:@data) # loads 'connection_pool' gem
       assert_kind_of ::ConnectionPool, pool

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -272,7 +272,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include ConnectionPoolBehavior
 
     def test_deprecated_connection_pool_works
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, pool_size: 2, pool_timeout: 1)
         pool = cache.redis # loads 'connection_pool' gem
         assert_kind_of ::ConnectionPool, pool

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -97,16 +97,16 @@ class ToSTest < ActiveSupport::TestCase
   def test_to_s_db
     collection = [TestDB.new, TestDB.new, TestDB.new]
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "null", [].to_s(:db)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "1,2,3", collection.to_s(:db)
     end
   end
 
   def test_to_s_not_existent
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "[]", [].to_s(:not_existent)
     end
   end

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -284,11 +284,11 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
       ActiveSupport.to_time_preserves_timezone = true
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       ActiveSupport.to_time_preserves_timezone = false
     end
   ensure
-    ActiveSupport::Deprecation.silence do
+    ActiveSupport.deprecator.silence do
       ActiveSupport.to_time_preserves_timezone = current_preserve_tz
     end
   end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -24,28 +24,28 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   def test_to_s
     date = Date.new(2005, 2, 21)
     assert_equal "2005-02-21",          date.to_s
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "21 Feb",              date.to_s(:short)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21, 2005",   date.to_s(:long)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21st, 2005", date.to_s(:long_ordinal)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21",          date.to_s(:db)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21",          date.to_s(:inspect)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "21 Feb 2005",         date.to_s(:rfc822)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21",          date.to_s(:iso8601)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21",          date.to_s(:not_existent)
     end
   end
@@ -53,28 +53,28 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
   def test_to_s_with_single_digit_day
     date = Date.new(2005, 2, 1)
     assert_equal "2005-02-01",          date.to_s
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "01 Feb",              date.to_s(:short)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 01, 2005",   date.to_s(:long)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 1st, 2005",  date.to_s(:long_ordinal)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-01",          date.to_s(:db)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-01",          date.to_s(:inspect)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "01 Feb 2005",         date.to_s(:rfc822)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-01",          date.to_s(:iso8601)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-01",          date.to_s(:not_existent)
     end
   end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -15,40 +15,40 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_s
     datetime = DateTime.new(2005, 2, 21, 14, 30, 0, 0)
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21 14:30:00",                 datetime.to_s(:db)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21 14:30:00.000000000 +0000", datetime.to_s(:inspect)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "14:30",                               datetime.to_s(:time)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "21 Feb 14:30",                        datetime.to_s(:short)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21, 2005 14:30",             datetime.to_s(:long)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "Mon, 21 Feb 2005 14:30:00 +0000",     datetime.to_s(:rfc822)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21st, 2005 14:30",           datetime.to_s(:long_ordinal)
     end
     assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_s)
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_s(:not_existent))
     end
 
     with_env_tz "US/Central" do
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2009-02-05T14:30:05-06:00", DateTime.civil(2009, 2, 5, 14, 30, 5, Rational(-21600, 86400)).to_s(:iso8601)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2008-06-09T04:05:01-05:00", DateTime.civil(2008, 6, 9, 4, 5, 1, Rational(-18000, 86400)).to_s(:iso8601)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2009-02-05T14:30:05+00:00", DateTime.civil(2009, 2, 5, 14, 30, 5).to_s(:iso8601)
       end
     end
@@ -83,7 +83,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_s_with_custom_date_format
     Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "20050221143000", DateTime.new(2005, 2, 21, 14, 30, 0).to_s(:custom)
     end
   ensure

--- a/activesupport/test/core_ext/digest/uuid_test.rb
+++ b/activesupport/test/core_ext/digest/uuid_test.rb
@@ -38,11 +38,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
   end
 
   def test_v3_uuids_with_rfc4122_namespaced_uuids_disabled
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "995e5d8e-364a-386e-8b3d-65d6a7d5478f", Digest::UUID.uuid_v3("6BA7B810-9DAD-11D1-80B4-00C04FD430C8", "www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "fe5a52d1-703f-3326-b919-2d96003288f3", Digest::UUID.uuid_v3("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com")
     end
 
@@ -50,11 +50,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "3d813cbb-47fb-32ba-91df-831e1593ac29", Digest::UUID.uuid_v3(Digest::UUID::DNS_NAMESPACE, "www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "1a27509f-2955-3d78-8f53-c92935fecc57", Digest::UUID.uuid_v3("6BA7B811-9DAD-11D1-80B4-00C04FD430C8", "http://www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2676127a-9073-36e3-b9db-14bc16b7c083", Digest::UUID.uuid_v3("6ba7b811-9dad-11d1-80b4-00c04fd430c8", "http://www.widgets.com")
     end
 
@@ -62,11 +62,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "86df55fb-428e-3843-8583-ba3c05f290bc", Digest::UUID.uuid_v3(Digest::UUID::URL_NAMESPACE, "http://www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2e2a2437-160c-36e7-952d-d6f494edea44", Digest::UUID.uuid_v3("6BA7B812-9DAD-11D1-80B4-00C04FD430C8", "1.2.3")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "719357e1-54f1-3930-8113-a1faffde48fa", Digest::UUID.uuid_v3("6ba7b812-9dad-11d1-80b4-00c04fd430c8", "1.2.3")
     end
 
@@ -74,11 +74,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "8c29ab0e-a2dc-3482-b5eb-20cb2e2387a1", Digest::UUID.uuid_v3(Digest::UUID::OID_NAMESPACE, "1.2.3")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "01c2671b-fd20-3e43-8cff-217f40e110c8", Digest::UUID.uuid_v3("6BA7B814-9DAD-11D1-80B4-00C04FD430C8", "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "32560c4a-c9f1-3974-9c1c-5e52761e091f", Digest::UUID.uuid_v3("6ba7b814-9dad-11d1-80b4-00c04fd430c8", "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
@@ -86,7 +86,7 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "ee49149d-53a4-304a-890b-468229f6afc3", Digest::UUID.uuid_v3(Digest::UUID::X500_NAMESPACE, "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "cd3d768f-7380-3d1f-8834-e034b40e65ea", Digest::UUID.uuid_v3("A non-UUID string", "some value")
     end
   end
@@ -118,11 +118,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
   end
 
   def test_v5_uuids_with_rfc4122_namespaced_uuids_disabled
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "442faf6c-4996-5266-aeef-ecadb5d49e54", Digest::UUID.uuid_v5("6BA7B810-9DAD-11D1-80B4-00C04FD430C8", "www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "027963ef-431c-5670-ab2c-820168da74e9", Digest::UUID.uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com")
     end
 
@@ -130,11 +130,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "21f7f8de-8051-5b89-8680-0195ef798b6a", Digest::UUID.uuid_v5(Digest::UUID::DNS_NAMESPACE, "www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "59207e54-33c5-5914-ab39-b7f3333a0097", Digest::UUID.uuid_v5("6BA7B811-9DAD-11D1-80B4-00C04FD430C8", "http://www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "d8e1e518-2337-58e5-bf52-6c563631db90", Digest::UUID.uuid_v5("6ba7b811-9dad-11d1-80b4-00c04fd430c8", "http://www.widgets.com")
     end
 
@@ -142,11 +142,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "4e570fd8-186d-5a74-90f0-4d28e34673a1", Digest::UUID.uuid_v5(Digest::UUID::URL_NAMESPACE, "http://www.widgets.com")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "72409eff-7406-5906-b86e-6c7a726ed04e", Digest::UUID.uuid_v5("6BA7B812-9DAD-11D1-80B4-00C04FD430C8", "1.2.3")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "b9b86653-48bb-5059-861a-2c72974b5c8d", Digest::UUID.uuid_v5("6ba7b812-9dad-11d1-80b4-00c04fd430c8", "1.2.3")
     end
 
@@ -154,11 +154,11 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "42d5e23b-3a02-5135-85c6-52d1102f1f00", Digest::UUID.uuid_v5(Digest::UUID::OID_NAMESPACE, "1.2.3")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "de6fe50e-eded-580a-81c9-f0774a3531da", Digest::UUID.uuid_v5("6BA7B814-9DAD-11D1-80B4-00C04FD430C8", "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "e84a8a4e-a5c7-55b8-ad09-020c0b5662a7", Digest::UUID.uuid_v5("6ba7b814-9dad-11d1-80b4-00c04fd430c8", "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
@@ -166,7 +166,7 @@ class DigestUUIDExt < ActiveSupport::TestCase
       assert_equal "fd5b2ddf-bcfe-58b6-90d6-db50f74db527", Digest::UUID.uuid_v5(Digest::UUID::X500_NAMESPACE, "cn=John Doe, ou=People, o=Acme, Inc., c=US")
     end
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "b42d5423-1047-5bb3-afd4-0dec60fb22d2", Digest::UUID.uuid_v5("A non-UUID string", "some value")
     end
   end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -57,10 +57,10 @@ class EnumerableTests < ActiveSupport::TestCase
     enum = GenericEnumerable.new(%w(a b c))
     assert_equal "abc", enum.sum("")
     assert_equal "aabbcc", enum.sum("") { |i| i * 2 }
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "abc", enum.sum
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "aabbcc", enum.sum { |i| i * 2 }
     end
 
@@ -69,12 +69,12 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 60, payments.sum { |p| p.price * 2 }
 
     payments = GenericEnumerable.new([ SummablePayment.new(5), SummablePayment.new(15) ])
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal SummablePayment.new(20), payments.sum
     end
     assert_equal SummablePayment.new(20), payments.sum(SummablePayment.new(0))
     assert_equal SummablePayment.new(20), payments.sum(SummablePayment.new(0)) { |p| p }
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal SummablePayment.new(20), payments.sum { |p| p }
     end
 
@@ -117,7 +117,7 @@ class EnumerableTests < ActiveSupport::TestCase
     expected_raise = TypeError
 
     assert_raise(expected_raise) { GenericEnumerable.new([5, 15, nil]).sum }
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal 0, [nil].sum
     end
 
@@ -141,7 +141,7 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 10, (1..4).sum
     assert_equal 10, (1..4.5).sum
     assert_equal 6, (1...4).sum
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "abc", ("a".."c").sum
     end
     assert_equal "abc", ("a".."c").sum("")
@@ -162,11 +162,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 60, enum.sum { |i| i * 2 }
 
     enum = %w(a b c)
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "abc", enum.sum
     end
     assert_equal "abc", enum.sum("")
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "aabbcc", enum.sum { |i| i * 2 }
     end
     assert_equal "aabbcc", enum.sum("") { |i| i * 2 }
@@ -176,11 +176,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal 60, payments.sum { |p| p.price * 2 }
 
     payments = [ SummablePayment.new(5), SummablePayment.new(15) ]
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal SummablePayment.new(20), payments.sum
     end
     assert_equal SummablePayment.new(20), payments.sum(SummablePayment.new(0))
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal SummablePayment.new(20), payments.sum { |p| p }
     end
     assert_equal SummablePayment.new(20), payments.sum(SummablePayment.new(0)) { |p| p }

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -586,7 +586,7 @@ class HashToXmlTest < ActiveSupport::TestCase
 
   def test_timezoned_attributes
     # TODO: Remove assertion in Rails 7.1 and add ActiveSupport::TimeWithZone to XML type mapping
-    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated", ActiveSupport.deprecator) do
       xml = {
         created_at: Time.utc(1999, 2, 2),
         local_created_at: Time.utc(1999, 2, 2).in_time_zone("Eastern Time (US & Canada)")

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -158,7 +158,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__phone
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal("555-1234", 5551234.to_s(:phone))
     end
     assert_equal("555-1234", 5551234.to_fs(:phone))
@@ -176,7 +176,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__currency
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal("$1,234,567,890.50", 1234567890.50.to_s(:currency))
     end
     assert_equal("$1,234,567,890.50", 1234567890.50.to_fs(:currency))
@@ -192,7 +192,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__rounded
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal("-111.235", -111.2346.to_s(:rounded))
     end
     assert_equal("-111.235", -111.2346.to_fs(:rounded))
@@ -255,7 +255,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__percentage
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal("100.000%", 100.to_s(:percentage))
     end
     assert_equal("100.000%", 100.to_fs(:percentage))
@@ -269,7 +269,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__delimited
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal("12,345,678", 12345678.to_s(:delimited))
     end
     assert_equal("12,345,678", 12345678.to_fs(:delimited))
@@ -292,7 +292,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__human_size
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "0 Bytes",   0.to_s(:human_size)
     end
     assert_equal "0 Bytes",   0.to_fs(:human_size)
@@ -344,7 +344,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_number_to_human
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "-123", -123.to_s(:human)
     end
     assert_equal "-123", -123.to_fs(:human)
@@ -416,7 +416,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs_with_invalid_formatter
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "123", 123.to_s(:invalid)
     end
     assert_equal "123", 123.to_fs(:invalid)

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -30,7 +30,7 @@ class RangeTest < ActiveSupport::TestCase
   def test_to_s_with_format
     number_range = (1..100)
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "BETWEEN '1' AND '100'", number_range.to_s(:db)
     end
   end
@@ -38,7 +38,7 @@ class RangeTest < ActiveSupport::TestCase
   def test_to_s_with_format_invalid_format
     number_range = (1..100)
 
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "1..100", number_range.to_s(:not_existent)
     end
   end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -836,7 +836,7 @@ class OutputSafetyTest < ActiveSupport::TestCase
 
   test "Adding an object not responding to `#to_str` to a safe string is deprecated" do
     string = @string.html_safe
-    assert_deprecated("Implicit conversion of #{@to_s_object.class} into String by ActiveSupport::SafeBuffer is deprecated") do
+    assert_deprecated("Implicit conversion of #{@to_s_object.class} into String by ActiveSupport::SafeBuffer is deprecated", ActiveSupport.deprecator) do
       string << @to_s_object
     end
     assert_equal "helloto_s", string

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -822,61 +822,61 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
   def test_to_s
     time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
     assert_equal time.to_default_s,                 time.to_s
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal time.to_default_s,                 time.to_s(:doesnt_exist)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2005-02-21 17:44:30",             time.to_s(:db)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "21 Feb 17:44",                    time.to_s(:short)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "17:44",                           time.to_s(:time)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "20050221174430",                  time.to_s(:number)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "20050221174430123456789",         time.to_s(:nsec)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "20050221174430123456",            time.to_s(:usec)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21, 2005 17:44",         time.to_s(:long)
     end
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "February 21st, 2005 17:44",       time.to_s(:long_ordinal)
     end
     with_env_tz "UTC" do
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "Mon, 21 Feb 2005 17:44:30 +0000", time.to_s(:rfc822)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2005-02-21 17:44:30.123456789 +0000", time.to_s(:inspect)
       end
     end
     with_env_tz "US/Central" do
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "Thu, 05 Feb 2009 14:30:05 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_s(:rfc822)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "Mon, 09 Jun 2008 04:05:01 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_s(:rfc822)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2009-02-05T14:30:05-06:00", Time.local(2009, 2, 5, 14, 30, 5).to_s(:iso8601)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2008-06-09T04:05:01-05:00", Time.local(2008, 6, 9, 4, 5, 1).to_s(:iso8601)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2009-02-05T14:30:05Z", Time.utc(2009, 2, 5, 14, 30, 5).to_s(:iso8601)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2009-02-05 14:30:05.000000000 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_s(:inspect)
       end
-      assert_deprecated do
+      assert_deprecated(ActiveSupport.deprecator) do
         assert_equal "2008-06-09 04:05:01.000000000 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_s(:inspect)
       end
     end
@@ -912,7 +912,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_to_s_custom_date_format
     Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_s(:custom)
     end
   ensure

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -147,19 +147,19 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_to_s_db
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "2000-01-01 00:00:00", @twz.to_s(:db)
     end
   end
 
   def test_to_s_inspect
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "1999-12-31 19:00:00.000000000 -0500", @twz.to_s(:inspect)
     end
   end
 
   def test_to_s_not_existent
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       assert_equal "1999-12-31 19:00:00 -0500", @twz.to_s(:not_existent)
     end
   end
@@ -595,7 +595,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_class_name
     # TODO: Remove assertion in Rails 7.1 and change expected value
-    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated", ActiveSupport.deprecator) do
       assert_equal "Time", ActiveSupport::TimeWithZone.name
     end
   end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -72,7 +72,7 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
 
   def test_deprecated_bold_format_for_messages
     ActiveSupport::LogSubscriber.colorize_logging = true
-    assert_deprecated do
+    assert_deprecated(ActiveSupport.deprecator) do
       @log_subscriber.deprecated(nil)
     end
   end

--- a/activesupport/test/per_thread_registry_test.rb
+++ b/activesupport/test/per_thread_registry_test.rb
@@ -4,7 +4,7 @@ require_relative "abstract_unit"
 
 class PerThreadRegistryTest < ActiveSupport::TestCase
   class TestRegistry
-    ActiveSupport::Deprecation.silence do
+    ActiveSupport.deprecator.silence do
       extend ActiveSupport::PerThreadRegistry
     end
 

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -19,13 +19,13 @@ module TimeZoneTestHelpers
   def with_preserve_timezone(value)
     old_preserve_tz = ActiveSupport.to_time_preserves_timezone
 
-    ActiveSupport::Deprecation.silence do
+    ActiveSupport.deprecator.silence do
       ActiveSupport.to_time_preserves_timezone = value
     end
 
     yield
   ensure
-    ActiveSupport::Deprecation.silence do
+    ActiveSupport.deprecator.silence do
       ActiveSupport.to_time_preserves_timezone = old_preserve_tz
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3902,6 +3902,7 @@ module ApplicationTests
 
       assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
+      assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end
 
     test "can entirely opt out of deprecation warnings" do
@@ -3963,19 +3964,19 @@ module ApplicationTests
 
       app "production"
 
-      assert_deprecated do
+      assert_deprecated(Rails.application.deprecators[:active_support]) do
         assert_equal "21 Feb", Date.new(2005, 2, 21).to_s(:short)
       end
-      assert_deprecated do
+      assert_deprecated(Rails.application.deprecators[:active_support]) do
         assert_equal "2005-02-21 14:30:00", DateTime.new(2005, 2, 21, 14, 30, 0, 0).to_s(:db)
       end
-      assert_deprecated do
+      assert_deprecated(Rails.application.deprecators[:active_support]) do
         assert_equal "555-1234", 5551234.to_s(:phone)
       end
-      assert_deprecated do
+      assert_deprecated(Rails.application.deprecators[:active_support]) do
         assert_equal "BETWEEN 'a' AND 'z'", ("a".."z").to_s(:db)
       end
-      assert_deprecated do
+      assert_deprecated(Rails.application.deprecators[:active_support]) do
         assert_equal "2005-02-21 17:44:30", Time.utc(2005, 2, 21, 17, 44, 30.12345678901).to_s(:db)
       end
     end


### PR DESCRIPTION
This commit adds `ActiveSupport.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `activesupport/lib` with `ActiveSupport.deprecator`.

Additionally, this commit adds `ActiveSupport.deprecator` to `Rails.application.deprecators` so that it can be configured using e.g. `config.active_support.report_deprecations`.
