### PR TITLE
Fix `clear_all_connections!` deprecation warning

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -35,7 +35,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
   def teardown
     super
 
-    ActiveRecord::Base.clear_all_connections!
+    ActiveRecord::Base.connection.clear_all_connections!
   end
 
   def cable_config


### PR DESCRIPTION
This fixes the following warning when running Action Cable tests:

  ```
  DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_all_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_all_connections!`.
  ```

---

Example warnings: https://buildkite.com/rails/rails/builds/90549#0184109e-c7fb-45f7-92b5-f59d99953e5b/1052-1058
