### PR TITLE
Add support for multi-database applications to `db:check_protected_environments` task

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -30,8 +30,8 @@ module ActiveRecord
       end
 
       def purge
-        drop
         connection.disconnect!
+        drop
       rescue NoDatabaseError
       ensure
         create

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -443,6 +443,9 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
           db_create_and_drop_namespace db_config.name, db_config.database
+        ensure
+          # secondary databases might have been created by check_protected_environments task
+          rails("db:drop:all")
         end
       end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Similarly to https://github.com/rails/rails/pull/46336, this change brings the `db:check_protected_environments` task up to parity with the rest of tasks that support multi-database applications.

Today, misconfiguration of non-primary databases in multi-db applications is not checked against the `ar_internal_metadata` table's `environment` row, posing a risk to production environments.

### Detail

Similarly to my other PRs (https://github.com/rails/rails/pull/46097, https://github.com/rails/rails/pull/46336), we iterate through each of the relevant database configurations and re-establish `ActiveRecord::Base` using each configuration. This is safe to do since the `check_protected_environments!` method is only ever called from the `databases.rake` file/tasks.

**A hidden change, but critical (for the purposes that I'm working on), that is happening here** is that database configurations with `database_tasks: false` will be excluded from the logic in this task – due to the usage of the `ActiveRecord::Base.configurations.configs_for` method, which by default has `include_hidden: false`!



### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

cc @eileencodes 