### PR TITLE
Improve missing template error page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -1,19 +1,23 @@
 <header role="banner">
-  <h1>No template for interactive request</h1>
+  <h1>No view template for interactive request</h1>
 </header>
 
 <main id="container">
   <h2><%= h @exception.message %></h2>
 
-  <p class="summary">
-    <strong>NOTE!</strong><br>
-    Unless told otherwise, Rails expects an action to render a template with the same name,<br>
-    contained in a folder named after its controller.
-
-    If this controller is an API responding with 204 (No Content), <br>
-    which does not require a template,
-    then this error will occur when trying to access it via browser,<br>
-    since we expect an HTML template
-    to be rendered for such requests. If that's the case, carry on.
-  </p>
+  <div class="summary">
+    <p>
+      <strong>NOTE:</strong>Rails usually expects a controller action to render a view template with the same name. 
+    </p>
+    <p>
+      For example, a <code>BooksController#index</code> action defined in <code>app/controller/books_controller.rb</code> should have a corresponding view template 
+      in a file named <code>app/views/books/index.erb.html</code>.
+    </p>
+    <p>
+      However, if this controller is an API endpoint responding with 204 (No Content), which does not require a view template because it doesn't serve an HTML response, then this error will occur when trying to access it with a browser. In this particular scenario, you can ignore this error.
+    </p>
+    <p>
+      You can find more about view template rendering conventions in the <a href="https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-by-default-convention-over-configuration-in-action">Rails Guides on Layouts and Rendering in Rails</a>.
+    </p>
+  </div>
 </main>


### PR DESCRIPTION
This may be one of the most common error pages encountered by Rails beginners and it's improved quite a bit over the years but we can still do much better. Here's an attempt.

Before: 
<img width="1350" alt="Screen Shot 2022-10-26 at 12 50 12 AM" src="https://user-images.githubusercontent.com/65950/197939442-e30a2e7b-2e90-400f-a77c-e91721042e5e.png">

After: 
<img width="1352" alt="Screen Shot 2022-10-26 at 1 09 01 AM" src="https://user-images.githubusercontent.com/65950/197940079-9c15d021-4d33-4b15-a3a7-80299de00524.png">

Some goals here:
- Be less obtuse with word choices for folks who use English as a second language.
- Stop referring to view templates as "templates" when the literal directory is called `app/views` which has and will confuse beginners (otherwise let's rename the directory).
- Stop formatting the HTML with `<br>` tags like it's 2005 and let the text flow with the viewport as appropriate.
- Give a *concrete* example of the naming relationship between a controller and its view template, based on
[the ActionView Rails Guides][1].
- Give an actionable link to the Rails Guides on this specific topic so folks aren't left fumbling to find more context if they need it.

I also tried to clarify the frankly confusing copy explaining the 204 No Content rendering case, which I think should probably mention that such endpoints shouldn't be allowed to render HTML to avoid this error, but that might be pushing the scope of the error feedback a bit too far.

[1]: https://guides.rubyonrails.org/layouts_and_rendering.html