### PR TITLE
Introducing `where.present` and `where.absent` query methods.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Implements `exists` and `not exists` through chaining `where.present` and `where.absent`
+
+    Before, slow with many authors:
+
+    ```ruby
+    Post.where(author: Author.all)
+    Post.where.not(author: Author.all)
+    ```
+
+    After, fast with many authors:
+
+    ```ruby
+    Post.where.present(Author.where("authors.id = posts.author_id"))
+    Post.where.absent(Author.where("authors.id = posts.author_id"))
+    ```
+
+    *Lázaro Nixon*
+
 *   Adds `validate` to foreign keys and check constraints in schema.rb
 
     Previously, `schema.rb` would not record if `validate: false` had been used when adding a foreign key or check

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -68,6 +68,21 @@ module ActiveRecord
       assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a
     end
 
+    def test_present
+      Post.where.present(Author.where("authors.id = posts.author_id")).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_includes     relation, posts(:sti_habtm)
+        assert_not_includes relation, posts(:authorless)
+      end
+    end
+
+    def test_absent
+      relation = Post.where.absent(Author.where("authors.id = posts.author_id"))
+
+      assert posts(:authorless).author.blank?
+      assert_equal [posts(:authorless)], relation.to_a
+    end
+
     def test_not_inverts_where_clause
       relation = Post.where.not(title: "hello")
       expected_where_clause = Post.where(title: "hello").where_clause.invert


### PR DESCRIPTION
### Motivation / Background

As discussed [here](https://discuss.rubyonrails.org/t/proposal-activerecord-support-for-exists-clause), I would like to introduce a way to create queries with the `EXISTS` clause without relying on string fragments or internal APIs.

[`EXISTS` is faster than `IN` when the sub-query results is very large](https://stackoverflow.com/a/3964770), so it's common to optimize queries like that:

https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization-with-exists.html

Before:

```ruby

# Slow with many authors
Post.where(author_id: Author.select("authors.id"))   
Post.where.not(author_id: Author.select("authors.id"))

# Fast, but the syntax is awful
Post.where(Author.where("authors.id = posts.author_id").arel.exists)
Post.where(Author.where("authors.id = posts.author_id").arel.exists.not)
```

After:

```ruby
# Fast with many authors
Post.where.present(Author.where("authors.id = posts.author_id"))
Post.where.absent(Author.where("authors.id = posts.author_id"))    
```


