### PR TITLE
Add nil to valid options for dependent

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -14,7 +14,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete, :destroy_async]
+      [nil, :destroy, :delete, :destroy_async]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -16,7 +16,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception, :destroy_async]
+      [nil, :destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception, :destroy_async]
     end
 
     private_class_method :macro, :valid_options, :valid_dependent_options

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -16,7 +16,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_dependent_options
-      [:destroy, :destroy_async, :delete, :nullify, :restrict_with_error, :restrict_with_exception]
+      [nil, :destroy, :destroy_async, :delete, :nullify, :restrict_with_error, :restrict_with_exception]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1134,7 +1134,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     error = assert_raise ArgumentError do
       Class.new(Author).belongs_to :special_author_address, dependent: :nullify
     end
-    assert_equal error.message, "The :dependent option must be one of [:destroy, :delete, :destroy_async], but is :nullify"
+    assert_equal error.message, "The :dependent option must be one of [nil, :destroy, :delete, :destroy_async], but is :nullify"
   end
 
   class EssayDestroy < ActiveRecord::Base

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3132,6 +3132,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_invalid_dependent_option_raises_exception
+    error = assert_raise ArgumentError do
+      Class.new(Account).has_many :firms, dependent: :none
+    end
+    assert_equal error.message, "The :dependent option must be one of [nil, :destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception, :destroy_async], but is :none"
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -201,6 +201,13 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_nothing_raised { firm.destroy }
   end
 
+  def test_has_one_invalid_dependent_option_raises_exception
+    error = assert_raise ArgumentError do
+      Class.new(Account).has_one :firm, dependent: :none
+    end
+    assert_equal error.message, "The :dependent option must be one of [nil, :destroy, :destroy_async, :delete, :nullify, :restrict_with_error, :restrict_with_exception], but is :none"
+  end
+
   def test_restrict_with_exception
     firm = RestrictedWithExceptionFirm.create!(name: "restrict")
     firm.create_account(credit_limit: 10)


### PR DESCRIPTION
### Motivation / Background

`nil` is a valid value for the `dependent` option on `has_many`, `has_one` and `belongs_to`, but the error message you got didn't specify this.

### Detail

This changes what Rails sees as specified valid options for `dependent`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
* [ ] CI is passing.

