### PR TITLE
Fix a memory leak in #prepend_view_path

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -17,8 +17,6 @@ module ActionView
 
     singleton_class.attr_accessor :registered_details
     self.registered_details = []
-    singleton_class.attr_accessor :view_path_cache
-    self.view_path_cache = Concurrent::Map.new
 
     def self.register_detail(name, &block)
       registered_details << name
@@ -151,11 +149,11 @@ module ActionView
       alias :any_templates? :any?
 
       def append_view_paths(paths)
-        @view_paths = build_view_paths(@view_paths.to_a + cache_paths(paths))
+        @view_paths = build_view_paths(@view_paths.to_a + paths)
       end
 
       def prepend_view_paths(paths)
-        @view_paths = build_view_paths(cache_paths(paths) + @view_paths.to_a)
+        @view_paths = build_view_paths(paths + @view_paths.to_a)
       end
 
     private
@@ -166,22 +164,6 @@ module ActionView
           paths
         else
           ActionView::PathSet.new(Array(paths))
-        end
-      end
-
-      # #build_view_paths creates a new PathSet on each invocation. This helper
-      # caches stringish path arguments, enabling template caching for
-      # dynamically added view paths (e.g. added in a request context).
-      def cache_paths(paths)
-        Array(paths).map do |path|
-          if ActionView::Resolver.caching? && (path.is_a?(String) || path.is_a?(Pathname))
-            # Let PathSet transform `path` and cache the result
-            LookupContext.view_path_cache.fetch_or_store(path.to_s) do
-              PathSet.new([path]).paths[0]
-            end
-          else
-            path
-          end
         end
       end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -769,12 +769,15 @@ class RenderTest < ActionController::TestCase
 
     @old_view_paths = ActionController::Base.view_paths
     ActionController::Base.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
+
+    @path_set_cache = ActionView::PathSet.class_variable_get(:@@cache)
   end
 
   def teardown
     ActionView::Base.logger = nil
 
     ActionController::Base.view_paths = @old_view_paths
+    ActionView::PathSet.class_variable_set(:@@cache, Concurrent::Map.new)
   end
 
   # :ported:

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -769,8 +769,6 @@ class RenderTest < ActionController::TestCase
 
     @old_view_paths = ActionController::Base.view_paths
     ActionController::Base.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
-
-    @path_set_cache = ActionView::PathSet.class_variable_get(:@@cache)
   end
 
   def teardown

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -102,6 +102,28 @@ class ViewLoadPathsTest < ActionController::TestCase
     assert_paths TestController, *class_view_paths
   end
 
+  def test_append_view_path_does_not_bust_template_cache
+    template_instances = 2.times.map do
+      controller = Test::SubController.new
+      controller.append_view_path "#{FIXTURE_LOAD_PATH}/override2"
+      controller.lookup_context.find_all("layouts/test/sub")
+    end
+
+    object_ids = template_instances.flatten.map(&:object_id)
+    assert_equal 1, object_ids.uniq.count
+  end
+
+  def test_prepend_view_path_does_not_bust_template_cache
+    template_instances = 2.times.map do
+      controller = TestController.new
+      controller.prepend_view_path "#{FIXTURE_LOAD_PATH}/override"
+      controller.lookup_context.find_all("hello_world", "test")
+    end
+
+    object_ids = template_instances.flatten.map(&:object_id)
+    assert_equal 1, object_ids.uniq.count
+  end
+
   def test_view_paths
     get :hello_world
     assert_response :success

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -41,6 +41,7 @@ class ViewLoadPathsTest < ActionController::TestCase
 
   def teardown
     TestController.view_paths = @paths
+    ActionView::PathSet.class_variable_set(:@@cache, Concurrent::Map.new)
   end
 
   def expand(array)

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -31,6 +31,7 @@ class TemplateDigestorTest < ActionView::TestCase
   def teardown
     Dir.chdir @cwd
     FileUtils.rm_r @tmp_dir
+    ActionView::PathSet.class_variable_set(:@@cache, Concurrent::Map.new)
   end
 
   def test_top_level_change_reflected


### PR DESCRIPTION
### Issue
Adding view paths with `prepend_view_path` or `append_view_path` _in a request context_ disables template caching for these paths and creates a memory leak.

### Details
When prepending or appending view paths, [Rails will create an ActionView::Resolver for each String or Pathname argument](https://github.com/rails/rails/blob/1562651e5fb02d7687ffe13498c0cc3aee9249f0/actionview/lib/action_view/path_set.rb#L70). Previously, these were not cached. If view paths were added in a request context (which is a common thing in a multi-tenant application), [new resolvers were created on each request](https://github.com/rails/rails/blob/1562651e5fb02d7687ffe13498c0cc3aee9249f0/actionview/lib/action_view/lookup_context.rb#L166). This effectively disabled template caching for the added view paths.

Further, it also created a memory leak, which is how we noticed this issue in the first place. It goes somewhat like this: [for each rendered template, Rails defines a method](https://medium.com/rubyinside/disassembling-rails-template-rendering-2-a99214c6fde8#43ce). This creates [immortal symbols](https://stackoverflow.com/questions/34200946/garbage-collection-of-symbols-ruby-2-2-1/34201264#34201264). Since template caching was off, each request triggered many of these method definitions, flooding memory with symbols.

This commit fixes both issues by caching dynamic view path strings as resolver instances. I believe it also fixes #14301 and resolves #22580.

### Additional Information
* https://makandracards.com/makandra/515345-rails-fixing-the-memory-leak-performance-issues-in-prepend_view_path
* https://www.spacevatican.org/2019/5/4/debugging-a-memory-leak-in-a-rails-app/

### Checklist
* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
  _I have not mentioned the two issues above in the commit message, because I am not 100% sure they are related. My PR is not based on them, they just inspired the solution. If you wish, however, I will add them._
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.