### PR TITLE
Add `{Abstract,Action}Controller.deprecator`

### DIFF
--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -4,6 +4,7 @@ require "action_pack"
 require "active_support"
 require "active_support/rails"
 require "active_support/i18n"
+require "abstract_controller/deprecator"
 
 module AbstractController
   extend ActiveSupport::Autoload

--- a/actionpack/lib/abstract_controller/deprecator.rb
+++ b/actionpack/lib/abstract_controller/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AbstractController
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -2,6 +2,7 @@
 
 require "abstract_controller"
 require "action_dispatch"
+require "action_controller/deprecator"
 require "action_controller/metal/strong_parameters"
 require "action_controller/metal/exceptions"
 

--- a/actionpack/lib/action_controller/deprecator.rb
+++ b/actionpack/lib/action_controller/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionController
+  def self.deprecator # :nodoc:
+    AbstractController.deprecator
+  end
+end

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -277,7 +277,7 @@ module ActionController
         permitted? == other.permitted? && parameters == other.parameters
       else
         if self.class.allow_deprecated_parameters_hash_equality && Hash === other
-          ActiveSupport::Deprecation.warn <<-WARNING.squish
+          ActionController.deprecator.warn <<-WARNING.squish
             Comparing equality between `ActionController::Parameters` and a
             `Hash` is deprecated and will be removed in Rails 7.2. Please only do
             comparisons between instances of `ActionController::Parameters`. If

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -17,6 +17,10 @@ module ActionController
     config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
 
+    initializer "action_controller.deprecator" do |app|
+      app.deprecators[:action_controller] = ActionController.deprecator
+    end
+
     initializer "action_controller.assets_config", group: :all do |app|
       app.config.action_controller.assets_dir ||= app.config.paths["public"].first
     end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -53,6 +53,7 @@ Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
+ActionController.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -83,14 +83,14 @@ class ControllerClassTests < ActiveSupport::TestCase
     record.save
 
     dom_id = nil
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       dom_id = RecordIdentifierIncludedController.new.dom_id(record)
     end
 
     assert_equal "comment_1", dom_id
 
     dom_class = nil
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       dom_class = RecordIdentifierIncludedController.new.dom_class(record)
     end
     assert_equal "comment", dom_class

--- a/actionpack/test/controller/parameters/equality_test.rb
+++ b/actionpack/test/controller/parameters/equality_test.rb
@@ -21,7 +21,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "deprecated comparison works" do
     @hash = @params.each_pair.to_h
-    assert_deprecated do
+    assert_deprecated(ActionController.deprecator) do
       assert_equal @params, @hash
     end
   end
@@ -29,7 +29,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "deprecated comparison disabled" do
     without_deprecated_params_hash_equality do
       @hash = @params.each_pair.to_h
-      assert_not_deprecated do
+      assert_not_deprecated(ActionController.deprecator) do
         assert_not_equal @params, @hash
       end
     end
@@ -38,7 +38,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "not eql? to equivalent hash" do
     @hash = {}
     @params = ActionController::Parameters.new(@hash)
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       assert_not @params.eql?(@hash)
     end
   end
@@ -46,7 +46,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "not eql? to equivalent nested hash" do
     @params1 = ActionController::Parameters.new({ foo: {} })
     @params2 = ActionController::Parameters.new({ foo: ActionController::Parameters.new({}) })
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       assert_not @params1.eql?(@params2)
     end
   end
@@ -62,7 +62,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   end
 
   test "has_value? converts hashes to parameters" do
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       params = ActionController::Parameters.new(foo: { bar: "baz" })
       assert params.has_value?("bar" => "baz")
       params[:foo] # converts value to AC::Params

--- a/actionpack/test/controller/parameters_integration_test.rb
+++ b/actionpack/test/controller/parameters_integration_test.rb
@@ -43,7 +43,7 @@ permitted: false
       }
     }
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActionController.deprecator) do
       post :permit_params, params: params
     end
     assert_response :ok

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3901,6 +3901,8 @@ module ApplicationTests
       app "production"
 
       assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
+      assert_equal AbstractController.deprecator, Rails.application.deprecators[:action_controller]
+      assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end


### PR DESCRIPTION
This commit adds `AbstractController.deprecator` and `ActionController.deprecator`, and replaces all usages of `ActiveSupport::Deprecation.warn` in `actionpack/lib/action_controller` with the latter.

Additionally, this commit adds `ActionController.deprecator` to `Rails.application.deprecators`.  Because `AbstractController` does not have its own railtie to do the same, `AbstractController` and `ActionController` use the same deprecator instance.  Thus, both can be configured via `Rails.application.deprecators[:action_controller]` or via config settings such as `config.active_support.report_deprecations`.
