### PR TITLE
Add primary_key_default option to create table migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Add `primary-key-default` option to create table migrations.
+
+    This allows setting the `default` argument when creating a migration
+
+    ```bash
+    rails generate migration create_books --primary-key-type=uuid --primary-key-default="uuid_generate_v4()"
+    ```
+
+    ```ruby
+    class CreateBooks < ActiveRecord::Migration[7.0]
+      def change
+        create_table :books, id: :uuid, default: "uuid_generate_v4()" do |t|
+
+          t.timestamps
+        end
+      end
+    end
+    ```
+
+    It also allows you to create an initializer to configure the generator to
+    use the `primary_key_default` value for all new create table migrations.
+
+    ```ruby
+    Rails.application.config.generators do |g|
+      g.orm(:active_record, primary_key_type: :uuid)
+      g.orm(:active_record, primary_key_default: "\"uuid_generate_v4()\"")
+    end
+    ```
+
+    *Paul Yoder*
+
 *   Clear locking column on #dup
 
     This change fixes not to duplicate locking_column like id and timestamps.

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -22,6 +22,11 @@ module ActiveRecord
           ", id: :#{key_type}" if key_type
         end
 
+        def primary_key_default
+          key_default = options[:primary_key_default]
+          ", default: #{key_default}" if key_default
+        end
+
         def foreign_key_type
           key_type = options[:primary_key_type]
           ", type: :#{key_type}" if key_type

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
       class_option :timestamps, type: :boolean
       class_option :primary_key_type, type: :string, desc: "The type for primary key"
+      class_option :primary_key_default, type: :string, desc: "The default value for primary key"
       class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
       def create_migration_file

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
-    create_table :<%= table_name %><%= primary_key_type %> do |t|
+    create_table :<%= table_name %><%= primary_key_type %><%= primary_key_default %> do |t|
 <% attributes.each do |attribute| -%>
 <% if attribute.password_digest? -%>
       t.string :password_digest<%= attribute.inject_options %>

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -520,6 +520,27 @@ When building a model with a foreign key that will reference this UUID, treat
 rails generate model Case device_id:uuid
 ```
 
+To set the default value on the primary key, pass it in the
+`--primary-key-default={default value}` argument to the model generator.
+
+For example:
+
+```ruby
+rails generate model Device --primary-key-type=uuid --primary-key-default="uuid_generate_v4()" kind:string
+```
+
+```ruby
+# db/migrate/20221028135255_create_devices.rb
+class CreateDevices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :devices, id: :uuid, default: "uuid_generate_v4()" do |t|
+      t.string :kind
+      t.timestamps
+    end
+  end
+end
+```
+
 
 Generated Columns
 -----------------

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -301,6 +301,15 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_add_primary_key_default_value_to_create_table_migration
+    run_generator ["create_books", "--primary_key_type=uuid", "--primary_key_default=\"uuid_generate_v4()\""]
+    assert_migration "db/migrate/create_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :books, id: :uuid, default: "uuid_generate_v4\(\)"/, change)
+      end
+    end
+  end
+
   def test_database_puts_migrations_in_configured_folder
     with_database_configuration do
       run_generator ["create_books", "--database=secondary"]


### PR DESCRIPTION

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I want to automatically set the `default:` argument on create table migrations to "uuid_generate_v4()". The primary key type on my tables are :uuid and I want to use the uuid_generate_v4() method from Postgres to generate the id values.

### Detail

It adds the `primary_key_default` option on the migration generator, which allows an initializer to set the value to automatically use on all create table migrations.

```ruby
Rails.application.config.generators do |g|
  g.orm(:active_record, primary_key_type: :uuid)
  g.orm(:active_record, primary_key_default: "\"uuid_generate_v4()\"")
end
```

```bash
rails generate migration create_books
```

```ruby
class CreateBooks < ActiveRecord::Migration[7.0]
  def change
    create_table :books, id: :uuid, default: "uuid_generate_v4()" do |t|

      t.timestamps
    end
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

