### PR TITLE
Fix invalid content type deprecation warning

### DIFF
--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -201,7 +201,9 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg")
 
     # image/jpg is not recognised by mini_mime (image/jpeg is correct)
-    blob.update(content_type: "image/jpg")
+    assert_deprecated do
+      blob.update(content_type: "image/jpg")
+    end
 
     assert_nothing_raised do
       blob.variant(resize_to_limit: [100, 100])


### PR DESCRIPTION
This fixes the following warning when running Active Storage tests:

  ```
  DEPRECATION WARNING: image/jpg is not a valid content type, it should not be used when creating a blob, and support for it will be removed in Rails 7.1. If you want to keep supporting this content type past Rails 7.1, add it to `config.active_storage.variable_content_types`. Dismiss this warning by setting `config.active_storage.silence_invalid_content_types_warning = true`.
  ```

Note that this test should eventually be removed.  It was written to test the fix from #42225; however, after the deprecation from #42227 is complete and invalid content types have been removed from `config.active_storage.variable_content_types`, calling `variant` when the content type is invalid will [raise `ActiveStorage::InvariableError`](https://github.com/rails/rails/blob/c097635fa35e1a27d425366f30d4cd86f3b5ccab/activestorage/app/models/active_storage/blob/representable.rb#L35-L38) (instead of the `NoMethodError` mentioned in #42225 / #41777).  And that behavior is already tested by the ["variation of invariable blob" test](https://github.com/rails/rails/blob/c097635fa35e1a27d425366f30d4cd86f3b5ccab/activestorage/test/models/variant_test.rb#L149-L153).

---

Example warning: https://buildkite.com/rails/rails/builds/90549#0184109e-c819-48a1-92eb-21f6d30926d1/1071-1117
