### PR TITLE
Add missing defaults to new_framework_defaults

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -68,3 +68,42 @@
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
 # Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+
+# Specify the serializer used by `MessageEncryptor` by default.
+# Options are `:json`, `:hybrid`, and `:marshal`.
+#
+# New apps by default will use `:json`.
+#
+# Rails.application.config.active_support.default_message_encryptor_serializer = :json
+#
+# However, if you are upgrading an app, you will likely want to start with
+# `:hybrid`. If you switch to `:json` before existing messages have expired or 
+# been converted, those messages will no longer be readable.
+#
+# Rails.application.config.active_support.default_message_encryptor_serializer = :hybrid
+#
+# For detailed migration steps, check out https://guides.rubyonrails.org/v7.1/upgrading_ruby_on_rails.html#new-activesupport-messageencryptor-default-serializer
+
+# Specify the serializer used by `MessageVerifier` by default.
+# Options are `:json`, `:hybrid`, and `:marshal`.
+#
+# New apps by default will use `:json`.
+#
+# Rails.application.config.active_support.default_message_verifier_serializer = :json
+#
+# However, if you are upgrading an app, you will likely want to start with
+# `:hybrid`. If you switch to `:json` before existing messages have expired or
+# been converted, those messages will no longer be readable.
+#
+# Rails.application.config.active_support.default_message_verifier_serializer = :hybrid
+#
+# For detailed migration steps, check out https://guides.rubyonrails.org/v7.1/upgrading_ruby_on_rails.html#new-activesupport-messageverifier-default-serializer
+
+# Set the maximum size for Rails log files.
+#
+# `load_defaults 7.1` does not set this value for environments other than
+# development and test.
+#
+# if Rails.env.development? || Rails.env.test?
+#   Rails.application.config.log_file_size = 100 * 1024 * 1024
+# end


### PR DESCRIPTION
### Motivation / Background

These were added in cdce275, 5d0c2b0d, and 5256c90

### Detail

For the new MessageVerifier and MessageEncryptor defaults, I modeled the documentation after cb76ede. The goal is to warn users that they should pay attention to the config and not just uncomment it without doing additional work.

I also added an extra note to log_file_size since it is the first load_default I'm aware of that is environment dependent.

### Additional Information

I've added this as a check to one of my scripts so that this will be caught faster in the future: https://github.com/skipkayhil/rails-bin/commit/b48a7768c34478e7fc2ed24d109e0afd97488428

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

