### PR TITLE
Fix missed connection handler call

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -646,7 +646,7 @@ module ActiveRecord
           # Roundtrip to Rake to allow plugins to hook into database initialization.
           root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
           FileUtils.cd(root) do
-            Base.connection_handler.clear_all_connections!
+            Base.connection_handler.clear_all_connections!(:all)
             system("bin/rails db:test:prepare")
           end
         end


### PR DESCRIPTION
In #45924 I updated the methods on connection handler to clear all connections regardless of role. I missed this call because it doesn't throw deprecation warnings in the Active Record tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

