### PR TITLE
Only ask people to run migration in a environment in non-development environments

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -150,7 +150,7 @@ module ActiveRecord
     private
       def detailed_migration_message
         message = "Migrations are pending. To resolve this issue, run:\n\n        bin/rails db:migrate"
-        message += " RAILS_ENV=#{::Rails.env}" if defined?(Rails.env)
+        message += " RAILS_ENV=#{::Rails.env}" if defined?(Rails.env) && !(Rails.env.development? || Rails.env.test?)
         message += "\n\n"
 
         pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations


### PR DESCRIPTION
When running test, you might have pending migrations. Before, Rails would tell you to run migrations with `RAILS_ENV=test`.

This causes the problem that now the development environment still have pending migrations.

The correct workflow is to run migrations in the development environment and let Rails prepare the test database based on the schema or structure file.

In the development environment we don't need to tell to use the `RAILS_ENV` environment variable.