### PR TITLE
Add `ActionDispatch.deprecator`

### DIFF
--- a/actionmailer/test/i18n_with_controller_test.rb
+++ b/actionmailer/test/i18n_with_controller_test.rb
@@ -27,7 +27,7 @@ end
 class ActionMailerI18nWithControllerTest < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
-    ActiveSupport::Deprecation.silence do
+    ActionDispatch.deprecator.silence do
       get ":controller(/:action(/:id))"
     end
   end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -29,6 +29,7 @@ require "active_support/core_ext/module/attribute_accessors"
 
 require "action_pack"
 require "rack"
+require "action_dispatch/deprecator"
 
 module Rack
   autoload :Test, "rack/test"

--- a/actionpack/lib/action_dispatch/deprecator.rb
+++ b/actionpack/lib/action_dispatch/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -35,7 +35,7 @@ module ActionDispatch
 
       def content_type
         if self.class.return_only_media_type_on_content_type
-          ActiveSupport::Deprecation.warn(
+          ActionDispatch.deprecator.warn(
             "Rails 7.1 will return Content-Type header without modification." \
             " If you want just the MIME type, please use `#media_type` instead."
           )

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -134,7 +134,7 @@ module ActionDispatch # :nodoc:
 
     %w[speaker vibrate vr].each do |directive|
       define_method(directive) do |*sources|
-        ActiveSupport::Deprecation.warn(<<~MSG)
+        ActionDispatch.deprecator.warn(<<~MSG)
           The `#{directive}` permissions policy directive is deprecated
           and will be removed in Rails 7.2.
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -64,7 +64,7 @@ module ActionDispatch
       elsif custom_proxies.respond_to?(:any?)
         custom_proxies
       else
-        ActiveSupport::Deprecation.warn(<<~EOM)
+        ActionDispatch.deprecator.warn(<<~EOM)
           Setting config.action_dispatch.trusted_proxies to a single value has
           been deprecated. Please set this to an enumerable instead. For
           example, instead of:

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -41,6 +41,10 @@ module ActionDispatch
 
     config.eager_load_namespaces << ActionDispatch
 
+    initializer "action_dispatch.deprecator" do |app|
+      app.deprecators[:action_dispatch] = ActionDispatch.deprecator
+    end
+
     initializer "action_dispatch.configure" do |app|
       ActionDispatch::Http::URL.secure_protocol = app.config.force_ssl
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -596,14 +596,14 @@ module ActionDispatch
         named_routes[name] = route if name
 
         if route.segment_keys.include?(:controller)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActionDispatch.deprecator.warn(<<-MSG.squish)
             Using a dynamic :controller segment in a route is deprecated and
             will be removed in Rails 7.1.
           MSG
         end
 
         if route.segment_keys.include?(:action)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActionDispatch.deprecator.warn(<<-MSG.squish)
             Using a dynamic :action segment in a route is deprecated and
             will be removed in Rails 7.1.
           MSG

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -13,7 +13,7 @@ module ActionDispatch
         @capabilities = capabilities
 
         if [:poltergeist, :webkit].include?(driver_type)
-          ActiveSupport::Deprecation.warn <<~MSG.squish
+          ActionDispatch.deprecator.warn <<~MSG.squish
             Poltergeist and capybara-webkit are not maintained already.
             Driver registration of :poltergeist or :webkit is deprecated and will be removed in Rails 7.1.
             You can still use :selenium, and also :cuprite is available for alternative to Poltergeist.

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -52,8 +52,8 @@ ActionPackTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
 ActionController.deprecator.debug = true
+ActionDispatch.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
@@ -63,7 +63,7 @@ FIXTURE_LOAD_PATH = File.join(__dir__, "fixtures")
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 
 SharedTestRoutes.draw do
-  ActiveSupport::Deprecation.silence do
+  ActionDispatch.deprecator.silence do
     get ":controller(/:action)"
   end
 end
@@ -72,7 +72,7 @@ module ActionDispatch
   module SharedRoutes
     def before_setup
       @routes = Routing::RouteSet.new
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         @routes.draw { get ":controller(/:action)" }
       end
       super
@@ -119,7 +119,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   self.app = build_app
 
   app.routes.draw do
-    ActiveSupport::Deprecation.silence do
+    ActionDispatch.deprecator.silence do
       get ":controller(/:action)"
     end
   end

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -204,7 +204,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
         get "route_one", to: "action_pack_assertions#nothing", as: :route_one
         get "route_two", to: "action_pack_assertions#nothing", id: "two", as: :route_two
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -231,7 +231,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       set.draw do
         get "admin/inner_module", to: "admin/inner_module#index", as: :admin_inner_module
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -248,7 +248,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       set.draw do
         get "/action_pack_assertions/:id", to: "action_pack_assertions#index", as: :top_level
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -267,7 +267,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
         # this controller exists in the admin namespace as well which is the only difference from previous test
         get "/user/:id", to: "user#index", as: :top_level
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -220,7 +220,7 @@ class UrlOptionsTest < ActionController::TestCase
       set.draw do
         get "from_view", to: "url_options#from_view", as: :from_view
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -257,7 +257,7 @@ class DefaultUrlOptionsTest < ActionController::TestCase
       set.draw do
         get "from_view", to: "default_url_options#from_view", as: :from_view
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -277,7 +277,7 @@ class DefaultUrlOptionsTest < ActionController::TestCase
           resources :descriptions
         end
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -380,7 +380,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":action", to: FlashIntegrationTest::TestController
           end
         end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -627,7 +627,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         set.draw do
           get "moved" => redirect("/method")
 
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             match ":action", to: controller, via: [:get, :post], as: :action
             get "get/:action", to: controller, as: :get_action
           end
@@ -1041,7 +1041,7 @@ class IntegrationRequestsWithoutSetup < ActionDispatch::IntegrationTest
   def test_request
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action" => FooController
         end
       end
@@ -1085,7 +1085,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_standard_json_encoding_works
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           post ":action" => FooController
         end
       end
@@ -1112,7 +1112,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_doesnt_mangle_request_path
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           post ":action" => FooController
         end
       end
@@ -1153,7 +1153,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_parsed_body_without_as_option
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action" => FooController
         end
       end
@@ -1167,7 +1167,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_get_parameters_with_as_option
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action" => FooController
         end
       end
@@ -1181,7 +1181,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_get_request_with_json_uses_method_override_and_sends_a_post_request
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action" => FooController
         end
       end
@@ -1197,7 +1197,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
   def test_get_request_with_json_excludes_null_query_string
     with_routing do |routes|
       routes.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action" => FooController
         end
       end
@@ -1212,7 +1212,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     def post_to_foos(as:)
       with_routing do |routes|
         routes.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             post ":action" => FooController
           end
         end

--- a/actionpack/test/controller/new_base/content_type_test.rb
+++ b/actionpack/test/controller/new_base/content_type_test.rb
@@ -45,7 +45,7 @@ module ContentType
     test "default response is text/plain and UTF8" do
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller", action: "index"
           end
         end

--- a/actionpack/test/controller/new_base/render_body_test.rb
+++ b/actionpack/test/controller/new_base/render_body_test.rb
@@ -87,7 +87,7 @@ module RenderBody
 
     test "rendering body from an action with default options renders the body with the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_body/simple"
         assert_body "hello david"
@@ -97,7 +97,7 @@ module RenderBody
 
     test "rendering body from an action with default options renders the body without the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_body/with_layout"
 

--- a/actionpack/test/controller/new_base/render_html_test.rb
+++ b/actionpack/test/controller/new_base/render_html_test.rb
@@ -90,7 +90,7 @@ module RenderHtml
 
     test "rendering text from an action with default options renders the text with the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_html/simple"
         assert_body "hello david"
@@ -100,7 +100,7 @@ module RenderHtml
 
     test "rendering text from an action with default options renders the text without the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_html/with_layout"
 

--- a/actionpack/test/controller/new_base/render_plain_test.rb
+++ b/actionpack/test/controller/new_base/render_plain_test.rb
@@ -82,7 +82,7 @@ module RenderPlain
 
     test "rendering text from an action with default options renders the text with the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_plain/simple"
         assert_body "hello david"
@@ -92,7 +92,7 @@ module RenderPlain
 
     test "rendering text from an action with default options renders the text without the layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: "index" } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: "index" } }
 
         get "/render_plain/with_layout"
 

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -177,7 +177,7 @@ module RenderTemplate
   class TestWithLayout < Rack::TestCase
     test "rendering with implicit layout" do
       with_routing do |set|
-        set.draw { ActiveSupport::Deprecation.silence { get ":controller", action: :index } }
+        set.draw { ActionDispatch.deprecator.silence { get ":controller", action: :index } }
 
         get "/render_template/with_layout"
 

--- a/actionpack/test/controller/new_base/render_test.rb
+++ b/actionpack/test/controller/new_base/render_test.rb
@@ -58,7 +58,7 @@ module Render
     test "render with blank" do
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller", action: "index"
           end
         end
@@ -73,7 +73,7 @@ module Render
     test "rendering more than once raises an exception" do
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller", action: "index"
           end
         end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -389,7 +389,7 @@ class RedirectTest < ActionController::TestCase
       set.draw do
         resources :workshops
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -411,7 +411,7 @@ class RedirectTest < ActionController::TestCase
           resources :workshops
         end
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -429,7 +429,7 @@ class RedirectTest < ActionController::TestCase
           resources :workshops
         end
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -476,7 +476,7 @@ class RedirectTest < ActionController::TestCase
   def test_redirect_to_with_block_and_accepted_options
     with_routing do |set|
       set.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -395,7 +395,7 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_dynamic_render
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
-      assert_deprecated do
+      assert_deprecated(ActionDispatch.deprecator) do
         get :dynamic_render, params: { id: '../\\../test/abstract_unit.rb' }
       end
     end
@@ -884,7 +884,7 @@ class HeadRenderTest < ActionController::TestCase
       set.draw do
         resources :customers
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end

--- a/actionpack/test/controller/render_xml_test.rb
+++ b/actionpack/test/controller/render_xml_test.rb
@@ -74,7 +74,7 @@ class RenderXmlTest < ActionController::TestCase
       set.draw do
         resources :customers
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -17,7 +17,7 @@ class UriReservedCharactersRoutingTest < ActiveSupport::TestCase
   def setup
     @set = ActionDispatch::Routing::RouteSet.new
     @set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:variable/*additional"
       end
     end
@@ -330,7 +330,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_default_setup
-    rs.draw { ActiveSupport::Deprecation.silence { get "/:controller(/:action(/:id))" } }
+    rs.draw { ActionDispatch.deprecator.silence { get "/:controller(/:action(/:id))" } }
     assert_equal({ controller: "content", action: "index" }, rs.recognize_path("/content"))
     assert_equal({ controller: "content", action: "list" },  rs.recognize_path("/content/list"))
     assert_equal({ controller: "content", action: "show", id: "10" }, rs.recognize_path("/content/show/10"))
@@ -353,7 +353,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_colon_first
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/:controller/:action/:id", action: "index", id: nil
       end
 
@@ -364,7 +364,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_route_with_regexp_for_action
-    rs.draw { ActiveSupport::Deprecation.silence { get "/:controller/:action", action: /auth[-|_].+/ } }
+    rs.draw { ActionDispatch.deprecator.silence { get "/:controller/:action", action: /auth[-|_].+/ } }
 
     assert_equal({ action: "auth_google", controller: "content" }, rs.recognize_path("/content/auth_google"))
     assert_equal({ action: "auth-twitter", controller: "content" }, rs.recognize_path("/content/auth-twitter"))
@@ -375,7 +375,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_for_controller
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:admintoken(/:action(/:id))", controller: /admin\/.+/
         get "/:controller(/:action(/:id))"
       end
@@ -392,7 +392,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_and_captures_for_controller
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/:controller(/:action(/:id))", controller: /admin\/(accounts|users)/
       end
     end
@@ -403,7 +403,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_regexp_and_dot
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:file",
                   controller: /admin|user/,
                   action: /upload|download/,
@@ -493,7 +493,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_without_hash
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id", as: "normal"
       end
     end
@@ -548,7 +548,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       get "page/:year/:month/:day/:title" => "page#show", :as => "article",
         :year => /\d+/, :month => /\d+/, :day => /\d+/
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -560,7 +560,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_changing_controller
-    rs.draw { ActiveSupport::Deprecation.silence { get ":controller/:action/:id" } }
+    rs.draw { ActionDispatch.deprecator.silence { get ":controller/:action/:id" } }
 
     get URI("http://test.host/admin/user/index/10")
 
@@ -572,7 +572,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "file/*path" => "content#show_file", :as => "path"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -599,7 +599,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_non_controllers_cannot_be_matched
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -628,7 +628,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "/dynamic/:dynamic_segment" => "subpath_books#show", as: :dynamic
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -642,7 +642,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "/wildcard/*wildcard_segment" => "subpath_books#show", as: :wildcard
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -667,7 +667,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_backwards
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "page/:id(/:action)" => "pages#show"
         get ":controller(/:action(/:id))"
       end
@@ -683,7 +683,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "page(/:id)" => "content#show_page", :id => 1
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -703,7 +703,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "page/:id" => "content#show_page", :id => 1
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -720,7 +720,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_action_expiry
-    rs.draw { ActiveSupport::Deprecation.silence { get ":controller(/:action(/:id))" } }
+    rs.draw { ActionDispatch.deprecator.silence { get ":controller(/:action(/:id))" } }
     get URI("http://test.host/content/show")
     assert_equal "/content", controller.url_for(controller: "content", only_path: true)
   end
@@ -744,7 +744,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
         :constraints => { year: /\d{4}/ }
       )
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -759,7 +759,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "pages(/:year(/:month(/:day)))" => "content#list_pages", :month => nil, :day => nil
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -809,7 +809,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.draw do
       get "categories" => "content#categories", :as => "categories"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller(/:action(/:id))"
       end
     end
@@ -828,7 +828,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       get "journal" => "content#list_journal",
         :date => nil, :user_id => nil
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -869,7 +869,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_subpath_recognized
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/books/:id/edit"    => "subpath_books#edit"
         get "/items/:id/:action" => "subpath_books"
         get "/posts/new/:action" => "subpath_books"
@@ -896,7 +896,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_subpath_generated
     rs.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/books/:id/edit"    => "subpath_books#edit"
         get "/items/:id/:action" => "subpath_books"
         get "/posts/new/:action" => "subpath_books"
@@ -925,7 +925,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       get "cb" => "cb#ab"
       get "cc" => "cc#ac"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
         get ":controller/:action/:id.:format"
       end
@@ -940,7 +940,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       get "cb" => "cb#ab"
       get "cc" => "cc#ac"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
         get ":controller/:action/:id.:format"
       end
@@ -1007,7 +1007,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @default_route_set ||= begin
       set = ActionDispatch::Routing::RouteSet.new
       set.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get "/:controller(/:action(/:id))"
         end
       end
@@ -1016,21 +1016,21 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_generate_extras
-    set.draw { ActiveSupport::Deprecation.silence { get ":controller/(:action(/:id))" } }
+    set.draw { ActionDispatch.deprecator.silence { get ":controller/(:action(/:id))" } }
     path, extras = set.generate_extras(controller: "foo", action: "bar", id: 15, this: "hello", that: "world")
     assert_equal "/foo/bar/15", path
     assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_extra_keys
-    set.draw { ActiveSupport::Deprecation.silence { get ":controller/:action/:id" } }
+    set.draw { ActionDispatch.deprecator.silence { get ":controller/:action/:id" } }
     extras = set.extra_keys(controller: "foo", action: "bar", id: 15, this: "hello", that: "world")
     assert_equal %w(that this), extras.map(&:to_s).sort
   end
 
   def test_generate_extras_not_first
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id.:format"
         get ":controller/:action/:id"
       end
@@ -1042,7 +1042,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_generate_not_first
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id.:format"
         get ":controller/:action/:id"
       end
@@ -1053,7 +1053,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_extra_keys_not_first
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id.:format"
         get ":controller/:action/:id"
       end
@@ -1188,7 +1188,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_draw_default_route
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -1206,7 +1206,7 @@ class RouteSetTest < ActiveSupport::TestCase
     set.draw do
       get "page/:id" => "pages#show", :id => /\d+/
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/:controller(/:action(/:id))"
       end
     end
@@ -1461,7 +1461,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:id/:action"
       end
     end
@@ -1477,7 +1477,7 @@ class RouteSetTest < ActiveSupport::TestCase
     set.draw do
       get "about" => "welcome#about"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:id/:action"
       end
     end
@@ -1490,7 +1490,7 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_generate
-    set.draw { ActiveSupport::Deprecation.silence { get ":controller/:action/:id" } }
+    set.draw { ActionDispatch.deprecator.silence { get ":controller/:action/:id" } }
 
     args = { controller: "foo", action: "bar", id: "7", x: "y" }
     assert_equal "/foo/bar/7?x=y",     url_for(set, args)
@@ -1501,7 +1501,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_generate_with_path_prefix
     set.draw do
       scope "my" do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end
@@ -1514,7 +1514,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_generate_with_blank_path_prefix
     set.draw do
       scope "" do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end
@@ -1528,7 +1528,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/connection/manage(/:action)" => "connection/manage#index"
         get "/connection/connection" => "connection/connection#index"
         get "/connection" => "connection#index", :as => "family_connection"
@@ -1550,7 +1550,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller(/:action(/:id))"
       end
     end
@@ -1568,7 +1568,7 @@ class RouteSetTest < ActiveSupport::TestCase
     set.draw do
       get "show_weblog/:parameter" => "weblog#show"
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller(/:action(/:id))"
       end
     end
@@ -1598,7 +1598,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_expiry_determination_should_consider_values_with_to_param
     @set = make_set false
 
-    set.draw { ActiveSupport::Deprecation.silence { get "projects/:project_id/:controller/:action" } }
+    set.draw { ActionDispatch.deprecator.silence { get "projects/:project_id/:controller/:action" } }
 
     get URI("http://test.host/projects/1/weblog/show")
 
@@ -1775,7 +1775,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_assign_route_options_with_anchor_chars
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/cars/:action/:person/:car/", controller: "cars"
       end
     end
@@ -1787,7 +1787,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_segmentation_of_dot_path
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/books/:action.rss", controller: "books"
       end
     end
@@ -1799,7 +1799,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_segmentation_of_dynamic_dot_path
     set.draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/books(/:action(.:format))", controller: "books"
       end
     end
@@ -1816,7 +1816,7 @@ class RouteSetTest < ActiveSupport::TestCase
   end
 
   def test_slashes_are_implied
-    set.draw { ActiveSupport::Deprecation.silence { get("/:controller(/:action(/:id))") } }
+    set.draw { ActionDispatch.deprecator.silence { get("/:controller(/:action(/:id))") } }
 
     assert_equal "/content",        url_for(set, controller: "content", action: "index")
     assert_equal "/content/list",   url_for(set, controller: "content", action: "list")
@@ -1907,7 +1907,7 @@ class RouteSetTest < ActiveSupport::TestCase
                              :constraints => { page: /\d+/ },
                              :defaults => { page: 1 }
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
       end
     end
@@ -1931,7 +1931,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
       get "blog/show/:id", controller: "blog", action: "show", id: /\d+/
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "blog/:controller/:action(/:id)"
       end
 
@@ -2023,7 +2023,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
     get "news(.:format)" => "news#index"
 
-    ActiveSupport::Deprecation.silence do
+    ActionDispatch.deprecator.silence do
       get "comment/:id(/:action)" => "comments#show"
       get "ws/:controller(/:action(/:id))", ws: true
       get "account(/:action)" => "account#subscription"
@@ -2033,7 +2033,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
     get "こんにちは/世界", controller: "news", action: "index"
 
-    ActiveSupport::Deprecation.silence do
+    ActionDispatch.deprecator.silence do
       match ":controller(/:action(/:id))(.:format)", via: :all
     end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -183,7 +183,7 @@ XML
     @request.delete_header "PATH_INFO"
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end
@@ -661,7 +661,7 @@ XML
       set.draw do
         get "file/*path", to: "test_case_test/test#test_params"
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller/:action"
         end
       end
@@ -1076,7 +1076,7 @@ class ResponseDefaultHeadersTest < ActionController::TestCase
     @request.env["PATH_INFO"] = nil
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end
@@ -1205,7 +1205,7 @@ class AnonymousControllerTest < ActionController::TestCase
 
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -53,7 +53,7 @@ module ActionPack
 
       get "news(.:format)" => "news#index"
 
-      ActiveSupport::Deprecation.silence {
+      ActionDispatch.deprecator.silence {
         get "comment/:id(/:action)" => "comments#show"
         get "ws/:controller(/:action(/:id))", ws: true
         get "account(/:action)" => "account#subscription"

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -8,7 +8,7 @@ module AbstractController
       class W
         include ActionDispatch::Routing::RouteSet.new.tap { |r|
           r.draw {
-            ActiveSupport::Deprecation.silence {
+            ActionDispatch.deprecator.silence {
               get ":controller(/:action(/:id(.:format)))"
             }
           }
@@ -268,7 +268,7 @@ module AbstractController
         w = Class.new {
           config = ActionDispatch::Routing::RouteSet::Config.new "/subdir"
           r = ActionDispatch::Routing::RouteSet.new(config)
-          r.draw { ActiveSupport::Deprecation.silence { get ":controller(/:action(/:id(.:format)))" } }
+          r.draw { ActionDispatch.deprecator.silence { get ":controller(/:action(/:id(.:format)))" } }
           include r.url_helpers
         }
         add_host!(w)
@@ -324,7 +324,7 @@ module AbstractController
           set.draw do
             get "home/sweet/home/:user", to: "home#index", as: :home
 
-            ActiveSupport::Deprecation.silence do
+            ActionDispatch.deprecator.silence do
               get ":controller/:action/:id"
             end
           end

--- a/actionpack/test/controller/url_rewriter_test.rb
+++ b/actionpack/test/controller/url_rewriter_test.rb
@@ -22,7 +22,7 @@ class UrlRewriterTests < ActionController::TestCase
     @rewriter = Rewriter.new(@request)
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
       r.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":controller(/:action(/:id))"
         end
       end

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -41,11 +41,11 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
   end
 
   def test_deprecated_directives
-    assert_deprecated { @policy.speaker :self }
-    assert_deprecated { @policy.vibrate :self }
-    assert_deprecated { @policy.vr :self }
+    assert_deprecated(ActionDispatch.deprecator) { @policy.speaker :self }
+    assert_deprecated(ActionDispatch.deprecator) { @policy.vibrate :self }
+    assert_deprecated(ActionDispatch.deprecator) { @policy.vr :self }
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActionDispatch.deprecator) do
       assert_equal "speaker 'self'; vibrate 'self'; vr 'self'", @policy.build
     end
   end

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -112,7 +112,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             post ":action", to: ::JsonParamsParsingTest::TestController
           end
         end
@@ -205,7 +205,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing(controller)
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             post ":action", to: controller
           end
         end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -173,7 +173,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   test "does not raise EOFError on GET request with multipart content-type" do
     with_routing do |set|
       set.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action", controller: "multipart_params_parsing_test/test"
         end
       end
@@ -204,7 +204,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             post ":action", controller: "multipart_params_parsing_test/test"
           end
         end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -146,7 +146,7 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
   test "ambiguous query string returns a bad request" do
     with_routing do |set|
       set.draw do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action", to: ::QueryStringParsingTest::TestController
         end
       end
@@ -160,7 +160,7 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     def assert_parses(expected, actual)
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":action", to: ::QueryStringParsingTest::TestController
           end
         end

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -142,7 +142,7 @@ class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
     def with_test_routing
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             post ":action", to: ::UrlEncodedParamsParsingTest::TestController
           end
         end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1047,13 +1047,13 @@ class RequestMimeType < BaseRequestTest
 
     assert_equal(Mime[:xml], request.content_mime_type)
     assert_equal("application/xml", request.media_type)
-    assert_deprecated do
+    assert_deprecated(ActionDispatch.deprecator) do
       assert_nil(request.content_charset)
     end
-    assert_deprecated do
+    assert_deprecated(ActionDispatch.deprecator) do
       assert_equal({}, request.media_type_params)
     end
-    assert_deprecated do
+    assert_deprecated(ActionDispatch.deprecator) do
       assert_equal("application/xml", request.content_type)
     end
   ensure

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -130,7 +130,7 @@ module ActionDispatch
 
       def test_inspect_routes_shows_dynamic_action_route
         output = draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get "api/:action" => "api"
           end
         end
@@ -143,7 +143,7 @@ module ActionDispatch
 
       def test_inspect_routes_shows_controller_and_action_only_route
         output = draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller/:action"
           end
         end
@@ -156,7 +156,7 @@ module ActionDispatch
 
       def test_inspect_routes_shows_controller_and_action_route_with_constraints
         output = draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller(/:action(/:id))", id: /\d+/
           end
         end
@@ -400,7 +400,7 @@ module ActionDispatch
 
       def test_regression_route_with_controller_regexp
         output = draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":controller(/:action)", controller: /api\/[^\/]+/, format: false
           end
         end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -134,7 +134,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_raise(ArgumentError) do
       draw do
         namespace :admin do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get "/:controller(/:action(/:id(.:format)))"
           end
         end
@@ -145,7 +145,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_namespace_without_controller_segment
     draw do
       namespace :admin do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get "hello/:controllers/:action"
         end
       end
@@ -452,7 +452,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
         get "global/export",      action: :export, as: :export_request
         get "/export/:id/:file",  action: :export, as: :export_download, constraints: { file: /.*/ }
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get "global/:action"
         end
       end
@@ -477,7 +477,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_local
     draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/local/:action", controller: "local"
       end
     end
@@ -1624,7 +1624,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_not_matching_shorthand_with_dynamic_parameters
     draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller/:action/admin"
       end
     end
@@ -1662,7 +1662,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_scoped_controller_with_namespace_and_action
     draw do
       namespace :account do
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get ":action/callback", action: /twitter|github/, controller: "callbacks", as: :callback
         end
       end
@@ -1995,7 +1995,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_generic_route
     draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "whatever/:controller(/:action(/:id))"
       end
     end
@@ -2009,7 +2009,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_namespaced_generic_route
     draw do
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "whatever/:controller(/:action(/:id))", id: /\d+/
       end
     end
@@ -3797,7 +3797,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_dynamic_controller_segments_are_deprecated
-    assert_deprecated do
+    assert_deprecated(ActionDispatch.deprecator) do
       draw do
         get "/:controller", action: "index"
       end
@@ -3805,7 +3805,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_dynamic_action_segments_are_deprecated
-    assert_deprecated do
+    assert_deprecated(ActionDispatch.deprecator) do
       draw do
         get "/pages/:action", controller: "pages"
       end
@@ -4397,7 +4397,7 @@ class TestOptimizedNamedRoutes < ActionDispatch::IntegrationTest
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
       get "/foo" => ok, as: :foo
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/post(/:action(/:id))" => ok, as: :posts
       end
 
@@ -4578,7 +4578,7 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
         ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
         get "/foobar/:id", to: ok
 
-        ActiveSupport::Deprecation.silence do
+        ActionDispatch.deprecator.silence do
           get "/:controller(/:action(/:id))"
         end
       end
@@ -4966,7 +4966,7 @@ class TestErrorsInController < ActionDispatch::IntegrationTest
 
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
-    ActiveSupport::Deprecation.silence do
+    ActionDispatch.deprecator.silence do
       get "/:controller(/:action)"
     end
   end
@@ -5109,7 +5109,7 @@ class TestPathParameters < ActionDispatch::IntegrationTest
         end
       end
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get ":controller(/:action/(:id))"
       end
     end

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -207,7 +207,7 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":action", to: ::CacheStoreTest::TestController
           end
         end

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -423,7 +423,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set(options = {})
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":action", to: ::CookieStoreTest::TestController
           end
         end

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -190,7 +190,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
     def with_test_route_set
       with_routing do |set|
         set.draw do
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             get ":action", to: ::MemCacheStoreTest::TestController
           end
         end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -38,7 +38,7 @@ class DriverTest < ActiveSupport::TestCase
   end
 
   test "initializing the driver with a poltergeist" do
-    driver = assert_deprecated do
+    driver = assert_deprecated(ActionDispatch.deprecator) do
       ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
     end
     assert_equal :poltergeist, driver.instance_variable_get(:@driver_type)
@@ -47,7 +47,7 @@ class DriverTest < ActiveSupport::TestCase
   end
 
   test "initializing the driver with a webkit" do
-    driver = assert_deprecated do
+    driver = assert_deprecated(ActionDispatch.deprecator) do
       ActionDispatch::SystemTesting::Driver.new(:webkit, screen_size: [1400, 1400], options: { skip_image_loading: true })
     end
     assert_equal :webkit, driver.instance_variable_get(:@driver_type)

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -499,13 +499,13 @@ module ActionDispatch
         end
 
         def get(*args)
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             mapper.get(*args)
           end
         end
 
         def match(*args)
-          ActiveSupport::Deprecation.silence do
+          ActionDispatch.deprecator.silence do
             mapper.match(*args)
           end
         end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1072,7 +1072,7 @@ class UrlHelperControllerTest < ActionController::TestCase
         to: "url_helper_controller_test/url_helper#show_named_route",
         as: :show_named_route
 
-      ActiveSupport::Deprecation.silence do
+      ActionDispatch.deprecator.silence do
         get "/:controller(/:action(/:id))"
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3903,6 +3903,7 @@ module ApplicationTests
       assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
       assert_equal AbstractController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
+      assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -68,7 +68,7 @@ module ApplicationTests
         app.config.action_dispatch.trusted_proxies = [IPAddr.new("4.2.42.0/24"), /^4\.2\.42\.43$/, "4.2.42.44"]
       end
 
-      assert_not_deprecated do
+      assert_not_deprecated(ActionDispatch.deprecator) do
         assert_equal "1.1.1.1",
                      remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42,4.2.42.43,4.2.42.44")
       end
@@ -88,7 +88,7 @@ module ApplicationTests
         app.config.action_dispatch.trusted_proxies = IPAddr.new("4.2.42.0/24")
       end
 
-      assert_deprecated(/Setting config\.action_dispatch\.trusted_proxies to a single value/) do
+      assert_deprecated(/Setting config\.action_dispatch\.trusted_proxies to a single value/, ActionDispatch.deprecator) do
         assert_equal "1.1.1.1",
                      remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "10.0.0.0,4.2.42.42")
       end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -120,7 +120,7 @@ module TestHelpers
       routes = File.read("#{app_path}/config/routes.rb")
       if routes =~ /(\n\s*end\s*)\z/
         File.open("#{app_path}/config/routes.rb", "w") do |f|
-          f.puts $` + "\nActiveSupport::Deprecation.silence { match ':controller(/:action(/:id))(.:format)', via: :all }\n" + $1
+          f.puts $` + "\nActionDispatch.deprecator.silence { match ':controller(/:action(/:id))(.:format)', via: :all }\n" + $1
         end
       end
 


### PR DESCRIPTION
This commit adds `ActionDispatch.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `actionpack/lib/action_dispatch` with `ActionDispatch.deprecator`.

Additionally, this commit adds `ActionDispatch.deprecator` to `Rails.application.deprecators` so that it can be configured via settings such as `config.active_support.report_deprecations`.
