### PR TITLE
Invalidate transaction as early as possible

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Invalidate transaction as early as possible
+
+    After rescuing a `TransactionRollbackError` exception Rails invalidates transactions earlier in the flow
+    allowing the framework to skip issuing the `ROLLBACK` statement in more cases.
+    Only affects adapters that have `savepoint_errors_invalidate_transactions?` configured as `true`,
+    which at this point is only applicable to the `mysql2` adapter.
+
+    *Nikita Vasilevsky*
+
 *   Allow configuring columns list to be used in SQL queries issued by an `ActiveRecord::Base` object
 
     It is now possible to configure columns list that will be used to build an SQL query clauses when

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -457,10 +457,6 @@ module ActiveRecord
           ret
         rescue Exception => error
           if transaction
-            if error.is_a?(ActiveRecord::TransactionRollbackError) &&
-                @connection.savepoint_errors_invalidate_transactions?
-              transaction.state.invalidate!
-            end
             rollback_transaction
             after_failure_actions(transaction, error)
           end

--- a/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
@@ -78,6 +78,57 @@ module ActiveRecord
       assert_predicate connection, :active?
     end
 
+    test "rollback exception is swallowed after a rollback" do
+      barrier = Concurrent::CyclicBarrier.new(2)
+      deadlocks = 0
+
+      s1 = Sample.create value: 1
+      s2 = Sample.create value: 2
+
+      thread = Thread.new do
+        Sample.transaction(requires_new: false) do
+          make_parent_transaction_dirty
+          Sample.transaction(requires_new: true) do
+            assert_current_transaction_is_savepoint_transaction
+            s1.lock!
+            barrier.wait
+            s2.update value: 4
+
+          rescue ActiveRecord::Deadlocked
+            deadlocks += 1
+
+            # This rollback is actually wrong as mysql automatically rollbacks the transaction
+            # which means we have nothing to rollback on the db side
+            # but we expect the framework to handle our mistake gracefully
+            raise ActiveRecord::Rollback
+          end
+
+          s2.update value: 10
+        end
+      end
+
+      begin
+        Sample.transaction(requires_new: false) do
+          make_parent_transaction_dirty
+          Sample.transaction(requires_new: true) do
+            assert_current_transaction_is_savepoint_transaction
+            s2.lock!
+            barrier.wait
+            s1.update value: 3
+          rescue ActiveRecord::Deadlocked
+            deadlocks += 1
+            raise ActiveRecord::Rollback
+          end
+          s1.update value: 10
+        end
+      ensure
+        thread.join
+      end
+
+      assert_equal 1, deadlocks, "deadlock is required for the test setup"
+      assert_equal [10, 10], Sample.pluck(:value)
+    end
+
     test "deadlock inside nested SavepointTransaction is recoverable" do
       barrier = Concurrent::CyclicBarrier.new(2)
       deadlocks = 0


### PR DESCRIPTION
### Motivation / Background

This PR changes the way of invalidating a transaction for two reasons
- Avoid `Mysql2::Error: SAVEPOINT active_record_%n% does not exist` error being raised when application wrongly handles `ActiveRecord::Deadlocked` exception by manually trying to rollback transaction that has already been rolled back by the database itself
- Invalidating transaction as early as possible is a better design as it moves the transaction in a correct state as soon as possible so other parts of the framework can rely on that. I'll provide an example below

### Detail

- The main motivation behind this chance is to reduce the number of `Mysql2::Error: SAVEPOINT active_record_%n% does not exist`. I have to admit that this error is happening mainly because of the wrong design of an application or specifically transaction handling in an application. The test shows a simplified version of the design, generally it looks like: 1. start a transaction 2. define general `rescue` in the transaction block which basically rescues anything that inherits from `StandardError` 3. handle the exception by logging/submitting stats/ etc and raise an `ActiveRecord::Rollback` or basically any exception that causes framework to issue a `ROLLBACK` statement leading to a `Mysql2::Error` because there is nothing to rollback on the db side but framework can't know this just yet and the invalidation is only about to happen here 
https://github.com/rails/rails/blob/c8315a96f962b0702062197c5a37d6d0a4bc9bc8/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L459-L462
which is too late and happens after we do our own `rescue`-`raise` flow causing the `ROLLBACK` to be issued without necessity
It the transaction was invalidated earlier, as proposes this PR, the rollback would have been ignored:
https://github.com/rails/rails/blob/c8315a96f962b0702062197c5a37d6d0a4bc9bc8/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L276-L278
This may sound as a purely application problem and the simplicity of the test may hide the fact that in reality applications are much more complex and those steps 1. open transaction 2. rescue 3. raise/rollback are widely spread and it's not always easy to refactor especially with no proper domain context or even realize that as a developer that you are wrongly handling transactions.
I consider the knowledge about how deadlock behaves in mysql and how properly handle exceptions within a transaction to be closer to an advanced level which in my opinion justifies the proposal of making framework a bit smarter and a bit forgiving so it can prevent wrong thing from happening. Especially because we already, by design, do not issue `ROLLBACK` statements for a transaction with an invalidated state. This PR just helps to handle it in the same way in more cases.
Even if we can't consider my first point as a sufficient argument, I have the second one:

- Second motivation for this PR is that I strongly believe that invalidating a transaction as early as possible is a better design and "just makes sense". As I mentioned above, framework already makes certain decisions based on the transaction state so keeping the state as correct as possible is the right thing. 
For example after properly invalidating transaction state, we should be able to get rid of the following check - 
https://github.com/rails/rails/blob/999c58d41fe4726ef2b90910cea934f0593aad49/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1021
Specifically I strongly believe that `savepoint_errors_invalidate_transactions?` check should only be used for deciding whether a transaction should be invalidated or not. If the check is used in a different context it only means that we are checking for something by implication and we lack a more specific check. So I'll be also proposing refactoring this check to replace it with something like (pseudo code) `do_not_retry if current_transaction && current_transaction.state.invalidated?` which will basically make this comment redundant as the code will be self-explanatory
https://github.com/rails/rails/blob/999c58d41fe4726ef2b90910cea934f0593aad49/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1019-L1020


### What's next

- There is also a case when `COMMIT` statement can be ignored as well for an invalidated transaction. I need to double check it and I'll prepare a PR if it's still an issue
- As I mentioned above, I'd like to simplify this check https://github.com/rails/rails/blob/999c58d41fe4726ef2b90910cea934f0593aad49/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1021 as after this PR it should be unnecessary to perform all three checks as we can simply check the transaction state

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

