### PR TITLE
Fix "possibly useless use of ::" warning

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2722,10 +2722,6 @@ module ApplicationTests
     test "use_big_decimal_serializer is enabled in new apps" do
       app "development"
 
-      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
-      # Referencing the constant auto-loads it.
-      ActiveJob::Base
-
       assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled in new apps"
     end
 
@@ -2733,10 +2729,6 @@ module ApplicationTests
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "7.0"'
       app "development"
-
-      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
-      # Referencing the constant auto-loads it.
-      ActiveJob::Base
 
       assert_not ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be disabled in defaults prior to 7.1"
     end
@@ -2748,10 +2740,6 @@ module ApplicationTests
         Rails.application.config.active_job.use_big_decimal_serializer = true
       RUBY
       app "development"
-
-      # When loaded, ActiveJob::Base triggers the :active_job load hooks, which is where config is attached.
-      # Referencing the constant auto-loads it.
-      ActiveJob::Base
 
       assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled if set in config"
     end


### PR DESCRIPTION
This fixes a few warnings like the following when running `railties/test/application/configuration_test.rb`:

  ```
  warning: possibly useless use of :: in void context
  ```

---

Example warning: https://buildkite.com/rails/rails/builds/90549#0184109e-c8c4-40d5-96c4-73b9606a3446/1086-1088
