### PR TITLE
Fix timezone awareness for `tsrange` columns with unbounded values

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -40,7 +40,7 @@ module ActiveModel
         end
 
         def user_input_in_time_zone(value)
-          value.in_time_zone
+          value&.in_time_zone
         end
 
         private

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -284,6 +284,26 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_timezone_awareness_unbounded_tsrange
+    tz = "Pacific Time (US & Canada)"
+
+    in_time_zone tz do
+      PostgresqlRange.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PostgresqlRange.new(ts_range: ..time_string)
+      assert_equal(..time, record.ts_range)
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.end.time_zone
+
+      record.save!
+      record.reload
+
+      assert_equal(..time, record.ts_range)
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.end.time_zone
+    end
+  end
+
   def test_timezone_array_awareness_tsrange
     tz = "Pacific Time (US & Canada)"
 


### PR DESCRIPTION
Fixes #46371.