### PR TITLE
Fix flaky migrations test

### DIFF
--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -28,6 +28,7 @@ module ActiveRecord
         end
 
         teardown do
+          ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
           ActiveRecord::Base.configurations = @original_configurations
           ActiveRecord::Base.establish_connection(:arunit)
           FileUtils.rm_rf(@migration_dir)


### PR DESCRIPTION
Flaky test - https://buildkite.com/rails/rails/builds/90646#01841fca-9efc-47c8-96f3-2490eee66714

To reproduce locally:
```sh
cd activerecord
SEED=56617 rake sqlite3:test TESTOPTS="--name='/test_migrate_using_empty_scope_and_verbose_mode|test_understands_migrations_created_out_of_order/'"
```