### PR TITLE
Map through subtype in `PostgreSQL::OID::Array`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -19,8 +19,6 @@ module ActiveRecord
 
           if value.is_a?(Hash)
             set_time_zone_without_conversion(super)
-          elsif value.is_a?(Range)
-            Range.new(user_input_in_time_zone(value.begin), user_input_in_time_zone(value.end), value.exclude_end?)
           elsif value.respond_to?(:in_time_zone)
             begin
               super(user_input_in_time_zone(value)) || super
@@ -42,8 +40,6 @@ module ActiveRecord
               value.in_time_zone
             elsif value.respond_to?(:infinite?) && value.infinite?
               value
-            elsif value.is_a?(Range)
-              Range.new(convert_time_to_time_zone(value.begin), convert_time_to_time_zone(value.end), value.exclude_end?)
             else
               map_avoiding_infinite_recursion(value) { |v| convert_time_to_time_zone(v) }
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -65,7 +65,7 @@ module ActiveRecord
           end
 
           def map(value, &block)
-            value.map(&block)
+            value.map { |v| subtype.map(v, &block) }
           end
 
           def changed_in_place?(raw_old_value, new_value)

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -189,6 +189,46 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_timezone_awareness_endless_tzrange
+    tz = "Pacific Time (US & Canada)"
+
+    in_time_zone tz do
+      PostgresqlRange.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PostgresqlRange.new(tstz_range: time_string...)
+      assert_equal time..., record.tstz_range
+      assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+
+      record.save!
+      record.reload
+
+      assert_equal time..., record.tstz_range
+      assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
+    end
+  end
+
+  def test_timezone_awareness_beginless_tzrange
+    tz = "Pacific Time (US & Canada)"
+
+    in_time_zone tz do
+      PostgresqlRange.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PostgresqlRange.new(tstz_range: ..time_string)
+      assert_equal nil..time, record.tstz_range
+      assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.end.time_zone
+
+      record.save!
+      record.reload
+
+      assert_equal nil..time, record.tstz_range
+      assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.end.time_zone
+    end
+  end
+
   def test_timezone_array_awareness_tzrange
     tz = "Pacific Time (US & Canada)"
 
@@ -200,17 +240,21 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
       to_time_string = (from_time + 1.hour).to_s
       to_time = Time.zone.parse(to_time_string)
 
-      record = PostgresqlRange.new(tstz_ranges: [from_time_string...to_time_string, from_time_string..to_time_string])
-      assert_equal [from_time...to_time, from_time..to_time], record.tstz_ranges
-      assert_equal ActiveSupport::TimeZone[tz], record.tstz_ranges.first.begin.time_zone
-      assert_equal ActiveSupport::TimeZone[tz], record.tstz_ranges.last.begin.time_zone
+      record = PostgresqlRange.new(tstz_ranges: [from_time_string...to_time_string, from_time_string..to_time_string, from_time_string..., ..to_time_string])
+      assert_equal [from_time...to_time, from_time..to_time, from_time..., ..to_time], record.tstz_ranges
+      record.tstz_ranges.each do |range|
+        assert_equal ActiveSupport::TimeZone[tz], range.begin.time_zone if range.begin
+        assert_equal ActiveSupport::TimeZone[tz], range.end.time_zone if range.end
+      end
 
       record.save!
       record.reload
 
-      assert_equal [from_time...to_time, from_time..to_time], record.tstz_ranges
-      assert_equal ActiveSupport::TimeZone[tz], record.tstz_ranges.first.begin.time_zone
-      assert_equal ActiveSupport::TimeZone[tz], record.tstz_ranges.last.begin.time_zone
+      assert_equal [from_time...to_time, from_time..to_time, from_time...nil, nil..to_time], record.tstz_ranges
+      record.tstz_ranges.each do |range|
+        assert_equal ActiveSupport::TimeZone[tz], range.begin.time_zone if range.begin
+        assert_equal ActiveSupport::TimeZone[tz], range.end.time_zone if range.end
+      end
     end
   end
 
@@ -284,6 +328,46 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_timezone_awareness_endless_tsrange
+    tz = "Pacific Time (US & Canada)"
+
+    in_time_zone tz do
+      PostgresqlRange.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PostgresqlRange.new(ts_range: time_string...)
+      assert_equal time..., record.ts_range
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+
+      record.save!
+      record.reload
+
+      assert_equal time..., record.ts_range
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.begin.time_zone
+    end
+  end
+
+  def test_timezone_awareness_beginless_tsrange
+    tz = "Pacific Time (US & Canada)"
+
+    in_time_zone tz do
+      PostgresqlRange.reset_column_information
+      time_string = Time.current.to_s
+      time = Time.zone.parse(time_string)
+
+      record = PostgresqlRange.new(ts_range: ..time_string)
+      assert_equal nil..time, record.ts_range
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.end.time_zone
+
+      record.save!
+      record.reload
+
+      assert_equal nil..time, record.ts_range
+      assert_equal ActiveSupport::TimeZone[tz], record.ts_range.end.time_zone
+    end
+  end
+
   def test_timezone_array_awareness_tsrange
     tz = "Pacific Time (US & Canada)"
 
@@ -295,17 +379,21 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
       to_time_string = (from_time + 1.hour).to_s
       to_time = Time.zone.parse(to_time_string)
 
-      record = PostgresqlRange.new(ts_ranges: [from_time_string...to_time_string, from_time_string..to_time_string])
-      assert_equal [from_time...to_time, from_time..to_time], record.ts_ranges
-      assert_equal ActiveSupport::TimeZone[tz], record.ts_ranges.first.begin.time_zone
-      assert_equal ActiveSupport::TimeZone[tz], record.ts_ranges.last.begin.time_zone
+      record = PostgresqlRange.new(ts_ranges: [from_time_string...to_time_string, from_time_string..to_time_string, from_time_string..., ..to_time_string])
+      assert_equal [from_time...to_time, from_time..to_time, from_time..., ..to_time], record.ts_ranges
+      record.ts_ranges.each do |range|
+        assert_equal ActiveSupport::TimeZone[tz], range.begin.time_zone if range.begin
+        assert_equal ActiveSupport::TimeZone[tz], range.end.time_zone if range.end
+      end
 
       record.save!
       record.reload
 
-      assert_equal [from_time...to_time, from_time..to_time], record.ts_ranges
-      assert_equal ActiveSupport::TimeZone[tz], record.ts_ranges.first.begin.time_zone
-      assert_equal ActiveSupport::TimeZone[tz], record.ts_ranges.last.begin.time_zone
+      assert_equal [from_time...to_time, from_time..to_time, from_time..., ..to_time], record.ts_ranges
+      record.ts_ranges.each do |range|
+        assert_equal ActiveSupport::TimeZone[tz], range.begin.time_zone if range.begin
+        assert_equal ActiveSupport::TimeZone[tz], range.end.time_zone if range.end
+      end
     end
   end
 


### PR DESCRIPTION
This changes `PostgreSQL::OID::Array#map` to invoke `subtype.map` for each element of the array.  When `subtype` is a scalar, `subtype.map` (as implemented by `ActiveModel::Type::Value#map`) will simply call the block with the element.  When `subtype` is a non-scalar, such as a `PostgreSQL::OID::Range`, `subtype.map` ensures that the nested scalar values are properly mapped.

Partially reverts #45348, as an alternative fix.
Fixes #46371.
Closes #46372.

---

/cc @fatkodima I've added you as a co-author since I borrowed your test from #46372.
