### PR TITLE
Define a predicate method for boolean attributes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Boolean attributes defined with the `ActiveModel::Attributes` API will now
+    have their respective predicate method defined automatically.
+
+    For example:
+
+    ```ruby
+    class Person
+      include ActiveModel::Attributes
+
+      attribute :loves_rails, :boolean
+    end
+
+    person = Person.new
+    person.love_rails?  # => false
+    person.love_rails = true
+    person.love_rails?  # => true
+    ```
+
+    *Connor McQuillan*
+
 *   Custom attribute types that inherit from Active Model built-in types and do
     not override the `serialize` method will now benefit from an optimization
     when serializing attribute values for the database.

--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -16,6 +16,7 @@ module ActiveModel
         pending.type = type if type
         pending.default = default unless no_default
 
+        define_predicate_method(name) if type.is_a?(ActiveModel::Type::Boolean)
         reset_default_attributes
       end
 
@@ -71,6 +72,10 @@ module ActiveModel
 
         def resolve_type_name(name, **options)
           Type.lookup(name, **options)
+        end
+
+        def define_predicate_method(name)
+          define_method("#{name}?") { public_send(name) == true }
         end
     end
   end

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -115,6 +115,20 @@ module ActiveModel
       end
     end
 
+    test "boolean attributes define predicate methods" do
+      model = ModelForAttributesTest.new(boolean_field: "1")
+
+      assert_equal true, model.boolean_field?
+
+      model.boolean_field = "false"
+
+      assert_equal false, model.boolean_field?
+
+      model.boolean_field = nil
+
+      assert_equal false, model.boolean_field?
+    end
+
     test "children inherit attributes" do
       data = ChildModelForAttributesTest.new(integer_field: "4.4")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The `ActiveModel::Attributes` API allows us to define different types of attributes.

It handles type casting, default values, and defines read/write methods.

Typically when defining a boolean attribute, you will often define the respective predicate method.

For example:

```ruby
class Person
  include ActiveModel::Attributes

  attribute :loves_rails, :boolean

  def loves_rails?
    !!loves_rails
  end
end

person = Person.new

person.loves_rails  # => nil
person.loves_rails? # => false

person.loves_rails = true

person.loves_rails? # => true
```

This Pull Request has been created because it would be useful for boolean 
attributes to automatically have its respective predicate method defined.

### Detail

This Pull Request changes the `attribute` method in `ActiveModel::AttributeRegistration`, 
so that it defines `attribute?` methods for attributes with a boolean type.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

