### PR TITLE
Fix composed_of freezing

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix `composed_of` value freezing and duplication.
+
+    Previously composite values exhibited two confusing behaviors:
+
+    - When reading a compositve value it'd _NOT_ be frozen, allowing it to get out of sync with its underlying database
+      columns.
+    - When writing a compositve value the argument would be frozen, potentially confusing the caller.
+
+    Currently, composite values instantiated based on database columns are frozen (addressing the first issue) and
+    assigned compositve values are duplicated and the duplicate is frozen (addressing the second issue).
+
+    *Greg Navis*
+
 *   Fix redundant updates to the column insensitivity cache
 
     Fixed redundant queries checking column capability for insensitive

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   # See ActiveRecord::Aggregations::ClassMethods for documentation
   module Aggregations
     def initialize_dup(*) # :nodoc:
-      @aggregation_cache = {}
+      @aggregation_cache = @aggregation_cache.dup
       super
     end
 
@@ -250,7 +250,7 @@ module ActiveRecord
                 object = constructor.respond_to?(:call) ?
                   constructor.call(*attrs) :
                   class_name.constantize.send(constructor, *attrs)
-                @aggregation_cache[name] = object
+                @aggregation_cache[name] = object.freeze
               end
               @aggregation_cache[name]
             end
@@ -276,7 +276,7 @@ module ActiveRecord
                 @aggregation_cache[name] = nil
               else
                 mapping.each { |key, value| write_attribute(key, part.send(value)) }
-                @aggregation_cache[name] = part.freeze
+                @aggregation_cache[name] = part.dup.freeze
               end
             end
           end

--- a/activerecord/test/cases/aggregations_test.rb
+++ b/activerecord/test/cases/aggregations_test.rb
@@ -26,6 +26,8 @@ class AggregationsTest < ActiveRecord::TestCase
   end
 
   def test_immutable_value_objects
+    assert_raise(FrozenError) { customers(:david).balance.instance_eval { @amount = 20 } }
+
     customers(:david).balance = Money.new(100)
     assert_raise(FrozenError) { customers(:david).balance.instance_eval { @amount = 20 } }
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -971,9 +971,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_predicate dup, :persisted?
 
     # test if the attributes have been duped
-    original_amount = dup.salary.amount
-    dev.salary.amount = 1
-    assert_equal original_amount, dup.salary.amount
+    salary = DeveloperSalary.new(42)
+    dup.salary = salary
+    salary.amount = 1
+    assert_equal 42, dup.salary.amount
 
     assert dup.save
     assert_predicate dup, :persisted?


### PR DESCRIPTION
composed_of values should be automatically frozen by Active Record. This worked correctly when assigning a new value object via the writer, but objects instantiated based on database columns were NOT frozen.

The fix consists of calling #freeze on the cached value object when it's added to the aggregation cache in #reader_method.

### Motivation / Background

This Pull Request has been created because [the documentation for `composed_of`](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Aggregations/ClassMethods.html) mentions the value object is frozen **and** it's frozen after assigning it via the writer (e.g. `customer.address = ...`) but it is **not** frozen when instantiated after fetching from the database (e.g. `customer = Customer.first; customer.address` is **not** frozen).

### Detail

This Pull Request changes the fix consists of calling `freeze` when adding the object to `@aggregation_cache` upon reading. An assertion was added to the test suite to detect the presence of the bug.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

