### PR TITLE
Add link to external editor to rescue view

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -131,6 +131,10 @@ end
 
 autoload :Mime, "action_dispatch/http/mime_type"
 
+ActiveSupport.on_load(:i18n) do
+  I18n.load_path << File.expand_path("action_dispatch/locale/en.yml", __dir__)
+end
+
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime::SET.symbols
   ActionView::Template::Types.delegate_to Mime

--- a/actionpack/lib/action_dispatch/locale/en.yml
+++ b/actionpack/lib/action_dispatch/locale/en.yml
@@ -1,0 +1,2 @@
+en:
+  trace_customize: 'Customize via ActionDispatch::DebugView#ext_editor'

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -62,5 +62,9 @@ module ActionDispatch
     rescue ActionController::BadRequest
       false
     end
+
+    def int_editor(frame)
+      frame[:trace].sub(/([^:]+):([0-9]+)(:.*)?/, "file://#{Rails.root.join("\\1#\\2")}")
+    end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
@@ -19,6 +19,8 @@
           <a class="trace-frames trace-frames-<%= error_index %>" data-exception-object-id="<%= frame[:exception_object_id] %>" data-frame-id="<%= frame[:id] %>" href="#">
             <%= frame[:trace] %>
           </a>
+          &nbsp;
+          <a title="<%= I18n.t 'trace_customize' %>" href="<%= respond_to?(:ext_editor) ? ext_editor(frame) : int_editor(frame) -%>">&#128279;</a>
           <br>
         <% end %>
       </code>


### PR DESCRIPTION
This is a somewhat trivial diff.  Currently, when an exception is thrown, a page is rendered and part of the page has the paths and line numbers from the exception stack.  The lines are clickable and when clicked, the upper section changes to show more context of the line in the original source code.

The proposed change is to add an additional link whose text is the Unicode link symbol after the existing link.  The more common glyph was rejected by Unicode.

The href for the link symbol comes from Ruby code that first checks, at render time, to see if ActionDispatch::DebugView#ext_editor is defined.  If it is, it is called passing the "frame".  Otherwise, ActionDispatch::DebugView#int_editor is called.

int_editor creates a URL using the `file:` scheme.  While most browsers won't follow the link, it will show to the developer what is possible.  My example of ext_editor creates a URL using the `emacs:` scheme.

I've added a tool tip to try and tell the developers how they can configure the URL to invoke their favorite editor.

I thought the approach of checking to see if a method is defined and calling it would be preferred to having the user redefine the definition of an existing method.

Another piece of work to do would be to add something like the sample I have to the templates so that config/initializers/debug_view.rb would be created when the Rails app is created.

Having both links, the currently existing link that shows the code snippets and the new link that opens the file in the external editor, gives the users the best of both worlds.  They can view in the browser what happened and then click to get them placed in their favorite editor at the line number for the issue.

The key here is "their favorite editor" can be customized to their liking via the ext_editor method.

### Motivation / Background

This Pull Request has been created because adding a link to the exception rescue page to the files and lines that are in the exception stack will help the developer edit the area that caused the fault.

### Detail

This Pull Request changes:
M	actionpack/lib/action_dispatch.rb
M	actionpack/lib/action_dispatch/middleware/debug_view.rb
M	actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
A     actionpack/lib/action_dispatch/locale/en.yml

### Additional information

My example for what a developer can add to config/initializers/debug_view.rb:
```ruby
# frozen_string_literal: true

module ActionDispatch
  class DebugView < ActionView::Base # :nodoc:
    def ext_editor(frame)
      frame[:trace].sub(/([^:]+):([0-9]+)(:.*)?/, 'emacs:///Users/pedz/Source/hatred/\\1#\\2')
    end
  end
end
```
