### PR TITLE
Add `ActionMailer.deprecator`

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -25,6 +25,7 @@
 
 require "abstract_controller"
 require "action_mailer/version"
+require "action_mailer/deprecator"
 
 # Common Active Support usage in Action Mailer
 require "active_support"

--- a/actionmailer/lib/action_mailer/deprecator.rb
+++ b/actionmailer/lib/action_mailer/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionMailer
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -26,7 +26,7 @@ module ActionMailer
     end
 
     def preview_path
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+      ActionMailer.deprecator.warn(<<-MSG.squish)
         Using preview_path option is deprecated and will be removed in Rails 7.2.
         Please use preview_paths instead.
       MSG
@@ -35,7 +35,7 @@ module ActionMailer
 
     module ClassMethods
       def preview_path=(value)
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActionMailer.deprecator.warn(<<-MSG.squish)
           Using preview_path= option is deprecated and will be removed in Rails 7.2.
           Please use preview_paths= instead.
         MSG
@@ -43,7 +43,7 @@ module ActionMailer
       end
 
       def preview_path
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActionMailer.deprecator.warn(<<-MSG.squish)
           Using preview_path option is deprecated and will be removed in Rails 7.2.
           Please use preview_paths instead.
         MSG

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -11,6 +11,10 @@ module ActionMailer
     config.action_mailer.preview_paths = []
     config.eager_load_namespaces << ActionMailer
 
+    initializer "action_mailer.deprecator" do |app|
+      app.deprecators[:action_mailer] = ActionMailer.deprecator
+    end
+
     initializer "action_mailer.logger" do
       ActiveSupport.on_load(:action_mailer) { self.logger ||= Rails.logger }
     end

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -26,7 +26,7 @@ require "action_view"
 ActionMailer::Base.include(ActionView::Layouts)
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+ActionMailer.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3892,6 +3892,7 @@ module ApplicationTests
       assert_equal AbstractController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
+      assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -262,7 +262,7 @@ module ApplicationTests
     test "mailer preview_path option is deprecated" do
       prev = ActionMailer::Base.preview_paths
       ActionMailer::Base.preview_paths = ["#{app_path}/lib/mailer/previews"]
-      assert_deprecated do
+      assert_deprecated(ActionMailer.deprecator) do
         assert_equal "#{app_path}/lib/mailer/previews", ActionMailer::Base.preview_path
       end
     ensure
@@ -271,7 +271,7 @@ module ApplicationTests
 
     test "mailer preview_path= option is deprecated" do
       prev = ActionMailer::Base.preview_paths
-      assert_deprecated do
+      assert_deprecated(ActionMailer.deprecator) do
         ActionMailer::Base.preview_path = "#{app_path}/lib/mailer/previews"
       end
       assert_equal ["#{app_path}/lib/mailer/previews"], ActionMailer::Base.preview_paths


### PR DESCRIPTION
This commit adds `ActionMailer.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `actionmailer/lib` with `ActionMailer.deprecator`.

Additionally, this commit adds `ActionMailer.deprecator` to `Rails.application.deprecators` so that it can be configured via settings such as `config.active_support.report_deprecations`.
