### PR TITLE
Fix "possibly useless use of a constant" warnings

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -361,8 +361,8 @@ module ApplicationTests
 
       require "#{app_path}/config/environment"
 
-      A
-      M
+      assert A
+      assert M
       Post.current_scope = Post
       assert_not_nil ActiveRecord::Scoping::ScopeRegistry.current_scope(Post) # precondition
 


### PR DESCRIPTION
This fixes two warnings like the following when running `rails/railties/test/application/initializers/frameworks_test.rb`:

  ```
  warning: possibly useless use of a constant in void context
  ```

---

Example warning: https://buildkite.com/rails/rails/builds/90621#01841b72-5e2c-4723-b370-da4c8daf088f/1089-1091
