### PR TITLE
Ensure `reload` sets correct owner for each association (ActiveRecord::Persistence)

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -33,7 +33,8 @@ module ActiveRecord
     # <tt>owner</tt>, the collection of its posts as <tt>target</tt>, and
     # the <tt>reflection</tt> object represents a <tt>:has_many</tt> macro.
     class Association # :nodoc:
-      attr_reader :owner, :target, :reflection, :disable_joins
+      attr_accessor :owner
+      attr_reader :target, :reflection, :disable_joins
 
       delegate :options, to: :reflection
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1078,6 +1078,7 @@ module ActiveRecord
       end
 
       @association_cache = fresh_object.instance_variable_get(:@association_cache)
+      @association_cache.each_value { |association| association.owner = self }
       @attributes = fresh_object.instance_variable_get(:@attributes)
       @new_record = false
       @previously_new_record = false

--- a/activerecord/test/cases/persistence/reload_association_cache_test.rb
+++ b/activerecord/test/cases/persistence/reload_association_cache_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/publication"
+require "models/editorship"
+require "models/editor"
+
+class ReloadAssociationCacheTest < ActiveRecord::TestCase
+  def test_reload_sets_correct_owner_for_association_cache
+    publication = Publication.create!(name: "Rails Way")
+    assert_equal "Rails Way (touched)", publication.name
+    publication.reload
+    assert_equal "Rails Way", publication.name
+    publication.transaction do
+      publication.editors = [publication.build_editor_in_chief(name: "Alex Black")]
+      publication.save!
+    end
+    assert_equal "Rails Way (touched)", publication.name
+  end
+end

--- a/activerecord/test/models/editor.rb
+++ b/activerecord/test/models/editor.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Editor < ActiveRecord::Base
+  self.primary_key = "name"
+
+  has_one :publication, foreign_key: :editor_in_chief_id, inverse_of: :editor_in_chief
+  has_many :editorships
+end

--- a/activerecord/test/models/editorship.rb
+++ b/activerecord/test/models/editorship.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Editorship < ActiveRecord::Base
+  belongs_to :publication
+  belongs_to :editor
+end

--- a/activerecord/test/models/publication.rb
+++ b/activerecord/test/models/publication.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Publication < ActiveRecord::Base
+  belongs_to :editor_in_chief, class_name: "Editor", inverse_of: :publication, optional: true
+  has_many :editorships
+  has_many :editors, through: :editorships
+
+  after_initialize do
+    self.editor_in_chief = build_editor_in_chief(name: "John Doe")
+  end
+
+  after_save_commit :touch_name
+  def touch_name
+    self.name = "#{name} (touched)"
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -562,6 +562,15 @@ ActiveRecord::Schema.define do
     t.index [:source_id, :sink_id], unique: true, name: "unique_edge_index"
   end
 
+  create_table :editorships, force: true do |t|
+    t.string :publication_id
+    t.string :editor_id
+  end
+
+  create_table :editors, force: true do |t|
+    t.string :name
+  end
+
   create_table :engines, force: true do |t|
     t.references :car, index: false
   end
@@ -1036,6 +1045,11 @@ ActiveRecord::Schema.define do
     t.string :type
     t.references :firm, index: false
     t.integer :mentor_id
+  end
+
+  create_table :publications, force: true do |t|
+    t.column :name, :string
+    t.integer :editor_in_chief_id
   end
 
   create_table :randomly_named_table1, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

Fixes #46363 which was caused by https://github.com/rails/rails/pull/41112

Currently calling `reload` re-calculates the association cache based on the object freshly loaded from the database. The fresh object gets assigned as `owner` for each association in the association cache. That object however is not the same as `self` (even though they both point to the same record). Under some specific circumstances (using `has_one/has_many through` associations and transactions with `after_commit` callbacks) this might lead to losing the effects of assignments done inside the callback.

This commit fixes it by making `reload` point to `self` as `owner` for each association in the association cache.

I think this is safe because as far as I can see in https://github.com/rails/rails/blob/main/activerecord/lib/active_record/associations.rb#L320 it always passes `self` when creating a new association.

### Detail

This Pull Request changes `ActiveRecord::Persistence#reload` method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

