### PR TITLE
Add ids method to Enumerable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ids` method to `Enumerable`.
+
+    This can be used as same as `Enumerable#pluck` with id as argument.
+
+    ```ruby
+    people = [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }, { id: 3, name: "Aaron" }, {}]
+    people.ids
+    # => [1, 2, 3, nil]
+    ```
+
+    *Shingo Kobayashi*
+
 *   Fix `Time#change` and `Time#advance` for times around the end of Daylight
     Saving Time.
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -261,6 +261,13 @@ module Enumerable
     when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "multiple items found"
     end
   end
+
+  # Returns ids which can be fetched by using <tt>#pluck</tt> with id as argument.
+  #   [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }, { id: 3, name: "Aaron" }, {}].ids
+  #   # => [1, 2, 3, nil]
+  def ids
+    pluck(:id)
+  end
 end
 
 class Hash

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -370,6 +370,12 @@ class EnumerableTests < ActiveSupport::TestCase
     end
   end
 
+  def test_ids
+    cities = GenericEnumerable.new([{ id: 1, name: "Tokyo" }, { id: 2, name: "Osaka" }, { id: 3, name: "Fukuoka" }, {}])
+    assert_equal [1, 2, 3, nil], cities.ids
+    assert_equal [], [].ids
+  end
+
   private
     def constant_cache_invalidations
       RubyVM.stat(:constant_cache_invalidations)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`ActiveRecord::Relation` provides `ids` method which comes from `ActiveRecord::Calculations` when you want to fetch id.

https://github.com/rails/rails/blob/823c2883e3c926353a07b35af0121daabe3d3b47/activerecord/lib/active_record/relation/calculations.rb#L320-L326

Rails style guide prefers `ids` over `pluck(:id)`(see [ref](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspluckid)) and so rubocop offers `Rails/PluckId` rule(see [ref](https://github.com/rubocop/rails-style-guide#ids)).

On the other hand, `Enumerable` allows you to use `pluck` similar to `ActiveRecord::Calculation` one, but there is no `ids` method instead.

This difference might cause some confusion since you should use `ids` for `ActiveRecord::Relation` but `pluck(:id)` for ones including `Enumerable`.

In addition, `pluck(:id)` for `Enumerable` ones would be violated if you set `Rails/Pluckid` rule on rubocop enabled so you had to choose between adding a partial disable to the codes and getting the rule disabled on the whole ones.

I believe that adding `ids` method to `Enumerable` could be useful, helpful and more enjoyable to write codes for developers.

I would appreciate if you took a look at my suggestion.

Thank you :)

### Detail

* add `ids` method to `Enumerable`.
* add a test for `ids`.
* update `CHANGELOG.md`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

