### PR TITLE
Improve singular association creation

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -54,11 +54,13 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false, &block)
-          record = build_record(attributes, &block)
-          saved = record.save
-          set_new_record(record)
-          raise RecordInvalid.new(record) if !saved && raise_error
-          record
+          reflection.klass.transaction do
+            record = build(attributes, &block)
+            saved = record.save
+            set_new_record(record)
+            raise RecordInvalid.new(record) if !saved && raise_error
+            record
+          end
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Replacing a `has_one` association nowadays is very confusing...

- `create_association` calls `INSERT` then `DELETE` in different transactions while`record.assoctiation = new_record` calls `DELETE` then `INSERT` in a single transaction.
- `create_association` raises an exception if your association is backed by a unique index, since it first try to create the new record before delete the old one.
- `create_association` is prone to create duplicated rows if your association is not backed by a unique index, even though it has a logic to delete the old record later.

Fixes #45920

### Detail

This pull request improves the `create_association` method to work similarly to `record.assoctiation = new_record`, so when replacing an association, a single transaction is created and the old record is deleted before a new one is created, making the method safer with a unique index or not and less confusing.

Before:
```
# begin transaction
INSERT new_record;
# commit transaction

# begin transaction
DELETE old_record;
# commit transaction
```

After:
```
# begin transaction
DELETE old_record;
INSERT new_record;
# commit transaction
```

### Additional information

https://andycroll.com/ruby/be-careful-assigning-to-has-one-relations

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

