### PR TITLE
Add `ActionView.deprecator`

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -395,9 +395,7 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_dynamic_render
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
-      assert_deprecated(ActionDispatch.deprecator) do
-        get :dynamic_render, params: { id: '../\\../test/abstract_unit.rb' }
-      end
+      get :dynamic_render, params: { id: '../\\../test/abstract_unit.rb' }
     end
   end
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -26,6 +26,7 @@
 require "active_support"
 require "active_support/rails"
 require "action_view/version"
+require "action_view/deprecator"
 
 module ActionView
   extend ActiveSupport::Autoload

--- a/actionview/lib/action_view/deprecator.rb
+++ b/actionview/lib/action_view/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionView
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -73,6 +73,10 @@ module ActionView
       end
     end
 
+    initializer "action_view.deprecator" do |app|
+      app.deprecators[:action_view] = ActionView.deprecator
+    end
+
     initializer "action_view.logger" do
       ActiveSupport.on_load(:action_view) { self.logger ||= Rails.logger }
     end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -415,7 +415,7 @@ module ActionView
         locals = @locals - Module::RUBY_RESERVED_KEYWORDS
         deprecated_locals = locals.grep(/\A@+/)
         if deprecated_locals.any?
-          ActiveSupport::Deprecation.warn(<<~MSG)
+          ActionView.deprecator.warn(<<~MSG)
             Passing instance variables to `render` is deprecated.
             In Rails 7.1, #{deprecated_locals.to_sentence} will be ignored.
           MSG

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -10,8 +10,7 @@ require "concurrent/map"
 module ActionView
   # = Action View Resolver
   class Resolver
-    Path = ActionView::TemplatePath
-    deprecate_constant :Path
+    Path = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("ActionView::Resolver::Path", "ActionView::TemplatePath", ActionView.deprecator)
 
     class PathParser # :nodoc:
       ParsedPath = Struct.new(:path, :details)

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -39,7 +39,7 @@ ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers"
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+ActionView.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -52,7 +52,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
   def test_template_with_instance_variable_identifier
     expected_deprecation = "In Rails 7.1, @foo will be ignored."
-    assert_deprecated(expected_deprecation) do
+    assert_deprecated(expected_deprecation, ActionView.deprecator) do
       assert_equal "bar", render(template: "test/render_file_instance_variable", locals: { "@foo": "bar" })
     end
   end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -204,9 +204,7 @@ module RenderTestCases
   def test_render_outside_path
     assert File.exist?(File.expand_path("../../test/abstract_unit.rb", __dir__))
     assert_raises ActionView::MissingTemplate do
-      assert_deprecated do
-        @view.render(template: "../\\../test/abstract_unit.rb")
-      end
+      @view.render(template: "../\\../test/abstract_unit.rb")
     end
   end
 
@@ -334,7 +332,7 @@ module RenderTestCases
   end
 
   def test_render_template_with_errors
-    e = assert_raises(ActionView::Template::Error) { assert_deprecated { @view.render(template: "test/_raise") } }
+    e = assert_raises(ActionView::Template::Error) { @view.render(template: "test/_raise") }
     assert_match %r!method.*doesnt_exist!, e.message
     assert_equal "", e.sub_template_message
     assert_equal "1", e.line_number
@@ -537,7 +535,7 @@ module RenderTestCases
   end
 
   def test_optional_second_arg_works_without_deprecation
-    assert_not_deprecated do
+    assert_not_deprecated(ActionView.deprecator) do
       ActionView::Template.register_template_handler :ruby_handler, ->(view, source = nil) { source }
     end
     assert_equal "3", @view.render(inline: "(1 + 2).to_s", type: :ruby_handler)
@@ -588,9 +586,7 @@ module RenderTestCases
     %w(malformed malformed.erb malformed.html.erb malformed.en.html.erb).each do |name|
       assert File.exist?(File.expand_path("#{FIXTURE_LOAD_PATH}/test/malformed/#{name}~")), "Malformed file (#{name}~) which should be ignored does not exists"
       assert_raises(ActionView::MissingTemplate) do
-        ActiveSupport::Deprecation.silence do
-          @view.render(template: "test/malformed/#{name}")
-        end
+        @view.render(template: "test/malformed/#{name}")
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3893,6 +3893,7 @@ module ApplicationTests
       assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
       assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
+      assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end


### PR DESCRIPTION
This commit adds `ActionView.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `actionview/lib` with `ActionView.deprecator`.  This commit also replaces a call to Ruby's `Module#deprecate_constant` with Rails' `DeprecatedConstantProxy`, so that its deprecation behavior can be configured using `ActionView.deprecator`.

Additionally, this commit adds `ActionView.deprecator` to `Rails.application.deprecators` so that it can be configured via settings such as `config.active_support.report_deprecations`.

This commit also removes a few defunct `assert_deprecated` calls that were not failing because they were nested in `assert_raises`, and the raised error prevented checking the deprecation.  (One was mistakenly kept in d52d7739468153bd6cb7c629f60bd5cd7ebea3eb when converting `test_render_file_with_errors` to `test_render_template_with_errors`; the other two were added in dd9991bac598bb5da312278a749cf85e19b027cc but not removed when the deprecation was completed in 85ecf6e4098601222b604f7c1cbdcb4e49a6d1f0.)
