### PR TITLE
Add `ActiveJob.deprecator`

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -26,6 +26,7 @@
 require "active_support"
 require "active_support/rails"
 require "active_job/version"
+require "active_job/deprecator"
 require "global_id"
 
 module ActiveJob

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -94,7 +94,7 @@ module ActiveJob
           serialize_indifferent_hash(argument.to_h)
         else
           if BigDecimal === argument && !ActiveJob.use_big_decimal_serializer
-            ActiveSupport::Deprecation.warn(<<~MSG)
+            ActiveJob.deprecator.warn(<<~MSG)
               Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
               Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 

--- a/activejob/lib/active_job/deprecator.rb
+++ b/activejob/lib/active_job/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -10,6 +10,10 @@ module ActiveJob
     config.active_job.custom_serializers = []
     config.active_job.log_query_tags_around_perform = true
 
+    initializer "active_job.deprecator" do |app|
+      app.deprecators[:active_job] = ActiveJob.deprecator
+    end
+
     initializer "active_job.logger" do
       ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
     end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -53,7 +53,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   test "dangerously treats BigDecimal arguments as primitives not requiring serialization by default" do
-    assert_deprecated(<<~MSG.chomp) do
+    assert_deprecated(<<~MSG.chomp, ActiveJob.deprecator) do
       Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
       Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 

--- a/activejob/test/cases/callbacks_test.rb
+++ b/activejob/test/cases/callbacks_test.rb
@@ -56,9 +56,7 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "#enqueue does not run after_enqueue callbacks when previous callbacks aborted" do
     job = AbortBeforeEnqueueJob.new
-    ActiveSupport::Deprecation.silence do
-      job.enqueue
-    end
+    job.enqueue
 
     assert_nil(job.flag)
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3894,6 +3894,7 @@ module ApplicationTests
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
       assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
       assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
+      assert_equal ActiveJob.deprecator, Rails.application.deprecators[:active_job]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end


### PR DESCRIPTION
This commit adds `ActiveJob.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `activejob/lib` with `ActiveJob.deprecator`.

Additionally, this commit adds `ActiveJob.deprecator` to `Rails.application.deprecators` so that it can be configured via settings such as `config.active_support.report_deprecations`.

This commit also removes a defunct `ActiveSupport::Deprecation.silence` call that was added in 9eb4b4ed01f893c2fc7ff3ee4f99301dec7ea3c2 but not removed when the deprecation was completed in 10bd5e59c3291bb2034869e97cca30634a559afb.
