### PR TITLE
Add `ActiveStorage.deprecator`

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -345,7 +345,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   def content_type=(value)
     unless ActiveStorage.silence_invalid_content_types_warning
       if INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7.include?(value)
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveStorage.deprecator.warn(<<-MSG.squish)
           #{value} is not a valid content type, it should not be used when creating a blob, and support for it will be removed in Rails 7.1.
           If you want to keep supporting this content type past Rails 7.1, add it to `config.active_storage.variable_content_types`.
           Dismiss this warning by setting `config.active_storage.silence_invalid_content_types_warning = true`.
@@ -353,7 +353,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
       end
 
       if INVALID_VARIABLE_CONTENT_TYPES_TO_SERVE_AS_BINARY_DEPRECATED_IN_RAILS_7.include?(value)
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        ActiveStorage.deprecator.warn(<<-MSG.squish)
           #{value} is not a valid content type, it should not be used when creating a blob, and support for it will be removed in Rails 7.1.
           If you want to keep supporting this content type past Rails 7.1, add it to `config.active_storage.content_types_to_serve_as_binary`.
           Dismiss this warning by setting `config.active_storage.silence_invalid_content_types_warning = true`.

--- a/activestorage/app/models/active_storage/current.rb
+++ b/activestorage/app/models/active_storage/current.rb
@@ -4,12 +4,12 @@ class ActiveStorage::Current < ActiveSupport::CurrentAttributes # :nodoc:
   attribute :url_options
 
   def host=(host)
-    ActiveSupport::Deprecation.warn("ActiveStorage::Current.host= is deprecated, instead use ActiveStorage::Current.url_options=")
+    ActiveStorage.deprecator.warn("ActiveStorage::Current.host= is deprecated, instead use ActiveStorage::Current.url_options=")
     self.url_options = { host: host }
   end
 
   def host
-    ActiveSupport::Deprecation.warn("ActiveStorage::Current.host is deprecated, instead use ActiveStorage::Current.url_options")
+    ActiveStorage.deprecator.warn("ActiveStorage::Current.host is deprecated, instead use ActiveStorage::Current.url_options")
     self.url_options&.dig(:host)
   end
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -29,6 +29,7 @@ require "active_support/rails"
 require "active_support/core_ext/numeric/time"
 
 require "active_storage/version"
+require "active_storage/deprecator"
 require "active_storage/errors"
 
 require "marcel"

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -148,7 +148,7 @@ module ActiveStorage
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, attachables, pending_uploads: pending_uploads)
                 end
             else
-              ActiveSupport::Deprecation.warn \
+              ActiveStorage.deprecator.warn \
                 "config.active_storage.replace_on_assign_to_many is deprecated and will be removed in Rails 7.1. " \
                 "Make sure that your code works well with config.active_storage.replace_on_assign_to_many set to true before upgrading. " \
                 "To append new attachables to the Active Storage association, prefer using `attach`. " \
@@ -179,7 +179,7 @@ module ActiveStorage
           def deprecate(action)
             reflection_name = proxy_association.reflection.name
             attached_name = reflection_name.to_s.partition("_").first
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            ActiveStorage.deprecator.warn(<<-MSG.squish)
               Calling `#{action}` from `#{reflection_name}` is deprecated and will be removed in Rails 7.1.
               To migrate to Rails 7.1's behavior call `#{action}` from `#{attached_name}` instead: `#{attached_name}.#{action}`.
             MSG

--- a/activestorage/lib/active_storage/deprecator.rb
+++ b/activestorage/lib/active_storage/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -82,6 +82,10 @@ module ActiveStorage
 
     config.eager_load_namespaces << ActiveStorage
 
+    initializer "active_storage.deprecator" do |app|
+      app.deprecators[:active_storage] = ActiveStorage.deprecator
+    end
+
     initializer "active_storage.configs" do
       config.after_initialize do |app|
         ActiveStorage.logger            = app.config.active_storage.logger || Rails.logger

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -207,7 +207,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs within a transaction with append_on_assign config uploads all the files" do
     append_on_assign do
-      assert_deprecated do
+      assert_deprecated(ActiveStorage.deprecator) do
         ActiveRecord::Base.transaction do
           @user.highlights.attach fixture_file_upload("racecar.jpg")
           @user.highlights.attach fixture_file_upload("video.mp4")
@@ -223,7 +223,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs within a transaction with append_on_assign config create the exact amount of records" do
     append_on_assign do
-      assert_deprecated do
+      assert_deprecated(ActiveStorage.deprecator) do
         assert_difference -> { ActiveStorage::Blob.count }, +2 do
           ActiveRecord::Base.transaction do
             @user.highlights.attach fixture_file_upload("racecar.jpg")
@@ -414,7 +414,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "updating an existing record with attachments when appending on assign" do
     append_on_assign do
-      assert_deprecated do
+      assert_deprecated(ActiveStorage.deprecator) do
         @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
 
         assert_difference -> { @user.reload.highlights.count }, +2 do
@@ -605,7 +605,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
         Calling `purge` from `highlights_attachments` is deprecated and will be removed in Rails 7.1.
         To migrate to Rails 7.1's behavior call `purge` from `highlights` instead: `highlights.purge`.
       MSG
-      assert_deprecated(message) do
+      assert_deprecated(message, ActiveStorage.deprecator) do
         assert_changes -> { @user.updated_at } do
           @user.highlights_attachments.purge
         end
@@ -700,7 +700,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
         Calling `purge_later` from `highlights_attachments` is deprecated and will be removed in Rails 7.1.
         To migrate to Rails 7.1's behavior call `purge_later` from `highlights` instead: `highlights.purge_later`.
       MSG
-      assert_deprecated(message) do
+      assert_deprecated(message, ActiveStorage.deprecator) do
         perform_enqueued_jobs do
           assert_changes -> { @user.updated_at } do
             @user.highlights_attachments.purge_later
@@ -963,7 +963,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "successfully attaches new blobs and destroys attachments marked for destruction via nested attributes" do
     append_on_assign do
-      assert_deprecated do
+      assert_deprecated(ActiveStorage.deprecator) do
         town_blob = create_blob(filename: "town.jpg")
         @user.highlights.attach(town_blob)
         @user.reload
@@ -991,7 +991,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
         Using association setter would result in purging the existing attached attachments and replacing them with new ones.
       MSG
 
-      assert_deprecated(message) do
+      assert_deprecated(message, ActiveStorage.deprecator) do
         @user.update! highlights: [create_blob(filename: "whenever.jpg")]
       end
     end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -349,15 +349,15 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   end
 
   test "warning if blob is created with invalid mime type" do
-    assert_deprecated do
+    assert_deprecated(ActiveStorage.deprecator) do
       create_blob(filename: "funky.jpg", content_type: "image/jpg")
     end
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActiveStorage.deprecator) do
       create_blob(filename: "funky.jpg", content_type: "image/jpeg")
     end
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActiveStorage.deprecator) do
       create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     end
   end
@@ -366,15 +366,15 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     warning_was = ActiveStorage.silence_invalid_content_types_warning
     ActiveStorage.silence_invalid_content_types_warning = true
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActiveStorage.deprecator) do
       create_blob(filename: "funky.jpg", content_type: "image/jpg")
     end
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActiveStorage.deprecator) do
       create_blob(filename: "funky.jpg", content_type: "image/jpeg")
     end
 
-    assert_not_deprecated do
+    assert_not_deprecated(ActiveStorage.deprecator) do
       create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     end
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -201,7 +201,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg")
 
     # image/jpg is not recognised by mini_mime (image/jpeg is correct)
-    assert_deprecated do
+    assert_deprecated(ActiveStorage.deprecator) do
       blob.update(content_type: "image/jpg")
     end
 

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -51,7 +51,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
 
   test "URL generation keeps working with ActiveStorage::Current.host set" do
     ActiveStorage::Current.url_options = nil
-    assert_deprecated { ActiveStorage::Current.host = "https://example.com" }
+    assert_deprecated(ActiveStorage.deprecator) { ActiveStorage::Current.host = "https://example.com" }
 
     original_url_options = Rails.application.routes.default_url_options.dup
     Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3895,6 +3895,7 @@ module ApplicationTests
       assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
       assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
+      assert_equal ActiveStorage.deprecator, Rails.application.deprecators[:active_storage]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
     end
 


### PR DESCRIPTION
This commit adds `ActiveStorage.deprecator` and replaces all usages of `ActiveSupport::Deprecation.warn` in `activestorage/lib` and `activestorage/app` with `ActiveStorage.deprecator`.

Additionally, this commit adds `ActiveStorage.deprecator` to `Rails.application.deprecators` so that it can be configured via settings such as `config.active_support.report_deprecations`.
