### PR TITLE
Document ActiveModel#validation_context [skip ci]

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -45,6 +45,25 @@ module ActiveModel
       extend  HelperMethods
       include HelperMethods
 
+      ##
+      # :method: validation_context
+      # Returns the context when running validations.
+      #
+      # This is useful when running validations except a certain context (opposite to the +on+ option).
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     attr_accessor :name
+      #     validates :name, presence: true, if: -> { validation_context != :custom }
+      #   end
+      #
+      #   person = Person.new
+      #   person.valid?          #=> false
+      #   person.valid?(:new)    #=> false
+      #   person.valid?(:custom) #=> true
+
+      ##
       attr_accessor :validation_context
       private :validation_context=
       define_callbacks :validate, scope: :name


### PR DESCRIPTION
Background:

To run validations except in a certain context, we need to either

1. explicitly pass all validation contexts to the `on` option
2. access undocumented `validation_context`

Option 1 is error-prone. Additionally, adding the opposite behavior of
`on` was rejected https://github.com/rails/rails/pull/30710.

Solution:

Document `ActiveModel#validation_context` to make it clear that the API is
public.

Close https://github.com/rails/rails/issues/46391.