### PR TITLE
Fix collation for changing column to non-string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -619,6 +619,10 @@ module ActiveRecord
       end
 
       private
+        def text_type?(type)
+          TYPE_MAP.lookup(type).is_a?(Type::String) || TYPE_MAP.lookup(type).is_a?(Type::Text)
+        end
+
         def type_map
           emulate_booleans ? TYPE_MAP_WITH_BOOLEAN : TYPE_MAP
         end
@@ -711,8 +715,8 @@ module ActiveRecord
             options[:comment] = column.comment
           end
 
-          unless options.key?(:collation) || type == :binary
-            options[:collation] = column.collation
+          unless options.key?(:collation)
+            options[:collation] = column.collation if text_type?(type)
           end
 
           unless options.key?(:auto_increment)

--- a/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/charset_collation_test.rb
@@ -48,7 +48,7 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     assert_equal "utf8mb4_general_ci", column.collation
   end
 
-  test "change column ensures binary column type are set to nil" do
+  test "change column doesn't preserve collation for string to binary types" do
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :binary
 
@@ -58,7 +58,17 @@ class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
     assert_nil column.collation
   end
 
-  test "change column preserves collation" do
+  test "change column doesn't preserve collation for string to non-string types" do
+    @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
+    @connection.change_column :charset_collations, :description, :int
+
+    column = @connection.columns(:charset_collations).find { |c| c.name == "description" }
+
+    assert_equal :integer, column.type
+    assert_nil column.collation
+  end
+
+  test "change column preserves collation for string to text" do
     @connection.add_column :charset_collations, :description, :string, charset: "utf8mb4", collation: "utf8mb4_unicode_ci"
     @connection.change_column :charset_collations, :description, :text
 


### PR DESCRIPTION
3a0d0f4 made change_collumn preserve the existing column's collation. However, this leads to problems when the old and new column types have incompatible collations.

be0a58b addressed this by adding a check to ensure that the new column type isn't binary. However, this did not cover every column type impacted by this issue.

008d9d1 followed up by changing the collation to only be preserved if both the old and new column types are string-like, fixing the issue for other column types like :int or :blob.

This is a manual backport of 008d9d1 because it also touched some other code only present on main.

Co-authored-by: Andrew Hoglund <ahoglund@github.com>

cc @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

