### PR TITLE
Add other framework deprecators

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -30,7 +30,8 @@ require "zeitwerk"
 Zeitwerk::Loader.for_gem.tap do |loader|
   loader.ignore(
     "#{__dir__}/rails", # Contains generators, templates, docs, etc.
-    "#{__dir__}/action_cable/gem_version.rb"
+    "#{__dir__}/action_cable/gem_version.rb",
+    "#{__dir__}/action_cable/deprecator.rb",
   )
 
   loader.do_not_eager_load(
@@ -44,6 +45,7 @@ end.setup
 
 module ActionCable
   require_relative "action_cable/version"
+  require_relative "action_cable/deprecator"
 
   INTERNAL = {
     message_types: {

--- a/actioncable/lib/action_cable/deprecator.rb
+++ b/actioncable/lib/action_cable/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionCable
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -10,6 +10,10 @@ module ActionCable
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
 
+    initializer "action_cable.deprecator" do |app|
+      app.deprecators[:action_cable] = ActionCable.deprecator
+    end
+
     initializer "action_cable.helpers" do
       ActiveSupport.on_load(:action_view) do
         include ActionCable::Helpers::ActionCableHelper

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "action_mailbox/deprecator"
 require "action_mailbox/mail_ext"
 
 module ActionMailbox

--- a/actionmailbox/lib/action_mailbox/deprecator.rb
+++ b/actionmailbox/lib/action_mailbox/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionMailbox
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -22,6 +22,10 @@ module ActionMailbox
 
     config.action_mailbox.storage_service = nil
 
+    initializer "action_mailbox.deprecator" do |app|
+      app.deprecators[:action_mailbox] = ActionMailbox.deprecator
+    end
+
     initializer "action_mailbox.config" do
       config.after_initialize do |app|
         ActionMailbox.logger = app.config.action_mailbox.logger || Rails.logger

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -3,6 +3,8 @@
 require "active_support"
 require "active_support/rails"
 
+require "action_text/deprecator"
+
 require "nokogiri"
 
 module ActionText

--- a/actiontext/lib/action_text/deprecator.rb
+++ b/actiontext/lib/action_text/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActionText
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -19,6 +19,10 @@ module ActionText
       #{root}/app/models
     )
 
+    initializer "action_text.deprecator" do |app|
+      app.deprecators[:action_text] = ActionText.deprecator
+    end
+
     initializer "action_text.attribute" do
       ActiveSupport.on_load(:active_record) do
         include ActionText::Attribute

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -26,6 +26,7 @@
 require "active_support"
 require "active_support/rails"
 require "active_model/version"
+require "active_model/deprecator"
 
 module ActiveModel
   extend ActiveSupport::Autoload

--- a/activemodel/lib/active_model/deprecator.rb
+++ b/activemodel/lib/active_model/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  def self.deprecator # :nodoc:
+    @deprecator ||= ActiveSupport::Deprecation.new
+  end
+end

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -9,6 +9,10 @@ module ActiveModel
 
     config.active_model = ActiveSupport::OrderedOptions.new
 
+    initializer "active_model.deprecator" do |app|
+      app.deprecators[:active_model] = ActiveModel.deprecator
+    end
+
     initializer "active_model.secure_password" do
       ActiveModel::SecurePassword.min_cost = Rails.env.test?
     end

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -4,7 +4,7 @@ require "active_support/testing/strict_warnings"
 require "active_model"
 
 # Show backtraces for deprecated behavior for quicker cleanup.
-ActiveSupport::Deprecation.debug = true
+ActiveModel.deprecator.debug = true
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3889,6 +3889,7 @@ module ApplicationTests
       app "production"
 
       assert_includes Rails.application.deprecators.each, ActiveSupport::Deprecation.instance
+      assert_equal ActionCable.deprecator, Rails.application.deprecators[:action_cable]
       assert_equal AbstractController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3893,6 +3893,7 @@ module ApplicationTests
       assert_equal AbstractController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionController.deprecator, Rails.application.deprecators[:action_controller]
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
+      assert_equal ActionMailbox.deprecator, Rails.application.deprecators[:action_mailbox]
       assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
       assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
       assert_equal ActiveJob.deprecator, Rails.application.deprecators[:active_job]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3898,6 +3898,7 @@ module ApplicationTests
       assert_equal ActionText.deprecator, Rails.application.deprecators[:action_text]
       assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
       assert_equal ActiveJob.deprecator, Rails.application.deprecators[:active_job]
+      assert_equal ActiveModel.deprecator, Rails.application.deprecators[:active_model]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveStorage.deprecator, Rails.application.deprecators[:active_storage]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3895,6 +3895,7 @@ module ApplicationTests
       assert_equal ActionDispatch.deprecator, Rails.application.deprecators[:action_dispatch]
       assert_equal ActionMailbox.deprecator, Rails.application.deprecators[:action_mailbox]
       assert_equal ActionMailer.deprecator, Rails.application.deprecators[:action_mailer]
+      assert_equal ActionText.deprecator, Rails.application.deprecators[:action_text]
       assert_equal ActionView.deprecator, Rails.application.deprecators[:action_view]
       assert_equal ActiveJob.deprecator, Rails.application.deprecators[:active_job]
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]


### PR DESCRIPTION
This adds dedicated deprecators for the remaining frameworks that do not have them: Action Cable, Action Mailbox, Action Text, and Active Model.
