### PR TITLE
`ActiveRecord::Persistence#reload` respects `query_constraints` config

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1041,9 +1041,17 @@ module ActiveRecord
 
     def _find_record(options)
       if options && options[:lock]
-        self.class.preload(strict_loaded_associations).lock(options[:lock]).find(id)
+        self.class.preload(strict_loaded_associations).lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)
       else
-        self.class.preload(strict_loaded_associations).find(id)
+        self.class.preload(strict_loaded_associations).find_by!(_in_memory_query_constraints_hash)
+      end
+    end
+
+    def _in_memory_query_constraints_hash
+      return { @primary_key => id } unless self.class.query_constraints_list
+
+      self.class.query_constraints_list.index_with do |column_name|
+        attribute(column_name)
       end
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1357,6 +1357,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_match(/WHERE .*color/, sql)
   end
 
+  def test_reload_uses_query_constraints_config
+    clothing_item = clothing_items(:green_t_shirt)
+    sql = capture_sql { clothing_item.reload  }.first
+    assert_match(/WHERE .*clothing_type/, sql)
+    assert_match(/WHERE .*color/, sql)
+  end
+
   def test_destroy_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
     sql = capture_sql { clothing_item.destroy }.first


### PR DESCRIPTION
This is a follow-up for https://github.com/rails/rails/pull/46331

As was pointed out in the original PR, `reload` wasn't respecting `query_constraints_list` configuration and this PR aims to fix it.

The change is as simple as changing `find` to `find_by!` to keep the same behaviour but lookup record a `constraints_hash` instead of `id`

`_in_memory_query_constraints_hash` is a slight duplication of `_query_constraints_hash` to keep the following expectation of turning a `new_record` into a persisted object by explicitly assigning an `id` and reloading it:

https://github.com/rails/rails/blob/f9f0f7044c8c56b7371d65753e65e8eab34a5530/activerecord/test/cases/persistence_test.rb#L1273-L1283

But I would say this duplication is fine especially assuming that `return { @primary_key => id }` part is temporary and only kept for backwards-compatibility. We are going to simplify it after every model will start having `query_constraints_list` derived from schema.



