### PR TITLE
Improve memory store performance for large values

### DIFF
--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -28,19 +28,19 @@ module ActiveSupport
         extend self
 
         def dump(entry)
-          entry.dup_value! unless entry.compressed?
+          entry.serialize_value! unless entry.compressed?
           entry
         end
 
         def dump_compressed(entry, threshold)
           entry = entry.compressed(threshold)
-          entry.dup_value! unless entry.compressed?
+          entry.serialize_value! unless entry.compressed?
           entry
         end
 
         def load(entry)
           entry = entry.dup
-          entry.dup_value!
+          entry.deserialize_value!
           entry
         end
       end

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -19,4 +19,78 @@ class CacheEntryTest < ActiveSupport::TestCase
     clone = ActiveSupport::Cache::Entry.new("value", expires_at: entry.expires_at)
     assert_equal entry.expires_at, clone.expires_at
   end
+
+  def test_nil_is_not_serialized_or_deserialized
+    entry = ActiveSupport::Cache::Entry.new(nil)
+    assert_nil entry.value
+
+    entry.serialize_value!
+    assert_nil entry.value
+
+    entry.deserialize_value!
+    assert_nil entry.value
+  end
+
+  def test_numeric_is_not_serialized_or_deserialized
+    entry = ActiveSupport::Cache::Entry.new(1)
+    assert_equal 1, entry.value
+
+    entry.serialize_value!
+    assert_equal 1, entry.value
+
+    entry.deserialize_value!
+    assert_equal 1, entry.value
+  end
+
+  def test_true_is_not_serialized_or_deserialized
+    entry = ActiveSupport::Cache::Entry.new(true)
+    assert_equal true, entry.value
+
+    entry.serialize_value!
+    assert_equal true, entry.value
+
+    entry.deserialize_value!
+    assert_equal true, entry.value
+  end
+
+  def test_false_is_not_serialized_or_deserialized
+    entry = ActiveSupport::Cache::Entry.new(false)
+    assert_equal false, entry.value
+
+    entry.serialize_value!
+    assert_equal false, entry.value
+
+    entry.deserialize_value!
+    assert_equal false, entry.value
+  end
+
+  def test_string_serializes_by_duplication
+    entry = ActiveSupport::Cache::Entry.new("foo")
+
+    value = entry.value
+    serialized = entry.serialize_value!
+    deserialized = entry.deserialize_value!
+
+    assert_equal "foo", value
+    assert_equal "foo", deserialized
+    assert_equal "foo", serialized
+
+    assert_not_equal value.object_id, serialized.object_id
+    assert_not_equal serialized.object_id, deserialized.object_id
+    assert_not_equal deserialized.object_id, value.object_id
+  end
+
+  def test_hash_serializes_by_marshal
+    entry = ActiveSupport::Cache::Entry.new([])
+
+    value = entry.value
+    serialized = entry.serialize_value!
+    deserialized = entry.deserialize_value!
+
+    assert_equal [], value
+    assert_equal [], deserialized
+    assert_equal Marshal.dump([]), serialized
+
+    assert_not_equal value.object_id, deserialized.object_id
+  end
 end


### PR DESCRIPTION
### Motivation / Background
The current implementation of `MemoryStore` does `Marshal.dump` followed by `Marshal.load` both during writes and reads in order to avoid a pass by reference bug: https://github.com/rails/rails/issues/36956. This is fine for small values, but for large values it makes memory store slower than other stores.

### Detail
This PR splits `dup_value` into `serialize_value!` which is called on write, and `deserialize_value!` which is called on read, halving the work done on both operations. It also makes changes to `Entry` so that it can handle raw values and serialized values.

CC: @byroot 

### Additional information
Screenshots from the flamegraph showing before and after in a production application for the read step.
<img width="450" alt="before" src="https://user-images.githubusercontent.com/1793280/199381643-394f3f9e-c5b9-40bc-9f3e-07f34589e707.png">
<img width="450" alt="after" src="https://user-images.githubusercontent.com/1793280/199381635-0357d8e6-f40c-4308-bdd9-f950480e7de4.png">

