### PR TITLE
Update docs for ActiveRecord::AttributeMethods#[]=

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -332,7 +332,6 @@ module ActiveRecord
     end
 
     # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
-    # (Alias for the protected #write_attribute method).
     #
     #   class Person < ActiveRecord::Base
     #   end


### PR DESCRIPTION
The docs incorrectly claimed that write_attribute is protected despite the method being public.

---

This Pull Request has been created because [the documentation for `ActiveRecord::AttributeMethods#[]=`](https://github.com/rails/rails/blob/7db044f38594eb43e1d241cc82025155666cc6f1/activerecord/lib/active_record/attribute_methods.rb#L335) incorrectly claims that `write_attribute` is protected or that it's an alias. [`write_attribute` has it's own doc string](https://github.com/rails/rails/blob/7db044f38594eb43e1d241cc82025155666cc6f1/activerecord/lib/active_record/attribute_methods/write.rb#L28-L37) and isn't marked as `:nodoc:`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

