### PR TITLE
TypeMap (PG): Store Typemap in Schema Cache and use another cache class to keep it in memory

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -11,7 +11,7 @@ module ActiveRecord
   module ConnectionAdapters
     module AbstractPool # :nodoc:
       def get_schema_cache(connection)
-        self.schema_cache ||= SchemaCache.new(connection)
+        self.schema_cache ||= connection.init_schema_cache
         schema_cache.connection = connection
         schema_cache
       end
@@ -24,6 +24,8 @@ module ActiveRecord
         return unless ActiveRecord.lazily_load_schema_cache
 
         cache = SchemaCache.load_from(db_config.lazy_schema_cache_path)
+        PostgreSQL::TypeMapCache.init(cache) if connection.adapter_name == "PostgreSQL"
+
         set_schema_cache(cache)
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -203,6 +203,10 @@ module ActiveRecord
         end
       end
 
+      def init_schema_cache
+        SchemaCache.new(self)
+      end
+
       def check_if_write_query(sql) # :nodoc:
         if preventing_writes? && write_query?(sql)
           raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCache < ActiveRecord::ConnectionAdapters::SchemaCache
+        attr_accessor :additional_type_records, :known_coder_type_records
+
+        def initialize(conn)
+          super(conn)
+
+          @additional_type_records = PostgreSQL::TypeMapCache.instance.additional_type_records || []
+          @known_coder_type_records = PostgreSQL::TypeMapCache.instance.known_coder_type_records || []
+        end
+
+        def encode_with(coder)
+          super
+
+          coder["additional_type_records"] = @additional_type_records
+          coder["known_coder_type_records"] = @known_coder_type_records
+        end
+
+        def init_with(coder)
+          @additional_type_records = coder["additional_type_records"]
+          @known_coder_type_records = coder["known_coder_type_records"]
+
+          super
+        end
+
+        def marshal_dump
+          reset_version!
+
+          [@version, @columns, {}, @primary_keys, @data_sources, @indexes, database_version, @known_coder_type_records, @additional_type_records]
+        end
+
+        def marshal_load(array)
+          @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version, @known_coder_type_records, @additional_type_records = array
+          @indexes ||= {}
+
+          derive_columns_hash_and_deduplicate_values
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/type_map_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/type_map_cache.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # :stopdoc:
+  module ConnectionAdapters
+    module PostgreSQL
+      class TypeMapCache
+        include Singleton
+
+        attr_accessor :additional_type_records
+        attr_accessor :known_coder_type_records
+
+        def initialize
+          @additional_type_records = []
+          @known_coder_type_records = []
+        end
+
+        class << self
+          def init(schema_cache)
+            return if schema_cache.nil? || !schema_cache.is_a?(PostgreSQL::SchemaCache)
+
+            self.instance.known_coder_type_records = schema_cache.known_coder_type_records
+            self.instance.additional_type_records = schema_cache.additional_type_records
+          end
+
+          def clear
+            self.instance.additional_type_records = []
+            self.instance.known_coder_type_records = []
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -26,14 +26,13 @@ module ActiveRecord
 
       def test_reconnection_error
         fake_connection = Class.new do
+          attr_accessor :type_map_for_results
+
           def async_exec(*)
             [{}]
           end
 
           def type_map_for_queries=(_)
-          end
-
-          def type_map_for_results=(_)
           end
 
           def exec_params(*)
@@ -452,6 +451,7 @@ module ActiveRecord
 
       def test_only_reload_type_map_once_for_every_unrecognized_type
         reset_connection
+
         connection = ActiveRecord::Base.connection
 
         silence_warnings do

--- a/activerecord/test/cases/connection_adapters/postgresql/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/postgresql/schema_cache_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCacheTest < ActiveRecord::TestCase
+        if current_adapter?(:PostgreSQLAdapter)
+          def setup
+            @connection = ActiveRecord::Base.connection
+          end
+
+          def test_type_map_existence_in_schema_cache
+            assert_not(@connection.schema_cache.additional_type_records.empty?)
+            assert_not(@connection.schema_cache.known_coder_type_records.empty?)
+          end
+
+          def test_type_map_queries_when_initialize_connection
+            db_config = ActiveRecord::Base.configurations.configs_for(
+              env_name: "arunit",
+              name: "primary"
+            )
+
+            assert_no_sql("SELECT t.oid, t.typname") do
+              ActiveRecord::Base.postgresql_connection(db_config.configuration_hash)
+            end
+          end
+
+          def test_type_map_cache_with_lazy_load_option
+            PostgreSQL::TypeMapCache.clear
+            tempfile = Tempfile.new(["schema_cache-", ".yml"])
+
+            original_config = ActiveRecord::Base.connection_db_config
+            new_config = original_config.configuration_hash.merge(schema_cache_path: tempfile.path)
+
+            ActiveRecord::Base.establish_connection(new_config)
+
+            assert_not_empty(PostgreSQL::TypeMapCache.instance.additional_type_records)
+            assert_not_empty(PostgreSQL::TypeMapCache.instance.known_coder_type_records)
+
+            assert_not_empty(ActiveRecord::Base.connection.schema_cache.instance_variable_get(:@known_coder_type_records))
+            assert_not_empty(ActiveRecord::Base.connection.schema_cache.instance_variable_get(:@additional_type_records))
+
+            cache = PostgreSQL::SchemaCache.new(ActiveRecord::Base.connection)
+
+            cache.dump_to(tempfile.path)
+            ActiveRecord::Base.connection.schema_cache = cache
+
+            assert(File.exist?(tempfile))
+
+            ActiveRecord.lazily_load_schema_cache = true
+
+            PostgreSQL::TypeMapCache.clear
+
+            assert_sql(/SELECT t.oid, t.typname/) do
+              ActiveRecord::Base.establish_connection(new_config)
+            end
+          end
+
+          def test_type_map_queries_with_custom_types
+            cache = SchemaCache.new(@connection)
+            tempfile = Tempfile.new(["schema_cache-", ".yml"])
+
+            assert_no_sql("SELECT t.oid, t.typname") do
+              cache.dump_to(tempfile.path)
+            end
+
+            cache = SchemaCache.load_from(tempfile.path)
+            cache.connection = @connection
+
+            assert_sql(/SELECT t.oid, t.typname, t.typelem/) do
+              @connection.execute("CREATE TYPE account_status AS ENUM ('new', 'open', 'closed');")
+              @connection.execute("ALTER TABLE accounts ADD status account_status NOT NULL DEFAULT 'new';")
+              cache.dump_to(tempfile.path)
+            end
+          ensure
+            @connection.execute("DELETE FROM accounts; ALTER TABLE accounts DROP COLUMN status;DROP TYPE IF EXISTS account_status;")
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/connection_adapters/postgresql/type_map_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/postgresql/type_map_cache_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class TypeMapCacheTest < ActiveRecord::TestCase
+        if current_adapter?(:PostgreSQLAdapter)
+          def setup
+            @connection = ActiveRecord::Base.connection
+            @type_map_cache = TypeMapCache.instance
+          end
+
+          def test_type_map_cache_init_with_schema_cache
+            assert(@type_map_cache.additional_type_records.empty?)
+            assert(@type_map_cache.known_coder_type_records.empty?)
+
+            TypeMapCache.init(@connection.schema_cache)
+
+            assert_not(@type_map_cache.additional_type_records.empty?)
+            assert_not(@type_map_cache.known_coder_type_records.empty?)
+          end
+
+          def test_type_map_cache_clear
+            TypeMapCache.init(@connection.schema_cache)
+
+            assert_not(@type_map_cache.additional_type_records.empty?)
+            assert_not(@type_map_cache.known_coder_type_records.empty?)
+
+            TypeMapCache.clear
+
+            assert(@type_map_cache.additional_type_records.empty?)
+            assert(@type_map_cache.known_coder_type_records.empty?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -76,6 +76,18 @@ module ActiveRecord
       assert_queries(0, options, &block)
     end
 
+    def assert_no_sql(query_string)
+      ActiveRecord::Base.connection.materialize_transactions
+      SQLCounter.clear_log
+
+      yield
+      query_log = SQLCounter.log_all
+
+      query_existence = query_log.join('\n') =~ /#{query_string}/
+
+      assert(query_existence.nil?, "The query '#{query_string}' has been executed while it should not be")
+    end
+
     def assert_column(model, column_name, msg = nil)
       model.reset_column_information
       assert_includes model.column_names, column_name.to_s, msg


### PR DESCRIPTION
### Motivation / Background

This pull request is a rework of the other one after some feedbacks : https://github.com/rails/rails/pull/44478

In our project, we are using PG and Resque.
Right now, for every Resque job processed and new connection spawned, we are executing this method in Rails that run a costly query :

```ruby
def load_additional_types(oids = nil)
  initializer = OID::TypeMapInitializer.new(type_map)

  query = <<~SQL
    SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
    FROM pg_type as t
    LEFT JOIN pg_range as r ON oid = rngtypid
  SQL
     
  if oids
    query += "WHERE t.oid IN (%s)" % oids.join(", ")
  else
    query += initializer.query_conditions_for_initial_load
  end
      
  execute_and_clear(query, "SCHEMA", []) do |records|
    initializer.run(records)
  end
end
```

To fix this issue we have done a monkey patch, basically, the `ConnectionPool` stores a cache of the type_map, and a new connection will inherit from this cache, instead of querying it.

```ruby
module ActiveRecord
  module ConnectionAdapters
    class PoolManager
      attr_accessor :type_map
    end
  end

  class ConnectionAdapters::ConnectionPool
    def adopt_connection(conn)
      ....
      pool_manager = ConnectionAdapters::ConnectionPool.get_pool_manager

      pool_manager.type_map ||= conn.type_map
      ....
    end
  end

  class ConnectionAdapters::PostgreSQLAdapter
    attr_reader :type_map

    def initialize(connection, logger, connection_parameters, config)
      ....

      pool_manager = ConnectionAdapters::ConnectionPool.get_pool_manager
      type_map = pool_manager.type_map

      if type_map
        @type_map = type_map
      else
        @type_map = Type::HashLookupTypeMap.new
        initialize_type_map
      end
 
      ....
    end
  end
end
```

It also makes every Rails upgrade as complicated on our side.

In order not to have monkey patches we want to solve it on a Rails side which could be useful for other developers too.

First of all, we have dug in relevant PRs done in Rails and took some ideas.
The solutions to deal with issues maybe:

    - Store TypeMap into SchemaCache (relevant for PG only)
    - Switch off TypeMap if there is no usage of PG custom types
    - Introduce the monkey patch as the solution for Rails

We have selected the first one and would like to have feedback from Rails maintainers and complete this topic.
If there is something we have missed we are also ready to fix it shortly.

Base PRs for this PR:

#35311
https://github.com/rails/rails/pull/39821/files
https://github.com/rails/rails/pull/39077/files
https://github.com/rails/rails/pull/41288/files

I would like to tag also @piecehealth and @ted-hanson

### Detail

Currently in this PR we have TypeMap as a singleton (after trying to implement it as an instance variable we had issues with concurrency and now we have it as a single example in memory).

The general approach is to keep the TypeMap in the schema cache, and load from the `schema_cache.yml` when create a new connection. If TypeMap is not present in schema cache, it will be retrieved from the database.

The idea is still the same. During deploy, we run migrations and create a dump of schema cache. When initializing a Rails app, we load schema cache into a memory and initialize our `TypeMapCache` instance. Then we don't fire any query and retrieve Typemap from this cache when establish a new connection.

### Additional information

Unfortunately, it does not work with `lazily_load_schema_cache` option enabled since we load schema cache lazily after creating a connection.

### Checklist

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.