### PR TITLE
Fix touching has_one grand parent associations when the child is touched

### DIFF
--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -24,9 +24,13 @@ module ActiveRecord
       @_new_record_before_last_commit ||= false
 
       # touch the parents as we are not calling the after_save callbacks
-      self.class.reflect_on_all_associations(:belongs_to).each do |r|
+      self.class.reflect_on_all_associations.each do |r|
         if touch = r.options[:touch]
-          ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
+          if r.macro == :belongs_to
+            ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
+          elsif r.macro == :has_one
+            ActiveRecord::Associations::Builder::HasOne.touch_record(self, r.name, touch)
+          end
         end
       end
     end

--- a/activerecord/test/models/entry.rb
+++ b/activerecord/test/models/entry.rb
@@ -2,4 +2,5 @@
 
 class Entry < ActiveRecord::Base
   delegated_type :entryable, types: %w[ Message Comment ]
+  belongs_to :account, touch: true
 end

--- a/activerecord/test/models/message.rb
+++ b/activerecord/test/models/message.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Message < ActiveRecord::Base
-  has_one :entry, as: :entryable
+  has_one  :entry, as: :entryable, touch: true
+  has_many :recipients
 end

--- a/activerecord/test/models/recipient.rb
+++ b/activerecord/test/models/recipient.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Recipient < ActiveRecord::Base
+  belongs_to :message, touch: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema.define do
     t.string  :firm_name
     t.integer :credit_limit
     t.integer "a" * max_identifier_length
+    t.datetime :updated_at
   end
 
   create_table :admin_accounts, force: true do |t|
@@ -465,8 +466,10 @@ ActiveRecord::Schema.define do
   end
 
   create_table :entries, force: true do |t|
-    t.string  :entryable_type, null: false
-    t.integer :entryable_id, null: false
+    t.string   :entryable_type, null: false
+    t.integer  :entryable_id, null: false
+    t.integer  :account_id, null: false
+    t.datetime :updated_at
   end
 
   create_table :essays, force: true do |t|
@@ -672,7 +675,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :messages, force: true do |t|
-    t.string :subject
+    t.string   :subject
+    t.datetime :updated_at
   end
 
   create_table :minivans, force: true, id: false do |t|
@@ -1275,6 +1279,11 @@ ActiveRecord::Schema.define do
   create_table :recipes, force: true do |t|
     t.integer :chef_id
     t.integer :hotel_id
+  end
+
+  create_table :recipients, force: true do |t|
+    t.integer  :message_id
+    t.string   :email_address
   end
 
   create_table :records, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

I see this bug happening with delegated types but it can happen with any has_one association marked as touch.

```ruby
class User < ActiveRecord::Base
  has_one :profile
end

class Profile < ActiveRecord::Base
  delegated_type :profilable, types: %w[ doctor ]
  belongs_to :user, touch: true
end

class Doctor < ActiveRecord::Base
  has_one :profile, as: :profilable, touch: true
  has_many :skills
end

class Skill < ActiveRecord::Base
  belongs_to :doctor, touch: true
end
```

When you add a new skill, the touch flow should be `doctor -> profile -> user` but now it is `doctor -> profile`, user is never touched. The reason for this is that the actual logic search in `doctor` only for belongs_to parent associations marked as touch and has_one parent associations are ignored and never touched.

Fixes #46393

