### PR TITLE
Add link to Rollback in transactions doc.

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -99,8 +99,9 @@ module ActiveRecord
     # be propagated (after triggering the ROLLBACK), so you should be ready to
     # catch those in your application code.
     #
-    # One exception is the ActiveRecord::Rollback exception, which will trigger
-    # a ROLLBACK when raised, but not be re-raised by the transaction block.
+    # One exception is the {ActiveRecord::Rollback}[rdoc-ref:Rollback] exception, which will trigger
+    # a ROLLBACK when raised, but not be re-raised by the transaction block. Any
+    # other exception will be re-raised.
     #
     # *Warning*: one should not catch ActiveRecord::StatementInvalid exceptions
     # inside a transaction block. ActiveRecord::StatementInvalid exceptions indicate that an


### PR DESCRIPTION
### Motivation / Background

A common misconception with transaction rollback in Rails is that exceptions will not be re-raised from nested transactions. This is only true for `ActiveRecord::Rollback`. The documentation for that class makes that clear.

### Detail

A link to that class doc has been added in `Transactions::ClassMethods`, as well as an explicit restatement that all other exceptions will be re-raised.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] CI is passing.

