### PR TITLE
Simplify `retryable_query_error?` check

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1016,13 +1016,10 @@ module ActiveRecord
         end
 
         def retryable_query_error?(exception)
-          # We definitely can't retry if we were inside a transaction that was instantly
-          # rolled back by this error
-          if exception.is_a?(TransactionRollbackError) && savepoint_errors_invalidate_transactions? && open_transactions > 0
-            false
-          else
-            exception.is_a?(Deadlocked) || exception.is_a?(LockWaitTimeout)
-          end
+          # We definitely can't retry if we were inside an invalidated transaction
+          return false if current_transaction.state&.invalidated?
+
+          exception.is_a?(Deadlocked) || exception.is_a?(LockWaitTimeout)
         end
 
         def backoff(counter)


### PR DESCRIPTION
https://github.com/rails/rails/pull/46367 PR started to invalidate transactions earlier in the flow which opens opportunities for more places to rely on `transaction.state` to make certain decisions.

This PR aims to simplify `retryable_query_error?` method by getting rid of these conditions
https://github.com/rails/rails/blob/999c58d41fe4726ef2b90910cea934f0593aad49/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1021
which only imply the fact of transaction invalidation and replacing them with a direct `transaction.state` check

~I'm also splitting `retryable_query_error?` method into two:~ (not anymore)



Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

