### PR TITLE
Fix active model errors add documentation

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -287,7 +287,7 @@ module ActiveModel
     #   person.errors.messages
     #   # => {:name=>["can't be blank"]}
     #
-    #   person.errors.add(:name, :too_long, { count: 25 })
+    #   person.errors.add(:name, :too_long, count: 25)
     #   person.errors.messages
     #   # => ["is too long (maximum is 25 characters)"]
     #
@@ -338,7 +338,7 @@ module ActiveModel
     # If the error requires options, then it returns +true+ with
     # the correct options, or +false+ with incorrect or missing options.
     #
-    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.add :name, :too_long, count: 25
     #   person.errors.added? :name, :too_long, count: 25                     # => true
     #   person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
     #   person.errors.added? :name, :too_long, count: 24                     # => false
@@ -360,7 +360,7 @@ module ActiveModel
     # present, or +false+ otherwise. +type+ is treated the same as for +add+.
     #
     #   person.errors.add :age
-    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.add :name, :too_long, count: 25
     #   person.errors.of_kind? :age                                            # => true
     #   person.errors.of_kind? :name                                           # => false
     #   person.errors.of_kind? :name, :too_long                                # => true


### PR DESCRIPTION
Documentation is misleading, the 3rd expected argument is not a hash:

```
[2] pry(main)> u.errors.add(:email, :too_long, { count: 25 })
ArgumentError: wrong number of arguments (given 3, expected 1..2)
[3] pry(main)> u.errors.add(:email, :too_long, count: 25 )
=> #<ActiveModel::Error attribute=email, type=too_long, options={:count=>25}>
```
I've updated the doc accordingly.