### PR TITLE
Call pending_migrations once

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -682,8 +682,10 @@ module ActiveRecord
       end
 
       def check_pending_migrations # :nodoc:
-        if pending_migrations.any?
-          raise ActiveRecord::PendingMigrationError.new(pending_migrations: pending_migrations)
+        migrations = pending_migrations
+
+        if migrations.any?
+          raise ActiveRecord::PendingMigrationError.new(pending_migrations: migrations)
         end
       end
 


### PR DESCRIPTION
This was accidentally calling pending_migrations twice, and while probably not a big deal, there's no reason to.
