### PR TITLE
Add `Rails.deprecator`

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -10,8 +10,9 @@ require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/object/blank"
 
-require "rails/application"
 require "rails/version"
+require "rails/deprecator"
+require "rails/application"
 
 require "active_support/railtie"
 require "action_dispatch/railtie"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -231,7 +231,7 @@ module Rails
     # via <tt>deprecators[name] = deprecator</tt>.
     def deprecators
       @deprecators ||= ActiveSupport::Deprecation::Deprecators.new.tap do |deprecators|
-        deprecators[:rails] = ActiveSupport::Deprecation.instance
+        deprecators[:rails] = Rails.deprecator
       end
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -339,12 +339,12 @@ module Rails
       private_constant :ENABLE_DEPENDENCY_LOADING_WARNING
 
       def enable_dependency_loading
-        ActiveSupport::Deprecation.warn(ENABLE_DEPENDENCY_LOADING_WARNING)
+        Rails.deprecator.warn(ENABLE_DEPENDENCY_LOADING_WARNING)
         @enable_dependency_loading
       end
 
       def enable_dependency_loading=(value)
-        ActiveSupport::Deprecation.warn(ENABLE_DEPENDENCY_LOADING_WARNING)
+        Rails.deprecator.warn(ENABLE_DEPENDENCY_LOADING_WARNING)
         @enable_dependency_loading = value
       end
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -65,7 +65,7 @@ module Rails
       end
 
       def find_cmd_and_exec(commands, *args) # :doc:
-        ActiveSupport::Deprecation.warn(<<~MSG.squish)
+        Rails.deprecator.warn(<<~MSG.squish)
           Rails::DBConsole#find_cmd_and_exec is deprecated and will be removed in Rails 7.2.
           Please use find_cmd_and_exec on the connection adapter class instead.
         MSG

--- a/railties/lib/rails/deprecator.rb
+++ b/railties/lib/rails/deprecator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Rails
+  def self.deprecator # :nodoc:
+    ActiveSupport::Deprecation.instance
+  end
+end

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -108,7 +108,7 @@ module Rails
           end
       end
 
-      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Rails::Generators::Testing::Behaviour", "Rails::Generators::Testing::Behavior")
+      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Rails::Generators::Testing::Behaviour", "Rails::Generators::Testing::Behavior", Rails.deprecator)
     end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1392,8 +1392,8 @@ module ApplicationTests
     test "config.enable_dependency_loading is deprecated" do
       app "development"
 
-      assert_deprecated { Rails.application.config.enable_dependency_loading }
-      assert_deprecated { Rails.application.config.enable_dependency_loading = true }
+      assert_deprecated(Rails.deprecator) { Rails.application.config.enable_dependency_loading }
+      assert_deprecated(Rails.deprecator) { Rails.application.config.enable_dependency_loading = true }
     end
 
     test "ActionController::Base.raise_on_open_redirects is true by default for new apps" do
@@ -3902,6 +3902,7 @@ module ApplicationTests
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveStorage.deprecator, Rails.application.deprecators[:active_storage]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
+      assert_equal Rails.deprecator, Rails.application.deprecators[:rails]
     end
 
     test "can entirely opt out of deprecation warnings" do

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -255,7 +255,7 @@ class GeneratorsTest < Rails::Generators::TestCase
   end
 
   def test_behaviour_aliases_behavior
-    assert_deprecated do
+    assert_deprecated(Rails.deprecator) do
       assert_same Rails::Generators::Testing::Behavior, Rails::Generators::Testing::Behaviour.itself
     end
   end


### PR DESCRIPTION
This commit adds `Rails.deprecator`, which currently returns `ActiveSupport::Deprecation.instance`.  This commit also replaces all usages of `ActiveSupport::Deprecation.warn` in `railties/lib` with `Rails.deprecator.warn`.
