### PR TITLE
Make error highlight readable on dark mode

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -237,6 +237,10 @@
         background-color: #900;
       }
 
+      .error_highlight {
+        color: #333;
+      }
+
       input[type="submit"] {
         box-shadow: 0 3px #800;
       }


### PR DESCRIPTION
### Motivation / Background

Follow up to https://github.com/rails/rails/pull/45818 which on main right now looks like this on dark mode:

![Screen Shot 2022-11-04 at 5 53 40 PM](https://user-images.githubusercontent.com/496367/200081380-8ff3d7f9-3368-407d-8883-dbcae1f06f06.png)

After trying to find a shade of dark yellow that didn't remind me of urine 😅  I opted for this instead:

![Screen Shot 2022-11-04 at 5 56 36 PM](https://user-images.githubusercontent.com/496367/200081415-4c282f8c-f888-49a0-b767-b81d535c1931.png)

but I am definitely open for color suggestions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] CI is passing.

