### PR TITLE
Fix clear_all_connections! NoMethodError

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -35,7 +35,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
   def teardown
     super
 
-    ActiveRecord::Base.connection.clear_all_connections!
+    ActiveRecord::Base.connection_handler.clear_all_connections!
   end
 
   def cable_config


### PR DESCRIPTION
This fixes the following error when running Action Cable tests:

  ```
  NoMethodError: undefined method `clear_all_connections!' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
  actioncable/test/subscription_adapter/postgresql_test.rb:38:in `teardown'
  ```

### Motivation / Background

This Pull Request has been created because the Action Cable tests failed with an Error on 4d102ebbca

### Detail

This Pull Request changes the `#teardown` method in `actioncable/test/subscription_adapter/postgresql_test.rb` to call `#clear_all_connections!` on `ActiveRecord.connection_handler`.

### Additional information

This PR lists the deprecation warning it intends to fix, but the diff shows calling `clear_all_connections!` on `ActiveRecord.connection` rather than `ActiveRecord.connection_handler`. The deprecation warning advises to call on `connection_handler`.
- https://github.com/rails/rails/pull/46338

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

