### PR TITLE
Fix clear_reloadable_connections! deprecation warning

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -60,7 +60,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
       assert_equal "hello world", queue.pop
     end
 
-    ActiveRecord::Base.clear_reloadable_connections!
+    ActiveRecord::Base.connection_handler.clear_reloadable_connections!
 
     assert adapter.active?
   end


### PR DESCRIPTION
This fixes the following warning when running Action Cable tests:

  ```
  DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_reloadable_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_reloadable_connections!`.
  ```

### Motivation / Background

This Pull Request has been created because I noticed deprecation warnings once I could run the Action Cable tests without error, thanks to this PR:
- https://github.com/rails/rails/pull/46426

### Detail

This Pull Request changes a deprecated call `ActiveRecord::Base.clear_reloadable_connections!` to `ActiveRecord::Base.connection_handler.clear_reloadable_connections!` as per the deprecation warning.

### Additional information

This PR could be taken after:
- https://github.com/rails/rails/pull/46426

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

