### PR TITLE
Correct controller path on missing template error page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -7,10 +7,10 @@
 
   <div class="summary">
     <p>
-      <strong>NOTE:</strong>Rails usually expects a controller action to render a view template with the same name. 
+      <strong>NOTE:</strong> Rails usually expects a controller action to render a view template with the same name.
     </p>
     <p>
-      For example, a <code>BooksController#index</code> action defined in <code>app/controller/books_controller.rb</code> should have a corresponding view template 
+      For example, a <code>BooksController#index</code> action defined in <code>app/controllers/books_controller.rb</code> should have a corresponding view template 
       in a file named <code>app/views/books/index.html.erb</code>.
     </p>
     <p>


### PR DESCRIPTION
### Detail

Correct missing template error page

- Correct controller path `app/controller/books_controller.rb` to `app/controllers/books_controller.rb`
- Add space after `NOTE:`

Ref - https://github.com/rails/rails/pull/46342

**Before**
<img width="1439" alt="Screenshot 2022-11-05 at 8 14 55 AM" src="https://user-images.githubusercontent.com/5279284/200098085-27faacb2-54d8-467f-b360-52561c357377.png">

**After**
<img width="1439" alt="Screenshot 2022-11-05 at 8 17 42 AM" src="https://user-images.githubusercontent.com/5279284/200098097-0582b7f6-17fd-4087-a24c-e05fc73f69a1.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.
