### PR TITLE
Fixes flakey race condition in `railties/test/application/server_test.rb`

### DIFF
--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -7,7 +7,6 @@ require "rails/commands/server/server_command"
 
 module ApplicationTests
   class ServerTest < ActiveSupport::TestCase
-    include ActiveSupport::Testing::Isolation
     include ConsoleHelpers
 
     def setup


### PR DESCRIPTION
Run in parallel, both tests in `railties/test/application/server_test.rb` attempt to bind to the same port. This results in one of the tests failing. Local development environments do not support the forked processes binding to the same localhost port.

### Motivation / Background

This Pull Request has been created because the test fails in local development environments.

### Detail

This Pull Request changes the parallelism of `railties/test/application/server_test.rb` -- the two tests are no longer executed in parallel.

### Additional information

In local development environments the forked processes created for each of the two tests attempt to bind to the same host and port. Only one of the forked tests succeeds in binding to the localhost port 3000.

I attempted applying Minitest's `io_block` mutex to synchronize the Threads, but they're already forked by the time the mutex is hit.

Choosing different ports for each test that boots a rails server could be an option, but would change the scope of each test.

This change just changes how each test is run -- now they're run in serial.

This test is already run, relatively speaking, in parallel with other `railties` tests (ends up in group 12/12 in buildkite). The impact to test times is minor.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

