### PR TITLE
Introduce rate limit filter api via ratelimit method [ci-skip]

### DIFF
--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -21,6 +21,7 @@ module AbstractController
   autoload :Translation
   autoload :AssetPaths
   autoload :UrlFor
+  autoload :Ratelimiter
 
   def self.eager_load!
     super

--- a/actionpack/lib/abstract_controller/ratelimiter.rb
+++ b/actionpack/lib/abstract_controller/ratelimiter.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module AbstractController # :nodoc:
+  module Ratelimiter
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Registers a <tt>before_action</tt> callback wrapped by a rate limit logic.
+      #
+      # To use +ratelimit+, you should have kredis installed in your application,
+      # therefore follow these steps:
+      #
+      # ==== Kredis installation
+      # * Run ./bin/bundle add kredis
+      # * Run ./bin/rails kredis:install to add a default configuration at config/redis/shared.yml
+      #
+      # ==== Options
+      # * <tt>with</tt> - The method that will be called if the rate limit is exceeded,
+      #   the request cycle can be halt by a <tt>render</tt> or <tt>redirect_to</tt>.
+      #   Alternatively, a block can be given as the handler.
+      # * <tt>limit</tt> - The maximum number of permitted requests (default: 10).
+      # * <tt>period</tt> - The amount of time where requests are permitted (default: 1.hour).
+      # * <tt>only</tt> - The rate limit should be run only for this action.
+      # * <tt>except</tt> - The rate limit should be run for all actions except this action.
+      #
+      # ==== Examples
+      #   class PasswordResetsController < ActionController::Base
+      #     ratelimit with: :deny_access
+      #     ratelimit with: :deny_access, only: :create
+      #     ratelimit with: :redirect_to_root, limit: 30, period: 5.minutes
+      #
+      #     ratelimit limit: 15, period: 3.minutes do
+      #       render json: { error: "You've exceeded the maximum number of attempts" }, status: :too_many_requests
+      #     end
+      #
+      #     private
+      #       def deny_access
+      #         head :too_many_requests
+      #       end
+      #
+      #       def redirect_to_root
+      #         redirect_to root_url, alert: "You've exceeded the maximum number of attempts"
+      #       end
+      #   end
+      def ratelimit(options = {}, with: nil, limit: 10, period: 1.hour, &block)
+        begin
+          require "kredis"
+        rescue LoadError
+          $stderr.puts "You don't have kredis installed in your application. Please add it to your Gemfile and run bundle install."
+          raise
+        end
+
+        before_action(options) do
+          counter = Kredis.counter(ratelimit_key, expires_in: period)
+          counter.increment
+
+          if counter.value > limit
+            block_given? ? instance_exec(&block) : send(with)
+          end
+        end
+      end
+    end
+
+    private
+      def ratelimit_key
+        "ratelimiter:#{request.remote_ip}:#{controller_name}:#{action_name}"
+      end
+  end
+end

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -222,6 +222,7 @@ module ActionController
 
       # Before callbacks should also be executed as early as possible, so
       # also include them at the bottom.
+      AbstractController::Ratelimiter,
       AbstractController::Callbacks,
 
       # Append rescue at the bottom to wrap as much as possible.


### PR DESCRIPTION
### Motivation / Background

As discussed [here](https://discuss.rubyonrails.org/t/proposal-rate-limit-api/81700/3) I would like to introduce an API to handle rate limiting inside controllers. The API uses `before_action` and `kredis` under the hood, so basically it is a before_action with a rate limit logic, so the API is similar.

```ruby
class PasswordResetsController < ActionController::Base
  ratelimit with: :deny_access
  ratelimit with: :deny_access, only: :create
  ratelimit with: :redirect_to_root, limit: 30, period: 5.minutes

  ratelimit limit: 15, period: 3.minutes do
    render json: { error: "You've exceeded the maximum number of attempts" }, status: :too_many_requests
  end

  private
    def deny_access
      head :too_many_requests
    end

    def redirect_to_root
      redirect_to root_url, alert: "You've exceeded the maximum number of attempts"
    end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

