### PR TITLE
Lock error_highlight version to 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,5 +176,5 @@ gem "wdm", ">= 0.1.0", platforms: [:windows]
 # Also, Rails depends on a new API available since error_highlight 0.4.0.
 # (Note that Ruby 3.1 bundles error_highlight 0.3.0.)
 if RUBY_VERSION >= "3.1"
-  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
+  gem "error_highlight", ">= 0.4.0", "< 0.5.0", platforms: [:ruby]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -581,7 +581,7 @@ DEPENDENCIES
   debug (>= 1.1.0)
   delayed_job
   delayed_job_active_record
-  error_highlight (>= 0.4.0)
+  error_highlight (>= 0.4.0, < 0.5.0)
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails


### PR DESCRIPTION
### Motivation / Background

This commit locks error_highlight gem to 0.4.0 until https://github.com/ruby/error_highlight/issues/28 is resolved.

### Detail

It should workaround CI failures like:
https://buildkite.com/rails/rails/builds/90833#0184571b-307d-4e94-8a2d-3c8a2669a12c/1052-1078

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

