### PR TITLE
Revert "Merge pull request #46282 from jonathanhefner/active_model-forgetting_assignment-avoid-value_for_database

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -175,19 +175,6 @@ module ActiveModel
           type.deserialize(value)
         end
 
-        def forgetting_assignment
-          # If this attribute was not persisted (with a `value_for_database`
-          # that might differ from `value_before_type_cast`) and `value` has not
-          # changed in place, we can simply dup this attribute to avoid
-          # deserialize / cast / serialize calls from computing the new
-          # attribute's `value_before_type_cast`.
-          if !defined?(@value_for_database) && !changed_in_place?
-            dup
-          else
-            super
-          end
-        end
-
         private
           def _original_value_for_database
             value_before_type_cast


### PR DESCRIPTION
This reverts commit 1f039d8f400e2b9bf76a9c25bd3916eb0aefa0f7, reversing changes made to be0b5c65a175b6c92514375fc7044efb11cdbe90.

This revert is temporary while we debug some issues with our app. While we're pretty sure this is caused by code in our application and a compbination with `activerecord-typed_store`, the failure mode is easy to miss because it doesn't raise an exception.

We will un-revert after a bit more investigation. We just want to be confident that the other cases where this could cause issues are fixed without being blocked from upgrading for the next month or so.

cc/ @jonathanhefner @nvasilevski @byroot @adrianna-chang-shopify 