### PR TITLE
Fix `Enumerable#many?` to handle previous enumerator methods parameters

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -144,8 +144,8 @@ module Enumerable
   def many?
     cnt = 0
     if block_given?
-      any? do |element|
-        cnt += 1 if yield element
+      any? do |element, *args|
+        cnt += 1 if yield element, *args
         cnt > 1
       end
     else

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -255,6 +255,7 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal false, GenericEnumerable.new([ 2 ]).many? { |x| x > 1 }
     assert_equal false, GenericEnumerable.new([ 1, 2 ]).many? { |x| x > 1 }
     assert_equal true,  GenericEnumerable.new([ 1, 2, 2 ]).many? { |x| x > 1 }
+    assert_equal true,  GenericEnumerable.new([ 1, 2, 3]).each_with_index.many? { |x, i| x == i + 1 }
   end
 
   def test_many_iterates_only_on_what_is_needed


### PR DESCRIPTION
Fixes #46445.