### PR TITLE
Update ActiveRecord::Associations::CollectionProxy#== documentation

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -955,10 +955,13 @@ module ActiveRecord
       #   person.pets == other
       #   # => true
       #
+      #
+      # Note that unpersisted records can still be seen as equal:
+      #
       #   other = [Pet.new(id: 1), Pet.new(id: 2)]
       #
       #   person.pets == other
-      #   # => false
+      #   # => true
       def ==(other)
         load_target == other
       end


### PR DESCRIPTION
The current example for `ActiveRecord::Associations::CollectionProxy#==` documentation is incorrect. Here is a change to update the example accordingly. 

Maybe the example isn't relevant anymore. Do we want to discard it completely?

Here is the test:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
# ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :people, force: true do |t|
  end

  create_table :pets, force: true do |t|
    t.references :person
    t.string :name
  end
end

class Person < ActiveRecord::Base
  has_many :pets
end

class Pet < ActiveRecord::Base
  belongs_to :person
end

class TestEquality < Minitest::Test
  def test_association_stuff
    person = Person.create!
    person.pets.create(name: "Fancy-Fancy")
    person.pets.create(name: "Spook")

    assert ActiveRecord::Associations::CollectionProxy === person.pets

    other = person.pets.to_ary
    assert person.pets == other
    puts "(person.pets == other) returns #{person.pets == other}"

    other = [Pet.new(id: 1), Pet.new(id: 2)]
    assert person.pets == other
    puts "(person.pets == [Pet.new(id: 1), Pet.new(id: 2)]) returns #{person.pets == [Pet.new(id: 1), Pet.new(id: 2)]}"
  end
end
```

```
# Running:

(person.pets == other) returns true
(person.pets == [Pet.new(id: 1), Pet.new(id: 2)]) returns true
.

Finished in 0.018527s, 53.9753 runs/s, 161.9258 assertions/s.
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```