### PR TITLE
Add `AS::ParameterFilter.precompile_filters`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -74,6 +74,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
+- [`config.precompile_filter_parameters`](#config-precompile-filter-parameters): `true`
 
 #### Default Values for Target Version 7.0
 
@@ -386,6 +387,20 @@ config.logger      = ActiveSupport::TaggedLogging.new(mylogger)
 #### `config.middleware`
 
 Allows you to configure the application's middleware. This is covered in depth in the [Configuring Middleware](#configuring-middleware) section below.
+
+#### `config.precompile_filter_parameters`
+
+When `true`, will precompile [`config.filter_parameters`](#config-filter-parameters)
+using [`ActiveSupport::ParameterFilter.precompile_filters`][].
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
+
+[`ActiveSupport::ParameterFilter.precompile_filters`]: https://api.rubyonrails.org/classes/ActiveSupport/ParameterFilter.html#method-c-precompile_filters
 
 #### `config.public_file_server.enabled`
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `config.precompile_filter_parameters`, which enables precompilation of
+    `config.filter_parameters` using `ActiveSupport::ParameterFilter.precompile_filters`.
+    Precompilation can improve filtering performance, depending on the quantity
+    and types of filters.
+
+    `config.precompile_filter_parameters` defaults to `true` for
+    `config.load_defaults 7.1` and above.
+
+    *Jonathan Hefner*
+
 *   Add `after_routes_loaded` hook to `Rails::Railtie::Configuration` for
     engines to add a hook to be called after application routes have been
     loaded.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -301,7 +301,7 @@ module Rails
     # will be used by middlewares and engines to configure themselves.
     def env_config
       @app_env_config ||= super.merge(
-          "action_dispatch.parameter_filter" => config.filter_parameters,
+          "action_dispatch.parameter_filter" => filter_parameters,
           "action_dispatch.redirect_filter" => config.filter_redirect,
           "action_dispatch.secret_key_base" => secret_key_base,
           "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
@@ -674,6 +674,14 @@ module Rails
 
       def coerce_same_site_protection(protection)
         protection.respond_to?(:call) ? protection : proc { protection }
+      end
+
+      def filter_parameters
+        if config.precompile_filter_parameters
+          ActiveSupport::ParameterFilter.precompile_filters(config.filter_parameters)
+        else
+          config.filter_parameters
+        end
       end
   end
 end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -12,7 +12,7 @@ module Rails
     class Configuration < ::Rails::Engine::Configuration
       attr_accessor :allow_concurrency, :asset_host, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
-                    :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
+                    :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
                     :log_tags, :railties_order, :relative_url_root, :secret_key_base,
                     :ssl_options, :public_file_server,
@@ -278,6 +278,7 @@ module Rails
           load_defaults "7.0"
 
           self.add_autoload_paths_to_load_path = false
+          self.precompile_filter_parameters = true
 
           if Rails.env.development? || Rails.env.test?
             self.log_file_size = 100 * 1024 * 1024

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -117,3 +117,7 @@
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 # Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+
+# Enable precompilation of `config.filter_parameters`. Precompilation can
+# improve filtering performance, depending on the quantity and types of filters.
+# Rails.application.config.precompile_filter_parameters = true


### PR DESCRIPTION
`ActiveSupport::ParameterFilter.precompile_filters` precompiles filters that otherwise would be passed directly to `ParameterFilter.new`. Depending on the quantity and types of filters, precompilation can improve filtering performance, especially in the case where the `ParameterFilter` instance cannot be memoized, such as with per-request instances in `ActionDispatch::Http::FilterParameters`.

<details>
  <summary><strong>Benchmark script</strong></summary>

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "benchmark/memory"
  require "active_support"
  require "active_support/parameter_filter"

  ootb = [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
  mixed = [:passw, "secret", /token/, :crypt, "salt", /certificate/, "user.otp", /user\.ssn/, proc {}]
  precompiled_ootb = ActiveSupport::ParameterFilter.precompile_filters(ootb)
  precompiled_mixed = ActiveSupport::ParameterFilter.precompile_filters(mixed)

  params = {
    "user" => {
      "name" => :name,
      "email" => :email,
      "password" => :password,
      "ssn" => :ssn,
      "locations" => [
        { "city" => :city, "country" => :country },
        { "city" => :city, "country" => :country },
      ],
    }
  }

  Benchmark.ips do |x|
    x.report("ootb") do
      ActiveSupport::ParameterFilter.new(ootb).filter(params)
    end
    x.report("precompiled ootb") do
      ActiveSupport::ParameterFilter.new(precompiled_ootb).filter(params)
    end
    x.compare!
  end

  Benchmark.ips do |x|
    x.report("mixed") do
      ActiveSupport::ParameterFilter.new(mixed).filter(params)
    end
    x.report("precompiled mixed") do
      ActiveSupport::ParameterFilter.new(precompiled_mixed).filter(params)
    end
    x.compare!
  end

  Benchmark.memory do |x|
    x.report("ootb") do
      ActiveSupport::ParameterFilter.new(ootb).filter(params)
    end
    x.report("precompiled ootb") do
      ActiveSupport::ParameterFilter.new(precompiled_ootb).filter(params)
    end
  end

  Benchmark.memory do |x|
    x.report("mixed") do
      ActiveSupport::ParameterFilter.new(mixed).filter(params)
    end
    x.report("precompiled mixed") do
      ActiveSupport::ParameterFilter.new(precompiled_mixed).filter(params)
    end
  end
  ```
</details>

**Results**

  ```
  Warming up --------------------------------------
                  ootb     2.151k i/100ms
      precompiled ootb     4.251k i/100ms
  Calculating -------------------------------------
                  ootb     21.567k (± 1.1%) i/s -    109.701k in   5.086983s
      precompiled ootb     42.840k (± 0.8%) i/s -    216.801k in   5.061022s

  Comparison:
      precompiled ootb:    42840.4 i/s
                  ootb:    21567.5 i/s - 1.99x  (± 0.00) slower
  ```

  ```
  Warming up --------------------------------------
                 mixed     1.622k i/100ms
     precompiled mixed     2.455k i/100ms
  Calculating -------------------------------------
                 mixed     16.085k (± 1.3%) i/s -     81.100k in   5.042764s
     precompiled mixed     24.640k (± 1.0%) i/s -    125.205k in   5.081988s

  Comparison:
     precompiled mixed:    24639.6 i/s
                 mixed:    16085.0 i/s - 1.53x  (± 0.00) slower
  ```

  ```
  Calculating -------------------------------------
                  ootb     2.684k memsize (     0.000  retained)
                          30.000  objects (     0.000  retained)
                          10.000  strings (     0.000  retained)
      precompiled ootb     1.104k memsize (     0.000  retained)
                           9.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)
  ```

  ```
  Calculating -------------------------------------
                 mixed     3.541k memsize (     0.000  retained)
                          46.000  objects (     0.000  retained)
                          20.000  strings (     0.000  retained)
     precompiled mixed     1.856k memsize (     0.000  retained)
                          29.000  objects (     0.000  retained)
                          13.000  strings (     0.000  retained)
  ```

This commit also adds `config.precompile_filter_parameters`, which enables precompilation of `config.filter_parameters`.  It defaults to `true` for `config.load_defaults 7.1` and above.

---

A config might be overkill, but I wanted to provide an escape hatch for any upgraded apps that might be testing the exact value of the `action_dispatch.parameter_filter` header.
