### PR TITLE
Do not write additional new lines when dumping sql migration versions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Do not write additional new lines when dumping sql migration versions
+
+    This change updates the `insert_versions_sql` function so that the database insert string containing the current database migration versions does not end with two additional new lines.
+
+    *Misha Schwartz*
+
 *   Fix `composed_of` value freezing and duplication.
 
     Previously composite values exhibited two confusing behaviors:
@@ -367,6 +373,7 @@
     `active_connections?`, `clear_active_connections!`, `clear_reloadable_connections!`, `clear_all_connections!`, and `flush_idle_connections!` now operate on all pools by default. Previously they would default to using the `current_role` or `:writing` role unless specified.
 
     *Eileen M. Uchitelle*
+
 
 *   Allow ActiveRecord::QueryMethods#select to receive hash values.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1765,7 +1765,7 @@ module ActiveRecord
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
             sql << versions.reverse.map { |v| "(#{quote(v)})" }.join(",\n")
-            sql << ";\n\n"
+            sql << ";"
             sql
           else
             "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -34,9 +34,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
     ('20100301010101'),
     ('20100201010101'),
     ('20100101010101');
-
     STR
-    assert_equal expected, schema_info
+    assert_equal expected.strip, schema_info
   ensure
     @schema_migration.delete_all_versions
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because rails adds a bunch of extra newlines to the end of the `db/structure.sql` file when there are database migrations present. This seems unnecessary and causes style checkers to complain that there are unnecessary newlines at the end of a file. 

### Detail

This Pull Request changes the `insert_versions_sql` function to finish a database query string with a semicolon, instead of a semicolon followed by two newlines.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

