### PR TITLE
Fix `index_exists?` to handle empty columns argument

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -48,7 +48,7 @@ module ActiveRecord
       end
 
       def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, **options)
-        columns = options[:column] if columns.nil?
+        columns = options[:column] if columns.blank?
         (columns.nil? || Array(self.columns) == Array(columns).map(&:to_s)) &&
           (name.nil? || self.name == name.to_s) &&
           (unique.nil? || self.unique == unique) &&

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -172,6 +172,7 @@ module ActiveRecord
       def test_index_exists_with_custom_name_checks_columns
         connection.add_index :testings, [:foo, :bar], name: "my_index"
         assert connection.index_exists?(:testings, [:foo, :bar], name: "my_index")
+        assert connection.index_exists?(:testings, [], name: "my_index")
         assert_not connection.index_exists?(:testings, [:foo], name: "my_index")
       end
 


### PR DESCRIPTION
Previously, `index_exists?` ignored `columns` argument when it was passed as an empty array - https://github.com/rails/rails/blob/a5b2b6155ceac1c073979272bb1c424fdf35cbc7/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L102-L105

Now, it checks existing indexes columns against empty array and fails to find the existing index - https://github.com/rails/rails/blob/9caf1d77ee1644e8fc680195ff71a6d277213cf9/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L51-L52

So, this PR restores the previous behavior.

The bug was introduced in https://github.com/rails/rails/commit/d152a11a4c75ed21816e97191a1fce2110a4a2ce.