### PR TITLE
Add missing require to `railties/lib/rails/generators/testing/behavior.rb`

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/object/blank"
+require "rails/deprecator"
 
 require "thor"
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/46424.

After that PR, I have a failing CI - https://github.com/fatkodima/online_migrations/actions/runs/3432986855/jobs/5722837319. I am using only `activerecord` and `railties` in that repository, it is a gem, not a rails app.

cc @jonathanhefner 