### PR TITLE
Update ActiveRecord::Relation #reverse_order to support reversing `FIELD(...)` ordering

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add support for reversing the order of `ORDER BY FIELD(id, 1,2,3)`-style ordering via #reverse_order.
+
+    Calling #reverse_order on a relation that is ordered using the `FIELD` SQL function will no longer raise `ActiveRecord::IrreversibleOrderError`.
+
+    ```
+    Tag.order([Arel.sql("field(id, ?)"), [1, 3, 2]]).reverse_order.to_sql
+    # => SELECT "tags".* FROM "tags" ORDER BY field(id, 1,3,2) DESC
+    ```
+
+    *Sarah Vessels*
+
 *   Clear locking column on #dup
 
     This change fixes not to duplicate locking_column like id and timestamps.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

In a Rails app I work on, I have a MySQL query like this:

```sql
ORDER BY FIELD(users.id, 1, 2, 3) desc, name asc
```

I want to be able to use #reverse_order on that to get `ORDER BY FIELD(users.id, 1, 2, 3) ASC, name DESC`. Presently, that results in an ActiveRecord::IrreversibleOrderError exception because of the `FIELD` function in the `ORDER BY` clause.

### Detail

This Pull Request changes both #reverse_sql_order and #does_not_support_reverse? in ActiveRecord::Relation.

- I add a new regex constant, `FIELD_SQL_FUNC_REGEX`, to match orderings using the `FIELD` SQL function
    - Check out how the regex matches via https://rubular.com/r/wTWiURUAju65MU.
    - The regex uses a subexpression call which I think requires Ruby 2.0.
- #does_not_support_reverse? now will return `true` when it previously would return `false` if the order string matches the new regex
- #reverse_sql_order
    - Behaves the same as before when the order string doesn't match the new regex.
    - When the order string _does_ match, it makes a few passes over the order string to figure out how to flip each `FIELD` ordering, make those replacements, figure out what non-`FIELD` orderings remain that need to be flipped, and make those replacements.
- I pulled out a couple new private methods to try and help readability for my changes, including #reverse_order_string and #flip_sql_order_direction_for_each_non_field_function_ordering.

### Additional information

My change works for my original use case, based on the passing tests when I run `bundle exec ruby -w -Itest test/cases/relations_test.rb`. However, I think my #reverse_order_string function is ugly and could probably be improved. Feedback is definitely appreciated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

