### PR TITLE
Check for transaction  before invalidating the state

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1012,7 +1012,7 @@ module ActiveRecord
           return unless exception.is_a?(TransactionRollbackError)
           return unless savepoint_errors_invalidate_transactions?
 
-          current_transaction.state.invalidate! if current_transaction
+          current_transaction.state.invalidate! if current_transaction.open?
         end
 
         def retryable_query_error?(exception)


### PR DESCRIPTION
https://github.com/rails/rails/pull/46367 PR introduced the following check:
https://github.com/rails/rails/blob/bf24af73ff146e884339a215ebe30d3fc5a88091/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1015

which is meaningless as the `current_transaction` always returns something, either an actual opened transaction or a `NullTransaction`:
https://github.com/rails/rails/blob/bf24af73ff146e884339a215ebe30d3fc5a88091/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L515-L516

So I'm trying to turn this check into something meaningful. So I'm suggesting changing it to `if current_transaction.open?` where `.open?` will imply presence of an invalidatable transaction (non-nulltransaction).

### Alternatives

1. Similarly I could check for a `current_transaction` not being an instance of the `NullTransaction` class like `invalidate unless current_transaction.is_a?(NullTransaction)` but I don't like it as I don't want the code to depend on specific implementation or know about transaction classes. 
2.  Something I would like to see eventually - completely remove the `if` condition. There is a high chance that we can rely on an implication that we will never reach `current_transaction.state.invalidate!` line unless we have an open and invalidatable transaction. However at this point I don't have solid reasoning to support this so I'm choosing to keep the check
3. Probably the best from design point of view. It's the same as 2) but with an addition - make sure `NullTransaction` has some kind of a `NullState` that responds to `invalidate!` as currently it doesn't have one
https://github.com/rails/rails/blob/bf24af73ff146e884339a215ebe30d3fc5a88091/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L78
In this case we would be able to call `.invalidate!` without bothering about the underlying `current_transaction` as every transaction will respond to `.invalidate!` and even if we call it on a `NullTransaction` the invalidation can be simply ignored. However changing design of `NullTransaction` is a bigger topic and even if someone thinks that we should do it, I'd prefer doing it in a separate PR with a separate reasoning.

### Testing
Not adding test as I wasn't able to come up with a meaningful one. I could have asserted for a mocked `current_transaction` to receive `.open?` but not receive `.state.invalidate!` but it felt like I'm asserting specific implementation instead of behavior

I also wrote a test that uses no transaction but calls `with_raw_connection` and raises a deadlock exception but didn't like it because it looked like a completely made-up scenario. Such test would have revealed what I'm trying to fix though

Let me know if still prefer to cover this change with a test, either with one from the ones described above or a different one
