### PR TITLE
Improve the MissingExactTemplate error page

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -92,5 +92,13 @@ module ActionController
   end
 
   class MissingExactTemplate < UnknownFormat # :nodoc:
+    attr_reader :controller, :action_name
+
+    def initialize(message, controller, action_name)
+      @controller  = controller
+      @action_name = action_name
+
+      super(message)
+    end
   end
 end

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -42,7 +42,7 @@ module ActionController
         raise ActionController::UnknownFormat, message
       elsif interactive_browser_request?
         message = "#{self.class.name}\##{action_name} is missing a template for request formats: #{request.formats.map(&:to_s).join(',')}"
-        raise ActionController::MissingExactTemplate, message
+        raise ActionController::MissingExactTemplate.new(message, self.class, action_name)
       else
         logger.info "No template found for #{self.class.name}\##{action_name}, rendering head :no_content" if logger
         super

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -10,8 +10,8 @@
       <strong>NOTE:</strong> Rails usually expects a controller action to render a view template with the same name.
     </p>
     <p>
-      For example, a <code>BooksController#index</code> action defined in <code>app/controllers/books_controller.rb</code> should have a corresponding view template 
-      in a file named <code>app/views/books/index.html.erb</code>.
+      For example, a <code><%= @exception.controller %>#<%= @exception.action_name %></code> action defined in <code>app/controllers/<%= @exception.controller.controller_path %>_controller.rb</code> should have a corresponding view template
+      in a file named <code>app/views/<%= @exception.controller.controller_name %>/<%= @exception.action_name %>.html.erb</code>.
     </p>
     <p>
       However, if this controller is an API endpoint responding with 204 (No Content), which does not require a view template because it doesn't serve an HTML response, then this error will occur when trying to access it with a browser. In this particular scenario, you can ignore this error.


### PR DESCRIPTION
### Motivation / Background

This PR implements @jhawthorn's [suggestion](https://github.com/rails/rails/pull/46342#discussion_r1005248144) to pass through the controller and action name to the error page. It builds on @olivierlacan great PR https://github.com/rails/rails/pull/46342 with improvements for the error page.
