### PR TITLE
Improve layout of Sprockets 3 & 4 manifest documentation [ci-skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -656,24 +656,26 @@ JS/CSS is excluded, as well as raw JS/CSS files; for example, `.coffee` and
 `.scss` files are **not** automatically included as they compile to JS/CSS.
 
 If you have other manifests or individual stylesheets and JavaScript files to
-include, you can add them yourself:
+include, you can add them yourself.
 
-- **Sprockets 3:** Add files to the `precompile` array in `config/initializers/assets.rb`:
+When you are using **Sprockets 3**, add the files to the `precompile` array in
+`config/initializers/assets.rb`:
 
-  ```ruby
-  Rails.application.config.assets.precompile += %w( admin.js admin.css )
-  ```
+```ruby
+Rails.application.config.assets.precompile += %w( admin.js admin.css )
+```
 
-- **Sprockets 4:** Add files or directories inside `./app/assets/config/manifest.js`
+When you are using **Sprockets 4**, add the files or directories to
+`app/assets/config/manifest.js`:
 
-  ```js
-  //= link_tree ../images
-  //= link admin.js
-  //= link admin.css
-  // Or link whole directories:
-  //= link_directory ../javascripts .js
-  //= link_directory ../stylesheets .css
-  ```
+```js
+//= link_tree ../images
+//= link admin.js
+//= link admin.css
+// Or link whole directories:
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+```
 
 NOTE. Always specify an expected compiled filename that ends with `.js` or `.css`,
 even if you want to add Sass or CoffeeScript files to the precompile array or manifest file.


### PR DESCRIPTION
Commit c6d5ae5be48bf94193 improved documentation of adding more files to be precompiled. Using a list, made the layout a bit confusing, as the code samples weren't properly aligned.

## Before

<img width="675" alt="image" src="https://user-images.githubusercontent.com/28561/201372474-f5e11a26-af32-45bc-8a63-9e6656482df1.png">

## After

<img width="668" alt="image" src="https://user-images.githubusercontent.com/28561/201372406-1634d44d-1b04-49d8-8fc9-4b7f72347c1c.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

