### PR TITLE
Add `invalidate!` directly to `Transaction`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -83,11 +83,14 @@ module ActiveRecord
       def restartable?; false; end
       def dirty?; false; end
       def dirty!; end
+      def invalidate!; end
     end
 
     class Transaction # :nodoc:
       attr_reader :connection, :state, :savepoint_name, :isolation_level
       attr_accessor :written, :written_indirectly
+
+      delegate :invalidate!, to: :@state
 
       def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
         @connection = connection
@@ -496,7 +499,7 @@ module ActiveRecord
                 begin
                   commit_transaction
                 rescue ActiveRecord::ConnectionFailed
-                  transaction.state.invalidate! unless transaction.state.completed?
+                  transaction.invalidate! unless transaction.state.completed?
                   raise
                 rescue Exception
                   rollback_transaction(transaction) unless transaction.state.completed?

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1012,7 +1012,7 @@ module ActiveRecord
           return unless exception.is_a?(TransactionRollbackError)
           return unless savepoint_errors_invalidate_transactions?
 
-          current_transaction.state.invalidate! if current_transaction.open?
+          current_transaction.invalidate!
         end
 
         def retryable_query_error?(exception)


### PR DESCRIPTION
As suggested by @rafaelfranca in https://github.com/rails/rails/pull/46468#issuecomment-1311044332 there is a better way of preventing calling `invalidate!` on an empty state of an instance of `NullTransaction`
And this way is to make sure every instance of `Transaction` directly responds to `invalidate!`
In this case we can simply call `invalidate!` on any transaction letting transaction implementation to decide how to proceed. And a `NullTransaction` will proceed by doing nothing 


### Can we do more?

As discussed in the PR mentioned above, we could also added a `NullState` to the `NullTransaction` but at this point it seems unnecessary as at least for invalidation we are moving away from directly using the `state`
This PR opens a question whether `Transaction` should directly respond to state predicates like `Transaction#completed?` or `Transaction.invalidated?` but this is a question for a different PR as it requires more refactoring and more decision making.

### Testing

I was considering adding a test like:
```ruby
def test_invalidate_invalidates_transaction_state
  transaction = Transaction.new
  refute_predicate transaction.state, :invalidated?
  transaction.invalidate!
  
  assert_predicate transaction.state, :invalidated?
```

But such test feels excessive. `Transaction` doesn't seem to be a public class, at least judging by `:nodoc:` while we still test the invalidation flow through a more integration-like tests, for example:

Let me know if you see value in a unit-like test and I'll add one.
