### PR TITLE
Previews paths should not be eager loaded

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -68,7 +68,7 @@ module Rails
           paths.add "vendor",              load_path: true
           paths.add "vendor/assets",       glob: "*"
 
-          paths.add "test/mailers/previews", eager_load: true
+          paths.add "test/mailers/previews", autoload: true
 
           paths
         end


### PR DESCRIPTION
Right now they are being eager loaded that means they are being loaded in the production environment unnecessarily.

All we need is for those paths to be autoloaded in development, so code reload works.