### PR TITLE
Update comments in all three en.yml files relating to booleans

### DIFF
--- a/actionmailbox/test/dummy/config/locales/en.yml
+++ b/actionmailbox/test/dummy/config/locales/en.yml
@@ -1,6 +1,6 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
+# Files in the config/locales directory are used for internationalization and
+# are automatically loaded by Rails. If you want to use locales other than
+# English, add the necessary files in this directory.
 #
 # To use the locales, use `I18n.t`:
 #
@@ -16,18 +16,16 @@
 #
 # This would use the information in config/locales/es.yml.
 #
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
+# To learn more about the API, please read the Rails Internationalization guide
+# at https://guides.rubyonrails.org/i18n.html.
 #
-# true, false, on, off, yes, no
+# Be aware that YAML interprets the following case-insensitive strings as
+# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
+# must be quoted to be interpreted as strings. For example:
 #
-# Instead, surround them with double quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
+#     en:
+#       "yes": yup
+#       enabled: "ON"
 
 en:
   hello: "Hello world"

--- a/actiontext/test/dummy/config/locales/en.yml
+++ b/actiontext/test/dummy/config/locales/en.yml
@@ -1,6 +1,6 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
+# Files in the config/locales directory are used for internationalization and
+# are automatically loaded by Rails. If you want to use locales other than
+# English, add the necessary files in this directory.
 #
 # To use the locales, use `I18n.t`:
 #
@@ -16,18 +16,16 @@
 #
 # This would use the information in config/locales/es.yml.
 #
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
+# To learn more about the API, please read the Rails Internationalization guide
+# at https://guides.rubyonrails.org/i18n.html.
 #
-# true, false, on, off, yes, no
+# Be aware that YAML interprets the following case-insensitive strings as
+# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
+# must be quoted to be interpreted as strings. For example:
 #
-# Instead, surround them with double quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
+#     en:
+#       "yes": yup
+#       enabled: "ON"
 
 en:
   hello: "Hello world"

--- a/activestorage/test/dummy/config/locales/en.yml
+++ b/activestorage/test/dummy/config/locales/en.yml
@@ -1,6 +1,6 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
+# Files in the config/locales directory are used for internationalization and
+# are automatically loaded by Rails. If you want to use locales other than
+# English, add the necessary files in this directory.
 #
 # To use the locales, use `I18n.t`:
 #
@@ -16,18 +16,16 @@
 #
 # This would use the information in config/locales/es.yml.
 #
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
+# To learn more about the API, please read the Rails Internationalization guide
+# at https://guides.rubyonrails.org/i18n.html.
 #
-# true, false, on, off, yes, no
+# Be aware that YAML interprets the following case-insensitive strings as
+# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
+# must be quoted to be interpreted as strings. For example:
 #
-# Instead, surround them with double quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
+#     en:
+#       "yes": yup
+#       enabled: "ON"
 
 en:
   hello: "Hello world"

--- a/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
@@ -1,6 +1,6 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
+# Files in the config/locales directory are used for internationalization and
+# are automatically loaded by Rails. If you want to use locales other than
+# English, add the necessary files in this directory.
 #
 # To use the locales, use `I18n.t`:
 #
@@ -16,18 +16,16 @@
 #
 # This would use the information in config/locales/es.yml.
 #
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
+# To learn more about the API, please read the Rails Internationalization guide
+# at https://guides.rubyonrails.org/i18n.html.
 #
-# true, false, on, off, yes, no
+# Be aware that YAML interprets the following case-insensitive strings as
+# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
+# must be quoted to be interpreted as strings. For example:
 #
-# Instead, surround them with double quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
+#     en:
+#       "yes": yup
+#       enabled: "ON"
 
 en:
   hello: "Hello world"


### PR DESCRIPTION
This Pull Request has been created because I was using Yes/No as values for a translation key and was getting True/False as the translation and I lost my mind for about 30 minutes before I realized I needed to escape the value. This PR updates all en.yml files that contains the comments that only truthy or falsey keys needed to be escaped to also cover the values.

This PR also changes the double-quotes to single quotes to be inline with what the comments say, and also because single quotes for non-interpolated strings is good and makes Rubocop happy.

Fixes #46475 

### Detail

This Pull Request changes en.yml used by generators as well as dummy en.yml files for consistency purposes

Original commit message:
* The original comments only mentioned truthy and falsey keys, but the problem also effects truthy & falsey values
* Update the comments to be more accurate
* Also changed everything to single quotes because that's what the comment said anyhow. Plus it is the way of the Rubocop

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [✅] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [✅ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [N/A] Tests are added or updated if you fix a bug or add a feature.
* [N/A] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [🛑] CI is passing. EDIT: It is unclear to me why CI is failing. The failure does not align with my diffs.

