### PR TITLE
Add Bundler helper for `AppGeneratorTest`

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -825,7 +825,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_hotwire
-    run_generator [destination_root, "--no-skip-bundle"]
+    run_generator_and_bundler [destination_root]
     assert_gem "turbo-rails"
     assert_gem "stimulus-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
@@ -848,7 +848,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_asset_pipeline_tailwind
-    run_generator [destination_root, "--css", "tailwind", "--no-skip-bundle"]
+    run_generator_and_bundler [destination_root, "--css=tailwind"]
     assert_gem "tailwindcss-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_match(/tailwind/, content)
@@ -856,7 +856,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_cssbundling_gem
-    run_generator [destination_root, "--css", "postcss", "--no-skip-bundle"]
+    run_generator_and_bundler [destination_root, "--css=postcss"]
     assert_gem "cssbundling-rails"
     assert_file "app/assets/stylesheets/application.postcss.css"
   end
@@ -1068,6 +1068,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   private
+    def run_generator_and_bundler(args)
+      option_args, positional_args = args.partition { |arg| arg.start_with?("--") }
+      option_args << "--no-skip-bundle"
+      generator(positional_args, option_args)
+
+      # Stub `rails_gemfile_entry` so that Bundler resolves `gem "rails"` to the
+      # current repository instead of searching for an invalid version number
+      # (for a version that hasn't been released yet).
+      rails_gemfile_entry = Rails::Generators::AppBase::GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH)
+      generator.stub(:rails_gemfile_entry, -> { rails_gemfile_entry }) do
+        quietly { run_generator_instance }
+      end
+    end
+
     def run_app_update(app_root = destination_root)
       Dir.chdir(app_root) do
         gemfile_contents = File.read("Gemfile")


### PR DESCRIPTION
A few `AppGeneratorTest` tests require running Bundler.  When Bundler tries to resolve `gem "rails"`, it searches for an invalid version number (for a version that hasn't been released yet).  Doing so is slow and prints many lines of error output.  Furthermore, the same tests print additional output via the commands that the generator runs after Bundler.

This commit adds a `run_generator_and_bundler` helper which points `gem "rails"` to the current repository, and silences any additional output from the generator.

**Before**

  ```
  $ cd railties
  $ bin/test test/generators/app_generator_test.rb --verbose --seed 520 -n '/test_hotwire|test_css_option_with_asset_pipeline_tailwind|test_css_option_with_cssbundling_gem/'

  # Running:

  Could not find gem 'rails (~> 7.1.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

  The source contains the following gems matching 'rails':
    * rails-0.8.0
    * rails-0.8.5
    * rails-0.9.0
  ...431 MORE LINES...
    * rails-7.0.3
    * rails-7.0.3.1
    * rails-7.0.4
  Could not find gem 'rails (~> 7.1.0.alpha)' in locally installed gems.

  The source contains the following gems matching 'rails':
  ...MORE LINES...
  AppGeneratorTest#test_hotwire = 26.30 s = .
  Could not find gem 'rails (~> 7.1.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

  The source contains the following gems matching 'rails':
    * rails-0.8.0
    * rails-0.8.5
    * rails-0.9.0
  ...431 MORE LINES...
    * rails-7.0.3
    * rails-7.0.3.1
    * rails-7.0.4
  Could not find gem 'rails (~> 7.1.0.alpha)' in locally installed gems.

  The source contains the following gems matching 'rails':
  ...MORE LINES...
  Browserslist: caniuse-lite is outdated. Please run:
    npx browserslist@latest --update-db
    Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating

  Done in 645ms.
  AppGeneratorTest#test_css_option_with_asset_pipeline_tailwind = 45.64 s = .
  Could not find gem 'rails (~> 7.1.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

  The source contains the following gems matching 'rails':
    * rails-0.8.0
    * rails-0.8.5
    * rails-0.9.0
  ...431 MORE LINES...
    * rails-7.0.3
    * rails-7.0.3.1
    * rails-7.0.4
  Could not find gem 'rails (~> 7.1.0.alpha)' in locally installed gems.

  The source contains the following gems matching 'rails':
  ...MORE LINES...
  npm WARN set-script set-script is deprecated, use `npm pkg set scripts.scriptname="cmd" instead.

    app/assets/builds/application.js      55b
    app/assets/builds/application.js.map  93b

  npm WARN set-script set-script is deprecated, use `npm pkg set scripts.scriptname="cmd" instead.
  AppGeneratorTest#test_css_option_with_cssbundling_gem = 51.93 s = .

  Finished in 123.877633s, 0.0242 runs/s, 0.2180 assertions/s.
  3 runs, 27 assertions, 0 failures, 0 errors, 0 skips
  ```

**After**

  ```
  $ cd railties
  $ bin/test test/generators/app_generator_test.rb --verbose --seed 520 -n '/test_hotwire|test_css_option_with_asset_pipeline_tailwind|test_css_option_with_cssbundling_gem/'

  # Running:

  AppGeneratorTest#test_hotwire = 10.00 s = .
  AppGeneratorTest#test_css_option_with_asset_pipeline_tailwind = 22.61 s = .
  AppGeneratorTest#test_css_option_with_cssbundling_gem = 30.77 s = .

  Finished in 63.386282s, 0.0473 runs/s, 0.4260 assertions/s.
  3 runs, 27 assertions, 0 failures, 0 errors, 0 skips
  ```
