### PR TITLE
Consider methods defined on ancestors of a channel to be an action

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Methods defined on ancestors of a channel, except for ones available on `ActionCable::Channel::Base`,
+    now considered to be an action
+
+    In the following case, the action `display` is now available for `BarChannel`.
+
+    ```ruby
+    class FooChannel < ApplicationCable::Channel
+      def display(data)
+        # ...
+      end
+    end
+
+    class BarChannel < FooChannel
+    end
+    ```
+
+    *Kouhei Yanagita*
+
 *   The `connected()` callback can now take a `{reconnected}` parameter to differentiate
     connections from reconnections.
 

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -19,6 +19,9 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
     def chatters
       @last_action = [ :chatters ]
     end
+
+    def display
+    end
   end
 
   class ChatChannel < BasicChannel
@@ -179,7 +182,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "actions available on Channel" do
-    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? get_latest receive chatters topic error_action).to_set
+    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? get_latest receive chatters topic error_action display).to_set
     assert_equal available_actions, ChatChannel.action_methods
   end
 


### PR DESCRIPTION
### Motivation / Background

A channel has actions corresponding to methods defined on its class.

```ruby
# FooChannel has an action "appear".
class FooChannel < ApplicationCable::Channel
  def appear(data)
    # ...
  end
end
```

Inheritance works.

```ruby
# BarChannel also has an action "appear".
class BarChannel < FooChannel
end
```

But in the following case, BarChannel does not respond to an action "display" although FooChannel does.

```ruby
# FooChannel has an action "display".
class FooChannel < ApplicationCable::Channel
  def display(data)
    # ...
  end
end

# BarChannel does not have an action "display".
class BarChannel < FooChannel
end
```

This Pull Request fixes this problem.

### Detail

`ActionCable::Channel::Base.action_methods` which determines the action names of a channel is implemented as follows.

```ruby
def action_methods
  @action_methods ||= begin
    # All public instance methods of this class, including ancestors
    methods = (public_instance_methods(true) -
      # Except for public instance methods of Base and its ancestors
      ActionCable::Channel::Base.public_instance_methods(true) +
      # Be sure to include shadowed public instance methods of this class
      public_instance_methods(false)).uniq.map(&:to_s)
    methods.to_set
  end
end
```

`ActionCable::Channel::Base` has `display` method. (Yes, there is `Object#display`!)
So the action `display` is removed unless the channel itself has the method.
I am not sure if it is intentional that only the class itself (not including ancestors) is allowed.
But I think it would be better to be fixed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.
