### PR TITLE
Move Arel::Nodes::LeadingJoin into arel.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1517,9 +1517,6 @@ module ActiveRecord
         result
       end
 
-      class ::Arel::Nodes::LeadingJoin < Arel::Nodes::InnerJoin # :nodoc:
-      end
-
       def build_join_buckets
         buckets = Hash.new { |h, k| h[k] = [] }
 

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -63,6 +63,7 @@ require "arel/nodes/inner_join"
 require "arel/nodes/outer_join"
 require "arel/nodes/right_outer_join"
 require "arel/nodes/string_join"
+require "arel/nodes/leading_join"
 
 require "arel/nodes/comment"
 

--- a/activerecord/lib/arel/nodes/leading_join.rb
+++ b/activerecord/lib/arel/nodes/leading_join.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class LeadingJoin < Arel::Nodes::InnerJoin
+    end
+  end
+end


### PR DESCRIPTION
Recently I was searching for some stuff in API docs and I have found out there is wrongly exposed `Arel::Nodes` module.

![image](https://user-images.githubusercontent.com/193936/201499871-7fc395ba-1fe1-49c6-b66d-b021ddb7890a.png)

I was looking around to tweak rdoc using directives to ignore this, but there are various problems and it is not simple to achieve it this way since there is no way to ignore "namespace" in rdoc.

I decided to go with another way and moved LeadingJoin class (defined in active record resulting in arel/nodes being in docs) to `Arel`.

After this change docs are respecting Arel is totally private except `Arel.sql`.

![image](https://user-images.githubusercontent.com/193936/201499897-9eac7776-96fd-4c11-84ad-0a897177a260.png)

:thinking: Alternative solution would be to add this functionality to rdoc (like `# :nodoc: ignore`) or move `LeadingJoin` outside of `Arel` namespace to `ActiveRecord` one for example.