### PR TITLE
Add nodoc to Arel filter classes.

### DIFF
--- a/activerecord/lib/arel/filter_predications.rb
+++ b/activerecord/lib/arel/filter_predications.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Arel
+module Arel # :nodoc: all
   module FilterPredications
     def filter(expr)
       Nodes::Filter.new(self, expr)

--- a/activerecord/lib/arel/nodes/filter.rb
+++ b/activerecord/lib/arel/nodes/filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Arel
+module Arel # :nodoc: all
   module Nodes
     class Filter < Binary
       include Arel::WindowPredications


### PR DESCRIPTION
While recently looking how Arel and rdoc are used together, I have noticed there are two classes in Arel missing `nodoc` directive. Currently this doesn't make any change to docs, since those files are ignored.

https://github.com/rails/rails/blob/90cba59ddd26a1fbbad85e9a9810583e2de85279/railties/lib/rails/api/task.rb#L17-L23

But it could be handy in the future once it will be decided how to make Arel public API. Also this makes it consistent with other Arel files.

### before

```bash
grep -r "module Arel" activerecord/lib/ | grep -v nodoc
activerecord/lib/arel.rb:module Arel
activerecord/lib/arel/nodes/filter.rb:module Arel
activerecord/lib/arel/filter_predications.rb:module Arel
```

### after

```bash
grep -r "module Arel" activerecord/lib/ | grep -v nodoc
activerecord/lib/arel.rb:module Arel
```