### PR TITLE
Add from clause to update manager

### DIFF
--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,11 +3,12 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :from, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
 
       def initialize(relation = nil)
         super()
         @relation = relation
+        @from     = nil
         @wheres   = []
         @values   = []
         @groups   = []
@@ -25,12 +26,13 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @from, @wheres, @values, @orders, @limit, @offset, @key].hash
       end
 
       def eql?(other)
         self.class == other.class &&
           self.relation == other.relation &&
+          self.from == other.from &&
           self.wheres == other.wheres &&
           self.values == other.values &&
           self.groups == other.groups &&

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -29,6 +29,11 @@ module Arel # :nodoc: all
       self
     end
 
+    def from(table)
+      @ast.from = table
+      self
+    end
+
     def group(columns)
       columns.each do |column|
         column = Nodes::SqlLiteral.new(column) if String === column

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -43,6 +43,11 @@ module Arel # :nodoc: all
           collector = visit o.relation, collector
           collect_nodes_for o.values, collector, " SET "
 
+          if o.from
+            collector << " FROM "
+            visit o.from, collector
+          end
+
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -119,6 +119,17 @@ module Arel
         _(um.table(Table.new(:users))).must_equal um
       end
 
+      it "generates an update statement with from" do
+        um = Arel::UpdateManager.new
+
+        table = Table.new(:users)
+        from_item = Table.new(:posts)
+
+        um.table table
+        um.from from_item
+        _(um.to_sql).must_be_like %{ UPDATE "users" FROM "posts" }
+      end
+
       it "generates an update statement with joins" do
         um = Arel::UpdateManager.new
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request adds `FROM` clause to `Arel::UpdateManager` allowing columns from other tables to appear in the WHERE condition and update expressions, also it makes possible to use `JOIN` and generate valid queries through `Arel::Nodes::JoinSource`.

Example:
```ruby
table = Arel::Table.new(:users)
join_table = Arel::Table.new(:posts)

um.table table
um.from join_table
um.set [[table[:posts_count], join_table[:id].count]]
um.where table[:id].eq(join_table[:user_id])

ActiveRecord::Base.connection.update(um)
# UPDATE "users" SET "posts_count" = COUNT("posts"."id") FROM "posts" WHERE "users"."id" = "posts"."user_id"
```

Fix #44401

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

