### PR TITLE
Create ActiveRecord::Relation#cast_results_with [feature request]

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,45 @@
+*   Introduces the AttributeSet::Builder to classes with ActiveModel::Attributes
+    This allows classes to load results from the database by defining dynamic
+    attributes.
+
+    Example:
+
+    ```ruby
+    ActiveRecord::Schema.define do
+      create_table :people, force: true do |t|
+        t.string :name, null: false
+      end
+    end
+
+    class Person < ActiveRecord::Base; end
+
+    class PolitePerson
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+
+      def greeting
+        "Hello, my name is #{name}"
+      end
+    end
+
+    Person.create!(name: 'Alex')
+    Person.create!(name: 'Jess')
+
+    person = Person
+      .where(name: 'Jess')
+      .cast_results_with(PolitePerson)
+      .first
+
+    person.name
+    => "Jess"
+
+    person.greeting
+    => "Hello my name is Jess"
+    ```
+
+    *Alexandre Barret*
+
 *   Custom attribute types that inherit from Active Model built-in types and do
     not override the `serialize` method will now benefit from an optimization
     when serializing attribute values for the database.

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -74,6 +74,13 @@ module ActiveModel
         attribute_types.keys
       end
 
+      def attributes_builder # :nodoc:
+        unless defined?(@attributes_builder) && @attributes_builder
+          @attributes_builder = ActiveModel::AttributeSet::Builder.new(attribute_types, _default_attributes)
+        end
+        @attributes_builder
+      end
+
       private
         def define_method_attribute=(name, owner:)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
@@ -136,6 +143,12 @@ module ActiveModel
     def freeze # :nodoc:
       @attributes = @attributes.clone.freeze unless frozen?
       super
+    end
+
+    def init_with_attributes(attributes)
+      @attributes = attributes
+      yield self if block_given?
+      self
     end
 
     private

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,47 @@
+*   Introduce ActiveRecord::Relation#cast_results_with
+
+    This is method allows to load and map results of an active record relation
+    with another class when the query is loaded. The class needs to include
+    ActiveMode::Attributes module.
+
+    Example:
+
+    ```ruby
+    ActiveRecord::Schema.define do
+      create_table :people, force: true do |t|
+        t.string :name, null: false
+      end
+    end
+
+    class Person < ActiveRecord::Base; end
+
+    class PolitePerson
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+
+      def greeting
+        "Hello, my name is #{name}"
+      end
+    end
+
+    Person.create!(name: 'Alex')
+    Person.create!(name: 'Jess')
+
+    person = Person
+      .where(name: 'Jess')
+      .cast_results_with(PolitePerson)
+      .first
+
+    person.name
+    => "Jess"
+
+    person.greeting
+    => "Hello my name is Jess"
+    ```
+
+    *Alexandre Barret*
+
 *   Add automatic filtering of encrypted attributes on inspect
 
     This feature is enabled by default but can be disabled with

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -20,8 +20,7 @@ module ActiveRecord
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
 
     attr_reader :table, :klass, :loaded, :predicate_builder
-    attr_accessor :skip_preloading_value
-    attr_writer :instantiating_class
+    attr_accessor :skip_preloading_value, :instantiating_class
     alias :model :klass
     alias :loaded? :loaded
     alias :locked? :lock_value
@@ -827,13 +826,13 @@ module ActiveRecord
       ActiveRecord::Associations::AliasTracker.create(connection, table.name, joins, aliases)
     end
 
-    def cast_results_with(instantiating_class)
-      if instantiating_class < Base
+    def cast_results_with(casting_class)
+      if casting_class < Base
         raise ArgumentError, "ActiveRecord classes aren't allowed"
       end
 
       dup.tap do |relation|
-        relation.instantiating_class = instantiating_class
+        relation.instantiating_class = casting_class
       end
     end
 
@@ -976,7 +975,7 @@ module ActiveRecord
           @_join_dependency = nil
           records
         else
-          klass._load_from_sql(rows, @instantiating_class, &block).freeze
+          klass._load_from_sql(rows, instantiating_class, &block).freeze
         end
       end
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -207,6 +207,15 @@ class Post < ActiveRecord::Base
   end
 end
 
+class ActiveModelPostWithAttributes
+  include ActiveModel::Attributes
+
+  attribute :title, :string
+  attribute :type,  :string
+  attribute :published, :boolean, default: true
+  attribute :author_name, :string
+end
+
 class SpecialPost < Post; end
 
 class StiPost < Post


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I sometimes wish to load query results and wrap them with another class straight from the active record relation. Like `#pluck` or `#select` using proper Ruby classes instead of looping and mapping through records from the controller or the view.

### Example

[Here is a working example to test locally with the feature.](https://gist.github.com/AlexB52/5f238378a40ec097e31f86ac8be00870)

Here is a quick example to describe the intent. Is this something that would people consider adding to the framework?

```ruby
ActiveRecord::Schema.define do
  create_table :people, force: true do |t|
    t.string :name, null: false
  end
end

class Person < ActiveRecord::Base; end

class PolitePerson
  include ActiveModel::Attributes

  attribute :name, :string

  def greeting
    "Hello, my name is #{name}"
  end
end

Person.create!(name: 'Alex')
Person.create!(name: 'Jess')

# equivalent queries
person = Person.all.cast_results_with(PolitePerson).find_by(name: 'Jess')
person = Person.where(name: 'Jess').cast_results_with(PolitePerson).first

person.name 
=> "Jess"

person.greeting
=> "Hello my name is Jess"
```

### Detail

This Pull Request updates

  * `ActiveRecord::Querying._load_from_sql` to take a loading_class which is used to instantiate results when passed.
  * `ActiveModel::Attributes` modules to provide a default builder that can parse attributes from a database.

### Additional information

Here are some notes on the current implementation and questions I asked myself.

#### 1. load and cast array

I thought about returning an array when calling `cast_results_with` directly. The wouldn't be chainable and would need to be passed at the end of a relation but would reduce the risk of unexpected behaviours. I would love some guidance on how to approach this alternative.

#### 2. pluck(*columns, with:)

In the same spirit of returning an array, I thought about updating `#pluck` to `pluck(*colums, with:)` or like [JSON#parse](https://ruby-doc.org/stdlib-2.6.3/libdoc/json/rdoc/JSON.html#method-i-parse) maybe `pluck(*columns, object_class:)`. I would be happy to investigate and implement this route instead.

```ruby
person = Person.all.pluck('*', with: PolitePerson).first
person.name 
=> "Jess"

person.greeting
=> "Hello my name is Jess"
```

#### 3. Restricting ActiveRecords

Initially, I let other ActiveRecord classes as arguments in `cast_results_with`, but the `primary_key` will be loaded and mapped incorrectly. For this reason, I decided to restrict casting from other ActiveRecord classes. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.
