### PR TITLE
Backport puma 6 test updates to 6-1-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ end
 
 # Action Cable
 group :cable do
-  gem "puma", require: false
+  gem "puma", ">= 5.0.3", require: false
 
   gem "hiredis", require: false
   gem "redis", "~> 4.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,7 +580,7 @@ DEPENDENCIES
   nokogiri (>= 1.8.1)
   pg (>= 1.3.0.rc1)
   psych (~> 3.0)
-  puma
+  puma (>= 5.0.3)
   que (< 2)
   queue_classic!
   racc (>= 1.4.6)

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -65,10 +65,15 @@ class ClientTest < ActionCable::TestCase
   end
 
   def with_puma_server(rack_app = ActionCable.server, port = 3099)
-    server = ::Puma::Server.new(rack_app, ::Puma::Events.strings)
+    opts = { min_threads: 1, max_threads: 4 }
+    server = if Puma::Const::PUMA_VERSION >= "6"
+      opts[:log_writer] = ::Puma::LogWriter.strings
+      ::Puma::Server.new(rack_app, nil, opts)
+    else
+      # Puma >= 5.0.3
+      ::Puma::Server.new(rack_app, ::Puma::Events.strings, opts)
+    end
     server.add_tcp_listener "127.0.0.1", port
-    server.min_threads = 1
-    server.max_threads = 4
 
     thread = server.run
 


### PR DESCRIPTION
The 6-1-stable build is currently [failing](https://buildkite.com/rails/rails/builds?branch=6-1-stable) partly because of Puma 6.
This backports the 7-0-stable commit 42b066b6935441a5eb53bf032c4f64e3f95ff7b5 to 6-1-stable to fix the failing Action Cable tests.
This only changes test code, as mentioned by @byroot https://github.com/rails/rails/pull/46334#issuecomment-1298856434