### PR TITLE
Initialize encrypted attributes when using `ActiveRecord::Relation#first_or_initialize`/`first_or_create`

### DIFF
--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -33,6 +33,11 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
     assert EncryptedBook.find_by(name: "Dune")
   end
 
+  test "where(...).first_or_create works" do
+    EncryptedBook.where(name: "Dune").first_or_create
+    assert EncryptedBook.exists?(name: "Dune")
+  end
+
   test "exists?(...) works" do
     ActiveRecord::Encryption.without_encryption { EncryptedBook.create! name: "Dune" }
     assert EncryptedBook.exists?(name: "Dune")

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -379,6 +379,9 @@ class FakeKlass
     def base_class?
       true
     end
+
+    def deterministic_encrypted_attributes
+    end
   end
 
   inherited self


### PR DESCRIPTION
Fixes #46151 (see there for the problem description).

The problem is that when using something like `where(...).first_or_create`, in `first_or_create` Active Record selects only "equality" predicates from the `where` - https://github.com/rails/rails/blob/90cba59ddd26a1fbbad85e9a9810583e2de85279/activerecord/lib/active_record/relation.rb#L754, but the encryption feature transforms the respective predicate in `where` to an array of possible values for an attribute (to support keys/algorithms rotation) in `where` - https://github.com/rails/rails/blob/90cba59ddd26a1fbbad85e9a9810583e2de85279/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb#L66-L74, which begins to be not under the mentioned above "equality" predicate and is ignored.

So, we need to manually extend `scope_for_create` to take into account passed encrypted attributes.

Hope the explanation is more or less clear.  

cc @jorgemanrubia (as an initial implementer of this feature)
