### PR TITLE
Add foreign_key to field_error_proc instead of reflection name

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Adds foreign key to `field_error_proc` instead of the relation name.
+
+    Given you have a validation for a `belongs_to` association and it fails,
+    the foreign key is added to `field_error_proc` instead of the relation name,
+    this makes possible for example, style select tags.
+
+    ```ruby
+    class Mascot < ActiveRecord::Base
+      belongs_to :company, optional: false
+    end
+    ```
+
+    ```ruby
+    select "mascot", "company_id", Company.all
+    ```
+
+    Before:
+    ```html
+    <select name="mascot[company_id]" id="mascot_company_id">...</select>
+    ```
+
+    After:
+    ```html
+    <div class="field_with_errors">
+      <select name="mascot[company_id]" id="mascot_company_id">...</select>
+    </div>
+    ```
+
+    *Lázaro Nixon*
+
 *   `check_box_tag` and `radio_button_tag` now accept `checked` as a keyword argument
 
     This is to make the API more consistent with the `FormHelper` variants. You can now provide `checked` as a positional or keyword argument:

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -34,7 +34,11 @@ module ActionView
       end
 
       def error_message
-        object.errors[@method_name]
+        if association = find_association
+          object.errors[association.name]
+        else
+          object.errors[@method_name]
+        end
       end
 
       private
@@ -48,6 +52,14 @@ module ActionView
 
         def tag_generate_errors?(options)
           options["type"] != "hidden"
+        end
+
+        def find_association
+          return unless object.class.respond_to?(:reflect_on_all_associations)
+
+          object.class.reflect_on_all_associations(:belongs_to).find do |reflection|
+            reflection.foreign_key == @method_name
+          end
         end
     end
   end

--- a/actionview/test/fixtures/mascot.rb
+++ b/actionview/test/fixtures/mascot.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Mascot < ActiveRecord::Base
-  belongs_to :company
+  belongs_to :company, optional: false
 end

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "abstract_unit"
+require "active_record_unit"
 
 class ActiveModelHelperTest < ActionView::TestCase
   tests ActionView::Helpers::ActiveModelHelper
@@ -31,6 +31,9 @@ class ActiveModelHelperTest < ActionView::TestCase
     @post.category    = "rails"
     @post.published   = false
     @post.updated_at  = Date.new(2004, 6, 15)
+
+    @mascot = Mascot.new
+    @mascot.validate
   end
 
   def test_text_area_with_errors
@@ -69,6 +72,13 @@ class ActiveModelHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(<div class="field_with_errors"><select name="post[category]" id="post_category"><optgroup label="A"><option value="A1">A1</option>\n<option value="A2">A2</option></optgroup><optgroup label="B"><option value="B1">B1</option>\n<option value="B2">B2</option></optgroup></select></div>),
       select("post", "category", grouped_options)
+    )
+  end
+
+  def test_select_with_association_errors
+    assert_dom_equal(
+      %(<div class="field_with_errors"><select name="mascot[company_id]" id="mascot_company_id"><option value="a">a</option>\n<option value="b">b</option></select></div>),
+      select("mascot", "company_id", [:a, :b])
     )
   end
 


### PR DESCRIPTION
### Motivation / Background

I remember it was one of my first issues when I was learning rails... I was creating my forms, playing around with validations, so when I put a `belongs_to` (required by default) and added a `form.select` to my view, after a failed validation it was not in red.

Fixes #28772
Fixes #44160

### Detail

This Pull Request adds the `foreign_key` from `belongs_to` to the `field_error_proc` instead of the `relation name` itself when a validation is triggered, thus when you put a field in your form targeted to the association it will become red.

### Additional information

https://samuelmullen.com/2013/12/validating-presence-of-associations-and-foreign-keys-in-rails
https://launchacademy.com/blog/validating-associations-in-rails
https://railsguides.net/belongs-to-and-presence-validation-rule1

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

