### PR TITLE
Bump error_highlight 0.5.1 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,5 +176,5 @@ gem "wdm", ">= 0.1.0", platforms: [:windows]
 # Also, Rails depends on a new API available since error_highlight 0.4.0.
 # (Note that Ruby 3.1 bundles error_highlight 0.3.0.)
 if RUBY_VERSION >= "3.1"
-  gem "error_highlight", ">= 0.4.0", "< 0.5.0", platforms: [:ruby]
+  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       http_parser.rb (>= 0.6.0)
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
-    error_highlight (0.4.0)
+    error_highlight (0.5.1)
     erubi (1.11.0)
     et-orbi (1.2.6)
       tzinfo
@@ -581,7 +581,7 @@ DEPENDENCIES
   debug (>= 1.1.0)
   delayed_job
   delayed_job_active_record
-  error_highlight (>= 0.4.0, < 0.5.0)
+  error_highlight (>= 0.4.0)
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails


### PR DESCRIPTION
### Motivation / Background

error_highlight 0.5.1 only changes ArgumentError#detailed_message via https://github.com/ruby/error_highlight/pull/29

Therefore we can revert #46442 and bump the error_highlight version of Gemfile.lock to the latest one.

### Detail

None

### Additional information

Refer to 
https://github.com/rails/rails/pull/46442
https://github.com/ruby/error_highlight/issues/28
https://github.com/ruby/error_highlight/issues/29

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

