### PR TITLE
Introduce `:init_with` option for `#pluck` [feature request]

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -723,8 +723,8 @@ module ActiveRecord
         null_scope? ? scope.calculate(operation, column_name) : super
       end
 
-      def pluck(*column_names)
-        null_scope? ? scope.pluck(*column_names) : super
+      def pluck(*column_names, **opts)
+        null_scope? ? scope.pluck(*column_names, **opts) : super
       end
 
       ##

--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module NullRelation # :nodoc:
-    def pluck(*column_names)
+    def pluck(*column_names, **opts)
       []
     end
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -84,6 +84,12 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     assert_equal [BigDecimal("123.45")], PostgresqlMoney.pluck(Arel.sql("id * wealth"))
   end
 
+  def test_pluck_with_type_cast_with_init_class
+    klass = Struct.new(:product, keyword_init: true)
+    @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (1, '123.45'::money)")
+    assert_equal [klass.new(product: BigDecimal("123.45"))], PostgresqlMoney.pluck(Arel.sql("id * wealth product"), init_with: klass)
+  end
+
   def test_schema_dumping
     output = dump_table_schema("postgresql_moneys")
     assert_match %r{t\.money\s+"wealth",\s+scale: 2$}, output

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -50,10 +50,32 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
     assert_queries(1) { @author.comments.pluck(:id) }
   end
 
+  def test_pluck_on_disable_joins_through_with_init_class
+    klass = Struct.new(:id, keyword_init: true) do
+      def <=>(other)
+        id <=> other.id
+      end
+    end
+    assert_equal @author.comments.pluck(:id, init_with: klass).sort, @author.no_joins_comments.pluck(:id, init_with: klass).sort
+    assert_queries(2) { @author.no_joins_comments.pluck(:id, init_with: klass) }
+    assert_queries(1) { @author.comments.pluck(:id, init_with: klass) }
+  end
+
   def test_pluck_on_disable_joins_through_using_custom_foreign_key
     assert_equal @author.comments_with_foreign_key.pluck(:id).sort, @author.no_joins_comments_with_foreign_key.pluck(:id).sort
     assert_queries(2) { @author.no_joins_comments_with_foreign_key.pluck(:id) }
     assert_queries(1) { @author.comments_with_foreign_key.pluck(:id) }
+  end
+
+  def test_pluck_on_disable_joins_through_using_custom_foreign_key_with_init_class
+    klass = Struct.new(:id, keyword_init: true) do
+      def <=>(other)
+        id <=> other.id
+      end
+    end
+    assert_equal @author.comments_with_foreign_key.pluck(:id, init_with: klass).sort, @author.no_joins_comments_with_foreign_key.pluck(:id, init_with: klass).sort
+    assert_queries(2) { @author.no_joins_comments_with_foreign_key.pluck(:id, init_with: klass) }
+    assert_queries(1) { @author.comments_with_foreign_key.pluck(:id, init_with: klass) }
   end
 
   def test_fetching_on_disable_joins_through
@@ -107,6 +129,13 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
     rating_ids = Rating.where(comment: @comment).pluck(:id)
     assert_equal rating_ids, assert_queries(1) { @author.ratings.pluck(:id) }
     assert_equal rating_ids, assert_queries(3) { @author.no_joins_ratings.pluck(:id) }
+  end
+
+  def test_pluck_on_disable_joins_through_a_through_with_init_class
+    klass = Struct.new(:id, keyword_init: true)
+    rating_ids = Rating.where(comment: @comment).pluck(:id, init_with: klass)
+    assert_equal rating_ids, assert_queries(1) { @author.ratings.pluck(:id, init_with: klass) }
+    assert_equal rating_ids, assert_queries(3) { @author.no_joins_ratings.pluck(:id, init_with: klass) }
   end
 
   def test_count_on_disable_joins_through_a_through

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -274,6 +274,14 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_no_queries { david.first_posts.pluck(:title) }
   end
 
+  def test_pluck_uses_loaded_target_with_init_class
+    klass = Struct.new(:title, keyword_init: true)
+    david = authors(:david)
+    assert_equal david.first_posts.pluck(:title, init_with: klass), david.first_posts.load.pluck(:title, init_with: klass)
+    assert_predicate david.first_posts, :loaded?
+    assert_no_queries { david.first_posts.pluck(:title, init_with: klass) }
+  end
+
   def test_pick_uses_loaded_target
     david = authors(:david)
     assert_equal david.first_posts.pick(:title), david.first_posts.load.pick(:title)

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -205,6 +205,12 @@ module ActiveRecord
       assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
     end
 
+    def test_pluck_with_init_class
+      klass = Struct.new(:title, keyword_init: true)
+      titles = Post.where(author_id: 1).pluck(:title, init_with: klass)
+      assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title, init_with: klass)
+    end
+
     def test_size
       expected_size = Post.where(author_id: 1).size
 
@@ -324,6 +330,12 @@ module ActiveRecord
       def test_pluck
         titles = Post.where(author_id: 1).pluck(:title)
         assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      end
+
+      def test_pluck_with_init_class
+        klass = Struct.new(:title, keyword_init: true)
+        titles = Post.where(author_id: 1).pluck(:title, init_with: klass)
+        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title, init_with: klass)
       end
 
       def test_size
@@ -459,6 +471,12 @@ module ActiveRecord
       def test_pluck
         titles = Post.where(author_id: 1).pluck(:title)
         assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      end
+
+      def test_pluck_with_init_class
+        klass = Struct.new(:title, keyword_init: true)
+        titles = Post.where(author_id: 1).pluck(:title, init_with: klass)
+        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title, init_with: klass)
       end
 
       def test_size

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -199,6 +199,13 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal relation.pluck(:id), subquery.pluck(:id)
   end
 
+  def test_pluck_with_from_includes_original_table_name_with_init_class
+    klass = Struct.new(:id, keyword_init: true)
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from("#{Comment.table_name} /*! USE INDEX (PRIMARY) */").joins(:post).order(:id)
+    assert_equal relation.pluck(:id, init_with: klass), subquery.pluck(:id, init_with: klass)
+  end
+
   def test_select_with_from_includes_quoted_original_table_name
     relation = Comment.joins(:post).select(:id).order(:id)
     subquery = Comment.from("#{Comment.quoted_table_name} /*! USE INDEX (PRIMARY) */").joins(:post).select(:id).order(:id)
@@ -209,6 +216,13 @@ class RelationTest < ActiveRecord::TestCase
     relation = Comment.joins(:post).order(:id)
     subquery = Comment.from("#{Comment.quoted_table_name} /*! USE INDEX (PRIMARY) */").joins(:post).order(:id)
     assert_equal relation.pluck(:id), subquery.pluck(:id)
+  end
+
+  def test_pluck_with_from_includes_quoted_original_table_name_with_init_class
+    klass = Struct.new(:id, keyword_init: true)
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from("#{Comment.quoted_table_name} /*! USE INDEX (PRIMARY) */").joins(:post).order(:id)
+    assert_equal relation.pluck(:id, init_with: klass), subquery.pluck(:id, init_with: klass)
   end
 
   def test_select_with_subquery_in_from_uses_original_table_name
@@ -222,6 +236,13 @@ class RelationTest < ActiveRecord::TestCase
     relation = Comment.joins(:post).order(:id)
     subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).order(:id)
     assert_equal relation.pluck(:id), subquery.pluck(:id)
+  end
+
+  def test_pluck_with_subquery_in_from_uses_original_table_name_with_init_class
+    klass = Struct.new(:id, keyword_init: true)
+    relation = Comment.joins(:post).order(:id)
+    subquery = Comment.from(Comment.all, Comment.quoted_table_name).joins(:post).order(:id)
+    assert_equal relation.pluck(:id, init_with: klass), subquery.pluck(:id, init_with: klass)
   end
 
   def test_select_with_subquery_in_from_does_not_use_original_table_name

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -193,12 +193,24 @@ module Enumerable
   #
   #   [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }].pluck(:id, :name)
   #   # => [[1, "David"], [2, "Rafael"]]
-  def pluck(*keys)
+  #
+  #   Person = Struct.new(:name, keyworkd_init: true)
+  #   [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }].pluck(:id, :name, init_with: Person)
+  #   # => [Person.new(id: id, name: "David"), Person.new(id: id, name: "Rafael")]
+  def pluck(*keys, init_with: nil)
     if keys.many?
-      map { |element| keys.map { |key| element[key] } }
+      if init_with
+        map { |element| init_with.new(**keys.index_with { |key| element[key] }) }
+      else
+        map { |element| keys.map { |key| element[key] } }
+      end
     else
       key = keys.first
-      map { |element| element[key] }
+      if init_with
+        map { |element| init_with.new(Hash[key.to_sym, element[key]]) }
+      else
+        map { |element| element[key] }
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This is another take on https://github.com/rails/rails/pull/46488 to wrap records with an init class

>This Pull Request has been created because I sometimes wish to load query results and wrap them with another class straight from the active record relation. Like #pluck or #select using proper Ruby classes instead of looping and mapping through records from the controller or the view.

It's inspired by the [JSON.parse](https://ruby-doc.org/stdlib-2.6.3/libdoc/json/rdoc/JSON.html#method-i-parse) where we can define `array_class` and `object_class` options.

Is this something that people would consider adding to the framework?

This works like so:

```ruby
class Person < ActiveRecord::Base
end

class PolitePerson
  include ActiveModel::Model

  attr_accessor :name
  attr_accessor :registered

  def greeting
    "Hello, my name is #{name}"
  end
end

Person.create!(name: 'Alex', registered: false)
Person.create!(name: 'Jess', registered: true)
person = Person.where(registered: true).pluck(:name, :registered, init_with: PolitePerson).first

PolitePerson === person
=> true

person.greeting
=> "Hello, my name is Jess"
```

### Detail

This Pull Request adds a new option `:init_with` to `pluck` so that we can initialize the values returned.

I've duplicated tests everywhere but have two specs failing locally so far and added a skip for now. I would love some help if this PR is considered.

#### First skipped test

* activerecord/test/cases/calculations_test.rb:896
* test_pluck_type_cast_with_conflict_column_names_with_init_class

#### Second skipped test

* activerecord/test/cases/calculations_test.rb:1354
* test_pluck_functions_without_alias_with_init_class

### Additional information

This PR is a second take on casting query results with another class. First PR was https://github.com/rails/rails/pull/46488

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.
