### PR TITLE
Update meta tag in mailer template layout.html.erb.tt

### DIFF
--- a/actionmailbox/test/dummy/app/views/layouts/mailer.html.erb
+++ b/actionmailbox/test/dummy/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/actiontext/test/dummy/app/views/layouts/mailer.html.erb
+++ b/actiontext/test/dummy/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/railties/lib/rails/generators/erb/mailer/templates/layout.html.erb.tt
+++ b/railties/lib/rails/generators/erb/mailer/templates/layout.html.erb.tt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/mailer.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/mailer.html.erb.tt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>


### PR DESCRIPTION
This Pull Request has been created because the latest version of [Shopify/erb-lint](https://github.com/Shopify/erb-lint)  complains about the generated mailer layout in a fresh Rails 7 project: 

```
Tag `meta` is a void element, it must end with `>` and not `/>`.
In file: app/views/layouts/mailer.html.erb:4
```

### Detail

This Pull Request changes the generated mailer layout template

### Additional information

Meta tag now matches that in the generated application layout template

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

