### PR TITLE
Support ERB in Rails.credentials

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support ERB in `ActiveSupport::EncryptedConfiguration`.
+
+    Allows dynamic content in `config/credentials.yml.enc`, as supported in
+    other YAML configs like `config/database.yml`. Useful if you want overrides
+    in different environments without using multi environment credentials.
+
+    *Trevor Turk*
+
 *   Ensure `ActiveSupport::Testing::Isolation::Forking` closes pipes
 
     Previously, `Forking.run_in_isolation` opened two ends of a pipe. The fork

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "erb"
 require "active_support/encrypted_file"
 require "active_support/ordered_options"
 require "active_support/core_ext/object/inclusion"
@@ -57,6 +58,8 @@ module ActiveSupport
       end
 
       def deserialize(content)
+        content = ERB.new(content).result
+
         config = YAML.respond_to?(:unsafe_load) ?
           YAML.unsafe_load(content, filename: content_path) :
           YAML.load(content, filename: content_path)

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -66,6 +66,12 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal "things", @credentials[:new]
   end
 
+  test "parses erb in the config" do
+    @credentials.write({ erb: "<%= 1 + 1 %>" }.to_yaml)
+
+    assert_equal "2", @credentials[:erb]
+  end
+
   test "raises helpful error when loading invalid content" do
     @credentials.write("key: value\nbad")
 


### PR DESCRIPTION
I'm using multi-environment credentials in my Rails app (see #30067 and #33521) but I broke my production app because of a typo in my `config/credentials/production.yml.enc` file. My fault, I know, but now I'm nervous about making changes to my production credentials file!

I started looking into the concept of "merging" the default `config/credentials.yml.enc` together with `config/credentials/production.yml.enc` but then I realized perhaps I could use ERB as we do in `config.database.yml` to optionally override certain credentials in production. For example, from the default `config.database.yml`:

```ruby
default: &default
  adapter: postgresql
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
```

I referenced `ActiveSupport::ConfigurationFile` and attempted to leverage the `#parse` method there, but it seemed unnecessarily complex given the potentially simple solution I've found. That being said, I'm not sure if this is the best approach and I'd be happy to have any feedback/advice!

As an aside, I wonder if "merging" multiple credential files might be a nice thing to have as well... but I think adding ERB support to the encrypted credentials system seems worthwhile on its own, and should be enough for my use case.

Thanks for your consideration!