### PR TITLE
Add "attribute_for_pretty_print" method

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -288,6 +288,15 @@ module ActiveRecord
       format_for_inspect(attr_name, value)
     end
 
+    def attribute_for_pretty_print(attr_name)
+      value = _read_attribute(attr_name)
+      if value.is_a?(String) && value.length > 50
+        "#{value[0, 50]}..."
+      else
+        value
+      end
+    end
+
     # Returns +true+ if the specified +attribute+ has been set by the user or by a
     # database load and is neither +nil+ nor <tt>empty?</tt> (the latter only applies
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -698,7 +698,7 @@ module ActiveRecord
               pp.text attr_name
               pp.text ":"
               pp.breakable
-              value = _read_attribute(attr_name)
+              value = attribute_for_pretty_print(attr_name)
               value = inspection_filter.filter_param(attr_name, value) unless value.nil?
               pp.pp value
             end


### PR DESCRIPTION
I think it'd be helpful to improve the output of records in a Rails console when some of the fields have very long values.

As of IRB version 1.3.1 (released in Jan 2021) records are pretty_printed in the console instead of inspected, so records with large values (e.g. the content of a document) look like this:
<img width="962" alt="c3232d95be8437bd4805342285ea360ffa905c00" src="https://user-images.githubusercontent.com/23050/202197117-84b6a66a-3557-44f3-a6b2-70aaef64f99f.png">
This makes it hard to navigate output in a console. Especially for arrays of items like this.

One option is to override `inspect` (or `attribute_for_inspect`), but then you lose the nice formatting of pretty-printing:
![0846069992b0ec3adf6f7f001da375344085e128](https://user-images.githubusercontent.com/23050/202197523-6577e9cf-c40f-4e0d-913f-e802add8a87b.jpeg)

I think it would be great to:

- Provide a better default for long strings
- Provide a method that can be overridden in applications for customizing the display of fields

Does that seem reasonable?  I can add tests if so.
