### PR TITLE
Support optional collation in create_table output.

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -32,7 +32,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   test "table options with CHARSET" do
     @connection.create_table "mysql_table_options", force: true, options: "CHARSET=latin1"
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", charset: "latin1", force: :cascade/
+    expected = /create_table "mysql_table_options", charset: "latin1"(?:, collation: "\w+")?, force: :cascade/
     assert_match expected, output
   end
 


### PR DESCRIPTION
- introduced in MariaDB 10.9.4
- fixed by applying same pattern in regexp check to optionally support collation

fixes https://github.com/rails/rails/issues/46499