### PR TITLE
Small refactor on singular association creation

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,6 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            set_new_record(record)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1428,6 +1428,22 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.id, client.client_of
   end
 
+  def test_should_set_foreign_key_on_save
+    client = Client.create! name: "fuu"
+    firm   = client.build_firm name: "baa"
+
+    firm.save
+    assert_equal firm.id, client.client_of
+  end
+
+  def test_should_set_foreign_key_on_save!
+    client = Client.create! name: "fuu"
+    firm   = client.build_firm name: "baa"
+
+    firm.save!
+    assert_equal firm.id, client.client_of
+  end
+
   def test_self_referential_belongs_to_with_counter_cache_assigning_nil
     comment = Comment.create! post: posts(:thinking), body: "fuu"
     comment.parent = nil

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -84,6 +84,8 @@ class Firm < Company
   has_one :account_with_inexistent_foreign_key, class_name: "Account", foreign_key: "inexistent"
   has_one :deletable_account, foreign_key: "firm_id", class_name: "Account", dependent: :delete
 
+  has_one :client, foreign_key: "client_of"
+
   has_one :account_limit_500_with_hash_conditions, -> { where credit_limit: 500 }, foreign_key: "firm_id", class_name: "Account"
 
   has_one :unautosaved_account, foreign_key: "firm_id", class_name: "Account", autosave: false
@@ -134,7 +136,7 @@ class Agency < Firm
 end
 
 class Client < Company
-  belongs_to :firm, foreign_key: "client_of"
+  belongs_to :firm, foreign_key: "client_of", inverse_of: :client
   belongs_to :firm_with_basic_id, class_name: "Firm", foreign_key: "firm_id"
   belongs_to :firm_with_select, -> { select("id") }, class_name: "Firm", foreign_key: "firm_id"
   belongs_to :firm_with_other_name, class_name: "Firm", foreign_key: "client_of"


### PR DESCRIPTION
### Motivation / Background

Just a small refactor from my last [pull request](https://github.com/rails/rails/pull/46386). 

### Detail

After the record is saved I was calling [set_new_record](https://github.com/rails/rails/compare/main...lazaronixon:refactor-singular-association-creation?expand=1#diff-17dcb8ddd2493c4699d040dfbedff0fdfecdc409ce1ce6e9008c806e2818997eL60) again (called inside [build](https://github.com/rails/rails/compare/main...lazaronixon:refactor-singular-association-creation?expand=1#diff-17dcb8ddd2493c4699d040dfbedff0fdfecdc409ce1ce6e9008c806e2818997eL24)), in order to just [set the foreign key](https://github.com/rails/rails/blob/061bf3156fb90ac6b8ec255dfa39492cf22d7b13/activerecord/lib/active_record/associations/belongs_to_association.rb#L93). To make the intention clearer here and avoid unnecessary method calls I'm just calling the method that matters `replace_keys`.

