### PR TITLE
Add notice about primary_key_type in ActiveStorage migration guide [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -62,7 +62,7 @@ tables. Use `bin/rails db:migrate` to run the migration.
 
 WARNING: `active_storage_attachments` is a polymorphic join table that stores your model's class name. If your model's class name changes, you will need to run a migration on this table to update the underlying `record_type` to your model's new class name.
 
-WARNING: If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of `active_storage_attachments.record_id` and `active_storage_variant_records.id` in the generated migration accordingly.
+WARNING: If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of `active_storage_attachments.record_id` and `active_storage_variant_records.id` in the generated migration accordingly. This can be skipped if you set `Rails.application.config.generators { |g| g.orm :active_record, primary_key_type: :uuid }` in a config file.
 
 Declare Active Storage services in `config/storage.yml`. For each service your
 application uses, provide a name and the requisite configuration. The example


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to improve the ActiveStorage guide, adding a notice how to handle UUID primary_key_type without manually changing the generated migration. When the ActiveStorage generated migrations run, the primary_key_type is read from the `Rails.configuration.generators` settings. The guide should notice the user about this, because it's very useful, instead of manually change the generated migration.

### Detail

The warning message in the ActiveStorage guide is changed adding this sentence:

_This can be skipped if you set `Rails.application.config.generators { |g| g.orm :active_record, primary_key_type: :uuid }` in a config file._



### Checklist


* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. NOT NEEDED
* [x] CI is passing. NOT NEEDED

