### PR TITLE
AbstractAdapter: only synchronize when necessary

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -4,6 +4,7 @@ require "set"
 require "active_record/connection_adapters/sql_type_metadata"
 require "active_record/connection_adapters/abstract/schema_dumper"
 require "active_record/connection_adapters/abstract/schema_creation"
+require "active_support/concurrency/null_lock"
 require "active_support/concurrency/load_interlock_aware_monitor"
 require "arel/collectors/bind"
 require "arel/collectors/composite"
@@ -155,7 +156,7 @@ module ActiveRecord
         @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @visitor = arel_visitor
         @statements = build_statement_pool
-        @lock = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
+        self.synchronized = false
 
         @prepared_statements = self.class.type_cast_config_to_boolean(
           @config.fetch(:prepared_statements) { default_prepared_statements }
@@ -169,6 +170,14 @@ module ActiveRecord
 
         @raw_connection_dirty = false
         @verified = false
+      end
+
+      def synchronized=(synchronized) # :nodoc:
+        @lock = if synchronized
+          ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
+        else
+          ActiveSupport::Concurrency::NullLock
+        end
       end
 
       EXCEPTION_NEVER = { Exception => :never }.freeze # :nodoc:

--- a/activesupport/lib/active_support/concurrency/null_lock.rb
+++ b/activesupport/lib/active_support/concurrency/null_lock.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Concurrency
+    module NullLock # :nodoc:
+      extend self
+
+      def synchronize
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/28083

Right now all database operations are synchronized with a monitor even though it's useless in the vast majority of cases.

The synchronization is only useful when transactional fixtures are enabled.

In production, connections are never shared across threads, as such this extra synchronization is wasteful.

### Motivation

Well, there is obviously the performance overhead of that synchronization.

But beyond this, what prompted me to work on this is that I think it may help with https://github.com/rails/rails/issues/45994. If the lock is only used in test, it's much less of a problem to use a slower lock implementation, which open the door to use a pure ruby monitor that is owned by `Thread` rather than `Fiber`, allowing us to bring back the original behavior.

cc @matthewd @eileencodes, I'd love your thoughts on this.
FYI: @ngan @technicalpickles