### PR TITLE
Avoid validating `belongs_to` association if it has not changed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Avoid validating `belongs_to` association if it has not changed.
+
+    Previously, when updating a record, Active Record will perform an extra query to check for the presence of
+    `belongs_to` associations (if the presence is configured to be mandatory), even if that attribute hasn't changed.
+
+    Currently, only `belongs_to`-related columns are checked for presence. It is possible to have orphaned records with
+    this approach. To avoid this problem, you need to use a foreign key.
+
+    This behavior can be controlled by configuration:
+
+    ```ruby
+    config.active_record.belongs_to_required_validates_foreign_key = false
+    ```
+
+    and will be disabled by default with `load_defaults 7.1`.
+
+    *fatkodima*
+
 *   `has_one` and `belongs_to` associations now define a `reset_association` method
     on the owner model (where `association` is the name of the association). This
     method unloads the cached associate record, if any, and causes the next access

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -271,6 +271,9 @@ module ActiveRecord
   singleton_class.attr_accessor :raise_on_assign_to_attr_readonly
   self.raise_on_assign_to_attr_readonly = false
 
+  singleton_class.attr_accessor :belongs_to_required_validates_foreign_key
+  self.belongs_to_required_validates_foreign_key = true
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -37,6 +37,7 @@ module ActiveRecord
     config.active_record.query_log_tags_format = :legacy
     config.active_record.cache_query_log_tags = false
     config.active_record.raise_on_assign_to_attr_readonly = false
+    config.active_record.belongs_to_required_validates_foreign_key = true
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -31,6 +31,7 @@ ARTest.connect
 QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name("type")
 
 ActiveRecord.raise_on_assign_to_attr_readonly = true
+ActiveRecord.belongs_to_required_validates_foreign_key = false
 
 def current_adapter?(*types)
   types.any? do |type|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -66,6 +66,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
+- [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
 - [`config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`](#config-active-record-run-commit-callbacks-on-first-saved-instances-in-transaction): `false`
 - [`config.active_record.sqlite3_adapter_strict_strings_by_default`](#config-active-record-sqlite3-adapter-strict-strings-by-default): `true`
 - [`config.active_support.default_message_encryptor_serializer`](#config-active-support-default-message-encryptor-serializer): `:json`
@@ -1001,6 +1002,17 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `nil`                |
 | 5.0                   | `true`               |
+
+#### `config.active_record.belongs_to_required_validates_foreign_key`
+
+Enable validating only parent-related columns for presence when the parent is mandatory.
+The previous behavior was to validate the presence of the parent record, which performed an extra query
+to get the parent every time the child record was updated, even when parent has not changed.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 7.1                   | `false`              |
 
 #### `config.active_record.action_on_strict_loading_violation`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -289,6 +289,7 @@ module Rails
             active_record.sqlite3_adapter_strict_strings_by_default = true
             active_record.query_log_tags_format = :sqlcommenter
             active_record.raise_on_assign_to_attr_readonly = true
+            active_record.belongs_to_required_validates_foreign_key = false
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -112,3 +112,8 @@
 # behavior would allow assignment but silently not persist changes to the
 # database.
 # Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+
+# Enable validating only parent-related columns for presence when the parent is mandatory.
+# The previous behavior was to validate the presence of the parent record, which performed an extra query
+# to get the parent every time the child record was updated, even when parent has not changed.
+# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false


### PR DESCRIPTION
```ruby
class User < ApplicationRecord
  has_many :posts
end

class Post < ApplicationRecord
  belongs_to :user
end
```

`belongs_to` associations are required by default, so they are checked for presence when the child record is saved. This is done every time the record is updated, even when the parent record hasn't changed.

For example,
```
post.update!(title: "Rails is the best")
TRANSACTION (0.1ms)  BEGIN
User Load (0.5ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
Post Update (0.3ms)  UPDATE "posts" SET "title" = $1 WHERE "posts"."id" = $2  [["title", "Rails is the best"], ["id", 3]]
TRANSACTION (39.5ms)  COMMIT
```

If we have a relevant foreign key, there is *no need* to check for the user (and thus performing an extra SQL query).

After the changes from this PR:
```
post.update!(title: "Rails is the best")
TRANSACTION (0.1ms)  BEGIN
UPDATE "posts" SET "title" = $1 WHERE "posts"."id" = $2  [["title", "Rails is the best"], ["id", 4]]
TRANSACTION (0.4ms)  COMMIT
```

Since, from my observation, most records do not change its `belongs_to` association values during their lifetime, this will greatly reduce the number of database queries for updates. And this will be even more notably for models with multiple `belongs_to`'s.

cc @byroot (since we implemented a similar optimization previously - https://github.com/rails/rails/pull/45149)