### PR TITLE
Add ActiveRecord::Relation#increment_all and decrement_all

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActiveRecord::Relation#increment_all` and `decrement_all` as a clearer
+    way to increment and decrement values on multiple records.
+
+    ```ruby
+    Post.active.increment_all(:score, 10)
+    ```
+
+    *Nikola Šantić*
+
 *   Raise on assignment to readonly attributes
 
     ```ruby

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -542,6 +542,24 @@ module ActiveRecord
       update_all updates
     end
 
+    # Updates all records in the current relation by initializing +attribute+ to zero if +nil+
+    # and adding the value passed as +by+ (default is 1). It does not instantiate the involved models,
+    # and it does not trigger Active Record callbacks or validations. Supports the +touch+ option from
+    # +update_counters+, see that for more.
+    # Returns the number of rows affected.
+    def increment_all(attribute, by = 1, touch: nil)
+      update_counters(attribute => by, touch: touch)
+    end
+
+    # Updates all records in the current relation by initializing +attribute+ to zero if +nil+
+    # and subtracting the value passed as +by+ (default is 1). It does not instantiate the involved models,
+    # and it does not trigger Active Record callbacks or validations. Supports the +touch+ option from
+    # +update_counters+, see that for more.
+    # Returns the number of rows affected.
+    def decrement_all(attribute, by = 1, touch: nil)
+      update_counters(attribute => -by, touch: touch)
+    end
+
     # Touches all records in the current relation, setting the +updated_at+/+updated_on+ attributes to the current time or the time specified.
     # It does not instantiate the involved models, and it does not trigger Active Record callbacks or validations.
     # This method can be passed attribute names and an optional time argument.

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -111,6 +111,24 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal 1, pets(:parrot).reload.integer
   end
 
+  def test_increment_all
+    assert_equal 2, posts(:welcome).legacy_comments_count
+    assert_equal 1, Post.where(id: posts(:welcome).id).increment_all(:legacy_comments_count, 2)
+    assert_equal 4, posts(:welcome).reload.legacy_comments_count
+  end
+
+  def test_increment_all_nil_attribute
+    assert_nil comments(:greetings).parent_id
+    assert_equal 1, Comment.where(id: comments(:greetings).id).increment_all(:parent_id, 2)
+    assert_equal 2, comments(:greetings).reload.parent_id
+  end
+
+  def test_decrement_all
+    assert_equal 2, posts(:welcome).legacy_comments_count
+    assert_equal 1, Post.where(id: posts(:welcome).id).decrement_all(:legacy_comments_count, 2)
+    assert_equal 0, posts(:welcome).reload.legacy_comments_count
+  end
+
   def test_touch_all_updates_records_timestamps
     david = developers(:david)
     david_previously_updated_at = david.updated_at


### PR DESCRIPTION
### Motivation / Background

Say you want to update a numeric column on a subset of records. `update_all` is fine:
`Player.active.update_all("score = score + 10")`

But using update_all with user input is very unsafe:
`Player.active.update_all("score = score + #{params[:extra]}")`

A safe way to do it is to use `update_counters`:
`Player.active.update_counters(score: params[:extra])`

But the naming of that method is a bit weird. We’re not updating these columns, we’re incrementing them. Also, these columns don’t need to be counters, they can be any number column.

### Detail

This pull request adds `increment_all` and `decrement_all` methods, corresponding to the ActiveRecord instance `increment` and `decrement`. This allows us to write:

`Player.active.increment_all(:score, 10)`

the result of which is immediately clear.

