### PR TITLE
Execute the before_committed! callbacks on the most recent copy of the record

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -40,7 +40,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       klass._counter_cache_columns << cache_column if klass && klass.respond_to?(:_counter_cache_columns)
     end
 
-    def self.touch_record(o, changes, foreign_key, name, touch, touch_method) # :nodoc:
+    def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:
       old_foreign_id = changes[foreign_key] && changes[foreign_key].first
 
       if old_foreign_id
@@ -58,9 +58,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
         if old_record
           if touch != true
-            old_record.public_send(touch_method, touch)
+            old_record.touch_later(touch)
           else
-            old_record.public_send(touch_method)
+            old_record.touch_later
           end
         end
       end
@@ -68,9 +68,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
       record = o.public_send name
       if record && record.persisted?
         if touch != true
-          record.public_send(touch_method, touch)
+          record.touch_later(touch)
         else
-          record.public_send(touch_method)
+          record.touch_later
         end
       end
     end
@@ -81,7 +81,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       touch       = reflection.options[:touch]
 
       callback = lambda { |changes_method| lambda { |record|
-        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch, belongs_to_touch_method)
+        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch)
       }}
 
       if reflection.counter_cache_column

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1165,11 +1165,5 @@ module ActiveRecord
         persisted?, new_record?, or destroyed? before touching.
       MSG
     end
-
-    # The name of the method used to touch a +belongs_to+ association when the
-    # +:touch+ option is used.
-    def belongs_to_touch_method
-      :touch
-    end
   end
 end

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       self.class.reflect_on_all_associations.each do |r|
         if touch = r.options[:touch]
           if r.macro == :belongs_to
-            ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch, :touch_later)
+            ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch)
           elsif r.macro == :has_one
             ActiveRecord::Associations::Builder::HasOne.touch_record(self, r.name, touch)
           end
@@ -60,10 +60,6 @@ module ActiveRecord
 
       def has_defer_touch_attrs?
         defined?(@_defer_touch_attrs) && @_defer_touch_attrs.present?
-      end
-
-      def belongs_to_touch_method
-        :touch_later
       end
   end
 end

--- a/activerecord/test/cases/touch_later_test.rb
+++ b/activerecord/test/cases/touch_later_test.rb
@@ -6,9 +6,11 @@ require "models/line_item"
 require "models/topic"
 require "models/node"
 require "models/tree"
+require "models/owner"
+require "models/pet"
 
 class TouchLaterTest < ActiveRecord::TestCase
-  fixtures :nodes, :trees
+  fixtures :nodes, :trees, :owners, :pets
 
   def test_touch_later_raise_if_non_persisted
     invoice = Invoice.new
@@ -119,5 +121,19 @@ class TouchLaterTest < ActiveRecord::TestCase
     assert_not_equal nodes(:parent_a).reload.updated_at, previous_parent_updated_at
     assert_not_equal nodes(:grandparent).reload.updated_at, previous_grandparent_updated_at
     assert_not_equal trees(:root).reload.updated_at, previous_tree_updated_at
+  end
+
+  def test_touching_through_nested_attributes
+    time = Time.now.utc - 25.days
+
+    owner = owners(:blackbeard)
+
+    owner.touch(time: time)
+
+    assert_equal time.to_i, owner.reload.updated_at.to_i
+
+    owner.update pets_attributes: { "0" => { id: "1", name: "Alfred" } }
+
+    assert_not_equal time.to_i, owner.reload.updated_at.to_i
   end
 end


### PR DESCRIPTION
Same as https://github.com/rails/rails/pull/36190 but for `before_committed!` callbacks.

Before only the early copy of the same record (different object ids, but
pointing to the same record in the database) was used to execute the
callback, but it didn't have the touch_later information.

Fixes https://github.com/rails/rails/issues/26726.