### PR TITLE
Read `.ruby-version` file in `Gemfile`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "\"#{Gem.ruby_version}\"" -%>
+ruby File.read(".ruby-version").strip
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -909,8 +909,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby "#{Gem.ruby_version}"/, content)
+      assert_match(/ruby File.read\(".ruby-version"\)/, content)
     end
+
     assert_file ".ruby-version" do |content|
       if ENV["RBENV_VERSION"]
         assert_match(/#{ENV["RBENV_VERSION"]}/, content)


### PR DESCRIPTION
### Motivation / Background

I have been doing this on all of my Ruby apps and other apps that use Gemfile such as iOS with CocoaPods.

### Detail

Reads the `.ruby-version` so that it's always in sync with `Gemfile`'s ruby version.

### Additional information

* https://andycroll.com/ruby/read-ruby-version-in-your-gemfile/
* https://render.com/docs/ruby-version (Heroku alternative)
* https://stackoverflow.com/a/35823132/9375533

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

