### PR TITLE
Use memoized dup of `url_helpers` for reinclusion

### DIFF
--- a/actionpack/lib/abstract_controller/railties/routes_helpers.rb
+++ b/actionpack/lib/abstract_controller/railties/routes_helpers.rb
@@ -10,25 +10,10 @@ module AbstractController
           define_method(:inherited) do |klass|
             super(klass)
 
-            namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
-            actual_routes = namespace ? namespace.railtie_routes_url_helpers._routes : routes
-
-            if namespace
+            if namespace = klass.module_parents.detect { |m| m.respond_to?(:railtie_routes_url_helpers) }
               klass.include(namespace.railtie_routes_url_helpers(include_path_helpers))
             else
               klass.include(routes.url_helpers(include_path_helpers))
-            end
-
-            # In the case that we have ex.
-            #   class A::Foo < ApplicationController
-            #   class Bar < A::Foo
-            # We will need to redefine _routes because it will not be correct
-            # via inheritance.
-            unless klass._routes.equal?(actual_routes)
-              klass.redefine_singleton_method(:_routes) { actual_routes }
-              klass.include(Module.new do
-                define_method(:_routes) { @_routes || actual_routes }
-              end)
             end
           end
         end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -574,6 +574,20 @@ module ActionDispatch
           end
 
           private :_generate_paths_by_default
+
+          # If the module is included more than once (for example, in a subclass
+          # of an ancestor that includes the module), ensure that the `_routes`
+          # singleton and instance methods return the desired route set by
+          # including a new copy of the module (recursively if necessary). Note
+          # that this method is called for each inclusion, whereas the above
+          # `included` block is run only for the initial inclusion of each copy.
+          def self.included(base)
+            super
+            if !base._routes.equal?(@_proxy._routes)
+              @dup_for_reinclude ||= self.dup
+              base.include @dup_for_reinclude
+            end
+          end
         end
       end
 

--- a/actionpack/test/controller/route_helpers_test.rb
+++ b/actionpack/test/controller/route_helpers_test.rb
@@ -3,19 +3,6 @@
 require "abstract_unit"
 
 class RouteHelperIntegrationTest < ActionDispatch::IntegrationTest
-  def self.routes
-    @routes ||= ActionDispatch::Routing::RouteSet.new
-  end
-
-  class FakeACBase < ActionController::Base
-    # Normally done by app initialization to ActionController::Base
-    app = RouteHelperIntegrationTest
-    extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
-  end
-
-  class ApplicationController < FakeACBase
-  end
-
   class FooController < ApplicationController
   end
 
@@ -24,18 +11,16 @@ class RouteHelperIntegrationTest < ActionDispatch::IntegrationTest
   # duplicate these modules and make method cache invalidation expensive.
   # https://github.com/rails/rails/pull/37927
   test "only includes one module with route helpers" do
-    app = self.class
-
-    url_helpers_module = app.routes.named_routes.url_helpers_module
-    path_helpers_module = app.routes.named_routes.path_helpers_module
+    url_helpers_module = SharedTestRoutes.named_routes.url_helpers_module
+    path_helpers_module = SharedTestRoutes.named_routes.path_helpers_module
 
     assert_operator FooController, :<, url_helpers_module
     assert_operator ApplicationController, :<, url_helpers_module
-    assert_not_operator FakeACBase, :<, url_helpers_module
+    assert_not_operator ActionController::Base, :<, url_helpers_module
 
     assert_operator FooController, :<, path_helpers_module
     assert_operator ApplicationController, :<, path_helpers_module
-    assert_not_operator FakeACBase, :<, path_helpers_module
+    assert_not_operator ActionController::Base, :<, path_helpers_module
 
     included_modules = FooController.ancestors.grep_v(Class)
     included_modules -= [url_helpers_module, path_helpers_module]


### PR DESCRIPTION
In the case where a controller subclasses an engine's controller that, in turn, subclasses a controller that includes the application's `url_helpers` (for example, in the ["isolated engine routes and helpers are isolated to that engine" test](https://github.com/rails/rails/blob/85edd855d0a1c4127fa5ba56c2b0c07148ce80e6/railties/test/railties/engine_test.rb#L724-L867) in `railties/test/railties/engine_test.rb`), this commit avoids allocating a new module per controller:

  ```ruby
  ActionController::Base.include Rails.application.routes.url_helpers
  C1 = Class.new(ActiveStorage::DirectUploadsController)
  C2 = Class.new(ActiveStorage::DirectUploadsController)

  C1.ancestors - C2.ancestors
  # BEFORE:
  # => [C1, #<Module:0x...>]
  # AFTER:
  # => [C1]
  ```

This commit also modifies the `RouteHelperIntegrationTest` test to use the controllers defined in `actionpack/test/abstract_unit.rb`. Otherwise, `extend AbstractController::Railties::RoutesHelpers.with(...)` happens twice — [once for `ActionController::Base`](https://github.com/rails/rails/blob/85edd855d0a1c4127fa5ba56c2b0c07148ce80e6/actionpack/test/abstract_unit.rb#L225-L226) and once for `FakeACBase` — which causes `FooController` to include an extra module as it flip-flops its `_routes` definition.  Previously, the extra module only defined a `_routes` method; now, the extra module would be the memoized dup of `routes.url_helpers`, which would cause the "only includes one module with route helpers" test to falsely fail.
