### PR TITLE
Rename AJAX to Ajax for consistency [ci-skip]

### DIFF
--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -16,7 +16,7 @@ module ActionView
       #
       # You don't need to use these tags for regular forms as they generate their own hidden fields.
       #
-      # For AJAX requests other than GETs, extract the "csrf-token" from the meta-tag and send as the
+      # For Ajax requests other than GETs, extract the "csrf-token" from the meta-tag and send as the
       # "X-CSRF-Token" HTTP header. If you are using rails-ujs this happens automatically.
       #
       def csrf_meta_tags

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1286,9 +1286,9 @@ All of request types have equivalent methods that you can use. In a typical C.R.
 
 NOTE: Functional tests do not verify whether the specified request type is accepted by the action, we're more concerned with the result. Request tests exist for this use case to make your tests more purposeful.
 
-### Testing XHR (AJAX) Requests
+### Testing XHR (Ajax) Requests
 
-To test AJAX requests, you can specify the `xhr: true` option to `get`, `post`,
+To test Ajax requests, you can specify the `xhr: true` option to `get`, `post`,
 `patch`, `put`, and `delete` methods. For example:
 
 ```ruby

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -34,7 +34,7 @@ gem "bootsnap", require: false
 <% end -%>
 <%- if options.api? -%>
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
+# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 <%- end -%>
 <% if RUBY_ENGINE == "ruby" -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb.tt
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
 
 # Read more: https://github.com/cyu/rack-cors
 


### PR DESCRIPTION
### Motivation / Background

Currently we use both `AJAX` (11 times) and `Ajax` (22 times).
Wikipedia uses `Ajax`: https://en.wikipedia.org/wiki/Ajax_(programming)
Mozilla uses `Ajax`: https://developer.mozilla.org/en-US/docs/Web/Guide/AJAX

As `Ajax` is currently used the most and it's preferred by Wikipedia and Mozilla, we can change all it's occurences to `Ajax`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

