### PR TITLE
Remove not needed thread-safe primitive

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -2,7 +2,6 @@
 
 require "active_support/core_ext/module/redefine_method"
 require "active_support/core_ext/time/calculations"
-require "concurrent/map"
 
 module ActiveSupport
   module Testing

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -11,9 +11,7 @@ module ActiveSupport
       Stub = Struct.new(:object, :method_name, :original_method)
 
       def initialize
-        @stubs = Concurrent::Map.new do |h, k|
-          h.compute_if_absent(k) { {} }
-        end
+        @stubs = Hash.new { |h, k| h[k] = {} }
       end
 
       # Stubs object.method_name with the given block

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -11,7 +11,9 @@ module ActiveSupport
       Stub = Struct.new(:object, :method_name, :original_method)
 
       def initialize
-        @stubs = Concurrent::Map.new { |h, k| h[k] = {} }
+        @stubs = Concurrent::Map.new do |h, k|
+          h.compute_if_absent(k) { {} }
+        end
       end
 
       # Stubs object.method_name with the given block


### PR DESCRIPTION
This change makes the initialization of the hash upon missing key fully thread-safe. Before this change, initialization that would occur in two threads could overwrite each other, as illustrated here:

https://github.com/ruby-concurrency/concurrent-ruby/issues/970

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I spotted this problem in this repo and several others.

### Detail

This Pull Request changes how the default value for concurrent map is initialized

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

