### PR TITLE
Fix `as_json` call on ActiveModel::Type's child classes.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise `NoMethodError` in `ActiveModel::Type::Value#as_json` to avoid unpredictable
+    results.
+
+    *Vasiliy Ermolovich*
+
 *   Custom attribute types that inherit from Active Model built-in types and do
     not override the `serialize` method will now benefit from an optimization
     when serializing attribute values for the database.

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -135,6 +135,10 @@ module ActiveModel
         value
       end
 
+      def as_json(*)
+        raise NoMethodError
+      end
+
       private
         # Convenience method for types which do not need separate type casting
         # behavior for user and database inputs. Called by Value#cast for

--- a/activemodel/test/cases/type/value_test.rb
+++ b/activemodel/test/cases/type/value_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/json"
 
 module ActiveModel
   module Type
@@ -9,6 +10,12 @@ module ActiveModel
         assert_equal Type::Value.new, Type::Value.new
         assert_not_equal Type::Value.new, Type::Integer.new
         assert_not_equal Type::Value.new(precision: 1), Type::Value.new(precision: 2)
+      end
+
+      def test_as_json_not_defined
+        assert_raises NoMethodError do
+          Type::Value.new.as_json
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Right now since we have instance variable called `itself_if_serialize_cast_value_compatible` assigned to self when we run `as_json` we get stack too deep error because `as_json` calls `as_json` on every instance variable. And since `@itself_if_serialize_cast_value_compatible` references to `self` we run into recursion.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

