### PR TITLE
Make sure that concurrent map usage is thread-safe

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -31,7 +31,7 @@ module ActionView
 
     module ObjectRendering # :nodoc:
       PREFIXED_PARTIAL_NAMES = Concurrent::Map.new do |h, k|
-        h[k] = Concurrent::Map.new
+        h.compute_if_absent(k) { Concurrent::Map.new }
       end
 
       def initialize(lookup_context, options)


### PR DESCRIPTION
Behavior upon missing prefix partial name may cause a key to overwrite when executed in multiple threads at the same time.

ref https://github.com/ruby-concurrency/concurrent-ruby/issues/970

### Motivation / Background

Same as here: https://github.com/rails/rails/pull/46534

But since guidelines state to isolate PRs, hence the second one.

### Detail

This Pull Request changes the way a cache miss is handled. It makes it thread safe and ensures that it's not ovewritten in the middle of execution.

### Additional information

ref: https://github.com/rails/rails/pull/46534
ref: https://github.com/ruby-concurrency/concurrent-ruby/issues/970

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

