### PR TITLE
Add conversion of array to ActiveRecord relation 

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -211,4 +211,17 @@ class Array
       end
     end
   end
+
+  def to_relation
+    return ApplicationRecord.none if self.empty?
+    
+    classes = self.collect(&:class).uniq
+    raise "Objects of different type. Array cannot be converted to ActiveRecord::Relation." if classes.size > 1
+
+    if classes.first.ancestors.include? ApplicationRecord
+      classes.first.where(id: self.collect(&:id))
+    else
+      raise "Array element doesn't inherit from ApplicationRecord and can't converted" 
+    end
+  end
 end

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -212,6 +212,13 @@ class Array
     end
   end
 
+  # Returns ActiveRecord::Relation, if array of objects consists of:
+  #
+  # 1. Objects belonging to the same class
+  # 2. Objects that inherit from ApplicationRecord
+  #
+  # If either one of the requirements is not fulfilled, the exception is raised.
+
   def to_relation
     return ApplicationRecord.none if self.empty?
     

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -218,9 +218,10 @@ class Array
   # 2. Objects that inherit from ApplicationRecord
   #
   # If either one of the requirements is not fulfilled, the exception is raised.
+  # If passed array is empty ActiveRecord::NullRelation will be returned.
 
   def to_relation
-    return ApplicationRecord.none if empty?
+    return ActiveRecord::NullRelation if self.empty?
 
     classes = collect(&:class).uniq
     raise "Objects of different type. Array cannot be converted to ActiveRecord::Relation." if classes.size > 1

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -215,7 +215,7 @@ class Array
   # Returns ActiveRecord::Relation, if array of objects consists of:
   #
   # 1. Objects belonging to the same class
-  # 2. Objects that inherit from ApplicationRecord
+  # 2. Objects that inherit from ActiveRecord
   #
   # If either one of the requirements is not fulfilled, the exception is raised.
   # If passed array is empty ActiveRecord::NullRelation will be returned.
@@ -224,12 +224,12 @@ class Array
     return ActiveRecord::NullRelation if self.empty?
 
     classes = collect(&:class).uniq
-    raise "Objects of different type. Array cannot be converted to ActiveRecord::Relation." if classes.size > 1
+    raise "Objects of different class. Array cannot be converted to ActiveRecord::Relation" if classes.size > 1
 
     if classes.first.ancestors.include? ActiveRecord::Base
       classes.first.where(id: collect(&:id))
     else
-      raise "Array element doesn't inherit from ActiveRecord and can't converted"
+      raise "Array element doesn't inherit from ActiveRecord and can't be converted"
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -220,15 +220,15 @@ class Array
   # If either one of the requirements is not fulfilled, the exception is raised.
 
   def to_relation
-    return ApplicationRecord.none if self.empty?
-    
-    classes = self.collect(&:class).uniq
+    return ApplicationRecord.none if empty?
+
+    classes = collect(&:class).uniq
     raise "Objects of different type. Array cannot be converted to ActiveRecord::Relation." if classes.size > 1
 
-    if classes.first.ancestors.include? ApplicationRecord
-      classes.first.where(id: self.collect(&:id))
+    if classes.first.ancestors.include? ActiveRecord::Base
+      classes.first.where(id: collect(&:id))
     else
-      raise "Array element doesn't inherit from ApplicationRecord and can't converted" 
+      raise "Array element doesn't inherit from ActiveRecord and can't converted"
     end
   end
 end

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -284,7 +284,7 @@ class ToRelationTest < ActiveSupport::TestCase
   end
 
   def test_to_relation_with_empty_array
-    assert_raise(Exception) { [].to_relation }
+    assert_equal(ActiveRecord::NullRelation, [].to_relation)
   end
 
   def test_to_relation_with_correct_objects

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2617,6 +2617,11 @@ NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
 
 [Array#to_xml]: https://api.rubyonrails.org/classes/Array.html#method-i-to_xml
 
+#### to_relation
+
+The to_relation method convers an array of ActiveRecord objects into ActiveRecord::Relation. Exception is raised if array consists of objects with different classes or if one of the objects isn't from ActiveRecord. In case of using to_relation on 
+empty array the ActiveRecord::NullRelation is returned.
+
 ### Wrapping
 
 The method [`Array.wrap`][Array.wrap] wraps its argument in an array unless it is already an array (or array-like).

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2619,8 +2619,44 @@ NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
 
 #### to_relation
 
-The to_relation method convers an array of ActiveRecord objects into ActiveRecord::Relation. Exception is raised if array consists of objects with different classes or if one of the objects isn't from ActiveRecord. In case of using to_relation on 
-empty array the ActiveRecord::NullRelation is returned.
+The to_relation method converts the array of ActiveRecord objects into ActiveRecord::Relation. Exception is raised if array consists of objects belonging to a different class or if one of the objects isn't from ActiveRecord. In case of using to_relation on empty array the ActiveRecord::NullRelation is returned. Example:
+
+For classes:
+```ruby
+# class Dog < ActiveRecord::Base
+#   [...]
+# end
+#
+# class Cat < ActiveRecord::Base
+#   [...]
+# end
+#
+# class Duck
+#   [...]
+# end
+```
+
+```ruby
+dog = Dog.create!
+cat = Cat.create!
+duck = Duck.new
+
+[dog, cat].to_relation
+# =>
+# RuntimeError: Objects of different class. Array cannot be converted to ActiveRecord::Relation
+
+[dog, duck].to_relation
+# =>
+# RuntimeError: Array element doesn't inherit from ActiveRecord and can't be converted
+
+[cat, cat].to_relation
+# =>
+# ActiveRecord::Relation
+
+[].to_relation
+# =>
+# ActiveRecord::NullRelation
+```
 
 ### Wrapping
 


### PR DESCRIPTION
### Motivation / Background

This pr aims to add conversion to active record relation from array of objects. If you know what objects array contains it's enough to do `Model.where(id: arr.map(&:id))`. There are however edge cases where you may not know if all elements belong to the same class or inherit from ActiveRecord. I had a situation within the project where I've extended Array class, because of that.
It's my first rails contribution so if its uneccesary feature or there are some problems within the code, let me know :)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

