### PR TITLE
Add `after_routes_loaded` hook for Engines to trigger code after application routes have been loaded

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -172,6 +172,16 @@ config.after_initialize do
 end
 ```
 
+### `config.after_routes_loaded`
+
+Takes a block which will be run after Rails has finished loading the application routes. This block will also be run whenever routes are reloaded.
+
+```ruby
+config.after_routes_loaded do
+  # Code that does something with Rails.application.routes
+end
+```
+
 #### `config.allow_concurrency`
 
 Controls whether requests should be handled concurrently. This should only

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `after_routes_loaded` hook to `Rails::Railtie::Configuration` for
+    engines to add a hook to be called after application routes have been
+    loaded.
+
+    ```ruby
+    MyEngine.config.after_routes_loaded do
+      # code that must happen after routes have been loaded
+    end
+    ```
+
+    *Chris Salzberg*
+
 *   Send 303 See Other status code back for the destroy action on newly generated
     scaffold controllers.
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -166,6 +166,7 @@ module Rails
           # some sort of reloaders dependency support, to be added.
           require_unload_lock!
           reloader.execute
+          ActiveSupport.run_load_hooks(:after_routes_loaded, self)
         end
       end
 

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -71,6 +71,11 @@ module Rails
         ActiveSupport.on_load(:after_initialize, yield: true, &block)
       end
 
+      # Called after application routes have been loaded.
+      def after_routes_loaded(&block)
+        ActiveSupport.on_load(:after_routes_loaded, yield: true, &block)
+      end
+
       # Array of callbacks defined by #to_prepare.
       def to_prepare_blocks
         @@to_prepare_blocks ||= []


### PR DESCRIPTION
### Motivation / Background

We have a situation where some code in `config/application.rb` memoizes a method which depends on routes being loaded. Currently, this is achieved using code like this:

```ruby
initializer :do_some_stuff_after_routes_loaded, after: :set_routes_reloader_hook do |app|
  # code that depends on routes being loaded
end
```

When trying to move this code to an engine that owns constants referenced in the block, we found that there is no way to do what the initializer above does from an engine. Copying the same code to an engine results in the `:set_routes_reloader_hook` getting moved _forward_ in the initializer chain due to how `after` works, which is not what we want (and which breaks many things). OTOH switching to `after_initialize` in the engine does not work either since it is called before application routes are loaded.

### Detail

To resolve this issue, I've added a new `after_routes_loaded` hook that can be used by an engine to do this like this:

```ruby
class MyEngine < Rails::Engine
  config.after_routes_loaded do
    # code that depends on routes being loaded
  end
end
```

### Additional information

I have called the hook directly after the the routes reloader has been triggered, _inside_ the `to_run` block, so the hook would be called on _every_ routes reload. I think this makes sense since if you're depending on routes for something, you probably also depend on knowing when they change.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.