### PR TITLE
Rename initializer to respect convention

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -106,7 +106,7 @@ module ActiveRecord
       end
     end
 
-    initializer "Check for cache versioning support" do
+    initializer "active_record.cache_versioning_support" do
       config.after_initialize do |app|
         ActiveSupport.on_load(:active_record) do
           if app.config.active_record.cache_versioning && Rails.cache


### PR DESCRIPTION
There's one initializer in Active Record which uses spaces in its name instead of the conventional `underscore_framework.underscore_name`. This fixes it.

There's potential risk of breaking an application if an initializer is defined as needing to run before or after this one but I couldn't find any such cases in open source projects or our apps.