### PR TITLE
Initialize deprecators before config/initializers run

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -10,7 +10,7 @@ module ActionCable
     config.action_cable.mount_path = ActionCable::INTERNAL[:default_mount_path]
     config.action_cable.precompile_assets = true
 
-    initializer "action_cable.deprecator" do |app|
+    initializer "action_cable.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_cable] = ActionCable.deprecator
     end
 

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -22,7 +22,7 @@ module ActionMailbox
 
     config.action_mailbox.storage_service = nil
 
-    initializer "action_mailbox.deprecator" do |app|
+    initializer "action_mailbox.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_mailbox] = ActionMailbox.deprecator
     end
 

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -11,7 +11,7 @@ module ActionMailer
     config.action_mailer.preview_paths = []
     config.eager_load_namespaces << ActionMailer
 
-    initializer "action_mailer.deprecator" do |app|
+    initializer "action_mailer.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_mailer] = ActionMailer.deprecator
     end
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -17,7 +17,7 @@ module ActionController
     config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
 
-    initializer "action_controller.deprecator" do |app|
+    initializer "action_controller.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_controller] = ActionController.deprecator
     end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -41,7 +41,7 @@ module ActionDispatch
 
     config.eager_load_namespaces << ActionDispatch
 
-    initializer "action_dispatch.deprecator" do |app|
+    initializer "action_dispatch.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_dispatch] = ActionDispatch.deprecator
     end
 

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -19,7 +19,7 @@ module ActionText
       #{root}/app/models
     )
 
-    initializer "action_text.deprecator" do |app|
+    initializer "action_text.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_text] = ActionText.deprecator
     end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -73,7 +73,7 @@ module ActionView
       end
     end
 
-    initializer "action_view.deprecator" do |app|
+    initializer "action_view.deprecator", before: :load_environment_config do |app|
       app.deprecators[:action_view] = ActionView.deprecator
     end
 

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -10,7 +10,7 @@ module ActiveJob
     config.active_job.custom_serializers = []
     config.active_job.log_query_tags_around_perform = true
 
-    initializer "active_job.deprecator" do |app|
+    initializer "active_job.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_job] = ActiveJob.deprecator
     end
 

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -9,7 +9,7 @@ module ActiveModel
 
     config.active_model = ActiveSupport::OrderedOptions.new
 
-    initializer "active_model.deprecator" do |app|
+    initializer "active_model.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_model] = ActiveModel.deprecator
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -75,7 +75,7 @@ module ActiveRecord
       require "active_record/base"
     end
 
-    initializer "active_record.deprecator" do |app|
+    initializer "active_record.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_record] = ActiveRecord.deprecator
     end
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -82,7 +82,7 @@ module ActiveStorage
 
     config.eager_load_namespaces << ActiveStorage
 
-    initializer "active_storage.deprecator" do |app|
+    initializer "active_storage.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_storage] = ActiveStorage.deprecator
     end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -10,7 +10,7 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
-    initializer "active_support.deprecator" do |app|
+    initializer "active_support.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_support] = ActiveSupport.deprecator
     end
 


### PR DESCRIPTION
### Motivation / Background

In config/initializers, I have some code that sets up an additional deprecator behavior (by taking the current behavior, which is an Array, prepending to it a new behavior, and setting the array as the new behavior). I want to do that only to Rails frameworks initializers since I only care about Rails deprecations in my situation.

When I updated my code to work with the new `deprecators` introduced in #46049 and later, I discovered that only 8 out of the total 13 frameworks have deprecators at this point in the boot process. That's because 5 of the frameworks are engines, and their own initializers by default run after all the engines initializers, which includes `:load_config_initializers`.

You can see an example app here https://github.com/etiennebarrie/rails-app/tree/deprecators:

```sh-session
$ bin/rails runner ''                                                                                                                                                                                       
{:application=>1}
{:development=>1}
{:deprecators=>8}
```

[Alternatively, I'd like a better way to configure all the Rails frameworks deprecators, without configuring any of the deprecators that gem engines may add to the application. Setting values on Rails.application.deprecators apply to all existing and later added deprecators, which isn't quite what I'm looking for. Plus I can only set a behavior, not query the existing one and add another one, but I understand that this makes sense for a deprecators collection. Very often people will want the same behavior to apply to all deprecators, in my specific case I only care about the Rails ones. I currently check the `gem_name` in the deprecation behavior, but given we have now multiple deprecators, I thought I might as well configure them separately.]

### Detail

This pull request configures all the deprecator initializers to run before config/initializers.

### Additional information

cc @jonathanhefner since you've been implementing all the deprecators.

Running before config/initializers is a bit arbitrary, and we may want to actually have the deprecators registered before. I tried by changing to `:load_environment_config`, and all the deprecators are then accessible in the environment file, but still not in application, and I think having `config/application.rb` and `config/environments/development.rb` so different isn't wanted.

There are two other ways I can see to fix this:
- We could move the initializer to Railtie (which doesn't have any initializers yet), and by providing a method on Railtie, which would optionally return the framework name and deprecator, we could have the initializer run early in the process. 
- We could not use an initializer at all and use a `before_initialize` (to run before all the railties initializers, including config/initializers files) or even `before_configuration` (for the deprecators to be available as soon as the application is created in `config/application.rb`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

