### PR TITLE
Add example for data-turbo-confirm on button_to in Working with JavaScript Guide

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -290,3 +290,11 @@ This generates:
 ```html
 <a href="..." data-turbo-confirm="Are you sure?" data-turbo-method="delete">Delete post</a>
 ```
+
+In case of buttons the `data-turbo-confirm` attribute must be associated to the generated form as in this example:
+
+```erb
+<%= button_to "Delete post', post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } } %>
+```
+
+


### PR DESCRIPTION
Example to complete 5.2 Confirmations paragraph with button_to method. 