### PR TITLE
Add X-Forwarded-To addresses to recipients

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Add X-Forwarded-To addresses to recipients.
 
+    *Andrew Stewart*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -7,7 +7,7 @@ module Mail
     end
 
     def recipients_addresses
-      to_addresses + cc_addresses + bcc_addresses + x_original_to_addresses
+      to_addresses + cc_addresses + bcc_addresses + x_original_to_addresses + x_forwarded_to_addresses
     end
 
     def to_addresses
@@ -24,6 +24,10 @@ module Mail
 
     def x_original_to_addresses
       Array(header[:x_original_to]).collect { |header| Mail::Address.new header.to_s }
+    end
+
+    def x_forwarded_to_addresses
+      Array(header[:x_forwarded_to]).collect { |header| Mail::Address.new header.to_s }
     end
   end
 end

--- a/actionmailbox/lib/action_mailbox/mail_ext/recipients.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/recipients.rb
@@ -3,7 +3,8 @@
 module Mail
   class Message
     def recipients
-      Array(to) + Array(cc) + Array(bcc) + Array(header[:x_original_to]).map(&:to_s)
+      Array(to) + Array(cc) + Array(bcc) + Array(header[:x_original_to]).map(&:to_s) +
+        Array(header[:x_forwarded_to]).map(&:to_s)
     end
   end
 end

--- a/actionmailbox/test/unit/mail_ext/addresses_test.rb
+++ b/actionmailbox/test/unit/mail_ext/addresses_test.rb
@@ -10,15 +10,16 @@ module MailExt
         to: "david@basecamp.com",
         cc: "jason@basecamp.com",
         bcc: "andrea@basecamp.com",
-        x_original_to: "ryan@basecamp.com"
+        x_original_to: "ryan@basecamp.com",
+        x_forwarded_to: "jane@example.com"
     end
 
     test "from address uses address object" do
       assert_equal "example.com", @mail.from_address.domain
     end
 
-    test "recipients include everyone from to, cc, bcc, and x-original-to" do
-      assert_equal %w[ david@basecamp.com jason@basecamp.com andrea@basecamp.com ryan@basecamp.com ], @mail.recipients
+    test "recipients include everyone from to, cc, bcc, x-original-to, and x-forwarded-to" do
+      assert_equal %w[ david@basecamp.com jason@basecamp.com andrea@basecamp.com ryan@basecamp.com jane@example.com ], @mail.recipients
     end
 
     test "recipients addresses use address objects" do
@@ -39,6 +40,10 @@ module MailExt
 
     test "x_original_to addresses use address objects" do
       assert_equal "basecamp.com", @mail.x_original_to_addresses.first.domain
+    end
+
+    test "x_forwarded_to addresses use address objects" do
+      assert_equal "example.com", @mail.x_forwarded_to_addresses.first.domain
     end
   end
 end


### PR DESCRIPTION
This pull request enhances `Mail::Message#recipients` to include the address an email was forwarded to.

A common pattern with ActionMailbox is to process emails sent to addresses containing identifiers, e.g. for a user or a ticket.  In this pattern the application needs the address the email was sent to so it can obtain the identifier and look up the model in question.

If an email is sent directly to an address, `#recipients` will find the address in the `To` header.

However if an email is forwarded to an address, `#recipients` may not find it.  It depends on how the forwarding mail server sets the `From` and `To` headers.  Sometimes the mail server preserves the original `From` and `To` and sometimes it does not.  If it does, the address the email was forwarded to becomes invisible to `#recipients`.

In particular when Gmail forwards an email it preserves the original `From` and `To` headers and records the forwarding address in the `X-Forwarded-To` header.

Previously support was added for [obtaining the original To](https://github.com/rails/actionmailbox/commit/dd43f6e7d90ab0d2c354a9bef1970e4f3a7e6471) when the mail server sets the `To` header to the forwarding address.

This pull request adds support for obtaining the forwarding address when the mail server sets the `To` header to the original `To`.
