### PR TITLE
Make AbstractAdapter#lock thread local by default

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -175,7 +175,7 @@ module ActiveRecord
         end
 
         if (active_connection = @thread_cached_conns[connection_cache_key(current_thread)])
-          active_connection.synchronized = lock_thread
+          active_connection.lock_thread = @lock_thread
         end
       end
 
@@ -357,7 +357,7 @@ module ActiveRecord
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
         connection = checkout_and_verify(acquire_connection(checkout_timeout))
-        connection.synchronized = @lock_thread
+        connection.lock_thread = @lock_thread
         connection
       end
 
@@ -375,6 +375,7 @@ module ActiveRecord
               conn.expire
             end
 
+            conn.lock_thread = nil
             @available.add conn
           end
         end

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -801,6 +801,19 @@ module ActiveRecord
         @connection_test_model_class = ThreadConnectionTestModel
       end
 
+      def test_lock_thread_allow_fiber_reentrency
+        @pool.lock_thread = true
+        connection = @pool.checkout
+        connection.transaction do
+          enumerator = Enumerator.new do |yielder|
+            connection.transaction do
+              yielder.yield 1
+            end
+          end
+          assert_equal 1, enumerator.next
+        end
+      end
+
       private
         def new_thread(...)
           Thread.new(...)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/45994

A semi-common issue since Ruby 3.0.2 is that using a fiber inside a transaction cause a deadlock:

```ruby
Post.transaction do
 enum =  Enumerator.new do |y|
   y.yield Post.first # stuck
 end
 enum.next
end
```

This is because in https://bugs.ruby-lang.org/issues/17827 Ruby changed Monitor to be owned by the calling Fiber rather than Thread.

And since the Active Record connection pool is per Thread, we end up in a situation where a Fiber tries to acquire a lock owned by another fiber with no change to ever resolve.

In https://github.com/rails/rails/pull/46519 We've made that lock optional as it's only needed for system tests.

Now this PR introduce an alternative lock implementation that behave like Monitor used to up to Ruby 2.7, and we use this one if `ActiveSupport::IsolatedExecutionState.context` is a Thread.

If it's a Fiber, we continue to use the implementation derived from the stdlib that is Fiber based.

Co-Authored-By: @wildmaples

FYI @eileencodes @matthewd @rafaelfranca @ngan @simi 
