### PR TITLE
Allow hash-like model in FormBuilder#fields and FormBuilder#fields_for

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2084,6 +2084,18 @@ module ActionView
       # DateHelper that are designed to work with an object as base, like
       # FormOptionsHelper#collection_select and DateHelper#datetime_select.
       #
+      # +fields_for+ tries to be smart about parameters, but it can be confused if both
+      # name and value parameters are provided and the provided value has the shape of an
+      # option Hash. To remove the ambiguity, explicitly pass an option Hash, even if empty.
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= fields_for :permission, @person.permission, {} do |permission_fields| %>
+      #       Admin?: <%= check_box_tag permission_fields.field_name(:admin), @person.permission[:admin] %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
       # === Nested Attributes Examples
       #
       # When the object belonging to the current scope has a nested attribute
@@ -2264,8 +2276,9 @@ module ActionView
       # to store the ID of the record. There are circumstances where this
       # hidden field is not needed and you can pass <tt>include_id: false</tt>
       # to prevent fields_for from rendering it automatically.
-      def fields_for(record_name, record_object = nil, fields_options = {}, &block)
-        fields_options, record_object = record_object, nil if record_object.is_a?(Hash) && record_object.extractable_options?
+      def fields_for(record_name, record_object = nil, fields_options = nil, &block)
+        fields_options, record_object = record_object, nil if fields_options.nil? && record_object.is_a?(Hash) && record_object.extractable_options?
+        fields_options ||= {}
         fields_options[:builder] ||= options[:builder]
         fields_options[:namespace] = options[:namespace]
         fields_options[:parent_builder] = self

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -164,6 +164,17 @@ class HashBackedAuthor < Hash
   end
 end
 
+class HashWithIndifferentAccessBackedAuthor < HashWithIndifferentAccess
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+
+  def persisted?; false; end
+
+  def name
+    "hash backed author"
+  end
+end
+
 module Blog
   def self.use_relative_model_naming?
     true

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2000,6 +2000,22 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
+  def test_nested_fields_with_hash_with_indifferent_access_like_model
+    @author = HashWithIndifferentAccessBackedAuthor.new
+
+    form_with(model: @post) do |f|
+      concat f.fields(:author, model: @author) { |af|
+        concat af.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/posts/123", method: "patch") do
+      '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name" />'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_fields
     @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3538,6 +3538,36 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_nested_fields_for_with_hash_with_indifferent_access_like_model_and_options
+    @author = HashWithIndifferentAccessBackedAuthor.new
+
+    form_for(@post) do |f|
+      concat f.fields_for(:author, @author, {}) { |af|
+        concat af.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author" />'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_nested_fields_for_with_hash_with_indifferent_access_like_model_without_options
+    @author = HashWithIndifferentAccessBackedAuthor.new
+
+    form_for(@post) do |f|
+      concat f.fields_for(:author, @author) { |af|
+        concat af.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch")
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_fields_for
     @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)


### PR DESCRIPTION
### Motivation / Background

When passing a model to `ActionView::Helpers::FormBuilder#fields`, if this model is a Hash or an instance of a Hash subclass responding true to `extractable_options?` (eg `HashWithIndifferentAccess`), the code incorrectly interprets this model as if being an options hash, ignoring both the provided model and any provided options.

The problem lies in `ActionView::Helpers::FormBuilder#fields_for` parameters handling. #1778 partially fixed the problem: When `record_object` is an instance of a subclass of Hash which is not overloading `extractable_options?`,  everything work fine thanks to the restrictive `Hash#extractable_options?`.

But the problem still exists if `record_object` is a directly a Hash or a HashWithIndifferentAccess for example, as can be seen in #46154. 

This PR does not provide a fix for this as I could not think of one, but it add a way to force the `record_object`  provided to `fields_for` to be used as such, by checking if the calling code provides a `fields_options`parameter. This in turns fixes the problem for `fields`,  as the method definition ensure we at least provide an empty hash as fields_options.

### Detail

This Pull Request changes the way `ActionView::Helpers::FormBuilder#fields_for` interprets its provided parameters. 
Before deciding that the `record_object` parameter is in fact the `fields_options` parameter, we now check if this `fields_options` has not been explicitly provided.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

