### PR TITLE
Small PR: Apply Rails backtrace cleaner to ActiveJob backtrace printout

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -60,6 +60,7 @@ module ActiveJob
       ex = event.payload[:exception_object]
       if ex
         cleaned_backtrace = backtrace_cleaner.clean(ex.backtrace)
+
         error do
           "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(cleaned_backtrace).join("\n")
         end

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -5,6 +5,8 @@ require "active_support/log_subscriber"
 
 module ActiveJob
   class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
+    class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new
+
     def enqueue(event)
       job = event.payload[:job]
       ex = event.payload[:exception_object]
@@ -57,7 +59,7 @@ module ActiveJob
       job = event.payload[:job]
       ex = event.payload[:exception_object]
       if ex
-        cleaned_backtrace = Rails.backtrace_cleaner.clean(ex.backtrace)
+        cleaned_backtrace = backtrace_cleaner.clean(ex.backtrace)
         error do
           "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(cleaned_backtrace).join("\n")
         end

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -57,8 +57,9 @@ module ActiveJob
       job = event.payload[:job]
       ex = event.payload[:exception_object]
       if ex
+        cleaned_backtrace = Rails.backtrace_cleaner.clean(ex.backtrace)
         error do
-          "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(ex.backtrace).join("\n")
+          "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(cleaned_backtrace).join("\n")
         end
       elsif event.payload[:aborted]
         error do

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -18,6 +18,10 @@ module ActiveJob
       ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
     end
 
+    initializer "active_job.backtrace_cleaner" do
+      ActiveSupport.on_load(:active_job) { LogSubscriber.backtrace_cleaner = ::Rails.backtrace_cleaner }
+    end
+
     initializer "active_job.custom_serializers" do |app|
       config.after_initialize do
         custom_serializers = app.config.active_job.custom_serializers


### PR DESCRIPTION
### Motivation / Background

ActiveJob produces a large amount of log noise, because errors that are emitted from ActiveJob don't have the standard Rails BacktraceCleaner applied. This is especially apparent when using Sorbet for Ruby types, since each application method call is wrapped by multiple Sorbet typechecking functions. My application's activejob error backtraces would typically log 4 non-relevant Sorbet function calls for each application function call. My workaround has been to monkey-patch Rails in our application. However, it seems to make sense to simply bring this behavior into ActiveJob as the default, as the backtrace cleaner is a pretty standard piece of Rails machinery that is used for most other backtraces in Rails.

### Additional information

When ActiveJob encounters an error performing a job, rather than printing the full unfiltered (and noisy) exception backtrace, print the cleaned backtrace using Rails's BacktraceCleaner.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

