### PR TITLE
Return boolean from shard_swapping_prohibited?

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -204,7 +204,7 @@ module ActiveRecord
 
     # Determine whether or not shard swapping is currently prohibited
     def shard_swapping_prohibited?
-      ActiveSupport::IsolatedExecutionState[:active_record_prohibit_shard_swapping]
+      ActiveSupport::IsolatedExecutionState[:active_record_prohibit_shard_swapping] ||= false
     end
 
     # Prevent writing to the database regardless of role.


### PR DESCRIPTION
### Detail

**shard_swapping_prohibited?** appears as a boolean method but its returned values are inconsistent with boolean methods

### Expected returned value
value from [true, false]

### Actual returned value
value from [true, nil]

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are already in place.
* [x] CI is passing.