### PR TITLE
Include original message when reflecting on an association gets a `NameError`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -437,7 +437,8 @@ module ActiveRecord
           end
 
           klass
-        rescue NameError
+        rescue NameError => e
+          msg = [msg, "The original error was: #{e.message}"].join("\n")
           raise NameError, msg
         end
       end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -151,6 +151,13 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_reflection_nameerror_includes_original_error
+    e = assert_raise(NameError) do
+      UserWithInvalidRelation.reflect_on_association(:class_does_not_exist).klass
+    end
+    assert e.message.include?("The original error was: uninitialized constant UserWithInvalidRelation::ClassDoesNotExist")
+  end
+
   def test_aggregation_reflection
     reflection_for_address = AggregateReflection.new(
       :address, nil, { mapping: [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer

--- a/activerecord/test/models/user_with_invalid_relation.rb
+++ b/activerecord/test/models/user_with_invalid_relation.rb
@@ -12,6 +12,8 @@ class UserWithInvalidRelation < ActiveRecord::Base
 
   has_many :user_infos_class_name, class_name: "UserInfoInvalid"
   has_many :infos_through_class_name, through: :user_infos_class_name, class_name: "InfoInvalid"
+
+  has_one :class_does_not_exist
 end
 
 class AccountInvalid; end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46532

There wasn't an easy way to test the same behaviour for autoloading, but it should be the same outcome, which is that any `NameError`s are reported as well as the original message.
