### PR TITLE
Restore Action Cable Redis pub/sub listener on connection failure

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Redis pub/sub adapter now automatically reconnects when Redis connection is lost.
+
+    *Vladimir Dementyev*
+
 *   The `connected()` callback can now take a `{reconnected}` parameter to differentiate
     connections from reconnections.
 


### PR DESCRIPTION
### Motivation / Background

Closes #27659

Based on [this comment](https://github.com/rails/rails/pull/45478#discussion_r960107957)

### Detail

This PR makes Redis pub/sub adapter (more precisely, its listener part) resilient to network disruptions (e.g., when connection is terminated due to some strict ttl settings).

We keep track of all channels in a set and perform `SUBSCRIBE chan1 chan2 ...` when pub/sub connection is restored.

### Additional information

The retry mechanism uses on the `reconnect_attempts` passed to configuration (if present). The behaviour mimics the `redis-client` one (incl. the default value of 1).

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

