### PR TITLE
Where exists - Allow identify associated or missing records using another relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `where.associated` and `where.missing` now supports a relation as parameter, it will
+    generate an exists clause to identify associated or missing relations.
+
+    ```ruby
+    Post.where.associated(Author.correlates(:post))
+    # => SELECT "posts".* FROM "posts" WHERE EXISTS (SELECT 1 FROM "authors" WHERE authors.id = posts.author_id)
+
+    Post.where.missing(Author.correlates(:post))
+    # => SELECT "posts".* FROM "posts" WHERE NOT EXISTS (SELECT 1 FROM "authors" WHERE authors.id = posts.author_id)
+    ```
+
+    *Lázaro Nixon*
+
 *   `AbstractAdapter#execute` and `#exec_query` now clear the query cache
 
     If you need to perform a read only SQL query without clearing the query

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with,
+      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :correlates,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -35,6 +35,14 @@ module ActiveRecord
       end
     end
 
+    def test_associated_with_relation
+      Post.where.associated(Author.correlates(:post)).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_includes     relation, posts(:sti_habtm)
+        assert_not_includes relation, posts(:authorless)
+      end
+    end
+
     def test_associated_with_invalid_association_name
       e = assert_raises(ArgumentError) do
         Post.where.associated(:cars).to_a
@@ -53,6 +61,13 @@ module ActiveRecord
         assert_includes     relation, comments(:more_greetings)
         assert_not_includes relation, comments(:greetings)
       end
+    end
+
+    def test_missing_with_relation
+      relation = Author.correlates(:post)
+
+      assert posts(:authorless).author.blank?
+      assert_equal [posts(:authorless)], Post.where.missing(relation).to_a
     end
 
     def test_missing_with_invalid_association_name

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -491,5 +491,21 @@ module ActiveRecord
       Comment.create!(label: :default, post: post, body: "Nice weather today")
       assert_equal [post], Post.joins(:comments).where(comments: { label: :default, body: "Nice weather today" }).to_a
     end
+
+    def test_correlates_with_invalid_association_name
+      e = assert_raises(ArgumentError) do
+        Post.correlates(:cars)
+      end
+
+      assert_match(/An association named `:cars` does not exist on the model `Post`/, e.message)
+    end
+
+    def test_correlates_with_through_association
+      e = assert_raises(ArgumentError) do
+        Author.correlates(:comments)
+      end
+
+      assert_match(/Correlation is not supported for through association/, e.message)
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This pull request adds support for passing a relation to `where.associated` and `where.missing`, it will returns a new relation with an exists clause with the relation on it.

[`EXISTS` is faster than `IN` when the sub-query results is very large](https://stackoverflow.com/a/3964770)

https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization-with-exists.html

### Detail

~~Post.where.associated(Author.where("authors.id = posts.author_id"))~~
~~Post.where.missing(Author.where("authors.id = posts.author_id"))~~

```ruby
Post.where.associated(Author.correlates(:post))
# SELECT "posts".* FROM "posts"
# WHERE EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id))

Post.where.missing(Author.correlates(:post))
# SELECT "posts".* FROM "posts"
# WHERE NOT EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id))
```

### Additional information

Previous attempt: https://github.com/rails/rails/pull/46343

Discussed here: 
https://github.com/rails/rails/issues/40719
https://discord.com/channels/849034466856665118/1044367827974492211
https://discuss.rubyonrails.org/t/proposal-activerecord-support-for-exists-clause/81618/9



