### PR TITLE
Allow binding a field to a different error message

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow binding a field to a different error message.
+    Following the example, suppose you have a validation on category,
+    you can decorate a field originally bound to category_id.
+
+    ```erb
+    <%= select("post", "category_id", [:a, :b], error_key: "category") %>
+    # => <div class="field_with_errors"><select name="post[category_id]" id="post_category_id"><option value="a">a</option>\n<option value="b">b</option></select></div>
+    ```
+
+    *Lázaro Nixon*
+
 *   Choices of `select` can optionally contain html attributes as the last element
     of the child arrays when using grouped/nested collections
 

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -34,7 +34,7 @@ module ActionView
       end
 
       def error_message
-        object.errors[@method_name]
+        object.errors[error_key]
       end
 
       private
@@ -48,6 +48,10 @@ module ActionView
 
         def tag_generate_errors?(options)
           options["type"] != "hidden"
+        end
+
+        def error_key
+          @options[:error_key] || @method_name
         end
     end
   end

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -6,7 +6,7 @@ class ActiveModelHelperTest < ActionView::TestCase
   tests ActionView::Helpers::ActiveModelHelper
 
   silence_warnings do
-    Post = Struct.new(:author_name, :body, :category, :published, :updated_at) do
+    Post = Struct.new(:author_name, :body, :category, :category_id, :published, :updated_at) do
       include ActiveModel::Conversion
       include ActiveModel::Validations
 
@@ -153,6 +153,13 @@ class ActiveModelHelperTest < ActionView::TestCase
     assert_dom_equal(
       %(<input id="post_author_name" name="post[author_name]" type="hidden" value="" autocomplete="off" />),
       hidden_field("post", "author_name")
+    )
+  end
+
+  def test_field_with_error_key
+    assert_dom_equal(
+      %(<div class="field_with_errors"><select name="post[category_id]" id="post_category_id"><option value="a">a</option>\n<option value="b">b</option></select></div>),
+      select("post", "category_id", [:a, :b], error_key: "category")
     )
   end
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1404,7 +1404,8 @@ Assuming we have a model that's been saved in an instance variable named
 
 Furthermore, if you use the Rails form helpers to generate your forms, when
 a validation error occurs on a field, it will generate an extra `<div>` around
-the entry.
+the entry. Additionally you can use the option `error_key` to bind the field
+to a different error message.
 
 ```html
 <div class="field_with_errors">


### PR DESCRIPTION
### Motivation / Background

This pull request adds a new option to form helpers called `error_key`, this way we can specify a different error key that will be evaluated by `field_error_proc`. It allows us for example to bind the error of a select to the association instead of the foreign_key.

```ruby
class Post < ActiveRecord::Base
  belongs_to :person, optional: false
end
```
```ruby
<%= f.collection_select :person_id, Author.all, :id, :name, error_key: "person" %>
```
```html
<div class="field_with_errors"><select>...</select></div>
```

Fixes https://github.com/rails/rails/issues/28772
Fixes https://github.com/rails/rails/issues/44160

Previous PR: https://github.com/rails/rails/pull/46494