### PR TITLE
LoggerThreadSafeLevel only impact the receiving logger

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -18,7 +18,7 @@ module ActiveSupport
     end
 
     def local_level
-      IsolatedExecutionState[:logger_thread_safe_level]
+      IsolatedExecutionState[local_level_key]
     end
 
     def local_level=(level)
@@ -30,7 +30,11 @@ module ActiveSupport
       else
         raise ArgumentError, "Invalid log level: #{level.inspect}"
       end
-      IsolatedExecutionState[:logger_thread_safe_level] = level
+      if level.nil?
+        IsolatedExecutionState.delete(local_level_key)
+      else
+        IsolatedExecutionState[local_level_key] = level
+      end
     end
 
     def level
@@ -44,5 +48,10 @@ module ActiveSupport
     ensure
       self.local_level = old_local_level
     end
+
+    private
+      def local_level_key
+        @local_level_key ||= :"logger_thread_safe_level_#{object_id}"
+      end
   end
 end

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -392,6 +392,17 @@ class LoggerTest < ActiveSupport::TestCase
     assert_includes @output.string, "THIS IS HERE"
   end
 
+  def test_log_at_only_impact_receiver
+    logger2 = Logger.new(StringIO.new)
+    assert_equal Logger::DEBUG, logger2.level
+    assert_equal Logger::DEBUG, @logger.level
+
+    @logger.log_at :error do
+      assert_equal Logger::DEBUG, logger2.level
+      assert_equal Logger::ERROR, @logger.level
+    end
+  end
+
   private
     def level_name(level)
       ::Logger::Severity.constants.find do |severity|


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/46559

That's how it initially worked, but this was broken in https://github.com/rails/rails/pull/34055

That PR replaced an instance variable by a class variable, causing the level to be per thread, but to apply to all logger instances.
