### PR TITLE
Add details of cookie name and size to `CookieOverflow` exception

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add details of cookie name and size to `CookieOverflow` exception.
+
+    *Andy Waite*
+
 *   Don't double log the `controller` or `action` when using `ActiveRecord::QueryLog`
 
     Previously if you set `config.active_record.query_log_tags` to an array that included

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -632,7 +632,9 @@ module ActionDispatch
         def commit(name, options)
           options[:value] = @verifier.generate(serialize(options[:value]), **cookie_metadata(name, options))
 
-          raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
+          if options[:value].bytesize > MAX_COOKIE_SIZE
+            raise CookieOverflow, "#{name} cookie overflowed with size #{options[:value].bytesize} bytes"
+          end
         end
     end
 
@@ -684,7 +686,9 @@ module ActionDispatch
         def commit(name, options)
           options[:value] = @encryptor.encrypt_and_sign(serialize(options[:value]), **cookie_metadata(name, options))
 
-          raise CookieOverflow if options[:value].bytesize > MAX_COOKIE_SIZE
+          if options[:value].bytesize > MAX_COOKIE_SIZE
+            raise CookieOverflow, "#{name} cookie overflowed with size #{options[:value].bytesize} bytes"
+          end
         end
     end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -852,9 +852,10 @@ class CookiesTest < ActionController::TestCase
   end
 
   def test_raise_data_overflow
-    assert_raise(ActionDispatch::Cookies::CookieOverflow) do
+    error = assert_raise(ActionDispatch::Cookies::CookieOverflow) do
       get :raise_data_overflow
     end
+    assert_equal "foo cookie overflowed with size 5522 bytes", error.message
   end
 
   def test_tampered_cookies

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -189,9 +189,10 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
 
   def test_close_raises_when_data_overflows
     with_test_route_set do
-      assert_raise(ActionDispatch::Cookies::CookieOverflow) {
+      error = assert_raise(ActionDispatch::Cookies::CookieOverflow) {
         get "/raise_data_overflow"
       }
+      assert_equal "_myapp_session cookie overflowed with size 5612 bytes", error.message
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

My app was raising a `CookieOverflow` exception but it was difficult to pinpoint the cause, since error trackers and logging systems generally filter out cookies.

This Pull Request has been created because I want the exception to provide additional information:
- The name of the cookie that overflowed
- The magnitude of how much it overflowed by

I am assuming that only the cookie value is sensitive, and not its name or size.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

