### PR TITLE
Add `*_or_on?` methods to `DateAndTime::Calculations`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   `DateAndTime::Calculations` now includes `before_or_on?` and `after_or_on?`
+    calculation methods.
+
+    Human readable methods `before?` and `after?` already offer a natural syntax
+    for comparing Date and Time objects.
+
+    This adds two new methods that behave similarly and are analogous to `>=`
+    and `=<` comparisons.
+
+    ```ruby
+    birthday = Date.new(2022, 12, 25)
+    christmas_day = Date.new(2022, 12, 25)
+    new_years_day = Date.new(2023, 1, 1)
+
+    birthday.before_or_on?(christmas_day)
+    # => true
+    new_years_day.before_or_on?(christmas_day)
+    # => false
+
+    birthday.after_or_on?(new_years_day)
+    # => false
+    new_years_day.after_or_on?(christmas_day)
+    # => true
+    ```
+
+    *Connor McQuillan*
+
+
 *   `ActiveSupport::CurrentAttributes.resets` now accepts a method name
 
     The block API is still the recommended approach, but now both APIs are supported:

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -68,9 +68,19 @@ module DateAndTime
       self < date_or_time
     end
 
+    # Returns true if the date/time falls before on on <tt>date_or_time</tt>.
+    def before_or_on?(date_or_time)
+      self <= date_or_time
+    end
+
     # Returns true if the date/time falls after <tt>date_or_time</tt>.
     def after?(date_or_time)
       self > date_or_time
+    end
+
+    # Returns true if the date/time falls after on on <tt>date_or_time</tt>.
+    def after_or_on?(date_or_time)
+      self >= date_or_time
     end
 
     # Returns a new date/time the specified number of days ago.

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -346,10 +346,22 @@ module DateAndTimeBehavior
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
+  def test_before_or_on
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).before_or_on?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before_or_on?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before_or_on?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
   def test_after
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 5, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 6, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
+  def test_after_or_on
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after_or_on?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after_or_on?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after_or_on?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
   def with_bw_default(bw = :monday)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The `DateAndTime::Calculations` module provides two human readable methods for comparing Date and Time objects.

1. `before?` which is equivalent to the `<` comparison
2. `after?` which is equivalent to the `>` comparison

These were introduced in #32185, and make date comparisons much nicer to work with.

While changes to Active Support core extensions are generally rejected, I feel the addition of two extra methods that facilitate comparisons equivalent to `<=` and `>=` would be useful for the same reasons.

### Detail

This adds two new methods `before_or_on?` and `after_or_on?` that provide a more readable way to compare dates using the `<=` and `>=` comparison operators respectively.

For example:

```ruby
birthday = Date.new(2022, 12, 25)
christmas_day = Date.new(2022, 12, 25)
new_years_day = Date.new(2023, 1, 1)

birthday.before_or_on?(christmas_day)      
# => true
new_years_day.before_or_on?(christmas_day)
# => false

birthday.after_or_on?(new_years_day)
# => false
new_years_day.after_or_on?(christmas_day)
# => true
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

It is currently possible to achieve the same results, albeit in a less human readable way. If we focus on `before_or_on?`, it's behaviour could be achieved in a couple of ways.

1. Use `<=`

```ruby
birthday = Date.new(2022, 12, 25)
christmas_day = Date.new(2022, 12, 25)
new_years_day = Date.new(2023, 1, 1)

birthday <= christmas_day
# => true
new_years_day <= christmas_day
# => false
```

2. Negate `after_on?`

```ruby
birthday = Date.new(2022, 12, 25)
christmas_day = Date.new(2022, 12, 25)
new_years_day = Date.new(2023, 1, 1)

!birthday.after?(christmas_day)
# => true

!new_years_day.after?(christmas_day)
# => false
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

