### PR TITLE
Fix: Incorrectly preloading through association records when middle association has been loaded

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -74,7 +74,7 @@ module ActiveRecord
           end
 
           def middle_records
-            through_preloaders.flat_map(&:preloaded_records)
+            through_records_by_owner.values.flatten
           end
 
           def through_preloaders


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/45822

This Pull Request has been created to address https://github.com/rails/rails/issues/45822.

**Update:** Looks like this also resolves https://github.com/rails/rails/issues/45542.

### Detail

This Pull Request fixes `ActiveRecord::Associations::Preloader::ThroughAssociation#records_by_owner` to:
1. successfully fetch the loaded source records for an already loaded middle record
2. do so without performing unnecessary queries

**RE: 1**
Using a failing test and some logging, I found that the memoized keys in `source_records_by_owner` had different `object_id`s to the values in `through_records_by_owner` **at the point at which the value was fetched using `source_records_by_owner[record]`** and was therefore returning `nil`.

This was being caused by `def middle_records` loading new objects into `@preloaded_records` which would get passed in as the records for the source preloader, rather than using the already loaded through objects in `through_records_by_owner`.

This resulted in the `source_records_by_owner` hash containing keys which were different objects to the values in the `through_records_by_owner` hash.

**RE: 2**
This also happens to fix a circular dependency of sorts, since `def middle_records` would eventually call `def source_preloaders` while already in a previous call to it originating from `def source_records_by_owner`, causing the through record/s to reload and the source record/s to load, before finally loading the source records once again. These extra queries are visible in my comment below.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

