### PR TITLE
Prefer `deprecate_constant` over constant proxy

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -10,7 +10,8 @@ require "concurrent/map"
 module ActionView
   # = Action View Resolver
   class Resolver
-    Path = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("ActionView::Resolver::Path", "ActionView::TemplatePath", ActionView.deprecator)
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    deprecate_constant "Path", "ActionView::TemplatePath", deprecator: ActionView.deprecator
 
     class PathParser # :nodoc:
       ParsedPath = Struct.new(:path, :details)

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -108,7 +108,8 @@ module Rails
           end
       end
 
-      Behaviour = ActiveSupport::Deprecation::DeprecatedConstantProxy.new("Rails::Generators::Testing::Behaviour", "Rails::Generators::Testing::Behavior", Rails.deprecator)
+      include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+      deprecate_constant "Behaviour", "Rails::Generators::Testing::Behavior", deprecator: Rails.deprecator
     end
   end
 end

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -256,7 +256,7 @@ class GeneratorsTest < Rails::Generators::TestCase
 
   def test_behaviour_aliases_behavior
     assert_deprecated(Rails.deprecator) do
-      assert_same Rails::Generators::Testing::Behavior, Rails::Generators::Testing::Behaviour.itself
+      assert_same Rails::Generators::Testing::Behavior, Rails::Generators::Testing::Behaviour
     end
   end
 end


### PR DESCRIPTION
`deprecate_constant` will warn whenever the constant is referenced instead of when the constant is a method receiver, which increases the likelihood that the warning will be seen.  Additionally, `DeprecatedConstantProxy` prevents using the constant as a superclass, such as in `class MyClass < SomeDeprecatedConstant`.
