### PR TITLE
Add `Deprecators#disallowed_warnings=`

### DIFF
--- a/activesupport/lib/active_support/deprecation/deprecators.rb
+++ b/activesupport/lib/active_support/deprecation/deprecators.rb
@@ -69,6 +69,14 @@ module ActiveSupport
         set_option(:disallowed_behavior, disallowed_behavior)
       end
 
+      # Sets the disallowed deprecation warnings for all deprecators in this
+      # collection.
+      #
+      # See ActiveSupport::Deprecation::Disallowed#disallowed_warnings=.
+      def disallowed_warnings=(disallowed_warnings)
+        set_option(:disallowed_warnings, disallowed_warnings)
+      end
+
       # Silences all deprecators in this collection for the duration of the
       # given block.
       #

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -88,9 +88,7 @@ module ActiveSupport
         end
 
         if disallowed_warnings = app.config.active_support.disallowed_deprecation_warnings
-          app.deprecators.each do |deprecator|
-            deprecator.disallowed_warnings = disallowed_warnings
-          end
+          app.deprecators.disallowed_warnings = disallowed_warnings
         end
       end
     end

--- a/activesupport/test/deprecation/deprecators_test.rb
+++ b/activesupport/test/deprecation/deprecators_test.rb
@@ -63,6 +63,11 @@ class DeprecationTest < ActiveSupport::TestCase
     @deprecators.each { |deprecator| assert_equal [callback], deprecator.disallowed_behavior }
   end
 
+  test "#disallowed_warnings= applies to each deprecator" do
+    @deprecators.disallowed_warnings = :all
+    @deprecators.each { |deprecator| assert_equal :all, deprecator.disallowed_warnings }
+  end
+
   test "#silence silences each deprecator" do
     @deprecators.each { |deprecator| assert_not_silencing(deprecator) }
 


### PR DESCRIPTION
Although disallowed warnings are likely to be deprecator-specific, it can be useful to set this value once and have it applied to any deprecators that are added later.  For example, setting the value in an initializer via `config.active_support.disallowed_deprecation_warnings` and applying it to any third-party deprecators that are added later in the boot process.  Also, when using `:all`, it is more convenient to write `deprecators.disallowed_warnings = :all` instead of `deprecators.each { |deprecator| deprecator.disallowed_warnings = :all }`.
