### PR TITLE
FormBuilder#id finds id set by `form_for` & `form_with`

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1745,7 +1745,7 @@ module ActionView
       # <tt><button></tt> element should be treated as the <tt><form></tt>
       # element's submit button, regardless of where it exists in the DOM.
       def id
-        options.dig(:html, :id)
+        options.dig(:html, :id) || options[:id]
       end
 
       # Generate an HTML <tt>id</tt> attribute value for the given field

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2469,25 +2469,37 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_equal 1, initialization_count, "form builder instantiated more than once"
   end
 
-  def test_form_with_id
-    form_with(model: Post.new, id: "new_post") do |f|
-      concat f.button(form: f.id)
+  def test_form_with_with_id_option
+    form_with(model: Post.new, id: "new_special_post") do |form|
+      concat form.button(form: form.id)
     end
 
-    expected = whole_form("/posts", "new_post") do
-      '<button name="button" type="submit" form="new_post">Create Post</button>'
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
     end
 
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_id_having_html_id
-    form_with(model: Post.new, id: "new_post", html: { id: "html_new_post" }) do |f|
-      concat f.button(form: f.id)
+  def test_form_with_with_id_option_nested_in_html
+    form_with(model: Post.new, html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
     end
 
-    expected = whole_form("/posts", "html_new_post") do
-      '<button name="button" type="submit" form="html_new_post">Create Post</button>'
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_with_with_competing_id_option_nested_in_html
+    form_with(model: Post.new, id: "ignored", html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
     end
 
     assert_dom_equal expected, @rendered

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2469,6 +2469,30 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_equal 1, initialization_count, "form builder instantiated more than once"
   end
 
+  def test_form_with_id
+    form_with(model: Post.new, id: "new_post") do |f|
+      concat f.button(form: f.id)
+    end
+
+    expected = whole_form("/posts", "new_post") do
+      '<button name="button" type="submit" form="new_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_with_id_having_html_id
+    form_with(model: Post.new, id: "new_post", html: { id: "html_new_post" }) do |f|
+      concat f.button(form: f.id)
+    end
+
+    expected = whole_form("/posts", "html_new_post") do
+      '<button name="button" type="submit" form="html_new_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   private
     def hidden_fields(options = {})
       method = options[:method]


### PR DESCRIPTION
### Motivation / Background

When setting an HTML id attribute on a `form_with`, I noticed that the form builder's `id` was not returning as expected.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it addresses an inconsistency

### Detail

When a `form_with` gets built, it passes initial options and then begins to build what will become the html_options for the tag. As the `id` attribute acts like a convenience option for what would normally be set as an html_option, it is not placed in the expected location in the instantiated FormBuilder. 

There are many ways this could be addressed but I could see some complexity being introduced as an `id` option and an `html` option that contains `id` can still be passed at the same time. Luckily when building the form tag this is handled appropriately with the `html` key having precedence. However, the winning id never makes it back to being set in the FormBuilder instance's `options`.

Changing the lookup on FormBuilder#id seemed to be the simplest solution as a fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

