### PR TITLE
Correct closing quotation mark for data-turbo-confirm on button_to example [ci-skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -294,5 +294,5 @@ This generates:
 In case of buttons the `data-turbo-confirm` attribute must be associated to the generated form as in this example:
 
 ```erb
-<%= button_to "Delete post', post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } } %>
+<%= button_to "Delete post", post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } } %>
 ```


### PR DESCRIPTION
Correct closing quotation mark for data-turbo-confirm on button_to example