### PR TITLE
Don't use lower() for citext columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Stop using `LOWER()` for case-insensitive queries on `citext` columns
+
+    Previously, `LOWER()` was added for e.g. uniqueness validations with
+    `case_sensitive: false`.
+    It wasn't mentioned in the documentation that the index without `LOWER()`
+    wouldn't be used in this case.
+
+    *Phil Pirozhkov*
+
 *   Extract `#sync_timezone_changes` method in AbstractMysqlAdapter to enable subclasses
     to sync database timezone changes without overriding `#raw_execute`.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1031,7 +1031,10 @@ module ActiveRecord
         end
 
         def can_perform_case_insensitive_comparison_for?(column)
-          @case_insensitive_cache ||= {}
+          # NOTE: citext is an exception. It is possible to perform a
+          #       case-insensitive comparison using `LOWER()`, but it is
+          #       unnecessary, as `citext` is case-insensitive by definition.
+          @case_insensitive_cache ||= { "citext" => false }
           @case_insensitive_cache.fetch(column.sql_type) do
             @case_insensitive_cache[column.sql_type] = begin
               sql = <<~SQL

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -71,6 +71,12 @@ class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
     assert_equal "Cased Text", x.cival
   end
 
+  def test_case_insensitiveness
+    attr = Citext.arel_table[:cival]
+    comparison = @connection.case_insensitive_comparison(attr, nil)
+    assert_no_match(/lower/i, comparison.to_sql)
+  end
+
   def test_schema_dump_with_shorthand
     output = dump_table_schema("citexts")
     assert_match %r[t\.citext "cival"], output


### PR DESCRIPTION
### Motivation / Background

In case when an index is present, using `lower()` prevents from using the index.

### Detail

The index is typically present for columns with uniqueness, and `lower()` is added for `validates_uniqueness_of ..., case_sensitive: false`.

:warning: However, if the index is defined with `lower()`, the query without `lower()` wouldn't use the index either.

None of the resources on the first page of the search engine output, nor our docs recommended using an index with `lower()`.

Following the principle of the least surprise, I suggest to stop adding `lower()` to queries to use the regular index.

This Pull Request changes [REPLACE ME]

### Additional information

:warning: It can be considered as a performance regression for those who were diligent enough to notice that the index without `lower()` didn't work and added `lower()` to their indexes.

#### Benchmark

Setup:
```
CREATE EXTENSION citext;
CREATE TABLE citexts (cival citext);
INSERT INTO citexts (SELECT MD5(random()::text) FROM generate_series(1,1000000));
```

Without index:
```
EXPLAIN ANALYZE SELECT * from citexts WHERE cival = 'f00';
 Gather  (cost=1000.00..14542.43 rows=1 width=33) (actual time=165.923..169.065 rows=0 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on citexts  (cost=0.00..13542.33 rows=1 width=33) (actual time=158.218..158.218 rows=0 loops=3)
         Filter: (cival = 'f00'::citext)
         Rows Removed by Filter: 333333
 Planning Time: 0.070 ms
 Execution Time: 169.089 ms
Time: 169.466 ms

EXPLAIN ANALYZE SELECT * from citexts WHERE lower(cival) = lower('f00');
 Gather  (cost=1000.00..16084.00 rows=5000 width=33) (actual time=166.896..169.881 rows=0 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on citexts  (cost=0.00..14584.00 rows=2083 width=33) (actual time=157.348..157.349 rows=0 loops=3)
         Filter: (lower((cival)::text) = 'f00'::text)
         Rows Removed by Filter: 333333
 Planning Time: 0.084 ms
 Execution Time: 169.905 ms
Time: 170.338 ms
```

With index:
```
CREATE INDEX val_citexts ON citexts (cival);

EXPLAIN ANALYZE SELECT * from citexts WHERE cival = 'f00';
 Index Only Scan using val_citexts on citexts  (cost=0.42..4.44 rows=1 width=33) (actual time=0.051..0.052 rows=0 loops=1)
   Index Cond: (cival = 'f00'::citext)
   Heap Fetches: 0
 Planning Time: 0.118 ms
 Execution Time: 0.082 ms
Time: 0.616 ms

EXPLAIN ANALYZE SELECT * from citexts WHERE lower(cival) = lower('f00');
 Gather  (cost=1000.00..16084.00 rows=5000 width=33) (actual time=167.029..170.401 rows=0 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on citexts  (cost=0.00..14584.00 rows=2083 width=33) (actual time=157.180..157.181 rows=0 loops=3)
         Filter: (lower((cival)::text) = 'f00'::text)
         Rows Removed by Filter: 333333
 Planning Time: 0.132 ms
 Execution Time: 170.427 ms
Time: 170.946 ms

DROP INDEX val_citexts;
```

With an index with `lower()` has a reverse effect, a query with
`lower()` performs better:
```
CREATE INDEX val_citexts ON citexts (lower(cival));

EXPLAIN ANALYZE SELECT * from citexts WHERE cival = 'f00';
 Gather  (cost=1000.00..14542.43 rows=1 width=33) (actual time=174.138..177.311 rows=0 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on citexts  (cost=0.00..13542.33 rows=1 width=33) (actual time=165.983..165.984 rows=0 loops=3)
         Filter: (cival = 'f00'::citext)
         Rows Removed by Filter: 333333
 Planning Time: 0.080 ms
 Execution Time: 177.333 ms
Time: 177.701 ms

EXPLAIN ANALYZE SELECT * from citexts WHERE lower(cival) = lower('f00');
                                                            QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on citexts  (cost=187.18..7809.06 rows=5000 width=33) (actual time=0.021..0.022 rows=0 loops=1)
   Recheck Cond: (lower((cival)::text) = 'f00'::text)
   ->  Bitmap Index Scan on lower_val_on_citexts  (cost=0.00..185.93 rows=5000 width=0) (actual time=0.018..0.018 rows=0 loops=1)
         Index Cond: (lower((cival)::text) = 'f00'::text)
 Planning Time: 0.102 ms
 Execution Time: 0.048 ms
(6 rows)
Time: 0.491 ms
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.