### PR TITLE
Use cgi 0.3.6 or higher to address CookieStoreTest#test_session_store_with_all_domains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
+# Workaround until Ruby ships with cgi version 0.3.6 or higher.
+gem "cgi", ">= 0.3.6", require: false
+
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.3.6)
     childprocess (4.1.0)
     coffee-script (2.4.1)
       coffee-script-source
@@ -576,6 +577,7 @@ DEPENDENCIES
   blade
   bootsnap (>= 1.4.4)
   capybara (>= 3.26)
+  cgi (>= 0.3.6)
   connection_pool
   cssbundling-rails
   dalli (>= 3.0.1)


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following error by using cgi 0.3.6 that includes https://github.com/ruby/cgi/pull/29

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

```ruby
$ ruby -v
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]
$ gem info cgi

*** LOCAL GEMS ***

cgi (0.3.5)
    Author: Yukihiro Matsumoto
    Homepage: https://github.com/ruby/cgi
    Licenses: Ruby, BSD-2-Clause
    Installed at (default): /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0

    Support for the Common Gateway Interface protocol.
$
```

```ruby
$ cd actionpack
$ bin/test test/dispatch/session/cookie_store_test.rb -n test_session_store_with_all_domains
Running 27 tests in a single process (parallelization threshold is 50)
Run options: -n test_session_store_with_all_domains --seed 24288

E

Error:
CookieStoreTest#test_session_store_with_all_domains:
ArgumentError: invalid domain: ".example.com"
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/3.1.0/cgi/cookie.rb:128:in `domain='
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/3.1.0/cgi/cookie.rb:95:in `initialize'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-2.2.4/lib/rack/mock.rb:239:in `new'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-2.2.4/lib/rack/mock.rb:239:in `block in parse_cookies_from_header'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-2.2.4/lib/rack/mock.rb:236:in `each'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-2.2.4/lib/rack/mock.rb:236:in `parse_cookies_from_header'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-2.2.4/lib/rack/mock.rb:187:in `initialize'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:360:in `new'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:360:in `process_request'
    /home/yahonda/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rack-test-2.0.2/lib/rack/test.rb:155:in `request'
    /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:285:in `process'
    /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:16:in `get'
    /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:376:in `get'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:420:in `get'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:379:in `block in test_session_store_with_all_domains'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:438:in `block in with_test_route_set'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:157:in `with_routing'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:424:in `with_test_route_set'
    /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:378:in `test_session_store_with_all_domains'

bin/test test/dispatch/session/cookie_store_test.rb:377

Finished in 0.079807s, 12.5303 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
### Additional information

Related to
https://github.com/ruby/cgi/pull/29
https://github.com/rails/rails/issues/46578

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

