### PR TITLE
Add failing test for `raise_on_assign_to_attr_readonly` with `abstract_class`

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -66,6 +66,16 @@ class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
+class ReadonlyTitleAbstractPost < ActiveRecord::Base
+  self.abstract_class = true
+
+  attr_readonly :title
+end
+
+class ReadonlyTitlePostWithAbstractParent < ReadonlyTitleAbstractPost
+  self.table_name = "posts"
+end
+
 previous_value, ActiveRecord.raise_on_assign_to_attr_readonly = ActiveRecord.raise_on_assign_to_attr_readonly, false
 
 class NonRaisingPost < Post
@@ -766,7 +776,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "changed via write_attribute", post.title
     assert_equal "changed via write_attribute", post.body
 
-
     post.assign_attributes(body: "changed via assign_attributes", title: "changed via assign_attributes")
     assert_equal "changed via assign_attributes", post.title
     assert_equal "changed via assign_attributes", post.body
@@ -781,6 +790,14 @@ class BasicsTest < ActiveRecord::TestCase
     post = Post.find(post.id)
     assert_equal "changed via []=", post.title
     assert_equal "changed via []=", post.body
+  end
+
+  def test_readonly_attributes_in_abstract_class_descendant
+    assert_equal Set.new([ "title" ]), ReadonlyTitlePostWithAbstractParent.readonly_attributes
+
+    assert_nothing_raised do
+      ReadonlyTitlePostWithAbstractParent.new(title: "can change this until you save")
+    end
   end
 
   def test_readonly_attributes_when_configured_to_not_raise


### PR DESCRIPTION
### Motivation / Background

I observed some tests for our monolith were failing with the latest commit on `main`, which bisecting led me to https://github.com/rails/rails/pull/46105. The problem is a subtle conflict between the changes to `attr_readonly` and having a parent class that is abstract which calls `attr_readonly`.

### Detail

This PR adds a failing test that reproduces the issue.

The problem is where an abstract class defines a readonly attribute. In this case, the readonly wrapper method ends up coming _before_ the method defined in subclasses' generated attribute methods module. Since the method is defined, child classes do not define it. As a result, when you call that writer, you hit `super` but no super method is defined, ending up in a `NoMethodError`.

I'd like to first confirm the issue, then I'll work on a fix.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

