### PR TITLE
Allow `Arel.sql` to accept bind parameters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -47,13 +47,9 @@ module ActiveRecord
         end
       end
 
-      # Quote a value to be used as a bound parameter of unknown type. For example,
+      # Cast a value to be used as a bound parameter of unknown type. For example,
       # MySQL might perform dangerous castings when comparing a string to a number,
       # so this method will cast numbers to string.
-      def quote_bound_value(value)
-        quote(cast_bound_value(value))
-      end
-
       def cast_bound_value(value)
         value
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -51,7 +51,7 @@ module ActiveRecord
       # MySQL might perform dangerous castings when comparing a string to a number,
       # so this method will cast numbers to string.
       def quote_bound_value(value)
-        quote(value)
+        quote(cast_bound_value(value))
       end
 
       def cast_bound_value(value)

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -54,6 +54,10 @@ module ActiveRecord
         quote(value)
       end
 
+      def cast_bound_value(value)
+        value
+      end
+
       # If you are having to call this function, you are likely doing something
       # wrong. The column does not have sufficient type information if the user
       # provided a custom type on the class level either explicitly (via

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -6,6 +6,26 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
+        def cast_bound_value(value)
+          case value
+          when Rational
+            value.to_f.to_s
+          when Numeric
+            value.to_s
+          when BigDecimal
+            value.to_s("F")
+          when true
+            "1"
+          when false
+            "0"
+          when ActiveSupport::Duration
+            warn_quote_duration_deprecated
+            value.to_s
+          else
+            value
+          end
+        end
+
         def quote_bound_value(value)
           case value
           when Rational

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -26,26 +26,6 @@ module ActiveRecord
           end
         end
 
-        def quote_bound_value(value)
-          case value
-          when Rational
-            quote(value.to_f.to_s)
-          when Numeric
-            quote(value.to_s)
-          when BigDecimal
-            quote(value.to_s("F"))
-          when true
-            "'1'"
-          when false
-            "'0'"
-          when ActiveSupport::Duration
-            warn_quote_duration_deprecated
-            quote(value.to_s)
-          else
-            quote(value)
-          end
-        end
-
         def quote_column_name(name)
           self.class.quoted_column_names[name] ||= "`#{super.gsub('`', '``')}`"
         end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -215,13 +215,13 @@ module ActiveRecord
           if value.respond_to?(:map) && !value.acts_like?(:string)
             values = value.map { |v| v.respond_to?(:id_for_database) ? v.id_for_database : v }
             if values.empty?
-              c.quote_bound_value(nil)
+              c.quote(c.cast_bound_value(nil))
             else
-              values.map! { |v| c.quote_bound_value(v) }.join(",")
+              values.map! { |v| c.quote(c.cast_bound_value(v)) }.join(",")
             end
           else
             value = value.id_for_database if value.respond_to?(:id_for_database)
-            c.quote_bound_value(value)
+            c.quote(c.cast_bound_value(value))
           end
         end
 

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -38,8 +38,19 @@ module Arel
   #
   # Take a look at the {security guide}[https://edgeguides.rubyonrails.org/security.html#sql-injection]
   # for more information.
-  def self.sql(raw_sql)
-    Arel::Nodes::SqlLiteral.new raw_sql
+  #
+  # To construct a more complex query fragment, including the possible
+  # use of user-provided values, the +sql_string+ may contain +?+ and
+  # +:key+ placeholders, corresponding to the additional arguments. Note
+  # that this behavior only applies when bind value parameters are
+  # supplied in the call; without them, the placeholder tokens have no
+  # special meaning, and will be passed through to the query as-is.
+  def self.sql(sql_string, *positional_binds, **named_binds)
+    if positional_binds.empty? && named_binds.empty?
+      Arel::Nodes::SqlLiteral.new sql_string
+    else
+      Arel::Nodes::BoundSqlLiteral.new sql_string, positional_binds, named_binds
+    end
   end
 
   def self.star # :nodoc:

--- a/activerecord/lib/arel/errors.rb
+++ b/activerecord/lib/arel/errors.rb
@@ -6,4 +6,14 @@ module Arel # :nodoc: all
 
   class EmptyJoinError < ArelError
   end
+
+  class BindError < ArelError
+    def initialize(message, sql = nil)
+      if sql
+        super("#{message} in: #{sql.inspect}")
+      else
+        super(message)
+      end
+    end
+  end
 end

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -69,5 +69,6 @@ require "arel/nodes/leading_join"
 require "arel/nodes/comment"
 
 require "arel/nodes/sql_literal"
+require "arel/nodes/bound_sql_literal"
 
 require "arel/nodes/casted"

--- a/activerecord/lib/arel/nodes/bound_sql_literal.rb
+++ b/activerecord/lib/arel/nodes/bound_sql_literal.rb
@@ -23,6 +23,12 @@ module Arel # :nodoc: all
       end
       alias :== :eql?
 
+      def +(other)
+        raise ArgumentError, "Expected Arel node" unless Arel.arel_node?(other)
+
+        Fragments.new([self, other])
+      end
+
       def inspect
         "#<#{self.class.name} #{sql_with_placeholders.inspect} #{positional_binds.inspect} #{named_binds.inspect}>"
       end

--- a/activerecord/lib/arel/nodes/bound_sql_literal.rb
+++ b/activerecord/lib/arel/nodes/bound_sql_literal.rb
@@ -56,10 +56,6 @@ module Arel # :nodoc: all
       def inspect
         "#<#{self.class.name} #{sql_with_placeholders.inspect} #{(named_binds || positional_binds).inspect}>"
       end
-
-      def ast
-        self
-      end
     end
   end
 end

--- a/activerecord/lib/arel/nodes/bound_sql_literal.rb
+++ b/activerecord/lib/arel/nodes/bound_sql_literal.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class BoundSqlLiteral < NodeExpression
+      attr_reader :sql_with_placeholders, :positional_binds, :named_binds
+
+      def initialize(sql_with_placeholders, positional_binds, named_binds)
+        @sql_with_placeholders = sql_with_placeholders
+        @positional_binds = positional_binds
+        @named_binds = named_binds
+      end
+
+      def hash
+        [self.class, sql_with_placeholders, positional_binds, named_binds].hash
+      end
+
+      def eql?(other)
+        self.class == other.class &&
+          sql_with_placeholders == other.sql_with_placeholders &&
+          positional_binds == other.positional_binds &&
+          named_binds == other.named_binds
+      end
+      alias :== :eql?
+
+      def inspect
+        "#<#{self.class.name} #{sql_with_placeholders.inspect} #{positional_binds.inspect} #{named_binds.inspect}>"
+      end
+
+      def ast
+        self
+      end
+    end
+  end
+end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -772,10 +772,11 @@ module Arel # :nodoc: all
                 if value.empty?
                   collector << @connection.quote(nil)
                 else
-                  collector.add_binds(value, &bind_block)
+                  values = value.map { |v| @connection.cast_bound_value(v) }
+                  collector.add_binds(values, &bind_block)
                 end
               else
-                collector.add_bind(value, &bind_block)
+                collector.add_bind(@connection.cast_bound_value(value), &bind_block)
               end
             end
           end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -8,6 +8,31 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
     @conn = ActiveRecord::Base.connection
   end
 
+  def test_cast_bound_integer
+    assert_equal "42", @conn.cast_bound_value(42)
+  end
+
+  def test_cast_bound_big_decimal
+    assert_equal "4.2", @conn.cast_bound_value(BigDecimal("4.2"))
+  end
+
+  def test_cast_bound_rational
+    assert_equal "0.75", @conn.cast_bound_value(Rational(3, 4))
+  end
+
+  def test_cast_bound_duration
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.cast_bound_value(42.seconds) }
+    assert_equal "42", expected
+  end
+
+  def test_cast_bound_true
+    assert_equal "1", @conn.cast_bound_value(true)
+  end
+
+  def test_cast_bound_false
+    assert_equal "0", @conn.cast_bound_value(false)
+  end
+
   def test_quote_bound_integer
     assert_equal "'42'", @conn.quote_bound_value(42)
   end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -32,29 +32,4 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
   def test_cast_bound_false
     assert_equal "0", @conn.cast_bound_value(false)
   end
-
-  def test_quote_bound_integer
-    assert_equal "'42'", @conn.quote_bound_value(42)
-  end
-
-  def test_quote_bound_big_decimal
-    assert_equal "'4.2'", @conn.quote_bound_value(BigDecimal("4.2"))
-  end
-
-  def test_quote_bound_rational
-    assert_equal "'0.75'", @conn.quote_bound_value(Rational(3, 4))
-  end
-
-  def test_quote_bound_duration
-    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(42.seconds) }
-    assert_equal "'42'", expected
-  end
-
-  def test_quote_bound_true
-    assert_equal "'1'", @conn.quote_bound_value(true)
-  end
-
-  def test_quote_bound_false
-    assert_equal "'0'", @conn.quote_bound_value(false)
-  end
 end

--- a/activerecord/test/cases/arel/nodes/bound_sql_literal_test.rb
+++ b/activerecord/test/cases/arel/nodes/bound_sql_literal_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "yaml"
+
+module Arel
+  module Nodes
+    class BoundSqlLiteralTest < Arel::Spec
+      describe "equality" do
+        it "is equal with equal components" do
+          node1 = BoundSqlLiteral.new("foo + ?", [2], {})
+          node2 = BoundSqlLiteral.new("foo + ?", [2], {})
+
+          array = [node1, node2]
+
+          assert_equal 1, array.uniq.size
+        end
+
+        it "is not equal with different components" do
+          node1 = BoundSqlLiteral.new("foo + ?", [2], {})
+          node2 = BoundSqlLiteral.new("foo + ?", [3], {})
+          node3 = BoundSqlLiteral.new("foo + :bar", [], { bar: 2 })
+
+          array = [node1, node2, node3]
+
+          assert_equal 3, array.uniq.size
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -86,6 +86,10 @@ module FakeRecord
         "'#{thing.to_s.gsub("'", "\\\\'")}'"
       end
     end
+
+    def cast_bound_value(thing)
+      thing
+    end
   end
 
   class ConnectionPool

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -644,6 +644,36 @@ module Arel
         end
       end
 
+      describe "Nodes::BoundSqlLiteral" do
+        it "works with positional binds" do
+          node = Nodes::BoundSqlLiteral.new("id = ?", [1], {})
+          _(compile(node)).must_be_like %{
+            id = ?
+          }
+        end
+
+        it "works with named binds" do
+          node = Nodes::BoundSqlLiteral.new("id = :id", [], { id: 1 })
+          _(compile(node)).must_be_like %{
+            id = ?
+          }
+        end
+
+        it "works with mixed binds" do
+          node = Nodes::BoundSqlLiteral.new("id = ? AND name = :name", [1], { name: "Aaron" })
+          _(compile(node)).must_be_like %{
+            id = ? AND name = ?
+          }
+        end
+
+        it "works with array values" do
+          node = Nodes::BoundSqlLiteral.new("id IN (?)", [[1, 2, 3]], {})
+          _(compile(node)).must_be_like %{
+            id IN (?, ?, ?)
+          }
+        end
+      end
+
       describe "TableAlias" do
         it "should use the underlying table for checking columns" do
           test = Table.new(:users).alias("zomgusers")[:id].eq "3"

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -229,6 +229,20 @@ if ActiveRecord::Base.connection.prepared_statements
           authors = Author.where(id: [1, 2, 3, 9223372036854775808])
           assert_equal sql, @connection.to_sql(authors.arel)
           assert_sql(sql) { assert_equal 3, authors.length }
+
+          # prepared_statements: true
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (?, ?, ?)
+          #
+          # prepared_statements: false
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (1, 2, 3)
+          #
+          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})"
+
+          arel_node = Arel.sql("SELECT #{table}.* FROM #{table} WHERE #{pk} IN (?)", [1, 2, 3])
+          assert_equal sql, @connection.to_sql(arel_node)
+          assert_sql(sql) { assert_equal 3, @connection.select_all(arel_node).length }
         end
 
         def bind_params(ids)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -487,6 +487,21 @@ class RelationTest < ActiveRecord::TestCase
     assert_match(/field\(id, NULL\)/, query)
   end
 
+  def test_finding_with_arel_sql_order
+    query = Tag.order(Arel.sql("field(id, ?)", [1, 3, 2])).to_sql
+    if current_adapter?(:Mysql2Adapter)
+      assert_match(/field\(id, '1', '3', '2'\)/, query)
+    else
+      assert_match(/field\(id, 1, 3, 2\)/, query)
+    end
+
+    query = Tag.order(Arel.sql("field(id, ?)", [])).to_sql
+    assert_match(/field\(id, NULL\)/, query)
+
+    query = Tag.order(Arel.sql("field(id, ?)", nil)).to_sql
+    assert_match(/field\(id, NULL\)/, query)
+  end
+
   def test_finding_with_order_limit_and_offset
     entrants = Entrant.order("id ASC").limit(2).offset(1)
 


### PR DESCRIPTION
This keeps `Arel.sql(single_argument)` behaviour unchanged, but now also supports multi-argument invocations with `?` / `:foo` SQL placeholders, similar to `where`.

Co-authored-by: @codeminator 