### PR TITLE
Fix undefined attribute method with attr_readonly

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -324,7 +324,7 @@ module ActiveRecord
           persisted.map! do |record|
             if mem_record = memory.delete(record)
 
-              ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save).each do |name|
+              ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save - mem_record.class._attr_readonly).each do |name|
                 mem_record._write_attribute(name, record[name])
               end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -455,7 +455,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_readonly_attributes
-    assert_equal Set.new([ "name" ]), ReadonlyNameShip.readonly_attributes
+    assert_equal [ "name" ], ReadonlyNameShip.readonly_attributes
 
     s = ReadonlyNameShip.create(name: "unchangeable name")
     s.reload


### PR DESCRIPTION
### Motivation / Background

The problem is where an abstract class defines a readonly attribute. When another class subclasses that parent with
`raise_on_assign_to_attr_readonly`, it will define the readonly method before the abstract parent has defined its attributes. As a result, when those methods are defined, they will not define the readonly attribute writer, so that `super` called from the readonly accessor will fail with a `NoMethodError`.

### Detail

Instead of trying to make the overriden attribute method lazier by defining it after the real attribute method has been defined, this commit changes the method override to be one layer down on _write_attribute. This avoids the issue of the attribute method being undefined because the real _write_attribute will always be defined.

### Additional information

Closes #46598

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>
Co-authored-by: Chris Salzberg <chris.salzberg@shopify.com>

cc @rafaelfranca @shioyama @adrianna-chang-shopify 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

