### PR TITLE
Add `perform_all_later` to enqueue multiple jobs at once

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `perform_all_later` to enqueue multiple jobs at once
+
+    This adds the ability to bulk enqueue jobs, without running callbacks, by
+    passing multiple jobs or an array of jobs. For example:
+
+    ```ruby
+    ActiveJob.perform_all_later(MyJob.new("hello", 42), MyJob.new("world", 0))
+
+    user_jobs = User.pluck(:id).map { |id| UserJob.new(user_id: id) }
+    ActiveJob.perform_all_later(user_jobs)
+    ```
+
+    This can greatly reduce the number of round-trips to the queue datastore.
+    For queue adapters that do not implement the new `enqueue_all` method, we
+    fall back to enqueuing jobs indvidually. The Sidekiq adapter implements
+    `enqueue_all` with `push_bulk`.
+
+    This method does not use the existing `enqueue.active_job` event, but adds a
+    new event `enqueue_all.active_job`.
+
+    *Sander Verdonschot*
+
 *   Don't double log the `job` when using `ActiveRecord::QueryLog`
 
     Previously if you set `config.active_record.query_log_tags` to an array that included

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -14,5 +14,9 @@ module ActiveJob
     def perform_later(...)
       @job_class.new(...).enqueue @options
     end
+
+    def perform_all_later(multi_args)
+      @job_class.perform_all_later(multi_args, options: @options)
+    end
   end
 end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -9,6 +9,35 @@ module ActiveJob
   # why the adapter was unexpectedly unable to enqueue a job.
   class EnqueueError < StandardError; end
 
+  class << self
+    # Push many jobs onto the queue at once without running enqueue callbacks.
+    # Queue adapters may communicate the enqueue status of each job by setting
+    # successfully_enqueued and/or enqueue_error on the passed-in job instances.
+    def perform_all_later(*jobs)
+      jobs.flatten!
+      jobs.group_by(&:queue_adapter).each do |queue_adapter, adapter_jobs|
+        instrument_enqueue_all(queue_adapter, adapter_jobs) do
+          if queue_adapter.respond_to?(:enqueue_all)
+            queue_adapter.enqueue_all(adapter_jobs)
+          else
+            adapter_jobs.each do |job|
+              job.successfully_enqueued = false
+              if job.scheduled_at
+                queue_adapter.enqueue_at(job, job.scheduled_at)
+              else
+                queue_adapter.enqueue(job)
+              end
+              job.successfully_enqueued = true
+            rescue EnqueueError => e
+              job.enqueue_error = e
+            end
+          end
+        end
+      end
+      nil
+    end
+  end
+
   module Enqueuing
     extend ActiveSupport::Concern
 

--- a/activejob/lib/active_job/instrumentation.rb
+++ b/activejob/lib/active_job/instrumentation.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 module ActiveJob
+  class << self
+    private
+      def instrument_enqueue_all(queue_adapter, jobs)
+        payload = { adapter: queue_adapter, jobs: jobs }
+        ActiveSupport::Notifications.instrument("enqueue_all.active_job", payload) do
+          result = yield payload
+          payload[:enqueued_count] = result
+          result
+        end
+      end
+  end
+
   module Instrumentation # :nodoc:
     extend ActiveSupport::Concern
 

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -77,6 +77,16 @@ class QueuingTest < ActiveSupport::TestCase
     skip
   end
 
+  test "should run job bulk enqueued in the future at the specified time" do
+    ActiveJob.perform_all_later([TestJob.new(@id).set(wait: 5.seconds)])
+    wait_for_jobs_to_finish_for(2.seconds)
+    assert_job_not_executed
+    wait_for_jobs_to_finish_for(10.seconds)
+    assert_job_executed
+  rescue NotImplementedError
+    skip
+  end
+
   test "should supply a provider_job_id when available for immediate jobs" do
     skip unless adapter_is?(:async, :delayed_job, :sidekiq, :queue_classic)
     test_job = TestJob.perform_later @id


### PR DESCRIPTION
### Motivation / Background

Sidekiq has a useful optimisation called `push_bulk` that enqueues many jobs at once, eliminating the repeated Redis roundtrips. However, this feature is not exposed through Active Job, so it only works for `Sidekiq::Worker` jobs. This adds a barrier to Active Job adoption for apps that rely on this feature. It also makes it harder for other queue adapters to implement similar functionality, as they then have to take care of serialization, callbacks, etc. themselves.

### Detail

This PR adds `ActiveJob.perform_all_later([<job 1>, <job2>])`, backed by Sidekiq's `push_bulk` and with a fallback to enqueuing serially if the queue adapter does not support bulk enqueue.

#### Arguments

It's hard to support the full diversity of ways a Ruby method can be called with a simple array. In particular, jobs with a mix of positional and keyword arguments are difficult to distinguish from jobs with positional arguments that include a hash. Sidekiq gets around this by not supporting keyword arguments.

While it is possible to support everything by treating the last hash in the array of arguments as keywords and requiring jobs with a hash as last positional argument to include an additional empty hash of keyword arguments, based on feedback on the PR, we chose to pass instantiated jobs, so we can let Ruby handle all these complexities.

#### Delay

Passing in instantiated jobs also makes it easy for the user to specify delays for each job:

```ruby
user_jobs = users.map.with_index do |user, user_index|
  UserJob.new(user).set(wait: user_index.seconds)
end
ActiveJob.perform_all_later(user_jobs)
```

<!-- out-of-date, keeping here for context
Sidekiq supports enqueuing the jobs with a delay, either all with the same delay, or each with a different delay. In order to reduce the scope of this PR, I decided to only support direct enqueues for now. We can always add support for delay once this is merged.
-->

#### Return value

The return value of `perform_all_later` is limited by Sidekiq's current behaviour. `push_bulk` returns the (provider) ids of all jobs that were successfully enqueued. This means that if we try to enqueue 2 jobs, we may get back a single id with no way of knowing which job it belongs to, so we can't even map it back to Active Job's job ids. I chose to return the number of successfully enqueued jobs, but it may be better to always return `true` for now, so that we can more easily change it later? In an ideal world, I think the return value would be an array of either the job or `false`, to mirror the return value of `perform_later`.

#### Callbacks

Based on feedback in this PR, `perform_all_later` does not run any callbacks. This is in line with the Active Record bulk methods, so it shouldn't be too surprising to users and it is clearly stated in the documentation.

There are several issues with running callbacks:

- I don't see a good way to run `around_enqueue` callbacks for each job in a way that the callback begins before the job is enqueued and ends after. Running them another way breaks the assumptions and gives strange results, for instance for Active Job's own enqueue instrumentation.
- The callbacks run on individual jobs, so they can't take advantage of the bulk nature of this method. This could lead to N+1 queries and greatly slow down what is meant to be a performance optimization.

<!-- out-of-date, keeping here for context
I chose to run `before_enqueue` and `after_enqueue` callbacks on all jobs individually. We can't properly run `around_enqueue` callbacks (they would end before the job was actually enqueued), so the docs mention that those don't run.

This is a compromise between not running any callbacks (like the Active Record bulk updates, but which reduces the usefulness) and trying to run all callbacks, which would break expectations with respect to the `around_enqueue` callbacks.
-->

<!-- out-of-date, keeping here for context
There is a subtle difference in callback behaviour between a direct enqueue and a bulk enqueue. As we want to pass an array of jobs to the queue adapter, we have to run any callbacks that can prevent the job from being enqueued while constructing the array. This means that `around_enqueue` callbacks finish before the job is actually enqueued. (We run `after_enqueue` callbacks separately after the actual bulk enqueue, so those do not experience this problem.)

To align with the expectations of non-bulk enqueueing, we also serialize the job within the `around_enqueue` callback, before passing the jobs to the queue adapter. Not doing this could lead to very subtle bugs where a job serializes successfully on its own, but not in bulk, because it relies on some global state (for example a current user or database connection) being set by an `around_enqueue` callback.
-->

#### Batching

Sidekiq recommends batches of no more than 1000 jobs, and their newer bulk API `perform_bulk` will automatically break them up into batches of that size if you pass a larger array. As recommended batch sizes will vary between back-ends, I'm not sure if this should be something that Active Job handles as opposed to the adapter, although we could make it configurable. This is also easy to add later.

### Additional information

The performance benefit for 1000 jobs can be more than an order of magnitude:

| Enqueue type       | Serial time (ms) | Bulk time (ms) | Speedup |
| ------------------ | ---------------- | -------------- | ------- |
| Raw Sidekiq        |             2661 |            119 |     22x |
| Active Job Sidekiq |             2853 |            208 |     14x |

(Measured in a simple test app in our production environment.)

See also https://github.com/rails/rails/pull/39499 which was a previous stab at this and where I stole the name from (🙇 @vinistock).

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] CI is passing.

