### PR TITLE
Extract `#sync_timezone_changes` method in AbstractMysqlAdapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Extract `#sync_timezone_changes` method in AbstractMysqlAdapter to enable subclasses
+    to sync database timezone changes without overriding `#raw_execute`.
+
+    *Adrianna Chang*, *Paarth Madan*
+
 *   Do not write additional new lines when dumping sql migration versions
 
     This change updates the `insert_versions_sql` function so that the database insert string containing the current database migration versions does not end with two additional new lines.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -731,9 +731,15 @@ module ActiveRecord
 
           log(sql, name, async: async) do
             with_raw_connection(allow_retry: allow_retry, uses_transaction: uses_transaction) do |conn|
+              sync_timezone_changes(conn)
               conn.query(sql)
             end
           end
+        end
+
+        # Make sure we carry over any changes to ActiveRecord.default_timezone that have been
+        # made since we established the connection
+        def sync_timezone_changes(raw_connection)
         end
 
         def internal_execute(sql, name = "SCHEMA", allow_retry: true, uses_transaction: false)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -314,6 +314,14 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
+  def test_database_timezone_changes_synced_to_connection
+    with_timezone_config default: :local do
+      assert_changes(-> { @conn.raw_connection.query_options[:database_timezone] }, from: :utc, to: :local) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
   private
     def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)
       super(@conn, "ex", definition, &block)


### PR DESCRIPTION
### Motivation / Background

This enables subclasses to sync database timezone changes without overriding `#raw_execute`, which removes the need to redefine `#raw_execute` in the `Mysql2Adapter` and other adapters subclassing `AbstractMysqlAdapter` (the Trilogy adapter is doing something similar [here](https://github.com/github/activerecord-trilogy-adapter/blob/000ed42f5023e447b2c28e970fcd1fbac325232c/lib/active_record/connection_adapters/trilogy_adapter.rb#L162-L166)).

Some extra background: We're making some changes to `#raw_execute`, and we were hoping to have to only make them in the `AbstractMysqlAdapter` class instead of in multiple places (The abstract class, the version of `#raw_execute` that Mysql2 uses, and then also in the Trilogy adapter). When looking into these methods, we realized that they're all virtually identical except for the database syncing logic, so it seemed reasonable to pull it out and allow the adapters to share the common logic.

### Detail

Extract private `#sync_timezone_changes` method that adapters can use to specialize the logic needed to sync database changes. This is a non-breaking change, since adapters can continue to override `#raw_execute` if they'd like without being impacted.

We've added a test to assert on the timezone syncing behaviour since that appears to not currently be tested. We also added an entry to the CHANGELOG since this does technically impact AbstractMysqlAdapter subclasses, but we can remove it if this addition isn't significant enough.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [X] CI is passing.

