### PR TITLE
More detailed error message for `compute_class` errors

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -423,22 +423,16 @@ module ActiveRecord
           raise ArgumentError, "Polymorphic associations do not support computing the class."
         end
 
-        msg = <<-MSG.squish
-          Rails couldn't find a valid model for #{name} association.
-          Please provide the :class_name option on the association declaration.
-          If :class_name is already provided, make sure it's an ActiveRecord::Base subclass.
-        MSG
-
         begin
           klass = active_record.send(:compute_type, name)
 
           unless klass < ActiveRecord::Base
-            raise ArgumentError, msg
+            raise ArgumentError, compute_class_error_message(klass)
           end
 
           klass
         rescue NameError
-          raise NameError, msg
+          raise ArgumentError, compute_class_error_message
         end
       end
 
@@ -605,6 +599,16 @@ module ActiveRecord
       end
 
       private
+        def compute_class_error_message(klass = nil)
+          msg = +"Rails couldn't find a valid model for the #{name} association. "
+          if !options[:class_name]
+            msg << "Use the :class_name option on the association declaration to tell Rails which model to use."
+          else
+            msg << "Ensure the class provided to :class_name exists and is an ActiveRecord::Base subclass."
+          end
+          msg
+        end
+
         # Attempts to find the inverse association name automatically.
         # If it cannot find a suitable inverse association name, it returns
         # +nil+.

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -417,15 +417,15 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_associations_raise_with_name_error_if_associated_to_classes_that_do_not_exist
-    assert_raises NameError do
+    assert_raises ArgumentError do
       ModelAssociatedToClassesThatDoNotExist.new.non_existent_has_one_class
     end
 
-    assert_raises NameError do
+    assert_raises ArgumentError do
       ModelAssociatedToClassesThatDoNotExist.new.non_existent_belongs_to_class
     end
 
-    assert_raises NameError do
+    assert_raises ArgumentError do
       ModelAssociatedToClassesThatDoNotExist.new.non_existent_has_many_classes
     end
   end

--- a/activerecord/test/models/user_with_invalid_relation.rb
+++ b/activerecord/test/models/user_with_invalid_relation.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class UserWithInvalidRelation < ActiveRecord::Base
-  has_one :account_invalid
+  has_one :account_invalid_no_class_name_option
 
   has_one :account_class_name, class_name: "AccountInvalid"
+
+  has_one :class_name_provided_not_a_class, class_name: "NotAClass"
 
   has_many :user_info_invalid
   has_many :info_invalids, through: :user_info_invalid


### PR DESCRIPTION
### Motivation / Background

ref: https://github.com/rails/rails/pull/46560#discussion_r1030718963

As suggested by @matthewd, this PR makes `compute_class` error message smarter based on how the association is set up. The message will now differ based on if a `class_name` option is provided to the association.

### Detail

I changed the error raised from a `NameError` to an `ArgumentError` as that is arguably more relevant here, and it also means we aren't throwing two types of errors in fairly similar circumstances. Incidentally this also makes the testing simpler.

### Additional information

This issue inspired the initial work, though I'm not sure this PR fixes it. https://github.com/rails/rails/issues/46532

See also these PRs that originally added and expanded the error message:

- https://github.com/rails/rails/pull/42124
- https://github.com/rails/rails/pull/40836

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

