### PR TITLE
Memoize the value of show_exceptions?

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -180,10 +180,6 @@ module ActionDispatch
       get_header "action_dispatch.http_auth_salt"
     end
 
-    def show_exceptions? # :nodoc:
-      get_header("action_dispatch.show_exceptions")
-    end
-
     # Returns a symbol form of the #request_method.
     def request_method_symbol
       HTTP_METHOD_LOOKUP[request_method]

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -181,10 +181,7 @@ module ActionDispatch
     end
 
     def show_exceptions? # :nodoc:
-      # We're treating `nil` as "unset", and we want the default setting to be
-      # `true`. This logic should be extracted to `env_config` and calculated
-      # once.
-      !(get_header("action_dispatch.show_exceptions") == false)
+      get_header("action_dispatch.show_exceptions")
     end
 
     # Returns a symbol form of the #request_method.

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -16,11 +16,12 @@ module ActionDispatch
       interceptors << interceptor
     end
 
-    def initialize(app, routes_app = nil, response_format = :default, interceptors = self.class.interceptors)
+    def initialize(app, routes_app = nil, response_format = :default, interceptors = self.class.interceptors, show_exceptions: true)
       @app             = app
       @routes_app      = routes_app
       @response_format = response_format
       @interceptors    = interceptors
+      @show_exceptions = show_exceptions != false
     end
 
     def call(env)
@@ -38,7 +39,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
 
       invoke_interceptors(request, exception, wrapper)
-      raise exception unless request.show_exceptions?
+      raise exception unless @show_exception
       render_exception(request, exception, wrapper)
     end
 

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -16,16 +16,17 @@ module ActionDispatch
   # If any exception happens inside the exceptions app, this middleware
   # catches the exceptions and returns a failsafe response.
   class ShowExceptions
-    def initialize(app, exceptions_app)
+    def initialize(app, exceptions_app, show_exceptions: true)
       @app = app
       @exceptions_app = exceptions_app
+      @show_exceptions = show_exceptions != false
     end
 
     def call(env)
       request = ActionDispatch::Request.new env
       @app.call(env)
     rescue Exception => exception
-      if request.show_exceptions?
+      if @show_exceptions
         render_exception(request, exception)
       else
         raise exception

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -304,7 +304,7 @@ module Rails
           "action_dispatch.parameter_filter" => filter_parameters,
           "action_dispatch.redirect_filter" => config.filter_redirect,
           "action_dispatch.secret_key_base" => secret_key_base,
-          "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
+          "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions != false,
           "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,
           "action_dispatch.log_rescued_responses" => config.action_dispatch.log_rescued_responses,
           "action_dispatch.logger" => Rails.logger,

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -49,8 +49,8 @@ module Rails
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           middleware.use ::Rails::Rack::Logger, config.log_tags
-          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
-          middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
+          middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app, show_exceptions: config.action_dispatch.show_exceptions
+          middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format, show_exceptions: config.action_dispatch.show_exceptions
 
           if config.consider_all_requests_local
             middleware.use ::ActionDispatch::ActionableExceptions

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1463,33 +1463,6 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_open_redirects
     end
 
-    test "config.action_dispatch.show_exceptions is true for all values except false" do
-      make_basic_app do |application|
-        application.config.action_dispatch.show_exceptions = true
-      end
-
-      class ::OmgController < ActionController::Base
-        def index
-          render plain: request.show_exceptions?
-        end
-      end
-
-      get "/"
-      assert_equal "true", last_response.body
-
-      Rails.configuration.action_dispatch.show_exceptions = false
-      Rails.application.instance_variable_set(:@app_env_config, nil)
-
-      get "/"
-      assert_equal "false", last_response.body
-
-      Rails.configuration.action_dispatch.show_exceptions = nil
-      Rails.application.instance_variable_set(:@app_env_config, nil)
-
-      get "/"
-      assert_equal "true", last_response.body
-    end
-
     test "config.action_controller.wrap_parameters is set in ActionController::Base" do
       app_file "config/initializers/wrap_parameters.rb", <<-RUBY
         ActionController::Base.wrap_parameters format: [:json]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1463,16 +1463,28 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_open_redirects
     end
 
-    test "config.action_dispatch.show_exceptions is sent in env" do
+    test "config.action_dispatch.show_exceptions is true for all values except false" do
       make_basic_app do |application|
         application.config.action_dispatch.show_exceptions = true
       end
 
       class ::OmgController < ActionController::Base
         def index
-          render plain: request.env["action_dispatch.show_exceptions"]
+          render plain: request.show_exceptions?
         end
       end
+
+      get "/"
+      assert_equal "true", last_response.body
+
+      Rails.configuration.action_dispatch.show_exceptions = false
+      Rails.application.instance_variable_set(:@app_env_config, nil)
+
+      get "/"
+      assert_equal "false", last_response.body
+
+      Rails.configuration.action_dispatch.show_exceptions = nil
+      Rails.application.instance_variable_set(:@app_env_config, nil)
 
       get "/"
       assert_equal "true", last_response.body


### PR DESCRIPTION
### Motivation / Background

Previously, the value of `action_dispatch.show_exceptions` would be compared with `false` every time `show_exceptions?` is called. As described in the previous comment, the purpose of the comparison is to treat a `nil` configuration as `true`.

### Detail

This commit does what the rest of the comment suggests, which is to move the comparison into `env_config` so that `show_exceptions?` just looks up the value stored in `env` and doesn't have to do any comparisons.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

