### PR TITLE
Add ability to match exception messages to `assert_raises` assertion

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Add ability to match exception messages to `assert_raises` assertion
+
+    Instead of this
+    ```ruby
+    error = assert_raises(ArgumentError) do
+      perform_service(param: 'exception')
+    end
+    assert_match(/incorrect param/i, error.message)
+    ```
+
+    you can now write this
+    ```ruby
+    assert_raises(ArgumentError, match: /incorrect param/i) do
+      perform_service(param: 'exception')
+    end
+    ```
+
+    *fatkodima*
+
 *   Add `Rails.env.local?` shorthand for `Rails.env.development? || Rails.env.test?`.
 
     *DHH*

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -23,6 +23,19 @@ module ActiveSupport
         assert !object, message
       end
 
+      # Asserts that a block raises one of <tt>exp</tt>. This is an enhancement of the
+      # standard Minitest assertion method with the ability to test error messages.
+      #
+      #   assert_raises(ArgumentError, match: /incorrect param/i) do
+      #     perform_service(param: 'exception')
+      #   end
+      #
+      def assert_raises(*exp, match: nil, &block)
+        error = super(*exp, &block)
+        assert_match(match, error.message) if match
+        error
+      end
+
       # Assertion that the block should not raise an exception.
       #
       # Passes if evaluated code in the yielded block raises no exception.

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -28,6 +28,20 @@ class AssertionsTest < ActiveSupport::TestCase
     assert_equal "custom", e.message
   end
 
+  def test_assert_raises_with_match_pass
+    assert_raises(ArgumentError, match: /incorrect/i) do
+      raise ArgumentError, "Incorrect argument"
+    end
+  end
+
+  def test_assert_raises_with_match_fail
+    assert_raises(Minitest::Assertion, match: "Expected /incorrect/i to match \"Wrong argument\".") do
+      assert_raises(ArgumentError, match: /incorrect/i) do
+        raise ArgumentError, "Wrong argument"
+      end
+    end
+  end
+
   def test_assert_no_difference_pass
     assert_no_difference "@object.num" do
       # ...


### PR DESCRIPTION
Instead of this
```ruby
error = assert_raises(SomeError) do
  do_something
end
assert_equal "Some error message", error.message
```

it is now possible to write this
```ruby
assert_raises(SomeError, match: "Some error message") do # or using a regexp
  do_something
end
```

It is a very popular pattern in tests. I found 373 matches of it in the Rails itself.
There are even 2 implementations of the similar helper in the codebase: https://github.com/rails/rails/blob/12ae2e2e648dc4c26da777e7809504a8d2cde962/activerecord/test/cases/finder_test.rb#L1743 and https://github.com/rails/rails/blob/12ae2e2e648dc4c26da777e7809504a8d2cde962/activesupport/test/core_ext/object/json_gem_encoding_test.rb#L64

This change will also help to avoid a common pitfall when people pass the last argument (as a string/regexp) to `assert_raises` thinking that it will be matched against the error too. There is even a rubocop cop for this - https://github.com/rubocop/rubocop-minitest/blob/master/lib/rubocop/cop/minitest/assert_raises_with_regexp_argument.rb. Personally, I was in this trap several times.

Relevant discussion - https://discuss.rubyonrails.org/t/add-assert-raises-with-message-testing-helper/81831.

cc @byroot 