### PR TITLE
Peek before attempting to deserialize `ActiveSupport::Messages::Metadata` with JSON

### DIFF
--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -37,7 +37,10 @@ module ActiveSupport
           end
 
           def extract_metadata(message)
-            data = JSON.decode(message) rescue nil
+            begin
+              data = JSON.decode(message) if message.start_with?("{")
+            rescue ::JSON::JSONError
+            end
 
             if data.is_a?(Hash) && data.key?("_rails")
               new(decode(data["_rails"]["message"]), data["_rails"]["exp"], data["_rails"]["pur"])


### PR DESCRIPTION
### Motivation / Background

When verifying the signature of a message, we noticed 22ms overhead on each request when attempting to decode message metadata. In our case, we use `Marshal` to serialize the message (since we need 8bit encoding for the string). Since we are using `Marshal` and attempting to decode in `JSON`, an exception will be raised every time a message is decoded... which causes the overhead.

![speedscope](https://screenshot.click/Screenshot_2022-11-29_at_12.50.29_PM.png)


### Detail

This PR is mostly an RFC... it avoids the exceptions here by peeking to see if the message starts with `{`. The real fix here is probably to make `Metadata` aware of the serializer, but wanted to get some feedback before committing to that approach.


### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

