### PR TITLE
Fix: Strict Loading error after initializing association owner with primary key

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -119,7 +119,7 @@ module ActiveRecord
       def concat(*records)
         records = records.flatten
         if owner.new_record?
-          load_target
+          loaded!
           concat_records(records)
         else
           transaction { concat_records(records) }

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -478,7 +478,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     new_tag = Tag.new(name: "new")
 
     saved_post.tags << new_tag
-    assert new_tag.persisted? # consistent with habtm!
+    assert_predicate new_tag, :persisted? # consistent with habtm!
     assert_predicate saved_post, :persisted?
     assert_includes saved_post.tags, new_tag
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -157,16 +157,20 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
   def test_push_does_not_lose_additions_to_new_record
     josh = Author.new(name: "Josh")
-    josh.posts << Post.new(title: "New on Edge", body: "More cool stuff!")
+    new_post = Post.new(title: "New on Edge", body: "More cool stuff!")
+    josh.posts << new_post
     assert_predicate josh.posts, :loaded?
     assert_equal 1, josh.posts.size
+    assert_includes josh.posts, new_post
   end
 
   def test_append_behaves_like_push
     josh = Author.new(name: "Josh")
-    josh.posts.append Post.new(title: "New on Edge", body: "More cool stuff!")
+    new_post = Post.new(title: "New on Edge", body: "More cool stuff!")
+    josh.posts.append new_post
     assert_predicate josh.posts, :loaded?
     assert_equal 1, josh.posts.size
+    assert_includes josh.posts, new_post
   end
 
   def test_prepend_is_not_defined

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -162,6 +162,33 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_on_concat_is_ignored
+    developer = Developer.first
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs << AuditLog.new(message: "message")
+    end
+  end
+
+  def test_strict_loading_with_new_record_on_concat_is_ignored
+    developer = Developer.new(id: Developer.first.id)
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs << AuditLog.new(message: "message")
+    end
+  end
+
+  def test_strict_loading_with_new_record_on_build_is_ignored
+    developer = Developer.new(id: Developer.first.id)
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs.build(message: "message")
+    end
+  end
+
   def test_strict_loading_has_one_reload
     with_strict_loading_by_default(Developer) do
       ship = Ship.create!(developer: Developer.first, name: "The Great Ship")


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46392

See inline comments for explanation of the change.