### PR TITLE
Add `#<<` alias for `#write` to ActionDispatch::Response::Buffer

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -126,6 +126,7 @@ module ActionDispatch # :nodoc:
         @response.commit!
         @buf.push string
       end
+      alias_method :<<, :write
 
       def each(&block)
         if @str_body


### PR DESCRIPTION
### Motivation / Background

This makes the stream object a closer analog of an `IO`. Some code, like Ruby's built-in `CSV` (https://github.com/ruby/ruby/blob/master/lib/csv/writer.rb#L56), will always try to use `#<<` when writing.

I previously used this workaround in an ActionController::Live action:
```ruby
response.stream.singleton_class.class_eval do alias_method :<<, :write end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

