### PR TITLE
Return a copy of the source string when transliterating

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -65,8 +65,8 @@ module ActiveSupport
       raise ArgumentError, "Can only transliterate strings. Received #{string.class.name}" unless string.is_a?(String)
       raise ArgumentError, "Cannot transliterate strings with #{string.encoding} encoding" unless ALLOWED_ENCODINGS_FOR_TRANSLITERATE.include?(string.encoding)
 
+      return string.dup if string.ascii_only?
       string = string.dup if string.frozen?
-      return string if string.ascii_only?
 
       input_encoding = string.encoding
 

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -106,4 +106,11 @@ class TransliterateTest < ActiveSupport::TestCase
     string = String.new("\255", encoding: Encoding::GB18030).freeze
     assert_equal "?", ActiveSupport::Inflector.transliterate(string)
   end
+
+  def test_transliterate_returns_a_copy_of_ascii_strings
+    string = "Test String".dup
+    assert_not string.frozen?
+    assert string.ascii_only?
+    assert_not_equal string.object_id, ActiveSupport::Inflector.transliterate(string).object_id
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because a recent change in rails/rails caused unexpected string mutations when parameterizing strings.

### Detail

This Pull Request changes `ActiveSupport::Inflector#transliterate` to return a copy of the string argument when it early-returns an `ascii_only?` string.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

The behavior was introduced in https://github.com/rails/rails/pull/46586 and we were able to reproduce the behavior in this code:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.text :name
    t.text :slug
  end
end

class Post < ActiveRecord::Base
  validate :generate_slug

  def generate_slug
    self.slug = name.parameterize
  end
end

class BugTest < Minitest::Test
  def test_name_gets_corrupted
    post = Post.create!(name: "hi there")

    assert_equal "hi there", post.name # This test fails, "hi-there"
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

