### PR TITLE
Remove unnecessary isolation_level setting from load_defaults 7.0

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -106,7 +106,6 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.cache_format_version`](#config-active-support-cache-format-version): `7.0`
 - [`config.active_support.executor_around_test_case`](#config-active-support-executor-around-test-case): `true`
 - [`config.active_support.hash_digest_class`](#config-active-support-hash-digest-class): `OpenSSL::Digest::SHA256`
-- [`config.active_support.isolation_level`](#config-active-support-isolation-level): `:thread`
 - [`config.active_support.key_generator_hash_digest_class`](#config-active-support-key-generator-hash-digest-class): `OpenSSL::Digest::SHA256`
 
 #### Default Values for Target Version 6.1

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -239,7 +239,6 @@ module Rails
             active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
             active_support.cache_format_version = 7.0
             active_support.executor_around_test_case = true
-            active_support.isolation_level = :thread
           end
 
           if respond_to?(:action_mailer)


### PR DESCRIPTION
### Motivation / Background

The default value of `ActiveSupport::IsolatedExecutionState.isolation_level` is set to `:thread`, regardless of whether `load_defaults 7.0` is used or not.

- https://github.com/rails/rails/blob/v7.0.4/activesupport/lib/active_support/isolated_execution_state.rb

If so, there is no need to set this in `load_defaults 7.0`. This Pull Request has been created to remove this unnecessary setting.

Or if there is any reason to set this in `load_defaults 7.0`, I would like to know that.

### Detail

This Pull Request simply removes this setting.

### Additional information

I confirmed that `ActiveSupport::IsolatedExecutionState.isolation_level` returns `:thread` on Rails 7.0.4 with `load_defaults 6.1`.

```
$ bin/rails c -e test
Loading test environment (Rails 7.0.4)
irb: warn: can't alias context from irb_context.
irb(main):001:0> ActiveSupport::IsolatedExecutionState.isolation_level
=> :thread
irb(main):002:0> exit
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

