### PR TITLE
Allow disabling error markup generation on a per-field basis

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Error markup generation can now be disabled on a per-field basis.
+
+    Rails wraps form inputs in a `<div class="field_with_errors">` if
+    the associated active record field is invalid. This is not always
+    desirable, and can only be customized application-wide by setting
+    ActionView::Base.field_error_proc.
+
+    Now developers can opt out of the default behavior on a per-field
+    basis by passing `generate_error_markup: false` to form helpers, eg:
+
+    ```erb
+    <%= form_with(model: user) do |f|
+      <%= f.text_field(:name, generate_error_markup: false)
+    <% end %>
+    ```
+
+    *Cameron Dutro*
+
 *   Choices of `select` can optionally contain html attributes as the last element
     of the child arrays when using grouped/nested collections
 

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -13,7 +13,9 @@ module ActionView
         end
 
         def render
-          error_wrapping(datetime_selector(@options, @html_options).public_send("select_#{select_type}").html_safe)
+          error_wrapping(@options) do
+            datetime_selector(@options, @html_options).public_send("select_#{select_type}").html_safe
+          end
         end
 
         class << self

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -169,4 +169,11 @@ class ActiveModelHelperTest < ActionView::TestCase
   ensure
     ActionView::Base.field_error_proc = old_proc if old_proc
   end
+
+  def test_field_does_not_render_error_markup_if_option_is_passed
+    assert_dom_equal(
+      %(<input id="post_author_name" name="post[author_name]" type="text" value="" />),
+      text_field("post", "author_name", generate_error_markup: false)
+    )
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I'm working on a forms framework on the Primer team at GitHub that allows rendering forms declaratively. My pair and I noticed today that Rails will wrap invalid inputs and labels with a `<div>` containing a class of `field_with_errors`, ostensibly allowing for custom styling of invalid fields. We also learned this behavior can be customized by setting the application-level `ActionView::Base.field_error_proc` option.

Our framework automatically handles styling invalid fields in accordance with our design system. The additional wrapper `<div>`, while something we can work around, unexpectedly led to a visual regression today in our testing.

### Detail

My pair and I were unable to find any field-level option to disable wrapping, so I have submitted this PR. You can now pass  `generate_error_markup: false` to form helpers to skip wrapping fields with the aforementioned `<div>`:

```erb
<%= form_with(model: user) do |f| %>
  <%= f.text_field(:name, generate_error_markup: false) %>
<% end %>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

