### PR TITLE
Add matcher support to `assert_enqueued_email_with`

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Accept procs for args and params in `assert_enqueued_email_with`
+
+    ```ruby
+    assert_enqueued_email_with DeliveryJob, params: -> p { p[:token] =~ /\w+/ } do
+      UserMailer.with(token: user.generate_token).email_verification.deliver_later
+    end
+    ```
+
+    *Max Chernyak*
+
 *   Added `*_deliver` callbacks to `ActionMailer::Base` that wrap mail message delivery.
 
     Example:

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -488,6 +488,62 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
+  def test_assert_enqueued_email_with_supports_params_matcher_proc
+    mail_params = { all: "good" }
+
+    silence_stream($stdout) do
+      TestHelperMailer.with(mail_params).test_parameter_args.deliver_later
+    end
+
+    matcher_params = nil
+
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_parameter_args, params: ->(params) { matcher_params = params }
+    end
+
+    assert_equal mail_params, matcher_params
+
+    assert_raises ActiveSupport::TestCase::Assertion do
+      assert_enqueued_email_with TestHelperMailer, :test_parameter_args, params: ->(_) { false }
+    end
+  end
+
+  def test_assert_enqueued_email_with_supports_args_matcher_proc
+    mail_args = ["some_email", "some_name"]
+
+    silence_stream($stdout) do
+      TestHelperMailer.test_args(*mail_args).deliver_later
+    end
+
+    matcher_args = nil
+
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_args, args: ->(args) { matcher_args = args }
+    end
+
+    assert_equal mail_args, matcher_args
+
+    assert_raises ActiveSupport::TestCase::Assertion do
+      assert_enqueued_email_with TestHelperMailer, :test_args, args: ->(_) { false }
+    end
+  end
+
+  def test_assert_enqueued_email_with_supports_named_args_matcher_proc
+    mail_args = [{ email: "some_email", name: "some_name" }]
+
+    silence_stream($stdout) do
+      TestHelperMailer.test_named_args(**mail_args[0]).deliver_later
+    end
+
+    matcher_args = nil
+
+    assert_nothing_raised do
+      assert_enqueued_email_with TestHelperMailer, :test_named_args, args: ->(args) { matcher_args = args }
+    end
+
+    assert_equal mail_args, matcher_args
+  end
+
   def test_deliver_enqueued_emails_with_no_block
     assert_nothing_raised do
       silence_stream($stdout) do


### PR DESCRIPTION
### Motivation / Background

Currently `assert_enqueued_with` allows you to pass procs for matching `args`.

However, `assert_enqueued_email_with` doesn't let you do that for `args` and `params`.

I propose that we should.

For example, if you are passing a generated token to an email, you would have to mock/stub your way to verify that it looks right in job args. Or you have to reach for the lower level `assert_enqueued_with` helper. With this change you could simply do something like this:

```ruby
assert_enqueued_email_with UserMailer, :verification, params: -> p { p[:token] =~ /\w+/ }
```

Fixes #46621.

### Detail

Since `assert_enqueued_email_with` tries to be clever about figuring out whether `args` are `params`, I decided to leave that logic completely intact (to preserve current behavior), and add another conditional branch which only kicks in if either args or params are a proc. In such a case, it never acts clever about args/params, and simply passes down a lambda that fails if any job args don't match, and succeeds if they do.

**One unrelated question**: why are we [currently overwriting](https://github.com/rails/rails/blob/main/actionmailer/lib/action_mailer/test_helper.rb#L153) the passed-in params? Is that a bug?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.
