### PR TITLE
Allow `f.select` to be called with a single hash containing options and HTML options

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,22 @@
-*   Datatime form helpers (`time_field`, `date_field`, `datetime_field`, `week_field`, `month_field`) now accept an instance of Time/Date/DateTime as `:value` option.
+*   `select` can now be called with a single hash containing options and some HTML options
+
+    Previously this would not work as expected:
+
+    ```erb
+    <%= select :post, :author, authors, required: true %>
+    ```
+
+    Instead you needed to do this:
+
+    ```erb
+    <%= select :post, :author, authors, {}, required: true %>
+    ```
+
+    Now, either form is accepted, for the following HTML attributes: `required`, `multiple`, `size`.
+
+    *Alex Ghiculescu*
+
+*   Datetime form helpers (`time_field`, `date_field`, `datetime_field`, `week_field`, `month_field`) now accept an instance of Time/Date/DateTime as `:value` option.
 
     Before:
     ```erb

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -122,6 +122,10 @@ module ActionView
 
           def select_content_tag(option_tags, options, html_options)
             html_options = html_options.stringify_keys
+            [:required, :multiple, :size].each do |prop|
+              html_options[prop.to_s] = options.delete(prop) if options.key?(prop) && !html_options.key?(prop.to_s)
+            end
+
             add_default_name_and_id(html_options)
 
             if placeholder_required?(html_options)

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -873,52 +873,56 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_array
     @continent = Continent.new
     @continent.countries = ["Africa", "Europe"]
-    assert_dom_equal(
-      %(<select name="continent[countries]" id="continent_countries"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>),
-      select("continent", "countries", %W(Africa Europe America), { multiple: true })
-    )
+
+    expected_with_hidden_field_and_multiple = %(<input name="continent[countries][]" type="hidden" value="" autocomplete="off"/><select name="continent[countries][]" id="continent_countries" multiple="multiple"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>)
+    expected_without_hidden_field = %(<select name="continent[countries]" id="continent_countries"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>)
+
+    assert_dom_equal(expected_with_hidden_field_and_multiple, select("continent", "countries", %W(Africa Europe America), { multiple: true }))
+    assert_dom_equal(expected_with_hidden_field_and_multiple, select("continent", "countries", %W(Africa Europe America), multiple: true))
+    assert_dom_equal(expected_with_hidden_field_and_multiple, select("continent", "countries", %W(Africa Europe America), {}, { multiple: true }))
+    assert_dom_equal(expected_without_hidden_field, select("continent", "countries", %W(Africa Europe America)))
   end
 
   def test_required_select
-    assert_dom_equal(
-      %(<select id="post_category" name="post[category]" required="required"><option value="" label=" "></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, { required: true })
-    )
+    expected = %(<select id="post_category" name="post[category]" required="required"><option value="" label=" "></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), {}, { required: true }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), required: true))
   end
 
   def test_required_select_with_include_blank_prompt
-    assert_dom_equal(
-      %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), { include_blank: "Select one" }, { required: true })
-    )
+    expected = %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), { include_blank: "Select one" }, { required: true }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), include_blank: "Select one", required: true))
   end
 
   def test_required_select_with_prompt
-    assert_dom_equal(
-      %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), { prompt: "Select one" }, { required: true })
-    )
+    expected = %(<select id="post_category" name="post[category]" required="required"><option value="">Select one</option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), { prompt: "Select one" }, { required: true }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), prompt: "Select one", required: true))
   end
 
   def test_required_select_display_size_equals_to_one
-    assert_dom_equal(
-      %(<select id="post_category" name="post[category]" required="required" size="1"><option value="" label=" "></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, { required: true, size: 1 })
-    )
+    expected = %(<select id="post_category" name="post[category]" required="required" size="1"><option value="" label=" "></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), {}, { required: true, size: 1 }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), required: true, size: 1))
   end
 
   def test_required_select_with_display_size_bigger_than_one
-    assert_dom_equal(
-      %(<select id="post_category" name="post[category]" required="required" size="2"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, { required: true, size: 2 })
-    )
+    expected = %(<select id="post_category" name="post[category]" required="required" size="2"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), {}, { required: true, size: 2 }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), required: true, size: 2))
   end
 
   def test_required_select_with_multiple_option
-    assert_dom_equal(
-      %(<input name="post[category][]" type="hidden" value="" autocomplete="off"/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
-      select("post", "category", %w(abe mus hest), {}, { required: true, multiple: true })
-    )
+    expected = %(<input name="post[category][]" type="hidden" value="" autocomplete="off"/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), {}, { required: true, multiple: true }))
+    assert_dom_equal(expected, select("post", "category", %w(abe mus hest), required: true, multiple: true))
   end
 
   def test_select_with_integer


### PR DESCRIPTION






<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I do this a lot:

```erb
<%= select :post, :author, authors, required: true %>
```

It doesn't work; the `required` attribute is ignored! Instead, you need to do this:

```erb
<%= select :post, :author, authors, {}, required: true %>
```

It's hard to remember the right API, and it looks to me like a code smell. It looks even smellier when you end up with this:

```erb
<%= select :post, :author, authors, { include_blank: "Choose an option" }, { required: true } %>
```

Where this would be nicer, but again, the `required` attribute is ignored:

```erb
<%= select :post, :author, authors, include_blank: "Choose an option", required: true %>
```

### Detail

This PR implements a special handling for `required`, `multiple`, and `size` HTML attributes so that these now do the same thing:

```erb
<%= select :post, :author, authors, include_blank: "Choose an option", required: true %>
<%= select :post, :author, authors, { include_blank: "Choose an option" }, { required: true } %>
```

### Additional information

As proof I'm not the only person who makes this mistake, one of the tests in the Rails test suite was wrong! The test added in https://github.com/rails/rails/pull/40522 puts the `multiple` attribute in the wrong place and has the wrong assertion as as result. This PR includes a fix for the test.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

