### PR TITLE
Remove CI requirement from PR template [ci skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,5 +43,3 @@ Before submitting the PR make sure the following are checked:
 * [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
 * [ ] Tests are added or updated if you fix a bug or add a feature.
 * [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
-* [ ] CI is passing.
-


### PR DESCRIPTION
You can't check if "CI is passing" until you create a PR, because Buildkite will only run the build when a PR is created (It will run on branch push only if you push to a branch of the `rails/rails` repo, which only people with write access can do.). So we shouldn't tell people to wait for CI to pass before submitting a PR.

~~This PR just tweaks the CI template to explain this in a comment so that people know to check back once CI has actually run.~~

This PR removes the CI requirement from the PR template.
