### PR TITLE
Add set_new_record to singular create associations

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,6 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
+            set_new_record(record)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1443,6 +1443,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.id, client.client_of
   end
 
+  def test_should_set_foreign_key_on_create_association_with_unpersisted_owner
+    tagging = Tagging.new
+    tag = tagging.create_tag
+
+    assert_not_predicate tagging, :persisted?
+    assert_predicate tag, :persisted?
+    assert_equal tag.id, tagging.tag_id
+  end
+
   def test_should_set_foreign_key_on_save
     client = Client.create! name: "fuu"
     firm   = client.build_firm name: "baa"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because a change in rails/rails#46515 caused some existing model validations to fail because the foreign key attribute is no longer being set on an unpersisted owner instance when creating a singular association.

### Detail

This Pull Request changes adds back the call to `set_new_record` when creating a singular association.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

We reproduced the validation error in this code:

```ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post

  validates_presence_of :post_id

  def create_with_post
    new_post = create_post
    save
  end
end

class BugTest < Minitest::Test
  def test_association_stuff
    comment = Comment.new
    comment.create_with_post

    assert_predicate comment.post, :persisted?
    assert_equal Post.last, comment.post

    assert_predicate comment, :valid?
      # Failure:
      # BugTest#test_association_stuff [repro_fk_validation_change.rb:53]:
      # Expected #<Comment id: nil, post_id: nil> to be valid?.
    assert_predicate comment, :persisted?
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] CI is passing.

