### PR TITLE
Convert `No or no` to `false` in `ActiveModel::Type::Boolean`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Coerce `NO` or `no` to `false` in `ActiveModel::Type::Boolean`
+
+    *Dino Maric*
+
 *   Raise `NoMethodError` in `ActiveModel::Type::Value#as_json` to avoid unpredictable
     results.
 

--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -19,6 +19,8 @@ module ActiveModel
         "FALSE", :FALSE,
         "off", :off,
         "OFF", :OFF,
+        "no", :no,
+        "NO", :NO,
       ].to_set.freeze
 
       def type # :nodoc:

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -19,6 +19,8 @@ module ActiveModel
         assert type.cast("TRUE")
         assert type.cast("on")
         assert type.cast("ON")
+        assert type.cast("yes")
+        assert type.cast("YES")
         assert type.cast(" ")
         assert type.cast("\u3000\r\n")
         assert type.cast("\u0000")
@@ -30,6 +32,8 @@ module ActiveModel
         assert type.cast(:TRUE)
         assert type.cast(:on)
         assert type.cast(:ON)
+        assert type.cast(:yes)
+        assert type.cast(:YES)
 
         # explicitly check for false vs nil
         assert_equal false, type.cast(false)
@@ -41,6 +45,8 @@ module ActiveModel
         assert_equal false, type.cast("FALSE")
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")
+        assert_equal false, type.cast("no")
+        assert_equal false, type.cast("NO")
         assert_equal false, type.cast(:"0")
         assert_equal false, type.cast(:f)
         assert_equal false, type.cast(:F)
@@ -48,6 +54,8 @@ module ActiveModel
         assert_equal false, type.cast(:FALSE)
         assert_equal false, type.cast(:off)
         assert_equal false, type.cast(:OFF)
+        assert_equal false, type.cast(:no)
+        assert_equal false, type.cast(:NO)
       end
     end
   end


### PR DESCRIPTION
This PR changes `ActiveModel::Type::Boolean` to convert `no` to `false`.

```ruby
  ActiveModel::Type::Boolean.new.cast("NO") #==> false
  ActiveModel::Type::Boolean.new.cast("no") #==> false
```