### PR TITLE
Fix typo: rediss -> redis

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -784,7 +784,7 @@ The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parame
 ```
 production:
   adapter: redis
-  url: rediss://10.10.3.153:tls_port
+  url: redis://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params: {
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
I fixed a typo in the Action Cable guide.
