### PR TITLE
Fix indentation  inside the rails engine gemspec

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -8,9 +8,9 @@ Gem::Specification.new do |spec|
   spec.homepage    = "TODO"
   spec.summary     = "TODO: Summary of <%= camelized_modules %>."
   spec.description = "TODO: Description of <%= camelized_modules %>."
-  <% unless inside_application? -%>
+  <%- unless inside_application? -%>
   spec.license     = "MIT"
-  <% end -%>
+  <%- end -%>
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
`spec.license` indentation is messed up. This PF fixes the indentation.

Before:

<img width="1440" alt="Screenshot 2022-12-04 at 14 14 10" src="https://user-images.githubusercontent.com/7427365/205493082-56fad0a8-cab9-4bcd-985f-9b02ba7eb174.png">


After:
<img width="1440" alt="Screenshot 2022-12-04 at 14 20 49" src="https://user-images.githubusercontent.com/7427365/205493091-bbc7d347-3099-4e72-880c-8264a145c445.png">
