### PR TITLE
Query Logs: `namespaced_controller` tag should match `controller` format

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -123,7 +123,15 @@ module ActionController
           ActiveRecord::QueryLogs.taggings.merge!(
             controller:            ->(context) { context[:controller]&.controller_name },
             action:                ->(context) { context[:controller]&.action_name },
-            namespaced_controller: ->(context) { context[:controller].class.name if context[:controller] }
+            namespaced_controller: ->(context) {
+              if context[:controller]
+                controller_class = context[:controller].class
+                # based on ActionController::Metal#controller_name, but does not demodulize
+                unless controller_class.anonymous?
+                  controller_class.name.delete_suffix("Controller").underscore
+                end
+              end
+            }
           )
         end
       end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   The `namespaced_controller` Query Log tag now matches the `controller` format
+
+    For example, a request processed by `NameSpaced::UsersController` will now log as:
+
+    ```
+    :controller # "users"
+    :namespaced_controller # "name_spaced/users"
+    ```
+
+    *Alex Ghiculescu*
+
 *   Return only unique ids from ActiveRecord::Calculations#ids
 
     Updated ActiveRecord::Calculations#ids to only return the unique ids of the base model

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -27,6 +27,14 @@ module ApplicationTests
         end
       RUBY
 
+      app_file "app/controllers/name_spaced/users_controller.rb", <<-RUBY
+        class NameSpaced::UsersController < ApplicationController
+          def index
+            render inline: ActiveRecord::QueryLogs.call("")
+          end
+        end
+      RUBY
+
       app_file "app/jobs/user_job.rb", <<-RUBY
         class UserJob < ActiveJob::Base
           def perform
@@ -42,6 +50,7 @@ module ApplicationTests
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get "/", to: "users#index"
+          get "/namespaced/users", to: "name_spaced/users#index"
         end
       RUBY
     end
@@ -136,7 +145,7 @@ module ApplicationTests
       get "/"
       comment = last_response.body.strip
 
-      assert_match(/\/\*action='index',namespaced_controller='UsersController',pid='\d+'\*\//, comment)
+      assert_match(/\/\*action='index',namespaced_controller='users',pid='\d+'\*\//, comment)
     end
 
     test "job perform method has tagging filters enabled by default" do
@@ -200,6 +209,37 @@ module ApplicationTests
       second_tags = UserJob.new.perform_now
 
       assert_not_equal first_tags, second_tags
+    end
+
+    test "controller and namespaced_controller are named correctly" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :namespaced_controller, :controller ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+      assert_equal %(/*action='index',controller='users',namespaced_controller='users'*/), comment
+
+      get "/namespaced/users"
+      comment = last_response.body.strip
+      assert_equal %(/*action='index',controller='users',namespaced_controller='name_spaced%2Fusers'*/), comment
+    end
+
+    test "controller and namespaced_controller are named correctly, legacy" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :namespaced_controller, :controller ]"
+      add_to_config "config.active_record.query_log_tags_format = :legacy"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+      assert_equal %(/*action:index,namespaced_controller:users,controller:users*/), comment
+
+      get "/namespaced/users"
+      comment = last_response.body.strip
+      assert_equal %(/*action:index,namespaced_controller:name_spaced/users,controller:users*/), comment
     end
 
     private


### PR DESCRIPTION
Currently if you do this:

```ruby
config.active_record.query_log_tags = [:namespaced_controller]
```

A request that's processed by the `NameSpaced::UsersController` will log as `namespaced_controller='NameSpaced%3A%3AUsersController'`.

By contrast if you set the tag to `:controller` it would log as `controller='user'`,  which is much nicer!

This PR makes the `:namespaced_controller` formatting more similar to `:controller` - it will now log as `namespaced_controller='name_spaced/users'`.
