### PR TITLE
Fix more double logging in `ActiveRecord::QueryLogs`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,10 +2,11 @@
 
     *Andy Waite*
 
-*   Don't double log the `controller` or `action` when using `ActiveRecord::QueryLog`
+*   Don't double log the `controller`, `action`, or `namespaced_controller` when using `ActiveRecord::QueryLog`
 
     Previously if you set `config.active_record.query_log_tags` to an array that included
-    `:controller` or `:action`, that item would get logged twice. This bug has been fixed.
+    `:controller`, `:namespaced_controller`, or `:action`, that item would get logged twice.
+    This bug has been fixed.
 
     *Alex Ghiculescu*
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -116,7 +116,8 @@ module ActionController
         app.config.action_controller.log_query_tags_around_actions
 
       if query_logs_tags_enabled
-        app.config.active_record.query_log_tags |= [:controller, :action]
+        app.config.active_record.query_log_tags |= [:controller] unless app.config.active_record.query_log_tags.include?(:namespaced_controller)
+        app.config.active_record.query_log_tags |= [:action]
 
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::QueryLogs.taggings.merge!(

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -127,6 +127,18 @@ module ApplicationTests
       assert_match(/\/\*action='index',controller='users',pid='\d+'\*\//, comment)
     end
 
+    test "namespace controller tags are not doubled up if already configured" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :job, :namespaced_controller, :pid ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+
+      assert_match(/\/\*action='index',namespaced_controller='UsersController',pid='\d+'\*\//, comment)
+    end
+
     test "job perform method has tagging filters enabled by default" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
 


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/46279

That PR missed the case where if you set `config.active_record.query_log_tags = [:namespaced_controller]`, it would log the controller twice:

```
/*namespaced_controller:Foo::BarController,controller:bar*
```

So this PR just fixes that bug, and tweaks the changelog entry rather than adding another one for the same bug.
