### PR TITLE
Fix CI for Mail 2.8+

### DIFF
--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -3,7 +3,7 @@
 module Mail
   class Message
     def from_address
-      header[:from]&.address_list&.addresses&.first
+      address_list(header[:from])&.addresses&.first
     end
 
     def recipients_addresses
@@ -11,15 +11,15 @@ module Mail
     end
 
     def to_addresses
-      Array(header[:to]&.address_list&.addresses)
+      Array(address_list(header[:to])&.addresses)
     end
 
     def cc_addresses
-      Array(header[:cc]&.address_list&.addresses)
+      Array(address_list(header[:cc])&.addresses)
     end
 
     def bcc_addresses
-      Array(header[:bcc]&.address_list&.addresses)
+      Array(address_list(header[:bcc])&.addresses)
     end
 
     def x_original_to_addresses
@@ -29,5 +29,16 @@ module Mail
     def x_forwarded_to_addresses
       Array(header[:x_forwarded_to]).collect { |header| Mail::Address.new header.to_s }
     end
+
+    private
+      def address_list(obj)
+        if obj&.respond_to?(:element)
+          # Mail 2.8+
+          obj.element
+        else
+          # Mail <= 2.7.x
+          obj&.address_list
+        end
+      end
   end
 end


### PR DESCRIPTION
CI is broken since https://github.com/mikel/mail/pull/1120, which is in the new `mail` release. Example: https://buildkite.com/rails/rails/builds/91421#0184e03b-58dc-43f9-aa40-55949848dc67

This commit fixes it. The `adddress_list` method was renamed. I have tested that it works with `mail` 2.8 and 2.7.1.

cc @jeremy