### PR TITLE
Add how to set default_url_options for integration test

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -274,6 +274,27 @@ Do take special care about the **order of your routes**, so this route declarati
 
 NOTE: Have a look at various gems which simplify working with routes: [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
 
+##### Setting the test helper for the Locale from URL Params
+
+For tests that inherit `ActionDispatch::IntegrationTest`, you can use the following code to avoid `ActionController::UrlGenerationError: No route matches` without including an explicit option in every URL, e.g. `link_to(books_url(locale: I18n.locale))`.
+
+```ruby
+# test/test_helper.rb
+class ActionDispatch::IntegrationTest
+  app.default_url_options = { locale: I18n.locale }
+end
+```
+
+If you want to use `default_url_options()` defined in `ApplicationController` for tests, you can use the following code.
+
+```ruby
+# test/test_helper.rb
+class ActionDispatch::IntegrationTest
+  app.default_url_options =
+    ApplicationController.new.send(:default_url_options)
+end
+```
+
 #### Setting the Locale from User Preferences
 
 An application with authenticated users may allow users to set a locale preference through the application's interface. With this approach, a user's selected locale preference is persisted in the database and used to set the locale for authenticated requests by that user.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I met `ActionController::UrlGenerationError: No route matches` when I follow "2.2.2 Setting the Locale from URL Params" of rails guides ([Rails Internationalization (I18n) API](https://edgeguides.rubyonrails.org/i18n.html)) and it was hard to find a solution.

### Detail

This Pull Request adds texts and codes to show how to set `default_url_options` in the test helper to deal with setting of the Locale from URL Params.

### Additional information

Though I referred to [this issue of Rails](https://github.com/rails/rails/issues/546), I am not sure about what code should be shown in the Rails guides as the best practice. So, please let me know if there is the better code than what I wrote in this commit. If there is, I will make a new commit with the better code and remake the pull request with the new commit.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
