### PR TITLE
Bump timeout gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
       rack (>= 1, < 3)
     thor (1.2.1)
     tilt (2.0.10)
-    timeout (0.3.0)
+    timeout (0.3.1)
     trailblazer-option (0.1.2)
     turbo-rails (1.0.0)
       actionpack (>= 6.0.0)


### PR DESCRIPTION
I think this should fix:

```
Running bug_report_templates/action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
# ...
Installing rails 7.0.4
/usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated timeout 0.3.0, but your Gemfile requires timeout 0.3.1. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:25:in `block in setup'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/spec_set.rb:155:in `each'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:24:in `map'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:24:in `setup'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/inline.rb:66:in `block in gemfile'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/settings.rb:131:in `temporary'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/inline.rb:50:in `gemfile'
	from bug_report_templates/action_controller_gem.rb:5:in `<main>'
```

The problem is that rubygems/bundler do use the `timeout` gem, so they tend to load it before the `Gemfile.lock` or equivalent could be parsed, and it can cause the version to mismatch.