### PR TITLE
Better `enable_reloading` comment in `environments/test.rb`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn true under Spring and add config.action_view.cache_template_loading = true.
+  # Code is not reloaded while tests run.
   config.enable_reloading = false
 
   # Eager loading loads your entire application. When running a single test locally,


### PR DESCRIPTION
In the process of removing spring, https://github.com/rails/rails/pull/42997 added a comment for `config.cache_classes`. Through that PR and subsequent revisions the comment has gotten a bit confusing - it doesn't explain what the `enable_reloading` setting does, just how to revert it if you are using Spring (which isn't included in new apps anymore).

So this PR just updates the template with a comment about what the setting does. If someone really wants to use Spring there's other places to learn about how to change this setting, as that's not a default path we're encouraging anymore.

cc @dhh @fxn
