### PR TITLE
Change sendmail default options to match Mail 2.8.x arguments format.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,8 +315,11 @@ GEM
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -439,7 +439,7 @@ module ActionMailer
   #
   # * <tt>sendmail_settings</tt> - Allows you to override options for the <tt>:sendmail</tt> delivery method.
   #   * <tt>:location</tt> - The location of the sendmail executable. Defaults to <tt>/usr/sbin/sendmail</tt>.
-  #   * <tt>:arguments</tt> - The command line arguments. Defaults to <tt>-i</tt> with <tt>-f sender@address</tt>
+  #   * <tt>:arguments</tt> - The command line arguments. Defaults to <tt>%w[ -i ]</tt> with <tt>-f sender@address</tt>
   #     added automatically before the message is sent.
   #
   # * <tt>file_settings</tt> - Allows you to override options for the <tt>:file</tt> delivery method.

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -31,7 +31,8 @@ module ActionMailer
 
       add_delivery_method :sendmail, Mail::Sendmail,
         location:  "/usr/sbin/sendmail",
-        arguments: "-i"
+        # See breaking change in the mail gem - https://github.com/mikel/mail/commit/7e1196bd29815a0901d7290c82a332c0959b163a
+        arguments: Gem::Version.new(Mail::VERSION.version) >= Gem::Version.new("2.8.0") ? %w[-i] : "-i"
 
       add_delivery_method :test, Mail::TestMailer
     end
@@ -46,7 +47,7 @@ module ActionMailer
       #
       #   add_delivery_method :sendmail, Mail::Sendmail,
       #     location:  '/usr/sbin/sendmail',
-      #     arguments: '-i'
+      #     arguments: %w[ -i ]
       def add_delivery_method(symbol, klass, default_options = {})
         class_attribute(:"#{symbol}_settings") unless respond_to?(:"#{symbol}_settings")
         public_send(:"#{symbol}_settings=", default_options)

--- a/actionmailer/test/delivery_methods_test.rb
+++ b/actionmailer/test/delivery_methods_test.rb
@@ -41,7 +41,7 @@ class DefaultsDeliveryMethodsTest < ActiveSupport::TestCase
   test "default sendmail settings" do
     settings = {
       location:  "/usr/sbin/sendmail",
-      arguments: "-i"
+      arguments: %w[ -i ]
     }
     assert_equal settings, ActionMailer::Base.sendmail_settings
   end

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -839,7 +839,7 @@ config.action_mailer.delivery_method = :sendmail
 # Defaults to:
 # config.action_mailer.sendmail_settings = {
 #   location: '/usr/sbin/sendmail',
-#   arguments: '-i'
+#   arguments: %w[ -i ]
 # }
 config.action_mailer.perform_deliveries = true
 config.action_mailer.raise_delivery_errors = true

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1910,7 +1910,7 @@ The default value depends on the `config.load_defaults` target version:
 Allows detailed configuration for the `sendmail` delivery method. It accepts a hash of options, which can include any of these options:
 
 * `:location` - The location of the sendmail executable. Defaults to `/usr/sbin/sendmail`.
-* `:arguments` - The command line arguments. Defaults to `-i`.
+* `:arguments` - The command line arguments. Defaults to `%w[ -i ]`.
 
 #### `config.action_mailer.raise_delivery_errors`
 


### PR DESCRIPTION
### Motivation / Background
The Mail gem changed the format of the delivery method arguments for sendmail from a string to an array of strings. https://github.com/mikel/mail/commit/7e1196bd29815a0901d7290c82a332c0959b163a

The current default settings for sendmail delivery produce the following error:
```
.../mail-2.8.0/lib/mail/network/delivery_methods/sendmail.rb:53:in 
`initialize': :arguments expected to be an Array of individual string args (ArgumentError)
```

### Detail

This Pull Request changes the default options from '-i' to %w[ -i ], same as the change in the mail gem, conditionally, only if the newer mail gem is being used.
