### PR TITLE
Actual parameter value is Rack::Request, make naming consistent

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -41,11 +41,11 @@ module ActionDispatch
     end
 
     module StaleSessionCheck
-      def load_session(env)
+      def load_session(req)
         stale_session_check! { super }
       end
 
-      def extract_session_id(env)
+      def extract_session_id(req)
         stale_session_check! { super }
       end
 

--- a/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cache_store.rb
@@ -20,7 +20,7 @@ module ActionDispatch
       end
 
       # Get a session from the cache.
-      def find_session(env, sid)
+      def find_session(req, sid)
         unless sid && (session = get_session_with_fallback(sid))
           sid, session = generate_sid, {}
         end
@@ -28,7 +28,7 @@ module ActionDispatch
       end
 
       # Set a session in the cache.
-      def write_session(env, sid, session, options)
+      def write_session(req, sid, session, options)
         key = cache_key(sid.private_id)
         if session
           @cache.write(key, session, expires_in: options[:expire_after])
@@ -39,7 +39,7 @@ module ActionDispatch
       end
 
       # Remove a session from the cache.
-      def delete_session(env, sid, options)
+      def delete_session(req, sid, options)
         @cache.delete(cache_key(sid.private_id))
         @cache.delete(cache_key(sid.public_id))
         generate_sid

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -167,25 +167,25 @@ module ActionDispatch
       private
         def store
           Class.new {
-            def load_session(env); [1, {}]; end
-            def session_exists?(env); true; end
-            def delete_session(env, id, options); 123; end
+            def load_session(req); [1, {}]; end
+            def session_exists?(req); true; end
+            def delete_session(req, id, options); 123; end
           }.new
         end
 
         def store_with_data
           Class.new {
-            def load_session(env); [1, { "sample_key" => "sample_value" }]; end
-            def session_exists?(env); true; end
-            def delete_session(env, id, options); 123; end
+            def load_session(req); [1, { "sample_key" => "sample_value" }]; end
+            def session_exists?(req); true; end
+            def delete_session(req, id, options); 123; end
           }.new
         end
 
         def store_for_session_that_does_not_exist
           Class.new {
-            def load_session(env); [1, {}]; end
-            def session_exists?(env); false; end
-            def delete_session(env, id, options); 123; end
+            def load_session(req); [1, {}]; end
+            def session_exists?(req); false; end
+            def delete_session(req, id, options); 123; end
           }.new
         end
     end

--- a/actionpack/test/dispatch/session/abstract_secure_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_secure_store_test.rb
@@ -21,13 +21,13 @@ module ActionDispatch
           super
         end
 
-        def find_session(env, sid)
+        def find_session(req, sid)
           sid ||= 1
           session = @sessions[sid] ||= {}
           [sid, session]
         end
 
-        def write_session(env, sid, session, options)
+        def write_session(req, sid, session, options)
           @sessions[sid] = SessionId.new(sid, session)
         end
 

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -12,13 +12,13 @@ module ActionDispatch
           super
         end
 
-        def find_session(env, sid)
+        def find_session(req, sid)
           sid ||= 1
           session = @sessions[sid] ||= {}
           [sid, session]
         end
 
-        def write_session(env, sid, session, options)
+        def write_session(req, sid, session, options)
           @sessions[sid] = session
         end
 


### PR DESCRIPTION
### Motivation / Background

Since rack 2.0.0.alpha [request is passed to session objects](https://github.com/rack/rack/blob/main/CHANGELOG.md#200alpha-2015-12-04) instead of rack env:
> Change Session internals to use Request objects for looking up session information. This allows us to only allocate one request object when dealing with session objects (rather than doing it every time we need to manipulate cookies, etc).

And `ActionDispatch::Session:CookieStore` was changed accordingly, but other stores where the parameter was not used (and thus stores were not broken by the change) were not changed.

Leftover name `env` is misleading for anyone writing or debugging a custom session store, because one would expect value to be a rack environment hash.

### Detail

This Pull Request changes parameter names for rack request in abstract and cache stores to be consistent with `ActionDispatch::Session:CookieStore` (from `env` to `req`)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
