### PR TITLE
Document has_many through association with source_type using associated model within the current module's namespace

### DIFF
--- a/activerecord/test/fixtures/devices.yml
+++ b/activerecord/test/fixtures/devices.yml
@@ -1,0 +1,7 @@
+washing_machine:
+  id: 1
+  name: $LABEL
+
+vacuum_cleaner:
+  id: 2
+  name: $LABEL

--- a/activerecord/test/fixtures/user/devices.yml
+++ b/activerecord/test/fixtures/user/devices.yml
@@ -1,0 +1,5 @@
+johns_iphone:
+  id: 1
+  user_id: 1
+  token: "phony_push_notification_token_123"
+  locale: "hr"

--- a/activerecord/test/fixtures/user/favorites.yml
+++ b/activerecord/test/fixtures/user/favorites.yml
@@ -1,0 +1,14 @@
+johns_washing_machine:
+  user_id: 1
+  favorable_id: 1
+  favorable_type: Device
+
+johns_vacuum_cleaner:
+  user_id: 1
+  favorable_id: 2
+  favorable_type: Device
+
+johns_iphone:
+  user_id: 1
+  favorable_id: 3
+  favorable_type: User::Device

--- a/activerecord/test/fixtures/users.yml
+++ b/activerecord/test/fixtures/users.yml
@@ -1,0 +1,2 @@
+john_doe:
+  id: 1

--- a/activerecord/test/models/device.rb
+++ b/activerecord/test/models/device.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Device < ActiveRecord::Base
+end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -18,6 +18,19 @@ class User < ActiveRecord::Base
   has_one :family_tree, -> { where(token: nil) }, foreign_key: "member_id"
   has_one :family, through: :family_tree
   has_many :family_members, through: :family, source: :members
+
+  has_many :devices
+  has_many :favorites,
+           class_name: "User::Favorite"
+  has_many :favorite_devices,
+           through: :favorites,
+           source: :favorable,
+           source_type: "Device",
+           class_name: "::Device"
+  has_many :favorite_user_devices,
+           through: :favorites,
+           source: :favorable,
+           source_type: "Device"
 end
 
 class UserWithNotification < User

--- a/activerecord/test/models/user/device.rb
+++ b/activerecord/test/models/user/device.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class User::Device < ActiveRecord::Base
+  belongs_to :user
+end

--- a/activerecord/test/models/user/favorite.rb
+++ b/activerecord/test/models/user/favorite.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class User::Favorite < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :favorable, polymorphic: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -476,6 +476,11 @@ ActiveRecord::Schema.define do
     t.boolean :deleted
   end
 
+  create_table :devices, force: true do |t|
+    t.string :name
+    t.timestamps null: true
+  end
+
   create_table :discounts, force: true do |t|
     t.integer :amount
   end
@@ -1438,8 +1443,21 @@ ActiveRecord::Schema.define do
     t.timestamps null: true
   end
 
+  create_table :user_devices, force: true do |t|
+    t.references :user, null: false, index: true
+    t.string :token
+    t.string :locale
+    t.timestamps null: true
+  end
+
   create_table :user_comments_counts, force: true do |t|
     t.integer :comments_count, default: 0
+  end
+
+  create_table :user_favorites, force: true do |t|
+    t.references :user, null: false, index: true
+    t.references :favorable, polymorphic: true, null: false
+    t.timestamps null: true
   end
 
   create_table :test_with_keyword_column_name, force: true do |t|

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1637,6 +1637,31 @@ end
 class DustJacket < ApplicationRecord; end
 ```
 
+`:source_type` will look for the associated model within the current module's scope. E.g.
+
+```ruby
+class User < ApplicationRecord
+  has_one :favorite
+  has_one :favorite_device,
+    through: :favorite,
+    source: :favorable,
+    source_type: "Device"
+end
+
+class User::Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :favorable, polymorphic: true
+end
+
+class Device < ApplicationRecord
+end
+
+class User::Device < ApplicationRecord
+end
+```
+
+The `favorite_device` association will return a `User::Device` record. To get back a `Device` record you have to pass `class_name: "::Device"` in addition to `source_type: "Device"`.
+
 ##### `:strict_loading`
 
 Enforces strict loading every time the associated record is loaded through this association.
@@ -2128,6 +2153,34 @@ end
 class Hardback < ApplicationRecord; end
 class Paperback < ApplicationRecord; end
 ```
+
+`:source_type` will look for the associated model within the current module's scope. E.g.
+
+```ruby
+class User < ApplicationRecord
+  has_many :devices
+  has_many :favorites
+  has_many :favorite_devices,
+    through: :favorites,
+    source: :favorable,
+    source_type: "Device"
+end
+
+class User::Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :favorable, polymorphic: true
+end
+
+class Device < ApplicationRecord
+end
+
+class User::Device < ApplicationRecord
+  belongs_to :user
+end
+```
+
+The `favorite_devices` association will return `User::Device` records. To get back `Device` records you have to pass `class_name: "::Device"` in addition to `source_type: "Device"`.
+
 
 ##### `:strict_loading`
 


### PR DESCRIPTION
### Motivation / Background

Defining `source_type` can cause an association to fetch records from a
different model than the one defined in `source_type`.

For example, if there are three models - `User`, `Device` and `User::Device`.
Defining a `has_many :favorite_devices, through: ...` relationship on
the `User` that uses `source_type: "Device"` should return objects
of class `Device`, but it returns objects of class `User::Device` instead.

This behavior can be corrected by specifying `class_name: "::Device"` on the
`has_many :favorite_devices, through: ...` relationship. With it the
association returns objects of type `Device`.

I believe that this is a bug because the behavior changes based on the model
that resolves the association. E.g. if I add a fourth model - `Widget` with
a `has_many :favorite_devices, through: :user` then this association returns
`Device` objects.

<details>
  <summary>Test case</summary>

  ```ruby
  # frozen_string_literal: true

  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    git_source(:github) { |repo| "https://github.com/#{repo}.git" }

    rails_options = if ENV.key?("LOCAL")
      { path: "#{Dir.pwd}/rails" }
    else
      { github: "rails/rails", branch: "main" }
    end

    gem "rails", rails_options
    gem "sqlite3"
    gem "timeout" # Fixes an issue with Ruby 3.1, ignore this
  end

  require "active_record"
  require "minitest/autorun"
  require "logger"

  # This connection will do for database-independent bug reports.
  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
  ActiveRecord::Base.logger = Logger.new(STDOUT)

  ActiveRecord::Schema.define do
    create_table :users, force: true do |t|
    end

    create_table :user_devices, force: true do |t|
      t.integer :user_id
      # t.string :push_notifification_token
      # t.string :locale
    end

    create_table :widgets, force: true do |t|
      t.integer :user_id
      # t.string :name
    end

    create_table :user_favorites, force: true do |t|
      t.integer :user_id
      t.string :favorable_type
      t.integer :favorable_id
    end

    create_table :devices, force: true do |t|
      # t.string :name
    end
  end

  # A person that uses the app
  class User < ActiveRecord::Base
    has_many :devices,
             class_name: "User::Device"
    has_many :favorites,
             class_name: "User::Favorite"
    has_many :favorite_devices,
             through: :favorites,
             source: :favorable,
             source_type: "Device"
    has_many :widgets
  end

  # Anything the user wants to pin as their favorite
  # E.g. to show up in a dashboard after they sign in
  class User::Favorite < ActiveRecord::Base
    belongs_to :favorable, polymorphic: true
    belongs_to :user
  end

  # Used for session tracking and push notification
  # This model represents a person's phone or browser and would usually store
  # their push notification token, preffered language for that device and other
  # metadata
  class User::Device < ActiveRecord::Base
    belongs_to :user
  end

  # An IoT devices
  # THis model stores all configration data for the device and is used to
  # associate other models to a device
  class Device < ActiveRecord::Base
  end

  # An UI widget
  class Widget < ActiveRecord::Base
    belongs_to :user
    has_many :favorite_devices, through: :user
  end

  class BugTest < Minitest::Test
    def test_association_stuff
      user = User.create!
      widget = user.widgets.create!

      # The ID is important to demo this problem, that's why I set it manually
      # If the ID of the User::Device record and the Device record are the same
      # then this test passes due to a false positive
      user_device = User::Device.create!(id: 13, user: user)
      washing_machine = Device.create!(id: 13)
      vacuum_cleaner = Device.create!(id: 12)

      # The user adds an IoT Device to their favorites
      favorite1 = User::Favorite.create!(user: user, favorable: washing_machine)
      favorite2 = User::Favorite.create!(user: user, favorable: vacuum_cleaner)

      assert_equal [user_device], user.devices,
        "The user can access their devices (phones / browsers)"
      assert_equal [favorite1, favorite2], user.favorites,
        "The user can access their favorites"

      assert_equal ["Device", "Device"], user.favorites.pluck(:favorable_type),
        "The user's favorites are models of class Device"
      assert_equal [washing_machine.id, vacuum_cleaner.id].sort,
        user.favorites.pluck(:favorable_id).sort,
        "The user's favorites have the same IDs as the associated devices"

      assert_equal [washing_machine, vacuum_cleaner],
        [favorite1.favorable, favorite2.favorable]
        "The user can access their favorite device through the User::Favorite object"
      assert_equal [washing_machine, vacuum_cleaner].sort_by(&:id),
        widget.favorite_devices.sort_by(&:id),
        "The widget can access the user's favorite devices"

      # These fail because `user.favorite_devices` queries User::Device instead
      # of Device when `#compute_class` is called
      assert_equal [washing_machine, vacuum_cleaner].sort_by(&:id),
        user.favorite_devices.sort_by(&:id),
        "The user can access their own favorite devices"
      assert_equal [washing_machine.id, vacuum_cleaner.id].sort,
        user.favorite_device_ids.sort,
        "The user can access the IDs of their own favorite devices"
    end
  end
  ```
</details>

### Detail

When you specify a `source_type` it gets used in the `klass` method which
is responsible for returning the class of the objects returned by the
association.

The `klass` method determines the class using two other methods - `class_name`
and `compute_class`.

`class_name` returns the sanitized value from the `derive_class_name` method,
which returns the value from the passed `source_type` option.

`compute_class` tries to resolve this class name to a class in the usual way.
In the example from before, where the `User` has an association with
`source_type: "Device"`, it would search for the `User::Device` class first and
then for the `Device` class. Since `User::Device` exists it gets used as the
association's model instead of `Device`.

When a `Widget` calls `favorite_devices` through its
`has_many :favorite_devices, through: :user` association, `compute_class`
returns the `Device` class because it can't find a `Widget::Device` class and
falls back to the `Device` class.

To fix this, I made the returned class name from `derive_class_name`
absolute by prefixing it with `::` if the value comes from the `source_type`
option.

This makes class lookups from `source_type` consistent with the query behavior,
resolves similar issues with mixed-in and inherited associations that use
`source_type`, and it makes the class name in the polymorphic `*_type` column
absolute when used with `source_type` (which seems to be how polymorphic
relationships are supposed to be stored).

The downside of this solution is that it breaks associations that relied on
this lookup behavior for `source_type`.

### Additional information

This patch still allows the use of `class_name` with `source_type` and it works as
usual - `class_name` takes precedence. Maybe the combined use of `source_type`
and `class_name` should prohibited? I haven't investigated this possibility.

---

I'm not sure what the convention for adding new test models is.

I tried extending the `Tag` test model to have an associated `Rating` to avoid
adding three extra models, but that caused other unrelated tests to fail so I
opted for the extra few models instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.