### PR TITLE
Disable Rails console IRB's autocompletion in production by default.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Rails console now disables `IRB`'s autocompletion feature in production by default.
+
+    Setting `IRB_USE_AUTOCOMPLETE=true` can override this default.
+
+    *Stan Lo*
+
 *   Add `config.precompile_filter_parameters`, which enables precompilation of
     `config.filter_parameters` using `ActiveSupport::ParameterFilter.precompile_filters`.
     Precompilation can improve filtering performance, depending on the quantity

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -38,6 +38,10 @@ module Rails
 
       if @console == IRB
         IRB::WorkSpace.prepend(BacktraceCleaner)
+
+        if Rails.env == "production"
+          ENV["IRB_USE_AUTOCOMPLETE"] ||= "false"
+        end
       end
     end
 

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -58,6 +58,45 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_equal IRB, Rails::Console.new(app).console
   end
 
+  def test_console_disables_IRB_auto_completion_in_production
+    original_use_autocomplete = ENV["IRB_USE_AUTOCOMPLETE"]
+    ENV["IRB_USE_AUTOCOMPLETE"] = nil
+
+    with_rack_env "production" do
+      app = build_app(nil)
+      assert_equal IRB, Rails::Console.new(app).console
+      assert_equal "false", ENV["IRB_USE_AUTOCOMPLETE"]
+    end
+  ensure
+    ENV["IRB_USE_AUTOCOMPLETE"] = original_use_autocomplete
+  end
+
+  def test_console_accepts_override_on_IRB_auto_completion_flag
+    original_use_autocomplete = ENV["IRB_USE_AUTOCOMPLETE"]
+    ENV["IRB_USE_AUTOCOMPLETE"] = "true"
+
+    with_rack_env "production" do
+      app = build_app(nil)
+      assert_equal IRB, Rails::Console.new(app).console
+      assert_equal "true", ENV["IRB_USE_AUTOCOMPLETE"]
+    end
+  ensure
+    ENV["IRB_USE_AUTOCOMPLETE"] = original_use_autocomplete
+  end
+
+  def test_console_doesnt_disable_IRB_auto_completion_in_non_production
+    original_use_autocomplete = ENV["IRB_USE_AUTOCOMPLETE"]
+    ENV["IRB_USE_AUTOCOMPLETE"] = nil
+
+    with_rails_env nil do
+      app = build_app(nil)
+      assert_equal IRB, Rails::Console.new(app).console
+      assert_nil ENV["IRB_USE_AUTOCOMPLETE"]
+    end
+  ensure
+    ENV["IRB_USE_AUTOCOMPLETE"] = original_use_autocomplete
+  end
+
   def test_default_environment_with_no_rails_env
     with_rails_env nil do
       start


### PR DESCRIPTION
### Motivation / Background

1. Autocompletion increases data transmission significantly. This could cause noticeable slowdown when connecting to remote servers, which is usually the case in production.
2. The autocompletion feature still has many issues, as listed in https://github.com/ruby/irb/issues/445. They may be just annoying when happened locally, but in production they could cause real issues (e.g. typos caused by slow backspacing).

Due to these reasons, I think it's safer to disable this feature in production.

### Detail

Because `IRB.start` doesn't take configuration arguments and rebuilds the `IRB.conf` object, the only way we can turn off autocompletion is through the `IRB_USE_AUTOCOMPLETE` env var.

The env var was added in https://github.com/ruby/irb/pull/469 and will be available in IRB 1.6+ and Ruby 3.2+. The name wasn't used before so it won't cause issues with older IRB versions.

### Additional information

Users can still override this by setting `IRB_USE_AUTOCOMPLETE=true`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
