### PR TITLE
Fix protected envs multi-db test

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -154,6 +154,7 @@ module ActiveRecord
 
       def test_with_multiple_databases
         env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+
         with_multi_db_configurations(env) do
           protected_environments = ActiveRecord::Base.protected_environments
           current_env = ActiveRecord::Base.connection.migration_context.current_environment
@@ -167,7 +168,7 @@ module ActiveRecord
 
           assert_not_includes protected_environments, current_env
           # Assert not raises
-          ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!("test")
+          ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!(env)
 
           ActiveRecord::Base.establish_connection(:secondary)
           connection = ActiveRecord::Base.connection
@@ -176,8 +177,9 @@ module ActiveRecord
           schema_migration.create_version("1")
 
           ActiveRecord::Base.protected_environments = [current_env.to_sym]
+
           assert_raise(ActiveRecord::ProtectedEnvironmentError) do
-            ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!("test")
+            ActiveRecord::Tasks::DatabaseTasks.check_protected_environments!(env)
           end
         ensure
           ActiveRecord::Base.protected_environments = protected_environments


### PR DESCRIPTION
Locally, this test was failing because the configurations for the test
environment were empty. If they are empty, we won't raise the
appropriate error.

In the Rails test suite locally the environment in this test is
`default_env`, but in CI it's `test`. We can fix this by pass `env` to
`check_protected_environment!` instead of passing a string of the
environment.

Followup to #46340

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
