### PR TITLE
Fix internal_metadata connection

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1410,8 +1410,8 @@ module ActiveRecord
       # Stores the current environment in the database.
       def record_environment
         return if down?
-        connection = ActiveRecord::Base.connection
-        connection.internal_metadata[:environment] = connection.migration_context.current_environment
+
+        @internal_metadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
       end
 
       def ran?(migration)


### PR DESCRIPTION
Previously, this code was using `ActiveRecord::Base.connection` for the internal metadata. However, if a MigrationContext was initialized with a different connection's internal metadata we should use that. This fixes the `record_environment` method to use the correct connection for storing the environment. We noticed this in flaky tests at Shopify causing internal metadata to get written to the wrong readonly connection. I have added a test so we don't miss this in the future.

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
