### PR TITLE
Use a single lock for all connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -172,13 +172,19 @@ module ActiveRecord
         @verified = false
       end
 
+      THREAD_LOCK = ActiveSupport::Concurrency::ThreadLoadInterlockAwareMonitor.new
+      private_constant :THREAD_LOCK
+
+      FIBER_LOCK = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
+      private_constant :FIBER_LOCK
+
       def lock_thread=(lock_thread) # :nodoc:
         @lock =
         case lock_thread
         when Thread
-          ActiveSupport::Concurrency::ThreadLoadInterlockAwareMonitor.new
+          THREAD_LOCK
         when Fiber
-          ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
+          FIBER_LOCK
         else
           ActiveSupport::Concurrency::NullLock
         end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/46519
Followup: https://github.com/rails/rails/pull/46553
Fix: https://github.com/rails/rails/issues/45994

When using multiple database, `clear_query_caches_for_current_thread` goes over all connections pool and have to acquire locks one by one to clear each query cache.

If two threads do this in a different order they might deadlock.

By using a single lock for all connections we avoid this problem entirely and properly prevent the puma thread from competing with the main thread.

As for previous PRs, it would be cleaner to have this lock around a Rack middleware, and to release it when calling Capybara primitives like `visit`. But we need a good chokepoint in Capybara for that, I need to explore that upstream.

@eileencodes @matthewd @kuahyeow