### PR TITLE
TimeHelpers: include with_usec keyword parameter on travel & freeze too

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveSupport::Testing::TimeHelpers` now accepts named `with_usec` argument
+    to `freeze_time`, `travel`, and `travel_to` methods. Passing true prevents
+    truncating the destination time with `change(usec: 0)`.
+
+    *KevSlashNull*, and *serprex*
+
 *   `ActiveSupport::CurrentAttributes.resets` now accepts a method name
 
     The block API is still the recommended approach, but now both APIs are supported:

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -75,6 +75,11 @@ module ActiveSupport
       # stubbing +Time.now+, +Date.today+, and +DateTime.now+. The stubs are automatically removed
       # at the end of the test.
       #
+      # Note that the usec for the resulting time will be set to 0 to prevent rounding
+      # errors with external services, like MySQL (which will round instead of floor,
+      # leading to off-by-one-second errors), unless the <tt>with_usec</tt> argument
+      # is set to <tt>true</tt>.
+      #
       #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       #   travel 1.day
       #   Time.current     # => Sun, 10 Nov 2013 15:34:49 EST -05:00
@@ -89,8 +94,8 @@ module ActiveSupport
       #     User.create.created_at # => Sun, 10 Nov 2013 15:34:49 EST -05:00
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
-      def travel(duration, &block)
-        travel_to Time.now + duration, &block
+      def travel(duration, with_usec: false, &block)
+        travel_to Time.now + duration, with_usec: with_usec, &block
       end
 
       # Changes current time to the given time by stubbing +Time.now+,
@@ -217,7 +222,7 @@ module ActiveSupport
       end
       alias_method :unfreeze_time, :travel_back
 
-      # Calls +travel_to+ with +Time.now+.
+      # Calls +travel_to+ with +Time.now+. Forwards optional <tt>with_usec</tt> argument.
       #
       #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
       #   freeze_time
@@ -233,8 +238,8 @@ module ActiveSupport
       #     User.create.created_at # => Sun, 09 Jul 2017 15:34:49 EST -05:00
       #   end
       #   Time.current # => Sun, 09 Jul 2017 15:34:50 EST -05:00
-      def freeze_time(&block)
-        travel_to Time.now, &block
+      def freeze_time(with_usec: false, &block)
+        travel_to Time.now, with_usec: with_usec, &block
       end
 
       private

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -204,7 +204,7 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
-  def test_time_helper_travel_to_with_usec_true
+  def test_time_helper_with_usec_true
     Time.stub(:now, Time.now) do
       duration_usec = 0.1.seconds
       expected_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
@@ -214,10 +214,23 @@ class TimeTravelTest < ActiveSupport::TestCase
 
         assert_equal expected_time.to_f, Time.now.to_f
 
+        travel 0.5, with_usec: true
+
+        assert_equal((expected_time + 0.5).to_f, Time.now.to_f)
+
         travel_back
       end
     ensure
       travel_back
+    end
+  end
+
+  def test_time_helper_freeze_time_with_usec_true
+    # repeatedly test in case Time.now happened to actually be 0 usec
+    assert 9.times.any? do
+      freeze_time(with_usec: true) do
+        Time.now.usec != 0
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background
`travel_to` recently had a `with_usec` keyword parameter added, include it on the rest of the methods to be consistent

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.