### PR TITLE
Run `test:prepare` before `bin/rails test` commands

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -462,6 +462,18 @@ Known extensions: rails, pride
     -p, --pride                      Pride. Show your testing pride!
 ```
 
+### Running tests in Continuous Integration (CI)
+
+To run all tests in a CI environment, there's just one command you need:
+
+```
+bin/rails test
+```
+
+If you are using [System Tests](#system-testing), `bin/rails test` will not run them, since
+they can be slow. To also run them, add an another CI step that runs `bin/rails test:system`,
+or change your first step to `bin/rails test:all`, which runs all tests including system tests.
+
 Parallel Testing
 ----------------
 

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -12,7 +12,7 @@ module Rails
           formatted_rake_tasks
         end
 
-        def perform(task, args, config)
+        def perform(task, args, config, optional: false)
           require_rake
 
           Rake.with_application do |rake|
@@ -21,11 +21,19 @@ module Rails
             if Rails.respond_to?(:root)
               rake.options.suppress_backtrace_pattern = /\A(?!#{Regexp.quote(Rails.root.to_s)})/
             end
-            rake.standard_exception_handling { rake.top_level }
+            rake.standard_exception_handling { rake.top_level } unless optional && !task_exists?(rake, task)
           end
         end
 
         private
+          def task_exists?(rake, task)
+            name, _args = rake.parse_task_string(task)
+            rake[name]
+            true
+          rescue Exception
+            false
+          end
+
           def rake_tasks
             require_rake
 

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/command"
+require "rails/commands/rake/rake_command"
 require "rails/test_unit/runner"
 require "rails/test_unit/reporter"
 
@@ -30,6 +31,7 @@ module Rails
         $LOAD_PATH << Rails::Command.root.join("test").to_s
 
         Rails::TestUnit::Runner.parse_options(args)
+        run_prepare_task(args)
         Rails::TestUnit::Runner.run(args)
       end
 
@@ -44,11 +46,13 @@ module Rails
 
       desc "test:all", "Runs all tests, including system tests", hide: true
       def all(*)
+        @force_prepare = true
         args.prepend("test/**/*_test.rb")
         perform
       end
 
       def system(*)
+        @force_prepare = true
         args.prepend("test/system")
         perform
       end
@@ -57,6 +61,13 @@ module Rails
         args.prepend("test/lib/generators")
         perform
       end
+
+      private
+        def run_prepare_task(args)
+          if @force_prepare || args.empty?
+            Rails::Command::RakeCommand.perform("test:prepare", nil, {}, optional: true)
+          end
+        end
     end
   end
 end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1133,6 +1133,97 @@ module ApplicationTests
       assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
+    def test_rake_test_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = Dir.chdir(app_path) { `bin/rake test` }
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rake_test_all_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = Dir.chdir(app_path) { `bin/rake test:all` }
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rake_test_db_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = Dir.chdir(app_path) { `bin/rake test:db` }
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rake_test_with_path_runs_test_prepare # unlike bin/rails test, bin/rake test does not accept a path argument - it always runs the whole suite
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = Dir.chdir(app_path) { `bin/rake test test/models/foo_test.rb` }
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rails_test_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = run_test_command("", allow_failure: false)
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rails_all_test_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = rails "test:all", allow_failure: false
+      assert_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
+    def test_rails_test_with_path_does_not_run_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      create_test_file :models, "foo"
+      output = run_test_command("test/models/foo_test.rb", allow_failure: false)
+      assert_not_includes output, "echo"
+      assert_includes output, "1 runs, 1 assertions, 0 failures"
+    end
+
     private
       def run_test_command(arguments = "test/unit/test_test.rb", **opts)
         rails "t", *Shellwords.split(arguments), allow_failure: true, **opts


### PR DESCRIPTION
First, some background. Currently there's two ways to run Rails tests.

**`bin/rake test`**

This executes one of the rake tasks from [testing.rake](https://github.com/rails/rails/blob/main/railties/lib/rails/test_unit/testing.rake), which all call `Rails::TestUnit::Runner.rake_run`, which makes a `system` call to `rails test` ([here](https://github.com/rails/rails/blob/90a272a1de6f13711943139c4292336dbff19c7c/railties/lib/rails/test_unit/runner.rb#L34)).

But because it's a Rake task, you can also enhance it with other tasks. Most of the tasks in `testing.rake` are enhanced with `test:prepare`. This is a [placeholder](https://github.com/rails/rails/blob/90a272a1de6f13711943139c4292336dbff19c7c/railties/lib/rails/test_unit/testing.rake#L20) task, which gets hooked into by other things. For example, `cssbundling-rails` [enhances](https://github.com/rails/cssbundling-rails/blob/def749dc2dbc31f64c489438a765ce1e4315e14e/lib/tasks/cssbundling/build.rake#L15) this task to build your CSS file when you run tests. This is necessary, becuase otherwise things like `stylesheet_link_tag "tailwind"` will crash in a CI environment (because the asset does not exist).

**`bin/rails test`**

This runs the `Rails::Command::TestCommand`, which actually launches the `Rails::TestUnit::Runner` via its [`run` method](https://github.com/rails/rails/blob/90a272a1de6f13711943139c4292336dbff19c7c/railties/lib/rails/test_unit/runner.rb#L40).

As noted above, when you do `bin/rake test` you are also indirectly calling `bin/rails test`.

But because `bin/rails test` does *not* call `bin/rake test`, `rake test:prepare` is never run.

## The problem

The [Testing Rails Applications](https://guides.rubyonrails.org/testing.html#the-rails-test-runner) guide is pretty clear that you should use `bin/rails test`.

As described above, this doesn't work if you have anything that relies on `test:prepare`. Instead you have to run some other commands to properly set up your test environment. You might get lucky in development (because your CSS might get compiled during development) but you won't in CI, or production. This leads to confusing instructions like https://github.com/rails/tailwindcss-rails/pull/230 and https://github.com/rails/tailwindcss-rails/pull/134 and makes it just that little bit harder to get started and run tests all with one command.

## The solution

@dhh alluded to it [here](https://github.com/rails/tailwindcss-rails/pull/134#discussion_r786416181) - we should just run the `test:prepare` in more cases. This PR implements a few things:

- `bin/rake test` will now run `test:prepare`. Previously it did not, only subcommands (eg. `bin/rake test:all`) did.
- `bin/rails test` will now run `test:prepare`. It does this by making a `system` call to the `rake` command. Basically the inverse of how `bin/rake test` works in making a system call to the `rails` command.

That's what happens if you just call the commands with no argument. If you include a file path for a specific test:

- `bin/rake test test/models/foo_test.rb` will run `test:prepare` and run all tests. This was the behaviour before this PR. Rake tasks don't support passing arguments like this, so this has always run the full test suite.
- `bin/rails test test/models/foo_test.rb` will *not* run `test:prepare`, and will only run `foo_test.rb`. This matches the behaviour before this PR.

To summarise. Before this PR:

| Does `test:prepare` run? | `bin/rake test` | `bin/rails test` | `bin/rake test:all` |`bin/rails test:all` |
|--------------------------|----------------|---------------|-------------------|-------------------|
| No file path provided        | 🔴                      | 🔴                     | ✅                           | 🔴                           |
| File path provided             | ✅ (path is ignored) | 🔴                      | ✅                           |N/A                         |

With this PR:

| Does `test:prepare` run? | `bin/rake test` | `bin/rails test` | `bin/rake test:all` | `bin/rails test:all` |
|--------------------------|----------------|---------------|-------------------|-------------------|
| No file path provided        | ✅                      | ✅                      | ✅                           | ✅                           |
| File path provided             | ✅ (path is ignored) | 🔴                      | ✅                           | N/A                         |

Which means the "just run `bin/rails test`" advice now works in CI 👍 