### PR TITLE
Allow disabling error markup generation on a per-field basis

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow disabling error markup generation on a per-field basis. This augments the existing
+    global option, `ActionView::Base.field_error_proc`, that can be used to customize error
+    markup for the entire application. The `generate_error_markup:` option allows bypassing
+    error markup entirely for a single input.
+
+    Example:
+
+    ```erb
+    <%= form_with(model: user) do |f| %>
+      <%= f.text_field(:name, generate_error_markup: false) %>
+    <% end %>
+    ```
+
+    *Cameron Dutro*
+
 *   Fix the `capture` view helper compatibility with HAML and Slim
 
     When a blank string was captured in HAML or Slim (and possibly other template engines)

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -16,6 +16,7 @@ module ActionView
           @object = retrieve_object(options.delete(:object))
           @skip_default_ids = options.delete(:skip_default_ids)
           @allow_method_names_outside_object = options.delete(:allow_method_names_outside_object)
+          @generate_error_markup = options.delete(:generate_error_markup) { true }
           @options = options
 
           if Regexp.last_match
@@ -131,6 +132,10 @@ module ActionView
 
           def generate_ids?
             !@skip_default_ids
+          end
+
+          def tag_generate_errors?(*)
+            @generate_error_markup && super
           end
       end
     end

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -169,4 +169,11 @@ class ActiveModelHelperTest < ActionView::TestCase
   ensure
     ActionView::Base.field_error_proc = old_proc if old_proc
   end
+
+  def test_field_does_not_render_error_markup_if_option_is_passed
+    assert_dom_equal(
+      %(<input id="post_author_name" name="post[author_name]" type="text" value="" />),
+      text_field("post", "author_name", generate_error_markup: false)
+    )
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

This PR is a replacement for https://github.com/rails/rails/pull/46618

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I'm working on a forms framework on the Primer team at GitHub that allows rendering forms declaratively. My pair and I noticed today that Rails will wrap invalid inputs and labels with a `<div>` containing a class of `field_with_errors`, ostensibly allowing for custom styling of invalid fields. We also learned this behavior can be customized by setting the application-level `ActionView::Base.field_error_proc` option.

Our framework automatically handles styling invalid fields in accordance with our design system. The additional wrapper `<div>`, while something we can work around, unexpectedly led to a visual regression today in our testing:

![image](https://user-images.githubusercontent.com/575280/206300064-047fb2c4-871b-461d-8110-0f7f5f08ad22.png)

As you can see, the little arrows on the right-hand side of the select list are outside the red outline. The arrows are implemented as an `:after` selector and live [here](https://github.com/primer/view_components/blob/main/app/components/primer/alpha/text_field.pcss#L476). The additional `<div>` causes the `:after` selector to place the mask after the `<div>` instead of after the `<select>`.

### Detail

My pair and I were unable to find any field-level option to disable wrapping, so I have submitted this PR. You can now pass  `generate_error_markup: false` to form helpers to skip wrapping fields with the aforementioned `<div>`:

```erb
<%= form_with(model: user) do |f| %>
  <%= f.text_field(:name, generate_error_markup: false) %>
<% end %>
```

### Open Questions

- [ ] As the `generate_error_markup:` option can be passed to all form helpers and form builder methods, I'm not sure where the most appropriate place is to document the changes. Is someone able to help me with that?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

