### PR TITLE
Pull binary defaults from show create table

### DIFF
--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -88,7 +88,7 @@ class DefaultBinaryTest < ActiveRecord::TestCase
 
   self.use_transactional_tests = false
 
-  BLOB = (0..127).map(&:chr).join('')*2
+  BLOB = (0..255).map(&:chr).join('')*2
 
   setup do
     @connection = ActiveRecord::Base.connection


### PR DESCRIPTION
This updates mysql binary column default to use the default mysql
prints from SHOW CREATE TABLE.  This prevents the truncation bug found
in current mysql default value parsing from SHOW FULL FIELDS.

This isn't actually mergable because `SHOW CREATE TABLE` replaces most high bytes with `?` which makes these defaults also unreliable.