### PR TITLE
Raise `ArgumentError` on empty `query_constraints` configuration

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -485,6 +485,8 @@ module ActiveRecord
       #   developer.reload
       #   # => SELECT "developers".* FROM "developers" WHERE "developers"."company_id" = 1 AND "developers"."id" = 1 LIMIT 1
       def query_constraints(*columns_list)
+        raise ArgumentError, "You must specify at least one column to be used in querying" if columns_list.empty?
+
         @_query_constraints_list = columns_list.map(&:to_s)
       end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1476,4 +1476,13 @@ class QueryConstraintsTest < ActiveRecord::TestCase
       assert_match(/WHERE .*#{column}/, sql)
     end
   end
+
+  def test_query_constraints_raises_an_error_when_no_columns_provided
+    assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        query_constraints
+      end
+    end
+  end
 end


### PR DESCRIPTION
We don't expect `query_constraints` to be explicitly configurable as an empty array so let's add an exception if it is being called with no arguments. It should also help with internal development as occasionally I was trying to use `query_constraints` as a reader while we should read the list using `query_constraints_list` instead.

*Note: Even though we don't expect `query_constraints` to be configured as an empty array, `query_constraints_list` may end up being empty if `primary_key` was nil and `query_constraints_list` was implicitly derived based on the model's `primary_key`