### PR TITLE
Ensure `query_constraints_list` is empty if `primary_key` is `nil`

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1439,6 +1439,15 @@ class QueryConstraintsTest < ActiveRecord::TestCase
     assert_equal("id", ClothingItem.primary_key)
   end
 
+  def test_query_constraints_list_is_an_empty_array_if_primary_key_is_nil
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers_projects"
+    end
+
+    assert_nil klass.primary_key
+    assert_empty klass.query_constraints_list
+  end
+
   def test_query_constraints_uses_primary_key_by_default
     post = posts(:welcome)
     assert_uses_query_constraints_on_reload(post, "id")


### PR DESCRIPTION
I wanted to ensure that `query_constraints_list` is never an array with `nil` value like `[nil]` when `primary_key` is `nil` and `query_constraints` are implicitly derived based on the primary key but we already handle it by calling `Array(primary_key)`:
https://github.com/rails/rails/blob/ee4f905090a5dff471c359deaa92c62e17f2f98e/activerecord/lib/active_record/persistence.rb#L632

```ruby
irb(main):001:0> Array(nil)
=> []
```

So I'm adding a test to make sure it always stays the same