### PR TITLE
Run `test:prepare` before `bin/rake test` command

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -462,6 +462,20 @@ Known extensions: rails, pride
     -p, --pride                      Pride. Show your testing pride!
 ```
 
+### Running tests in Continuous Integration (CI)
+
+In a CI environment there will typically be at least two steps you need to run. Rails provides
+comands for each step:
+
+1. Set up your database: `bin/rake db:test:prepare`
+2. Run your tests: `bin/rake test`
+
+Alternatively you could just call `bin/rake test:db`, which runs the above two commands.
+
+If you are using [System Tests](#system-testing), `bin/rake test` will not run them, since
+they can sometimes be quite slow. You could either add a third step that runs `bin/rake test:system`,
+or you could use use `bin/rake test:all` which runs all tests including system tests.
+
 Parallel Testing
 ----------------
 

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -7,7 +7,7 @@ require "rails/test_unit/runner"
 task default: :test
 
 desc "Runs all tests in test folder except system ones"
-task :test do
+task test: "test:prepare" do
   if ENV.key?("TEST")
     Rails::TestUnit::Runner.rake_run([ENV["TEST"]])
   else

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1062,6 +1062,39 @@ module ApplicationTests
       assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
+    def test_rake_test_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      output = Dir.chdir(app_path) { `bin/rake test` }
+      assert_includes output, "echo"
+    end
+
+    def test_rake_test_all_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      output = Dir.chdir(app_path) { `bin/rake test:all` }
+      assert_includes output, "echo"
+    end
+
+    def test_rake_test_db_runs_test_prepare
+      app_file "Rakefile", <<~RUBY, "a"
+        task :echo do
+          puts "echo"
+        end
+        Rake::Task["test:prepare"].enhance(["echo"])
+      RUBY
+      output = Dir.chdir(app_path) { `bin/rake test:db` }
+      assert_includes output, "echo"
+    end
+
     private
       def run_test_command(arguments = "test/unit/test_test.rb", **opts)
         rails "t", *Shellwords.split(arguments), allow_failure: true, **opts


### PR DESCRIPTION
Alternative approach to https://github.com/rails/rails/pull/46664. This PR tries to tackle the same problem, but does a bit less in the implementation.

Here, we only modify `bin/rake test` to run `rake test:prepare`. This allows us to have one command that will reliably run all tests and run asset bundling (or anything else that's a prerequisite for tests) in a CI environment.

I've also updated the Testing with Rails guide with instructions on how to run tests in CI.

`cssbundling-rails` and friends can now just tell users to run `bin/rake test` (or point to the guide) rather than the current [confusing instructions](https://github.com/rails/tailwindcss-rails#building-for-testing).