### PR TITLE
Allow false options in ConnectionUrlResolver

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -38,7 +38,11 @@ module ActiveRecord
       # Converts the given URL to a full connection hash.
       def to_hash
         config = raw_config.compact_blank
-        config.map { |key, value| config[key] = uri_parser.unescape(value) if value.is_a? String }
+        config.map do |key, value|
+          next unless value.is_a? String
+
+          config[key] = value.downcase == "false" ? false : uri_parser.unescape(value)
+        end
         config
       end
 

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -120,6 +120,15 @@ module ActiveRecord
         assert_equal expected, actual.configuration_hash
       end
 
+      def test_resolver_with_database_uri_and_false_option
+        ENV["DATABASE_URL"] = "postgres://localhost/foo?schema_dump=false"
+        config = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
+        actual = resolve_db_config(:default_env, config)
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", schema_dump: false }
+
+        assert_equal expected, actual.configuration_hash
+      end
+
       def test_jdbc_url
         config   = { "production" => { "url" => "jdbc:postgres://localhost/foo" } }
         actual   = resolve_config(config, "production")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently DATABASE_URL does not provide a way to pass an option with a `false` value, eg:

```shell
DATABASE_URL="postgresql://postgres@localhost:5432/db_name?schema_dump=false" bundle exec rails c
```

### Expected behavior
```ruby
ActiveRecord::Base.connection_db_config.schema_dump
=> false
```

### Actual behavior
```ruby
ActiveRecord::Base.connection_db_config.schema_dump
=> "false"
```
The problem with this is that it's actually truthy and there is no way to pass a falsy value, as nil is compacted.

### Detail

This changes the option value to `false` if it is a string that equals `"false"` (insensitive) 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
