### PR TITLE
`#last` and `#first` finders should use `query_constraints` for ordering

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -456,13 +456,14 @@ module ActiveRecord
       end
 
       # Accepts a list of attribute names to be used in the WHERE clause
-      # of SELECT / UPDATE / DELETE queries.
+      # of SELECT / UPDATE / DELETE queries and in the ORDER BY clause for `#first` and `#last` finder methods.
       #
       #   class Developer < ActiveRecord::Base
       #     query_constraints :company_id, :id
       #   end
       #
       #   developer = Developer.first
+      #   SELECT "developers".* FROM "developers" ORDER BY "developers"."company_id" ASC, "developers"."id" ASC LIMIT 1
       #   developer.inspect # => #<Developer id: 1, company_id: 1, ...>
       #
       #   developer.update!(name: "Nikita")

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -576,12 +576,12 @@ module ActiveRecord
       end
 
       def ordered_relation
-        if order_values.empty? && (implicit_order_column || primary_key)
-          if implicit_order_column && primary_key && implicit_order_column != primary_key
-            order(table[implicit_order_column].asc, table[primary_key].asc)
-          else
-            order(table[implicit_order_column || primary_key].asc)
-          end
+        if order_values.empty? && (implicit_order_column || !query_constraints_list.empty?)
+          # use query_constraints_list as the order clause if there is no implicit_order_column
+          # otherwise remove the implicit order column from the query constraints list if it's there
+          # and prepend it to the beginning of the list
+          order_columns = implicit_order_column.nil? ? query_constraints_list : ([implicit_order_column] | query_constraints_list)
+          order(*order_columns.map { |column| table[column].asc })
         else
           self
         end


### PR DESCRIPTION
Since[ the newly introduced](https://github.com/rails/rails/pull/46331) `query_constraints` config is a higher abstraction for the existing `ActiveRecord::Base#primary_key` and can be treated as a "virtual primary key", we should be moving towards substituting `primary_key` usages with `query_constraints_list` on the Active Record models level.

This PR changes `#last` and `#first` finders which both internally call into the `ordered_relation` method to use `query_constraints_list` to build the `ORDER BY` clause. This is a non-breaking change as all existing Active Record models will have `query_constraints_list` [implicitly configured](https://github.com/rails/rails/pull/46439) as `[primary_key]` which for most of these models will be the same as `[id]`


### Possible extensions

While doing this refactoring I realized that it would be relatively easy to turn `implicit_order_column` into `implicit_order_columns` and allow defining multiple columns for the `ORDER BY` clause. I don't see an immediate need for doing this, just wanted to mention that it is easily achievable 
