### PR TITLE
Fix Issue #46677

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Datatime form helpers (`time_field`, `date_field`, `datetime_field`, `week_field`, `month_field`) now accept an instance of Time/Date/DateTime as `:value` option.
+
+    Before:
+    ```erb
+    <%= form.datetime_field :written_at, value: Time.current.strftime("%Y-%m-%dT%T") %>
+    ```
+
+    After:
+    ```erb
+    <%= form.datetime_field :written_at, value: Time.current %>
+    ```
+
+    *Andrey Samsonov*
+
 *   Choices of `select` can optionally contain html attributes as the last element
     of the child arrays when using grouped/nested collections
 

--- a/actionview/lib/action_view/helpers/tags/date_field.rb
+++ b/actionview/lib/action_view/helpers/tags/date_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class DateField < DatetimeField # :nodoc:
         private
-          def format_date(value)
+          def format_datetime(value)
             value&.strftime("%Y-%m-%d")
           end
       end

--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -6,19 +6,23 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] ||= format_date(value)
-          options["min"] = format_date(datetime_value(options["min"]))
-          options["max"] = format_date(datetime_value(options["max"]))
+          options["value"] = normalize_datetime(options["value"] || value)
+          options["min"] = normalize_datetime(options["min"])
+          options["max"] = normalize_datetime(options["max"])
           @options = options
           super
         end
 
         private
-          def format_date(value)
+          def format_datetime(value)
             raise NotImplementedError
           end
 
-          def datetime_value(value)
+          def normalize_datetime(value)
+            format_datetime(parse_datetime(value))
+          end
+
+          def parse_datetime(value)
             if value.is_a? String
               DateTime.parse(value) rescue nil
             else

--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -16,7 +16,7 @@ module ActionView
         end
 
         private
-          def format_date(value)
+          def format_datetime(value)
             if @include_seconds
               value&.strftime("%Y-%m-%dT%T")
             else

--- a/actionview/lib/action_view/helpers/tags/month_field.rb
+++ b/actionview/lib/action_view/helpers/tags/month_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class MonthField < DatetimeField # :nodoc:
         private
-          def format_date(value)
+          def format_datetime(value)
             value&.strftime("%Y-%m")
           end
       end

--- a/actionview/lib/action_view/helpers/tags/time_field.rb
+++ b/actionview/lib/action_view/helpers/tags/time_field.rb
@@ -10,7 +10,7 @@ module ActionView
         end
 
         private
-          def format_date(value)
+          def format_datetime(value)
             if @include_seconds
               value&.strftime("%T.%L")
             else

--- a/actionview/lib/action_view/helpers/tags/week_field.rb
+++ b/actionview/lib/action_view/helpers/tags/week_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class WeekField < DatetimeField # :nodoc:
         private
-          def format_date(value)
+          def format_datetime(value)
             value&.strftime("%Y-W%V")
           end
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1102,6 +1102,12 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
+  def test_date_field_with_datetime_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
+    value = DateTime.new(2013, 6, 29)
+    assert_dom_equal(expected, date_field("post", "written_on", value: value))
+  end
+
   def test_date_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
     expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
@@ -1151,6 +1157,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
     step = 60
     assert_dom_equal(expected, time_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_time_field_with_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
+    value = DateTime.new(2004, 6, 15, 1, 2, 3)
+    assert_dom_equal(expected, time_field("post", "written_on", value: value))
   end
 
   def test_time_field_with_timewithzone_value
@@ -1213,7 +1225,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_field_with_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2013-06-29T13:37:00+00:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2013-06-29T13:37:00" />}
     value = DateTime.new(2013, 6, 29, 13, 37)
     assert_dom_equal(expected, datetime_field("post", "written_on", value: value))
   end
@@ -1285,6 +1297,12 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, month_field("post", "written_on", min: min_value, max: max_value, step: step))
   end
 
+  def test_month_field_with_datetime_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
+    value = DateTime.new(2004, 6, 15, 1, 2, 3)
+    assert_dom_equal(expected, month_field("post", "written_on", value: value))
+  end
+
   def test_month_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
     expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
@@ -1318,6 +1336,12 @@ class FormHelperTest < ActionView::TestCase
     max_value = DateTime.new(2010, 12, 23)
     step = 2
     assert_dom_equal(expected, week_field("post", "written_on", min: min_value, max: max_value, step: step))
+  end
+
+  def test_week_field_with_datetime_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25" />}
+    value = DateTime.new(2004, 6, 15, 1, 2, 3)
+    assert_dom_equal(expected, week_field("post", "written_on", value: value))
   end
 
   def test_week_field_with_timewithzone_value


### PR DESCRIPTION
Fix inconsistent behavior in form helper date/time tags with options.

This change makes date/time options (value, min, max) in `time_field`, `date_field`, `datetime_field`, `week_field`, `month_field` form helpers behave in a unified way.