### PR TITLE
Allow SQL warnings to be reported.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow SQL warnings to be reported.
+
+    Active Record configs can be set to enable SQL warning reporting.
+
+    ```ruby
+    # Configure action to take when SQL query produces warning
+    config.active_record.db_warnings_action = :raise
+
+    # Configure allowlist of warnings that should always be ignored
+    config.active_record.db_warnings_ignore = [
+      /Invalid utf8mb4 character string/,
+      "An exact warning message",
+    ]
+    ```
+
+    This is supported for the MySQL and PostgreSQL adapters.
+
+    *Adrianna Chang*, *Paarth Madan*
+
 *   Add `#regroup` query method as a short-hand for `.unscope(:group).group(fields)`
 
     Example:
@@ -15,7 +34,6 @@
     Example: `enable_extension('heroku_ext.hstore')`
 
     *Leonardo Luarte*
-
 
 *   `ActiveRecord::Relation`’s `#any?`, `#none?`, and `#one?` methods take an optional pattern
     argument, more closely matching their `Enumerable` equivalents.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1185,6 +1185,10 @@ module ActiveRecord
         def default_prepared_statements
           true
         end
+
+        def warning_ignored?(warning)
+          ActiveRecord.db_warnings_ignore.any? { |warning_matcher| warning.message.match?(warning_matcher) }
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -65,7 +65,8 @@ module ActiveRecord
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
           if without_prepared_statement?(binds)
             with_raw_connection do |conn|
-              execute_and_free(sql, name) { conn.affected_rows }
+              @affected_rows_before_warnings = nil
+              execute_and_free(sql, name) { @affected_rows_before_warnings || conn.affected_rows }
             end
           else
             exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -257,6 +257,19 @@ module ActiveRecord
   class RangeError < StatementInvalid
   end
 
+  # Raised when a statement produces an SQL warning.
+  class SQLWarning < ActiveRecordError
+    attr_reader :code, :level
+    attr_accessor :sql
+
+    def initialize(message = nil, code = nil, level = nil, sql = nil)
+      super(message)
+      @code = code
+      @level = level
+      @sql = sql
+    end
+  end
+
   # Raised when the number of placeholders in an SQL fragment passed to
   # {ActiveRecord::Base.where}[rdoc-ref:QueryMethods#where]
   # does not match the number of values supplied.

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -4,6 +4,8 @@ require "cases/helper"
 require "support/ddl_helper"
 require "support/connection_helper"
 
+require "active_support/error_reporter/test_helper"
+
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapterTest < ActiveRecord::PostgreSQLTestCase
@@ -13,6 +15,7 @@ module ActiveRecord
 
       def setup
         @connection = ActiveRecord::Base.connection
+        @original_db_warnings_action = :ignore
       end
 
       def test_connection_error
@@ -482,6 +485,96 @@ module ActiveRecord
             @connection.case_insensitive_comparison(attribute, "foo")
           end
         end
+      end
+
+      def test_ignores_warnings_when_behaviour_ignore
+        ActiveRecord.db_warnings_action = :ignore
+
+        result = @connection.execute("do $$ BEGIN RAISE WARNING 'foo'; END; $$")
+
+        assert_equal [], result.to_a
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+      end
+
+      def test_logs_warnings_when_behaviour_log
+        ActiveRecord.db_warnings_action = :log
+
+        sql_warning = "[ActiveRecord::SQLWarning] PostgreSQL SQL warning (01000)"
+
+        assert_called_with(ActiveRecord::Base.logger, :warn, [sql_warning]) do
+          @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+        end
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+      end
+
+      def test_raises_warnings_when_behaviour_raise
+        ActiveRecord.db_warnings_action = :raise
+
+        assert_raises(ActiveRecord::SQLWarning) do
+          @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+        end
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+      end
+
+      def test_reports_when_behaviour_report
+        ActiveRecord.db_warnings_action = :report
+
+        error_reporter = ActiveSupport::ErrorReporter.new
+        subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+
+        Rails.define_singleton_method(:error) { error_reporter }
+        Rails.error.subscribe(subscriber)
+
+        @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+        warning_event, * = subscriber.events.first
+
+        assert_kind_of ActiveRecord::SQLWarning, warning_event
+        assert_equal "PostgreSQL SQL warning", warning_event.message
+      ensure
+        Rails.singleton_class.remove_method(:error)
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+      end
+
+      def test_warnings_behaviour_can_be_customized_with_a_proc
+        warning_message = nil
+        warning_level = nil
+        ActiveRecord.db_warnings_action = ->(warning) do
+          warning_message = warning.message
+          warning_level = warning.level
+        end
+
+        @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+
+        assert_equal "PostgreSQL SQL warning", warning_message
+        assert_equal "WARNING", warning_level
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+      end
+
+      def test_allowlist_of_warnings_to_ignore
+        old_ignored_warnings = ActiveRecord.db_warnings_ignore
+        ActiveRecord.db_warnings_action = :raise
+        ActiveRecord.db_warnings_ignore = [/PostgreSQL SQL warning/]
+
+        result = @connection.execute("do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$")
+
+        assert_equal [], result.to_a
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
+        ActiveRecord.db_warnings_ignore = old_ignored_warnings
+      end
+
+      def test_does_not_raise_notice_level_warnings
+        ActiveRecord.db_warnings_action = :raise
+
+        result = @connection.execute("DROP TABLE IF EXISTS non_existent_table")
+
+        assert_equal [], result.to_a
+      ensure
+        ActiveRecord.db_warnings_action = @original_db_warnings_action
       end
 
       private

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -946,6 +946,46 @@ Specifies if an error should be raised if the order of a query is ignored during
 
 Controls whether migrations are numbered with serial integers or with timestamps. The default is `true`, to use timestamps, which are preferred if there are multiple developers working on the same application.
 
+#### `config.active_record.db_warnings_action`
+
+Controls the action to be taken when a SQL query produces a warning. The following options are available:
+
+  * `:ignore` - Database warnings wil be ignored. This is the default.
+
+  * `:log` - Database warnings will be logged via `ActiveRecord.logger` at the `:warn` level.
+
+  * `:raise` - Database warnings will be raised as `ActiveRecord::SQLWarning`.
+
+  * `:report` - Database warnings be will reported to subscribers of Rails' error reporter.
+
+  * Custom proc - A custom proc can be provided. It should accept a `SQLWarning` error object.
+
+    For example:
+
+    ```ruby
+    config.active_record.db_warnings_action = ->(warning) do
+      # Report to custom exception reporting service
+      Bugsnag.notify(warning.message) do |notification|
+        notification.add_metadata(:warning_code, warning.code)
+        notification.add_metadata(:warning_level, warning.level)
+      end
+    end
+    ```
+
+#### `config.active_record.db_warnings_ignore`
+
+Specifies an allowlist of warnings that will be ignored, regardless of the configured `db_warnings_action`.
+The default behavior is to report all warnings. Warnings to ignore can be specified as Strings or Regexps. For example:
+
+  ```ruby
+  config.active_record.db_warnings_action = :raise
+  # The following warnings will not be raised
+  config.active_record.db_warnings_ignore = [
+    /Invalid utf8mb4 character string/,
+    "An exact warning message",
+  ]
+  ```
+
 #### `config.active_record.migration_strategy`
 
 Controls the strategy class used to perform schema statement methods in a migration. The default class


### PR DESCRIPTION
### Motivation / Background

At Shopify, we use https://github.com/Shopify/activerecord-pedantmysql2-adapter to raise SQL warnings as errors so they can be identified and fixed. We believe this provides value upstream, so we'd like to propose an API in Rails that provides warning reporting.

`Activerecord::PedantMysql2` provides a more comprehensive API, including the ability to capture / silence warnings within certain scopes. We've reduced the API to what we believe is most critical: allowing users to raise, log, or ignore warnings. Users can also specify a custom proc to be called when a warning is encountered, which provides some of the flexibility that the pedant gem was offering.

### Detail

We've introduced two configurations to Active Record:
* `config.active_record.db_warnings_action` can be used to configure the action to take when a query produces a warning. The warning can be ignored, logged, raised, or trigger custom behaviour provided via a proc.
* `config.active_record.db_warnings_ignore` allows applications to set an allowlist of SQL warnings that should always be ignored, regardless of the configured action.

For now, this is only scoped to MySQL adapters, internally relying on MySQL's `SHOW WARNINGS` statement, and the PostgreSQL adapter, relying on [`#set_notice_processor`](https://deveiate.org/code/pg/PG/Connection.html#method-i-set_notice_processor).

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
