### PR TITLE
Fix: `StrictLoadingViolationError` when concatenating or setting association when non-persisted owner has primary key

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -119,7 +119,7 @@ module ActiveRecord
       def concat(*records)
         records = records.flatten
         if owner.new_record?
-          load_target
+          skip_strict_loading { load_target }
           concat_records(records)
         else
           transaction { concat_records(records) }
@@ -233,7 +233,7 @@ module ActiveRecord
       # and delete/add only records that have changed.
       def replace(other_array)
         other_array.each { |val| raise_on_type_mismatch!(val) }
-        original_target = load_target.dup
+        original_target = skip_strict_loading { load_target }.dup
 
         if owner.new_record?
           replace_records(other_array, original_target)

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -162,6 +162,60 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_on_concat_is_ignored
+    developer = Developer.first
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs << AuditLog.new(message: "message")
+    end
+  end
+
+  def test_strict_loading_on_build_is_ignored
+    developer = Developer.first
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs.build(message: message)
+    end
+  end
+
+  def test_strict_loading_on_writer_is_ignored
+    developer = Developer.first
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs = [AuditLog.new(message: "message")]
+    end
+  end
+
+  def test_strict_loading_with_new_record_on_concat_is_ignored
+    developer = Developer.new(id: Developer.first.id)
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs << AuditLog.new(message: "message")
+    end
+  end
+
+  def test_strict_loading_with_new_record_on_build_is_ignored
+    developer = Developer.new(id: Developer.first.id)
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs.build(message: "message")
+    end
+  end
+
+  def test_strict_loading_with_new_record_on_writer_is_ignored
+    developer = Developer.new(id: Developer.first.id)
+    developer.strict_loading!
+
+    assert_nothing_raised do
+      developer.audit_logs = [AuditLog.new(message: "message")]
+    end
+  end
+
   def test_strict_loading_has_one_reload
     with_strict_loading_by_default(Developer) do
       ship = Ship.create!(developer: Developer.first, name: "The Great Ship")


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46689

I think this is a neater (and safer!) solution than https://github.com/rails/rails/pull/46613 anyway.

cc @richardboehme please verify the fix.
cc @adrianna-chang-shopify please check this doesn't cause https://github.com/rails/rails/issues/46685 again!
cc @eileencodes because strict loading.