### PR TITLE
Use storage/ instead of db/ for sqlite3 db files

### DIFF
--- a/actionmailbox/test/dummy/config/database.yml
+++ b/actionmailbox/test/dummy/config/database.yml
@@ -11,15 +11,15 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: storage/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3

--- a/actiontext/test/dummy/config/database.yml
+++ b/actiontext/test/dummy/config/database.yml
@@ -11,15 +11,15 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: storage/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -697,7 +697,7 @@
     ```yaml
     development:
         <<: *default
-        database: db/development.sqlite3
+        database: storage/development.sqlite3
         foreign_keys: false
     ```
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -272,7 +272,7 @@ module ActiveRecord
     #
     #  ActiveRecord::Base.connection_db_config
     #    #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-    #      @name="primary", @config={pool: 5, timeout: 5000, database: "db/development.sqlite3", adapter: "sqlite3"}>
+    #      @name="primary", @config={pool: 5, timeout: 5000, database: "storage/development.sqlite3", adapter: "sqlite3"}>
     #
     # Use only for reading.
     def connection_db_config

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -53,19 +53,19 @@ module ActiveRecord
       #
       #   development:
       #     adapter: sqlite3
-      #     database: db/development.sqlite3
+      #     database: storage/development.sqlite3
       #
       #   production:
       #     adapter: sqlite3
-      #     database: db/production.sqlite3
+      #     database: storage/production.sqlite3
       #
       # ...would result in ActiveRecord::Base.configurations to look like this:
       #
       #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-      #       @name="primary", @config={adapter: "sqlite3", database: "db/development.sqlite3"}>,
+      #       @name="primary", @config={adapter: "sqlite3", database: "storage/development.sqlite3"}>,
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
-      #       @name="primary", @config={adapter: "sqlite3", database: "db/production.sqlite3"}>
+      #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
       #   ]>
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -204,13 +204,13 @@ module ActiveRecord
           development: {
             primary: {
               adapter: "sqlite3",
-              database: "test/db/development.sqlite3",
+              database: "test/storage/development.sqlite3",
             },
           },
           test: {
             primary: {
               adapter: "sqlite3",
-              database: "test/db/test.sqlite3",
+              database: "test/storage/test.sqlite3",
             },
           },
         }

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -418,7 +418,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
         ActiveRecord::Base.establish_connection(
           {
             adapter: "sqlite3",
-            database: "test/db/test.sqlite3",
+            database: "test/storage/test.sqlite3",
             foreign_keys: false,
           }
         )

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2772,7 +2772,7 @@ Here's the section of the default configuration file (`config/database.yml`) wit
 ```yaml
 development:
   adapter: sqlite3
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
   pool: 5
   timeout: 5000
 ```
@@ -2844,7 +2844,7 @@ If you choose to use SQLite3 and are using JRuby, your `config/database.yml` wil
 ```yaml
 development:
   adapter: jdbcsqlite3
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
 ```
 
 #### Configuring a MySQL or MariaDB Database for JRuby Platform
@@ -3198,7 +3198,7 @@ Active Record database connections are managed by `ActiveRecord::ConnectionAdapt
 ```ruby
 development:
   adapter: sqlite3
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
   pool: 5
   timeout: 5000
 ```

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Always generate the storage/ directory with rails new to ensure there's a stable place to 
+    put permanent files, and a single mount point for containers to map. Then default sqlite3 databases
+    to live there instead of db/, which is only meant for configuration, not data.
+
+    *DHH*
+
 *   Rails console now disables `IRB`'s autocompletion feature in production by default.
 
     Setting `IRB_USE_AUTOCOMPLETE=true` can override this default.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -406,7 +406,7 @@ module Rails
       end
 
       def create_storage_files
-        build(:storage) unless skip_active_storage?
+        build(:storage)
       end
 
       def delete_app_assets_if_api_option

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -10,15 +10,15 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: storage/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -11,15 +11,15 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: storage/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: storage/production.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -7,12 +7,6 @@
 # Ignore bundler config.
 /.bundle
 
-<% if sqlite3? -%>
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-*
-
-<% end -%>
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
@@ -27,7 +21,7 @@
 <% end -%>
 
 <% unless skip_active_storage? -%>
-# Ignore uploaded files in development.
+# Ignore uploaded files in development (and any SQLite databases).
 /storage/*
 <% if keeps? -%>
 !/storage/.keep

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -20,15 +20,13 @@
 !/tmp/pids/.keep
 <% end -%>
 
-<% unless skip_active_storage? -%>
-# Ignore uploaded files in development (and any SQLite databases).
+# Ignore storage (uploaded files in development and any SQLite databases).
 /storage/*
 <% if keeps? -%>
 !/storage/.keep
 /tmp/storage/*
 !/tmp/storage/
 !/tmp/storage/.keep
-<% end -%>
 <% end -%>
 <% unless options.api? -%>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -9,8 +9,6 @@
 /<%= dummy_path %>/db/*.sqlite3-*
 <% end -%>
 /<%= dummy_path %>/log/*.log
-<% unless skip_active_storage? -%>
 /<%= dummy_path %>/storage/
-<% end -%>
 /<%= dummy_path %>/tmp/
 <% end -%>

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -29,7 +29,7 @@ module ApplicationTests
 
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do
-          config.database = "db/development.sqlite3"
+          config.database = "storage/development.sqlite3"
         end
       RUBY
 
@@ -49,11 +49,11 @@ module ApplicationTests
 
         development:
           <<: *default
-          database: db/development.sqlite3
+          database: storage/development.sqlite3
 
         production:
           <<: *default
-          database: db/production.sqlite3
+          database: storage/production.sqlite3
       YAML
 
       primary, replica = PTY.open

--- a/railties/test/application/multi_db_rake_test.rb
+++ b/railties/test/application/multi_db_rake_test.rb
@@ -43,7 +43,7 @@ module ApplicationTests
         development:
           primary:
             <<: *default
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
           animals:
             <<: *default
             database: db/development_animals.sqlite3

--- a/railties/test/application/multi_db_rake_test.rb
+++ b/railties/test/application/multi_db_rake_test.rb
@@ -46,7 +46,7 @@ module ApplicationTests
             database: storage/development.sqlite3
           animals:
             <<: *default
-            database: db/development_animals.sqlite3
+            database: storage/development_animals.sqlite3
             migrations_paths:
               - db/animals_migrate
               - db/common

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -59,17 +59,17 @@ module ApplicationTests
         File.write("#{app_path}/config/database.yml", <<~YAML)
           test:
             adapter: sqlite3
-            database: db/test.sqlite3
+            database: storage/test.sqlite3
 
           development:
             adapter: sqlite3
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
         YAML
 
         with_rails_env "development" do
           db_create_and_drop database_url_db_name do
-            assert_not File.exist?("#{app_path}/db/test.sqlite3")
-            assert_not File.exist?("#{app_path}/db/development.sqlite3")
+            assert_not File.exist?("#{app_path}/storage/test.sqlite3")
+            assert_not File.exist?("#{app_path}/storage/development.sqlite3")
           end
         end
       end
@@ -84,18 +84,18 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML with alias ERB" do
         app_file "config/database.yml", <<-YAML
           sqlite: &sqlite
             adapter: sqlite3
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
 
           development:
             <<: *<%= ENV["DB"] || "sqlite" %>
@@ -103,11 +103,11 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML with multiline ERB" do
@@ -121,17 +121,17 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading ERB accessing nested configurations" do
         app_file "config/database.yml", <<-YAML
           development:
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
             adapter: sqlite3
             other: <%= Rails.application.config.other.value %>
         YAML
@@ -142,7 +142,7 @@ module ApplicationTests
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML containing conditional statements in ERB" do
@@ -158,11 +158,11 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML containing multiple ERB statements on the same line" do
@@ -174,44 +174,44 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML with single-line ERB" do
         app_file "config/database.yml", <<-YAML
           development:
-            <%= Rails.application.config.database ? 'database: db/development.sqlite3' : 'database: db/development.sqlite3' %>
+            <%= Rails.application.config.database ? 'database: storage/development.sqlite3' : 'database: storage/development.sqlite3' %>
             adapter: sqlite3
         YAML
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       test "db:create and db:drop don't raise errors when loading YAML which contains a key's value as an ERB statement" do
         app_file "config/database.yml", <<-YAML
           development:
-            database: <%= Rails.application.config.database ? 'db/development.sqlite3' : 'db/development.sqlite3' %>
+            database: <%= Rails.application.config.database ? 'storage/development.sqlite3' : 'storage/development.sqlite3' %>
             custom_option: <%= ENV['CUSTOM_OPTION'] %>
             adapter: sqlite3
         YAML
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop("db/development.sqlite3", environment_loaded: false)
+        db_create_and_drop("storage/development.sqlite3", environment_loaded: false)
       end
 
       def with_database_existing
@@ -430,7 +430,7 @@ module ApplicationTests
                 statement_timeout: 1000
             development:
               <<: *default
-              database: db/development.sqlite3
+              database: storage/development.sqlite3
               schema_cache_path: db/special_schema_cache.yml
             YAML
           end
@@ -464,7 +464,7 @@ module ApplicationTests
             development:
               some_entry:
                 <<: *default
-                database: db/development.sqlite3
+                database: storage/development.sqlite3
               another_entry:
                 <<: *default
                 database: db/another_entry_development.sqlite3

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -955,7 +955,7 @@ module ApplicationTests
               %>
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
         YAML
 
@@ -975,11 +975,11 @@ module ApplicationTests
             <% if Rails.application.config.database %>
               database: <%= Rails.application.config.database %>
             <% else %>
-              database: db/default.sqlite3
+              database: storage/default.sqlite3
             <% end %>
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
 
         YAML
@@ -998,12 +998,12 @@ module ApplicationTests
           development:
             <% 5.times do |i| %>
             shard_<%= i %>:
-              database: db/development_shard_<%= i %>.sqlite3
+              database: storage/development_shard_<%= i %>.sqlite3
               adapter: sqlite3
             <% end %>
         YAML
 
-        db_create_and_drop_namespace("shard_3", "db/development_shard_3.sqlite3")
+        db_create_and_drop_namespace("shard_3", "storage/development_shard_3.sqlite3")
       end
 
       test "schema generation when dump_schema_after_migration is true schema_dump is false" do
@@ -1137,10 +1137,10 @@ module ApplicationTests
         app_file "config/database.yml", <<-YAML
           development:
             primary:
-              database: <% if Rails.application.config.database %><%= Rails.application.config.database %><% else %>db/default.sqlite3<% end %>
+              database: <% if Rails.application.config.database %><%= Rails.application.config.database %><% else %>storage/default.sqlite3<% end %>
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
         YAML
 
@@ -1160,7 +1160,7 @@ module ApplicationTests
               <%= Rails.application.config.database ? 'database: storage/development.sqlite3' : 'database: storage/development.sqlite3' %>
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
         YAML
 
@@ -1181,7 +1181,7 @@ module ApplicationTests
               custom_option: <%= ENV['CUSTOM_OPTION'] %>
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
         YAML
 
@@ -1198,10 +1198,10 @@ module ApplicationTests
         app_file "config/database.yml", <<-YAML
           development:
             default:
-              database: db/default.sqlite3
+              database: storage/default.sqlite3
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
               migrations_paths: db/animals_migrate
         YAML
@@ -1214,10 +1214,10 @@ module ApplicationTests
         app_file "config/database.yml", <<-YAML
           development:
             primary:
-              database: db/default.sqlite3
+              database: storage/default.sqlite3
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
               database_tasks: false
               schema_dump: true ### database_tasks should override all sub-settings
@@ -1268,18 +1268,18 @@ module ApplicationTests
         app_file "config/database.yml", <<-YAML
           development:
             primary:
-              database: db/default.sqlite3
+              database: storage/default.sqlite3
               adapter: sqlite3
             animals:
-              database: db/development_animals.sqlite3
+              database: storage/development_animals.sqlite3
               adapter: sqlite3
               migrations_paths: db/animals_migrate
           test:
             primary:
-              database: db/default_test.sqlite3
+              database: storage/default_test.sqlite3
               adapter: sqlite3
             animals:
-              database: db/test_animals.sqlite3
+              database: storage/test_animals.sqlite3
               adapter: sqlite3
               migrations_paths: db/animals_migrate
         YAML

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -834,8 +834,8 @@ module ApplicationTests
           rails("db:migrate")
           output = rails("db:version")
 
-          assert_match(/database: db\/development.sqlite3\nCurrent version: #{primary_version}/, output)
-          assert_match(/database: db\/development_animals.sqlite3\nCurrent version: #{animals_version}/, output)
+          assert_match(/database: storage\/development.sqlite3\nCurrent version: #{primary_version}/, output)
+          assert_match(/database: storage\/development_animals.sqlite3\nCurrent version: #{animals_version}/, output)
         end
       end
 

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -940,7 +940,7 @@ module ApplicationTests
         RUBY
 
         output = rails("db:seed")
-        assert_equal output, "db/development.sqlite3"
+        assert_equal output, "storage/development.sqlite3"
       ensure
         ENV["RAILS_ENV"] = @old_rails_env
         ENV["RACK_ENV"] = @old_rack_env
@@ -961,11 +961,11 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop_namespace("primary", "db/development.sqlite3")
+        db_create_and_drop_namespace("primary", "storage/development.sqlite3")
       end
 
       test "db:create and db:drop don't raise errors when loading YAML containing conditional statements in ERB" do
@@ -986,11 +986,11 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop_namespace("primary", "db/development.sqlite3")
+        db_create_and_drop_namespace("primary", "storage/development.sqlite3")
       end
 
       test "db:create and db:drop don't raise errors when loading YAML containing ERB in database keys" do
@@ -1146,18 +1146,18 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop_namespace("primary", "db/development.sqlite3")
+        db_create_and_drop_namespace("primary", "storage/development.sqlite3")
       end
 
       test "db:create and db:drop don't raise errors when loading YAML with single-line ERB" do
         app_file "config/database.yml", <<-YAML
           development:
             primary:
-              <%= Rails.application.config.database ? 'database: db/development.sqlite3' : 'database: db/development.sqlite3' %>
+              <%= Rails.application.config.database ? 'database: storage/development.sqlite3' : 'database: storage/development.sqlite3' %>
               adapter: sqlite3
             animals:
               database: db/development_animals.sqlite3
@@ -1166,18 +1166,18 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop_namespace("primary", "db/development.sqlite3")
+        db_create_and_drop_namespace("primary", "storage/development.sqlite3")
       end
 
       test "db:create and db:drop don't raise errors when loading YAML which contains a key's value as an ERB statement" do
         app_file "config/database.yml", <<-YAML
           development:
             primary:
-              database: <%= Rails.application.config.database ? 'db/development.sqlite3' : 'db/development.sqlite3' %>
+              database: <%= Rails.application.config.database ? 'storage/development.sqlite3' : 'storage/development.sqlite3' %>
               custom_option: <%= ENV['CUSTOM_OPTION'] %>
               adapter: sqlite3
             animals:
@@ -1187,11 +1187,11 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.database = "db/development.sqlite3"
+            config.database = "storage/development.sqlite3"
           end
         RUBY
 
-        db_create_and_drop_namespace("primary", "db/development.sqlite3")
+        db_create_and_drop_namespace("primary", "storage/development.sqlite3")
       end
 
       test "when there is no primary config, the first is chosen as the default" do

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -64,7 +64,7 @@ module Rails
 
             assert_file("config/database.yml") do |content|
               assert_match "adapter: sqlite3", content
-              assert_match "db/development.sqlite3", content
+              assert_match "storage/development.sqlite3", content
             end
 
             assert_file("Gemfile") do |content|

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -249,8 +249,6 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-    assert_no_directory "#{application_path}/storage"
-    assert_no_directory "#{application_path}/tmp/storage"
 
     assert_file ".gitignore" do |content|
       assert_no_match(/\/storage\//, content)

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -174,22 +174,6 @@ module SharedGeneratorTests
     end
   end
 
-  def test_gitignore_when_sqlite3
-    run_generator
-
-    assert_file ".gitignore" do |content|
-      assert_match(/sqlite3/, content)
-    end
-  end
-
-  def test_gitignore_when_non_sqlite3_db
-    run_generator([destination_root, "-d", "mysql"])
-
-    assert_file ".gitignore" do |content|
-      assert_no_match(/sqlite/i, content)
-    end
-  end
-
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_directory "#{application_path}/db/"
@@ -201,9 +185,6 @@ module SharedGeneratorTests
     end
     assert_file "#{application_path}/bin/setup" do |setup_content|
       assert_no_match(/db:prepare/, setup_content)
-    end
-    assert_file ".gitignore" do |content|
-      assert_no_match(/sqlite/i, content)
     end
   end
 
@@ -225,10 +206,6 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/storage.yml"
     assert_directory "#{application_path}/storage"
     assert_directory "#{application_path}/tmp/storage"
-
-    assert_file ".gitignore" do |content|
-      assert_match(/\/storage\//, content)
-    end
   end
 
   def test_generator_if_skip_active_storage_is_given
@@ -249,10 +226,6 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-
-    assert_file ".gitignore" do |content|
-      assert_no_match(/\/storage\//, content)
-    end
   end
 
   def test_generator_does_not_generate_active_storage_contents_if_skip_active_record_is_given
@@ -273,12 +246,6 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-    assert_no_directory "#{application_path}/storage"
-    assert_no_directory "#{application_path}/tmp/storage"
-
-    assert_file ".gitignore" do |content|
-      assert_no_match(/\/storage\//, content)
-    end
   end
 
   def test_generator_if_skip_action_mailer_is_given

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -155,13 +155,13 @@ module TestHelpers
           timeout: 5000
         development:
           <<: *default
-          database: db/development.sqlite3
+          database: storage/development.sqlite3
         test:
           <<: *default
-          database: db/test.sqlite3
+          database: storage/test.sqlite3
         production:
           <<: *default
-          database: db/production.sqlite3
+          database: storage/production.sqlite3
       YAML
     end
 
@@ -176,10 +176,10 @@ module TestHelpers
         development:
           primary:
             <<: *default
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
           primary_readonly:
             <<: *default
-            database: db/development.sqlite3
+            database: storage/development.sqlite3
             replica: true
           animals:
             <<: *default
@@ -193,10 +193,10 @@ module TestHelpers
         test:
           primary:
             <<: *default
-            database: db/test.sqlite3
+            database: storage/test.sqlite3
           primary_readonly:
             <<: *default
-            database: db/test.sqlite3
+            database: storage/test.sqlite3
             replica: true
           animals:
             <<: *default
@@ -210,10 +210,10 @@ module TestHelpers
         production:
           primary:
             <<: *default
-            database: db/production.sqlite3
+            database: storage/production.sqlite3
           primary_readonly:
             <<: *default
-            database: db/production.sqlite3
+            database: storage/production.sqlite3
             replica: true
           animals:
             <<: *default

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -183,11 +183,11 @@ module TestHelpers
             replica: true
           animals:
             <<: *default
-            database: db/development_animals.sqlite3
+            database: storage/development_animals.sqlite3
             migrations_paths: db/animals_migrate
           animals_readonly:
             <<: *default
-            database: db/development_animals.sqlite3
+            database: storage/development_animals.sqlite3
             migrations_paths: db/animals_migrate
             replica: true
         test:
@@ -200,11 +200,11 @@ module TestHelpers
             replica: true
           animals:
             <<: *default
-            database: db/test_animals.sqlite3
+            database: storage/test_animals.sqlite3
             migrations_paths: db/animals_migrate
           animals_readonly:
             <<: *default
-            database: db/test_animals.sqlite3
+            database: storage/test_animals.sqlite3
             migrations_paths: db/animals_migrate
             replica: true
         production:
@@ -217,11 +217,11 @@ module TestHelpers
             replica: true
           animals:
             <<: *default
-            database: db/production_animals.sqlite3
+            database: storage/production_animals.sqlite3
             migrations_paths: db/animals_migrate
           animals_readonly:
             <<: *default
-            database: db/production_animals.sqlite3
+            database: storage/production_animals.sqlite3
             migrations_paths: db/animals_migrate
             replica: true
       YAML


### PR DESCRIPTION
The directory db/ should be for configuration only, not data. This will make it easier to mount a single data volume into a container for testing, development, and even sqlite3 in production.