### PR TITLE
Add instructions on how to use `db/seeds` to `test_helper` template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -14,6 +14,9 @@ module ActiveSupport
 <% unless options[:skip_active_record] -%>
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
+    # To use seed data (db/seeds.rb) as an alternative to fixtures, replace the `fixtures` call with:
+    #  ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    #  Rails.application.load_seed
 
 <% end -%>
     # Add more helper methods to be used by all tests here...


### PR DESCRIPTION
ref: https://discuss.rubyonrails.org/t/should-dbprepare-also-call-db-seed-by-default/74835/14?u=ghiculescu

Adds a new line to the `test_helper.rb` template. The relevant section now looks like this:

```ruby
  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
  fixtures :all
  # To use seed data (db/seeds.rb) as an alternative to fixtures, replace the `fixtures` call with:
  #  ActiveRecord::Tasks::DatabaseTasks.truncate_all
  #  Rails.application.load_seed
```

Hopefully this makes it clear to developers that if you want to use your seed file for test data, you just remove the `fixtures :all` and add the other two lines.

Note: It is possible to use both fixtures and seeds concurrently, but that only works if the fixtures and seeds do not touch the same tables at all. This is becuase [Active Record truncates every table that will have fixture data before inserting fixtures](https://github.com/rails/rails/blob/e90bc0d9e9e5d146bb4a16eb56028ec29a4ea7d7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L434). Advanced users could work around this, but I think that's overly complicated for this template (and frankly I haven't found a good pattern for it yet...). So I've decided it's best to not mention this in the template.
