### PR TITLE
Lock sqlite3 gem to 1.4 to run Rails CI using rubylang/ruby:master-nightly-focal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", "~> 1.4", "< 1.5"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,7 @@ DEPENDENCIES
   sneakers
   sprockets-export
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.4)
+  sqlite3 (~> 1.4, < 1.5)
   stackprof
   stimulus-rails
   sucker_punch


### PR DESCRIPTION
### Motivation / Background

I have managed to reproduce https://buildkite.com/rails/rails/builds/90045#01839e89-85d4-4ef5-a443-6b2993f08f36 

### Detail

- Steps to reproduce

```
Install Docker
git clone https://github.com/rails/rails
cd rails
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=rubylang/ruby:master-nightly-focal docker-compose -f .buildkite/docker-compose.yml build base
```

- Actual behavior without this change

It gets `Gem::Ext::BuildError: ERROR: Failed to build gem native extension.`

The entire error message can be seen via
https://buildkite.com/rails/rails/builds/90045#01839e89-85d4-4ef5-a443-6b2993f08f36

### Additional information

The last successful build installed `sqlite3 1.5.1`. however, now it cannot install 1.5.1, 1.5.0 anymore.
https://buildkite.com/rails/rails/builds/90006#01839032-3ccd-4aca-ad58-2c08beb4351f/142-862

I still have not found the actual reason why. I've just found a related issue https://bugs.ruby-lang.org/issues/19189

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
