### PR TITLE
Fix parallel testing databases

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -384,7 +384,7 @@ module ActiveRecord
 
         check_schema_file(file) if file
 
-        with_temporary_connection(db_config) do
+        with_temporary_pool(db_config) do
           if schema_up_to_date?(db_config, format, file)
             truncate_tables(db_config)
           else


### PR DESCRIPTION
In #46270 it was reported that there were database errors when running the tests in an app. I set up a demo app to use parallel testing and was able to reproduce. The issue was that the `reconstruct_from_schema` method needs to use the `pool` and not the `connection` because the database might not exist yet and will raise an error. I don't know how to test this inside Rails but I verified this behavior in my demo app.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`