### PR TITLE
Add missing end to code example [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -610,6 +610,7 @@ module ActiveRecord
       #     def log_after_remove(record)
       #       # ...
       #     end
+      #   end
       #
       # It's possible to stack callbacks by passing them as an array. Example:
       #


### PR DESCRIPTION
The missing `end` seems to mess-up code highlighting on https://rubydoc.info.

<img width="608" alt="image" src="https://user-images.githubusercontent.com/28561/207427271-174c8d12-720a-49e2-b866-dad0d32ed523.png">
