### PR TITLE
`ParallelizeExecutor` should print info when running with a single worker

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -68,7 +68,7 @@ module ActiveSupport
       # The default parallelization method is to fork processes. If you'd like to
       # use threads instead you can pass <tt>with: :threads</tt> to the +parallelize+
       # method. Note the threaded parallelization does not create multiple
-      # database and will not work with system tests at this time.
+      # databases and will not work with system tests at this time.
       #
       #   parallelize(workers: :number_of_processors, with: :threads)
       #
@@ -81,8 +81,6 @@ module ActiveSupport
       def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold)
         workers = Concurrent.physical_processor_count if workers == :number_of_processors
         workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
-
-        return if workers <= 1
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
       end

--- a/activesupport/lib/active_support/testing/parallelize_executor.rb
+++ b/activesupport/lib/active_support/testing/parallelize_executor.rb
@@ -53,7 +53,7 @@ module ActiveSupport
         end
 
         def should_parallelize?
-          ENV["PARALLEL_WORKERS"] || tests_count > threshold
+          size > 1 && (ENV["PARALLEL_WORKERS"] || tests_count > threshold)
         end
 
         def tests_count

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -728,9 +728,9 @@ module ApplicationTests
         end
       RUBY
 
-      output = run_test_command(file_name)
+      output = run_test_command(file_name, allow_failure: false)
 
-      assert_match(/Finished in.*2 runs, 2 assertions/m, output)
+      assert_match(/Finished in.*2 runs, 2 assertions, 0 failures, 0 errors, 0 skips/m, output)
       assert_match %r{Running \d+ tests in parallel using \d+ processes}, output
       assert_no_match "create_table(:users)", output
     end
@@ -738,7 +738,7 @@ module ApplicationTests
     def test_parallelization_is_disabled_when_number_of_tests_is_below_threshold
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, threshold: 100)
 
-      file_name = create_parallel_processes_test_file
+      file_name = create_parallel_blank_test_file
 
       app_file "db/schema.rb", <<-RUBY
         ActiveRecord::Schema.define(version: 1) do
@@ -748,7 +748,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = run_test_command(file_name)
+      output = run_test_command(file_name, allow_failure: false)
 
       assert_match %r{Running \d+ tests in a single process}, output
       assert_no_match %r{Running \d+ tests in parallel using \d+ processes}, output
@@ -756,22 +756,29 @@ module ApplicationTests
 
     def test_parallel_is_enabled_when_PARALLEL_WORKERS_is_set
       @old = ENV["PARALLEL_WORKERS"]
-      ENV["PARALLEL_WORKERS"] = "5"
+      ENV["PARALLEL_WORKERS"] = "2"
 
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, threshold: 100)
 
-      file_name = app_file "test/unit/parallel_test.rb", <<-RUBY
-        require "test_helper"
+      file_name = create_parallel_blank_test_file
+      output = run_test_command(file_name, allow_failure: false)
 
-        class ParallelTest < ActiveSupport::TestCase
-          def test_verify_test_order
-          end
-        end
-      RUBY
+      assert_match %r{Running \d+ tests in parallel using 2 processes}, output
+    ensure
+      ENV["PARALLEL_WORKERS"] = @old
+    end
 
-      output = run_test_command(file_name)
+    def test_parallelization_is_disabled_when_PARALLEL_WORKERS_is_set_to_1
+      @old = ENV["PARALLEL_WORKERS"]
+      ENV["PARALLEL_WORKERS"] = "1"
 
-      assert_match %r{Running \d+ tests in parallel using \d+ processes}, output
+      exercise_parallelization_regardless_of_machine_core_count(with: :processes, threshold: 50)
+
+      file_name = create_parallel_blank_test_file
+      output = run_test_command(file_name, allow_failure: false)
+
+      assert_match %r{Running \d+ tests in a single process \(parallelization threshold is 50\)}, output
+      assert_no_match %r{Running \d+ tests in parallel using \d+ processes}, output
     ensure
       ENV["PARALLEL_WORKERS"] = @old
     end
@@ -807,9 +814,9 @@ module ApplicationTests
         end
       RUBY
 
-      output = run_test_command(file_name)
+      output = run_test_command(file_name, allow_failure: false)
 
-      assert_match(/Finished in.*2 runs, 2 assertions/m, output)
+      assert_match(/Finished in.*2 runs, 2 assertions, 0 failures, 0 errors, 0 skips/m, output)
       assert_no_match "create_table(:users)", output
     end
 
@@ -1221,6 +1228,17 @@ module ApplicationTests
             def test_truth
               puts "#{name.camelize}Test" if #{print}
               assert #{pass}, 'wups!'
+            end
+          end
+        RUBY
+      end
+
+      def create_parallel_blank_test_file
+        app_file "test/unit/parallel_test.rb", <<-RUBY
+          require "test_helper"
+
+          class ParallelTest < ActiveSupport::TestCase
+            def test_verify_test_order
             end
           end
         RUBY


### PR DESCRIPTION
Currently if you do `bin/test` you might get output like:

```
Running 35 tests in a single process (parallelization threshold is 50)
```

And if you do `PARALLEL_WORKERS=2 bin/test` you might get:

```
Running 35 tests in parallel using 2 processes
```

But if you do `PARALLEL_WORKERS=1 bin/test` you get neither. Since you have explicitly set the environment variable, I think it would be good to log what is happening. So with this PR you will also get this output:

```
Running 35 tests in a single process (parallelization threshold is 50)
```

--------

This PR also contains some fixes to tests (the tests generated in the tests were failing... now they pass), and a typo fix. I can extract those to a separate PR if desired.