### PR TITLE
Parallelization test improvements

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -68,7 +68,7 @@ module ActiveSupport
       # The default parallelization method is to fork processes. If you'd like to
       # use threads instead you can pass <tt>with: :threads</tt> to the +parallelize+
       # method. Note the threaded parallelization does not create multiple
-      # database and will not work with system tests at this time.
+      # databases and will not work with system tests.
       #
       #   parallelize(workers: :number_of_processors, with: :threads)
       #


### PR DESCRIPTION
This fixes some issues I found while working on https://github.com/rails/rails/pull/46718

- Some of the tests in `test_runner_test.rb` generate a new test file, then run it. In some cases, the generated tests were failing. The calling test didn't expect this, but didn't fail despite that. So in this PR I have fixed the generated tests to always pass, and added `allow_failure: false` to enforce this.
- Added a missing test for when `PARALLEL_WORKERS=1`.
- Fixed a typo and removed some unnecessary wording in the docs.
