### PR TITLE
Dynamic cookie domain per request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow cookie options[:domain] to accept a proc to set the cookie domain on a more flexible per-request basis
+
+    *RobL*
+
 *   When a host is not specified for an `ActionController::Renderer`'s env,
     the host and related options will now be derived from the routes'
     `default_url_options` and `ActionDispatch::Http::URL.secure_protocol`.

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -160,13 +160,18 @@ module ActionDispatch
   #   to <tt>:all</tt>. To support multiple domains, provide an array, and
   #   the first domain matching <tt>request.host</tt> will be used. Make
   #   sure to specify the <tt>:domain</tt> option with <tt>:all</tt> or
-  #   <tt>Array</tt> again when deleting cookies.
+  #   <tt>Array</tt> again when deleting cookies. For more flexibility you
+  #   can set the domain on a per-request basis by specifying <tt>:domain</tt>
+  #   with a proc.
   #
   #     domain: nil  # Does not set cookie domain. (default)
   #     domain: :all # Allow the cookie for the top most level
   #                  # domain and subdomains.
   #     domain: %w(.example.com .example.org) # Allow the cookie
   #                                           # for concrete domain names.
+  #     domain: proc { Tenant.current.cookie_domain } # Set cookie domain dynamically
+  #     domain: proc { |req| ".sub.#{req.host}" }     # Set cookie domain dynamically based on request
+  #
   #
   # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, this option can be used to explicitly
   #   set the TLD length when using a short (<= 3 character) domain that is being interpreted as part of a TLD.
@@ -472,6 +477,8 @@ module ActionDispatch
               domain = domain.delete_prefix(".")
               request.host == domain || request.host.end_with?(".#{domain}")
             end
+          elsif options[:domain].respond_to?(:call)
+            options[:domain] = options[:domain].call(request)
           end
         end
     end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -232,6 +232,16 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def set_cookie_with_domain_proc
+      cookies[:user_name] = { value: "braindeaf", domain: proc { ".sub.www.nextangle.com" } }
+      head :ok
+    end
+
+    def set_cookie_with_domain_proc_with_request
+      cookies[:user_name] = { value: "braindeaf", domain: proc { |req| ".sub.#{req.host}" } }
+      head :ok
+    end
+
     def delete_cookie_with_domain
       cookies.delete(:user_name, domain: :all)
       head :ok
@@ -1220,6 +1230,18 @@ class CookiesTest < ActionController::TestCase
     get :set_cookie_with_domains
     assert_response :success
     assert_cookie_header "user_name=rizwanreza; domain=.example3.com; path=/; SameSite=Lax"
+  end
+
+  def test_cookie_with_domain_proc
+    get :set_cookie_with_domain_proc
+    assert_response :success
+    assert_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
+  end
+
+  def test_cookie_with_domain_proc_with_request
+    get :set_cookie_with_domain_proc_with_request
+    assert_response :success
+    assert_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_several_preset_domains_using_one_of_these_domains


### PR DESCRIPTION
### Motivation / Background

We've recently been looking at authentication across multiple applications where a multi-tenanted application needs to set a specific cookie domain e.g .tenant1.company.name for the application. Since this needs to work across multiple applications whether it be auth.tenant1.company.name, jam.tenant1.company.name we need just a little more flexibility and the :tld_length option won't cut it. Hence using a proc to set the cookie domain.

This pull request allows option[:domain] to be a proc

### Detail

This is a small change to actionpack/lib/action_dispatch/middleware/cookies.rb, coping with that additional option.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
