### PR TITLE
`ActiveRecord::Relation#none?`/`#any?`/`#one?`: support pattern arg

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveRecord::Relation`’s `#any?`, `#none?`, and `#one?` methods take an optional pattern
+    argument, more closely matching their `Enumerable` equivalents.
+
+    *George Claghorn*
+
 *   Add `ActiveRecord::Base::normalizes` to declare attribute normalizations.
 
     A normalization is applied when the attribute is assigned or updated, and

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -280,20 +280,20 @@ module ActiveRecord
     end
 
     # Returns true if there are no records.
-    def none?
-      return super if block_given?
+    def none?(*args)
+      return super if args.present? || block_given?
       empty?
     end
 
     # Returns true if there are any records.
-    def any?
-      return super if block_given?
+    def any?(*args)
+      return super if args.present? || block_given?
       !empty?
     end
 
     # Returns true if there is exactly one record.
-    def one?
-      return super if block_given?
+    def one?(*args)
+      return super if args.present? || block_given?
       return records.one? if loaded?
       limited_count == 1
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1157,6 +1157,9 @@ class RelationTest < ActiveRecord::TestCase
 
       assert posts.any? { |p| p.id > 0 }
       assert_not posts.any? { |p| p.id <= 0 }
+
+      assert posts.any?(Post)
+      assert_not posts.any?(Comment)
     end
 
     assert_predicate posts, :loaded?
@@ -1196,6 +1199,9 @@ class RelationTest < ActiveRecord::TestCase
     assert_queries(1) do
       assert posts.none? { |p| p.id < 0 }
       assert_not posts.none? { |p| p.id == 1 }
+
+      assert posts.none?(Comment)
+      assert_not posts.none?(Post)
     end
 
     assert_predicate posts, :loaded?
@@ -1212,6 +1218,9 @@ class RelationTest < ActiveRecord::TestCase
     assert_queries(1) do
       assert_not posts.one? { |p| p.id < 3 }
       assert posts.one? { |p| p.id == 1 }
+
+      assert_not posts.one?(Post)
+      assert_not posts.one?(Comment)
     end
 
     assert_predicate posts, :loaded?


### PR DESCRIPTION
The [`Enumerable`](https://ruby-doc.org/core-2.7.0/Enumerable.html) versions of the [`#none?`](https://ruby-doc.org/core-2.7.0/Enumerable.html#method-i-none-3F), [`#any?`](https://ruby-doc.org/core-2.7.0/Enumerable.html#method-i-any-3F), and [`#one?`](https://ruby-doc.org/core-2.7.0/Enumerable.html#method-i-one-3F) predicate methods each take an optional pattern argument instead of a block. When a pattern is provided, these methods check whether elements in the `Enumerable` match the pattern via the case-equality operator, `===`.

The following are equivalent:

```ruby
products.any?(MediaBlock)
products.any? { |product| MediaBlock === product }
```

It would sometimes be convenient to use this style on polymorphic associations. For example, in the `Order#plan?` method here:

```ruby
class Order
  has_many :line_items
  has_many :products, through: :line_items

  # Returns true if the order contains a plan.
  def plan?
    products.any?(Plan)
  end
end

class LineItem
  belongs_to :order
  has_one :product, polymorphic: true
end
```

However, `ActiveRecord::Relation`’s versions of these methods do not take an optional pattern argument. Update them to do so by delegating to the underlying loaded `records` array, as they do when a block is provided.