### PR TITLE
Fix for a Ruby 3.2 + Active Support test failure

### DIFF
--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -226,7 +226,7 @@ class ExecutorTest < ActiveSupport::TestCase
   end
 
   def test_class_serial_is_unaffected
-    skip if !defined?(RubyVM)
+    skip if !defined?(RubyVM) || !RubyVM.stat.has_key?(:class_serial)
 
     hook = Class.new do
       define_method(:run) do


### PR DESCRIPTION
### Motivation / Background

I found that Active Support CI fails on Ruby 3.2 (which used not to be running for months and just re-enabled yesterday via rails/buildkite-config#24 ) https://buildkite.com/rails/rails/builds/91681#018513b9-4dc6-445b-86d6-81691c97ef3a

### Detail

The cause of the error is that the test code calls RubyVM's class serial that has been removed since ruby/ruby@13bd617ea6fdf72467c593639cf33312a06c330c. So this patch changes the test to reference either `class_serial` or `next_shape_id`.

I'm not confident if I'm doing it correctly though. I'm glad if @tenderlove or @jemmaissroff could take a look on this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.