### PR TITLE
Bump Rake version to 13 or higher for Ruby 3.2 compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ else
 end
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
-gem "rake", ">= 11.1"
+gem "rake", ">= 13"
 
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,7 +607,7 @@ DEPENDENCIES
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!
-  rake (>= 11.1)
+  rake (>= 13)
   redcarpet (~> 3.2.3)
   redis (>= 4.0.1)
   redis-namespace


### PR DESCRIPTION
### Motivation / Background

Rake 12 seems not to play nice with Ruby 3.2 because it does not include https://github.com/ruby/rake/commit/baa23cc8a8cc624bc8f46c8a55d2f0caade568ea and thus cannot handle kwargs properly on Ruby 3.2.

I think it's time now to move our dev dependency to Rake 13.x that was firstly released 3.years.ago.

### Additional information

This patch aims to fix this CI failure (ArgumentError: wrong number of arguments (given 2, expected 1)) happening here.
https://buildkite.com/rails/rails/builds/91681#018513b9-4d8e-4c0b-a85c-ff932ce3bd1f

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
