### PR TITLE
Backport double logging fix in `ActiveRecord::QueryLog` to 7-0-stable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Don't double log the `controller`, `action`, or `namespaced_controller` when using `ActiveRecord::QueryLog`
+
+    Previously if you set `config.active_record.query_log_tags` to an array that included
+    `:controller`, `:namespaced_controller`, or `:action`, that item would get logged twice.
+    This bug has been fixed.
+
+    *Alex Ghiculescu*
+
 *   Rescue `EOFError` exception from `rack` on a multipart request.
 
     *Nikita Vasilevsky*

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -111,7 +111,8 @@ module ActionController
         app.config.action_controller.log_query_tags_around_actions
 
       if query_logs_tags_enabled
-        app.config.active_record.query_log_tags += [:controller, :action]
+        app.config.active_record.query_log_tags |= [:controller] unless app.config.active_record.query_log_tags.include?(:namespaced_controller)
+        app.config.active_record.query_log_tags |= [:action]
 
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::QueryLogs.taggings.merge!(

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Don't double log the `job` when using `ActiveRecord::QueryLog`
+
+    Previously if you set `config.active_record.query_log_tags` to an array that included
+    `:job`, the job name would get logged twice. This bug has been fixed.
+
+    *Alex Ghiculescu*
+
 ## Rails 7.0.4 (September 09, 2022) ##
 
 *   Update `ActiveJob::QueueAdapters::QueAdapter` to remove deprecation warning.

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -63,7 +63,7 @@ module ActiveJob
         app.config.active_job.log_query_tags_around_perform
 
       if query_logs_tags_enabled
-        app.config.active_record.query_log_tags << :job
+        app.config.active_record.query_log_tags |= [:job]
 
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::QueryLogs.taggings[:job] = ->(context) { context[:job].class.name if context[:job] }

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -99,6 +99,30 @@ module ApplicationTests
       assert_not_includes comment, "controller:users"
     end
 
+    test "controller tags are not doubled up if already configured" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :job, :controller, :pid ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+
+      assert_match(/\/\*action:index,controller:users,pid:\d+\*\//, comment)
+    end
+
+    test "namespace controller tags are not doubled up if already configured" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :job, :namespaced_controller, :pid ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+
+      assert_match(/\/\*action:index,namespaced_controller:UsersController,pid:\d+\*\//, comment)
+    end
+
     test "job perform method has tagging filters enabled by default" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
 
@@ -118,6 +142,17 @@ module ApplicationTests
       comment = UserJob.new.perform_now
 
       assert_not_includes comment, "UserJob"
+    end
+
+    test "job tags are not doubled up if already configured" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :action, :job, :controller, :pid ]"
+
+      boot_app
+
+      comment = UserJob.new.perform_now
+
+      assert_match(/\/\*job:UserJob,pid:\d+\*\//, comment)
     end
 
     test "query cache is cleared between requests" do


### PR DESCRIPTION
### Motivation / Background

Backports https://github.com/rails/rails/pull/46279 and https://github.com/rails/rails/pull/46642 to `7-0-stable`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
