### PR TITLE
Hide changes to `before_committed!` behaviour behind config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Hide changes to before_committed! callback behaviour behind flag.
+
+    In #46525, behavior around before_committed! callbacks was changed so that callbacks
+    would run on every enrolled record in a transaction, not just the first copy of a record.
+    This change in behavior is now controlled by a configuration option,
+    `config.active_record.before_committed_on_all_records`. It will be enabled by default on Rails 7.1.
+
+    *Adrianna Chang*
+
 *   The `namespaced_controller` Query Log tag now matches the `controller` format
 
     For example, a request processed by `NameSpaced::UsersController` will now log as:

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -274,6 +274,9 @@ module ActiveRecord
   singleton_class.attr_accessor :belongs_to_required_validates_foreign_key
   self.belongs_to_required_validates_foreign_key = true
 
+  singleton_class.attr_accessor :before_committed_on_all_records
+  self.before_committed_on_all_records = false
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -171,14 +171,18 @@ module ActiveRecord
         return unless records
 
         if @run_commit_callbacks
-          ite = unique_records
+          if ActiveRecord.before_committed_on_all_records
+            ite = unique_records
 
-          instances_to_run_callbacks_on = records.each_with_object({}) do |record, candidates|
-            candidates[record] = record
-          end
+            instances_to_run_callbacks_on = records.each_with_object({}) do |record, candidates|
+              candidates[record] = record
+            end
 
-          run_action_on_records(ite, instances_to_run_callbacks_on) do |record, should_run_callbacks|
-            record.before_committed! if should_run_callbacks
+            run_action_on_records(ite, instances_to_run_callbacks_on) do |record, should_run_callbacks|
+              record.before_committed! if should_run_callbacks
+            end
+          else
+            records.uniq.each(&:before_committed!)
           end
         end
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,6 +64,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.active_job.use_big_decimal_serializer`](#config-active-job-use-big-decimal-serializer): `true`
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
+- [`config.active_record.before_committed_on_all_records`](#config-active-record-before-committed-on-all-records): `true`
 - [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
@@ -1005,6 +1006,17 @@ Controls which database schemas will be dumped when calling `db:schema:dump`.
 The options are `:schema_search_path` (the default) which dumps any schemas listed in `schema_search_path`,
 `:all` which always dumps all schemas regardless of the `schema_search_path`,
 or a string of comma separated schemas.
+
+#### `config.active_record.before_committed_on_all_records`
+
+Enable before_committed! callbacks on all enrolled records in a transaction.
+The previous behavior was to only run the callbacks on the first copy of a record
+if there were multiple copies of the same record enrolled in the transaction.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
 
 #### `config.active_record.belongs_to_required_by_default`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -291,6 +291,7 @@ module Rails
             active_record.query_log_tags_format = :sqlcommenter
             active_record.raise_on_assign_to_attr_readonly = true
             active_record.belongs_to_required_validates_foreign_key = false
+            active_record.before_committed_on_all_records = true
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -121,3 +121,8 @@
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
 # Rails.application.config.precompile_filter_parameters = true
+
+# Enable before_committed! callbacks on all enrolled records in a transaction.
+# The previous behavior was to only run the callbacks on the first copy of a record
+# if there were multiple copies of the same record enrolled in the transaction.
+# Rails.application.config.active_record.before_committed_on_all_records = true


### PR DESCRIPTION
### Motivation / Background

As of https://github.com/rails/rails/pull/46525, the behaviour around `before_committed!` callbacks has changed: callbacks are run on every enrolled record in a transaction, even multiple copies of the same record. This is a significant change that apps should be able to opt into in order to avoid unexpected issues. At Shopify, some of our application code is relying on callbacks being triggered for only the first copy of a record that is touched inside a transaction. A config will make it easier to address this code properly.

### Detail

Introduces new config option that will default to true in Rails 7.1.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
