### PR TITLE
AR default scopes: only include `all_queries` default scopes on `reload`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1046,7 +1046,7 @@ module ActiveRecord
       self.class.connection.clear_query_cache
 
       fresh_object = if apply_scoping?(options)
-        _find_record(options)
+        _find_record((options || {}).merge(all_queries: true))
       else
         self.class.unscoped { _find_record(options) }
       end
@@ -1120,10 +1120,13 @@ module ActiveRecord
     end
 
     def _find_record(options)
+      all_queries = options ? options[:all_queries] : nil
+      base = self.class.all(all_queries: all_queries).preload(strict_loaded_associations)
+
       if options && options[:lock]
-        self.class.preload(strict_loaded_associations).lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)
+        base.lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)
       else
-        self.class.preload(strict_loaded_associations).find_by!(_in_memory_query_constraints_hash)
+        base.find_by!(_in_memory_query_constraints_hash)
       end
     end
 

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -170,8 +170,8 @@ module ActiveRecord
           # If all_queries is nil, only execute on select and insert queries.
           #
           # If all_queries is true, check if the default_scope object has
-          # all_queries set, then execute on all queries; select, insert, update
-          # and delete.
+          # all_queries set, then execute on all queries; select, insert, update,
+          # delete, and reload.
           def execute_scope?(all_queries, default_scope_obj)
             all_queries.nil? || all_queries && default_scope_obj.all_queries
           end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         #
         # You can define a scope that applies to all finders using
         # {default_scope}[rdoc-ref:Scoping::Default::ClassMethods#default_scope].
-        def all
+        def all(all_queries: nil)
           scope = current_scope
 
           if scope
@@ -29,7 +29,7 @@ module ActiveRecord
               relation.merge!(scope)
             end
           else
-            default_scoped
+            default_scoped(all_queries: all_queries)
           end
         end
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -225,6 +225,15 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, reload_sql)
   end
 
+  def test_default_scope_with_all_queries_runs_on_reload_but_default_scope_without_all_queries_does_not
+    Mentor.create!
+    dev = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries.create!(name: "Eileen")
+    reload_sql = capture_sql { dev.reload }.first
+
+    assert_no_match(/mentor_id/, reload_sql)
+    assert_match(/firm_id/, reload_sql)
+  end
+
   def test_nilable_default_scope_with_all_queries_runs_on_reload
     dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     reload_sql = capture_sql { dev.reload }.first


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46731

The current behaviour on `reload` is to apply all the default scopes, if any are marked as `all_queries: true`. The correct behaviour is to only apply `all_queries: true` default scopes on `reload`.