### PR TITLE
Do no delete assocation if replacement is not saved

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -59,8 +59,9 @@ module ActiveRecord
             saved = record.save
             set_new_record(record)
             raise RecordInvalid.new(record) if !saved && raise_error
-            record
+            raise Rollback if !saved
           end
+          target
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background
Fixes #46737

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The `create_assocation` method for singular associations may commit changes to the database even if the new record is not saved. This might be the expected behavior as mentioned in the linked issue.

### Detail

This Pull Request changes `ActiveRecord::Associations::SingularAssociation#_create_record` to roll back the transaction if the new record has not been saved.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
