### PR TITLE
Revert "Lock sqlite3 gem to 1.4 to run Rails CI using rubylang/ruby:master-nightly-focal"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,7 +140,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.4", "< 1.5"
+  gem "sqlite3", "~> 1.4"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,7 @@ DEPENDENCIES
   sneakers
   sprockets-export
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.4, < 1.5)
+  sqlite3 (~> 1.4)
   stackprof
   stimulus-rails
   sucker_punch


### PR DESCRIPTION
Reverts rails/rails#46711

Since https://github.com/ruby/ruby/commit/613fca01486e47dee9364a2fd86b5f5e77fe23c8 addresses https://bugs.ruby-lang.org/issues/19233 , we no longer need to lock sqlite3 gem version to 1.4.