### PR TITLE
Revert "Lock sqlite3 gem to 1.4 to run bug report templates"

### DIFF
--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.0.0"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.0.0"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_main.rb
+++ b/guides/bug_report_templates/active_record_main.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.0.0"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations_main.rb
+++ b/guides/bug_report_templates/active_record_migrations_main.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -9,7 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.0.0"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_storage_main.rb
+++ b/guides/bug_report_templates/active_storage_main.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "sqlite3", "< 1.5"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
Reverts rails/rails#46721

Since https://github.com/ruby/ruby/commit/613fca01486e47dee9364a2fd86b5f5e77fe23c8 addresses https://bugs.ruby-lang.org/issues/19233 , we no longer need to lock sqlite3 gem version to 1.4.

Related to #46744 