### PR TITLE
Call after_rollback callback on new records

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -361,7 +361,8 @@ module ActiveRecord
     end
 
     def trigger_transactional_callbacks? # :nodoc:
-      (@_new_record_before_last_commit || _trigger_update_callback) && persisted? ||
+      (@_new_record_before_last_commit && !persisted? && has_transactional_callbacks?) ||
+        (@_new_record_before_last_commit || _trigger_update_callback) && persisted? ||
         _trigger_destroy_callback && destroyed?
     end
 


### PR DESCRIPTION
This commit makes sure after_rollback callbacks are called on new records.

I have to admit, I really don't understand this patch.  I feel like I'm playing boolean whack-a-mole.

Fixes #36965