### PR TITLE
Ensure schema_migrations' version to be inserted as a string type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1287,7 +1287,7 @@ module ActiveRecord
         versions = migration_context.migrations.map(&:version)
 
         unless migrated.include?(version)
-          execute "INSERT INTO #{sm_table} (version) VALUES (#{quote(version)})"
+          execute "INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})"
         end
 
         inserting = (versions - migrated).select { |v| v < version }
@@ -1764,11 +1764,11 @@ module ActiveRecord
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-            sql << versions.reverse.map { |v| "(#{quote(v)})" }.join(",\n")
+            sql << versions.reverse.map { |v| "(#{quote(v.to_s)})" }.join(",\n")
             sql << ";"
             sql
           else
-            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"
+            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions.to_s)});"
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because current SQLS to insert migration version value into `schema_migrations` depends on implicit type conversion.

A `version` value is now inserted as an integer type and implicitly converted to a string type by each RDBMS even though `schema_migrations` table defines the `version` column as a string type.

Many RDBMSs can implicitly convert integer values to string values, but I was faced with a type error with [ActiveRecord Cloud Spanner Adapter](https://github.com/googleapis/ruby-spanner-activerecord) as Cloud Spanner doesn't convert values implicitly.

With RDBMSs which don't have implicit type conversion like Cloud Spanner, it is critical to insert versions as string types. 

### Detail

This Pull Request changes the type of `version` in SQLs that insert migration version into `schema_migrations` table.

### Additional information

* [reproduction code](https://github.com/nownabe/bug-report-activerecord-spanner/tree/main/schema-load-ruby/01_fix_spanner_dump_ruby)
* Sorry, it was difficult for me to test this. I appreciate it if you could give me advice for testing this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
