### PR TITLE
Avoid using hardcoded statement for deletion in fixtures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -431,7 +431,7 @@ module ActiveRecord
 
       def insert_fixtures_set(fixture_set, tables_to_delete = [])
         fixture_inserts = build_fixture_statements(fixture_set)
-        table_deletes = tables_to_delete.map { |table| "DELETE FROM #{quote_table_name(table)}" }
+        table_deletes = build_truncate_statements(tables_to_delete)
         statements = table_deletes + fixture_inserts
 
         with_multi_statements do


### PR DESCRIPTION
 ### Motivation / Background

This Pull Request has been created because a statement to delete records in tests is hardcoded and overwriting the statement is accompanied by overwirint the whole method.

In particular, with [Cloud Spanner Adapter](https://github.com/googleapis/ruby-spanner-activerecord), we have to change the statement because Cloud Spanner needs `WHERE` clause to delete records.

### Detail

This Pull Request changes `ActiveRecord::ConnectionAdapters::DatabaseStatements#insert_fixtures_set`, which is used for fixtures, to avoid the hardcoded statement, instead, makes it use `build_truncate_statements` method.

### Additional information

* I'd like to overwrite the deletion statement like [this](https://github.com/nownabe/bug-report-activerecord-spanner/tree/main/rails-testing/myapp#2-patch-activerecord-and-cloud-spanner) with Cloud Spanner Adapter.
* I think it's a kind of refactor and doesn't need to update tests...

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. 
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
