### PR TITLE
Avoid unnecessary replacements in action text when the replacement node is unchanged

### DIFF
--- a/actiontext/lib/action_text/fragment.rb
+++ b/actiontext/lib/action_text/fragment.rb
@@ -37,7 +37,8 @@ module ActionText
     def replace(selector)
       update do |source|
         source.css(selector).each do |node|
-          node.replace(yield(node).to_s)
+          replacement_node = yield(node)
+          node.replace(replacement_node.to_s) if node != replacement_node
         end
       end
     end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -134,6 +134,33 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_match %r/\A#{Regexp.escape '<div class="trix-content">'}/, rendered
   end
 
+  test "replace certain nodes" do
+    html = <<~HTML
+      <div>
+        <p>replace me</p>
+        <p>ignore me</p>
+      </div>
+    HTML
+
+    expected_html = <<~HTML
+      <div>
+        <p>replaced</p>
+        <p>ignore me</p>
+      </div>
+    HTML
+
+    content = content_from_html(html)
+    replaced_fragment = content.fragment.replace("p") do |node|
+      if node.text =~ /replace me/
+        "<p>replaced</p>"
+      else
+        node
+      end
+    end
+
+    assert_equal expected_html.strip, replaced_fragment.to_html
+  end
+
   private
     def content_from_html(html)
       ActionText::Content.new(html).tap do |content|


### PR DESCRIPTION
This is a performance improvement for the case where the replacement logic is based on some condition, and it returns the same unchanged node when it wants to skip it. For example:

```ruby
content.fragment.replace("p") do |node|
  if node.text =~ /replace me/
   "<p>replaced</p>"
  else
    node
  end
end
```

## Benchmark

The new implementation is 2.3x times faster:

```ruby
html = <<~HTML
      <div>
        #{'<p>ignore me</p>' * 1000}
        #{'<p>replace me</p>' * 1000}
      </div>
HTML

content = content_from_html(html)

replacement_example = -> do
  content.fragment.replace("p") do |node|
    if node.text =~ /replace me/
      "<p>replaced</p>"
    else
      node
    end
  end
end

current_implementation = -> do
  class ActionText::Fragment
    def replace(selector)
      update do |source|
        source.css(selector).each do |node|
          replacement_node = yield(node)
          node.replace(replacement_node.to_s)
        end
      end
    end
  end

  replacement_example.call
end

new_implementation = -> do
  class ActionText::Fragment
    def replace(selector)
      update do |source|
        source.css(selector).each do |node|
          replacement_node = yield(node)
          node.replace(replacement_node.to_s) if node != replacement_node
        end
      end
    end
  end

  replacement_example.call
end

Benchmark.ips do |x|
  x.report "Current implementation", &current_implementation
  x.report "New implementation", &new_implementation

  x.compare!
end
```

Results:

```
Warming up --------------------------------------
Current implementation
                         2.000  i/100ms
  New implementation     5.000  i/100ms
Calculating -------------------------------------
  Current implementation
                         32.484  (±30.8%) i/s -    134.000  in   5.036419s
  New implementation     74.878  (±38.7%) i/s -    250.000  in   5.052168s

Comparison:
  New implementation:       74.9 i/s
  Current implementation:       32.5 i/s - 2.31x  (± 0.00) slower
```
