### PR TITLE
Update RequestForgeryProtection docs to encourage wrapper method for skipping [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -111,9 +111,11 @@ module ActionController # :nodoc:
       #     protect_from_forgery except: :index
       #   end
       #
-      # You can disable forgery protection on controller by skipping the verification before_action:
+      # You can disable forgery protection on a controller using skip_forgery_protection:
       #
-      #   skip_before_action :verify_authenticity_token
+      #   class BarController < ApplicationController
+      #     skip_forgery_protection
+      #   end
       #
       # Valid Options:
       #


### PR DESCRIPTION
The docs currently advise skipping CSRF protection in a controller via:

```ruby
skip_before_action :verify_authenticity_token
```

But there is a wrapper method ([`skip_forgery_protection`](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-skip_forgery_protection)) to avoid relying on this "magic symbol" and protecting your application from future changes in Rails to the `RequestForgeryProtection` internals.

This changes updates the docs to recommend the wrapper method instead