### PR TITLE
Avoid incorrect binary defaults on mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -189,6 +189,8 @@ module ActiveRecord
             elsif type_metadata.type == :text && default&.start_with?("'")
               # strip and unescape quotes
               default = default[1...-1].gsub("\\'", "'")
+            elsif type_metadata.type == :binary && default
+              default = nil
             elsif default&.match?(/\A\d/)
               # Its a number so we can skip the query to check if it is a function
             elsif default && default_type(table_name, field_name) == :function


### PR DESCRIPTION
Mysql seems to have no consistent way to get accurate binary column
default values.  Because of this, it makes most sense to treat them
like database functions and leave them `nil` until the record is
persisted.

Briefly summarizing some of the things that do not work,

After the mysql 8 release, `SHOW FULL FIELDS` returns the column
defaults hex encoded, which does not cause issues. On top of being hex
encoded, the hex number will truncate at the first null/zero byte
leaving with you potentially incorrect default values in cases where
you have a zero byte in your binary default data. The hex encoding is new,
but mysql 5.7 has the same null termination issue.

`SHOW CREATE TABLE` has a similar issue, but instead of truncating at
null bytes, high bytes are converted to `?`s. This could potentially
work for cases where your defaults are ascii strings, but leaves
another gatcha.

[Fix #45832]

More discussion:
https://github.com/rails/rails/pull/45834
https://github.com/rails/rails/pull/46668

Easier to review with `?w=1` https://github.com/rails/rails/pull/46753/files?w=1