### PR TITLE
Add `config.rotate_message_verifiers`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -442,6 +442,20 @@ Enables or disables reloading of classes only when tracked files change. By defa
 
 Causes the app to not boot if a master key hasn't been made available through `ENV["RAILS_MASTER_KEY"]` or the `config/master.key` file.
 
+#### `config.rotate_message_verifiers`
+
+The range of Rails versions from which to derive rotation options for
+[`Rails.application.message_verifiers`][]. Defaults to `"7.0".."7.0"`.
+
+To prevent `Rails.application.message_verifiers` from being preconfigured, set
+`config.rotate_message_verifiers` to `false`. This will allow you to completely
+customize the rotations using [`rotate`][ActiveSupport::MessageVerifiers#rotate].
+Note, however, that you must do so before `Rails.application.message_verifiers`
+is used to build any message verifiers; otherwise, an error will be raised.
+
+[`Rails.application.message_verifiers`]: https://api.rubyonrails.org/classes/Rails/Application.html#method-i-message_verifiers
+[ActiveSupport::MessageVerifiers#rotate]: https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifiers.html#method-i-rotate
+
 #### `config.secret_key_base`
 
 The fallback for specifying the input secret for an application's key generator.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `config.rotate_message_verifiers`, which controls the range of rotated
+    defaults for `Rails.application.message_verifiers`.
+
+    For example, setting `config.rotate_message_verifiers` to `"7.0".."7.2"`
+    would first rotate any default options that were added in Rails 7.2, then
+    rotate any default options from Rails 7.1, and lastly rotate any default
+    options from Rails 7.0.
+
+    `config.rotate_message_verifiers` may also be set to false to leave
+    `Rails.application.message_verifiers` unconfigured.  In that case, the user
+    is expected to configure `Rails.application.message_verifiers` (e.g. in an
+    initializer) before it is used to create any message verifiers; otherwise,
+    an error will be raised.
+
+    *Jonathan Hefner*
+
 *   Show descriptions for all commands in Rails help
 
     When calling `rails help` most commands missed their description. We now

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -14,7 +14,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
-                    :log_tags, :railties_order, :relative_url_root, :secret_key_base,
+                    :log_tags, :railties_order, :relative_url_root, :rotate_message_verifiers, :secret_key_base,
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x,
@@ -64,6 +64,7 @@ module Rails
         @autoflush_log                           = true
         @log_formatter                           = ActiveSupport::Logger::SimpleFormatter.new
         @eager_load                              = nil
+        @rotate_message_verifiers                = "7.0".."7.0"
         @secret_key_base                         = nil
         @api_only                                = false
         @debug_exception_response_format         = nil


### PR DESCRIPTION
This commit adds `config.rotate_message_verifiers`, which controls the the range of rotated defaults for `Rails.application.message_verifiers`. Currently, there is only one set of defaults, but
`config.rotate_message_verifiers` will allow users to easily opt in to new defaults as we add them, and opt out of old defaults as appropriate.

For example, setting `config.rotate_message_verifiers` to `"7.0".."7.2"` would first rotate any default options that were added in Rails 7.2, then rotate any default options from Rails 7.1, and lastly rotate any default options from Rails 7.0.

`config.rotate_message_verifiers` may also be set to false to leave `Rails.application.message_verifiers` unconfigured.  In that case, the user is expected to configure `Rails.application.message_verifiers` (e.g. in an initializer) before it is used to create any message verifiers; otherwise, an error will be raised.
