### PR TITLE
Add `Message{Encryptors,Verifiers}#transitional`

### DIFF
--- a/activesupport/lib/active_support/message_encryptors.rb
+++ b/activesupport/lib/active_support/message_encryptors.rb
@@ -5,6 +5,29 @@ require "active_support/messages/rotation_coordinator"
 module ActiveSupport
   class MessageEncryptors < Messages::RotationCoordinator
     ##
+    # :attr_accessor: transitional
+    #
+    # If true, the first two rotation option sets are swapped when building
+    # message encryptors. For example, with the following configuration, message
+    # encryptors will encrypt messages using <tt>serializer: Marshal, url_safe: true</tt>,
+    # and will able to decrypt messages that were encrypted using any of the
+    # three option sets:
+    #
+    #   encryptors = ActiveSupport::MessageEncryptors.new { ... }
+    #   encryptors.rotate(serializer: JSON, url_safe: true)
+    #   encryptors.rotate(serializer: Marshal, url_safe: true)
+    #   encryptors.rotate(serializer: Marshal, url_safe: false)
+    #   encryptors.transitional = true
+    #
+    # This can be useful when performing a rolling deploy of an application,
+    # wherein servers that have not yet been updated must still be able to
+    # decrypt messages from updated servers. In such a scenario, first perform a
+    # rolling deploy with the new rotation (e.g. <tt>serializer: JSON, url_safe: true</tt>)
+    # as the first rotation and <tt>transitional = true</tt>. Then, after all
+    # servers have been updated, perform a second rolling deploy with
+    # <tt>transitional = false</tt>.
+
+    ##
     # :method: initialize
     # :call-seq: initialize(&secret_generator)
     #

--- a/activesupport/lib/active_support/message_verifiers.rb
+++ b/activesupport/lib/active_support/message_verifiers.rb
@@ -5,6 +5,29 @@ require "active_support/messages/rotation_coordinator"
 module ActiveSupport
   class MessageVerifiers < Messages::RotationCoordinator
     ##
+    # :attr_accessor: transitional
+    #
+    # If true, the first two rotation option sets are swapped when building
+    # message verifiers. For example, with the following configuration, message
+    # verifiers will generate messages using <tt>serializer: Marshal, url_safe: true</tt>,
+    # and will able to verify messages that were generated using any of the
+    # three option sets:
+    #
+    #   verifiers = ActiveSupport::MessageVerifiers.new { ... }
+    #   verifiers.rotate(serializer: JSON, url_safe: true)
+    #   verifiers.rotate(serializer: Marshal, url_safe: true)
+    #   verifiers.rotate(serializer: Marshal, url_safe: false)
+    #   verifiers.transitional = true
+    #
+    # This can be useful when performing a rolling deploy of an application,
+    # wherein servers that have not yet been updated must still be able to
+    # verify messages from updated servers. In such a scenario, first perform a
+    # rolling deploy with the new rotation (e.g. <tt>serializer: JSON, url_safe: true</tt>)
+    # as the first rotation and <tt>transitional = true</tt>. Then, after all
+    # servers have been updated, perform a second rolling deploy with
+    # <tt>transitional = false</tt>.
+
+    ##
     # :method: initialize
     # :call-seq: initialize(&secret_generator)
     #


### PR DESCRIPTION
This commit adds a `transitional` attribute to `ActiveSupport::MessageEncryptors` and `ActiveSupport::MessageVerifiers`. Setting `transitional = true` will swap the first two rotations when building a message encryptor / verifier.  For example, with the following configuration, message verifiers will generate messages using `serializer: Marshal, url_safe: true`, and will able to verify messages that were generated using any of the three option sets:

  ```ruby
  verifiers = ActiveSupport::MessageVerifiers.new { ... }
  verifiers.rotate(serializer: JSON, url_safe: true)
  verifiers.rotate(serializer: Marshal, url_safe: true)
  verifiers.rotate(serializer: Marshal, url_safe: false)
  verifiers.transitional = true
  ```

This can be useful when performing a rolling deploy of an application, wherein servers that have not yet been updated must still be able to verify messages from updated servers.  In particular, as it can be applied to the default rotations of `Rails.application.message_verifiers`.
