### PR TITLE
Support `Message{Encryptors,Verifiers}#rotate` block

### DIFF
--- a/activesupport/lib/active_support/message_encryptors.rb
+++ b/activesupport/lib/active_support/message_encryptors.rb
@@ -60,7 +60,9 @@ module ActiveSupport
 
     ##
     # :method: rotate
-    # :call-seq: rotate(**options)
+    # :call-seq:
+    #   rotate(**options)
+    #   rotate(&block)
     #
     # Adds +options+ to the list of option sets. Messages will be encrypted
     # using the first set in the list. When decrypting, however, each set will
@@ -75,6 +77,35 @@ module ActiveSupport
     # If any options match the kwargs of the operative secret generator, those
     # options will be passed to the secret generator instead of to the message
     # encryptor.
+    #
+    # For fine-grained per-salt rotations, a block form is supported. The block
+    # will receive the salt, and should return an appropriate options Hash. The
+    # block may also return +nil+ to indicate that the rotation does not apply
+    # to the given salt. For example:
+    #
+    #   encryptors = ActiveSupport::MessageEncryptors.new { ... }
+    #
+    #   encryptors.rotate do |salt|
+    #     case salt
+    #     when :foo
+    #       { serializer: JSON, url_safe: true }
+    #     when :bar
+    #       { serializer: Marshal, url_safe: true }
+    #     end
+    #   end
+    #
+    #   encryptors.rotate(serializer: Marshal, url_safe: false)
+    #
+    #   # Uses `serializer: JSON, url_safe: true`.
+    #   # Falls back to `serializer: Marshal, url_safe: false`.
+    #   encryptors[:foo]
+    #
+    #   # Uses `serializer: Marshal, url_safe: true`.
+    #   # Falls back to `serializer: Marshal, url_safe: false`.
+    #   encryptors[:bar]
+    #
+    #   # Uses `serializer: Marshal, url_safe: false`.
+    #   encryptors[:baz]
 
     ##
     # :method: rotate_defaults

--- a/activesupport/lib/active_support/message_verifiers.rb
+++ b/activesupport/lib/active_support/message_verifiers.rb
@@ -73,6 +73,35 @@ module ActiveSupport
     # If any options match the kwargs of the operative secret generator, those
     # options will be passed to the secret generator instead of to the message
     # verifier.
+    #
+    # For fine-grained per-salt rotations, a block form is supported. The block
+    # will receive the salt, and should return an appropriate options Hash. The
+    # block may also return +nil+ to indicate that the rotation does not apply
+    # to the given salt. For example:
+    #
+    #   verifiers = ActiveSupport::MessageVerifiers.new { ... }
+    #
+    #   verifiers.rotate do |salt|
+    #     case salt
+    #     when :foo
+    #       { serializer: JSON, url_safe: true }
+    #     when :bar
+    #       { serializer: Marshal, url_safe: true }
+    #     end
+    #   end
+    #
+    #   verifiers.rotate(serializer: Marshal, url_safe: false)
+    #
+    #   # Uses `serializer: JSON, url_safe: true`.
+    #   # Falls back to `serializer: Marshal, url_safe: false`.
+    #   verifiers[:foo]
+    #
+    #   # Uses `serializer: Marshal, url_safe: true`.
+    #   # Falls back to `serializer: Marshal, url_safe: false`.
+    #   verifiers[:bar]
+    #
+    #   # Uses `serializer: Marshal, url_safe: false`.
+    #   verifiers[:baz]
 
     ##
     # :method: rotate_defaults

--- a/activesupport/lib/active_support/messages/rotation_coordinator.rb
+++ b/activesupport/lib/active_support/messages/rotation_coordinator.rb
@@ -16,22 +16,18 @@ module ActiveSupport
       end
 
       def [](salt)
-        @codecs[salt] ||= build_with_rotations(salt.to_s)
+        @codecs[salt] ||= build_with_rotations(salt)
       end
 
       def []=(salt, codec)
         @codecs[salt] = codec
       end
 
-      def rotate(**options)
+      def rotate(**options, &block)
+        raise ArgumentError, "Options cannot be specified when using a block" if block && !options.empty?
         changing_configuration!
 
-        options[:secret_generator] ||= @secret_generator
-        secret_generator_kwargs = options[:secret_generator].parameters.
-          filter_map { |type, name| name if type == :key || type == :keyreq }
-        options[:secret_generator_options] = options.extract!(*secret_generator_kwargs)
-
-        @rotate_options << options
+        @rotate_options << (block || options)
 
         self
       end
@@ -63,16 +59,30 @@ module ActiveSupport
           end
         end
 
+        def normalize_options(options)
+          options = options.dup
+
+          options[:secret_generator] ||= @secret_generator
+
+          secret_generator_kwargs = options[:secret_generator].parameters.
+            filter_map { |type, name| name if type == :key || type == :keyreq }
+          options[:secret_generator_options] = options.extract!(*secret_generator_kwargs)
+
+          options[:on_rotation] = @on_rotation
+
+          options
+        end
+
         def build_with_rotations(salt)
-          raise "No options have been configured" if @rotate_options.empty?
+          rotate_options = @rotate_options.map { |options| options.is_a?(Proc) ? options.(salt) : options }
+          transitional = self.transitional && rotate_options.first
+          rotate_options.compact!
+          rotate_options[0..1] = rotate_options[0..1].reverse if transitional
+          rotate_options = rotate_options.map { |options| normalize_options(options) }.uniq
 
-          if transitional
-            rotate_options = [@rotate_options[1], @rotate_options[0], *@rotate_options[2..]].compact
-          else
-            rotate_options = @rotate_options
-          end
+          raise "No options have been configured for #{salt}" if rotate_options.empty?
 
-          rotate_options.map { |options| build(salt, **options, on_rotation: @on_rotation) }.reduce(&:fall_back_to)
+          rotate_options.map { |options| build(salt.to_s, **options) }.reduce(&:fall_back_to)
         end
 
         def build(salt, secret_generator:, secret_generator_options:, **options)

--- a/activesupport/test/message_encryptors_test.rb
+++ b/activesupport/test/message_encryptors_test.rb
@@ -22,6 +22,14 @@ class MessageEncryptorsTest < ActiveSupport::TestCase
     assert_equal "message", roundtrip("message", coordinator["salt"])
   end
 
+  test "supports arbitrary secret generator kwargs when using #rotate block" do
+    secret_generator = ->(salt, secret_length:, foo:, bar: nil) { foo[bar] * secret_length }
+    coordinator = ActiveSupport::MessageEncryptors.new(&secret_generator)
+    coordinator.rotate { { foo: "foo", bar: 0 } }
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+  end
+
   test "supports separate secrets for encryption and signing" do
     secret_generator = proc { |*args, **kwargs| [SECRET_GENERATOR.call(*args, **kwargs), "signing secret"] }
     coordinator = ActiveSupport::MessageEncryptors.new(&secret_generator)

--- a/activesupport/test/message_verifiers_test.rb
+++ b/activesupport/test/message_verifiers_test.rb
@@ -22,6 +22,14 @@ class MessageVerifiersTest < ActiveSupport::TestCase
     assert_equal "message", roundtrip("message", coordinator["salt"])
   end
 
+  test "supports arbitrary secret generator kwargs when using #rotate block" do
+    secret_generator = ->(salt, foo:, bar: nil) { foo + bar }
+    coordinator = ActiveSupport::MessageVerifiers.new(&secret_generator)
+    coordinator.rotate { { foo: "foo", bar: "bar" } }
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+  end
+
   private
     def make_coordinator
       ActiveSupport::MessageVerifiers.new { |salt| salt * 10 }

--- a/activesupport/test/rotation_coordinator_tests.rb
+++ b/activesupport/test/rotation_coordinator_tests.rb
@@ -34,6 +34,66 @@ module RotationCoordinatorTests
       assert_nil roundtrip("message", codec, obsolete_codec)
     end
 
+    test "raises when building a codec and no rotations are configured" do
+      assert_raises { make_coordinator["salt"] }
+    end
+
+    test "#rotate supports a block" do
+      coordinator = make_coordinator.rotate do |salt|
+        { digest: salt == "salt" ? "SHA1" : "MD5" }
+      end
+
+      sha1_coordinator = make_coordinator.rotate(digest: "SHA1")
+      md5_coordinator = make_coordinator.rotate(digest: "MD5")
+
+      assert_equal "message", roundtrip("message", coordinator["salt"], sha1_coordinator["salt"])
+      assert_nil roundtrip("message", coordinator["salt"], md5_coordinator["salt"])
+
+      assert_equal "message", roundtrip("message", coordinator["other salt"], md5_coordinator["other salt"])
+      assert_nil roundtrip("message", coordinator["other salt"], sha1_coordinator["other salt"])
+    end
+
+    test "#rotate block receives salt in its original form" do
+      coordinator = make_coordinator.rotate do |salt|
+        assert_equal :salt, salt
+        {}
+      end
+
+      coordinator[:salt]
+    end
+
+    test "#rotate raises when both a block and options are provided" do
+      assert_raises ArgumentError do
+        make_coordinator.rotate(digest: "MD5") { {} }
+      end
+    end
+
+    test "#rotate block can return nil to skip a rotation for specific salts" do
+      coordinator = make_coordinator.rotate(digest: "SHA1")
+      coordinator.rotate do |salt|
+        { digest: "MD5" } if salt == "salt"
+      end
+
+      sha1_coordinator = make_coordinator.rotate(digest: "SHA1")
+      md5_coordinator = make_coordinator.rotate(digest: "MD5")
+
+      assert_equal "message", roundtrip("message", sha1_coordinator["salt"], coordinator["salt"])
+      assert_equal "message", roundtrip("message", md5_coordinator["salt"], coordinator["salt"])
+
+      assert_equal "message", roundtrip("message", sha1_coordinator["other salt"], coordinator["other salt"])
+      assert_nil roundtrip("message", md5_coordinator["other salt"], coordinator["other salt"])
+    end
+
+    test "raises when building a codec and no rotations are configured for a specific salt" do
+      coordinator = make_coordinator.rotate do |salt|
+        { digest: "MD5" } if salt == "salt"
+      end
+
+      assert_nothing_raised { coordinator["salt"] }
+      error = assert_raises { coordinator["other salt"] }
+      assert_match "other salt", error.message
+    end
+
     test "#transitional swaps the first two rotations when enabled" do
       coordinator = make_coordinator.rotate(digest: "SHA1")
       coordinator.rotate(digest: "MD5")
@@ -65,6 +125,48 @@ module RotationCoordinatorTests
       end
     end
 
+    test "#transitional treats a nil first rotation as a new rotation" do
+      coordinator = make_coordinator
+      coordinator.rotate do |salt|       # (3) Finally, one salt upgraded to SHA1
+        { digest: "SHA1" } if salt == "salt"
+      end
+      coordinator.rotate(digest: "MD5")  # (2) Then, everything upgraded to MD5
+      coordinator.rotate(digest: "MD4")  # (1) Originally, everything used MD4
+      coordinator.transitional = true
+
+      sha1_coordinator = make_coordinator.rotate(digest: "SHA1")
+      md5_coordinator = make_coordinator.rotate(digest: "MD5")
+
+      # "salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, MD5, MD4] => [MD5, SHA1, MD4])
+      assert_equal "message", roundtrip("message", coordinator["salt"], md5_coordinator["salt"])
+      assert_equal "message", roundtrip("message", sha1_coordinator["salt"], coordinator["salt"])
+
+      # "other salt" encodes with MD5 and cannot decode SHA1 (i.e. [nil, MD5, MD4] => [MD5, MD4])
+      assert_equal "message", roundtrip("message", coordinator["other salt"], md5_coordinator["other salt"])
+      assert_nil roundtrip("message", sha1_coordinator["other salt"], coordinator["other salt"])
+    end
+
+    test "#transitional swaps the first rotation with the next non-nil rotation" do
+      coordinator = make_coordinator
+      coordinator.rotate(digest: "SHA1") # (3) Finally, everything upgraded to SHA1
+      coordinator.rotate do |salt|       # (2) Then, one salt upgraded to SHA1
+        { digest: "SHA1" } if salt == "salt"
+      end
+      coordinator.rotate(digest: "MD5")  # (1) Originally, everything used MD5
+      coordinator.transitional = true
+
+      sha1_coordinator = make_coordinator.rotate(digest: "SHA1")
+      md5_coordinator = make_coordinator.rotate(digest: "MD5")
+
+      # "salt" encodes with SHA1 and can decode SHA1 (i.e. [SHA1, SHA1, MD5] => [SHA1, MD5])
+      assert_equal "message", roundtrip("message", coordinator["salt"], sha1_coordinator["salt"])
+      assert_equal "message", roundtrip("message", sha1_coordinator["salt"], coordinator["salt"])
+
+      # "other salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, nil, MD5] => [MD5, SHA1])
+      assert_equal "message", roundtrip("message", coordinator["other salt"], md5_coordinator["other salt"])
+      assert_equal "message", roundtrip("message", sha1_coordinator["other salt"], coordinator["other salt"])
+    end
+
     test "can clear rotations" do
       @coordinator.clear_rotations.rotate(digest: "MD5")
       codec = @coordinator["salt"]
@@ -84,6 +186,24 @@ module RotationCoordinatorTests
       assert_equal 1, rotated
     end
 
+    test "rotation options are deduped" do
+      coordinator = make_coordinator
+      coordinator.rotate(digest: "SHA1") # (3) Finally, everything upgraded to SHA1
+      coordinator.rotate do |salt|       # (2) Then, one salt upgraded to SHA1
+        { digest: "SHA1" } if salt == "salt"
+      end
+      coordinator.rotate(digest: "MD5")  # (1) Originally, everything used MD5
+
+      rotated = 0
+      coordinator.on_rotation { rotated += 1 }
+
+      codec = coordinator["salt"]
+      md5_codec = (make_coordinator.rotate(digest: "MD5"))["salt"]
+
+      assert_equal "message", roundtrip("message", md5_codec, codec)
+      assert_equal 1, rotated # SHA1 tried only once
+    end
+
     test "prevents adding a rotation after rotations have been applied" do
       @coordinator["salt"]
       assert_raises { @coordinator.rotate(digest: "MD5") }
@@ -97,11 +217,6 @@ module RotationCoordinatorTests
     test "prevents changing on_rotation after on_rotation has been applied" do
       @coordinator["salt"]
       assert_raises { @coordinator.on_rotation { "this block will not be evaluated" } }
-    end
-
-    test "raises when building an codec and no rotations are configured" do
-      @coordinator.clear_rotations
-      assert_raises { @coordinator["salt"] }
     end
   end
 end


### PR DESCRIPTION
This commit adds a block form of `ActiveSupport::MessageEncryptors#rotate` and `ActiveSupport::MessageVerifiers#rotate`, which supports fine-grained per-salt rotation options.  The block will receive a salt, and should return an appropriate options Hash.  The block may also return `nil` to indicate that the rotation does not apply to the given salt.  For example:

  ```ruby
  verifiers = ActiveSupport::MessageVerifiers.new { ... }
  verifiers.rotate(serializer: JSON, url_safe: true)
  verifiers.rotate do |salt|
   case salt
   when :foo
     { serializer: Marshal, url_safe: true }
   when :bar
     { serializer: Marshal, url_safe: false }
   end
  end

  # Uses `serializer: JSON, url_safe: true`.
  # Falls back to `serializer: Marshal, url_safe: true`.
  verifiers[:foo]

  # Uses `serializer: JSON, url_safe: true`.
  # Falls back to `serializer: Marshal, url_safe: false`.
  verifiers[:bar]

  # Uses `serializer: JSON, url_safe: true`.
  verifiers[:baz]
  ```

This can be particularly useful when migrating older configurations to a unified configuration.

---

This is based on top of #46755.
