### PR TITLE
Fix crash for invalid Content-Type format

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -62,6 +62,7 @@ module ActionDispatch
         request.formats
       rescue ActionDispatch::Http::MimeNegotiation::InvalidType
         request.set_header "HTTP_ACCEPT", "text/html"
+        request.set_header 'CONTENT_TYPE', 'text/html'
       end
 
       def pass_response(status)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the application raises [500 Internal Server Error with the generic message](https://github.com/rails/rails/blob/v6.1.4.1/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L20-L24) as it cannot parse the invalid MIME type for `Content-Type` HTTP header. The [PR 43094](https://github.com/rails/rails/issues/43094) addressed the issue for `Accept` header, but 406 errors are still translated to 500s in case of invalid `Content-Type` HTTP header.

### Detail

This Pull Request fixes the web app crash in case of invalid `Content-Type` HTTP header. It sets the `Content-Type` to `text/html` for the ActionDispatch::Http::MimeNegotiation::InvalidType error. The fix is on top of the [PR 43094](https://github.com/rails/rails/issues/43094). After the change, the web app returns 406 instead of 500 for invalid `Content-Type` HTTP header.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
