### PR TITLE
Don't re-assign unchanged belongs_to associations during saves

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -501,7 +501,7 @@ module ActiveRecord
 
             if association.updated?
               association_id = record.public_send(reflection.options[:primary_key] || :id)
-              self[reflection.foreign_key] = association_id
+              self[reflection.foreign_key] = association_id unless self[reflection.foreign_key] == association_id
               association.loaded!
             end
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46758

This avoids a write op, which usually wouldn't be a big deal, but is if `raise_on_assign_to_attr_readonly` is enabled.

cc @hmcguire-shopify @skipkayhil 