### PR TITLE
Allow assets:precompile to be run in a production build step without passing in RAILS_MASTER_KEY

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add ENV["SECRET_KEY_BASE_DUMMY"] for starting production environment with a generated secret base key,
+    which can be used to run tasks like `assets:precompile` without making the RAILS_MASTER_KEY available
+    to the build process.
+    
+    Dockerfile layer example:
+
+    ```
+    RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
+    ```
+
+    *DHH*
+
 *   Show descriptions for all commands in Rails help
 
     When calling `rails help` most commands missed their description. We now

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -465,6 +465,8 @@ module Rails
     # secret_key_base that's stored in a temporary file. This is useful when precompiling assets for
     # production as part of a build step that otherwise does not need access to the production secrets.
     #
+    # Dockerfile example: <tt>RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile</tt>.
+    #
     # In all other environments, we look for it first in <tt>ENV["SECRET_KEY_BASE"]</tt>,
     # then +credentials.secret_key_base+, and finally +secrets.secret_key_base+. For most applications,
     # the correct place to store it is in the encrypted credentials file.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -461,11 +461,15 @@ module Rails
     # In development and test, this is randomly generated and stored in a
     # temporary file in <tt>tmp/development_secret.txt</tt>.
     #
+    # You can also set <tt>ENV["SECRET_KEY_BASE_DUMMY"]</tt> to trigger the use of a randomly generated
+    # secret_key_base that's stored in a temporary file. This is useful when precompiling assets for
+    # production as part of a build step that otherwise does not need access to the production secrets.
+    #
     # In all other environments, we look for it first in <tt>ENV["SECRET_KEY_BASE"]</tt>,
     # then +credentials.secret_key_base+, and finally +secrets.secret_key_base+. For most applications,
     # the correct place to store it is in the encrypted credentials file.
     def secret_key_base
-      if Rails.env.development? || Rails.env.test?
+      if Rails.env.development? || Rails.env.test? || ENV["SECRET_KEY_BASE_DUMMY"]
         secrets.secret_key_base ||= generate_development_secret
       else
         validate_secret_key_base(

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -762,6 +762,20 @@ module ApplicationTests
       assert_match(/Missing `secret_key_base`./, error.message)
     end
 
+    test "dont raise in production when dummy secret_key_base is used" do
+      ENV["SECRET_KEY_BASE_DUMMY"] = "1"
+
+      app_file "config/initializers/secret_token.rb", <<-RUBY
+        Rails.application.credentials.secret_key_base = nil
+      RUBY
+
+      assert_nothing_raised do
+        app "production"
+      end
+    ensure
+      ENV["SECRET_KEY_BASE_DUMMY"] = nil
+    end
+
     test "raise when secret_key_base is not a type of string" do
       add_to_config <<-RUBY
         Rails.application.credentials.secret_key_base = 123


### PR DESCRIPTION
When compiling assets in production as part of an image build step, it's inconvenient to have to pass in the real `RAILS_MASTER_KEY`. So allow passing in a dummy secret_key_base, just like we do in development and test, via `ENV["SECRET_KEY_BASE_DUMMY"] = 1`. This will not give access to any of the real credentials or message verifiers, but allow the build step to complete, since it typically does not need it anyway.