### PR TITLE
[docs] Code samples for postgres configs

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1288,15 +1288,34 @@ up performance but adds a risk of data loss if the database crashes. It is
 highly recommended that you do not enable this in a production environment.
 Defaults to `false` in all environments.
 
+To enable this for tests:
+
+```ruby
+# config/environments/test.rb
+
+ActiveSupport.on_load(:active_record_postgresqladapter) do
+  self.create_unlogged_tables = true
+end
+```
+
 #### `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type`
 
 Controls what native type the Active Record PostgreSQL adapter should use when you call `datetime` in
 a migration or schema. It takes a symbol which must correspond to one of the
 configured `NATIVE_DATABASE_TYPES`. The default is `:timestamp`, meaning
 `t.datetime` in a migration will create a "timestamp without time zone" column.
-To use "timestamp with time zone", change this to `:timestamptz` in an
-initializer. You should run `bin/rails db:migrate` to rebuild your schema.rb
-if you change this.
+
+To use "timestamp with time zone":
+
+```ruby
+# config/application.rb
+
+ActiveSupport.on_load(:active_record_postgresqladapter) do
+  self.datetime_type = :timestamptz
+end
+```
+
+You should run `bin/rails db:migrate` to rebuild your schema.rb if you change this.
 
 #### `ActiveRecord::SchemaDumper.ignore_tables`
 


### PR DESCRIPTION
The `PostgreSQLAdapter` introduces two configs, `datetime_type` and `create_unlogged_tables`. To configure these you can't just do `config.active_record.whatever` like you can with other configs, it's a bit more involved. So this PR adds some code examples to the [configuration guide](https://edgeguides.rubyonrails.org/configuring.html) to show how to do it.

It was inspired by [this conversation](https://github.com/opf/openproject/pull/11226#discussion_r962624726); the guide should have had the answers!
