### PR TITLE
Backport #45979 to 7-0-stable

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "\"#{RUBY_VERSION}\"" -%>
+ruby <%= "\"#{Gem.ruby_version}\"" -%>
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -935,7 +935,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby "#{RUBY_VERSION}"/, content)
+      assert_match(/ruby "#{Gem.ruby_version}"/, content)
     end
     assert_file ".ruby-version" do |content|
       if ENV["RBENV_VERSION"]


### PR DESCRIPTION
Proposing we backport https://github.com/rails/rails/pull/45979 to `7-0-stable`.

Fixes https://github.com/rails/rails/issues/46716