### PR TITLE
Silence credentials generator in app generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -179,7 +179,7 @@ module Rails
       return if options[:pretend] || options[:dummy_app]
 
       require "rails/generators/rails/credentials/credentials_generator"
-      Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file
+      Rails::Generators::CredentialsGenerator.new([], quiet: true).add_credentials_file
     end
 
     def credentials_diff_enroll


### PR DESCRIPTION
Follow-up to #45543.

In #45543, `CredentialsGenerator#add_credentials_file_silently` was removed in favor of setting Thor's `quiet: true` option.  However, the call to `CredentialsGenerator` in the app generator was not updated to
use `quiet: true`.
