### PR TITLE
Remind of credentials diff enrollment on edit

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
@@ -13,7 +13,8 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
       gitattributes.write(GITATTRIBUTES_ENTRY, mode: "a")
 
       say "Enrolled project in credentials file diffing!"
-      say "Rails ensures the rails_credentials diff driver is set when running `#{executable(:edit)}`. See `#{executable(:help)}` for more."
+      say ""
+      say "Rails will configure the Git diff driver for credentials when running `#{executable(:edit)}`. See `#{executable(:help)}` for more information."
     end
   end
 
@@ -43,6 +44,7 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
 
     def configure_diffing_driver
       system "git config diff.rails_credentials.textconv '#{executable(:diff)}'"
+      say "Configured Git diff driver for credentials."
     end
 
     def gitattributes

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -185,7 +185,9 @@ module Rails
     def credentials_diff_enroll
       return if options[:skip_decrypted_diffs] || options[:skip_git] || options[:dummy_app] || options[:pretend]
 
-      rails_command "credentials:diff --enroll", inline: true, shell: @generator.shell
+      @generator.shell.mute do
+        rails_command "credentials:diff --enroll", inline: true, shell: @generator.shell
+      end
     end
 
     def database_yml

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -237,11 +237,14 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
 
   test "running edit after enrolling in diffing sets diff driver" do
     run_diff_command(enroll: true)
-    run_edit_command
+
+    assert_match %r/git diff driver/i, run_edit_command
 
     Dir.chdir(app_path) do
       assert_equal "bin/rails credentials:diff", `git config --get 'diff.rails_credentials.textconv'`.strip
     end
+
+    assert_no_match %r/git diff driver/i, run_edit_command
   end
 
   test "diff from git diff left file" do


### PR DESCRIPTION
When users create a new app or `git clone` an existing app, they may not realize it is enrolled in decrypted diffing of credentials (or be aware of the feature).

This commit adds a confirmation message when configuring the Git diff driver for credentials, to serve as a reminder.  The message will be shown when running `bin/rails credentials:edit` for the first time after `rails new` or `git clone`.

This commit also silences the enrollment confirmation message when creating a new app, to reduce noise.
