### PR TITLE
Eager autoload ActiveSupport::ExecutionContext

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -41,7 +41,6 @@ module ActiveSupport
   autoload :CurrentAttributes
   autoload :Dependencies
   autoload :DescendantsTracker
-  autoload :ExecutionContext
   autoload :ExecutionWrapper
   autoload :Executor
   autoload :ErrorReporter
@@ -64,6 +63,7 @@ module ActiveSupport
     autoload :Configurable
     autoload :Deprecation
     autoload :Digest
+    autoload :ExecutionContext
     autoload :Gzip
     autoload :Inflector
     autoload :JSON


### PR DESCRIPTION
### Motivation / Background

ExecutionContext was added as a regular autoload when it was introduced in 6bad959. However, the class is not currently referenced anywhere on the boot path. This means that the file will currently be required during the first request/job/query (currently its loaded when the to_run callback defined in active_support.reset_execution_context is executed).

### Detail

To maximize CoW and ensure that the first request/job/query doesn't have any extra latency, ExecutionContext should be eager autoloaded instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
