### PR TITLE
Adjust STI preloading docs to run collapse also when eager loading

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -359,9 +359,10 @@ In this example, we still want `app/models/shapes/circle.rb` to define `Circle`,
 ```ruby
 # config/initializers/preload_stis.rb
 
+shapes = "#{Rails.root}/app/models/shapes"
+Rails.autoloaders.main.collapse(shapes) # Not a namespace.
+
 unless Rails.application.config.eager_load
-  shapes = "#{Rails.root}/app/models/shapes"
-  Rails.autoloaders.main.collapse(shapes) # Not a namespace.
   Rails.application.config.to_prepare do
     Rails.autoloaders.main.eager_load_dir(shapes)
   end


### PR DESCRIPTION
Zeitwerk should still apply collapsing in described option 2 of handling STI (Preload a collapsed directory) when eager loading the application, because the collapsing prevents the undesired namespace to be defined. When eager loading the application, you also don't want that namespace.

