### PR TITLE
Update sdoc to 2.5.0 to support better code highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.4.0"
+  gem "sdoc", ">= 2.5.0"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    sdoc (2.4.0)
+    sdoc (2.5.0)
       rdoc (>= 5.0)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
@@ -621,7 +621,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubyzip (~> 2.0)
-  sdoc (>= 2.4.0)
+  sdoc (>= 2.5.0)
   selenium-webdriver (>= 4.0.0)
   sequel
   sidekiq


### PR DESCRIPTION
### Motivation / Background

Currently the api docs don't have any special css for constants.
Anytime we show an example of a class method it is all black text.
By using the same css as '.class', examples become more easier to scan.

### Detail

### Before
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/28561/208455155-2a917a54-601f-4f71-ab04-5f19b3986e0b.png">

### After
<img width="915" alt="image" src="https://user-images.githubusercontent.com/28561/208455086-7e47c1bd-9e58-4292-b564-8278474fba05.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
