### PR TITLE
Add additional ignored files to the .dockerignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -1,11 +1,18 @@
 # See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
 
+# Ignore git directory.
+/.git/
+
 # Ignore bundler config.
 /.bundle
 
-# Ignore all default key files
+# Ignore all default key files.
 config/master.key
 config/credentials/*.key
+
+# Ignore all environment files.
+.env*
+!.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*
@@ -30,5 +37,9 @@ config/credentials/*.key
 <% end -%>
 <% unless options.api? -%>
 
+# Ignore assets.
+/node_modules/
+/app/assets/builds/*
+!/app/assets/builds/.keep
 /public/assets
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -7,12 +7,12 @@
 /.bundle
 
 # Ignore all default key files.
-config/master.key
-config/credentials/*.key
+/config/master.key
+/config/credentials/*.key
 
 # Ignore all environment files.
-.env*
-!.env.example
+/.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
The goals of this PR are to:

- Reduce the size of the Docker image
- Avoid copying potentially sensitive files into the image such as an `.env` or `.env.prod` file