### PR TITLE
Serialized attributes assigned with accepts_nested_attributes_for throw Psych::DisallowedClass errors

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         return if obj.nil?
 
         assert_valid_value(obj, action: "dump")
-        YAML.dump obj
+        YAML.dump object_class == Hash ? obj.to_h : obj
       end
 
       def load(yaml)

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/author"
+require "models/topic"
 
 module ActiveRecord
   module Coders
@@ -142,6 +144,17 @@ module ActiveRecord
         assert_raises(Psych::DisallowedClass) do
           coder.load(missing_class_yaml)
         end
+      end
+
+      def test_serialized_hash_nested_attributes
+        Author.accepts_nested_attributes_for :topics
+        Topic.serialize :content, Hash
+
+        author = Author.new name: 'Pen', topics_attributes: [{content: {test: 1}}]
+        assert_equal Hash, author.topics[0].content.class
+        assert_equal({'test' => 1}, author.topics[0].content)
+
+        Topic.serialize :content
       end
     end
   end

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -150,9 +150,9 @@ module ActiveRecord
         Author.accepts_nested_attributes_for :topics
         Topic.serialize :content, Hash
 
-        author = Author.new name: 'Pen', topics_attributes: [{content: {test: 1}}]
+        author = Author.new name: "Pen", topics_attributes: [{ content: { test: 1 } }]
         assert_equal Hash, author.topics[0].content.class
-        assert_equal({'test' => 1}, author.topics[0].content)
+        assert_equal({ "test" => 1 }, author.topics[0].content)
 
         Topic.serialize :content
       end


### PR DESCRIPTION
YAML by default now uses safe loading and only accepts a limited number of classes which includes `Hash`, but not `HashWithIndifferentAccess`.

When using `accepts_nested_attributes_for` with a serialized Hash attribute, a `Psych::DisallowedClass: Tried to load unspecified class: ActiveSupport::HashWithIndifferentAccess` error would be thrown even if the nested attribute is a regular hash.

This patch forces the nested attribute to a regular Hash attribute when using a serialized Hash. In general, the nested attributes are converted to a HashWithIndifferentAccess for processing, but this breaks the safe loading for YAML which doesn't accept HashWithIndifferentAccess, so the serialized attribute must be forced to a Hash.

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Safe YAML loading is enabled by default now and `accepts_nested_attributes_for` accepts serialized attributes, but if the serialized attribute is a Hash, then a `Psych::DisallowedClass` error is thrown.  There is no way to force the nested value to a Hash as the code for `accepts_nested_attributes_for` converts the parameters to a HashWithIndifferentAccess and thus generating an error serializing the serialized attribute.

Fixes #46684

### Detail

This Pull Request changes the ability to allow serialized hash attributes with `accepts_nested_attributes_for`

### Additional information

The linked issue number above includes additional information regarding the issue and the location in the rails code where conversion of the Hash to a HashWithIndifferentAccess occurs.
