### PR TITLE
Fix a generators guide link to Thor actions

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -52,7 +52,7 @@ class InitializerGenerator < Rails::Generators::Base
 end
 ```
 
-NOTE: `create_file` is a method provided by `Thor::Actions`. Documentation for `create_file` and other Thor methods can be found in [Thor's documentation](https://rdoc.info/gems/thor/Thor/Actions).
+NOTE: `create_file` is a method provided by `Thor::Actions`. Documentation for `create_file` and other Thor methods can be found in [Thor's documentation](https://www.rubydoc.info/gems/thor/Thor/Actions).
 
 Our new generator is quite simple: it inherits from `Rails::Generators::Base` and has one method definition. When a generator is invoked, each public method in the generator is executed sequentially in the order that it is defined. Finally, we invoke the `create_file` method that will create a file at the given destination with the given content. If you are familiar with the Rails Application Templates API, you'll feel right at home with the new generators API.
 


### PR DESCRIPTION
Just fixing a link. The correct link is already used lower in the same guide.