### PR TITLE
Skip Docker-related files for plugin dummy apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -351,9 +351,8 @@ module Rails
       remove_task :update_active_storage
 
       def create_dockerfiles
-        unless options[:skip_docker]
-          build(:dockerfiles)
-        end
+        return if options[:skip_docker] || options[:dummy_app]
+        build(:dockerfiles)
       end
 
       def create_config_files

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1017,6 +1017,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_skip_docker
+    run_generator [destination_root, "--skip-docker"]
+
+    assert_no_file ".dockerignore"
+    assert_no_file "Dockerfile"
+    assert_no_file "bin/docker-entrypoint"
+  end
+
   def test_system_tests_directory_generated
     run_generator
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -613,6 +613,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/dummy/README.md"
     assert_no_file "test/dummy/config/master.key"
     assert_no_file "test/dummy/config/credentials.yml.enc"
+    assert_no_file "test/dummy/Dockerfile"
+    assert_no_file "test/dummy/.dockerignore"
     assert_no_directory "test/dummy/lib/tasks"
     assert_no_directory "test/dummy/test"
     assert_no_directory "test/dummy/vendor"

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -132,13 +132,6 @@ module SharedGeneratorTests
     assert_no_file("app/models/concerns/.keep")
   end
 
-  def test_skip_docker
-    run_generator [destination_root, "--skip-docker", "--full"]
-    assert_no_file(".dockerignore")
-    assert_no_file("Dockerfile")
-    assert_no_file("bin/docker-entrypoint")
-  end
-
   def test_default_frameworks_are_required_when_others_are_removed
     run_generator [
       destination_root,


### PR DESCRIPTION
Follow-up to #46762.

Docker-related files are intended for production deployment, not development.  Therefore, this commit prevents those files from being generated for plugin dummy apps.
