### PR TITLE
Add CMD and refactor ENTRYPOINT in the Docker generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -44,7 +44,9 @@ RUN bundle exec bootsnap precompile --gemfile app/ lib/
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
-# Entrypoint prepares database and starts app on 0.0.0.0:3000 by default,
-# but can also take a rails command, like "console" or "runner" to start instead.
+# Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime.
 EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,12 +1,8 @@
 #!/bin/sh
 
-if [ $# -eq 0 ]; then
-  # Create new or migrate existing database
+#  If running the rails server then create or migrate existing database
+if [ "${*}" == "./bin/rails server" ]; then
   ./bin/rails db:prepare
-
-  # Start the server by default
-  exec bin/rails server
-else
-  # Allow other commands, like console or runner, to be called
-  exec bin/rails "$@"
 fi
+
+exec "${@}"

--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#  If running the rails server then create or migrate existing database
+# If running the rails server then create or migrate existing database
 if [ "${*}" == "./bin/rails server" ]; then
   ./bin/rails db:prepare
 fi


### PR DESCRIPTION
**The goal of this PR is to:**

- Make it easier to run the Rails server by default
- Still allow running other commands of your choosing
- Re-use the same Docker image for your `web` and `worker` containers by supplying a custom `CMD` for your `worker`, this could also be applied to running a separate `cable `container

**Examples:**

- `docker container run -it myapp` will start `./bin/rails server` as PID 1 in the container
  - `./bin/rails db:prepare` will execute due to the `ENTRYPOINT` script
- `docker container run -it myapp rails console` will start the rails console
  - The `ENTRYPOINT` script will not run `./bin/rails db:prepare` because the arguments didn't match `./bin/rails server`

*Note, I didn't run this patch locally based on the output of the generator. I modified an existing Rails app I had running in Docker and ported over the changes here.*