### PR TITLE
make bypass_local_cache as public method

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -640,6 +640,12 @@ module ActiveSupport
         raise NotImplementedError.new("#{self.class.name} does not support clear")
       end
 
+      # Skip +ActiveSupport::Cache::Strategy::LocalCache::Middleware+,
+      # in specific cache store implementation execute operation.
+      def bypass_local_cache(&block)
+        block.call
+      end
+
       private
         def default_coder
           Coders[Cache.format_version]

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -112,6 +112,10 @@ module ActiveSupport
           value
         end
 
+        def bypass_local_cache(&block) # :nodoc:
+          use_temporary_local_cache(nil, &block)
+        end
+
         private
           def read_serialized_entry(key, raw: false, **options)
             if cache = local_cache
@@ -173,10 +177,6 @@ module ActiveSupport
 
           def local_cache
             LocalCacheRegistry.cache_for(local_cache_key)
-          end
-
-          def bypass_local_cache(&block)
-            use_temporary_local_cache(nil, &block)
           end
 
           def use_temporary_local_cache(temporary_cache)

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -66,7 +66,7 @@ module LocalCacheBehavior
       @cache.write(key, value)
       assert_equal value, @cache.read(key)
 
-      @cache.send(:bypass_local_cache) { @cache.write(key, other_value) }
+      @cache.bypass_local_cache { @cache.write(key, other_value) }
       assert_equal value, @cache.read(key)
 
       @cache.cleanup
@@ -109,7 +109,7 @@ module LocalCacheBehavior
     value = SecureRandom.alphanumeric
     @cache.with_local_cache do
       assert_nil @cache.read(key)
-      @cache.send(:bypass_local_cache) { @cache.write(key, value) }
+      @cache.bypass_local_cache { @cache.write(key, value) }
       assert_nil @cache.read(key)
     end
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because:
There is no way to easily skip `ActiveSupport::Cache::Strategy::LocalCache` at present.

### Detail

This Pull Request changes as follows:
- `ActiveSupport::Cache::Strategy::LocalCache#bypass_local_cache` changed private method to public method.
-  Added `Rails::Cache::Store#bypass_local_cache` public method, so that ensure all cache store implementations support call `bypass_local_cache` method.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (_I'm not sure about this option. please let me know if necessary_)

_PS: English is not my native language; please excuse typing errors._