### PR TITLE
Only register CurrentAttributes hooks if used

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -224,3 +224,5 @@ module ActiveSupport
       end
   end
 end
+
+ActiveSupport.run_load_hooks :active_support_current_attributes, ActiveSupport::CurrentAttributes

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -55,9 +55,11 @@ module ActiveSupport
     end
 
     initializer "active_support.reset_all_current_attributes_instances" do |app|
-      app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
-      app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
-      app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+      ActiveSupport.on_load(:active_support_current_attributes) do
+        app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
+        app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
+        app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+      end
 
       ActiveSupport.on_load(:active_support_test_case) do
         if app.config.active_support.executor_around_test_case


### PR DESCRIPTION
### Motivation / Background

Previously, executor hooks were always defined to clear ActiveSupport::CurrentAttributes whether or not an application defines a Current class. However, those apps without CurrentAttributes will end up autoloading the class when the executor hooks run, which adds additional overhead to the first request or job processed.

### Detail

One possible solution would be to eager load CurrentAttributes to prevent it from being autoloaded mid request, however this would be extraneous for applications not using it. Therefore a better solution is to only register the executor hooks when CurrentAttributes is loaded.

### Additional Information

Should all load hooks be documented in https://edgeguides.rubyonrails.org/engines.html ? If so I can add this one

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
