### PR TITLE
Add Rails.env.local?

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Rails.env.local?` shorthand for `Rails.env.development? || Rails.env.test?`.
+
+    *DHH*
+
 *   `ActiveSupport::Testing::TimeHelpers` now accepts named `with_usec` argument
     to `freeze_time`, `travel`, and `travel_to` methods. Passing true prevents
     truncating the destination time with `change(usec: 0)`.

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -13,6 +13,8 @@ module ActiveSupport
     LOCAL_ENVIRONMENTS = %w[ development test ]
 
     def initialize(env)
+      raise(ArgumentError, "'local' is a reserved environment name") if env == "local"
+
       super(env)
 
       DEFAULT_ENVIRONMENTS.each do |default|

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require "active_support/string_inquirer"
+require "active_support/core_ext/object/inclusion"
 
 module ActiveSupport
   class EnvironmentInquirer < StringInquirer # :nodoc:
     # Optimization for the three default environments, so this inquirer doesn't need to rely on
     # the slower delegation through method_missing that StringInquirer would normally entail.
     DEFAULT_ENVIRONMENTS = %w[ development test production ]
+
+    # Environments that'll respond true for #local?
+    LOCAL_ENVIRONMENTS = %w[ development test ]
+
     def initialize(env)
       super(env)
 
@@ -17,6 +22,11 @@ module ActiveSupport
 
     DEFAULT_ENVIRONMENTS.each do |env|
       class_eval "def #{env}?; @#{env}; end"
+    end
+
+    # Returns true if we're in the development or test environment.
+    def local?
+      in? LOCAL_ENVIRONMENTS
     end
   end
 end

--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -8,4 +8,10 @@ class EnvironmentInquirerTest < ActiveSupport::TestCase
     assert ActiveSupport::EnvironmentInquirer.new("test").local?
     assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
   end
+
+  test "prevent local from being used as an actual environment name" do
+    assert_raises(ArgumentError) do
+      ActiveSupport::EnvironmentInquirer.new("local")
+    end
+  end
 end

--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class EnvironmentInquirerTest < ActiveSupport::TestCase
+  test "local predicate" do
+    assert ActiveSupport::EnvironmentInquirer.new("development").local?
+    assert ActiveSupport::EnvironmentInquirer.new("test").local?
+    assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
+  end
+end


### PR DESCRIPTION
So many checks against Rails.env is whether we're running test or development, so combine into just one.

Before:

```ruby
if Rails.env.development? || Rails.env.test?
```

After:

```ruby
if Rails.env.local?
```