### PR TITLE
Support string keys for queries on deterministic attributes

### DIFF
--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -44,12 +44,12 @@ module ActiveRecord
             return args if owner.deterministic_encrypted_attributes&.empty?
 
             if args.is_a?(Array) && (options = args.first).is_a?(Hash)
-              options = options.dup
+              options = options.stringify_keys
               args[0] = options
 
               owner.deterministic_encrypted_attributes&.each do |attribute_name|
                 type = owner.type_for_attribute(attribute_name)
-                if !type.previous_types.empty? && value = options[attribute_name]
+                if !type.previous_types.empty? && value = options[attribute_name.to_s]
                   options[attribute_name] = process_encrypted_query_argument(value, check_for_additional_values, type)
                 end
               end

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -25,6 +25,11 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
     assert EncryptedBookWithDowncaseName.find_by(name: "DUNE")
   end
 
+  test "Works well with string attribute names" do
+    UnencryptedBook.create! "name" => "Dune"
+    assert EncryptedBook.find_by("name" => "Dune")
+  end
+
   test "find_or_create works" do
     EncryptedBook.find_or_create_by!(name: "Dune")
     assert EncryptedBook.find_by(name: "Dune")


### PR DESCRIPTION
Closes #46788. Open to suggestions if there's a better approach since this is [a performance-critical area](https://github.com/rails/rails/blob/d95366cd881acb930b95d7011f0e0fb2c8cc54f5/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb#L26-L27).