### PR TITLE
Small refactor on build singular association

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -87,6 +87,10 @@ module ActiveRecord
           replace(record, false)
         end
 
+        def replace_keys(record, force: false)
+          # Has one association doesn't have foreign keys to replace.
+        end
+
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            set_new_record(record)
+            replace_keys(record, force: true)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end


### PR DESCRIPTION
### Motivation / Background

After the record is saved, set_new_record is called again in order to just set the foreign key. To make the intention clearer and avoid unnecessary method calls I'm just calling the method that matters, replace_keys.

Already proposed here #46515, but I did the silly mistake of removing the method call, introducing a new bug reverted on this PR #46632. So this time I'm making sure I'm doing the right thing.
