### PR TITLE
Update libxml-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       railties (>= 6.0.0)
     json (2.6.1)
     jwt (2.3.0)
-    libxml-ruby (3.2.1)
+    libxml-ruby (3.2.4)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
I am having trouble to install libxml-ruby version 3.2.1 on FreeBSD, however the current version 3.2.4 is installing just fine. I think it would make more sense to update this gem in rails instead of opening an issue at [libxml-ruby](https://github.com/xml4r/libxml-ruby), because the current version is working.

```
current directory: /usr/home/kandy/.gem/ruby/3.1.3/gems/libxml-ruby-3.2.1/ext/libxml
/usr/home/kandy/.rubies/ruby-3.1.3/bin/ruby -I /usr/home/kandy/.rubies/ruby-3.1.3/lib/ruby/3.1.0 extconf.rb
/usr/home/kandy/.rubies/ruby-3.1.3/bin/ruby: warning: shebang line ending with \r may cause problems
checking for libxml/xmlversion.h in /opt/include/libxml2,/opt/local/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2,/usr/local/include... yes
checking for xmlParseDoc() in -lxml2... yes
creating extconf.h
creating Makefile

current directory: /usr/home/kandy/.gem/ruby/3.1.3/gems/libxml-ruby-3.2.1/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20221222-16903-1wclxf sitelibdir\=./.gem.20221222-16903-1wclxf clean

current directory: /usr/home/kandy/.gem/ruby/3.1.3/gems/libxml-ruby-3.2.1/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20221222-16903-1wclxf sitelibdir\=./.gem.20221222-16903-1wclxf
compiling libxml.c
compiling ruby_xml.c
ruby_xml.c:775:7: warning: implicit declaration of function 'xmlGetFeaturesList' is invalid in C99 [-Wimplicit-function-declaration]
  if (xmlGetFeaturesList(&len, (const char **) list) == -1)
      ^
1 warning generated.
compiling ruby_xml_attr.c
compiling ruby_xml_attr_decl.c
compiling ruby_xml_attributes.c
compiling ruby_xml_cbg.c
compiling ruby_xml_document.c
compiling ruby_xml_dtd.c
compiling ruby_xml_encoding.c
ruby_xml_encoding.c:200:3: warning: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_module_function(mXMLEncoding, "to_rb_encoding", rxml_encoding_to_rb_encoding, 2);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/home/kandy/.rubies/ruby-3.1.3/include/ruby-3.1.0/ruby/internal/anyargs.h:337:142: note: expanded from macro 'rb_define_module_function'
#define rb_define_module_function(mod, mid, func, arity)    RBIMPL_ANYARGS_DISPATCH_rb_define_module_function((arity), (func))((mod), (mid), (func), (arity))
                                                                                                                                             ^~~~~~
/usr/home/kandy/.rubies/ruby-3.1.3/include/ruby-3.1.0/ruby/internal/anyargs.h:273:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_module_function, VALUE, const char *)
^
/usr/home/kandy/.rubies/ruby-3.1.3/include/ruby-3.1.0/ruby/internal/anyargs.h:256:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _02(__VA_ARGS__, VALUE(*)(VALUE, VALUE, VALUE), int); \
                                                                       ^
1 warning generated.
compiling ruby_xml_error.c
compiling ruby_xml_html_parser.c
compiling ruby_xml_html_parser_context.c
ruby_xml_html_parser_context.c:245:3: warning: 'htmlDefaultSAXHandlerInit' is deprecated [-Wdeprecated-declarations]
  htmlDefaultSAXHandlerInit();
  ^
/usr/local/include/libxml2/libxml/SAX2.h:162:1: note: 'htmlDefaultSAXHandlerInit' has been explicitly marked deprecated here
XML_DEPRECATED
^
/usr/local/include/libxml2/libxml/xmlversion.h:464:43: note: expanded from macro 'XML_DEPRECATED'
#    define XML_DEPRECATED __attribute__((deprecated))
                                          ^
1 warning generated.
compiling ruby_xml_html_parser_options.c
compiling ruby_xml_input_cbg.c
compiling ruby_xml_io.c
compiling ruby_xml_namespace.c
compiling ruby_xml_namespaces.c
compiling ruby_xml_node.c
ruby_xml_node.c:780:21: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
    return (INT2NUM((long) line_num));
            ~~~~~~~ ^~~~~~~~~~~~~~~
ruby_xml_node.c:792:3: error: use of undeclared identifier 'xlinkType'
  xlinkType xlt;
  ^
ruby_xml_node.c:795:3: error: use of undeclared identifier 'xlt'
  xlt = xlinkIsLink(xnode->doc, xnode);
  ^
ruby_xml_node.c:795:9: warning: implicit declaration of function 'xlinkIsLink' is invalid in C99 [-Wimplicit-function-declaration]
  xlt = xlinkIsLink(xnode->doc, xnode);
        ^
ruby_xml_node.c:797:7: error: use of undeclared identifier 'xlt'
  if (xlt == XLINK_TYPE_NONE)
      ^
ruby_xml_node.c:797:14: error: use of undeclared identifier 'XLINK_TYPE_NONE'
  if (xlt == XLINK_TYPE_NONE)
             ^
ruby_xml_node.c:814:3: error: use of undeclared identifier 'xlinkType'
  xlinkType xlt;
  ^
ruby_xml_node.c:817:3: error: use of undeclared identifier 'xlt'
  xlt = xlinkIsLink(xnode->doc, xnode);
  ^
ruby_xml_node.c:817:9: warning: implicit declaration of function 'xlinkIsLink' is invalid in C99 [-Wimplicit-function-declaration]
  xlt = xlinkIsLink(xnode->doc, xnode);
        ^
ruby_xml_node.c:819:7: error: use of undeclared identifier 'xlt'
  if (xlt == XLINK_TYPE_NONE)
      ^
ruby_xml_node.c:819:14: error: use of undeclared identifier 'XLINK_TYPE_NONE'
  if (xlt == XLINK_TYPE_NONE)
             ^
ruby_xml_node.c:822:21: error: use of undeclared identifier 'xlt'
    return (INT2NUM(xlt));
                    ^
ruby_xml_node.c:836:3: error: use of undeclared identifier 'xlinkType'
  xlinkType xlt;
  ^
ruby_xml_node.c:839:3: error: use of undeclared identifier 'xlt'
  xlt = xlinkIsLink(xnode->doc, xnode);
  ^
ruby_xml_node.c:839:9: warning: implicit declaration of function 'xlinkIsLink' is invalid in C99 [-Wimplicit-function-declaration]
  xlt = xlinkIsLink(xnode->doc, xnode);
        ^
ruby_xml_node.c:841:11: error: use of undeclared identifier 'xlt'
  switch (xlt)
          ^
ruby_xml_node.c:843:8: error: use of undeclared identifier 'XLINK_TYPE_NONE'
  case XLINK_TYPE_NONE:
       ^
ruby_xml_node.c:845:8: error: use of undeclared identifier 'XLINK_TYPE_SIMPLE'
  case XLINK_TYPE_SIMPLE:
       ^
ruby_xml_node.c:847:8: error: use of undeclared identifier 'XLINK_TYPE_EXTENDED'
  case XLINK_TYPE_EXTENDED:
       ^
ruby_xml_node.c:849:8: error: use of undeclared identifier 'XLINK_TYPE_EXTENDED_SET'
  case XLINK_TYPE_EXTENDED_SET:
       ^
ruby_xml_node.c:852:41: error: use of undeclared identifier 'xlt'
    rb_fatal("Unknowng xlink type, %d", xlt);
                                        ^
4 warnings and 17 errors generated.
*** Error code 1

Stop.
make: stopped in /usr/home/kandy/.gem/ruby/3.1.3/gems/libxml-ruby-3.2.1/ext/libxml

make failed, exit code 1

```

```
ruby -v
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-freebsd13.1]
```