### PR TITLE
Increase `socket_timeout` for Memcached inside memcached tests

### DIFF
--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -198,7 +198,8 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         @app = self.class.build_app(set) do |middleware|
           middleware.use ActionDispatch::Session::MemCacheStore,
             key: "_session_id", namespace: "mem_cache_store_test:#{SecureRandom.hex(10)}",
-            memcache_server: ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+            memcache_server: ENV["MEMCACHE_SERVERS"] || "localhost:11211",
+            socket_timeout: 60
           middleware.delete ActionDispatch::ShowExceptions
         end
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -45,7 +45,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def lookup_store(*addresses, **options)
-    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, *addresses, { namespace: @namespace, pool: false }.merge(options))
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, *addresses, { namespace: @namespace, pool: false, socket_timeout: 60 }.merge(options))
     (@_stores ||= []) << cache
     cache
   end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -179,7 +179,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     cache = lookup_store(raw: true, namespace: nil)
 
     Time.stub(:now, Time.now) do
-      assert_called_with client(cache), :set, ["key_with_expires_at", "bar", 30 * 60], namespace: nil, pool: false, raw: true, compress_threshold: 1024, expires_in: 1800.0 do
+      assert_called_with client(cache), :set, ["key_with_expires_at", "bar", 30 * 60], namespace: nil, pool: false, raw: true, compress_threshold: 1024, expires_in: 1800.0, socket_timeout: 60 do
         cache.write("key_with_expires_at", "bar", expires_at: 30.minutes.from_now)
       end
     end
@@ -265,7 +265,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   def test_unless_exist_expires_when_configured
     cache = lookup_store(namespace: nil)
 
-    assert_called_with client(cache), :add, ["foo", Object, 1], namespace: nil, pool: false, compress_threshold: 1024, expires_in: 1, unless_exist: true do
+    assert_called_with client(cache), :add, ["foo", Object, 1], namespace: nil, pool: false, compress_threshold: 1024, expires_in: 1, socket_timeout: 60, unless_exist: true do
       cache.write("foo", "bar", expires_in: 1, unless_exist: true)
     end
   end


### PR DESCRIPTION
Co-authored-by: @matthewd 

It sounds like a default 1 second `socket_timeout` for Memcached server can sometimes not be enough for some builds like [this flaky failure](https://buildkite.com/rails/rails/builds/91875#01853521-73eb-43f7-b81f-075fe7be3010/1171-1182).

In normal operations, this should be fine (will result in a cache miss), but in these memchaced-specific tests, we always expect the cache to return the value, hence increasing the `socket_timeout` for these tests only.