### PR TITLE
GMT+0, GMT-0, GMT0 and GMT for timezone tests

### DIFF
--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -74,7 +74,10 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Africa/Abidjan"]).utc?
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Africa/Banjul"]).utc?
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Africa/Freetown"]).utc?
-    assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["GMT"]).utc?
+    assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["GMT"]).utc? unless
+      RbConfig::CONFIG["target_os"] =~ /bsd/
+    assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["GMT+0"]).utc?
+    assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["GMT-0"]).utc?
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["GMT0"]).utc?
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Greenwich"]).utc?
     assert_equal false, ActiveSupport::TimeWithZone.new(Time.utc(2000), ActiveSupport::TimeZone["Iceland"]).utc?


### PR DESCRIPTION
FreeBSD does not have GMT file in /usr/share/zoneinfo. FreeBSD has GMT0, GMT+0 and GMT-0.

```
ls /usr/share/zoneinfo
Africa          CET             Egypt           GMT-0           Israel          Mexico          Portugal        UTC
America         CST6CDT         Eire            GMT0            Jamaica         NZ              ROC             Universal
Antarctica      Canada          Etc             Greenwich       Japan           NZ-CHAT         ROK             W-SU
Arctic          Chile           Europe          HST             Kwajalein       Navajo          Singapore       WET
Asia            Cuba            Factory         Hongkong        Libya           PRC             SystemV         Zulu
Atlantic        EET             GB              Iceland         MET             PST8PDT         Turkey          posixrules
Australia       EST             GB-Eire         Indian          MST             Pacific         UCT             zone.tab
Brazil          EST5EDT         GMT+0           Iran            MST7MDT         Poland          US              zone1970.tab
```

```
irb(main):001:0> irb_info
=>
Ruby version: 3.1.3
IRB version: irb 1.6.1 (2022-12-13)
InputMethod: RelineInputMethod with Reline 0.3.2
RUBY_PLATFORM: x86_64-freebsd13.1
LANG env: C.UTF-8
East Asian Ambiguous Width: 1

irb(main):002:0> require "tzinfo"
=> true
irb(main):003:0> TZInfo::Timezone.all_identifiers.select { _1.match? /^GMT/ }
=> ["GMT+0", "GMT-0", "GMT0"]
```