### PR TITLE
[docs] Add `where.missing` and `where.associated` to Active Record Querying guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1409,6 +1409,43 @@ LEFT OUTER JOIN reviews ON reviews.customer_id = customers.id GROUP BY customers
 Which means: "return all customers with their count of reviews, whether or not they
 have any reviews at all"
 
+### `where.associated` and `where.missing`
+
+The `associated` and `missing` query methods let you select a set of records
+based on the presence or absence of an association.
+
+To use `where.associated`:
+
+```ruby
+Customer.where.associated(:reviews)
+```
+
+Produces:
+
+```sql
+SELECT customers.* FROM customers
+INNER JOIN reviews ON reviews.customer_id = customers.id
+WHERE reviews.customer_id IS NOT NULL
+```
+
+Which means "return all customers that have made at least one review".
+
+To use `where.missing`:
+
+```ruby
+Customer.where.missing(:reviews)
+```
+
+Produces:
+
+```sql
+SELECT customers.* FROM customers
+LEFT OUTER JOIN reviews ON reviews.customer_id = customers.id
+WHERE reviews.customer_id IS NULL
+```
+
+Which means "return all customers that have not made any reviews".
+
 
 Eager Loading Associations
 --------------------------


### PR DESCRIPTION
Guide: https://edgeguides.rubyonrails.org/active_record_querying.html#scopes

Methods: https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-missing, https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-associated

I grouped them in one section as they are conceptually similar.

<img width="970" alt="image" src="https://user-images.githubusercontent.com/509837/209219974-85a71bd9-2f07-4226-afd1-d230555d820b.png">
