### PR TITLE
Eager load Rails::BacktraceCleaner

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -13,6 +13,7 @@ require "active_support/core_ext/object/blank"
 require "rails/version"
 require "rails/deprecator"
 require "rails/application"
+require "rails/backtrace_cleaner"
 
 require "active_support/railtie"
 require "action_dispatch/railtie"
@@ -49,11 +50,7 @@ module Rails
     end
 
     def backtrace_cleaner
-      @backtrace_cleaner ||= begin
-        # Relies on Active Support, so we have to lazy load to postpone definition until Active Support has been loaded
-        require "rails/backtrace_cleaner"
-        Rails::BacktraceCleaner.new
-      end
+      @backtrace_cleaner ||= Rails::BacktraceCleaner.new
     end
 
     # Returns a Pathname object of the current Rails project,


### PR DESCRIPTION
### Motivation / Background

Previously, Rails::BacktraceCleaner was both lazily required and instantiated. While it would end up being loaded during initialization for apps that use Active Record (due to active_record.backtrace_cleaner initializer), it would not be loaded until the first request for those that don't.

### Detail

The solution is similar to daff36c, however ::Rails is not currently in the list of eager_load_namespaces. Therefore simply requiring it seems like the easiest solution.

### Additional information

The removed comment indicating the lazy require is necessary due to load order dates back to the addition of Rails::BacktraceCleaner in f42c77f. This predates the integration of Bundler and reorganization of framework loading, so it is no longer accurate.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
