### PR TITLE
Backport `create_association` fix to 7-0-stable

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -87,6 +87,10 @@ module ActiveRecord
           replace(record, false)
         end
 
+        def replace_keys(record, force: false)
+          # Has one association doesn't have foreign keys to replace.
+        end
+
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -54,11 +54,13 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false, &block)
-          record = build_record(attributes, &block)
-          saved = record.save
-          set_new_record(record)
-          raise RecordInvalid.new(record) if !saved && raise_error
-          record
+          reflection.klass.transaction do
+            record = build(attributes, &block)
+            saved = record.save
+            replace_keys(record, force: true)
+            raise RecordInvalid.new(record) if !saved && raise_error
+            record
+          end
         end
     end
   end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1428,6 +1428,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.id, client.client_of
   end
 
+  def test_should_set_foreign_key_on_create_association_with_unpersisted_owner
+    tagging = Tagging.new
+    tag = tagging.create_tag
+
+    assert_not_predicate tagging, :persisted?
+    assert_predicate tag, :persisted?
+    assert_equal tag.id, tagging.tag_id
+  end
+
   def test_self_referential_belongs_to_with_counter_cache_assigning_nil
     comment = Comment.create! post: posts(:thinking), body: "fuu"
     comment.parent = nil


### PR DESCRIPTION
Backport of: https://github.com/rails/rails/pull/46790
Fix: https://github.com/rails/rails/issues/46737

I'm opening a PR to make sure there is no failure on CI, as this change is quite subtle.