### PR TITLE
Introduce ActiveStorage::AttachRemoteFileJob

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support attaching files with remote URLs from background jobs
+
+    Generate `#{name}_url` and `#{name}_urls` accessors (for `has_one_attached`
+    and `has_many_attached`, respectively), then enqueue
+    `ActiveStorage::AttachRemoteFileJob` jobs for each in an `after_save` callback.
+
+    *Sean Doyle*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Disables the session in `ActiveStorage::Blobs::ProxyController`

--- a/activestorage/app/jobs/active_storage/attach_remote_file_job.rb
+++ b/activestorage/app/jobs/active_storage/attach_remote_file_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "open-uri"
+
+# Downloads and attaches a File from a URL
+class ActiveStorage::AttachRemoteFileJob < ActiveStorage::BaseJob
+  queue_as { ActiveStorage.queues[:attach_remote_file] }
+
+  discard_on ActiveRecord::RecordNotFound, OpenURI::HTTPError
+
+  def perform(record, name, url)
+    attachment = record.public_send(name)
+    uri = URI.parse(url)
+
+    attachment.attach(io: uri.open, filename: File.basename(uri.path))
+  end
+end

--- a/activestorage/test/jobs/attach_remote_file_job_test.rb
+++ b/activestorage/test/jobs/attach_remote_file_job_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+require "webmock/minitest"
+
+class ActiveStorage::AttachRemoteFileJobTest < ActiveJob::TestCase
+  setup do
+    @user = User.create! name: "Test"
+  end
+
+  test "#perform downloads and attaches a file" do
+    url = "https://example.com/racecar.jpg"
+    stub_request(:get, url).to_return(body: file_fixture("racecar.jpg"))
+
+    assert_changes -> { @user.reload.avatar.attached? }, from: false, to: true do
+      ActiveStorage::AttachRemoteFileJob.perform_now(@user, :avatar, url)
+    end
+  end
+
+  test "#perform discards the job on a 404" do
+    url = "https://example.com/racecar.jpg"
+    stub_request(:get, url).to_return(status: 404)
+
+    assert_no_changes -> { @user.reload.avatar.attached? }, from: false do
+      ActiveStorage::AttachRemoteFileJob.perform_now(@user, :avatar, url)
+    end
+  end
+
+  test "#perform discards the job when the attachment column does not exist" do
+    url = "http://junk"
+
+    perform_enqueued_jobs do
+      assert_raises NoMethodError do
+        ActiveStorage::AttachRemoteFileJob.perform_later(@user, :junk, url)
+      end
+    end
+
+    assert_no_enqueued_jobs
+  end
+
+  test "#perform discards the job when the record does not exist" do
+    url = "https://example.com/racecar.jpg"
+
+    perform_enqueued_jobs do
+      ActiveStorage::AttachRemoteFileJob.perform_later(@user.tap(&:destroy!), :avatar, url)
+    end
+
+    assert_no_enqueued_jobs
+  end
+end

--- a/activestorage/test/models/attached/many_callbacks_test.rb
+++ b/activestorage/test/models/attached/many_callbacks_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::ManyAttachedCallbacksTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @user = User.new name: "test"
+  end
+
+  test "#highlights_urls= will enqueue an ActiveStorage::AttachRemoteFileJob on save" do
+    url = "http://example.com/racecar.jpg"
+
+    assert_enqueued_with job: ActiveStorage::AttachRemoteFileJob, args: [@user, :highlights, url] do
+      @user.update! highlights_urls: [url]
+    end
+  end
+
+  test "sets the attribute to nil after save" do
+    @user.highlights_urls = ["http://example.com/racecar.jpg"]
+
+    assert_changes -> { @user.highlights_urls }, to: nil do
+      @user.save
+    end
+  end
+
+  test "#highlights_urls= won't enqueue an ActiveStorage::AttachRemoteFileJob when the value is nil" do
+    assert_no_enqueued_jobs do
+      @user.update! highlights_urls: nil
+    end
+  end
+
+  test "#highlights_urls= won't enqueue an ActiveStorage::AttachRemoteFileJob when the value is blank" do
+    assert_no_enqueued_jobs do
+      @user.update! highlights_urls: [""]
+    end
+  end
+
+  test "#highlights_urls= won't enqueue an ActiveStorage::AttachRemoteFileJob on a failed save" do
+    url = "http://example.com/racecar.jpg"
+
+    assert_no_enqueued_jobs do
+      @user.update name: nil, highlights_urls: [url]
+    end
+  end
+end

--- a/activestorage/test/models/attached/one_callbacks_test.rb
+++ b/activestorage/test/models/attached/one_callbacks_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::OneAttachedCallbacksTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @user = User.new name: "test"
+  end
+
+  test "#avatar_url= will enqueue an ActiveStorage::AttachRemoteFileJob on save" do
+    url = "http://example.com/racecar.jpg"
+
+    assert_enqueued_with job: ActiveStorage::AttachRemoteFileJob, args: [@user, :avatar, url] do
+      @user.update! avatar_url: url
+    end
+  end
+
+  test "sets the attribute to nil after save" do
+    @user.avatar_url = "http://example.com/racecar.jpg"
+
+    assert_changes -> { @user.avatar_url }, to: nil do
+      @user.save
+    end
+  end
+
+  test "#avatar_url= won't enqueue an ActiveStorage::AttachRemoteFileJob when the value is nil" do
+    assert_no_enqueued_jobs do
+      @user.update! avatar_url: nil
+    end
+  end
+
+  test "#avatar_url= won't enqueue an ActiveStorage::AttachRemoteFileJob when the value is blank" do
+    assert_no_enqueued_jobs do
+      @user.update! avatar_url: ""
+    end
+  end
+
+  test "#avatar_url= won't enqueue an ActiveStorage::AttachRemoteFileJob on a failed save" do
+    url = "http://example.com/racecar.jpg"
+
+    assert_no_enqueued_jobs do
+      @user.update name: nil, avatar_url: url
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Active Support expects a `File` instance, or at the very least an open `IO` instance.
Unfortunately, a `URL` is neither, but can be transformed into one.

### Detail

 This commit introduces the `ActiveStorage::AttachRemoteFileJob` to download the remote file referenced by the `URL`.

When saving a record with attachments, support assignment to `#{name}_url` and `#{name}_urls` (for `has_one_attached` and `has_many_attached`, respectively), then download those for their underlying attachments.

```ruby
url = "http://example.com/racecar.jpg"
record = User.new(...)

assert_enqueued_with job: ActiveStorage::AttachRemoteFileJob, args: [record, :avatar, url] do
  record.update! avatar_url: url
end

 # some time later

record.avatar.attached? #=> true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
