### PR TITLE
Support attaching files with `URI` instances

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,14 @@
+*   Support attaching `URI` instances
+
+    ```ruby
+    uri = URI("https://example.com/racecar.jpg")
+
+    user.avatar.attach uri
+
+    user.avatar.filename.to_s
+    # => "racecar.jpg"
+    ```
+
+    *Sean Doyle*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -32,7 +32,7 @@ module ActiveStorage
         blob.upload_without_unfurling(attachable.fetch(:io))
       when File
         blob.upload_without_unfurling(attachable)
-      when Pathname
+      when Pathname, URI
         blob.upload_without_unfurling(attachable.open)
       when ActiveStorage::Blob
       when String
@@ -101,7 +101,7 @@ module ActiveStorage
             record: record,
             service_name: attachment_service_name
           )
-        when Pathname
+        when Pathname, URI
           ActiveStorage::Blob.build_after_unfurling(
             io: attachable.open,
             filename: File.basename(attachable),

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "database/setup"
+require "webmock/minitest"
 
 class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -74,6 +75,15 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     @user.save!
     assert_equal "funky.jpg", @user.highlights.reload.first.filename.to_s
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
+  end
+
+  test "attaching a new blob from a URI to an existing record" do
+    uri = URI.parse("https://example.com/racecar.jpg")
+    stub_request(:get, uri).to_return(body: file_fixture("racecar.jpg"))
+
+    @user.highlights.attach uri
+
+    assert_equal ["racecar.jpg"], @user.highlights.map { |attached| attached.filename.to_s }
   end
 
   test "attaching new blobs from Hashes to an existing, changed record" do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "database/setup"
 require "active_support/testing/method_call_assertions"
+require "webmock/minitest"
 
 class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -66,6 +67,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from a Hash to an existing record" do
     @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
     assert_equal "town.jpg", @user.avatar.filename.to_s
+  end
+
+  test "attaching a new blob from a URI to an existing record" do
+    uri = URI.parse("https://example.com/racecar.jpg")
+    stub_request(:get, uri).to_return(body: file_fixture("racecar.jpg"))
+
+    @user.avatar.attach uri
+
+    assert_equal "racecar.jpg", @user.avatar.filename.to_s
   end
 
   test "attaching a new blob from a Hash to an existing record passes record" do


### PR DESCRIPTION
### Motivation / Background

Active Storage attachments require a handle to a blob or open `IO` instance. A `URI` is neither, but can transform itself into an open `IO` instance.

### Detail

Extend the `attach` method to accept instances of `URI` to download and attach files directly inline.

### Additional information

Related to [rails/rails#46801][]

[rails/rails#46801]: https://github.com/rails/rails/pull/46801

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
