### PR TITLE
Reduce usage of method delegations to gain more speed

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -154,20 +154,41 @@ module ActionController
     # The ActionDispatch::Response instance for the current response.
     attr_internal :response
 
-    delegate :session, to: "@_request"
+    def session
+      @_request.session
+    end
 
     ##
     # Delegates to ActionDispatch::Response#headers.
     delegate :headers, to: "@_response"
 
-    delegate :status=, :location=, :content_type=,
-             :status, :location, :content_type, :media_type, to: "@_response"
+    delegate :location=, :location, to: "@_response"
 
     def initialize
       @_request = nil
       @_response = nil
       @_routes = nil
       super
+    end
+
+    def status
+      @_response.status
+    end
+
+    def status=(s)
+      @_response.status = s
+    end
+
+    def content_type
+      @_response.content_type
+    end
+
+    def content_type=(c)
+      @_response.content_type = c
+    end
+
+    def media_type
+      @_response.media_type
     end
 
     def params

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -7,7 +7,10 @@ module ActionController # :nodoc:
     included do
       class_attribute :_flash_types, instance_accessor: false, default: []
 
-      delegate :flash, to: :request
+      def flash
+        request.flash
+      end
+
       add_flash_types(:alert, :notice)
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -142,14 +142,6 @@ module ActionController
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
     ##
-    # :method: as_json
-    #
-    # :call-seq:
-    #   as_json(options=nil)
-    #
-    # Returns a hash that can be used as the JSON representation for the parameters.
-
-    ##
     # :method: each_key
     #
     # :call-seq:
@@ -157,6 +149,9 @@ module ActionController
     #
     # Calls block once for each key in the parameters, passing the key.
     # If no block is given, an enumerator is returned instead.
+    def each_key(&blk)
+      @parameters.each_key(&blk)
+    end
 
     ##
     # :method: empty?
@@ -165,6 +160,28 @@ module ActionController
     #   empty?()
     #
     # Returns true if the parameters have no key/value pairs.
+    def empty?
+      @parameters.empty?
+    end
+
+    ##
+    # :method: keys
+    #
+    # :call-seq:
+    #   keys()
+    #
+    # Returns a new array of the keys of the parameters.
+    def keys
+      @parameters.keys
+    end
+
+    ##
+    # :method: as_json
+    #
+    # :call-seq:
+    #   as_json(options=nil)
+    #
+    # Returns a hash that can be used as the JSON representation for the parameters.
 
     ##
     # :method: exclude?
@@ -207,14 +224,6 @@ module ActionController
     # Returns true if the given key is present in the parameters.
 
     ##
-    # :method: keys
-    #
-    # :call-seq:
-    #   keys()
-    #
-    # Returns a new array of the keys of the parameters.
-
-    ##
     # :method: to_s
     #
     # :call-seq:
@@ -222,8 +231,7 @@ module ActionController
     #
     # Returns the content of the parameters as a string.
 
-    delegate :keys, :key?, :has_key?, :member?, :empty?, :exclude?, :include?,
-      :as_json, :to_s, :each_key, to: :@parameters
+    delegate :key?, :has_key?, :member?, :exclude?, :include?, :as_json, :to_s, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
     # params are present. The default includes both 'controller' and 'action'

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -38,12 +38,20 @@ module ActionDispatch # :nodoc:
         super(header)
       end
 
+      def [](k)
+        __getobj__[k]
+      end
+
       def []=(k, v)
         if @response.sending? || @response.sent?
           raise ActionDispatch::IllegalStateError, "header already sent"
         end
 
-        super
+        __getobj__[k] = v
+      end
+
+      def key?(k)
+        __getobj__.key? k
       end
 
       def merge(other)

--- a/actionview/lib/action_view/buffers.rb
+++ b/actionview/lib/action_view/buffers.rb
@@ -24,7 +24,23 @@ module ActionView
       @raw_buffer.encode!
     end
 
-    delegate :length, :empty?, :blank?, :encoding, :encode!, :force_encoding, to: :@raw_buffer
+    delegate :encode!, :force_encoding, to: :@raw_buffer
+
+    def length
+      @raw_buffer.length
+    end
+
+    def empty?
+      @raw_buffer.empty?
+    end
+
+    def blank?
+      @raw_buffer.blank?
+    end
+
+    def encoding
+      @raw_buffer.encoding
+    end
 
     def to_s
       @raw_buffer.html_safe

--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -13,7 +13,13 @@ module ActionView
         :session, :cookies, :response, :headers, :flash, :action_name,
         :controller_name, :controller_path]
 
-      delegate(*CONTROLLER_DELEGATES, to: :controller)
+      CONTROLLER_DELEGATES.each do |meth|
+        eval <<~DEF
+          def #{meth}
+            controller.#{meth}
+          end
+        DEF
+      end
 
       def assign_controller(controller)
         if @_controller = controller

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -13,7 +13,7 @@ module ActionView # :nodoc:
 
     attr_reader :paths
 
-    delegate :[], :include?, :size, :each, to: :paths
+    delegate :[], :include?, :size, to: :paths
 
     def initialize(paths = [])
       @paths = typecast(paths).freeze
@@ -22,6 +22,10 @@ module ActionView # :nodoc:
     def initialize_copy(other)
       @paths = other.paths.dup.freeze
       self
+    end
+
+    def each(&blk)
+      paths.each(&blk)
     end
 
     def to_ary

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -19,10 +19,14 @@ module ActionView
   # that new object is called in turn. This abstracts the set up and rendering
   # into a separate classes for partials and templates.
   class AbstractRenderer # :nodoc:
-    delegate :template_exists?, :any_templates?, :formats, to: :@lookup_context
+    delegate :template_exists?, :any_templates?, to: :@lookup_context
 
     def initialize(lookup_context)
       @lookup_context = lookup_context
+    end
+
+    def formats
+      @lookup_context.formats
     end
 
     def render

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -5,7 +5,7 @@ require "concurrent/map"
 module ActionView
   class UnboundTemplate
     attr_reader :virtual_path, :details
-    delegate :locale, :format, :variant, :handler, to: :@details
+    delegate :locale, :format, :handler, to: :@details
 
     def initialize(source, identifier, details:, virtual_path:)
       @source = source
@@ -15,6 +15,10 @@ module ActionView
 
       @templates = Concurrent::Map.new(initial_capacity: 2)
       @write_lock = Mutex.new
+    end
+
+    def variant
+      @details.variant
     end
 
     def bind_locals(locals)

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -8,7 +8,7 @@ module ActionView
       ViewPaths.set_view_paths(self, ActionView::PathSet.new.freeze)
     end
 
-    delegate :template_exists?, :any_templates?, :view_paths, :formats, :formats=,
+    delegate :template_exists?, :any_templates?, :view_paths,
              :locale, :locale=, to: :lookup_context
 
     module ClassMethods
@@ -97,6 +97,14 @@ module ActionView
     def lookup_context
       @_lookup_context ||=
         ActionView::LookupContext.new(self.class._view_paths, details_for_lookup, _prefixes)
+    end
+
+    def formats
+      lookup_context.formats
+    end
+
+    def formats=(f)
+      lookup_context.formats = f
     end
 
     def details_for_lookup

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -252,7 +252,9 @@ module ActiveModel
   module Naming
     def self.extended(base) # :nodoc:
       base.silence_redefinition_of_method :model_name
-      base.delegate :model_name, to: :class
+      base.define_method(:model_name) {
+        self.class.model_name
+      }
     end
 
     # Returns an ActiveModel::Name object for module. It can be

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -113,7 +113,7 @@ module ActiveRecord
       attr_accessor :automatic_reconnect, :checkout_timeout
       attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
 
-      delegate :schema_cache, :schema_cache=, to: :pool_config
+      delegate :schema_cache=, to: :pool_config
 
       # Creates a new ConnectionPool object. +pool_config+ is a PoolConfig
       # object which describes database connection information (e.g. adapter,
@@ -165,6 +165,10 @@ module ActiveRecord
 
         @reaper = Reaper.new(self, db_config.reaping_frequency)
         @reaper.run
+      end
+
+      def schema_cache
+        pool_config.schema_cache
       end
 
       def lock_thread=(lock_thread)

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -327,10 +327,28 @@ module ActiveRecord
 
       attr_reader :transaction_manager # :nodoc:
 
-      delegate :within_new_transaction, :open_transactions, :current_transaction, :begin_transaction,
-               :commit_transaction, :rollback_transaction, :materialize_transactions,
-               :disable_lazy_transactions!, :enable_lazy_transactions!, :dirty_current_transaction,
+      delegate :within_new_transaction, :open_transactions, :begin_transaction, :commit_transaction, :rollback_transaction,
                to: :transaction_manager
+
+      def current_transaction
+        transaction_manager.current_transaction
+      end
+
+      def materialize_transactions
+        transaction_manager.materialize_transactions
+      end
+
+      def disable_lazy_transactions!
+        transaction_manager.disable_lazy_transactions!
+      end
+
+      def enable_lazy_transactions!
+        transaction_manager.enable_lazy_transactions!
+      end
+
+      def dirty_current_transaction
+        transaction_manager.dirty_current_transaction
+      end
 
       def mark_transaction_written_if_write(sql) # :nodoc:
         transaction = current_transaction

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
 
-      delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
+      delegate :precision, :scale, :limit, :type, to: :sql_type_metadata, allow_nil: true
 
       # Instantiates a new column in the table.
       #
@@ -25,6 +25,10 @@ module ActiveRecord
         @default_function = default_function
         @collation = collation
         @comment = comment
+      end
+
+      def sql_type
+        sql_type_metadata&.sql_type
       end
 
       def has_default?

--- a/activerecord/lib/active_record/explain_registry.rb
+++ b/activerecord/lib/active_record/explain_registry.rb
@@ -10,7 +10,11 @@ module ActiveRecord
   # returns the collected queries local to the current thread.
   class ExplainRegistry # :nodoc:
     class << self
-      delegate :reset, :collect, :collect=, :collect?, :queries, to: :instance
+      delegate :reset, :collect, :collect=, :queries, to: :instance
+
+      def collect?
+        instance.collect?
+      end
 
       private
         def instance

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -85,12 +85,22 @@ module ActiveRecord
     # may vary depending on the klass of a relation, so we create a subclass of Relation
     # for each different klass, and the delegations are compiled into that subclass only.
 
-    delegate :to_xml, :encode_with, :length, :each, :join,
+    delegate :to_xml, :encode_with, :length, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
-    delegate :primary_key, :connection, to: :klass
+    def each(&blk)
+      records.each(&blk)
+    end
+
+    def primary_key
+      klass.primary_key
+    end
+
+    def connection
+      klass.connection
+    end
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -5,10 +5,14 @@ require "active_support/core_ext/array/extract"
 module ActiveRecord
   class Relation
     class WhereClause # :nodoc:
-      delegate :any?, :empty?, to: :predicates
+      delegate :any?, to: :predicates
 
       def initialize(predicates)
         @predicates = predicates
+      end
+
+      def empty?
+        predicates.empty?
       end
 
       def +(other)

--- a/activesupport/lib/active_support/core_ext/module/deprecation.rb
+++ b/activesupport/lib/active_support/core_ext/module/deprecation.rb
@@ -20,6 +20,6 @@ class Module
   #     end
   #   end
   def deprecate(*method_names)
-    ActiveSupport::Deprecation.deprecate_methods(self, *method_names)
+    ActiveSupport::Deprecation.instance.deprecate_methods(self, *method_names)
   end
 end

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -97,7 +97,11 @@ module ActiveSupport
       logger.extend(self)
     end
 
-    delegate :push_tags, :pop_tags, :clear_tags!, to: :formatter
+    delegate :push_tags, :pop_tags, to: :formatter
+
+    def clear_tags!
+      formatter.clear_tags!
+    end
 
     def tagged(*tags)
       if block_given?

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -10,13 +10,17 @@ module Rails
       attr_reader :route_sets, :paths, :external_routes
       attr_accessor :eager_load
       attr_writer :run_after_load_paths # :nodoc:
-      delegate :execute_if_updated, :execute, :updated?, to: :updater
+      delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize
         @paths      = []
         @route_sets = []
         @external_routes = []
         @eager_load = false
+      end
+
+      def execute
+        updater.execute
       end
 
       def reload!

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -177,8 +177,11 @@ module Rails
       end
 
       no_commands do
-        delegate :executable, to: :class
         attr_reader :current_subcommand
+
+        def executable(subcommand = nil)
+          self.class.executable(subcommand)
+        end
 
         def invoke_command(command, *) # :nodoc:
           @current_subcommand ||= nil

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -3,7 +3,6 @@
 require "rails/railtie"
 require "rails/engine/railties"
 require "active_support/callbacks"
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/try"
 require "pathname"
 require "thread"
@@ -355,7 +354,9 @@ module Rails
       alias :isolated? :isolated
       alias :engine_name :railtie_name
 
-      delegate :eager_load!, to: :instance
+      def eager_load!
+        instance.eager_load!
+      end
 
       def inherited(base)
         unless base.abstract_railtie?
@@ -426,9 +427,6 @@ module Rails
     include ActiveSupport::Callbacks
     define_callbacks :load_seed
 
-    delegate :middleware, :root, :paths, to: :config
-    delegate :engine_name, :isolated?, to: :class
-
     def initialize
       @_all_autoload_paths = nil
       @_all_load_paths     = nil
@@ -439,6 +437,26 @@ module Rails
       @routes              = nil
       @app_build_lock      = Mutex.new
       super
+    end
+
+    def middleware
+      config.middleware
+    end
+
+    def root
+      config.root
+    end
+
+    def paths
+      config.paths
+    end
+
+    def engine_name
+      self.class.engine_name
+    end
+
+    def isolated?
+      self.class.isolated?
     end
 
     # Load console and invoke the registered hooks.

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -143,7 +143,10 @@ module Rails
 
     class << self
       private :new
-      delegate :config, to: :instance
+
+      def config
+        instance.config
+      end
 
       def subclasses
         super.reject(&:abstract_railtie?).sort
@@ -241,12 +244,14 @@ module Rails
         end
     end
 
-    delegate :railtie_name, to: :class
-
     def initialize # :nodoc:
       if self.class.abstract_railtie?
         raise "#{self.class.name} is abstract, you cannot instantiate it directly."
       end
+    end
+
+    def railtie_name
+      self.class.railtie_name
     end
 
     def inspect # :nodoc:


### PR DESCRIPTION
This PR is a suggestion to refrain from using Active Support delegation within the Rails framework codebase.

### Motivation / Background

As I reported here on bugs.r-l.o, https://bugs.ruby-lang.org/issues/19165
delegating a method that is defined to take `...`, or `*, **` and calling it without an argument performs measurably slowly.
And, this is what exactly is happening inside Active Support's `delegate`. It internally uses the `...` literal to define the delegation method, and in most cases the delegations in the framework are called without passing in any arguments.

### Detail

As I reported to Ruby bugs, we can speed up such delegations by not using the `...` literal, like 10 times faster on micro-benchmark basis. So, as an experiment, I replaced some occurrences of such delegation in the Rails codebase to be normal direct method call, and did a very simple more real-ish benchmark. In order to purely measure Action Pack request handling and filter out all other noise such as network overhead and logging, I benchmarked the controller `send_action` method on a simple action that returns HEAD OK response.

Here's the action code,
```ruby
class HelloController < ApplicationController
  def index
    head :ok
  end
end
```

and the benchmark code.
```ruby
class ApplicationController < ActionController::Base
  def send_action(*)
    ret = super
    Benchmark.ips do |x|
      x.report do
        super
      end
    end
    ret
  end
end
```

Then, the benchmark result on Ruby 3.2 (GH master as of today, with which delegation performs faster than 3.2.0-rc1) + newly created Rails 7.1 (edge) app is as follows.

```
before this patch
391.769k (± 1.2%) i/s -      1.965M in   5.017064s

after this patch
555.944k (± 1.1%) i/s -      2.780M in   5.001781s
```

It resulted in 42% performance improvement.

Honestly, I do like Active Support's `delegate` very much. It's easier to read and write than Ruby's Forwardable, and it shrinks the lines of delegation code from 3 lines to 1 line. It's certainly a good friend for the framework core maintainers and contributors. But... is it worth burdening the 40% extra load on all the application developers and the end users?


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
