### PR TITLE
Invoke `.focus()` on `<trix-editor>` after calling `fill_in_rich_text_area`

### DIFF
--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -41,6 +41,7 @@ module ActionText
         } else {
           this.editor.loadHTML(arguments[0])
         }
+        this.focus()
       JS
     end
     alias_method :fill_in_rich_text_area, :fill_in_rich_textarea

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -7,6 +7,14 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
     visit new_message_url
   end
 
+  test "filling in a rich-text area focuses the trix-editor" do
+    visit new_message_url
+
+    fill_in_rich_text_area "message_content", with: "Hello world!"
+
+    assert_selector(:rich_textarea, "message[content]", focused: true)
+  end
+
   test "filling in a rich-text area by ID" do
     assert_selector :element, "trix-editor", id: "message_content"
     fill_in_rich_textarea "message_content", with: "Hello world!"


### PR DESCRIPTION
### Motivation / Background

Follow-up to [rails/rails#46249][]
Closes [rails/rails#46803][]

### Detail

Invoke [HTMLElement.focus][] on the element instead of the `Trix.Editor` instance when calling `fill_in_rich_text_area`.

### Additional information

Defer merging this until https://github.com/rails/rails/pull/46808 is merged and https://github.com/rails/rails/issues/46804 is closed, this PR will re-introduce the focus behavior and test coverage.

[rails/rails#46803]: https://github.com/rails/rails/issues/46803
[rails/rails#46249]: https://github.com/rails/rails/pull/46249
[HTMLElement.focus]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
