### PR TITLE
Revert "Focus editor after calling `fill_in_rich_text_area`"

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -8,10 +8,6 @@
 
     *Jonathan Hefner*
 
-*   Focus rich-text editor after calling `fill_in_rich_text_area`
-
-    *Sean Doyle*
-
 *   Support `strict_loading:` option for `has_rich_text` declaration
 
     *Sean Doyle*

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -30,11 +30,7 @@ module ActionText
     #   # <trix-editor input="trix_input_1"></trix-editor>
     #   fill_in_rich_text_area "message[content]", with: "Hello <em>world!</em>"
     def fill_in_rich_text_area(locator = nil, with:)
-      javascript = <<~JS
-        this.editor.loadHTML(arguments[0])
-        this.editor.focus()
-      JS
-      find(:rich_text_area, locator).execute_script(javascript, with.to_s)
+      find(:rich_text_area, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
     end
   end
 end

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -3,14 +3,6 @@
 require "application_system_test_case"
 
 class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
-  test "filling in a rich-text area focuses the trix-editor" do
-    visit new_message_url
-
-    fill_in_rich_text_area "message_content", with: "Hello world!"
-
-    assert_selector(:rich_text_area, "message[content]", &:focused?)
-  end
-
   test "filling in a rich-text area by ID" do
     visit new_message_url
     assert_selector "trix-editor#message_content"


### PR DESCRIPTION
### Motivation / Background

Closes [rails/rails#46803][].

### Detail

This reverts commit 67a4ac6c5651a00e613de298631d460116bba38c.

### Additional information

Once the system test helper test suite executes in CI, we can re-introduce the changes as part of [rails/rails#46807][].

[rails/rails#46803]: https://github.com/rails/rails/issues/46803#issuecomment-1364112967
[rails/rails#46807]: https://github.com/rails/rails/pull/46807

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
