### PR TITLE
Support unencrypted joins on associations with deterministic encrypted attributes

### DIFF
--- a/activerecord/test/models/author_encrypted.rb
+++ b/activerecord/test/models/author_encrypted.rb
@@ -14,3 +14,9 @@ class EncryptedAuthorWithKey < Author
 
   encrypts :name, key: "some secret key!"
 end
+
+class EncryptedAuthorWithDeterministicName < Author
+  self.table_name = "authors"
+
+  encrypts :name, deterministic: true
+end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -4,6 +4,13 @@ class UnencryptedBook < ActiveRecord::Base
   self.table_name = "encrypted_books"
 end
 
+class UnencryptedBookWithAuthor < UnencryptedBook
+  belongs_to :author, class_name: "EncryptedAuthorWithDeterministicName"
+
+  scope :by_authors_name, -> name { joins(:author).where(authors: { name: name }) }
+  scope :by_author_name, -> name { joins(:author).where(author: { name: name }) }
+end
+
 class EncryptedBook < ActiveRecord::Base
   self.table_name = "encrypted_books"
 


### PR DESCRIPTION
Closes #46809. Same issue as #46789, but for joins on associations with deterministic encrypted attributes. Again, open to suggestions if there's a better approach since this is [a performance-critical area](https://github.com/rails/rails/blob/d95366cd881acb930b95d7011f0e0fb2c8cc54f5/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb#L26-L27).