### PR TITLE
Use `BUNDLE_ONLY: rubocop` suported since Bundler 2.3.19

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: default doc job cable storage ujs test db
+      BUNDLE_ONLY: rubocop
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Motivation / Background

Bundler 2.3.19 can install gems of the specific group now. I'd like to make use of this feature because it explains what we want clearly.

### Detail

This feature is available since Bundler 2.3.19 via https://github.com/rubygems/rubygems/pull/5759
https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2319-july-27-2022 

### Additional information
There was no BUNDLE_ONLY option available when https://github.com/rails/rails/pull/38836 was merged and now there is.

> Unfortunately it's not possible to tell Bundler to only install gems from a single group, so we have to tell it not to install every other group instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
