### PR TITLE
Bump required_rubygems_version to 3.3.13 or higher

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration."
 
   s.required_ruby_version     = ">= 2.7.0"
-  s.required_rubygems_version = ">= 1.8.11"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump `required_rubygems_version` to 3.3.13 or higher
+
+    *Yasuo Honda*
+
 *   Add Docker files by default to new apps: Dockerfile, .dockerignore, bin/docker-entrypoint.
     These files can be skipped with `--skip-docker`. They're intended as a starting point for
     a production deploy of the application. Not intended for development (see Docked Rails for that).


### PR DESCRIPTION
### Motivation / Background

This pull request bumps required_rubygems_version to 3.3.13 or higher because https://github.com/rails/rails/pull/45979 relies on https://github.com/rubygems/rubygems/pull/5486 which is included in https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#3313--2022-05-04

### Detail

- RubyGems 3.3.12` Gem.ruby_version` includes patch level
```ruby
$ gem -v
3.3.12
$ irb
irb(main):001:0> Gem.ruby_version
=> Gem::Version.new("3.1.3.p185")
```

- RubyGems 3.3.13` Gem.ruby_version` does not include patch level
```ruby
$ gem -v
3.3.13
$ irb
irb(main):001:0> Gem.ruby_version
=> Gem::Version.new("3.1.3")
irb(main):002:0>
```

### Additional information

The current version 1.8.11 has been updated to use Ruby 1.9.3-p0 https://github.com/rails/rails/pull/4576

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
