### PR TITLE
Add Rails.env.remote? 🙂 

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Rails.env.remote?` shorthand for `Rails.env.production?`.
+
+    *loqimean*
+
 *   Add `Rails.env.local?` shorthand for `Rails.env.development? || Rails.env.test?`.
 
     *DHH*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `Rails.env.remote?` shorthand for `Rails.env.production?`.
+*   Add `Rails.env.remote?` shorthand for `Rails.env.production?` or something another that you use on remote.
 
     *loqimean*
 

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -32,7 +32,7 @@ module ActiveSupport
       in? LOCAL_ENVIRONMENTS
     end
 
-    # Returns true if we are in the production or staging environment etc.
+    # Returns true if we aren't in development or test.
     def remote?
       !local?
     end

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -14,6 +14,7 @@ module ActiveSupport
 
     def initialize(env)
       raise(ArgumentError, "'local' is a reserved environment name") if env == "local"
+      raise(ArgumentError, "'remote' is a reserved environment name") if env == "remote"
 
       super(env)
 
@@ -29,6 +30,11 @@ module ActiveSupport
     # Returns true if we're in the development or test environment.
     def local?
       in? LOCAL_ENVIRONMENTS
+    end
+
+    # Returns true if we are in the production or staging environment etc.
+    def remote?
+      !local?
     end
   end
 end

--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -9,9 +9,22 @@ class EnvironmentInquirerTest < ActiveSupport::TestCase
     assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
   end
 
+  test "remote predicate" do
+    assert ActiveSupport::EnvironmentInquirer.new("production").remote?
+    assert ActiveSupport::EnvironmentInquirer.new("staging").remote?
+    assert_not ActiveSupport::EnvironmentInquirer.new("development").remote?
+    assert_not ActiveSupport::EnvironmentInquirer.new("test").remote?
+  end
+
   test "prevent local from being used as an actual environment name" do
     assert_raises(ArgumentError) do
       ActiveSupport::EnvironmentInquirer.new("local")
+    end
+  end
+
+  test "prevent remote from being used as an actual environment name" do
+    assert_raises(ArgumentError) do
+      ActiveSupport::EnvironmentInquirer.new("remote")
     end
   end
 end


### PR DESCRIPTION
Combined checks into one method `remote?` like a `local?` method

Before:

```ruby
if Rails.env.production? || Rails.env.staging? || Rails.env.ci?
```

After:

```ruby
if Rails.env.remote?
```