### PR TITLE
HWIA#transform_values may take no argument

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -330,9 +330,9 @@ module ActiveSupport
       dup.tap { |hash| hash.reject!(*args, &block) }
     end
 
-    def transform_values(*args, &block)
+    def transform_values(&block)
       return to_enum(:transform_values) unless block_given?
-      dup.tap { |hash| hash.transform_values!(*args, &block) }
+      dup.tap { |hash| hash.transform_values!(&block) }
     end
 
     def transform_keys(*args, &block)


### PR DESCRIPTION
because its delegation target  `Hash#transform_values!` takes no argument and so raises when delegating with the given arguments.

```ruby
{}.with_indifferent_access.transform_values!(1) { p :hello }
#=> wrong number of arguments (given 1, expected 0) (ArgumentError)
```
I don't think this change should be CHANGELOGed or tested because it used not to work at all already, so it needs no argument that no one was calling them with arguments.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.