### PR TITLE
Add comparison rows to i18n error interpolations table

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -996,6 +996,12 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 | numericality | :in                       | :in                       | count         |
 | numericality | :odd                      | :odd                      | -             |
 | numericality | :even                     | :even                     | -             |
+| comparison   | :greater_than             | :greater_than             | count         |
+| comparison   | :greater_than_or_equal_to | :greater_than_or_equal_to | count         |
+| comparison   | :equal_to                 | :equal_to                 | count         |
+| comparison   | :less_than                | :less_than                | count         |
+| comparison   | :less_than_or_equal_to    | :less_than_or_equal_to    | count         |
+| comparison   | :other_than               | :other_than               | count         |
 
 ### Translations for Action Mailer E-Mail Subjects
 


### PR DESCRIPTION
Let's add forgotten interpolation rows for `comparison` to the i18n guides table.
