### PR TITLE
Use precompute optimization for Rails.env.local?

### DIFF
--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -20,6 +20,8 @@ module ActiveSupport
       DEFAULT_ENVIRONMENTS.each do |default|
         instance_variable_set :"@#{default}", env == default
       end
+
+      @local = in? LOCAL_ENVIRONMENTS
     end
 
     DEFAULT_ENVIRONMENTS.each do |env|
@@ -28,7 +30,7 @@ module ActiveSupport
 
     # Returns true if we're in the development or test environment.
     def local?
-      in? LOCAL_ENVIRONMENTS
+      @local
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Ref: 09e0372

### Detail

This makes #local? behave the same as the predefined environment predicates (they immediately return a precomputed instance variable).

### Additional information

Benchmark:

```ruby
dev = ActiveSupport::EnvironmentInquirer.new("development")
test = ActiveSupport::EnvironmentInquirer.new("test")
prod = ActiveSupport::EnvironmentInquirer.new("production")

Benchmark.ips do |x|
  x.report("dev local?") { dev.local? }
  x.report("test local?") { test.local? }
  x.report("prod local?") { prod.local? }
  x.compare!
end
```

Before:
```
Warming up --------------------------------------
          dev local?   676.645k i/100ms
         test local?   627.687k i/100ms
         prod local?   671.078k i/100ms
Calculating -------------------------------------
          dev local?      6.785M (± 1.8%) i/s -     34.509M in   5.087679s
         test local?      6.284M (± 2.0%) i/s -     32.012M in   5.096338s
         prod local?      6.759M (± 1.8%) i/s -     34.225M in   5.065240s

Comparison:
          dev local?:  6785134.0 i/s
         prod local?:  6759023.6 i/s - same-ish: difference falls within error
         test local?:  6283910.1 i/s - 1.08x  (± 0.00) slower
```

After:
```
Warming up --------------------------------------
          dev local?     1.076M i/100ms
         test local?     1.049M i/100ms
         prod local?     1.028M i/100ms
Calculating -------------------------------------
          dev local?     10.586M (± 2.3%) i/s -     53.799M in   5.084729s
         test local?     10.350M (± 2.5%) i/s -     52.457M in   5.071399s
         prod local?     10.396M (± 2.2%) i/s -     52.422M in   5.045193s

Comparison:
          dev local?: 10586400.1 i/s
         prod local?: 10395758.6 i/s - same-ish: difference falls within error
         test local?: 10350328.8 i/s - same-ish: difference falls within error
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
