### PR TITLE
[issue-46741] remove `require pathname` from `drop` method

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -20,10 +20,8 @@ module ActiveRecord
       end
 
       def drop
-        require "pathname"
-        path = Pathname.new(db_config.database)
-        file = path.absolute? ? path.to_s : File.join(root, path)
-
+        db_path = db_config.database
+        file = File.absolute_path?(db_path) ? db_path : File.join(root, db_path)
         FileUtils.rm(file)
       rescue Errno::ENOENT => error
         raise NoDatabaseError.new(error.message)

--- a/activerecord/test/cases/tasks/sqlite_rake_test.rb
+++ b/activerecord/test/cases/tasks/sqlite_rake_test.rb
@@ -72,15 +72,17 @@ if current_adapter?(:SQLite3Adapter)
 
     class SqliteDBDropTest < ActiveRecord::TestCase
       def setup
+        @root          = "/rails/root"
         @database      = "db_create.sqlite3"
+        @database_root = File.join(@root, @database)
         @configuration = {
           "adapter"  => "sqlite3",
           "database" => @database
         }
-        @path = Class.new do
-          def to_s; "/absolute/path" end
-          def absolute?; true end
-        end.new
+        @configuration_root = {
+          "adapter"  => "sqlite3",
+          "database" => @database_root
+        }
 
         $stdout, @original_stdout = StringIO.new, $stdout
         $stderr, @original_stderr = StringIO.new, $stderr
@@ -90,45 +92,33 @@ if current_adapter?(:SQLite3Adapter)
         $stdout, $stderr = @original_stdout, @original_stderr
       end
 
-      def test_creates_path_from_database
-        assert_called_with(Pathname, :new, [@database], returns: @path) do
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
+      def test_checks_db_dir_is_absolute
+        assert_called_with(File, :absolute_path?, [@database], returns: false) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
         end
       end
 
       def test_removes_file_with_absolute_path
-        Pathname.stub(:new, @path) do
-          assert_called_with(FileUtils, :rm, ["/absolute/path"]) do
-            ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
-          end
+        assert_called_with(FileUtils, :rm, [@database_root]) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration_root, @root
         end
       end
 
       def test_generates_absolute_path_with_given_root
-        Pathname.stub(:new, @path) do
-          @path.stub(:absolute?, false) do
-            assert_called_with(File, :join, ["/rails/root", @path],
-              returns: "/former/relative/path"
-            ) do
-              ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
-            end
-          end
+        assert_called_with(File, :join, [@root, @database], returns: "#{@root}/#{@database}") do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
         end
       end
 
       def test_removes_file_with_relative_path
-        File.stub(:join, "/former/relative/path") do
-          @path.stub(:absolute?, false) do
-            assert_called_with(FileUtils, :rm, ["/former/relative/path"]) do
-              ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
-            end
-          end
+        assert_called_with(FileUtils, :rm, [@database_root]) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
         end
       end
 
       def test_when_db_dropped_successfully_outputs_info_to_stdout
         FileUtils.stub(:rm, nil) do
-          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, "/rails/root"
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
 
           assert_equal "Dropped database '#{@database}'\n", $stdout.string
         end


### PR DESCRIPTION
Fixes #46741 


### Motivation / Background

This is a simple refactoring of the drop method on the `sqlite` rake tasks to make it more efficient by removing the line: `require "pathname"` and using the `File` class to perform the necessary actions.

### Detail

This Pull Request changes `drop` method of `sqlite` rake tasks

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
