### PR TITLE
ActiveRecord multiple databases extended doc

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -319,8 +319,27 @@ parameters it's based on. Let's say you want to use a cookie instead of a sessio
 decide when to swap connections. You can write your own class:
 
 ```ruby
-class MyCookieResolver
-  # code for your cookie class
+class MyCookieResolver << ActiveRecord::Middleware::DatabaseSelector::Resolver
+  def self.call(request)
+    new(request.cookies)
+  end
+
+  def initialize(cookies)
+    @cookies = cookies
+  end
+
+  attr_reader :cookies
+
+  def last_write_timestamp
+    self.class.convert_timestamp_to_time(cookies[:last_write])
+  end
+
+  def update_last_write_timestamp
+    cookies[:last_write] = self.class.convert_time_to_timestamp(Time.now)
+  end
+
+  def save(response)
+  end
 end
 ```
 


### PR DESCRIPTION
Example of implementation for MyCookieResolver class in the active record multiple databases documentation similar to ActiveRecord::Middleware::DatabaseSelector::Resolver::Session.

This Pull Request has been created because #46693.

### Detail

This Pull Request changes documentation (guides/source/active_record_multiple_databases.md).
