### PR TITLE
Preserve bigint column types when altering a table in sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -527,7 +527,8 @@ module ActiveRecord
                 default = type.deserialize(column.default)
               end
 
-              @definition.column(column_name, column.type,
+              column_type = column.bigint? ? :bigint : column.type
+              @definition.column(column_name, column_type,
                 limit: column.limit, default: default,
                 precision: column.precision, scale: column.scale,
                 null: column.null, collation: column.collation,

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -184,7 +184,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
 
           @connection.create_table "astronauts", force: true do |t|
             t.string :name
-            t.references :rocket
+            t.references :rocket, type: :bigint
             t.references :favorite_rocket
           end
         end
@@ -763,6 +763,17 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
             @connection.add_foreign_key :astronauts, :rockets, if_not_exists: true
           end
         end
+
+        def test_add_foreign_key_preserves_existing_column_types
+          assert_no_changes -> { column_for(:astronauts, :rocket_id).bigint? }, from: true do
+            @connection.add_foreign_key :astronauts, :rockets
+          end
+        end
+
+        private
+          def column_for(table_name, column_name)
+            @connection.columns(table_name).find { |column| column.name == column_name.to_s }
+          end
       end
     end
   end


### PR DESCRIPTION
Fixes #46834.

> 3. Run rails db:migrate to migrate the db and generate the DB schema.
> 4. Run rails db:reset.
> 5. Run rails db:migrate again.

https://github.com/rails/rails/blob/0f0ec9908e25af36df2d937dc431f626a4102b3d/activerecord/lib/active_record/railties/databases.rake#L307-L308
https://github.com/rails/rails/blob/0f0ec9908e25af36df2d937dc431f626a4102b3d/activerecord/lib/active_record/railties/databases.rake#L394-L395

When running `rails db:reset`, firstly the database is dropped, then created and the `schema.rb` file is loaded to populate the schema. But `schema.rb` file is formatted in a way that it has `add_foreign_key`'s as separate lines for each lines.
So when loading the schema file, firstly the table is created - https://github.com/gsmendoza/solidus_store/blob/e65805aec0339fd48b83d9ed1f1bf1debeb8ddf4/db/schema.rb#L33-L41
and then a separate `ALTER TABLE` for sqlite is created to add a foreign key: https://github.com/gsmendoza/solidus_store/blob/e65805aec0339fd48b83d9ed1f1bf1debeb8ddf4/db/schema.rb#L1231
which is not able to preserve the original `bigint` type.

And the subsequent `rails db:migrate` just drops the existing (incorrect) schema.

This PR uses the same solution as inside schema dumper: https://github.com/rails/rails/blob/0f0ec9908e25af36df2d937dc431f626a4102b3d/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb#L54-L60