### PR TITLE
Split rails commands USAGE into commands inside/outside an application

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Split rails commands USAGE into commands inside/outside an application
+
+    Some commands require an application working directory and some commands
+    should be called outside an working directory. By splitting these
+    commands into different sections the USAGE becomes a bit clearer.
+
+    *Petrik de Heus*
+
 *   Bump `required_rubygems_version` to 3.3.13 or higher
 
     *Yasuo Honda*

--- a/railties/lib/rails/commands/help/USAGE
+++ b/railties/lib/rails/commands/help/USAGE
@@ -1,16 +1,20 @@
 The most common rails commands are:
- generate     Generate new code (short-cut alias: "g")
- console      Start the Rails console (short-cut alias: "c")
- server       Start the Rails server (short-cut alias: "s")
- test         Run tests except system tests (short-cut alias: "t")
- test:system  Run system tests
- dbconsole    Start a console for the database specified in config/database.yml
-              (short-cut alias: "db")
+
 <% unless engine? -%>
- new          Create a new Rails application. "rails new my_app" creates a
-              new application called MyApp in "./my_app"
- plugin new   Create a new Rails railtie or engine
+Outside a Rails application directory
+  new          Create a new Rails application. "rails new my_app" creates a
+               new application called MyApp in "./my_app"
+  plugin new   Create a new Rails railtie or engine
+
 <% end -%>
+Inside a Rails application directory
+  generate     Generate new code (short-cut alias: "g")
+  console      Start the Rails console (short-cut alias: "c")
+  server       Start the Rails server (short-cut alias: "s")
+  test         Run tests except system tests (short-cut alias: "t")
+  test:system  Run system tests
+  dbconsole    Start a console for the database specified in config/database.yml
+               (short-cut alias: "db")
 
 All commands can be run with -h (or --help) for more information.
 In addition to those commands, there are:


### PR DESCRIPTION
### Motivation / Background

Some commands require an application working directory and some commands should be called outside an working directory. By splitting these commands into different sections the USAGE becomes a bit clearer.

This also changes the identation to two spaces, similar to the Rake task based commands, for a clearer separation of commands and explanations.

I've kept the `engine?` check for backwards compatibility.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Related to #46164 and #40823

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
