### PR TITLE
Make belongs_to validate the presence of the foreign key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   By default, `belongs_to` will now validate the presence of the foreign key
+    field in addition to the association.
+
+    *Jon Dufresne*
+
 *   Add `#regroup` query method as a short-hand for `.unscope(:group).group(fields)`
 
     Example:

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -137,6 +137,12 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
           model.validates_presence_of reflection.name, message: :required, if: condition
         end
+
+        association_is_new = lambda { |record|
+          record.association_cached?(reflection.name) &&
+            record.send(reflection.name)&.new_record?
+        }
+        model.validates_presence_of reflection.foreign_key, message: :required, unless: association_is_new
       end
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -111,7 +111,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       self.table_name = "accounts"
       self.belongs_to_required_by_default = false
 
-      belongs_to :company
+      belongs_to :firm
 
       def self.name
         "FirstModel"
@@ -122,7 +122,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       self.table_name = "accounts"
       self.belongs_to_required_by_default = true
 
-      belongs_to :company
+      belongs_to :firm
 
       def self.name
         "SecondModel"
@@ -131,6 +131,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_predicate model1, :valid?
     assert_not_predicate model2, :valid?
+    assert_equal({ firm: [{ error: :blank }], firm_id: [{ error: :blank }] }, model2.errors.details)
   end
 
   def test_optional_relation
@@ -140,7 +141,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     model = Class.new(ActiveRecord::Base) do
       self.table_name = "accounts"
       def self.name; "Temp"; end
-      belongs_to :company, optional: true
+      belongs_to :firm, optional: true
     end
 
     account = model.new
@@ -156,12 +157,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     model = Class.new(ActiveRecord::Base) do
       self.table_name = "accounts"
       def self.name; "Temp"; end
-      belongs_to :company, optional: false
+      belongs_to :firm, optional: false
     end
 
     account = model.new
     assert_not_predicate account, :valid?
-    assert_equal [{ error: :blank }], account.errors.details[:company]
+    assert_equal({ firm: [{ error: :blank }], firm_id: [{ error: :blank }] }, account.errors.details)
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
@@ -173,12 +174,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     model = Class.new(ActiveRecord::Base) do
       self.table_name = "accounts"
       def self.name; "Temp"; end
-      belongs_to :company
+      belongs_to :firm
     end
 
     account = model.new
     assert_not_predicate account, :valid?
-    assert_equal [{ error: :blank }], account.errors.details[:company]
+    assert_equal({ firm: [{ error: :blank }], firm_id: [{ error: :blank }] }, account.errors.details)
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -47,7 +47,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
     record = model.new
     assert_not record.save
-    assert_equal ["Parent must exist"], record.errors.full_messages
+    assert_equal({ parent: [{ error: :blank }], parent_id: [{ error: :blank }] }, record.errors.details)
 
     record.parent = Parent.new
     assert record.save
@@ -64,7 +64,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
     record = model.new
     assert_not record.save
-    assert_equal ["Parent must exist"], record.errors.full_messages
+    assert_equal({ parent: [{ error: :blank }], parent_id: [{ error: :blank }] }, record.errors.details)
 
     record.parent = Parent.new
     assert record.save
@@ -113,7 +113,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
     end
 
     record = model.create
-    assert_equal ["Parent must exist"], record.errors.full_messages
+    assert_equal({ parent: [{ error: :blank }], parent_id: [{ error: :blank }] }, record.errors.details)
   end
 
   private


### PR DESCRIPTION
By default, `belongs_to` automatically validates the presence of the association. For example, given the following model:

```
class Article < ApplicationRecord
  belongs_to :author
end
```

Rails will validate Article.author is non-nil. Good!

However, per the Rails guides, one should add validation on the *_id foreign key field as these are the fields rendered in HTML forms. For examples, see the guides:

https://guides.rubyonrails.org/form_helpers.html (look for :city_id).

https://guides.rubyonrails.org/active_record_validations.html#custom-methods (look for :customer_id).

As of right now, if `author_id` is rendered in an HTML form using a `select` and the user fails to choose an option, the default validation doesn't render a message to the user. Instead, they receive no error.

To workaround this, applications must manually add `validate_presence_of` (or similar) to `belongs_to` foreign key that will be rendered in forms. We can avoid this repetitive code and make the validation work more smoothly with forms.

To solve the above, when adding validation on the belongs_to association, add it to the foreign key at the same time.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
