### PR TITLE
Update capybara gem to version 3.38

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "rake", ">= 13"
 
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
-gem "capybara", ">= 3.26"
+gem "capybara", ">= 3.38"
 gem "selenium-webdriver", ">= 4.0.0"
 
 gem "rack-cache", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     bunny (2.19.0)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
-    capybara (3.36.0)
+    capybara (3.38.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -577,7 +577,7 @@ DEPENDENCIES
   benchmark-ips
   blade
   bootsnap (>= 1.4.4)
-  capybara (>= 3.26)
+  capybara (>= 3.38)
   cgi (>= 0.3.6)
   connection_pool
   cssbundling-rails


### PR DESCRIPTION
### Motivation / Background

Updates capybara gem to 3.38 which is compat with puma 6 as per release notes https://github.com/teamcapybara/capybara/blob/master/History.md#version-3380.

When running system tests, there is an issue with the current version of capybara, hence the upgrade, error message:

```
#<Thread:0x000000010695b878 /Users/haroon/.gem/ruby/3.1.2/gems/capybara-3.36.0/lib/capybara/server.rb:76 run> terminated with exception (report_on_exception is true):
/Users/haroon/.gem/ruby/3.1.2/gems/capybara-3.36.0/lib/capybara/registrations/servers.rb:32:in `block in <top (required)>': undefined method `strings' for Puma::Events:Class (NoMethodError)

  events = conf.options[:Silent] ? ::Puma::Events.strings : ::Puma::Events.stdio
                                                 ^^^^^^^^
	from /Users/haroon/.gem/ruby/3.1.2/gems/capybara-3.36.0/lib/capybara/config.rb:64:in `block in server='
	from /Users/haroon/.gem/ruby/3.1.2/gems/capybara-3.36.0/lib/capybara/server.rb:77:in `block in boot'
```

For more context https://github.com/rails/rails/issues/46804.

I ran the system tests for action text and found a number of failures as mentioned in the issue.

### Detail

This Pull Request changes the capybara version to 3.38

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
