### PR TITLE
Run system tests for action text locally and on CI

### DIFF
--- a/actiontext/Rakefile
+++ b/actiontext/Rakefile
@@ -8,13 +8,7 @@ task :package
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"].exclude("test/system/**/*", "test/dummy/**/*")
-  t.verbose = true
-end
-
-Rake::TestTask.new "test:system" do |t|
-  t.libs << "test"
-  t.test_files = FileList["test/system/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"].exclude("test/dummy/**/*")
   t.verbose = true
 end
 


### PR DESCRIPTION
### Motivation / Background

As mentioned in https://github.com/rails/rails/issues/46804 system tests are currently not run for action text.

I copied action pack by running system tests by default for local and CI. Maybe these tests should only be run for CI (by adding a BUILD_KITE ENV check)?

This Pull Request has been created because https://github.com/rails/rails/issues/46804

### Detail

Run system tests for action text.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
