### PR TITLE
Add CTE support for joins

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Make `.joins` / `.left_outer_joins` work with CTEs.
+
+    For example:
+
+    ```ruby
+    Post
+     .with(commented_posts: Comment.select(:post_id).distinct)
+     .joins(:commented_posts)
+    #=> WITH (...) SELECT ... INNER JOIN commented_posts on posts.id = commented_posts.post_id
+    ```
+
+    *Vladimir Dementyev*
+
 *   Introduce adapter for Trilogy database client
 
     Trilogy is a MySQL-compatible database client. Rails applications can use Trilogy

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -61,6 +61,14 @@ module ActiveRecord
         assert_raise(ArgumentError) { Post.with(posts_with_tags: nil).load }
         assert_raise(ArgumentError) { Post.with(posts_with_tags: [Post.where("tags_count > 0")]).load }
       end
+
+      def test_with_joins
+        relation = Post
+          .with(commented_posts: Comment.select(:post_id).distinct)
+          .joins(:commented_posts)
+
+        assert_equal POSTS_WITH_COMMENTS, relation.order(:id).pluck(:id)
+      end
     else
       def test_common_table_expressions_are_unsupported
         assert_raises ActiveRecord::StatementInvalid do

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -69,6 +69,19 @@ module ActiveRecord
 
         assert_equal POSTS_WITH_COMMENTS, relation.order(:id).pluck(:id)
       end
+
+      def test_with_left_joins
+        relation = Post
+          .with(commented_posts: Comment.select(:post_id).distinct)
+          .left_outer_joins(:commented_posts)
+          .select("posts.*, commented_posts.post_id as has_comments")
+
+        records = relation.order(:id).to_a
+
+        # Make sure we load all records (thus, left outer join is used)
+        assert_equal Post.count, records.size
+        assert_equal POSTS_WITH_COMMENTS, records.filter_map { _1.id if _1.has_comments }
+      end
     else
       def test_common_table_expressions_are_unsupported
         assert_raises ActiveRecord::StatementInvalid do


### PR DESCRIPTION
### Motivation / Background

Follow-up for #37944.

Making `joins` work with CTEs smoothly:

```ruby
relation = Post
  .with(commented_posts: Comment.select(:post_id).distinct)
  #=> INNER JOIN commented_posts on posts.id = commented_posts.post_id
  .joins(:commented_posts)
```

**UPD:** `.left_outer_joins` is also supported. 

### Additional information

~~This is just a PoC. Not sure about the implementation; the existing code around joins seems to be coupled with associations (and creating some kind of _fake_ reflection just for the sake of simpler CTE joining looks like an overkill).~~

I think, we figured this out with @vlado.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
