### PR TITLE
Let HWIA#transform_keys take a Hash argument like Ruby's Hash#transform_keys

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `HashWithIndifferentAccess#transform_keys` now takes a Hash argument, just
+    as Ruby's `Hash#transform_keys` does.
+
+    *Akira Matsuda*
+
 *   `delegate` now defines method with proper arity when delegating to a Class.
     With this change, it defines faster method (3.5x faster with no argument).
     However, in order to gain this benefit, the delegation target method has to

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -431,6 +431,36 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(1, hash[:a])
     assert_equal(1, hash["a"])
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys({ "a" => "x", "y" => "z" })
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["x"])
+    assert_equal(2, hash["b"])
+    assert_nil(hash["y"])
+    assert_nil(hash["z"])
+    assert_equal(["x", "b"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys({ "a" => "A", "q" => "Q" }) { |k| k * 3 }
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["A"])
+    assert_equal(2, hash["bbb"])
+    assert_nil(hash["q"])
+    assert_nil(hash["Q"])
+    assert_equal(["A", "bbb"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    if RUBY_VERSION < "3"
+      assert_raise ArgumentError do
+        hash.transform_keys(nil)
+      end
+    else
+      assert_raise TypeError do
+        hash.transform_keys(nil)
+      end
+    end
   end
 
   def test_indifferent_deep_transform_keys
@@ -459,6 +489,38 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(1, indifferent_strings[:a])
     assert_equal(1, indifferent_strings["a"])
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    hash.transform_keys!({ "a" => "x", "y" => "z" })
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["x"])
+    assert_equal(2, hash["b"])
+    assert_nil(hash["y"])
+    assert_nil(hash["z"])
+    assert_equal(["x", "b"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    hash.transform_keys!({ "a" => "A", "q" => "Q" }) { |k| k * 3 }
+
+    assert_nil(hash["a"])
+    assert_equal(1, hash["A"])
+    assert_equal(2, hash["bbb"])
+    assert_nil(hash["q"])
+    assert_nil(hash["Q"])
+    assert_equal(["A", "bbb"], hash.keys) # asserting that order of keys is unchanged
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    if RUBY_VERSION < "3"
+      assert_raise ArgumentError do
+        hash.transform_keys(nil)
+      end
+    else
+      assert_raise TypeError do
+        hash.transform_keys(nil)
+      end
+    end
   end
 
   def test_indifferent_deep_transform_keys_bang


### PR DESCRIPTION
### Motivation / Background

Active Support's original `Hash#transform_keys` used not to take any argument, and that version has been transported to Ruby 2.5
https://github.com/ruby/ruby/commit/1405111722

Then since Ruby 3.0, that method in Ruby has been expanded to take a Hash argument https://github.com/ruby/ruby/commit/b25e27277d

Hence, we'd better update our own in-house Hash-like class `HashWithIndifferentAccess` to follow that Hash API change.

### Additional information

This patch was written because @skipkayhil pointed out about this new API at https://github.com/rails/rails/pull/46821#issuecomment-1365462266
(thanks @skipkayhil!)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.