### PR TITLE
[ci-skip] Document default error messages for some validations

### DIFF
--- a/activemodel/lib/active_model/validations/comparison.rb
+++ b/activemodel/lib/active_model/validations/comparison.rb
@@ -44,17 +44,23 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "failed comparison").
       # * <tt>:greater_than</tt> - Specifies the value must be greater than the
-      #   supplied value.
+      #   supplied value. The default error message for this option is _"must be
+      #   greater than %{count}"_.
       # * <tt>:greater_than_or_equal_to</tt> - Specifies the value must be
-      #   greater than or equal to the supplied value.
+      #   greater than or equal to the supplied value. The default error message
+      #   for this option is _"must be greater than or equal to %{count}"_.
       # * <tt>:equal_to</tt> - Specifies the value must be equal to the supplied
-      #   value.
+      #   value. The default error message for this option is _"must be equal to
+      #   %{count}"_.
       # * <tt>:less_than</tt> - Specifies the value must be less than the
-      #   supplied value.
+      #   supplied value. The default error message for this option is _"must be
+      #   less than %{count}"_.
       # * <tt>:less_than_or_equal_to</tt> - Specifies the value must be less
-      #   than or equal to the supplied value.
+      #   than or equal to the supplied value. The default error message for
+      #   this option is _"must be less than or equal to %{count}"_.
       # * <tt>:other_than</tt> - Specifies the value must not be equal to the
-      #   supplied value.
+      #   supplied value. The default error message for this option is _"must be
+      #   other than %{count}"_.
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -168,20 +168,29 @@ module ActiveModel
       #   +false+). Notice that for Integer and Float columns empty strings are
       #   converted to +nil+.
       # * <tt>:greater_than</tt> - Specifies the value must be greater than the
-      #   supplied value.
+      #   supplied value. The default error message for this option is _"must be
+      #   greater than %{count}"_.
       # * <tt>:greater_than_or_equal_to</tt> - Specifies the value must be
-      #   greater than or equal the supplied value.
+      #   greater than or equal the supplied value. The default error message
+      #   for this option is _"must be greater than or equal to %{count}"_.
       # * <tt>:equal_to</tt> - Specifies the value must be equal to the supplied
-      #   value.
+      #   value. The default error message for this option is _"must be equal to
+      #   %{count}"_.
       # * <tt>:less_than</tt> - Specifies the value must be less than the
-      #   supplied value.
+      #   supplied value. The default error message for this option is _"must be
+      #   less than %{count}"_.
       # * <tt>:less_than_or_equal_to</tt> - Specifies the value must be less
-      #   than or equal the supplied value.
+      #   than or equal the supplied value. The default error message for this
+      #   option is _"must be less than or equal to %{count}"_.
       # * <tt>:other_than</tt> - Specifies the value must be other than the
-      #   supplied value.
-      # * <tt>:odd</tt> - Specifies the value must be an odd number.
-      # * <tt>:even</tt> - Specifies the value must be an even number.
-      # * <tt>:in</tt> - Check that the value is within a range.
+      #   supplied value. The default error message for this option is _"must be
+      #   other than %{count}"_.
+      # * <tt>:odd</tt> - Specifies the value must be an odd number. The default
+      #   error message for this option is _"must be odd"_.
+      # * <tt>:even</tt> - Specifies the value must be an even number. The
+      #   default error message for this option is _"must be even"_.
+      # * <tt>:in</tt> - Check that the value is within a range. The default
+      #   error message for this option is _"must be in %{count}"_.
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -45,6 +45,13 @@ module ActiveModel
       #     validates_with MyValidator, MyOtherValidator, on: :create
       #   end
       #
+      # There is no default error message for +validates_with+. You must
+      # manually add errors to the record's errors collection in the validator
+      # class.
+      #
+      # To implement the validate method, you must have a +record+ parameter
+      # defined, which is the record to be validated.
+      #
       # Configuration options:
       # * <tt>:on</tt> - Specifies the contexts where this validation is active.
       #   Runs in all validation contexts by default +nil+. You can pass a symbol


### PR DESCRIPTION
This information was previously only available in the guides, so copying it over here as it feels useful information.