### PR TITLE
[ci-skip] Fix rdoc syntax for errors#add

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -121,9 +121,10 @@ module ActiveModel
     attr_reader :attribute
     # The type of error, defaults to +:invalid+ unless specified
     attr_reader :type
-    # The raw value provided as the second parameter when calling +errors#add+
+    # The raw value provided as the second parameter when calling
+    # <tt>errors#add</tt>
     attr_reader :raw_type
-    # The options provided when calling +errors#add+
+    # The options provided when calling <tt>errors#add</tt>
     attr_reader :options
 
     # Returns the error message.


### PR DESCRIPTION
This won't parse correctly with RDoc. ([ref](https://edgeapi.rubyonrails.org/classes/ActiveModel/Error.html))

See: 
<img width="652" alt="Screenshot 2022-12-29 at 11 59 57" src="https://user-images.githubusercontent.com/277819/210024648-cbb93722-4757-4124-afbf-1d2850a45492.png">
