### PR TITLE
Only use HostAuthorization if configured

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -13,7 +13,9 @@ module Rails
 
       def build_stack
         ActionDispatch::MiddlewareStack.new do |middleware|
-          middleware.use ::ActionDispatch::HostAuthorization, config.hosts, **config.host_authorization
+          unless config.hosts.empty?
+            middleware.use ::ActionDispatch::HostAuthorization, config.hosts, **config.host_authorization
+          end
 
           if config.force_ssl
             middleware.use ::ActionDispatch::SSL, **config.ssl_options,

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -147,6 +147,13 @@ module ApplicationTests
       assert_equal sorted, middleware
     end
 
+    test "ActionDispatch::HostAuthorization is not included if no hosts are configured" do
+      add_to_config "config.hosts = []"
+      boot!
+
+      assert_not_includes middleware, "ActionDispatch::HostAuthorization"
+    end
+
     test "Rack::Cache is not included by default" do
       boot!
 


### PR DESCRIPTION
### Motivation / Background

Previously, HostAuthorization would be added to the middleware stack whether or not config.hosts had any entries. While HostAuthorization does check config.hosts before doing computationally expensive things, its inclusion ends up being easily avoidable overhead on every request.

### Detail

Only use HostAuthorization if configured

### Additional information

Would this need a deprecation warnings for middleware operations? I figured I'd open the PR first to gauge interest before diving into that

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
