### PR TITLE
Allow adding/removing of existing `Content-Security-Policy` and `Permissions-Policy` directives

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow adding/removing of existing `Content-Security-Policy` and `Permissions-Policy` directives.
+
+    Previously, if you wanted to add/remove directives from either header, you had to redefine the defaults in the controller.
+
+    Now, you can adjust the policy directives without overwriting the global configuration.
+
+    *Alex Robbin*
+
 *   Include source location in routes extended view.
 
     ```bash

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -190,6 +190,20 @@ module ActionDispatch # :nodoc:
           @directives.delete(directive)
         end
       end
+
+      define_method("add_#{name}") do |*sources|
+        existing_sources = @directives.fetch(directive, [])
+
+        public_send(name, *(existing_sources + sources).uniq)
+      end
+
+      define_method("remove_#{name}") do |*sources|
+        existing_sources = @directives.fetch(directive, [])
+
+        sources.each { |source| existing_sources.delete(source) }
+
+        public_send(name, *(existing_sources - apply_mappings(sources)))
+      end
     end
 
     # Specify whether to prevent the user agent from loading any assets over

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -133,6 +133,18 @@ module ActionDispatch # :nodoc:
           @directives.delete(directive)
         end
       end
+
+      define_method("add_#{name}") do |*sources|
+        existing_sources = @directives.fetch(directive, [])
+
+        public_send(name, *(existing_sources + sources).uniq)
+      end
+
+      define_method("remove_#{name}") do |*sources|
+        existing_sources = @directives.fetch(directive, [])
+
+        public_send(name, *(existing_sources - apply_mappings(sources)))
+      end
     end
 
     %w[speaker vibrate vr].each do |directive|

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -247,6 +247,18 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_equal "script-src 'self' https:; style-src 'self' https:", @policy.build
   end
 
+  def test_add_directives
+    @policy.script_src :self
+    @policy.add_script_src :https
+    assert_equal "script-src 'self' https:", @policy.build
+  end
+
+  def test_remove_directives
+    @policy.script_src :self, :https
+    @policy.remove_script_src :https
+    assert_equal "script-src 'self'", @policy.build
+  end
+
   def test_dynamic_directives
     request = ActionDispatch::Request.new("HTTP_HOST" => "www.example.com")
     controller = Struct.new(:request).new(request)

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -32,6 +32,18 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
     assert_equal "geolocation 'self' https://example.com; usb 'none' https://example.com", @policy.build
   end
 
+  def test_add_directives
+    @policy.geolocation :self
+    @policy.add_geolocation "https://example.com"
+    assert_equal "geolocation 'self' https://example.com", @policy.build
+  end
+
+  def test_remove_directives
+    @policy.geolocation :self, "https://example.com"
+    @policy.remove_geolocation "https://example.com"
+    assert_equal "geolocation 'self'", @policy.build
+  end
+
   def test_invalid_directive_source
     exception = assert_raises(ArgumentError) do
       @policy.geolocation [:non_existent]


### PR DESCRIPTION
### Motivation / Background

Previously, if you wanted to add/remove directives from either header, you had to redefine the defaults in the controller.

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.default_src :none

    policy.script_src :self, 'a.com', 'b.com'
  end
end

class FooController < ApplicationController
  content_security_policy do |policy|
    policy.script_src :self, 'a.com', 'b.com', 'c.com'
  end
end
```

### Detail

Now, you can adjust the policy directives without overwriting the global configuration.

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.default_src :none

    policy.script_src :self, 'a.com', 'b.com'
  end
end

class FooController < ApplicationController
  content_security_policy do |policy|
    policy.add_script_src 'c.com'
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
