### PR TITLE
[ci-skip] Fix rdoc syntax for Kernel.Float

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -148,10 +148,11 @@ module ActiveModel
 
     module HelperMethods
       # Validates whether the value of the specified attribute is numeric by
-      # trying to convert it to a float with Kernel.Float (if <tt>only_integer</tt>
-      # is +false+) or applying it to the regular expression <tt>/\A[\+\-]?\d+\z/</tt>
-      # (if <tt>only_integer</tt> is set to +true+). Precision of Kernel.Float values
-      # are guaranteed up to 15 digits.
+      # trying to convert it to a float with +Kernel.Float+ (if
+      # <tt>only_integer</tt> is +false+) or applying it to the regular
+      # expression <tt>/\A[\+\-]?\d+\z/</tt> (if <tt>only_integer</tt> is set to
+      # +true+). Precision of +Kernel.Float+ values are guaranteed up to 15
+      # digits.
       #
       #   class Person < ActiveRecord::Base
       #     validates_numericality_of :value, on: :create

--- a/activerecord/lib/active_record/validations/numericality.rb
+++ b/activerecord/lib/active_record/validations/numericality.rb
@@ -21,10 +21,11 @@ module ActiveRecord
 
     module ClassMethods
       # Validates whether the value of the specified attribute is numeric by
-      # trying to convert it to a float with Kernel.Float (if <tt>only_integer</tt>
-      # is +false+) or applying it to the regular expression <tt>/\A[\+\-]?\d+\z/</tt>
-      # (if <tt>only_integer</tt> is set to +true+). Kernel.Float precision
-      # defaults to the column's precision value or 15.
+      # trying to convert it to a float with +Kernel.Float+ (if
+      # <tt>only_integer</tt> is +false+) or applying it to the regular
+      # expression <tt>/\A[\+\-]?\d+\z/</tt> (if <tt>only_integer</tt> is set to
+      # +true+). +Kernel.Float+ precision defaults to the column's precision
+      # value or 15.
       #
       # See ActiveModel::Validations::HelperMethods.validates_numericality_of for more information.
       def validates_numericality_of(*attr_names)


### PR DESCRIPTION
This created an unnecessary link to rails `Kernel` module, which has no method for `Float` as it exists in ruby's Kernel instead. We _could_ link to that? But I feel we rarely cross-link to ruby documentation, so unlink it for now.

### Before

![Screenshot 2022-12-30 at 11 24 28](https://user-images.githubusercontent.com/277819/210028622-3778fc09-5760-4b55-988e-5f4a36dd4ad5.png)


### After

![Screenshot 2022-12-30 at 11 29 02](https://user-images.githubusercontent.com/277819/210028630-c82cdc90-6c9b-465e-bbaf-6ebeb0773bf7.png)
