### PR TITLE
Support function table names in Arel Table

### DIFF
--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -10,9 +10,6 @@ module Arel # :nodoc: all
 
     attr_accessor :name, :table_alias
 
-    # TableAlias and Table both have a #table_name which is the name of the underlying table
-    alias :table_name :name
-
     def initialize(name, as: nil, klass: nil, type_caster: klass&.type_caster)
       @name =
         case name

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -14,7 +14,6 @@ module Arel # :nodoc: all
       @name =
         case name
         when Symbol then name.to_s
-        when Nodes::Node then Arel.sql(name.to_sql)
         else
           name
         end

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -14,7 +14,14 @@ module Arel # :nodoc: all
     alias :table_name :name
 
     def initialize(name, as: nil, klass: nil, type_caster: klass&.type_caster)
-      @name = name.to_s
+      @name =
+        case name
+        when Symbol then name.to_s
+        when Nodes::Node then Arel.sql(name.to_sql)
+        else
+          name
+        end
+
       @klass = klass
       @type_caster = type_caster
 

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -569,11 +569,17 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Table(o, collector)
-          if o.table_alias
-            collector << quote_table_name(o.name) << " " << quote_table_name(o.table_alias)
+          if Arel::Nodes::Node === o.name
+            visit o.name, collector
           else
             collector << quote_table_name(o.name)
           end
+
+          if o.table_alias
+            collector << " " << quote_table_name(o.table_alias)
+          end
+
+          collector
         end
 
         def visit_Arel_Nodes_In(o, collector)

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -186,10 +186,6 @@ module Arel
       _(@relation.name).must_equal "users"
     end
 
-    it "should have a table name" do
-      _(@relation.table_name).must_equal "users"
-    end
-
     describe "[]" do
       describe "when given a Symbol" do
         it "manufactures an attribute if the symbol names an attribute within the relation" do

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -130,15 +130,13 @@ module Arel
 
       it "should accept literal SQL"  do
         rel = Table.new Arel.sql("generate_series(4, 2)")
-        manager = rel.project(Arel.star)
-        _(manager.to_sql).must_be_like %{ SELECT * FROM generate_series(4, 2) }
+        assert_equal Arel.sql("generate_series(4, 2)"), rel.name
       end
 
       it "should accept Arel nodes"  do
         node = Arel::Nodes::NamedFunction.new("generate_series", [4, 2])
         rel = Table.new node
-        manager = rel.project(Arel.star)
-        _(manager.to_sql).must_be_like %{ SELECT * FROM generate_series(4, 2) }
+        assert_equal node, rel.name
       end
     end
 

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -127,6 +127,19 @@ module Arel
         rel = Table.new :users, as: "users"
         _(rel.table_alias).must_be_nil
       end
+
+      it "should accept literal SQL"  do
+        rel = Table.new Arel.sql("generate_series(4, 2)")
+        manager = rel.project(Arel.star)
+        _(manager.to_sql).must_be_like %{ SELECT * FROM generate_series(4, 2) }
+      end
+
+      it "should accept Arel nodes"  do
+        node = Arel::Nodes::NamedFunction.new("generate_series", [4, 2])
+        rel = Table.new node
+        manager = rel.project(Arel.star)
+        _(manager.to_sql).must_be_like %{ SELECT * FROM generate_series(4, 2) }
+      end
     end
 
     describe "order" do

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -696,6 +696,31 @@ module Arel
         end
       end
 
+      describe "Table" do
+        it "should compile node names" do
+          test = Table.new(:users).alias("zomgusers")[:id].eq "3"
+          _(compile(test)).must_be_like %{
+            "zomgusers"."id" = '3'
+          }
+        end
+
+        it "should compile literal SQL"  do
+          test = Table.new Arel.sql("generate_series(4, 2)")
+          _(compile(test)).must_be_like %{ generate_series(4, 2) }
+        end
+
+        it "should compile Arel nodes"  do
+          test = Arel::Nodes::NamedFunction.new("generate_series", [4, 2])
+          _(compile(test)).must_be_like %{ generate_series(4, 2) }
+        end
+
+        it "should compile nodes with bind params" do
+          bp = Nodes::BindParam.new(1)
+          test = Arel::Nodes::NamedFunction.new("generate_series", [4, bp])
+          _(compile(test)).must_be_like %{ generate_series(4, ?) }
+        end
+      end
+
       describe "TableAlias" do
         it "should use the underlying table for checking columns" do
           test = Table.new(:users).alias("zomgusers")[:id].eq "3"


### PR DESCRIPTION
### Motivation / Background

Make it possible to select from computed/function table using Arel, or pass arbitrary string as a table name

This makes it possible to use Arel to query against functions, e.g., generate_series in PostgreSQL, or json_each, or whatever.

### Detail

My particular use-case was in transforming the following SQL to Arel (for SQLite 3):

```ruby
# posts:
#   title string
#   tags json (array)
Post.where(
  "EXISTS (SELECT 1 FROM json_each(posts.tags) WHERE value = ?)",
   tag
)
```

Currently, it's not possible to use computed table sources with `Arel::Table` due to the `@name = name.to_s` call.
The workaround is:

```ruby
arel_table = Post.arel_table
table_name = Arel.sql(Arel::Nodes::NamedFunction.new("json_each", [arel_table[:tags]]).to_sql)
tags_arel = Arel::Table.new("", as: :json_tags)
# We can only overwrite the name value after the table is created
tags_arel.name = table_name

Post.where(tags_arel.project(1).where(tags_arel[:value].in(tags)).exists)
```

With this patch, we can provide a SqlLiteral (or a custom node) right to the Table constructor:

```ruby
table_name = Arel.sql("json_each(table.tags)")
tags_arel = Arel::Table.new(table_name, as: :json_tags)


table_name = Arel::Nodes::NamedFunction.new("json_each", [arel_table[:tags]]).to_sql
tags_arel = Arel::Table.new(table_name, as: :json_tags)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
