### PR TITLE
Use Ruby 3.2's native ISO 8601-ish String parser to cast String to Time in Active Record

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -69,20 +69,34 @@ module ActiveModel
             \z
           /x
 
-          def fast_string_to_time(string)
-            return unless ISO_DATETIME =~ string
+          if RUBY_VERSION >= "3.2"
+            def fast_string_to_time(string)
+              return unless ISO_DATETIME.match?(string)
 
-            usec = $7.to_i
-            usec_len = $7&.length
-            if usec_len&.< 6
-              usec *= 10**(6 - usec_len)
+              if is_utc?
+                ::Time.new(string, in: "UTC")
+              else
+                ::Time.new(string)
+              end
+            rescue ArgumentError
+              nil
             end
+          else
+            def fast_string_to_time(string)
+              return unless ISO_DATETIME =~ string
 
-            if $8
-              offset = $8 == "Z" ? 0 : $8.to_i * 3600 + $9.to_i * 60
+              usec = $7.to_i
+              usec_len = $7&.length
+              if usec_len&.< 6
+                usec *= 10**(6 - usec_len)
+              end
+
+              if $8
+                offset = $8 == "Z" ? 0 : $8.to_i * 3600 + $9.to_i * 60
+              end
+
+              new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec, offset)
             end
-
-            new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec, offset)
           end
       end
     end

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -74,7 +74,9 @@ module ActiveModel
               return unless ISO_DATETIME.match?(string)
 
               if is_utc?
-                ::Time.new(string, in: "UTC")
+                # XXX: Wrapping the Time object with Time.at because Time.new with `in:` in Ruby 3.2.0 used to return an invalid Time object
+                # see: https://bugs.ruby-lang.org/issues/19292
+                ::Time.at(::Time.new(string, in: "UTC"))
               else
                 ::Time.new(string)
               end

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -66,7 +66,7 @@ module ActiveModel
       private
         def cast_value(value)
           return apply_seconds_precision(value) unless value.is_a?(::String)
-          return if value.empty?
+          return if value.blank?
 
           dummy_time_value = value.sub(/\A\d{4}-\d\d-\d\d(?:T|\s)|/, "2000-01-01 ")
 


### PR DESCRIPTION
### Motivation / Background

The long awaited feature request "a faster way to parse ISO 8601-ish time string" https://bugs.ruby-lang.org/issues/16005
has finally came into an implementation by @nobu into Ruby 3.2 (time 0.2.1)!!

With this new API, we could completely replace our own hackish time parse puzzle with a single method call, then achieve 1.29 - 1.45 times performance improvement.

### Detail

Ruby 3.2.0's initial `Time.new` implementation was a little bit buggy though, so we had to recreate the once created Time instance as below.
`Time.at(Time.new(str))`
see https://bugs.ruby-lang.org/issues/19292 for more details.

### Benchmark

Here's another patch on top of this branch for running comparison benchmarks,

```diff
commit d748bbb7e4b9e7f4fd29978cecf0f4a69293cc7c
Author: Akira Matsuda <ronnie@dio.jp>
Date:   2023-01-01 21:05:21 +0900

    Enable both for benchmarking
---
 activemodel/lib/active_model/type/helpers/time_value.rb | 14 ++++++++++----
 1 file changed, 10 insertions(+), 4 deletions(-)

diff --git a/activemodel/lib/active_model/type/helpers/time_value.rb b/activemodel/lib/active_model/type/helpers/time_value.rb
index 09d1af268c..ee5e9c1fdb 100644
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -61,6 +61,14 @@ def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
             end
           end
 
+          #TODO: we can use this in the future
+          ISO_DATETIME_NEW = /
+            \A
+            \d{4}-\d\d-\d\d(?:T|\s)           # 2020-06-20T
+            \d\d:\d\d:\d\d(?:\.\d{1,6}\d*)?   # 10:20:30.123456
+            (?:Z(?=\z)|[+-]\d\d(?::?\d\d)?)?  # +09:00
+            \z
+          /x
           ISO_DATETIME = /
             \A
             (\d{4})-(\d\d)-(\d\d)(?:T|\s)            # 2020-06-20T
@@ -69,7 +77,6 @@ def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
             \z
           /x
 
-          if RUBY_VERSION >= "3.2"
             def fast_string_to_time(string)
               return unless ISO_DATETIME.match?(string)
 
@@ -83,8 +90,8 @@ def fast_string_to_time(string)
             rescue ArgumentError
               nil
             end
-          else
-            def fast_string_to_time(string)
+
+            def fast_string_to_time_old(string)
               return unless ISO_DATETIME =~ string
 
               usec = $7.to_i
@@ -99,7 +106,6 @@ def fast_string_to_time(string)
 
               new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec, offset)
             end
-          end
       end
     end
   end
```

the benchmark code,

```ruby
# frozen_string_literal: true

require 'active_record'
require 'benchmark/ips'

include ActiveModel::Type::Helpers::TimeValue

string = '2023-01-01 19:15:36'

p 'UTC'
def is_utc? = true

Benchmark.ips do |x|
  x.report('new') { fast_string_to_time string }
  x.report('old') { fast_string_to_time_old string }
  x.compare!
end


p 'non-UTC'
def is_utc? = false

Benchmark.ips do |x|
  x.report('new') { fast_string_to_time string }
  x.report('old') { fast_string_to_time_old string }
  x.compare!
end
```

and the final result.

```
"UTC"
Warming up --------------------------------------
                 new   146.681k i/100ms
                 old   112.821k i/100ms
Calculating -------------------------------------
                 new      1.542M (± 0.9%) i/s -      7.750M in   5.025003s
                 old      1.193M (± 2.4%) i/s -      6.040M in   5.067234s

Comparison:
                 new:  1542382.4 i/s
                 old:  1192721.1 i/s - 1.29x  (± 0.00) slower

"non-UTC"
Warming up --------------------------------------
                 new    85.220k i/100ms
                 old    62.541k i/100ms
Calculating -------------------------------------
                 new    927.019k (± 0.8%) i/s -      4.687M in   5.056394s
                 old    640.220k (± 1.8%) i/s -      3.252M in   5.081417s

Comparison:
                 new:   927018.9 i/s
                 old:   640219.7 i/s - 1.45x  (± 0.00) slower
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.