### PR TITLE
Prepend a '\n' to the string to be added to `application.js`

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -19,7 +19,7 @@ module ActionText
         destination = Pathname(destination_root)
 
         if (application_javascript_path = destination.join("app/javascript/application.js")).exist?
-          insert_into_file application_javascript_path.to_s, %(import "trix"\nimport "@rails/actiontext"\n)
+          insert_into_file application_javascript_path.to_s, %(\nimport "trix"\nimport "@rails/actiontext"\n)
         else
           say <<~INSTRUCTIONS, :green
             You must import the @rails/actiontext and trix JavaScript modules in your application entrypoint.


### PR DESCRIPTION
### Summary

Prepend a '\n' to the string to be added to `application.js` to prevent errors occurring when `application.js` doesn't end in a blank line.

### Background

Running `bin/rails action_text:install` appends `import "trix"` to the `application.js` file without inserting a newline first, which throws a `SyntaxError: Unexpected keyword 'import'` to the console on webpage load.

In my app this resulted in the following:

```js
// import statements....

import Rails from "@rails/ujs"
Rails.start()import "trix".   // <-- Problem here
import "@rails/actiontext"

```

I assume this bug occurred because my `application.js` was linted at some point and removed an extra line, which was not expected by this generator. I'd guess a good chunk of Action Text installs occur with existing apps, which may have been hit by a linter. Adding a new line removes the risk of all JS breaking.

### Detail

I recommend prepending the string to be inserted with a `\n` just to be safe. I've added the two characters in my commit.
