### PR TITLE
TZ offset minute has to be negated in the Western Hemisphere

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a bug where type casting of string to `Time` and `DateTime` doesn't
+    calculate minus minute value in TZ offset correctly.
+
+    *Akira Matsuda*
+
 *   Port the `type_for_attribute` method to Active Model. Classes that include
     `ActiveModel::Attributes` will now provide this method. This method behaves
     the same for Active Model as it does for Active Record.

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -94,7 +94,13 @@ module ActiveModel
               end
 
               if $8
-                offset = $8 == "Z" ? 0 : $8.to_i * 3600 + $9.to_i * 60
+                offset = \
+                  if $8 == "Z"
+                    0
+                  else
+                    offset_h, offset_m = $8.to_i, $9.to_i
+                    offset_h.to_i * 3600 + (offset_h.negative? ? -1 : 1) * offset_m * 60
+                  end
               end
 
               new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec, offset)

--- a/activemodel/test/cases/type/time_test.rb
+++ b/activemodel/test/cases/type/time_test.rb
@@ -18,6 +18,7 @@ module ActiveModel
         assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast("2015-06-13T19:45:54+03:00")
         assert_equal ::Time.utc(1999, 12, 31, 21,  7,  8), type.cast("06:07:08+09:00")
         assert_equal ::Time.utc(2000,  1,  1, 16, 45, 54), type.cast(4 => 16, 5 => 45, 6 => 54)
+        assert_equal ::Time.utc(2000,  1,  1, 3, 30, 0), type.cast("2023-01-01T00:00:00-03:30")
       end
 
       def test_user_input_in_time_zone


### PR DESCRIPTION
This patch fixes a bug in our AMo Time type caster that it doesn't handle minus offset in a given string correctly.

### Background / Detail

When the TZ in the given string contains minus offset, both hour and minute value has to be negated, but the current code nagates hour only.

For instance in Newfoundland Time Zone (UTC−03:30), the offset part goes like "-03:30" which has to be treated as "-3 hours and -30 minutes", but it used to be calculated as "-3 hours and +30 minutes", then it used to return 1 hour advanced value than the actual.

### Additional information

Parsing Time ourselves is too hard for non-professional. This bug may tell why I'm proposing to switch to Ruby's built in Time parser in #46868. And, this bug was found and reported by Time pro @nobu via https://bugs.ruby-lang.org/issues/19293#note-1 (thanks!)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.