### PR TITLE
fix comparison type issue in puma.rb template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -13,8 +13,8 @@ threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
 if ENV["RAILS_ENV"] == "production"
-  worker_count = ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count }
-  workers worker_count if worker_count && worker_count.to_i > 1
+  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
+  workers worker_count if worker_count > 1
 end
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -14,7 +14,7 @@ threads min_threads_count, max_threads_count
 # Specifies that the worker count should equal the number of processors in production.
 if ENV["RAILS_ENV"] == "production"
   worker_count = ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count }
-  workers worker_count if worker_count > 1
+  workers worker_count if worker_count && worker_count.to_i > 1
 end
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before


### PR DESCRIPTION
Fix for the comparison type issue at `worker_count` in this PR: https://github.com/rails/rails/pull/46838