### PR TITLE
Add documentation for #43487

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow raising an error when a callback's only/unless symbols aren't existing methods.
+
+    When `before_action :callback, only: :action_name` is declared on a controller that doesn't respond to `action_name`, raise an exception at request time. This is a safety measure to ensure that typos or forgetfulness don't prevent a crucial callback from being run when it should.
+
+    For new applications, raising an error for undefined actions is turned on by default. If you do not want to opt-in to this behavior set `config.action_pack.raise_on_missing_callback_actions` to `false` in your application configuration. See #43487 for more details.
+
+    *Jess Bees*
+
 *   Allow cookie options[:domain] to accept a proc to set the cookie domain on a more flexible per-request basis
 
     *RobL*

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -48,7 +48,17 @@ module AbstractController
           missing_action = @actions.find { |action| !controller.available_action?(action) }
           if missing_action
             filter_names = @filters.length == 1 ? @filters.first.inspect : @filters.inspect
-            message = "The #{missing_action} action could not be found for the #{filter_names} callback on #{controller.class.name}, but it is listed in its #{@conditional_key.inspect} option"
+
+            message = <<~MSG
+              The #{missing_action} action could not be found for the #{filter_names}
+              callback on #{controller.class.name}, but it is listed in the controller's
+              #{@conditional_key.inspect} option.
+
+              Raising for missing callback actions is a new default in Rails 7.1, if you'd
+              like to turn this off you can delete the option from the environment configurations
+              or set `config.action_pack.raise_on_missing_callback_actions` to `false`.
+            MSG
+
             raise ActionNotFound.new(message, controller, missing_action)
           end
         end


### PR DESCRIPTION
In #43487 we missed adding a changelog so that's been added here. In addition, since this isn't a new framework default unless you are creating a new application (and only in dev and test environments by default) it can be easy to miss this new option. I've updated the message to mention the option following DHH's suggestion on the original PR.

cc/ @dhh 