### PR TITLE
Store correct environment in `internal_metadata` when run `rails db:prepare`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1427,7 +1427,7 @@ module ActiveRecord
       def record_environment
         return if down?
 
-        @internal_metadata[:environment] = connection.migration_context.current_environment
+        @internal_metadata[:environment] = connection.pool.db_config.env_name
       end
 
       def ran?(migration)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -689,32 +689,17 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env     = env_name(@internal_metadata.connection)
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
     migrator.up
     assert_equal current_env, @internal_metadata[:environment]
-
-    original_rails_env  = ENV["RAILS_ENV"]
-    original_rack_env   = ENV["RACK_ENV"]
-    ENV["RAILS_ENV"]    = ENV["RACK_ENV"] = "foofoo"
-    new_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-
-    assert_not_equal current_env, new_env
-
-    sleep 1 # mysql by default does not store fractional seconds in the database
-    migrator.up
-    assert_equal new_env, @internal_metadata[:environment]
-  ensure
-    ENV["RAILS_ENV"] = original_rails_env
-    ENV["RACK_ENV"]  = original_rack_env
-    migrator.up
   end
 
   def test_internal_metadata_stores_environment_when_migration_fails
     @internal_metadata.delete_all_entries
-    current_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env = env_name(@internal_metadata.connection)
 
     migration = Class.new(ActiveRecord::Migration::Current) {
       def version; 101 end
@@ -732,7 +717,7 @@ class MigrationTest < ActiveRecord::TestCase
     @internal_metadata.delete_all_entries
     @internal_metadata[:foo] = "bar"
 
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env     = env_name(@internal_metadata.connection)
     migrations_path = MIGRATIONS_ROOT + "/valid"
 
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
@@ -1183,6 +1168,10 @@ class MigrationTest < ActiveRecord::TestCase
 
       test_terminated.count_down
       other_process.join
+    end
+
+    def env_name(connection)
+      connection.pool.db_config.env_name
     end
 end
 

--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -197,26 +197,13 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment
-    current_env     = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+    current_env     = ActiveRecord::Base.connection.pool.db_config.env_name
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration_b, @internal_metadata_b)
 
     migrator.up
     assert_equal current_env, @internal_metadata_b[:environment]
-
-    original_rails_env  = ENV["RAILS_ENV"]
-    original_rack_env   = ENV["RACK_ENV"]
-    ENV["RAILS_ENV"]    = ENV["RACK_ENV"] = "foofoo"
-    new_env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-
-    assert_not_equal current_env, new_env
-
-    sleep 1 # mysql by default does not store fractional seconds in the database
-    migrator.up
-    assert_equal new_env, @internal_metadata_b[:environment]
   ensure
-    ENV["RAILS_ENV"] = original_rails_env
-    ENV["RACK_ENV"]  = original_rack_env
     migrator.down if migrator
   end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -716,6 +716,12 @@ module ApplicationTests
 
           tables = rails("runner", "p ActiveRecord::Base.connection.tables.sort").strip
           assert_equal('["ar_internal_metadata", "books", "recipes", "schema_migrations"]', tables)
+
+          test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
+          development_environment = lambda { rails("runner", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
+
+          assert_equal "development", development_environment.call
+          assert_equal "test", test_environment.call
         end
       end
 


### PR DESCRIPTION
Fixes #46845.

[Rendered without space changes](https://github.com/rails/rails/pull/46879/files?w=1)

My suggestion (https://github.com/rails/rails/issues/46845#issuecomment-1370057047) was to have something like
```diff
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1427,7 +1427,7 @@ def migrate_without_lock
       def record_environment
         return if down?

-        @internal_metadata[:environment] = connection.migration_context.current_environment
+        @internal_metadata[:environment] = connection.pool.db_config.env_name
       end

       def ran?(migration)
```

But that did not worked out, because `db_config.env_name` is envs (top level keys) from the `database.yml`, but the rake task tries to store basically the `RAILS_ENV`, which could not be the same? Several test cases started to fail, for example, https://github.com/rails/rails/blob/c70a8f75d7a41212cbe358b2a0122a28321b040d/activerecord/test/cases/migration_test.rb#L691-L713

So I went with my original suggestion (https://github.com/rails/rails/issues/46845#issuecomment-1366646524) and enhanced it a bit to not depend on the rails' application presence.

It is not very elegant, but it works.

cc @eileencodes 