### PR TITLE
Document request.action_dispatch in guides [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -277,6 +277,12 @@ INFO. Additional keys may be added by the caller.
 | `:location` | URL to redirect to            |
 | `:request`  | The `ActionDispatch::Request` |
 
+#### request.action_dispatch
+
+| Key         | Value                         |
+| ----------- | ----------------------------- |
+| `:request`  | The `ActionDispatch::Request` |
+
 ### Action View
 
 #### render_template.action_view


### PR DESCRIPTION
### Motivation / Background

It was originally added in ffa9540 but never documented
