### PR TITLE
Remove sprockets-export from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,11 +110,6 @@ group :ujs do
   gem "webdrivers"
 end
 
-# Action View
-group :view do
-  gem "sprockets-export", require: false
-end
-
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,14 +178,6 @@ GEM
     digest (3.1.0)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
-    em-http-request (1.1.7)
-      addressable (>= 2.3.4)
-      cookiejar (!= 0.3.1)
-      em-socksify (>= 0.3)
-      eventmachine (>= 1.0.3)
-      http_parser.rb (>= 0.6.0)
-    em-socksify (0.3.2)
-      eventmachine (>= 1.0.0.beta.4)
     error_highlight (0.5.1)
     erubi (1.11.0)
     et-orbi (1.2.6)
@@ -465,7 +457,6 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-export (1.0.0)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -496,7 +487,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.3.0)
-    useragent (0.16.10)
     w3c_validators (1.3.6)
       json (>= 1.8)
       nokogiri (~> 1.6)
@@ -588,7 +578,6 @@ DEPENDENCIES
   sequel
   sidekiq
   sneakers
-  sprockets-export
   sprockets-rails (>= 2.0.0)
   sqlite3 (~> 1.4)
   stackprof


### PR DESCRIPTION
### Motivation / Background

Its usage was removed in 7d116c9 but I forgot to remove it

### Additional information

The other changes come from running bundle install, it looks like they were supposed to be removed in d9e79ce

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
