### PR TITLE
LogSubscriber: Fix example syntax for `color` in deprecation message

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -181,7 +181,7 @@ module ActiveSupport
       if options.is_a?(TrueClass) || options.is_a?(FalseClass)
         ActiveSupport.deprecator.warn(<<~MSG.squish)
           Bolding log text with a positional boolean is deprecated and will be removed
-          in Rails 7.2. Use an option hash instead (eg. `color(:red, "my text", bold: true)`).
+          in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`).
         MSG
         options = { bold: options }
       end


### PR DESCRIPTION
### Motivation / Background

This PR fixes a deprecation message in LogSubscriber by correcting the order of arguments in the example syntax.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
