### PR TITLE
Define each SafeBuffer method with same arity with String's original method

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -135,16 +135,40 @@ module ActiveSupport # :nodoc:
     end
 
     UNSAFE_STRING_METHODS.each do |unsafe_method|
-      if unsafe_method.respond_to?(unsafe_method)
-        class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
-            to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
-          end                                       # end
+      if "".respond_to?(unsafe_method)
+        parameters = "".method(unsafe_method).parameters
 
-          def #{unsafe_method}!(*args)              # def capitalize!(*args)
-            @html_safe = false                      #   @html_safe = false
-            super                                   #   super
-          end                                       # end
+        params =
+          if (parameters.map(&:first) & [:keyreq, :key, :keyrest]).any?
+            "..."
+          elsif (parameters.map(&:first) & [:opt, :rest]).any?
+            "*args"
+          else
+            defn = parameters.each.with_index(1).filter_map { |(type, arg), i| arg || "arg#{i}" if type == :req }
+            defn << "&block" if parameters.last&.first == :block
+            defn.join(", ")
+          end
+
+        params_for_super =
+          if (parameters.map(&:first) & [:keyreq, :key, :keyrest]).any?
+            "..."
+          elsif (parameters.map(&:first) & [:opt, :rest]).any?
+            "*"
+          else
+            defn = parameters.count { |type, _| type == :req }.times.map { "_" }
+            defn << "&block" if parameters.last&.first == :block
+            defn.join(", ")
+          end
+
+        class_eval <<-EOT, __FILE__, __LINE__ + 1
+          def #{unsafe_method}(#{params})       # def capitalize(*args, &block)
+            to_str.#{unsafe_method}(#{params})  #   to_str.capitalize(*args, &block)
+          end                                   # end
+
+          def #{unsafe_method}!(#{params_for_super})     # def capitalize!(*)
+            @html_safe = false                           #   @html_safe = false
+            super                                        #   super
+          end                                            # end
         EOT
       end
     end


### PR DESCRIPTION
Here's another patch on delegation improvement, targeting on AS::SafeBuffer.

### Motivation / Background

Currently, when SafeBuffer delegates its methods to its parent String, it defines almost all wrapper methods with `*args` parameter, which allocates an Array object on each method call.

### Detail

This patch tries to avoid that extra runtime allocation by counting each original method's arity and defining its wrapper method with proper arity.

### Additional information

As a result, this patch improves the IPS benchmark result of `SafeBuffer#chop` 1.8 times faster (this is just an example, and this patch improves so many others as well).

```
before
Warming up --------------------------------------
                       554.435k i/100ms
Calculating -------------------------------------
                          6.318M (± 4.6%) i/s -     31.603M in   5.014815s

after
Warming up --------------------------------------
                       839.767k i/100ms
Calculating -------------------------------------
                         11.222M (± 1.0%) i/s -     56.264M in   5.014127s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.