### PR TITLE
Backports ruby 3.2 compatibility fixes for rails 6.1

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -616,7 +616,7 @@ module ActionMailer
         @_message = NullMail.new unless @_mail_was_called
       end
     end
-    ruby2_keywords(:process)
+    ruby2_keywords(:process) if respond_to?(:ruby2_keywords, true)
 
     class NullMail #:nodoc:
       def body; "" end

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -616,6 +616,7 @@ module ActionMailer
         @_message = NullMail.new unless @_mail_was_called
       end
     end
+    ruby2_keywords(:process)
 
     class NullMail #:nodoc:
       def body; "" end

--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -20,7 +20,7 @@ module ActionMailer #:nodoc:
     end
 
     private
-      def process(*)
+      def process(...)
         handle_exceptions do
           super
         end

--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -20,10 +20,14 @@ module ActionMailer #:nodoc:
     end
 
     private
-      def process(...)
-        handle_exceptions do
-          super
-        end
+      all_args = RUBY_VERSION < "2.7" ? "*" : "..."
+
+      class_eval <<-RUBY
+    def process(#{all_args})
+      handle_exceptions do
+        super
       end
+    end
+      RUBY
   end
 end

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -164,6 +164,7 @@ module AbstractController
 
       process_action(action_name, *args)
     end
+    ruby2_keywords(:process)
 
     # Delegates to the class' ::controller_path
     def controller_path
@@ -224,8 +225,8 @@ module AbstractController
       #
       # Notice that the first argument is the method to be dispatched
       # which is *not* necessarily the same as the action name.
-      def process_action(method_name, *args)
-        send_action(method_name, *args)
+      def process_action(...)
+        send_action(...)
       end
 
       # Actually call the method associated with the action. Override

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -164,7 +164,7 @@ module AbstractController
 
       process_action(action_name, *args)
     end
-    ruby2_keywords(:process)
+    ruby2_keywords(:process) if respond_to?(:ruby2_keywords, true)
 
     # Delegates to the class' ::controller_path
     def controller_path
@@ -225,9 +225,13 @@ module AbstractController
       #
       # Notice that the first argument is the method to be dispatched
       # which is *not* necessarily the same as the action name.
-      def process_action(...)
-        send_action(...)
+      all_args = RUBY_VERSION < "2.7" ? "method_name, *args" : "..."
+
+      class_eval <<-RUBY
+      def process_action(#{all_args})
+        send_action(#{all_args})
       end
+      RUBY
 
       # Actually call the method associated with the action. Override
       # this method if you wish to change how action methods are called,

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -37,7 +37,7 @@ module AbstractController
 
     # Override <tt>AbstractController::Base#process_action</tt> to run the
     # <tt>process_action</tt> callbacks around the normal behavior.
-    def process_action(*)
+    def process_action(...)
       run_callbacks(:process_action) do
         super
       end

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -37,11 +37,15 @@ module AbstractController
 
     # Override <tt>AbstractController::Base#process_action</tt> to run the
     # <tt>process_action</tt> callbacks around the normal behavior.
-    def process_action(...)
+    all_args = RUBY_VERSION < "2.7" ? "*" : "..."
+
+    class_eval <<-RUBY
+    def process_action(#{all_args})
       run_callbacks(:process_action) do
         super
       end
     end
+    RUBY
 
     module ClassMethods
       # If +:only+ or +:except+ are used, convert the options into the

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -34,12 +34,16 @@ module ActionView
     end
 
     # Override process to set up I18n proxy.
-    def process(...) # :nodoc:
+    all_args = RUBY_VERSION < "2.7" ? "*" : "..."
+
+    class_eval <<-RUBY
+    def process(#{all_args}) # :nodoc:
       old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
       super
     ensure
       I18n.config = old_config
     end
+    RUBY
 
     module ClassMethods
       def _routes

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -33,8 +33,8 @@ module ActionView
       super
     end
 
-    # Overwrite process to set up I18n proxy.
-    def process(*) #:nodoc:
+    # Override process to set up I18n proxy.
+    def process(...) # :nodoc:
       old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
       super
     ensure

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -478,7 +478,7 @@ module ActiveModel
     def attribute_missing(match, *args, &block)
       __send__(match.target, match.attr_name, *args, &block)
     end
-    ruby2_keywords(:attribute_missing)
+    ruby2_keywords(:attribute_missing) if respond_to?(:ruby2_keywords, true)
 
     # A +Person+ instance with a +name+ attribute can ask
     # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -478,6 +478,7 @@ module ActiveModel
     def attribute_missing(match, *args, &block)
       __send__(match.target, match.attr_name, *args, &block)
     end
+    ruby2_keywords(:attribute_missing)
 
     # A +Person+ instance with a +name+ attribute can ask
     # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -406,12 +406,16 @@ module ActiveRecord
       already_in_scope? ? yield : _scoping(self) { yield }
     end
 
-    def _exec_scope(...) # :nodoc:
+    all_args = RUBY_VERSION < "2.7" ? "*args, &block" : "..."
+
+    class_eval <<-RUBY
+    def _exec_scope(#{all_args}) # :nodoc:
       @delegate_to_klass = true
-      _scoping(nil) { instance_exec(...) || self }
+      _scoping(nil) { instance_exec(#{all_args}) || self }
     ensure
       @delegate_to_klass = false
     end
+    RUBY
 
     # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
     # statement and sends it straight to the database. It does not instantiate the involved models and it does not

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -406,9 +406,9 @@ module ActiveRecord
       already_in_scope? ? yield : _scoping(self) { yield }
     end
 
-    def _exec_scope(*args, &block) # :nodoc:
+    def _exec_scope(...) # :nodoc:
       @delegate_to_klass = true
-      _scoping(nil) { instance_exec(*args, &block) || self }
+      _scoping(nil) { instance_exec(...) || self }
     ensure
       @delegate_to_klass = false
     end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/46883

### Motivation / Background

Ruby 3.2 deals with kwargs differently than previous versions, that causes some rails code paths trigger errors like:

```
ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: user)
``` 

Those problems are fixed in rails 7, this PR aims to backport those changes to rails 6.1.
[This](https://github.com/rails/rails/pull/44850) is the original PR where these changes were introduced.