### PR TITLE
Tweak doc to show helper methods need not be public [ci-skip]

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -117,6 +117,8 @@ module AbstractController
       #   class ApplicationController < ActionController::Base
       #     helper_method :current_user, :logged_in?
       #
+      #     private
+      #
       #     def current_user
       #       @current_user ||= User.find_by(id: session[:user])
       #     end


### PR DESCRIPTION
### Motivation / Background
Helper methods defined in application_controller do not need to be public, and in the majority of cases I believe it's just better to be made private so they are not inherited by non-abstract controllers as potential actions. I'd like to let the doc reflect it and give suggestive impression that they perhaps should be private. 

For the similar matter, there is an example in the guides that uses the private version of `current_user` as example without declaring the helper: https://guides.rubyonrails.org/action_controller_overview.html#accessing-the-session

I bet it would be better if we could arrange two of them in a more consistent manner and erase the false impression that either should be public and the other private. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
