### PR TITLE
Revert "Use cached instance of ruby_version inside RubyGems"

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if RubyGems.ruby_version < Gem::Version.new("2.7.0") && RUBY_ENGINE == "ruby"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0") && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 


### PR DESCRIPTION

### Motivation / Background
@amatsuda 
3ba079526ba0fb8732e459e3a4ff30b990dc5ba4 breaks main branch.
https://buildkite.com/rails/rails/builds/92163#018581e9-84ac-47fa-86fb-9fff6d08e130
```
/rails/railties/lib/rails/ruby_version_check.rb:3:in `<top (required)>': uninitialized constant RubyGems (NameError)
```

Where should this constant be defined?
Since I don't know where is the good place, I revert this change. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
