### PR TITLE
Don't swallow exception in actionmailer/actionmailbox when requiring "mail" fails

### DIFF
--- a/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
+++ b/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
@@ -5,6 +5,6 @@ begin
 rescue LoadError => error
   if error.message.match?(/net\/smtp/)
     $stderr.puts "You don't have net-smtp installed in your application. Please add it to your Gemfile and run bundle install"
-    raise
   end
+  raise
 end

--- a/actionmailer/lib/action_mailer/mail_with_error_handling.rb
+++ b/actionmailer/lib/action_mailer/mail_with_error_handling.rb
@@ -5,6 +5,6 @@ begin
 rescue LoadError => error
   if error.message.match?(/net\/smtp/)
     $stderr.puts "You don't have net-smtp installed in your application. Please add it to your Gemfile and run bundle install"
-    raise
   end
+  raise
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

PR https://github.com/rails/rails/pull/44600 introduced a fallback for missing system dependencies related to the Mail gem. That PR had the unintended side effect of swallowing exceptions when require "mail"  fails.

For example, recently, there was a regression in the Mail gem, where [some of the files had their permission removed](https://github.com/mikel/mail/issues/1489). This caused issues during the Rails initialization process when certain conditions were met:
 - rails 6.1.x
 - ruby 3.0.x
 - mail 2.8.0
 - `config.eager_load = true`
 - gems installed using a different system user from the one used by http server process (e.g.: most docker-based installations)

`require "mail"` under these conditions would fail but Rails would swallow the exception, causing eager_load (and potentially other calls) to fail with [weird error messages](https://github.com/mikel/mail/issues/1553).

Vanilla rails app with minimal settings changes to demonstrate the bug: https://github.com/chitty/repro-46898

### Detail

This PR changes the code introduced in #44600 so that it always re-raises the exception.

This does not affect Rails 7 since the fallback isn't needed in that case, as mentioned in #44600:

> For Rails 7 we could just make those gems dependencies of the framework.
But in Rails 6.1, which we need to support old rubies, installing those
gems can cause trouble. So instead we are intercepting the error and
telling people to add the gem to the Gemfile.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (Didn't add tests, but added a [link to a repo](https://github.com/rails/rails/pull/46898) that reproduces the bug being solved)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
