### PR TITLE
add_index: don't generate invalid index names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -952,7 +952,7 @@ module ActiveRecord
       def index_name(table_name, options) # :nodoc:
         if Hash === options
           if options[:column]
-            "index_#{table_name}_on_#{Array(options[:column]) * '_and_'}"
+            "index_#{table_name}_on_#{Array(options[:column]) * '_and_'}"[0, index_name_length]
           elsif options[:name]
             options[:name]
           else

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -83,7 +83,7 @@ module ActiveRecord
 
       def test_add_index_generates_valid_index_name
         assert_nothing_raised do
-          connection.add_index(table_name, connection.index_name_length.times.map { "col#{_1}" })
+          connection.add_index(table_name, 3.times.map { "really_long_column_name_#{_1}" })
         end
       end
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -81,6 +81,12 @@ module ActiveRecord
         connection.add_index(table_name, "foo", name: good_index_name)
       end
 
+      def test_add_index_generates_valid_index_name
+        assert_nothing_raised do
+          connection.add_index(table_name, connection.index_name_length.times.map { "col#{_1}" })
+        end
+      end
+
       def test_add_index_which_already_exists_does_not_raise_error_with_option
         connection.add_index(table_name, "foo")
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -15,9 +15,9 @@ module ActiveRecord
         connection.create_table table_name do |t|
           t.column :foo, :string, limit: 100
           t.column :bar, :string, limit: 100
+          t.column :really_long_column_name_0, :string, limit: 100
           t.column :really_long_column_name_1, :string, limit: 100
           t.column :really_long_column_name_2, :string, limit: 100
-          t.column :really_long_column_name_3, :string, limit: 100
 
           t.string :first_name
           t.string :last_name, limit: 100

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -15,6 +15,9 @@ module ActiveRecord
         connection.create_table table_name do |t|
           t.column :foo, :string, limit: 100
           t.column :bar, :string, limit: 100
+          t.column :really_long_column_name_1, limit: 100
+          t.column :really_long_column_name_2, limit: 100
+          t.column :really_long_column_name_3, limit: 100
 
           t.string :first_name
           t.string :last_name, limit: 100

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -15,9 +15,9 @@ module ActiveRecord
         connection.create_table table_name do |t|
           t.column :foo, :string, limit: 100
           t.column :bar, :string, limit: 100
-          t.column :really_long_column_name_1, limit: 100
-          t.column :really_long_column_name_2, limit: 100
-          t.column :really_long_column_name_3, limit: 100
+          t.column :really_long_column_name_1, :string, limit: 100
+          t.column :really_long_column_name_2, :string, limit: 100
+          t.column :really_long_column_name_3, :string, limit: 100
 
           t.string :first_name
           t.string :last_name, limit: 100


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because adding an index on multiple columns does not always work out-of-the-box. This is due to the fact that the generated index name is sometimes longer than the maximum supported index name length.

### Detail

When the automatically generated index name is longer than the maximum supported index name length, This Pull Request automatically truncates the index name to the appropriate length.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ I don't think this is necessary here.
