### PR TITLE
Prevent writes on non-writing roles

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -167,7 +167,7 @@ module ActiveRecord
         raise NotImplementedError, "connected_to_many can only be called on ActiveRecord::Base."
       end
 
-      prevent_writes = true if role == ActiveRecord.reading_role
+      prevent_writes = true unless role == ActiveRecord.writing_role
 
       append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes)
       yield
@@ -183,7 +183,7 @@ module ActiveRecord
     # It is not recommended to use this method in a request since it
     # does not yield to a block like +connected_to+.
     def connecting_to(role: default_role, shard: default_shard, prevent_writes: false)
-      prevent_writes = true if role == ActiveRecord.reading_role
+      prevent_writes = true unless role == ActiveRecord.writing_role
 
       append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
     end
@@ -348,7 +348,7 @@ module ActiveRecord
       end
 
       def with_role_and_shard(role, shard, prevent_writes)
-        prevent_writes = true if role == ActiveRecord.reading_role
+        prevent_writes = true unless role == ActiveRecord.writing_role
 
         append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
         return_value = yield


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the logic to automatically prevent database writes assumes there is only a single reading role. While it's difficult to reason about this in absolute terms, I believe a more correct assumption is that applications will have a *single writing* role.

### Detail

This Pull Request changes the existing logic to allow writes on the `writing` role only and prevent them for all other roles.

### Additional information

Our application has multiple reading roles for different use-cases. On one hand, we have reads originating from HTTP GET requests, these reads are latency-sensitive and the database cache needs to stay hot. On the other hand, we have reads related to long-running, asynchronous data exports which read so much data that the database cache is never warm.
This mecanism is handled by two different read replicas; each has their own role (`reading` and `exports`).

Today the write-preventing logic does not apply to the `exports` role.

This write-preventing logic is essential while running transactional tests. Tests run in non-committed transactions, therefore test data is only visible if all roles actually use the same database connection. Since this database connection is essentially the connection to the writing role, it doesn't behave like a connection to a read-replica: postgres will happily accept writes.

tl,dr: `ActiveRecord::Base.connected_to(role: :exports) { User.take.touch }` doesn't fail in tests without this change. It should.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
I'm not entirely sure if this warrants tests / how exactly they should be written. I'll be happy to implement them if you can suggest a relevant test case and where to put it 🙏🏻 . I anticipate that `test_multiple_connections_works_in_a_threaded_environment` is going to break and I'm not sure what to do about it.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ I think this is a minor change and doesn't necessarily warrant a changelog update.
