### PR TITLE
Implement spot and don't use `keep_script_lines` in Ruby 3.2

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -228,7 +228,12 @@ module ActionDispatch
         end
 
         def spot(exc)
-          location = super
+          if RubyVM::AbstractSyntaxTree.respond_to?(:node_id_for_backtrace_location)
+            location = @template.spot(__getobj__)
+          else
+            location = super
+          end
+
           if location
             @template.translate_location(__getobj__, location)
           end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -154,11 +154,19 @@ module ActionView
       end
     end
 
+    def spot(location) # :nodoc:
+      ast = RubyVM::AbstractSyntaxTree.parse(compiled_source, keep_script_lines: true)
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(location)
+      node = find_node_by_id(ast, node_id)
+
+      ErrorHighlight.spot(node)
+    end
+
     # Translate an error location returned by ErrorHighlight to the correct
     # source location inside the template.
     def translate_location(backtrace_location, spot)
       if handler.respond_to?(:translate_location)
-        handler.translate_location(spot, backtrace_location, source)
+        handler.translate_location(spot, backtrace_location, encode!)
       else
         spot
       end
@@ -303,6 +311,17 @@ module ActionView
     end
 
     private
+      def find_node_by_id(node, node_id)
+        return node if node.node_id == node_id
+
+        node.children.grep(node.class).each do |child|
+          found = find_node_by_id(child, node_id)
+          return found if found
+        end
+
+        false
+      end
+
       # Compile a template. This method ensures a template is compiled
       # just once and removes the source after it is compiled.
       def compile!(view)

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -34,10 +34,6 @@ module Rails
         @filter_redirect                         = []
         @helpers_paths                           = []
         if Rails.env.development?
-          if defined?(RubyVM) && RubyVM.respond_to?(:keep_script_lines=)
-            RubyVM.keep_script_lines = true
-          end
-
           @hosts = ActionDispatch::HostAuthorization::ALLOWED_HOSTS_IN_DEVELOPMENT +
             ENV["RAILS_DEVELOPMENT_HOSTS"].to_s.split(",").map(&:strip)
         else


### PR DESCRIPTION
We want to use error highlight with eval'd code, specifically ERB templates.

Previously we could only get the information we needed by setting `keep_script_lines` to true. In Ruby 3.2 and error_highlight we added the ability to get this information without setting `keep_script_lines`.

This change implements that new behavior for Rails.

I've kept the script lines code in for 3.1 but we could consider removing it and say this only works for Ruby 3.2 and above.

Ruby change: https://github.com/ruby/ruby/pull/6593 Erorr highlight change: https://github.com/ruby/error_highlight/pull/26

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>