### PR TITLE
Fix Performance/StringInclude that RuboCop can't

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -293,7 +293,7 @@ module Mime
     end
 
     def html?
-      (symbol == :html) || /html/.match?(@string)
+      (symbol == :html) || @string.include?("html")
     end
 
     def all?; false; end

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -55,7 +55,7 @@ module ActionDispatch # :nodoc:
       private
         def html_response?(headers)
           if content_type = headers[CONTENT_TYPE]
-            /html/.match?(content_type)
+            content_type.include?("html")
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

Performance/StringInclude was enabled in 3158bbb, however RuboCop does not flag these two because it is unable to determine that the variable passed to #match? is a string. In both these cases we know that the variable must be a string (Mime::Type must be initialized with a string, and Content-Type must be a string if present per Rack SPEC)

### Detail

This replaces two instances of /html/.match?(<string>) with the more performant <string>.include?("html").

### Additional information

These were found by `rg '/\[\w ]+/\.match\?'`, and while this search returns other entries they are either comments or in test files.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
