### PR TITLE
Direct support for assigning to `self.response`.

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -186,7 +186,7 @@ module ActionController
     end
 
     def response_body=(body)
-      body = [body] unless body.nil? || body.respond_to?(:each)
+      body = [body] unless body.nil? || body.respond_to?(:each) || body.respond_to?(:call)
 
       if body
         response.body = body

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -186,9 +186,8 @@ module ActionController
     end
 
     def response_body=(body)
-      body = [body] unless body.nil? || body.respond_to?(:each) || body.respond_to?(:call)
-
       if body
+        body = [body] if body.is_a?(String)
         response.body = body
         super
       else

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -210,13 +210,14 @@ module ActionController
     end
 
     def set_response!(response) # :nodoc:
-      # Force `performed?` to return true:
       @_response = response
     end
 
     # Assign the response and mark it as committed. No further processing will occur.
     def response=(response)
       set_response!(response)
+
+      # Force `performed?` to return true:
       @_response_body = true
     end
 

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -210,6 +210,11 @@ module ActionController
     end
 
     def set_response!(response) # :nodoc:
+      if @_response
+        _, _, body = @_response
+        body.close if body.respond_to?(:close)
+      end
+
       @_response = response
     end
 

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -210,8 +210,12 @@ module ActionController
     end
 
     def set_response!(response) # :nodoc:
+      # Force `performed?` to return true:
+      @_response_body = true
       @_response = response
     end
+
+    alias :response= :set_response! # :nodoc:
 
     def set_request!(request) # :nodoc:
       @_request = request

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -211,11 +211,14 @@ module ActionController
 
     def set_response!(response) # :nodoc:
       # Force `performed?` to return true:
-      @_response_body = true
       @_response = response
     end
 
-    alias :response= :set_response! # :nodoc:
+    # Assign the response and mark it as committed. No further processing will occur.
+    def response=(response)
+      set_response!(response)
+      @_response_body = true
+    end
 
     def set_request!(request) # :nodoc:
       @_request = request

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -51,9 +51,9 @@ module BareMetalTest
       controller.rack_response_array
 
       assert controller.performed?
-      assert_equal ["Hello world"], controller.response_body
-      assert_equal 200, controller.response.status
-      assert_equal "text/html", controller.response.headers["content-type"]
+      assert_equal true, controller.response_body
+      assert_equal 200, controller.response[0]
+      assert_equal "text/html", controller.response[1]["content-type"]
     end
 
     test "can assign rack response object as part of the controller execution" do
@@ -62,7 +62,7 @@ module BareMetalTest
       controller.rack_response_object
 
       assert controller.performed?
-      assert_equal ["Hello world"], controller.response_body
+      assert_equal true, controller.response_body
       assert_equal 200, controller.response.status
       assert_equal "text/html", controller.response.headers["content-type"]
     end

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -9,12 +9,18 @@ module BareMetalTest
       self.response_body = "Hello world"
     end
 
-    def rack_response_array
+    def assign_response_array
       self.response = [200, { "content-type" => "text/html" }, ["Hello world"]]
     end
 
-    def rack_response_object
+    def assign_response_object
       self.response = Rack::Response.new("Hello world", 200, { "content-type" => "text/html" })
+    end
+
+    def assign_response_body_proc
+      self.response_body = proc do |stream|
+        stream.close
+      end
     end
   end
 
@@ -45,10 +51,10 @@ module BareMetalTest
       assert_equal ["Hello world"], controller.response_body
     end
 
-    test "can assign rack response array as part of the controller execution" do
+    test "can assign response array as part of the controller execution" do
       controller = BareController.new
       controller.set_request!(ActionDispatch::Request.empty)
-      controller.rack_response_array
+      controller.assign_response_array
 
       assert controller.performed?
       assert_equal true, controller.response_body
@@ -56,15 +62,27 @@ module BareMetalTest
       assert_equal "text/html", controller.response[1]["content-type"]
     end
 
-    test "can assign rack response object as part of the controller execution" do
+    test "can assign response object as part of the controller execution" do
       controller = BareController.new
       controller.set_request!(ActionDispatch::Request.empty)
-      controller.rack_response_object
+      controller.assign_response_object
 
       assert controller.performed?
       assert_equal true, controller.response_body
       assert_equal 200, controller.response.status
       assert_equal "text/html", controller.response.headers["content-type"]
+    end
+
+    test "can assign response body streamable object as part of the controller execution" do
+      controller = BareController.new
+      controller.set_request!(ActionDispatch::Request.empty)
+      controller.set_response!(BareController.make_response!(controller.request))
+      controller.assign_response_body_proc
+
+      assert controller.performed?
+      assert controller.response_body.is_a?(Proc)
+      assert_equal 200, controller.response.status
+      assert controller.response.headers.empty?
     end
 
     test "connect a request to controller instance without dispatch" do

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -56,7 +56,7 @@ module BareMetalTest
       assert_equal "text/html", controller.response.headers["content-type"]
     end
 
-    test "can assign rack response array as part of the controller execution" do
+    test "can assign rack response object as part of the controller execution" do
       controller = BareController.new
       controller.set_request!(ActionDispatch::Request.empty)
       controller.rack_response_object

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -8,6 +8,14 @@ module BareMetalTest
     def index
       self.response_body = "Hello world"
     end
+
+    def rack_response_array
+      self.response = [200, {"content-type" => "text/html"}, ["Hello world"]]
+    end
+
+    def rack_response_object
+      self.response = Rack::Response.new("Hello world", 200, {"content-type" => "text/html"})
+    end
   end
 
   class BareTest < ActiveSupport::TestCase
@@ -32,7 +40,31 @@ module BareMetalTest
       controller.set_request!(ActionDispatch::Request.empty)
       controller.set_response!(BareController.make_response!(controller.request))
       controller.index
+
+      assert controller.performed?
       assert_equal ["Hello world"], controller.response_body
+    end
+
+    test "can assign rack response array as part of the controller execution" do
+      controller = BareController.new
+      controller.set_request!(ActionDispatch::Request.empty)
+      controller.rack_response_array
+
+      assert controller.performed?
+      assert_equal ["Hello world"], controller.response_body
+      assert_equal 200, controller.response.status
+      assert_equal "text/html", controller.response.headers["content-type"]
+    end
+
+    test "can assign rack response array as part of the controller execution" do
+      controller = BareController.new
+      controller.set_request!(ActionDispatch::Request.empty)
+      controller.rack_response_object
+
+      assert controller.performed?
+      assert_equal ["Hello world"], controller.response_body
+      assert_equal 200, controller.response.status
+      assert_equal "text/html", controller.response.headers["content-type"]
     end
 
     test "connect a request to controller instance without dispatch" do

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -10,11 +10,11 @@ module BareMetalTest
     end
 
     def rack_response_array
-      self.response = [200, {"content-type" => "text/html"}, ["Hello world"]]
+      self.response = [200, { "content-type" => "text/html" }, ["Hello world"]]
     end
 
     def rack_response_object
-      self.response = Rack::Response.new("Hello world", 200, {"content-type" => "text/html"})
+      self.response = Rack::Response.new("Hello world", 200, { "content-type" => "text/html" })
     end
   end
 


### PR DESCRIPTION
Allow assigning a `Rack::Response` to `self.response` in a Rails controller, which prevents any further rendering. This allows us to directly supply the rack response which can support both enumerable and streaming bodies in Rack 3. Tests include example usage.

```ruby
class MyController < ActionController::Base
  def streaming_csv
    body = proc new do |stream|
      csv = CSV.new(stream)
      # generate csv output
    end

    self.response = [200, {'content-type' => 'text/csv'}, body]
  end
end
```

An alternative approach to setting `@_response_body = true` would be to implement `#performed?` like so:

```ruby
    def performed?
      if response.respond_to?(:committed?)
        return response.committed?
      end
      
      # If we are not committed as per the above, we are performed if the response (or response body) was assigned:
      !!(@_response_body || @_response)
    end
```

In addition, calling `set_response!` should probably close the previous response, if there was any:

```ruby
    def set_response!(response) # :nodoc:
      if @_response
        _, _, body = @_response
        body.close if body.respond_to?(:close)
      end

      @_response = response
    end
```