### PR TITLE
Allow setting config.hosts to nil again

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -13,7 +13,7 @@ module Rails
 
       def build_stack
         ActionDispatch::MiddlewareStack.new do |middleware|
-          unless config.hosts.empty?
+          unless config.hosts.nil? || config.hosts.empty?
             middleware.use ::ActionDispatch::HostAuthorization, config.hosts, **config.host_authorization
           end
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -154,6 +154,13 @@ module ApplicationTests
       assert_not_includes middleware, "ActionDispatch::HostAuthorization"
     end
 
+    test "ActionDispatch::HostAuthorization is not included if hosts is set to nil" do
+      add_to_config "config.hosts = nil"
+      boot!
+
+      assert_not_includes middleware, "ActionDispatch::HostAuthorization"
+    end
+
     test "Rack::Cache is not included by default" do
       boot!
 


### PR DESCRIPTION
### Motivation / Background

Prior to #46858, uses can set `config.hosts = nil` to allow all hosts. But now it causes `NoMethodError` because the check uses only `empty?`.

### Detail

Given that the `HostAuthorization` itself [allows taking `nil` as hosts](https://github.com/rails/rails/blob/ab8128e7c8f5529808bc0ccc70331501c82c480e/actionpack/test/dispatch/host_authorization_test.rb#L27-L34), I think this breaking change is not intentional. Therefore this commit fixes the issue by also checking if the value is `nil`.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
