### PR TITLE
Trivial performance improvements for Inflector methods

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -232,7 +232,10 @@ module ActiveSupport
     #   classify('calculus')     # => "Calculu"
     def classify(table_name)
       # strip out any leading schema name
-      camelize(singularize(table_name.to_s.sub(/.*\./, "")))
+      table_name = table_name.to_s
+      dot_idx = table_name.index(".")
+      table_name = table_name[dot_idx + 1, table_name.length] if dot_idx && dot_idx > 0
+      camelize(singularize(table_name))
     end
 
     # Replaces underscores with dashes in the string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -163,7 +163,14 @@ module ActiveSupport
     #   upcase_first('w')                 # => "W"
     #   upcase_first('')                  # => ""
     def upcase_first(string)
-      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
+      case string.length
+      when 0
+        ""
+      when 1
+        string.upcase
+      else
+        string[0].upcase.concat(string[1..-1])
+      end
     end
 
     # Converts the first character in the string to lowercase.
@@ -172,7 +179,14 @@ module ActiveSupport
     #   downcase_first('I')                          # => "i"
     #   downcase_first('')                           # => ""
     def downcase_first(string)
-      string.length > 0 ? string[0].downcase.concat(string[1..-1]) : ""
+      case string.length
+      when 0
+        ""
+      when 1
+        string.downcase
+      else
+        string[0].downcase.concat(string[1..-1])
+      end
     end
 
     # Capitalizes all the words and replaces some characters in the string to

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -280,7 +280,7 @@ module ActiveSupport
     #   foreign_key('Message', false) # => "messageid"
     #   foreign_key('Admin::Post')    # => "post_id"
     def foreign_key(class_name, separate_class_name_and_id_with_underscore = true)
-      underscore(demodulize(class_name)) + (separate_class_name_and_id_with_underscore ? "_id" : "id")
+      underscore(demodulize(class_name)) << (separate_class_name_and_id_with_underscore ? "_id" : "id")
     end
 
     # Tries to find a constant with the name specified in the argument string.

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -169,7 +169,7 @@ module ActiveSupport
       when 1
         string.upcase
       else
-        string[0].upcase.concat(string[1..-1])
+        string[0].upcase.concat(string[1, string.length])
       end
     end
 
@@ -185,7 +185,7 @@ module ActiveSupport
       when 1
         string.downcase
       else
-        string[0].downcase.concat(string[1..-1])
+        string[0].downcase.concat(string[1, string.length])
       end
     end
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -147,9 +147,9 @@ module ActiveSupport
       end
 
       if capitalize
-        result.sub!(/\A\w/) do |match|
-          match.upcase!
-          match
+        first = result[0]
+        if first.upcase!
+          result[0] = first
         end
       end
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -132,6 +132,7 @@ module ActiveSupport
     #
     def humanize(lower_case_and_underscored_word, capitalize: true, keep_id_suffix: false)
       result = lower_case_and_underscored_word.to_s.dup
+      return result if result.empty?
 
       inflections.humans.each { |(rule, replacement)| break if result.sub!(rule, replacement) }
 


### PR DESCRIPTION
### Detail

Here are some patches that make Inflector methods a little bit more effective and GC friendly.

### Benchmark Results

```ruby
Benchmark.ips do |x|
  x.report('old') do
    ActiveSupport::Inflector.humanize_old('foo')
  end
  x.report('new') do
    ActiveSupport::Inflector.humanize('foo')
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old    53.656k i/100ms
                 new    59.915k i/100ms
Calculating -------------------------------------
                 old    534.355k (± 1.1%) i/s -      2.683M in   5.021228s
                 new    595.682k (± 1.0%) i/s -      2.996M in   5.029576s

Comparison:
                 new:   595682.2 i/s
                 old:   534354.7 i/s - 1.11x  (± 0.00) slower
```
<hr>

```ruby
Benchmark.ips do |x|
  x.report('old') do
    ActiveSupport::Inflector.upcase_first_old('x')
  end
  x.report('new') do
    ActiveSupport::Inflector.upcase_first('x')
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old   571.482k i/100ms
                 new   841.763k i/100ms
Calculating -------------------------------------
                 old      7.202M (± 0.8%) i/s -     36.575M in   5.078753s
                 new     11.487M (± 1.3%) i/s -     58.082M in   5.057086s

Comparison:
                 new: 11487367.0 i/s
                 old:  7202053.4 i/s - 1.60x  (± 0.00) slower
```
<hr>

```ruby
Benchmark.ips do |x|
  x.report('old') do
    ActiveSupport::Inflector.upcase_first_old('hello')
  end
  x.report('new') do
    ActiveSupport::Inflector.upcase_first('hello')
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old   569.202k i/100ms
                 new   645.977k i/100ms
Calculating -------------------------------------
                 old      6.930M (± 3.8%) i/s -     34.721M in   5.018755s
                 new      7.305M (± 1.0%) i/s -     36.821M in   5.041038s

Comparison:
                 new:  7304880.0 i/s
                 old:  6929655.8 i/s - 1.05x  (± 0.00) slower
```
<hr>

```ruby
Benchmark.ips do |x|
  x.report('old') do
    ActiveSupport::Inflector.foreign_key_old('Hello')
  end
  x.report('new') do
    ActiveSupport::Inflector.foreign_key('Hello')
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old   114.517k i/100ms
                 new   117.846k i/100ms
Calculating -------------------------------------
                 old      1.116M (± 4.2%) i/s -      5.666M in   5.088369s
                 new      1.193M (± 1.4%) i/s -      5.985M in   5.017492s

Comparison:
                 new:  1193154.1 i/s
                 old:  1115716.2 i/s - 1.07x  (± 0.00) slower

```

```ruby
Benchmark.ips do |x|
  x.report('old') do
    ActiveSupport::Inflector.classify_old('foo.bars')
  end
  x.report('new') do
    ActiveSupport::Inflector.classify('foo.bars')
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old    12.110k i/100ms
                 new    12.568k i/100ms
Calculating -------------------------------------
                 old    122.328k (± 1.0%) i/s -    617.610k in   5.049271s
                 new    126.656k (± 1.0%) i/s -    640.968k in   5.061174s

Comparison:
                 new:   126656.2 i/s
                 old:   122328.3 i/s - 1.04x  (± 0.00) slower
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
