### PR TITLE
Allow setting config.hosts to single IPAddr

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -13,7 +13,7 @@ module Rails
 
       def build_stack
         ActionDispatch::MiddlewareStack.new do |middleware|
-          unless config.hosts.nil? || config.hosts.empty?
+          unless Array(config.hosts).empty?
             middleware.use ::ActionDispatch::HostAuthorization, config.hosts, **config.host_authorization
           end
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -161,6 +161,13 @@ module ApplicationTests
       assert_not_includes middleware, "ActionDispatch::HostAuthorization"
     end
 
+    test "ActionDispatch::HostAuthorization is included if hosts is set to IPAddr" do
+      add_to_config "config.hosts = IPAddr.new('0.0.0.0/0')"
+      boot!
+
+      assert_includes middleware, "ActionDispatch::HostAuthorization"
+    end
+
     test "Rack::Cache is not included by default" do
       boot!
 


### PR DESCRIPTION
### Motivation / Background

This was broken in 0019dea and partially fixed for setting config.hosts to a nil value in 56ecea0.

### Detail

However, since HostAuthorization coerces the hosts param to an array to allow a single String or IPAddr as a valid value, the check should do the same.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
