### PR TITLE
Remove not null primary key condition from associated method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -63,7 +63,6 @@ module ActiveRecord
       #    Post.where.associated(:author)
       #    # SELECT "posts".* FROM "posts"
       #    # INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
-      #    # WHERE "authors"."id" IS NOT NULL
       #
       # Additionally, multiple relations can be combined. This will return posts
       # associated to both an author and any comments:
@@ -72,12 +71,10 @@ module ActiveRecord
       #    # SELECT "posts".* FROM "posts"
       #    # INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # INNER JOIN "comments" ON "comments"."post_id" = "posts"."id"
-      #    # WHERE "authors"."id" IS NOT NULL AND "comments"."id" IS NOT NULL
       def associated(*associations)
         associations.each do |association|
-          reflection = scope_association_reflection(association)
+          scope_association_reflection(association)
           @scope.joins!(association)
-          self.not(association => { reflection.association_primary_key => nil })
         end
 
         @scope
@@ -816,7 +813,6 @@ module ActiveRecord
     #    Post.where.associated(:author)
     #    # SELECT "posts".* FROM "posts"
     #    # INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
-    #    # WHERE "authors"."id" IS NOT NULL
     #
     # Chaining with WhereChain#missing:
     #

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1425,7 +1425,6 @@ Produces:
 ```sql
 SELECT customers.* FROM customers
 INNER JOIN reviews ON reviews.customer_id = customers.id
-WHERE reviews.customer_id IS NOT NULL
 ```
 
 Which means "return all customers that have made at least one review".
@@ -1441,7 +1440,7 @@ Produces:
 ```sql
 SELECT customers.* FROM customers
 LEFT OUTER JOIN reviews ON reviews.customer_id = customers.id
-WHERE reviews.customer_id IS NULL
+WHERE reviews.id IS NULL
 ```
 
 Which means "return all customers that have not made any reviews".


### PR DESCRIPTION
This pull request removes `WHERE "authors"."id" IS NOT NULL` when looking for associated records using the `where.associated` method, since we're already using the `INNER JOIN` clause and primary keys are not nullable this condition is useless.

## More details

https://github.com/rails/rails/pull/40696#issuecomment-734918163

Cc: @p8 
