### PR TITLE
Fix activejob integration test for Sidekiq 6

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -54,7 +54,7 @@ module SidekiqJobsManager
 
       require "sidekiq/cli"
       require "sidekiq/launcher"
-      if Sidekiq::MAJOR >= 7
+      if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7")
         config = Sidekiq.default_configuration
         config.queues = ["integration_tests"]
         config.concurrency = 1


### PR DESCRIPTION
### Motivation / Background

Sidekiq::MAJOR was added in mperham/sidekiq@b4092e3, which is only included in 7.0.0+ so we can't use it to check the version for Sidekiq 6.

### Detail

Since the test code is written to support both, the condition should also support both.

### Additional information

I believe this should be backported to 7-0-stable. I intentionally did not do `Gem::Version.new(Sidekiq::VERSION) >= "7"` so that this commit can be backported.

PR for 6-1-stable is here: #46922 with an additional backport

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
