### PR TITLE
Fix more ci issues for Ruby 2.6

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -53,7 +53,7 @@ module SidekiqJobsManager
 
       require "sidekiq/cli"
       require "sidekiq/launcher"
-      if Sidekiq::MAJOR >= 7
+      if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7")
         config = Sidekiq.default_configuration
         config.queues = ["integration_tests"]
         config.concurrency = 1

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -32,7 +32,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   test "table options with CHARSET" do
     @connection.create_table "mysql_table_options", force: true, options: "CHARSET=latin1"
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", charset: "latin1", force: :cascade/
+    expected = /create_table "mysql_table_options", charset: "latin1"(?:, collation: "\w+")?, force: :cascade/
     assert_match expected, output
   end
 


### PR DESCRIPTION
### Motivation / Background

CI is currently failing for Ruby 2.6

### Detail

See individual commits. Backports of #46511 and #46921

### Additional information

I also opened rubygems/rubygems#6251 as I believe the `DidYouMean` errors are caused by Bundler.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
