### PR TITLE
Fix ActiveRecord grouped calculations on joined tables on column present in both tables

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -491,9 +491,10 @@ module ActiveRecord
           end
 
           key_types = group_columns.each_with_object({}) do |(aliaz, col_name), types|
-            types[aliaz] = type_for(col_name) do
-              calculated_data.column_types.fetch(aliaz, Type.default_value)
-            end
+            types[aliaz] = col_name.try(:type_caster) ||
+              type_for(col_name) do
+                calculated_data.column_types.fetch(aliaz, Type.default_value)
+              end
           end
 
           hash_rows = calculated_data.cast_values(key_types).map! do |row|

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1551,7 +1551,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_attribute_names
-    expected = ["id", "type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id", "description", "metadata"]
+    expected = ["id", "type", "firm_id", "firm_name", "name", "client_of", "rating", "account_id", "description", "status", "metadata"]
     assert_equal expected, Company.attribute_names
   end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -658,6 +658,14 @@ class CalculationsTest < ActiveRecord::TestCase
     [1, 6, 2, 9].each { |firm_id| assert_includes c.keys, firm_id }
   end
 
+  def test_should_count_field_in_joined_table_with_group_by_when_tables_share_column_names
+    assert Company.columns_hash.key?("status")
+    assert Account.columns_hash.key?("status")
+
+    counts = Company.joins(:account).group("accounts.status").count
+    assert_equal({ "active" => 2, "trial" => 2, "suspended" => 1 }, counts)
+  end
+
   def test_should_count_field_of_root_table_with_conflicting_group_by_column
     expected = { 1 => 2, 2 => 1, 4 => 5, 5 => 3, 7 => 1 }
     assert_equal expected, Post.joins(:comments).group(:post_id).count
@@ -817,9 +825,9 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_pluck_without_column_names
     if current_adapter?(:OracleAdapter)
-      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, nil]], Company.order(:id).limit(1).pluck
+      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, nil, "active"]], Company.order(:id).limit(1).pluck
     else
-      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, ""]], Company.order(:id).limit(1).pluck
+      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, "", "active"]], Company.order(:id).limit(1).pluck
     end
   end
 

--- a/activerecord/test/fixtures/accounts.yml
+++ b/activerecord/test/fixtures/accounts.yml
@@ -3,6 +3,7 @@ signals37:
   firm_id: 1
   credit_limit: 50
   firm_name: 37signals
+  status: "active"
 
 unknown:
   id: 2
@@ -12,18 +13,22 @@ rails_core_account:
   id: 3
   firm_id: 6
   credit_limit: 50
+  status: "suspended"
 
 last_account:
   id: 4
   firm_id: 2
   credit_limit: 60
+  status: "trial"
 
 rails_core_account_2:
   id: 5
   firm_id: 6
   credit_limit: 55
+  status: "active"
 
 odegy_account:
   id: 6
   firm_id: 9
   credit_limit: 53
+  status: "trial"

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -7,6 +7,8 @@ end
 class Company < AbstractCompany
   self.sequence_name = :companies_nonstd_seq
 
+  enum :status, [:active, :suspended]
+
   validates_presence_of :name
 
   has_one :account, foreign_key: "firm_id"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define do
     t.references :firm, index: false
     t.string  :firm_name
     t.integer :credit_limit
+    t.string :status
     t.integer "a" * max_identifier_length
     t.datetime :updated_at
   end
@@ -296,6 +297,7 @@ ActiveRecord::Schema.define do
     t.bigint :rating, default: 1
     t.integer :account_id
     t.string :description, default: ""
+    t.integer :status, default: 0
     t.index [:name, :rating], order: :desc
     t.index [:name, :description], length: 10
     t.index [:firm_id, :type, :rating], name: "company_index", length: { type: 10 }, order: { rating: :desc }


### PR DESCRIPTION
Fixes #46892.

The previous logic always used a root class (`klass`) from the relation to get the column type, which is incorrect and the class from where that column came from should be used. 
Similar solution (`column.try(:type_caster)`) is used in many other places through the `calculations.rb` file. 