### PR TITLE
Add guide for `ActiveSupport::Deprecation.silenced` [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2207,6 +2207,10 @@ Is set to `false` to disable the ability to silence logging in a block. The defa
 
 Specifies the logger to use within cache store operations.
 
+#### `ActiveSupport::Deprecation.silenced`
+
+Is set to `true` to stop output all deprecation warnings. The default is `false`.
+
 #### `ActiveSupport.to_time_preserves_timezone`
 
 Specifies whether `to_time` methods preserve the UTC offset of their receivers. If `false`, `to_time` methods will convert to the local system UTC offset instead.


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::Deprecation.silenced` has a setter defined and can be set by the application.

https://github.com/rails/rails/blob/main/activesupport/lib/active_support/deprecation/deprecators.rb#L46-L49

No guide existed for this setting so I added it.
### Additional information

default is set at:

https://github.com/rails/rails/blob/main/activesupport/lib/active_support/deprecation.rb#L46

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
