### PR TITLE
Fix compatability between tests and Sidekiq 6.5

### DIFF
--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -64,6 +64,13 @@ module SidekiqJobsManager
           timeout: 1,
           poll_interval_average: 1
         )
+      elsif Sidekiq.respond_to?(:[]=)
+        # Sidekiq 6.5
+        config = Sidekiq
+        config[:queues] = ["integration_tests"]
+        config[:environment] = "test"
+        config[:concurrency] = 1
+        config[:timeout] = 1
       else
         config = {
           queues: ["integration_tests"],
@@ -117,7 +124,7 @@ module SidekiqJobsManager
   end
 
   def set_logger(logger)
-    if Sidekiq::MAJOR >= 7
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7")
       Sidekiq.default_configuration.logger = logger
     else
       Sidekiq.logger = logger


### PR DESCRIPTION
### Motivation / Background

Since Sidekiq 7.0 requires Ruby 2.7, older versions of Rails that support older Rubies are still tested against Sidekiq 6.x.

### Detail

Sidekiq::MAJOR was added in 7.0, see 862dc5b

The config change is due to changes in Sidekiq 6.5. These were accounted for in 7a069dc but removed in 6d31993.

### Additional information

This should definitely be backported to `7-0-stable` and `6-1-stable`. It looks like #46373 was also backported to `6-0-stable`, so it could be backported there as well (but I didn't think it was supported?)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
