### PR TITLE
Fix bundle install broken in Ruby 2.5 image builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,12 @@ gem "minitest", "~> 5.15.0"
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 
-# We need a newish Rake since Active Job sets its test tasks' descriptions.
-gem "rake", ">= 13"
+if RUBY_VERSION > "2.6"
+  # We need a newish Rake since Active Job sets its test tasks' descriptions.
+  gem "rake", ">= 13"
+else
+  gem "rake", ">= 11.1"
+end
 
 gem "capybara", ">= 3.26"
 gem "selenium-webdriver", "< 4.2"
@@ -175,7 +179,24 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
 
-if RUBY_VERSION <= "3.0"
+if RUBY_VERSION < "2.6"
+  # mail 2.8.0 defines net-smtp, net-imap, and net-pop as dependencies. All of
+  # these gems depend on the net-protocol gem. There's an issue in Ruby <= 2.7
+  # where the built in net-http uses require_relative to load built in
+  # net-protocol.
+  #
+  # To prevent warnings from net-protocol being loaded from two different
+  # places, we add net-http as an extra gem dependency so that the built in
+  # net-http is never required (so that built in net-protocol is never
+  # required).
+  #
+  # However, this workaround is impossible on Ruby 2.5 as net-http 0.1.0 has a
+  # minimum ruby version of 2.6.0. So to prevent redefinition warnings, we can
+  # lock mail so that the gem version of net-protocol is never required.
+  gem "mail", "< 2.8.0"
+
+  gem "strscan"
+elsif RUBY_VERSION <= "3.0"
   gem "net-http", require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ else
 end
 
 gem "capybara", ">= 3.26"
-gem "selenium-webdriver", "< 4.2"
+gem "selenium-webdriver", ">= 4.0.0.alpha7", "< 4.2"
 
 gem "rack-cache", "~> 1.2"
 gem "sass-rails"


### PR DESCRIPTION
There are two issues being fixed:

The first is that sneakers 2.12.0 requires rake 12, and bundler has trouble resolving this. This was reported as an issue in bundler 2.4.0-dev but appears to also affect 2.3.26 somehow. Since bundler 2.4+ no longer supports Ruby 2.5 it seems easier to relax the rake version on Ruby 2.5 than try to fix bundler.

The other is a continuation of the net-http issues. mail 2.8.0 defines net-smtp, net-imap, and net-pop as dependencies. All of these gems depend on the net-protocol gem. There's an issue in Ruby <= 2.7 where the built in net-http uses require_relative to load built in net-protocol.

To prevent warnings from net-protocol being loaded from two different places, we add net-http as an extra gem dependency so that the built in net-http is never required (so that built in net-protocol is never required).

However, this workaround is impossible on Ruby 2.5 as net-http 0.1.0 has a minimum ruby version of 2.6.0. So to prevent redefinition warnings, we can lock mail so that the gem version of net-protocol is never required.

Finally, strscan needs to be added to the Gemfile because it was previously a dependency of net-imap and the bug report templates need certain gems (like strscan) installed before they run or they will error out. See commits like 76ac6e9a9895cf6d431d8932547b6f721e08d86f, 48c9b48284e914e49b758b1777bfe8219f7b64f5, and 2e8381c8b25fc8ef92a7cc8c65666452bef5aee2 for related fixes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
