### PR TITLE
Add a default health controller

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add Rails::HealthController#show and map it to /up for newly generated applications.
+    Load balancers and uptime monitors all need a basic endpoint to tell whether the app is up.
+    This is a good starting point that'll work in many situations.
+
+    *DHH*
+
 *   Only use HostAuthorization middleware if `config.hosts` is not empty
 
     *Hartley McGuire*

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -28,6 +28,7 @@ module Rails
   extend ActiveSupport::Autoload
   extend ActiveSupport::Benchmarkable
 
+  autoload :HealthController
   autoload :Info
   autoload :InfoController
   autoload :MailersController

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up" => "rails/health#show"
+
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/railties/lib/rails/health_controller.rb
+++ b/railties/lib/rails/health_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Rails::HealthController < ActionController::Base # :nodoc:
+  rescue_from(Exception) { render_down }
+
+  def show
+    render_up
+  end
+
+  private
+    def render_up
+      render html: html_status(color: "green")
+    end
+
+    def render_down
+      render html: html_status(color: "red"), status: 500
+    end
+
+    def html_status(color:)
+      %(<html><body style="background-color: #{color}"></body></html>).html_safe
+    end
+end

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -130,6 +130,19 @@ module ApplicationTests
       assert_equal 404, last_response.status
     end
 
+    test "rails/health in production" do
+      app("production")
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "up" => "rails/health#show"
+        end
+      RUBY
+
+      get "/up"
+      assert_equal 200, last_response.status
+    end
+
     test "simple controller" do
       simple_controller
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -361,8 +361,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     route_path = File.expand_path("config/routes.rb", destination_root)
     content = File.read(route_path)
 
-    # Remove all of the comments and blank lines from the routes file
+    # Remove all of the comments, blank lines, and default health controller from the routes file
     content.gsub!(/^  \#.*\n/, "")
+    content.gsub!(/^  get "up".*\n/, "")
     content.gsub!(/^\n/, "")
 
     File.write(route_path, content)


### PR DESCRIPTION
Load balancers and uptime monitors all need a basic endpoint to tell whether the app is up. Here's a good starting point that'll work in many situations.