### PR TITLE
omit assets:precompile in Dockerfile for api only apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -41,9 +41,11 @@ COPY . .
 RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
 <% end -%>
+<% unless options.api? -%>
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
 
+<% end -%>
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1039,8 +1039,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Dockerfile" do |content|
+      assert_match(/assets:precompile/, content)
       assert_match(/libvips/, content)
       assert_no_match(/yarn/, content)
+    end
+  end
+
+  def test_api
+    run_generator [destination_root, "--api"]
+
+    assert_file "Dockerfile" do |content|
+      assert_no_match(/assets:precompile/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because api only rails applications don't have assets to precompile, and any attempt to run assets:precompile during a docker build will fail for such application.

### Detail

This Pull Request omits the `RUN bundle exec rails assets:precompile` step for api only applications.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.

No changelog entry is needed for this change.
