### PR TITLE
Use `#except!` in `HashWithIndifferentAccess#except`

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -305,7 +305,7 @@ module ActiveSupport
     #   hash.except(:a, "b") # => {c: 10}.with_indifferent_access
     #   hash                 # => { a: "x", b: "y", c: 10 }.with_indifferent_access
     def except(*keys)
-      slice(*self.keys - keys.map { |key| convert_key(key) })
+      dup.except!(*keys)
     end
     alias_method :without, :except
 


### PR DESCRIPTION
This avoids multiple unnecessary allocations.

__Benchmark__

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "active_support/all"

  class ActiveSupport::HashWithIndifferentAccess
    def old_except(*keys)
      slice(*self.keys - keys.map { |key| convert_key(key) })
    end

    def new_except(*keys)
      dup.except!(*keys)
    end
  end

  hwia = { foo: 1, bar: 2, baz: 3, qux: 4 }.with_indifferent_access
  splat_keys = [:bar, :baz]

  Benchmark.ips do |x|
    x.report("old except 1") do
      hwia.old_except(:bar)
    end

    x.report("new except 1") do
      hwia.new_except(:bar)
    end

    x.compare!
  end

  Benchmark.ips do |x|
    x.report("old except splat") do
      hwia.old_except(*splat_keys)
    end

    x.report("new except splat") do
      hwia.new_except(*splat_keys)
    end

    x.compare!
  end
  ```

__Results__

  ```
  Warming up --------------------------------------
          old except 1    18.079k i/100ms
          new except 1    28.205k i/100ms
  Calculating -------------------------------------
          old except 1    180.832k (± 1.7%) i/s -    903.950k in   5.000295s
          new except 1    282.729k (± 1.2%) i/s -      1.438M in   5.088540s

  Comparison:
          new except 1:   282729.2 i/s
          old except 1:   180831.5 i/s - 1.56x  (± 0.00) slower

  Warming up --------------------------------------
      old except splat    19.309k i/100ms
      new except splat    25.932k i/100ms
  Calculating -------------------------------------
      old except splat    194.091k (± 1.6%) i/s -    984.759k in   5.075044s
      new except splat    255.873k (± 1.3%) i/s -      1.297M in   5.068184s

  Comparison:
      new except splat:   255873.0 i/s
      old except splat:   194091.3 i/s - 1.32x  (± 0.00) slower
  ```
