### PR TITLE
Use `map!` in `HashWithIndifferentAccess#values_at`

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -233,7 +233,8 @@ module ActiveSupport
     #   hash[:b] = 'y'
     #   hash.values_at('a', 'b') # => ["x", "y"]
     def values_at(*keys)
-      super(*keys.map { |key| convert_key(key) })
+      keys.map! { |key| convert_key(key) }
+      super
     end
 
     # Returns an array of the values at the specified indices, but also


### PR DESCRIPTION
This avoids an extra allocation from `map`.

__Benchmark__

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "active_support/all"

  Hash.alias_method(:old_values_at, :values_at)
  Hash.alias_method(:new_values_at, :values_at)

  class ActiveSupport::HashWithIndifferentAccess
    def old_values_at(*keys)
      super(*keys.map { |key| convert_key(key) })
    end

    def new_values_at(*keys)
      keys.map! { |key| convert_key(key) }
      super
    end
  end

  hwia = { foo: 1, bar: 2, baz: 3, qux: 4 }.with_indifferent_access
  splat_keys = [:bar, :baz]

  Benchmark.ips do |x|
    x.report("old values_at 1") do
      hwia.old_values_at(:bar)
    end

    x.report("new values_at 1") do
      hwia.new_values_at(:bar)
    end

    x.compare!
  end

  Benchmark.ips do |x|
    x.report("old values_at splat") do
      hwia.old_values_at(*splat_keys)
    end

    x.report("new values_at splat") do
      hwia.new_values_at(*splat_keys)
    end

    x.compare!
  end
  ```

__Results__

  ```
  Warming up --------------------------------------
       old values_at 1   150.881k i/100ms
       new values_at 1   163.731k i/100ms
  Calculating -------------------------------------
       old values_at 1      1.509M (± 1.3%) i/s -      7.695M in   5.099286s
       new values_at 1      1.646M (± 1.1%) i/s -      8.350M in   5.072959s

  Comparison:
       new values_at 1:  1646260.9 i/s
       old values_at 1:  1509283.6 i/s - 1.09x  (± 0.00) slower

  Warming up --------------------------------------
   old values_at splat   110.815k i/100ms
   new values_at splat   118.871k i/100ms
  Calculating -------------------------------------
   old values_at splat      1.118M (± 1.3%) i/s -      5.652M in   5.057480s
   new values_at splat      1.194M (± 0.9%) i/s -      6.062M in   5.077104s

  Comparison:
   new values_at splat:  1194171.4 i/s
   old values_at splat:  1117670.4 i/s - 1.07x  (± 0.00) slower
  ```
