### PR TITLE
Use `map!` in `HashWithIndifferentAccess#fetch_values`

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -246,7 +246,8 @@ module ActiveSupport
     #   hash.fetch_values('a', 'c') { |key| 'z' } # => ["x", "z"]
     #   hash.fetch_values('a', 'c') # => KeyError: key not found: "c"
     def fetch_values(*indices, &block)
-      super(*indices.map { |key| convert_key(key) }, &block)
+      indices.map! { |key| convert_key(key) }
+      super
     end
 
     # Returns a shallow copy of the hash.


### PR DESCRIPTION
This avoids an extra allocation from `map`.

__Benchmark__

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "active_support/all"

  Hash.alias_method(:old_fetch_values, :fetch_values)
  Hash.alias_method(:new_fetch_values, :fetch_values)

  class ActiveSupport::HashWithIndifferentAccess
    def old_fetch_values(*indices, &block)
      super(*indices.map { |key| convert_key(key) }, &block)
    end

    def new_fetch_values(*indices, &block)
      indices.map! { |key| convert_key(key) }
      super
    end
  end

  hwia = { foo: 1, bar: 2, baz: 3, qux: 4 }.with_indifferent_access
  splat_keys = [:bar, :baz]

  Benchmark.ips do |x|
    x.report("old fetch_values 1") do
      hwia.old_fetch_values(:bar)
    end

    x.report("new fetch_values 1") do
      hwia.new_fetch_values(:bar)
    end

    x.compare!
  end

  Benchmark.ips do |x|
    x.report("old fetch_values splat") do
      hwia.old_fetch_values(*splat_keys)
    end

    x.report("new fetch_values splat") do
      hwia.new_fetch_values(*splat_keys)
    end

    x.compare!
  end
  ```

__Results__

  ```
  Warming up --------------------------------------
    old fetch_values 1   150.459k i/100ms
    new fetch_values 1   162.756k i/100ms
  Calculating -------------------------------------
    old fetch_values 1      1.503M (± 1.3%) i/s -      7.523M in   5.006517s
    new fetch_values 1      1.620M (± 1.0%) i/s -      8.138M in   5.022927s

  Comparison:
    new fetch_values 1:  1620310.5 i/s
    old fetch_values 1:  1502873.2 i/s - 1.08x  (± 0.00) slower

  Warming up --------------------------------------
  old fetch_values splat
                         109.967k i/100ms
  new fetch_values splat
                         117.143k i/100ms
  Calculating -------------------------------------
  old fetch_values splat
                            1.100M (± 1.5%) i/s -      5.498M in   5.001587s
  new fetch_values splat
                            1.168M (± 1.0%) i/s -      5.857M in   5.015409s

  Comparison:
  new fetch_values splat:  1167963.4 i/s
  old fetch_values splat:  1099558.2 i/s - 1.06x  (± 0.00) slower
  ```
