### PR TITLE
Match arity of `Hash#default` in `HWIA#default`

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -218,11 +218,11 @@ module ActiveSupport
     #   hash.default                   # => nil
     #   hash.default('foo')            # => 'foo'
     #   hash.default(:foo)             # => 'foo'
-    def default(*args)
-      if args.length == 1
-        super(convert_key(args[0]))
+    def default(key = (no_key = true))
+      if no_key
+        super()
       else
-        super(*args.map { |arg| convert_key(arg) })
+        super(convert_key(key))
       end
     end
 


### PR DESCRIPTION
Follow-up to b9beb3eee1ce1e49d69fff3437fde4feb44a0b77.

Ruby's `Hash#default` expects 0..1 args:

  ```ruby
  {}.default(:foo, :bar)
  # => wrong number of arguments (given 2, expected 0..1) (ArgumentError)
  ```

Using a sentinel value instead of `*args` improves performance:

__Benchmark__

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "active_support/all"

  Hash.alias_method(:old_default, :default)
  Hash.alias_method(:new_default, :default)

  class ActiveSupport::HashWithIndifferentAccess
    def old_default(*args)
      if args.length == 1
        super(convert_key(args[0]))
      else
        super(*args.map { |arg| convert_key(arg) })
      end
    end

    def new_default(key = (no_key = true))
      if no_key
        super()
      else
        super(convert_key(key))
      end
    end
  end

  hwia = {}.with_indifferent_access
  hwia.default_proc = -> (h, key) { key }

  Benchmark.ips do |x|
    x.report("old default nullary") do
      hwia.old_default
    end

    x.report("new default nullary") do
      hwia.new_default
    end

    x.compare!
  end

  Benchmark.ips do |x|
    x.report("old default unary") do
      hwia.old_default(:key)
    end

    x.report("new default unary") do
      hwia.new_default(:key)
    end

    x.compare!
  end
  ```

__Results__

  ```
  Warming up --------------------------------------
   old default nullary   266.594k i/100ms
   new default nullary   606.502k i/100ms
  Calculating -------------------------------------
   old default nullary      2.708M (± 1.3%) i/s -     13.596M in   5.022049s
   new default nullary      6.052M (± 0.5%) i/s -     30.325M in   5.011218s

  Comparison:
   new default nullary:  6051595.4 i/s
   old default nullary:  2707813.7 i/s - 2.23x  (± 0.00) slower

  Warming up --------------------------------------
     old default unary   220.776k i/100ms
     new default unary   305.148k i/100ms
  Calculating -------------------------------------
     old default unary      2.195M (± 1.3%) i/s -     11.039M in   5.030518s
     new default unary      3.081M (± 0.8%) i/s -     15.563M in   5.051871s

  Comparison:
     new default unary:  3080770.1 i/s
     old default unary:  2194765.4 i/s - 1.40x  (± 0.00) slower
  ```
