### PR TITLE
Dockerfile binfile fixups; primarily for Windows users

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -428,6 +428,35 @@ module Rails
         "latest"
       end
 
+      def dockerfile_binfile_fixups
+        # binfiles may have OS specific paths to ruby.  Normalize them.
+        shebangs = Dir['bin/*'].map {|file| IO.read(file).lines.first}.join
+        rubies = shebangs.scan(%r{#!/usr/bin/env (ruby.*)}).flatten.uniq
+
+        binfixups = (rubies - %w(ruby)).map do |ruby|
+          "sed -i 's/#{Regexp.quote(ruby)}$/ruby/' bin/*"
+        end
+
+        # Windows line endings will cause scripts to fail.  If any
+        # or found OR this generation is run on a windows platform
+        # and there are other binfixups required, then convert
+        # line endings.  This avoids adding unnecessary fixups if
+        # none are required, but prepares for the need to do the
+        # fix line endings if other fixups are required.
+        has_cr = Dir['bin/*'].any? {|file| IO.read(file) =~ /\r/}
+        if has_cr or (Gem.win_platform? and not binfixups.empty?)
+          binfixups.unshift 'sed -i "s/\r$//g" bin/*'
+        end
+
+        # Windows file systems may not have the concept of executable.
+        # In such cases, fix up during the build.
+        unless Dir['bin/*'].all? {|file| File.executable? file}
+          binfixups.unshift "chmod +x bin/*"
+        end
+
+        binfixups
+      end
+
       # CSS processors other than Tailwind require a node-based JavaScript environment. So overwrite the normal JS default
       # if one such processor has been specified.
       def adjusted_javascript_option

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -430,7 +430,7 @@ module Rails
 
       def dockerfile_binfile_fixups
         # binfiles may have OS specific paths to ruby.  Normalize them.
-        shebangs = Dir['bin/*'].map {|file| IO.read(file).lines.first}.join
+        shebangs = Dir["bin/*"].map { |file| IO.read(file).lines.first }.join
         rubies = shebangs.scan(%r{#!/usr/bin/env (ruby.*)}).flatten.uniq
 
         binfixups = (rubies - %w(ruby)).map do |ruby|
@@ -443,14 +443,14 @@ module Rails
         # line endings.  This avoids adding unnecessary fixups if
         # none are required, but prepares for the need to do the
         # fix line endings if other fixups are required.
-        has_cr = Dir['bin/*'].any? {|file| IO.read(file) =~ /\r/}
-        if has_cr or (Gem.win_platform? and not binfixups.empty?)
+        has_cr = Dir["bin/*"].any? { |file| IO.read(file).include? "\r" }
+        if has_cr || (Gem.win_platform? && !binfixups.empty?)
           binfixups.unshift 'sed -i "s/\r$//g" bin/*'
         end
 
         # Windows file systems may not have the concept of executable.
         # In such cases, fix up during the build.
-        unless Dir['bin/*'].all? {|file| File.executable? file}
+        unless Dir["bin/*"].all? { |file| File.executable? file }
           binfixups.unshift "chmod +x bin/*"
         end
 

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -41,6 +41,11 @@ COPY . .
 RUN bundle exec bootsnap precompile --gemfile app/ lib/
 
 <% end -%>
+<% unless dockerfile_binfile_fixups.empty? -%>
+# Adjust binfiles to be executable on Linux
+<%= "RUN " + dockerfile_binfile_fixups.join(" && \\\n    ") %>
+
+<% end -%>
 <% unless options.api? -%>
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -48,7 +48,7 @@ RUN bundle exec bootsnap precompile --gemfile app/ lib/
 <% end -%>
 <% unless options.api? -%>
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 <% end -%>
 # Entrypoint prepares the database.


### PR DESCRIPTION


### Motivation / Background

This Pull Request has been created because Rails applications created on Windows will fail to deploy using the generated Dockerfile as the binstubs they have won't work on Linux.

### Detail

This Pull Request will emit a Dockerfile RUN instruction, when needed, that will make the following conversions:

 * chmod +x
 * CRLF => LF
 * ruby.exe => ruby

If Rails new is run on a MacOS or Linux machine, no fixups are required or emitted to the Dockerfile.

### Additional information

On a new Windows 11 machine with Ruby installed with RubyInstaller, `rails new` produces binstubs with shebang lines that look like the following:

```
#!/usr/bin/env ruby.exe
```

These lines won't work on Linux machines.  Additionally, with NTFS, I don't have executable bits, so these scripts won't run anyway.  Finally, Windows users always seem to find ways to insert windows CRLF line endings into these files and that is also a source of failure.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

I don't know how to create tests for "Ruby was installed on a Windows 11 machine using Ruby Installer".  What I will say is that I have tested on a MacOS machine and verified that no sed commands were added to the Dockerfile; I have tested on a Windows machine and produced the following:

```
# Adjust binfiles to be executable on Linux
RUN chmod +x bin/* && \
    sed -i "s/\r$//g" bin/* && \
    sed -i 's/ruby\.exe$/ruby/' bin/*
```

And finally, I have tested those command on a Linux machine to verify that they perform the correct modifications.

No changelog entries are required for this change.