### PR TITLE
TaggedLogging accepts non-String objects

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -30,7 +30,7 @@ module ActiveSupport
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
         if t = tags_text
-          super(severity, timestamp, progname, t.concat(msg))
+          super(severity, timestamp, progname, t.concat(msg.to_s))
         else
           super(severity, timestamp, progname, msg)
         end

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -240,4 +240,9 @@ class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
     assert_respond_to tagged_logger.formatter, :tagged
     assert_respond_to tagged_logger.formatter, :crozz_method
   end
+
+  test "accepts non-String objects" do
+    @logger.tagged("tag") { @logger.info [1, 2, 3] }
+    assert_equal "[tag] [1, 2, 3]\n", @output.string
+  end
 end


### PR DESCRIPTION
Before 0671acfeeaf33d1a5d5a08deb45917767e22ed61, objects were coerced by the string interpolation, this brings it back.

cc @amatsuda 

### Motivation / Background

0671acfeeaf33d1a5d5a08deb45917767e22ed61 changed the interface of `ActiveSupport::TaggedLogging`.

### Detail

This brings back the call to `to_s`.

### Additional information

This adds a call to `to_s` if the object is already a string.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
