### PR TITLE
Add Arel functionality for "stitching together" SQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Multiple `Arel::Nodes::SqlLiteral` nodes can now be added together to
+    form `Arel::Nodes::Fragments` nodes. This allows joining several pieces
+    of SQL.
+
+    *Matthew Draper*, *Ole Friis*
+
 *   `ActiveRecord::Base#signed_id` raises if called on a new record
 
     Previously it would return an ID that was not usable, since it was based on `id = nil`.

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -8,6 +8,7 @@ require "arel/nodes/select_core"
 require "arel/nodes/insert_statement"
 require "arel/nodes/update_statement"
 require "arel/nodes/bind_param"
+require "arel/nodes/fragments"
 
 # terminal
 

--- a/activerecord/lib/arel/nodes/fragments.rb
+++ b/activerecord/lib/arel/nodes/fragments.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class Fragments < Arel::Nodes::Node
+      attr_reader :values
+
+      def initialize(values = [])
+        super()
+        @values = values
+      end
+
+      def initialize_copy(other)
+        super
+        @values = @values.clone
+      end
+
+      def hash
+        [@values].hash
+      end
+
+      def +(other)
+        raise ArgumentError, "Expected Arel node" unless Arel.arel_node?(other)
+
+        self.class.new([*@values, other])
+      end
+
+      def eql?(other)
+        self.class == other.class &&
+          self.values == other.values
+      end
+      alias :== :eql?
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/sql_literal.rb
+++ b/activerecord/lib/arel/nodes/sql_literal.rb
@@ -14,6 +14,12 @@ module Arel # :nodoc: all
 
       def fetch_attribute
       end
+
+      def +(other)
+        raise ArgumentError, "Expected Arel node" unless Arel.arel_node?(other)
+
+        Fragments.new([self, other])
+      end
     end
   end
 end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -791,6 +791,10 @@ module Arel # :nodoc: all
         end
         alias :visit_Set :visit_Array
 
+        def visit_Arel_Nodes_Fragments(o, collector)
+          inject_join o.values, collector, " "
+        end
+
         def quote(value)
           return value if Arel::Nodes::SqlLiteral === value
           @connection.quote value

--- a/activerecord/test/cases/arel/nodes/fragments_test.rb
+++ b/activerecord/test/cases/arel/nodes/fragments_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "yaml"
+
+module Arel
+  module Nodes
+    class FragmentsTest < Arel::Spec
+      describe "equality" do
+        it "is equal with equal values" do
+          array = [Fragments.new(["foo", "bar"]), Fragments.new(["foo", "bar"])]
+          assert_equal 1, array.uniq.size
+        end
+
+        it "is not equal with different values" do
+          array = [Fragments.new(["foo"]), Fragments.new(["bar"])]
+          assert_equal 2, array.uniq.size
+        end
+
+        it "can be joined with other nodes" do
+          fragments = Fragments.new(["foo", "bar"])
+          sql = Arel.sql("SELECT")
+          joined_fragments = fragments + sql
+
+          assert_equal ["foo", "bar"], fragments.values
+          assert_equal ["foo", "bar", sql], joined_fragments.values
+        end
+
+        it "fails if joined with something that is not an Arel node" do
+          fragments = Fragments.new
+          assert_raises ArgumentError do
+            fragments + "Not a node"
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/arel/nodes/sql_literal_test.rb
+++ b/activerecord/test/cases/arel/nodes/sql_literal_test.rb
@@ -70,6 +70,23 @@ module Arel
           assert_equal("foo", YAML.load(yaml_literal))
         end
       end
+
+      describe "addition" do
+        it "generates a Fragments node" do
+          sql1 = Arel.sql "SELECT *"
+          sql2 = Arel.sql "FROM users"
+          fragments = sql1 + sql2
+          _(fragments).must_be_kind_of Arel::Nodes::Fragments
+          assert_equal([sql1, sql2], fragments.values)
+        end
+
+        it "fails if joined with something that is not an Arel node" do
+          sql = Arel.sql "SELECT *"
+          assert_raises ArgumentError do
+            sql + "Not a node"
+          end
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -768,6 +768,20 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::Fragments" do
+        it "joins subexpressions" do
+          sql = Arel.sql("SELECT foo, bar") + Arel.sql(" FROM customers")
+          _(compile(sql)).must_be_like "SELECT foo, bar FROM customers"
+        end
+
+        it "can be built by adding SQL fragments one at a time" do
+          sql = Arel.sql("SELECT foo, bar")
+          sql += Arel.sql("FROM customers")
+          sql += Arel.sql("GROUP BY foo")
+          _(compile(sql)).must_be_like "SELECT foo, bar FROM customers GROUP BY foo"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

When hand-crafting SQL, there is currently no way to "stitch together" fragments of the SQL into one final SQL statement. Doing everything in "proper ActiveRecord syntax" is of course preferred, but sometimes there's a need to hand-craft SQL.

For simple SQL queries, you can just use regular string concatenation, but once the SQL fragments get a bit more complex, like using bind parameters enabled by https://github.com/rails/rails/pull/46600, this is not viable.

### Detail

This Pull Request add the `+` operator to `Arel::Nodes::SqlLiteral`. It will return a new Arel node type, `Arel::Nodes::Fragments`, which concatenates the SQL. More SQL can be added afterwards. Example:

```ruby
sql = Arel.sql("SELECT foo, bar") + Arel.sql("FROM customers")
sql += Arel.sql("GROUP BY foo")
```

### Additional Information

Better ideas for a name for the new node will be appreciated 😄 . I originally went with `Arel::Nodes::Concatenation`, but before submitting this PR it dawned on me that that was a very bad name...

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
