### PR TITLE
Do not drop schema migrations and internal metadata tables in `test/cases/tasks/database_tasks_test.rb`

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -207,8 +207,8 @@ module ActiveRecord
         ensure
           [:primary, :secondary].each do |db|
             ActiveRecord::Base.establish_connection(db)
-            ActiveRecord::Base.connection.schema_migration.drop_table
-            ActiveRecord::Base.connection.internal_metadata.drop_table
+            ActiveRecord::Base.connection.schema_migration.delete_all_versions
+            ActiveRecord::Base.connection.internal_metadata.delete_all_entries
           end
           ActiveRecord::Base.configurations = old_configurations
           ActiveRecord::Base.establish_connection(:arunit)


### PR DESCRIPTION
Fixes #46945.

`primary` and `secondary` (see a few lines above) are configured to use the same databases as are default `arunit`/`arunit2` - https://github.com/rails/rails/blob/19a6979cfc134951755a6b6fc311276ce0b98f3c/activerecord/test/config.example.yml#L93-L101, to which `old_configurations` refer. So, these tables are dropped, and then then `MigrationTest#test_internal_metadata_stores_environment_when_migration_fails` fails because of their absence.

There is really no need to drop these tables, I think just clearing them is enough.
