### PR TITLE
Fix `test_internal_metadata_stores_environment_when_migration_fails` failure

### DIFF
--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -212,6 +212,8 @@ module ActiveRecord
           end
           ActiveRecord::Base.configurations = old_configurations
           ActiveRecord::Base.establish_connection(:arunit)
+          ActiveRecord::Base.connection.schema_migration.create_table
+          ActiveRecord::Base.connection.internal_metadata.create_table
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Fix #46945

### Detail

```ruby
$ bin/test test/cases/tasks/database_tasks_test.rb test/cases/migration_test.rb -n "/^(?:ActiveRecord::DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest#(?:test_with_multiple_databases)|MigrationTest#(?:test_internal_metadata_stores_environment_when_migration_fails))$/" --seed 25489
Using sqlite3
Run options: -n "/^(?:ActiveRecord::DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest#(?:test_with_multiple_databases)|MigrationTest#(?:test_internal_metadata_stores_environment_when_migration_fails))$/" --seed 25489

.E

Error:
MigrationTest#test_internal_metadata_stores_environment_when_migration_fails:
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such table: ar_internal_metadata
    /home/yahonda/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sqlite3-1.5.4/lib/sqlite3/database.rb:152:in `initialize'
    /home/yahonda/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sqlite3-1.5.4/lib/sqlite3/database.rb:152:in `new'
    /home/yahonda/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/sqlite3-1.5.4/lib/sqlite3/database.rb:152:in `prepare'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:48:in `block (2 levels) in exec_query'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:989:in `block in with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:961:in `with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:45:in `block in exec_query'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1102:in `log'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:44:in `exec_query'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:72:in `exec_delete'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:186:in `delete'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `delete'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/internal_metadata.rb:56:in `delete_all_entries'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/migration_test.rb:701:in `test_internal_metadata_stores_environment_when_migration_fails'

bin/test test/cases/migration_test.rb:700

Finished in 0.199499s, 10.0251 runs/s, 20.0502 assertions/s.
2 runs, 4 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

This pull request recreates the` ar_internal_metadata` and `schema_migrations` tables that are dropped by 
`DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest#test_with_multiple_databases` drops `ar_internal_metadata` and `schema_migrations` tables at the end.

https://github.com/rails/rails/blob/35ca0bede9ea763d65d052fb3d61fd116c93c236/activerecord/test/cases/tasks/database_tasks_test.rb#L210-L211

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
