### PR TITLE
Ensure Dockerfile installs commonly needed packages

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,23 +1,21 @@
 # Make sure it matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=<%= Gem.ruby_version %>
-FROM ruby:$RUBY_VERSION
+FROM ruby:$RUBY_VERSION-slim
+
+# Install packages need to build gems<%= using_node? ? " and node modules" : "" %>
+RUN apt-get update -qq && \
+    apt-get install -y <%= dockerfile_packages.join(" ") %> && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 
 <% if using_node? -%>
 # Install JavaScript dependencies
 ARG NODE_VERSION=<%= dockerfile_node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
 ENV VOLTA_HOME="/root/.volta" \
-    PATH="$VOLTA_HOME/bin:/usr/local/bin:$PATH"
+    PATH="/root/.volta/bin:$PATH"
 RUN curl https://get.volta.sh | bash && \
     volta install node@$NODE_VERSION yarn@$YARN_VERSION
-
-<% end -%>
-<% if !skip_active_storage? -%>
-# Install libvips for Active Storage preview support
-RUN apt-get update -qq && \
-    apt-get install -y build-essential libvips && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 
 <% end -%>
 # Rails app lives here

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -772,6 +772,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Dockerfile" do |content|
       assert_match(/yarn/, content)
+      assert_match(/node-gyp/, content)
     end
 
     assert_file ".node-version" do |content|
@@ -1042,6 +1043,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/assets:precompile/, content)
       assert_match(/libvips/, content)
       assert_no_match(/yarn/, content)
+      assert_no_match(/node-gyp/, content)
     end
   end
 


### PR DESCRIPTION

### Motivation / Background

While libvips is an example of a dependency needed to build a native gem, it is not an exhaustive list.

This pull request always includes `build-essential` as installing native gems is common need, not just for applications that include active storage.

### Detail

 * Starts from the ruby:slim base instead of full ruby
 * Always install what is needed to build native packages
 * Include libraries for sqlite3, postgresql, mysql, and redis

### Additional information

While this started out simple, it became a minor yak shaving event.

Node also has native modules, and in order to install them you need node-gyp, pkg-config, and python.  And the way that python is packaged changed from debian buster to debian bullseye.  So heads up: wart warning here, but one that only affects node users, and one that is unlikely to be visible externally as it merely substitutes the name of one python package for another based on the ruby version.  See code/comments in app_base.rb for details.

Taking a step back, if we are installing packages, ruby:slim is a better starting point than ruby.  It installs a few less packages by default, but also removed docs, man pages, etc.  See https://stackoverflow.com/questions/59794891/how-does-debian-differ-from-debian-slim

This pull request explicitly installs libraries for sqlite3, postgresql, mysql, and redis as they are common requirements and don't take up much space.  

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.

A changelog entry is not needed for this change.