### PR TITLE
Clear metadata tables in tests instead of droping

### DIFF
--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -54,8 +54,8 @@ module ActiveRecord
       def define(info, &block) # :nodoc:
         instance_eval(&block)
 
+        connection.schema_migration.create_table
         if info[:version].present?
-          connection.schema_migration.create_table
           connection.assume_migrated_upto_version(info[:version])
         end
 

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -10,17 +10,14 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     ActiveRecord::Migration.verbose = false
     @connection = ActiveRecord::Base.connection
     @schema_migration = @connection.schema_migration
-    @schema_migration.drop_table
-    @internal_metadata = @connection.internal_metadata
+    @schema_migration.delete_all_versions
   end
 
   teardown do
     @connection.drop_table :fruits rescue nil
-    @connection.drop_table :nep_fruits rescue nil
-    @connection.drop_table :nep_schema_migrations rescue nil
     @connection.drop_table :has_timestamps rescue nil
     @connection.drop_table :multiple_indexes rescue nil
-    @schema_migration.delete_all_versions rescue nil
+    @schema_migration.delete_all_versions
     ActiveRecord::Migration.verbose = @original_verbose
   end
 
@@ -29,12 +26,10 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     ActiveRecord::Base.primary_key_prefix_type = :table_name_with_underscore
     assert_equal "version", @schema_migration.primary_key
 
-    @schema_migration.create_table
     assert_difference "@schema_migration.count", 1 do
       @schema_migration.create_version(12)
     end
   ensure
-    @schema_migration.drop_table
     ActiveRecord::Base.primary_key_prefix_type = old_primary_key_prefix_type
   end
 
@@ -80,6 +75,9 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     assert_equal 7, @connection.migration_context.current_version
   ensure
     ActiveRecord::Base.table_name_prefix = old_table_name_prefix
+    @connection.drop_table :nep_fruits
+    @connection.drop_table :nep_schema_migrations
+    @schema_migration.create_table
   end
 
   def test_schema_raises_an_error_for_invalid_column_type

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       end
 
       teardown do
-        @schema_migration.drop_table
+        @schema_migration.delete_all_versions
       end
 
       def test_migration_should_be_run_without_logger

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -140,12 +140,14 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_migration_detection_without_schema_migration_table
-    ActiveRecord::Base.connection.drop_table "schema_migrations", if_exists: true
+    @schema_migration.drop_table
 
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
     assert_equal true, migrator.needs_migration?
+  ensure
+    @schema_migration.create_table
   end
 
   def test_any_migrations

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1142,7 +1142,7 @@ module ActiveRecord
         assert_match(/down    001             Valid people have last names/, output)
         assert_match(/down    002             We need reminders/, output)
         assert_match(/down    003             Innocent jointable/, output)
-        @schema_migration.drop_table
+        @schema_migration.delete_all_versions
       end
 
       private


### PR DESCRIPTION
Follow up to #46949.

Was able to reproduce locally with `rake sqlite3:test SEED=27567` (but was not able to localize it to just a few test cases).

Previously, this line https://github.com/rails/rails/blob/ff224e618bf9042bb30afdbfafe1da050c8bd771/activerecord/test/cases/tasks/database_tasks_test.rb#L210
was `ActiveRecord::Base.connection.schema_migration.drop_table`. It hasn't caused problems, because it is implemented with `:if_exists` and so did not error out when table was not there.

So the CI errors are because somewhere in tests metadata tables are deleted, but here https://github.com/rails/rails/blob/ff224e618bf9042bb30afdbfafe1da050c8bd771/activerecord/test/cases/tasks/database_tasks_test.rb#L163-L177
`schema_migrations` table for `:primary` configuration was not created and thus https://github.com/rails/rails/blob/ff224e618bf9042bb30afdbfafe1da050c8bd771/activerecord/test/cases/tasks/database_tasks_test.rb#L210 errors out.

So in this PR I identified all the places in tests where metadata tables are unnecessary deleted and rewritten to clear them instead. 

Hope the explanation is +/- clear.