### PR TITLE
Improve `TaggedLogging::Formatter` performance

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -29,56 +29,86 @@ module ActiveSupport
     module Formatter # :nodoc:
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)
-        if t = tags_text
-          super(severity, timestamp, progname, t.concat(msg.to_s))
-        else
-          super(severity, timestamp, progname, msg)
-        end
+        super(severity, timestamp, progname, tag_stack.format_message(msg))
       end
 
       def tagged(*tags)
-        new_tags = push_tags(*tags)
+        pushed_count = tag_stack.push_tags(tags).size
         yield self
       ensure
-        pop_tags(new_tags.size)
+        pop_tags(pushed_count)
       end
 
       def push_tags(*tags)
-        tags.flatten!
-        tags.reject!(&:blank?)
-        current_tags.concat tags
-        tags
+        tag_stack.push_tags(tags)
       end
 
-      def pop_tags(size = 1)
-        current_tags.pop size
+      def pop_tags(count = 1)
+        tag_stack.pop_tags(count)
       end
 
       def clear_tags!
-        current_tags.clear
+        tag_stack.clear
+      end
+
+      def tag_stack
+        # We use our object ID here to avoid conflicting with other instances
+        @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}"
+        IsolatedExecutionState[@thread_key] ||= TagStack.new
       end
 
       def current_tags
-        # We use our object ID here to avoid conflicting with other instances
-        thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}"
-        IsolatedExecutionState[thread_key] ||= []
+        tag_stack.tags
       end
 
       def tags_text
-        tags = current_tags
-        if tags.one?
-          +"[#{tags[0]}] "
-        elsif tags.any?
-          tags.collect { |tag| "[#{tag}] " }.join
+        tag_stack.format_message("")
+      end
+    end
+
+    class TagStack # :nodoc:
+      attr_reader :tags
+
+      def initialize
+        @tags = []
+        @tags_string = nil
+      end
+
+      def push_tags(tags)
+        @tags_string = nil
+        tags.flatten!
+        tags.reject!(&:blank?)
+        @tags.concat(tags)
+        tags
+      end
+
+      def pop_tags(count)
+        @tags_string = nil
+        @tags.pop(count)
+      end
+
+      def clear
+        @tags_string = nil
+        @tags.clear
+      end
+
+      def format_message(message)
+        if @tags.empty?
+          message
+        elsif @tags.size == 1
+          "[#{@tags[0]}] #{message}"
+        else
+          @tags_string ||= "[#{@tags.join("] [")}] "
+          "#{@tags_string}#{message}"
         end
       end
     end
 
     module LocalTagStorage # :nodoc:
-      attr_accessor :current_tags
+      attr_accessor :tag_stack
 
       def self.extended(base)
-        base.current_tags = []
+        base.tag_stack = TagStack.new
       end
     end
 


### PR DESCRIPTION
This commit improves the performance of `TaggedLogging::Formatter` by factoring out a `TaggedLogging::TagStack` helper class that memoizes the tag string which is prepended to log messages.  `TagStack` is implemented as a separate class so that the array of tags and the memoized tag string can be stored in a single thread-local variable, minimizing the number of thread-local variable reads / writes.

Additionally, the construction of the tag string has been optimized to allocate O(1) objects instead of O(N), where N is the number of tags.  So even when the tag string is not yet memoized — e.g. for a singular logging call inside a `tagged` block — performance is improved.

__Benchmark__

  ```ruby
  # frozen_string_literal: true
  require "benchmark/ips"
  require "benchmark/memory"

  io = StringIO.new
  logger = ActiveSupport::TaggedLogging.new(Logger.new(io))
  message = "for your information, this is a message"

  benchmark = -> x do
    x.report("messages: 1, tags: 0") do
      logger.info(message)
      io.rewind
    end

    (1..3).each do |tag_count|
      tags = ["tag"] * tag_count

      x.report("messages: 1, tags: #{tag_count}") do
        logger.tagged(*tags) do
          logger.info(message)
        end
        io.rewind
      end
    end

    (1..3).each do |tag_count|
      tags = ["tag"] * tag_count

      x.report("messages: 3, tags: #{tag_count}") do
        logger.tagged(*tags) do
          logger.info(message)
          logger.info(message)
          logger.info(message)
        end
        io.rewind
      end
    end
  end

  Benchmark.ips(&benchmark)
  Benchmark.memory(&benchmark)
  ```

__Before__

  ```
  Warming up --------------------------------------
  messages: 1, tags: 0    27.525k i/100ms
  messages: 1, tags: 1     8.971k i/100ms
  messages: 1, tags: 2     8.538k i/100ms
  messages: 1, tags: 3     7.911k i/100ms
  messages: 3, tags: 1     4.540k i/100ms
  messages: 3, tags: 2     4.278k i/100ms
  messages: 3, tags: 3     3.948k i/100ms
  Calculating -------------------------------------
  messages: 1, tags: 0    274.500k (± 1.5%) i/s -      1.376M in   5.014770s
  messages: 1, tags: 1     90.649k (± 1.5%) i/s -    457.521k in   5.048251s
  messages: 1, tags: 2     84.970k (± 1.7%) i/s -    426.900k in   5.025548s
  messages: 1, tags: 3     78.819k (± 2.0%) i/s -    395.550k in   5.020476s
  messages: 3, tags: 1     46.517k (± 1.4%) i/s -    236.080k in   5.076084s
  messages: 3, tags: 2     43.062k (± 1.5%) i/s -    218.178k in   5.067764s
  messages: 3, tags: 3     39.822k (± 2.2%) i/s -    201.348k in   5.058528s
  Calculating -------------------------------------
  messages: 1, tags: 0   166.000  memsize (     0.000  retained)
                           2.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)
  messages: 1, tags: 1   562.000  memsize (     0.000  retained)
                           8.000  objects (     0.000  retained)
                           2.000  strings (     0.000  retained)
  messages: 1, tags: 2   550.000  memsize (     0.000  retained)
                          10.000  objects (     0.000  retained)
                           3.000  strings (     0.000  retained)
  messages: 1, tags: 3   758.000  memsize (     0.000  retained)
                          11.000  objects (     0.000  retained)
                           3.000  strings (     0.000  retained)
  messages: 3, tags: 1     1.366k memsize (     0.000  retained)
                          16.000  objects (     0.000  retained)
                           2.000  strings (     0.000  retained)
  messages: 3, tags: 2     1.330k memsize (     0.000  retained)
                          22.000  objects (     0.000  retained)
                           3.000  strings (     0.000  retained)
  messages: 3, tags: 3     1.954k memsize (     0.000  retained)
                          25.000  objects (     0.000  retained)
                           3.000  strings (     0.000  retained)
  ```

__After__

  ```
  Warming up --------------------------------------
  messages: 1, tags: 0    29.424k i/100ms
  messages: 1, tags: 1     9.156k i/100ms
  messages: 1, tags: 2     9.073k i/100ms
  messages: 1, tags: 3     8.263k i/100ms
  messages: 3, tags: 1     4.837k i/100ms
  messages: 3, tags: 2     5.331k i/100ms
  messages: 3, tags: 3     4.834k i/100ms
  Calculating -------------------------------------
  messages: 1, tags: 0    295.005k (± 1.1%) i/s -      1.501M in   5.087339s
  messages: 1, tags: 1     91.360k (± 1.4%) i/s -    457.800k in   5.011926s
  messages: 1, tags: 2     91.213k (± 1.1%) i/s -    462.723k in   5.073683s
  messages: 1, tags: 3     82.784k (± 0.9%) i/s -    421.413k in   5.090932s
  messages: 3, tags: 1     47.606k (± 1.7%) i/s -    241.850k in   5.081694s
  messages: 3, tags: 2     53.170k (± 0.8%) i/s -    266.550k in   5.013474s
  messages: 3, tags: 3     48.340k (± 1.4%) i/s -    246.534k in   5.100972s
  Calculating -------------------------------------
  messages: 1, tags: 0   166.000  memsize (     0.000  retained)
                           2.000  objects (     0.000  retained)
                           1.000  strings (     0.000  retained)
  messages: 1, tags: 1   522.000  memsize (     0.000  retained)
                           7.000  objects (     0.000  retained)
                           2.000  strings (     0.000  retained)
  messages: 1, tags: 2   446.000  memsize (     0.000  retained)
                           8.000  objects (     0.000  retained)
                           4.000  strings (     0.000  retained)
  messages: 1, tags: 3   678.000  memsize (     0.000  retained)
                           8.000  objects (     0.000  retained)
                           4.000  strings (     0.000  retained)
  messages: 3, tags: 1     1.326k memsize (     0.000  retained)
                          15.000  objects (     0.000  retained)
                           2.000  strings (     0.000  retained)
  messages: 3, tags: 2   938.000  memsize (     0.000  retained)
                          14.000  objects (     0.000  retained)
                           4.000  strings (     0.000  retained)
  messages: 3, tags: 3     1.490k memsize (     0.000  retained)
                          14.000  objects (     0.000  retained)
                           4.000  strings (     0.000  retained)
  ```

Note that this commit preserves the contract of `Formatter#current_tags` because it is used by [`ActionCable::Connection::TaggedLoggerProxy#tag`](https://github.com/rails/rails/blob/9bdd29c8317a9cc2faa72cf2060758dd41b8c267/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb#L23) and [`ActiveJob::Logging#logger_tagged_by_active_job?`](https://github.com/rails/rails/blob/9bdd29c8317a9cc2faa72cf2060758dd41b8c267/activejob/lib/active_job/logging.rb#L32).  Similarly, `Formatter#tags_text` is kept because it is used by [`ActionDispatch::DebugExceptions#log_array`](https://github.com/rails/rails/blob/9bdd29c8317a9cc2faa72cf2060758dd41b8c267/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L153-L154).
