### PR TITLE
Fix rare conflict of default_render with Minitest::Mock

### DIFF
--- a/actionpack/lib/action_controller/metal/basic_implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/basic_implicit_render.rb
@@ -3,7 +3,9 @@
 module ActionController
   module BasicImplicitRender # :nodoc:
     def send_action(method, *args)
-      super.tap { default_render unless performed? }
+      ret = super
+      default_render unless performed?
+      ret
     end
 
     def default_render

--- a/actionpack/test/controller/api/implicit_render_test.rb
+++ b/actionpack/test/controller/api/implicit_render_test.rb
@@ -5,6 +5,11 @@ require "abstract_unit"
 class ImplicitRenderAPITestController < ActionController::API
   def empty_action
   end
+
+  def returning_mock
+    require "minitest/mock"
+    Minitest::Mock.new
+  end
 end
 
 class ImplicitRenderAPITest < ActionController::TestCase
@@ -12,6 +17,11 @@ class ImplicitRenderAPITest < ActionController::TestCase
 
   def test_implicit_no_content_response
     get :empty_action
+    assert_response :no_content
+  end
+
+  def test_result_independence
+    get :returning_mock
     assert_response :no_content
   end
 end


### PR DESCRIPTION
### Detail

If your minitests mocked something that is a return value for a controller action, it will raise confusing `undefined #tap` error (because Mock undefines all methods internally).

Revert problematic line in BasicImplicitRender to a version before 6c165773117dc7e60f5bb4762e58c7c522d69fcc.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
