### PR TITLE
Support composite foreign keys in associations

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -35,7 +35,7 @@ module ActiveRecord
         binds = []
         last_reflection = chain.last
 
-        binds << last_reflection.join_id_for(owner)
+        binds.push(*last_reflection.join_id_for(owner))
         if last_reflection.type
           binds << owner.class.polymorphic_name
         end
@@ -56,12 +56,15 @@ module ActiveRecord
         end
 
         def last_chain_scope(scope, reflection, owner)
-          primary_key = reflection.join_primary_key
-          foreign_key = reflection.join_foreign_key
+          primary_key = Array(reflection.join_primary_key)
+          foreign_key = Array(reflection.join_foreign_key)
 
           table = reflection.aliased_table
-          value = transform_value(owner[foreign_key])
-          scope = apply_scope(scope, table, primary_key, value)
+          primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
+          primary_key_foreign_key_pairs.each do |join_key, foreign_key|
+            value = transform_value(owner[foreign_key])
+            scope = apply_scope(scope, table, join_key, value)
+          end
 
           if reflection.type
             polymorphic_type = transform_value(owner.class.polymorphic_name)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -131,7 +131,7 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          owner._read_attribute(reflection.foreign_key)
+          Array(reflection.foreign_key).all? { |fk| owner._read_attribute(fk) }
         end
 
         def invertible_for?(record)

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -65,7 +65,7 @@ module ActiveRecord
           updates.merge!(touch_updates)
         end
 
-        unscoped.where(primary_key => object.id).update_all(updates) if updates.any?
+        unscoped.where(primary_key => [object.id]).update_all(updates) if updates.any?
 
         true
       end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -466,7 +466,12 @@ module ActiveRecord
       end
 
       def foreign_key
-        @foreign_key ||= -(options[:foreign_key]&.to_s || derive_foreign_key)
+        @foreign_key ||= if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+          # composite foreign keys support
+          options[:foreign_key].map { |fk| fk.to_s.freeze }.freeze
+        else
+          -(options[:foreign_key]&.to_s || derive_foreign_key)
+        end
       end
 
       def association_foreign_key
@@ -478,7 +483,13 @@ module ActiveRecord
       end
 
       def active_record_primary_key
-        @active_record_primary_key ||= -(options[:primary_key]&.to_s || primary_key(active_record))
+        @active_record_primary_key ||= if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+          active_record.query_constraints_list
+        else
+          -(options[:primary_key]&.to_s || primary_key(active_record))
+        end
+
+        @active_record_primary_key
       end
 
       def join_primary_key(klass = nil)
@@ -506,7 +517,7 @@ module ActiveRecord
       end
 
       def join_id_for(owner) # :nodoc:
-        owner[join_foreign_key]
+        Array(join_foreign_key).map { |key| owner[key] }
       end
 
       def through_reflection
@@ -740,7 +751,9 @@ module ActiveRecord
 
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
-        if primary_key = options[:primary_key]
+        if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+          (klass || self.klass).query_constraints_list
+        elsif primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s
         else
           primary_key(klass || self.klass)

--- a/activerecord/test/fixtures/sharded_blog_posts.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts.yml
@@ -1,0 +1,10 @@
+_fixture:
+  model_class: Sharded::BlogPost
+
+great_post_blog_one:
+  title: "My first post!"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+great_post_blog_two:
+  title: "My first post!"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/fixtures/sharded_blogs.yml
+++ b/activerecord/test/fixtures/sharded_blogs.yml
@@ -1,0 +1,8 @@
+_fixture:
+  model_class: Sharded::Blog
+
+sharded_blog_one:
+  name: "Blog One"
+
+sharded_blog_two:
+  name: "Blog two"

--- a/activerecord/test/fixtures/sharded_comments.yml
+++ b/activerecord/test/fixtures/sharded_comments.yml
@@ -1,0 +1,17 @@
+_fixture:
+  model_class: Sharded::Comment
+
+great_comment_blog_post_one:
+  body: "I really enjoyed the post!"
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+wow_comment_blog_post_one:
+  body: "Wow!"
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+great_comment_blog_post_two:
+  body: "I really enjoyed the post!"
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/models/sharded/blog.rb
+++ b/activerecord/test/models/sharded/blog.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Models under `Sharded` namespace represent an application that can be sharded by a `blog_id` column.
+# `Blog` model plays the role of a tenant in the application.
+# Being sharded by the `blog_id` means that queries to the database include the `blog_id` column in the clauses
+# which serves as a sharding key allows presumed sharding implementation to route the query to a correct shard.
+
+module Sharded
+  class Blog < ActiveRecord::Base
+    self.table_name = :sharded_blogs
+  end
+end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sharded
+  class BlogPost < ActiveRecord::Base
+    self.table_name = :sharded_blog_posts
+    query_constraints :blog_id, :id
+
+    belongs_to :blog
+    has_many :comments, foreign_key: [:blog_id, :blog_post_id]
+  end
+end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sharded
+  class Comment < ActiveRecord::Base
+    self.table_name = :sharded_comments
+    query_constraints :blog_id, :id
+
+    belongs_to :blog_post, foreign_key: [:blog_id, :blog_post_id]
+    belongs_to :blog
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -243,6 +243,21 @@ ActiveRecord::Schema.define do
     t.index [:clothing_type, :color], unique: true
   end
 
+  create_table :sharded_blogs, force: true do |t|
+    t.string :name
+  end
+
+  create_table :sharded_blog_posts, force: true do |t|
+    t.string :title
+    t.integer :blog_id
+  end
+
+  create_table :sharded_comments, force: true do |t|
+    t.string :body
+    t.integer :blog_post_id
+    t.integer :blog_id
+  end
+
   create_table :clubs, force: true do |t|
     t.string :name
     t.integer :category_id


### PR DESCRIPTION
This is the first step towards supporting composite foreign keys in associations. With the introduction of `query_constraints` configuration https://github.com/rails/rails/pull/46331 models that use composite `query_constraints` config should have a possibility be queried using these constraints through associations. 
The initial approach supports simple `model.association` queries and expects `foreign_key` to be explicitly defined. The `primary_key` will be derived based on the `query_constraints_list`. This leads to the solution containing several `if` branches and `Array.wrap` calls for backwards compatibility however allows the PR to be smaller and approachable in reviews. Eventually we expect most of the branches and backwards-compatibility wraps to be removed. 

At this moment the change is undocumented as we are at an early stage.

### Next steps

- Gradually support other capabilities: joins, preloads, assignments like `blog_post.comments << Comment.new` 
- *Dynamically derive foreign & primary keys from `query_constraints` (if possible) 
- Cleanup of `Array.wrap` once Rails is fully ready to work with array-based primary and foreign keys