### PR TITLE
split build into base, build, and deploy images

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,31 +1,30 @@
 # Make sure it matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=<%= Gem.ruby_version %>
-FROM ruby:$RUBY_VERSION-slim
+FROM ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_WITHOUT="development"
+
+FROM base as build
 
 # Install packages need to build gems<%= using_node? ? " and node modules" : "" %>
 RUN apt-get update -qq && \
-    apt-get install -y <%= dockerfile_packages.join(" ") %> && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
+    apt-get install -y <%= dockerfile_packages.join(" ") %>
 
 <% if using_node? -%>
 # Install JavaScript dependencies
 ARG NODE_VERSION=<%= dockerfile_node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
-ENV VOLTA_HOME="/root/.volta" \
-    PATH="/root/.volta/bin:$PATH"
+ENV VOLTA_HOME="/usr/local"
 RUN curl https://get.volta.sh | bash && \
     volta install node@$NODE_VERSION yarn@$YARN_VERSION
 
 <% end -%>
-# Rails app lives here
-WORKDIR /rails
 
-# Set production environment
-ENV RAILS_LOG_TO_STDOUT="1" \
-    RAILS_SERVE_STATIC_FILES="true" \
-    RAILS_ENV="production" \
-    BUNDLE_WITHOUT="development"
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
@@ -49,6 +48,18 @@ RUN bundle exec bootsnap precompile --gemfile app/ lib/
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 <% end -%>
+
+FROM base
+
+# copy built artifacts: libraries, gems, application
+COPY --from=build /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /rails /rails
+
+# Deployment options
+ENV RAILS_LOG_TO_STDOUT="1" \
+    RAILS_SERVE_STATIC_FILES="true"
+
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 


### PR DESCRIPTION


### Motivation / Background

This Pull Request has been created because Rails Docker images are too big.

### Detail

The three build stages defined in this Dockerfile:

* base contains anything that is common.  The initial dockerfile only contains environment variables and the working dir.  But if, for example, your application uses execjs so it makes sense to install node on both the build and deployment images that part of the dockerfile can be moved into base.

* build contains all the things necessary to build your application, including things like compilers, etc.  In most cases, these things aren't needed in your final application and can be left behind.

* an unnamed final image that is what is pushed to the repository and deployed.  At the moment it starts with the base image and only copies selected artifacts from the build image, sets a few additional environment variables, exposes a port, and exposes an entrypoint and command.

### Additional information

Given that the entire build step is left behind, there is no need to clean up after apt-get.

`/usr/local` is where non packaged installs normally go, there is no reason to ghetoize volta.

Note that /usr/lib will contain libraries that are only needed at compile time, including some large ones like libLLVM.  This pull request doesn't try to pick and choose files in that directory.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

No tests are provided with this pull request.  There is no conditional logic added, and actually deploying the resulting application is beyond what is currently being done in the Rails CI.

No changelog is provided with this pull request.