### PR TITLE
Guides: AR Validations - Mention that Rails will autoload validators

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1269,8 +1269,10 @@ class Person < ApplicationRecord
 end
 ```
 
-As shown in the example, you can also combine standard validations with your
-own custom validators.
+Custom validator classes are conventionally stored in `app/validators` (e.g. 
+`EmailValidator` would be auto-loaded if stored in 
+`app/validators/email_validator.rb`). As shown in the example, you can also 
+combine standard validations with your own custom validators.
 
 [`ActiveModel::EachValidator`]: https://api.rubyonrails.org/classes/ActiveModel/EachValidator.html
 [`ActiveModel::Validator`]: https://api.rubyonrails.org/classes/ActiveModel/Validator.html


### PR DESCRIPTION
I don't write custom validators often, but have read this doc many times and it never occurred to me that validators could be autoloaded if placed in `app/validators` until I stumbled on it when trying to figure out how to "register" them (e.g. `EmailValidator` to `email:`). (Separately, it might be worth mentioning explicitly that the kwarg is derived from the class name).