### PR TITLE
Fix flaky test in `railties/test/applications/rake/dbs_test.rb`

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -479,7 +479,7 @@ module ApplicationTests
 
       test "db:schema:cache:dump dumps virtual columns" do
         Dir.chdir(app_path) do
-          use_postgresql(database_name: "railties_db")
+          use_postgresql
           rails "db:drop", "db:create"
 
           rails "runner", <<~RUBY
@@ -773,12 +773,12 @@ module ApplicationTests
 
       test "db:prepare creates test database if it does not exist" do
         Dir.chdir(app_path) do
-          use_postgresql(database_name: "railties_db")
+          db_name = use_postgresql
           rails "db:drop", "db:create"
-          rails "runner", "ActiveRecord::Base.connection.drop_database(:railties_db_test)"
+          rails "runner", "ActiveRecord::Base.connection.drop_database(:#{db_name}_test)"
 
           output = rails("db:prepare")
-          assert_match(%r{Created database 'railties_db_test'}, output)
+          assert_match(%r{Created database '#{db_name}_test'}, output)
         end
       ensure
         rails "db:drop" rescue nil

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -465,7 +465,8 @@ module TestHelpers
       $:.reject! { |path| path =~ %r'/(#{to_remove.join('|')})/' }
     end
 
-    def use_postgresql(multi_db: false, database_name: "railties_#{Process.pid}")
+    def use_postgresql(multi_db: false)
+      database_name = "railties_#{Process.pid}"
       if multi_db
         File.open("#{app_path}/config/database.yml", "w") do |f|
           f.puts <<-YAML
@@ -497,6 +498,7 @@ module TestHelpers
           YAML
         end
       end
+      database_name
     end
   end
 


### PR DESCRIPTION
A few recent CI failure examples:
https://buildkite.com/rails/rails/builds/92430#0185a069-e978-438d-b5d7-368e93a838cf
https://buildkite.com/rails/rails/builds/92444#0185a1ab-be07-4b8b-8709-1d0a822eba06
https://buildkite.com/rails/rails/builds/92401#01859d70-4586-4c31-b0bf-8792fbc0196b

To reproduce:
```
$ cd railties
$ SEED=59934 ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/rake/dbs_test.rb
```

The problem with `use_postgresql` is goodly described in the PR description - https://github.com/rails/rails/pull/45178.

I apologize, I am the one who introduced this flaky test in https://github.com/rails/rails/pull/46939 😄 
So I updated `use_postgresql` signature to not allow custom db names to avoid such mistake in the future.

cc @eileencodes  
