### PR TITLE
Use class_eval for readonly write_attribute

### DIFF
--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -47,13 +47,15 @@ module ActiveRecord
 
     module HasReadonlyAttributes # :nodoc:
       [:write_attribute, :_write_attribute].each do |name|
-        define_method(name) do |attr_name, value|
-          if !new_record? && self.class.readonly_attribute?(attr_name.to_s)
-            raise ReadonlyAttributeError.new(attr_name)
-          end
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{name}(attr_name, value)
+            if !new_record? && self.class.readonly_attribute?(attr_name.to_s)
+              raise ReadonlyAttributeError.new(attr_name)
+            end
 
-          super(attr_name, value)
-        end
+            super(attr_name, value)
+          end
+        RUBY
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

While this only affects models that have an attr_readonly, class_eval is faster than define_method, so it should be used

### Additional information

Benchmark:
```ruby
require "active_record"

ActiveRecord.raise_on_assign_to_attr_readonly = true

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title
  end
end

class Post < ActiveRecord::Base
  attr_readonly :title
end

p = Post.new

Benchmark.ips do |x|
  x.report("update attribute") { p.title = "Rails!" }
  x.compare!
end
```

Before:
```
Warming up --------------------------------------
    update attribute    75.839k i/100ms
Calculating -------------------------------------
    update attribute    758.473k (± 2.1%) i/s -      3.868M in   5.101723s
```

After:
```
Warming up --------------------------------------
    update attribute    82.912k i/100ms
Calculating -------------------------------------
    update attribute    821.484k (± 2.4%) i/s -      4.146M in   5.049410s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
