### PR TITLE
Scope generated route helpers to an instance of RoutesProxy

### DIFF
--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -29,7 +29,7 @@ module ActionDispatch
 
       def method_missing(method, *args)
         if @helpers.respond_to?(method)
-          self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          instance_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method}(*args)
               options = args.extract_options!
               options = url_options.merge((options || {}).symbolize_keys)

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -24,6 +24,7 @@ module ApplicationTests
           get "/engine_route" => "application_generating#engine_route"
           get "/engine_route_in_view" => "application_generating#engine_route_in_view"
           get "/weblog_engine_route" => "application_generating#weblog_engine_route"
+          get "/weblog_through_metric_engine_route" => "application_generating#weblog_through_metric_engine_route"
           get "/weblog_engine_route_in_view" => "application_generating#weblog_engine_route_in_view"
           get "/url_for_engine_route" => "application_generating#url_for_engine_route"
           get "/polymorphic_route" => "application_generating#polymorphic_route"
@@ -173,6 +174,13 @@ module ApplicationTests
             render plain: weblog.weblogs_path
           end
 
+          def weblog_through_metric_engine_route
+            # trigger definition of route helper
+            weblog.weblogs_path
+
+            render plain: metrics.respond_to?(:weblogs_path)
+          end
+
           def weblog_engine_route_in_view
             render inline: "<%= weblog.weblogs_path %>"
           end
@@ -285,6 +293,11 @@ module ApplicationTests
 
       get "/weblog_engine_route_in_view"
       assert_equal "/weblog", last_response.body
+    end
+
+    test "route helpers from weblog are not accessible through metrics engine" do
+      get "/weblog_through_metric_engine_route"
+      assert_equal "false", last_response.body
     end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `RoutesProxy` caches route helpers within its class using `self.class.class_eval(...)`. For example if two engine `Weblog::Engine` and `Metrics::Engine` are mounted within your app and only weblog defines the route helper `weblogs_path` calling `metrics.respond_to?(:weblogs_path)` will return true if previously `weblog.weblogs_path` has been called.

### Detail

This Pull Request changes `self.class.class_eval(...)` to `instance_eval(...)` so route helpers are cached within the instanced object instead of the class so they are not shared by all instances.  

### Additional information

I would love to get feedback if there is a better way to test this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
