### PR TITLE
install node modules prior to assets:precompile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -32,6 +32,12 @@ RUN curl https://get.volta.sh | bash && \
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
+<% if using_node? -%>
+# Install node modules
+COPY package.json yarn.lock ./
+RUN yarn install
+
+<% end -%>
 # Copy application code
 COPY . .
 


### PR DESCRIPTION
### Motivation / Background

If node modules are only installed during assets:precompile then they will need to installed on every build where any source file has changed.  On small esbuild projects this may be barely noticable, but on mega webpack projects this can approach the time it takes to do a gem install.

Better to do it only when package.json or yarn.lock changes.

### Detail

It add a COPY statement for package.json and yarn.lock, and a RUN statement for yarn install, but only when node is used.

### Additional information

Ideally bundle install and node install would be separate build stages; enabling both to be run in parallel when needed, and only one run when only one file changed.  By putting yarn install after bundle install this will mean that yarn install will be run unnecessarily if only Gemfile has changed.

Build caches on each of these steps would also make a noticeable difference.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

While no tests are added, the existing test that ensure yarn is not mentioned unless node is used apply to this change.

No changelog is required for this pull request.