### PR TITLE
Add test to BUNDLE_WITHOUT

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Set production environment
 ENV RAILS_ENV="production" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development:test"
 
 
 # Throw-away build stage to reduce size of final image


### PR DESCRIPTION
From #46978.

### Motivation / Background

This Pull Request has been created because test gems are not needed at deployment

### Detail

This Pull Request adds :test to BUNDLE_WITHOUT

### Additional information

Our Rails template at fly.io has been this way pretty much since we started creating Dockerfiles for Rails applications.  I haven't seen any issues or complaints.  If there is a reason to include test modules I would appreciate hearing the rationale.

See:

https://github.com/superfly/flyctl/blame/master/scanner/templates/rails/standard/Dockerfile#L38

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

No tests or CHANGELOG are required for this change.