### PR TITLE
Adjust newlines in runner command USAGE

### DIFF
--- a/railties/lib/rails/commands/runner/USAGE
+++ b/railties/lib/rails/commands/runner/USAGE
@@ -9,12 +9,13 @@ Run the Ruby file located at `path/to/filename.rb` after loading the app:
   <%= executable %> path/to/filename.rb
 
 Run the Ruby script read from stdin after loading the app:
+
   <%= executable %> -
 
-<% unless Gem.win_platform? %>
+<% unless Gem.win_platform? -%>
 You can also use the runner command as a shebang line for your executables:
 
   #!/usr/bin/env <%= File.expand_path(executable) %>
 
   Product.all.each { |p| p.price *= 2 ; p.save! }
-<% end %>
+<% end -%>


### PR DESCRIPTION
This adds a missing newline, and removes extra newlines (due to ERB) in the output of `bin/rails runner --help`:

__Before__

  ```console
  $ bin/rails runner --help
  ...

  Examples:

  Run `puts Rails.env` after loading the app:

    bin/rails runner 'puts Rails.env'

  Run the Ruby file located at `path/to/filename.rb` after loading the app:

    bin/rails runner path/to/filename.rb

  Run the Ruby script read from stdin after loading the app:
    bin/rails runner -
 

  You can also use the runner command as a shebang line for your executables:

    #!/usr/bin/env .../my_cool_app/bin/rails runner

    Product.all.each { |p| p.price *= 2 ; p.save! }

  $
  ```

__After__

  ```console
  $ bin/rails runner --help
  ...

  Examples:

  Run `puts Rails.env` after loading the app:

    bin/rails runner 'puts Rails.env'

  Run the Ruby file located at `path/to/filename.rb` after loading the app:

    bin/rails runner path/to/filename.rb

  Run the Ruby script read from stdin after loading the app:

    bin/rails runner -

  You can also use the runner command as a shebang line for your executables:

    #!/usr/bin/env .../my_cool_app/bin/rails runner

    Product.all.each { |p| p.price *= 2 ; p.save! }
  $
  ```
