### PR TITLE
Emphasize precedence of `RAILS_MASTER_KEY` in USAGE

### DIFF
--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -24,11 +24,14 @@ credentials.
 Don't commit the key! Add `config/master.key` to your source control's
 ignore file. If you use Git, Rails handles this for you.
 
-Rails also looks for the master key in `ENV["RAILS_MASTER_KEY"]`, if that's easier to manage.
-
-You could prepend that to your server's start command like this:
+Rails also looks for the master key in `ENV["RAILS_MASTER_KEY"]`, in case that
+is easier to manage. You could set `RAILS_MASTER_KEY` in a deployment
+configuration, or you could prepend it to your server's start command like so:
 
    RAILS_MASTER_KEY="very-secret-and-secure" server.start
+
+If `ENV["RAILS_MASTER_KEY"]` is present, it takes precedence over
+`config/master.key`.
 
 === Set up Git to Diff Credentials
 
@@ -68,8 +71,8 @@ will create `config/credentials/development.yml.enc` with the corresponding
 encryption key in `config/credentials/development.key` if the credentials file
 doesn't exist.
 
-The encryption key can also be put in `ENV["RAILS_MASTER_KEY"]`, which takes
-precedence over the file encryption key.
-
 In addition to that, the default credentials lookup paths can be overridden through
 `config.credentials.content_path` and `config.credentials.key_path`.
+
+Just as with `config/master.key`, `ENV["RAILS_MASTER_KEY"]` takes precedence
+over any environment specific or specially configured key files.

--- a/railties/lib/rails/commands/encrypted/USAGE
+++ b/railties/lib/rails/commands/encrypted/USAGE
@@ -5,8 +5,8 @@ See the `Rails.application.encrypted` documentation for using them in your app.
 
 === Encryption Keys
 
-By default, Rails looks for the encryption key in `config/master.key` or
-`ENV["RAILS_MASTER_KEY"]`, but that lookup can be overridden with `--key`:
+By default, Rails looks for the encryption key in `ENV["RAILS_MASTER_KEY"]` or
+`config/master.key`, but that lookup can be overridden with `--key`:
 
    <%= executable(:edit) %> config/encrypted_file.yml.enc --key config/encrypted_file.key
 


### PR DESCRIPTION
This clarifies the precedence of `ENV["RAILS_MASTER_KEY"]` over `config/master.key` (and any other key files) in the output of `bin/rails credentials:help` and `bin/rails encrypted:help`.
