### PR TITLE
Hide `runner:looks_like_a_file_path?`

### DIFF
--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -66,9 +66,10 @@ module Rails
         end
       end
 
-      def looks_like_a_file_path?(code_or_file)
-        code_or_file.ends_with?(".rb")
-      end
+      private
+        def looks_like_a_file_path?(code_or_file)
+          code_or_file.ends_with?(".rb")
+        end
     end
   end
 end


### PR DESCRIPTION
This prevents `runner:looks_like_a_file_path?` from showing up in the output of `bin/rails --help`.

__Before__

  ```console
  $ bin/rails --help
  You must specify a command. The most common commands are:

  ...

  In addition to those commands, there are:

  about                              List versions of all Rails frameworks and...
  ...
  runner
  runner:looks_like_a_file_path?
  secret                             Generate a cryptographically secure secre...
  secrets:edit
  ...
  ```

__After__

  ```console
  $ bin/rails --help
  You must specify a command. The most common commands are:

  ...

  In addition to those commands, there are:

  about                              List versions of all Rails frameworks and...
  ...
  runner
  secret                             Generate a cryptographically secure secre...
  secrets:edit
  ...
  ```
