### PR TITLE
Hide `routes:invoke_command`

### DIFF
--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -10,11 +10,13 @@ module Rails
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
 
-      def invoke_command(*)
-        if options.key?("unused")
-          Rails::Command.invoke "unused_routes", ARGV
-        else
-          super
+      no_commands do
+        def invoke_command(*)
+          if options.key?("unused")
+            Rails::Command.invoke "unused_routes", ARGV
+          else
+            super
+          end
         end
       end
 


### PR DESCRIPTION
This prevents `routes:invoke_command` from showing up in the output of `bin/rails --help`.

__Before__

  ```console
  $ bin/rails --help
  You must specify a command. The most common commands are:

  ...

  In addition to those commands, there are:

  about                              List versions of all Rails frameworks and...
  ...
  restart                            Restart app by touching tmp/restart.txt
  routes
  routes:invoke_command
  runner
  ...
  ```

__After__

  ```console
  $ bin/rails --help
  You must specify a command. The most common commands are:

  ...

  In addition to those commands, there are:

  about                              List versions of all Rails frameworks and...
  ...
  restart                            Restart app by touching tmp/restart.txt
  routes
  runner
  ...
  ```
