### PR TITLE
Load `version.rb` for Action Mailbox and Action Text

### DIFF
--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "action_mailbox/version"
 require "action_mailbox/deprecator"
 require "action_mailbox/mail_ext"
 

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "active_support/rails"
 
+require "action_text/version"
 require "action_text/deprecator"
 
 require "nokogiri"


### PR DESCRIPTION
This matches the other frameworks, ensuring that `ActionMailbox.version` and `ActionText.version` are available when using Action Mailbox and Action Text, respectively.

__Before__

  ```console
  $ bin/rails runner 'puts ActiveRecord.version'
  7.1.0.alpha

  $ bin/rails runner 'puts ActionMailbox.version'
  undefined method `version' for ActionMailbox:Module

  $ bin/rails runner 'puts ActionText.version'
  undefined method `version' for ActionText:Module
  ```

__After__

  ```console
  $ bin/rails runner 'puts ActiveRecord.version'
  7.1.0.alpha

  $ bin/rails runner 'puts ActionMailbox.version'
  7.1.0.alpha

  $ bin/rails runner 'puts ActionText.version'
  7.1.0.alpha
  ```
