### PR TITLE
discard marshal dumped values when reading a signed cookie

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -557,6 +557,8 @@ module ActionDispatch
     class JsonSerializer # :nodoc:
       def self.load(value)
         ActiveSupport::JSON.decode(value)
+      rescue JSON::ParserError
+        nil
       end
 
       def self.dump(value)
@@ -686,7 +688,7 @@ module ActionDispatch
           deserialize(name) do |rotate|
             @encryptor.decrypt_and_verify(encrypted_message, on_rotation: rotate, purpose: purpose)
           end
-        rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature, JSON::ParserError
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage, ActiveSupport::MessageVerifier::InvalidSignature
           nil
         end
 


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/45956, a change was made to discard the results of an encrypted cookie if it was serialized with Marshal and the application is using json cookies. This situation occurs after updating the application from `:hybrid` to `:json` before all of the encrypted cookies have migrated through users using the application. 

However, this change was only applied to encrypted cookies, and signed cookies using Marshal would still raise an error if the decoder.

### Detail

This Pull Request changes how we rescue from the JSON::Parsed error so that applies to both encrypted and signed cookies.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

The Changelog entry from https://github.com/rails/rails/pull/45956 appears to cover this change, so the Changelog entry was omitted.
