### PR TITLE
Move test to `api_app_generator_test.rb`

### DIFF
--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -59,6 +59,14 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_dockerfile
+    run_generator
+
+    assert_file "Dockerfile" do |content|
+      assert_no_match(/assets:precompile/, content)
+    end
+  end
+
   def test_generator_if_skip_action_cable_is_given
     run_generator [destination_root, "--api", "--skip-action-cable"]
     assert_file "config/application.rb", /#\s+require\s+["']action_cable\/engine["']/

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1047,14 +1047,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_api
-    run_generator [destination_root, "--api"]
-
-    assert_file "Dockerfile" do |content|
-      assert_no_match(/assets:precompile/, content)
-    end
-  end
-
   def test_skip_docker
     run_generator [destination_root, "--skip-docker"]
 


### PR DESCRIPTION
Follow-up to #46938.

This test specifically targets the `--api` option, so it can frolic with the other `--api` app generator tests.
