### PR TITLE
split build and deploy packages

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -476,7 +476,7 @@ module Rails
         binfixups
       end
 
-      def dockerfile_packages
+      def dockerfile_build_packages
         # start with the essentials
         packages = %w(build-essential git)
 
@@ -512,6 +512,19 @@ module Rails
             packages << "python"
           end
         end
+
+        packages.sort
+      end
+
+      def dockerfile_deploy_packages
+        # start with databases: sqlite3, postgres, mysql
+        packages = %w(libsqlite3-0 postgresql-client default-mysql-client)
+
+        # add redis in case Action Cable, caching, or sidekiq are added later
+        packages << "redis"
+
+        # ActiveStorage preview support
+        packages << "libvips" unless skip_active_storage?
 
         packages.sort
       end

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -17,7 +17,7 @@ FROM base as build
 
 # Install packages need to build gems<%= using_node? ? " and node modules" : "" %>
 RUN apt-get update -qq && \
-    apt-get install -y <%= dockerfile_packages.join(" ") %>
+    apt-get install -y <%= dockerfile_build_packages.join(" ") %>
 
 <% if using_node? -%>
 # Install JavaScript dependencies
@@ -60,9 +60,11 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 # Final stage for app image
 FROM base
 
-# Copy built artifacts: libraries, gems, application
-RUN --mount=type=bind,from=build,source=/usr/lib,target=/build \
-  cp -rp /build/*-linux-gnu/* /usr/lib/*-linux-gnu
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y <%= dockerfile_deploy_packages.join(" ") %> && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 


### PR DESCRIPTION
move one step closer to the dockerfiles produced by fly.  Slightly larger Dockerfile, significantly smaller images as we are not including the substantial libraries only needed at build time.


### Motivation / Background

This Pull Request has been created because images produced by Rails Dockerfiles still are substantially larger than images produced by fly's Dockerfiles.

### Detail

This Pull Request changes from copying the libs from the build step to installing (and perhaps re-installing) only the libs needed at runtime.

### Additional information

* One nice feature is that docker buildx will run the steps in parallel up to the point of the COPY --from statements.
* I'm currently splurging (like we do on fly) and installing the whole clients for mysql, etc.  They are not directly used by the application server, but can be handy for debugging.
* I likely can reduce further.  For example the fly Dockerfiles include such things as vim curl and gzip which I didn't cary over, and while my demos needed things like git that can be removed, but my focus on the moment is to determine what the final shape will look like before fine turning further.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

No tests or changelog are required for this change.