### PR TITLE
Fix missing requires in Action Mailbox

### DIFF
--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "active_support"
+require "active_support/rails"
+require "active_support/core_ext/numeric/time"
+
 require "action_mailbox/version"
 require "action_mailbox/deprecator"
 require "action_mailbox/mail_ext"


### PR DESCRIPTION
### Motivation / Background

Previously, trying to `require "action_mailbox"` would fail if Active Support was not previously required.

### Detail

This fixes requiring Action Mailbox by adding the standard "active_support" and "active_support/rails" requires. In addition, this files uses `30.days` and so it needs to require core_ext/numeric/time as well.

### Additional Information

Would it be worth adding some kind of isolated test that verifies all of the frameworks can be required on their own?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
