### PR TITLE
Show usage example for `rails --help`

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -137,6 +137,9 @@ You can get a list of rails commands available to you, which will often depend o
 
 ```bash
 $ rails --help
+Usage:
+  bin/rails COMMAND [options]
+
 You must specify a command. The most common commands are:
 
   generate     Generate new code (short-cut alias: "g")

--- a/railties/lib/rails/commands/gem_help/USAGE
+++ b/railties/lib/rails/commands/gem_help/USAGE
@@ -1,3 +1,6 @@
+Usage:
+  rails COMMAND [options]
+
 You must specify a command:
 
   new          Create a new Rails application. "rails new my_app" creates a

--- a/railties/lib/rails/commands/help/USAGE
+++ b/railties/lib/rails/commands/help/USAGE
@@ -1,3 +1,6 @@
+Usage:
+  bin/rails COMMAND [options]
+
 You must specify a command. The most common commands are:
 
   generate     Generate new code (short-cut alias: "g")


### PR DESCRIPTION
In 2a5c116f12c7716399f5da3fe788f7e23ae67c4c the `Usage:\n rails COMMAND` lines were removed from the help USAGE file.
The original PR https://github.com/rails/rails/pull/27601 doesn't mention why this was done, so I'm not sure if this was done by accident.

Most commands have help usages of the form:
```console
Usage:
  bin/rails notes [options]

...rest of usage. 
```

...so it is more consistent to use this for help as well. This also allows differentiating between `rails` outside application directories and `bin/rails` inside application directories.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
