### PR TITLE
Refactor schema dumping helper for tests

### DIFF
--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module SchemaDumpingHelper
-  def dump_table_schema(table, connection = ActiveRecord::Base.connection)
+  def dump_table_schema(table)
+    connection = ActiveRecord::Base.connection
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
     ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - [table]
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+
+    ActiveRecord::SchemaDumper.dump(connection, stream)
     stream.string
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables


### PR DESCRIPTION
There isn't a single test that passes a connection to this method so refactor this to remove that option until it is needed.
