### PR TITLE
Add warning for missing translate_location

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -168,6 +168,10 @@ module ActionView
       if handler.respond_to?(:translate_location)
         handler.translate_location(spot, backtrace_location, encode!)
       else
+        ActionView.deprecator.warn(<<-MSG.squish)
+          The templating engine being used does not define `translate_location`
+          so Rails is unable to highlight the source location inside the template.
+        MSG
         spot
       end
     end


### PR DESCRIPTION
If other libraries like `haml` don't implement `translate_location` then they won't get the error highlighting behavior that was implemented to underline errors coming from templates.

This deprecation is to notify templating engines that this change is necessary for them to get this highlighting.