### PR TITLE
Stop doc on ruby_version_check.rb

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :stopdoc:
+
 if Gem.ruby_version < "2.7.0" && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message


### PR DESCRIPTION
RDoc was crashing for me when trying to parse this file, maybe because using ruby-trunk?

This shouldn't be documented anyways. :pray: