### PR TITLE
Revert "Optimize for the default case where TaggedLogger takes only one tag name"

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -37,12 +37,7 @@ module ActiveSupport
       end
 
       def tagged(*tags)
-        new_tags = if tags.length == 1
-          current_tags << tags[0] unless tags[0].blank?
-          tags
-        else
-          push_tags(*tags)
-        end
+        new_tags = push_tags(*tags)
         yield self
       ensure
         pop_tags(new_tags.size)

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -40,6 +40,11 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
   end
 
+  test "tagged with an array" do
+    @logger.tagged(%w(BCX Jason New)) { @logger.info "Funky time" }
+    assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
+  end
+
   test "tagged are flattened" do
     @logger.tagged("BCX", %w(Jason New)) { @logger.info "Funky time" }
     assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string


### PR DESCRIPTION
The 1st commit in this PR reverts 3baffd31bea7a4e2bc6bb9892f867d5d7366c468 due to a regression when calling `TaggedLogging#tagged` with a single array argument.

The 2nd commit in this PR adds a regression test for that case.
