### PR TITLE
Add missing requires in generated plugin `bin/rails`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -1,22 +1,6 @@
 require_relative "boot"
 
-<% if include_all_railties? -%>
-require "rails/all"
-<% else -%>
-require "rails"
-# Pick the frameworks you want:
-require "active_model/railtie"
-<%= comment_if :skip_active_job %>require "active_job/railtie"
-<%= comment_if :skip_active_record %>require "active_record/railtie"
-<%= comment_if :skip_active_storage %>require "active_storage/engine"
-require "action_controller/railtie"
-<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
-<%= comment_if :skip_action_mailbox %>require "action_mailbox/engine"
-<%= comment_if :skip_action_text %>require "action_text/engine"
-require "action_view/railtie"
-<%= comment_if :skip_action_cable %>require "action_cable/engine"
-<%= comment_if :skip_test %>require "rails/test_unit/railtie"
-<% end -%>
+<%= rails_require_statement %>
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -11,19 +11,5 @@ APP_PATH = File.expand_path("../<%= dummy_path -%>/config/application", __dir__)
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
-<% if include_all_railties? -%>
-require "rails/all"
-<% else -%>
-require "rails"
-# Pick the frameworks you want:
-require "active_model/railtie"
-<%= comment_if :skip_active_job %>require "active_job/railtie"
-<%= comment_if :skip_active_record %>require "active_record/railtie"
-<%= comment_if :skip_active_storage %>require "active_storage/engine"
-require "action_controller/railtie"
-<%= comment_if :skip_action_mailer %>require "action_mailer/railtie"
-require "action_view/railtie"
-<%= comment_if :skip_action_cable %>require "action_cable/engine"
-<%= comment_if :skip_test %>require "rails/test_unit/railtie"
-<% end -%>
+<%= rails_require_statement %>
 require "rails/engine/commands"


### PR DESCRIPTION
Prior to this commit, when generating a plugin with the `--full` option and a framework skip option (e.g. `--skip-action-cable`), `require "action_mailbox/engine"` and `require "action_text/engine"` would be missing from the generated `bin/rails` file.

This commit fixes the generated `bin/rails` file by factoring out a `rails_require_statement` helper method, which is now also used in a generated app's `config/application.rb`.  Thus, whenever new frameworks are added in the future, both generated files will reflect any changes.
