### PR TITLE
Fix broken link to trix stylesheet in Action Text guide

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -124,7 +124,7 @@ By default, Action Text will render rich text content inside an element with the
 ```
 
 Elements with this class, as well as the Action Text editor, are styled by the
-[`trix` stylesheet](https://raw.githubusercontent.com/basecamp/trix/master/dist/trix.css).
+[`trix` stylesheet](https://unpkg.com/trix/dist/trix.css).
 To provide your own styles instead, remove the `= require trix` line from the
 `app/assets/stylesheets/actiontext.css` stylesheet created by the installer.
 


### PR DESCRIPTION
I've replaced the broken link with a unpkg.com one as it is the CDN also mentioned in the trix README: https://github.com/basecamp/trix/tree/v2.0.4#getting-started

The compiled CSS is not part of the trix GitHub repository anymore, so instead of linking to a CDN we could only link to the (uncompiled) CSS source: 

- https://github.com/basecamp/trix/blob/v2.0.4/assets/trix.scss
- https://github.com/basecamp/trix/tree/v2.0.4/assets/trix/stylesheets

Thanks a lot.