### PR TITLE
`ActiveSupport::CurrentAttributes`: raise if a restricted attribute name is used.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveSupport::CurrentAttributes` now raises if a restricted attribute name is used.
+
+    Attributes such as `set` and `reset` cannot be used as they clash with the
+    `CurrentAttributes` public API.
+
+    *Alex Ghiculescu*
+
 *   `HashWithIndifferentAccess#transform_keys` now takes a Hash argument, just
     as Ruby's `Hash#transform_keys` does.
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -98,6 +98,11 @@ module ActiveSupport
 
       # Declares one or more attributes that will be given both class and instance accessor methods.
       def attribute(*names)
+        invalid_attribute_names = names.map(&:to_sym) & [:set, :reset, :resets, :instance, :before_reset, :after_reset, :reset_all, :clear_all]
+        if invalid_attribute_names.any?
+          raise ArgumentError, "Restricted attribute names: #{invalid_attribute_names.join(", ")}"
+        end
+
         ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |owner|
           names.each do |name|
             owner.define_cached_method(name, namespace: :current_attributes) do |batch|

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -207,4 +207,12 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   ensure
     ActiveSupport::IsolatedExecutionState.isolation_level = previous_level
   end
+
+  test "CurrentAttributes restricted attribute names" do
+    assert_raises ArgumentError, match: /Restricted attribute names: reset, set/ do
+      class InvalidAttributeNames < ActiveSupport::CurrentAttributes
+        attribute :reset, :foo, :set
+      end
+    end
+  end
 end


### PR DESCRIPTION
Attributes such as `set` and `reset` should not be used as they clash with the  `CurrentAttributes` public API. This PR raises an `ArgumentError` if a restricted attribute name is used.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
