### PR TITLE
Unlink Callbacks module name from self

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -9,7 +9,7 @@ require "active_support/core_ext/object/blank"
 require "thread"
 
 module ActiveSupport
-  # Callbacks are code hooks that are run at key points in an object's life cycle.
+  # \Callbacks are code hooks that are run at key points in an object's life cycle.
   # The typical use case is to have a base class define a set of callbacks
   # relevant to the other functionality it supplies, so that subclasses can
   # install callbacks that enhance or modify the base functionality without


### PR DESCRIPTION
<img width="495" alt="Screenshot 2023-01-16 at 14 21 14" src="https://user-images.githubusercontent.com/277819/212604190-ce660070-2322-4920-ade8-9862cb0122d0.png">

This escapes the module name to remove the auto-link generated by RDoc to the exact same module definition we are reading.