### PR TITLE
Improve Rails' Shape friendliness

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -16,6 +16,11 @@ module ActionController
 
     attr_internal :view_runtime
 
+    def initialize(...) # :nodoc:
+      super
+      self.view_runtime = nil
+    end
+
     def render(*)
       render_output = nil
       self.view_runtime = cleanup_view_runtime do

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -339,6 +339,11 @@ module ActionController # :nodoc:
       end
     end
 
+    def initialize(...)
+      super
+      @marked_for_same_origin_verification = nil
+    end
+
     def reset_csrf_token(request) # :doc:
       request.env.delete(CSRF_TOKEN)
       csrf_token_storage_strategy.reset(request)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -142,6 +142,7 @@ module ActionView
       @variant           = variant
       @compile_mutex     = Mutex.new
       @strict_locals     = NONE
+      @type              = nil
     end
 
     # The locals this template has been or will be compiled for, or nil if this

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -350,6 +350,13 @@ module ActiveModel
       end
 
       private
+        def inherited(base) # :nodoc:
+          super
+          base.class_eval do
+            @attribute_method_patterns_cache = nil
+          end
+        end
+
         def resolve_attribute_name(name)
           attribute_aliases.fetch(super, &:itself)
         end

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -247,6 +247,12 @@ module ActiveModel
     end
 
     private
+      def init_internals
+        super
+        @mutations_before_last_save = nil
+        @mutations_from_database = nil
+      end
+
       def clear_attribute_change(attr_name)
         mutations_from_database.forget_change(attr_name.to_s)
       end

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -347,5 +347,13 @@ module ActiveModel
       end
     end
     private_class_method :model_name_from_record_or_class
+
+    private
+      def inherited(base)
+        super
+        base.class_eval do
+          @_model_name = nil
+        end
+      end
   end
 end

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -431,6 +431,11 @@ module ActiveModel
     alias :read_attribute_for_validation :send
 
   private
+    def init_internals
+      super
+      @validation_context = nil
+    end
+
     def run_validations!
       _run_validate_callbacks
       errors.empty?

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -19,8 +19,8 @@ module ActiveRecord
       end
 
       def init_internals
-        @aggregation_cache = {}
         super
+        @aggregation_cache = {}
       end
 
       # Active Record implements aggregation through a macro-like class method called #composed_of

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -319,8 +319,8 @@ module ActiveRecord
 
     private
       def init_internals
-        @association_cache = {}
         super
+        @association_cache = {}
       end
 
       # Returns the specified association instance if it exists, +nil+ otherwise.

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -20,6 +20,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
           attr_accessor :right_reflection
         end
 
+        @table_name = nil
         def self.table_name
           # Table name needs to be resolved lazily
           # because RHS class might not have been loaded

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -40,11 +40,6 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def inherited(child_class) # :nodoc:
-        child_class.initialize_generated_modules
-        super
-      end
-
       def initialize_generated_modules # :nodoc:
         @generated_attribute_methods = const_set(:GeneratedAttributeMethods, GeneratedAttributeMethods.new)
         private_constant :GeneratedAttributeMethods
@@ -187,6 +182,15 @@ module ActiveRecord
       def _has_attribute?(attr_name) # :nodoc:
         attribute_types.key?(attr_name)
       end
+
+      private
+        def inherited(child_class)
+          super
+          child_class.initialize_generated_modules
+          child_class.class_eval do
+            @attribute_names = nil
+          end
+        end
     end
 
     # A Person object with a name attribute can ask <tt>person.respond_to?(:name)</tt>,

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -183,6 +183,12 @@ module ActiveRecord
       end
 
       private
+        def init_internals
+          super
+          @mutations_before_last_save = nil
+          @mutations_from_database = nil
+        end
+
         def _touch_row(attribute_names, time)
           @_touch_attr_names = Set.new(attribute_names)
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -154,6 +154,13 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       private
+        def inherited(base)
+          super
+          base.class_eval do
+            @_already_called = nil
+          end
+        end
+
         def define_non_cyclic_method(name, &block)
           return if method_defined?(name, false)
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -123,11 +123,6 @@ module ActiveRecord
       base.class_attribute(:defined_enums, instance_writer: false, default: {})
     end
 
-    def inherited(base) # :nodoc:
-      base.defined_enums = defined_enums.deep_dup
-      super
-    end
-
     def load_schema! # :nodoc:
       attributes_to_define_after_schema_loads.each do |name, (cast_type, _default)|
         unless columns_hash.key?(name)
@@ -193,6 +188,11 @@ module ActiveRecord
     end
 
     private
+      def inherited(base)
+        base.defined_enums = defined_enums.deep_dup
+        super
+      end
+
       def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, **options)
         assert_valid_enum_definition_values(values)
         # statuses = { }

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -210,12 +210,6 @@ module ActiveRecord
         end
       end
 
-      def inherited(subclass)
-        subclass.set_base_class
-        subclass.instance_variable_set(:@_type_candidates_cache, Concurrent::Map.new)
-        super
-      end
-
       def dup # :nodoc:
         # `initialize_dup` / `initialize_copy` don't work when defined
         # in the `singleton_class`.
@@ -277,6 +271,15 @@ module ActiveRecord
         end
 
       private
+        def inherited(subclass)
+          super
+          subclass.set_base_class
+          subclass.instance_variable_set(:@_type_candidates_cache, Concurrent::Map.new)
+          subclass.class_eval do
+            @finder_needs_type_condition = nil
+          end
+        end
+
         # Called by +instantiate+ to decide which class to use for a new
         # record instance. For single-table inheritance, we check the record
         # for a +type+ column and return the corresponding class.

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -169,10 +169,7 @@ module ActiveRecord
           end
 
           # The version column used for optimistic locking. Defaults to +lock_version+.
-          def locking_column
-            @locking_column = DEFAULT_LOCKING_COLUMN unless defined?(@locking_column)
-            @locking_column
-          end
+          attr_reader :locking_column
 
           # Reset the column used for optimistic locking back to the +lock_version+ default.
           def reset_locking_column
@@ -192,6 +189,14 @@ module ActiveRecord
             end
             super
           end
+
+          private
+            def inherited(base)
+              super
+              base.class_eval do
+                @locking_column = DEFAULT_LOCKING_COLUMN
+              end
+            end
         end
     end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -316,11 +316,7 @@ module ActiveRecord
       # The list of columns names the model should ignore. Ignored columns won't have attribute
       # accessors defined, and won't be referenced in SQL queries.
       def ignored_columns
-        if defined?(@ignored_columns)
-          @ignored_columns
-        else
-          superclass.ignored_columns
-        end
+        @ignored_columns || superclass.ignored_columns
       end
 
       # Sets the columns names the model should ignore. Ignored columns won't have attribute
@@ -575,6 +571,9 @@ module ActiveRecord
           super
           child_class.initialize_load_schema_monitor
           child_class.reload_schema_from_cache(false)
+          child_class.class_eval do
+            @ignored_columns = nil
+          end
         end
 
         def schema_loaded?

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -600,6 +600,13 @@ module ActiveRecord
       end
 
       private
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @_query_constraints_list = nil
+          end
+        end
+
         # Given a class, an attributes hash, +instantiate_instance_of+ returns a
         # new instance of the class. Accepts only keys as strings.
         def instantiate_instance_of(klass, attributes, column_types = {}, &block)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1113,6 +1113,11 @@ module ActiveRecord
     end
 
   private
+    def init_internals
+      super
+      @_trigger_destroy_callback = @_trigger_update_callback = nil
+    end
+
     def strict_loaded_associations
       @association_cache.find_all do |_, assoc|
         assoc.owner.strict_loading? && !assoc.owner.strict_loading_n_plus_one_only?

--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -16,6 +16,11 @@ module ActiveRecord
         end
       end
 
+      def initialize(...) # :nodoc:
+        super
+        self.db_runtime = nil
+      end
+
       private
         attr_internal :db_runtime
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -128,6 +128,14 @@ module ActiveRecord
       def clear_reflections_cache # :nodoc:
         @__reflections = nil
       end
+
+      private
+        def inherited(subclass)
+          super
+          subclass.class_eval do
+            @__reflections = nil
+          end
+        end
     end
 
     # Holds all the methods that are shared between MacroReflection and ThroughReflection.

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -78,6 +78,14 @@ module ActiveRecord
         connection.default_timezone == :utc ? Time.now.utc : Time.now
       end
 
+      protected
+        def reload_schema_from_cache(recursive = true)
+          @timestamp_attributes_for_create_in_model = nil
+          @timestamp_attributes_for_update_in_model = nil
+          @all_timestamp_attributes_in_model = nil
+          super
+        end
+
       private
         def timestamp_attributes_for_create
           ["created_at", "created_on"].map! { |name| attribute_aliases[name] || name }
@@ -86,16 +94,14 @@ module ActiveRecord
         def timestamp_attributes_for_update
           ["updated_at", "updated_on"].map! { |name| attribute_aliases[name] || name }
         end
-
-        def reload_schema_from_cache
-          @timestamp_attributes_for_create_in_model = nil
-          @timestamp_attributes_for_update_in_model = nil
-          @all_timestamp_attributes_in_model = nil
-          super
-        end
     end
 
   private
+    def init_internals
+      super
+      @_touch_record = nil
+    end
+
     def _create_record
       if record_timestamps
         current_time = current_time_from_proper_timezone

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -368,6 +368,11 @@ module ActiveRecord
     private
       attr_reader :_committed_already_called, :_trigger_update_callback, :_trigger_destroy_callback
 
+      def init_internals
+        super
+        @_committed_already_called = nil
+      end
+
       # Save the new record state and id of a record so it can be restored later if a transaction fails.
       def remember_transaction_record_state
         @_start_transaction_state ||= {

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -154,11 +154,6 @@ module ActiveSupport
 
       @direct_descendants = {}
 
-      def inherited(base) # :nodoc:
-        DescendantsTracker.store_inherited(self, base)
-        super
-      end
-
       class << self
         def subclasses(klass)
           descendants = @direct_descendants[klass]
@@ -184,6 +179,12 @@ module ActiveSupport
       def descendants
         DescendantsTracker.descendants(self)
       end
+
+      private
+        def inherited(base) # :nodoc:
+          DescendantsTracker.store_inherited(self, base)
+          super
+        end
     end
   end
 end


### PR DESCRIPTION
Ruby 3.2 significantly changed how instance variables are store. It now use shapes, and in short, it's important for performance to define instance variables in a consistent order to limit the amount of shapes.

Otherwise, the number of shapes will increase past a point where MRI won't be able to cache instance variable access. The impact is even more important when YJIT is enabled.

This PR is data driven. I dump the list of Shapes from Shopify's monolith production environment, and Rails is very present among the top offenders:

```
Shape Edges Report
-----------------------------------
       770  @default_graphql_name
       697  @own_fields
       661  @to_non_null_type
       555  @own_interface_type_memberships
       472  @description
       389  @errors
       348  @oseid
       316  @_view_runtime
       310  @_db_runtime
       292  @visibility
       286  @shop
       271  @attribute_method_patterns_cache
       264  @namespace_for_serializer
       254  @locking_column
       254  @primary_key
       253  @validation_context
       244  @quoted_primary_key
       238  @access_controls
       234  @_trigger_destroy_callback
       226  @_trigger_update_callback
       224  @finder_needs_type_condition
       215  @_committed_already_called
       214  @api_type
       203  @mutations_before_last_save
       202  @access_controls_overrides
       201  @options
       198  @mutations_from_database
       190  @_already_called
       183  @name
       179  @_request
       176  @own_arguments
       175  @_assigns
       175  @virtual_path
       174  @context
       173  @_controller
       173  @output_buffer
       173  @view_flow
       172  @_default_form_builder
       169  @cache
       159  @_touch_record
       151  @attribute_names
       151  @default_attributes
       150  @columns_hash
       149  @attribute_types
       148  @columns
       147  @marked_for_same_origin_verification
       146  @schema_loaded
       143  @_config
       143  @type
       141  @column_names
```

All the changes are of similar nature, the goal is to preset the instance variable to nil when objects are allocated, or when classes are created.

For classes I leverage the `inherited` hook. If the patern becomes common enough it might make sense to add a helper for this in `ActiveSupport::Concern`.
