### PR TITLE
`assert_emails`: return the emails that were sent

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   `assert_emails` now returns the emails that were sent.
+
+    This makes it easier to do further analysis on those emails:
+
+    ```ruby
+    def test_emails_more_thoroughly
+      email = assert_emails 1 do
+        ContactMailer.welcome.deliver_now
+      end
+      assert_email "Hi there", email.subject
+
+      emails = assert_emails 2 do
+        ContactMailer.welcome.deliver_now
+        ContactMailer.welcome.deliver_later
+      end
+      assert_email "Hi there", emails.first.subject
+    end
+    ```
+
+    *Alex Ghiculescu*
+
 *   Added ability to download `.eml` file for the email preview.
 
     *Igor Kasyanchuk*

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -7,6 +7,7 @@ class TestHelperMailer < ActionMailer::Base
   def test
     @world = "Earth"
     mail body: render(inline: "Hello, <%= @world %>"),
+      subject: "Hi!",
       to: "test@example.com",
       from: "tester@example.com"
   end
@@ -87,6 +88,25 @@ class TestHelperMailerTest < ActionMailer::TestCase
       assert_emails 1 do
         TestHelperMailer.test.deliver_now
       end
+    end
+  end
+
+  def test_assert_emails_returns_the_emails_that_were_sent_if_a_block_is_given
+    assert_nothing_raised do
+      email = assert_emails 1 do
+        TestHelperMailer.test.deliver_now
+      end
+      assert_instance_of Mail::Message, email
+      assert_equal "Hello, Earth", email.body.to_s
+      assert_equal "Hi!", email.subject
+
+      emails = assert_emails 2 do
+        TestHelperMailer.test.deliver_now
+        TestHelperMailer.test.deliver_now
+      end
+      assert_instance_of Array, emails
+      assert_instance_of Mail::Message, emails.first
+      assert_instance_of Mail::Message, emails.second
     end
   end
 


### PR DESCRIPTION
This pattern is pretty common:

```ruby
assert_emails 1 do
  post invite_user_path # ...
end
email = ActionMailer::Base.deliveries.last
assert_equal "You were invited!", email.subject
```

We can make it a bit nicer, by returning the email object from `assert_emails`. This is similar to how `assert_raises` returns the error so you can do additional checks on it. With this PR:

```ruby
email = assert_emails 1 do
  post invite_user_path # ...
end
assert_equal "You were invited!", email.subject
```

If a single email is sent, a single `Mail::Message` is returned. If multiple emails were sent, an array is returned.

```ruby
emails = assert_emails 2 do
  post invite_user_path # ...
end
emails.each do |email|
  assert_equal "You were invited!", email.subject
end
```

Before this PR, `assert_emails` just returned `true` (or raised if the assertion failed). So while some tests may be relying on that return value, they don't really need to and it shouldn't be a very annoying change to fix them.