### PR TITLE
`ActiveRecord::Base#signed_id`: raise if called on a new record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveRecord::Base#signed_id` raises if called on a new record
+
+    Previously it would return an ID that was not usable, since it was based on `id = nil`.
+
+    *Alex Ghiculescu*
+
 *   Allow SQL warnings to be reported.
 
     Active Record configs can be set to enable SQL warning reporting.

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -110,6 +110,8 @@ module ActiveRecord
     # And you then change your +find_signed+ calls to require this new purpose. Any old signed ids that were not
     # created with the purpose will no longer find the record.
     def signed_id(expires_in: nil, expires_at: nil, purpose: nil)
+      raise ArgumentError, "Cannot get a signed_id for a new record" if new_record?
+
       self.class.signed_id_verifier.generate id, expires_in: expires_in, expires_at: expires_at, purpose: self.class.combine_signed_id_purposes(purpose)
     end
   end


### PR DESCRIPTION
Currently you can call `signed_id` on a new record, and it will generate a token. But the token won't work when you call `find_signed` since it was based on the ID being `nil`.

This PR makes `signed_id` raise an error to warn you about this, rather than letting the incorrect code subtly slip into use.

Similar to https://github.com/rails/rails/pull/47017#issuecomment-1383323996 I'm open to making this a deprecation first, but went with an error because currently the functionality just doesn't work.