### PR TITLE
Use `eval_gemfile` to read .Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ end
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
-instance_eval File.read local_gemfile if File.exist? local_gemfile
+eval_gemfile local_gemfile if File.exist? local_gemfile
 
 group :test do
   gem "minitest-bisect"


### PR DESCRIPTION
### Motivation / Background

[`eval_gemfile`](https://github.com/rubygems/rubygems/blob/7a144f3374f6a400cc9832f072dc1fc0bca8c724/bundler/lib/bundler/dsl.rb#L43-L58) includes some error handling and management of Bundler's internal state, and is more idiomatic.

### Detail

This Pull Request changes the optional `.Gemfile` to be read using `eval_gemfile` instead of by manually reading and eval'ing the file.

### Additional information

- @tenderlove added this code to read `.Gemfile` 2011 in https://github.com/rails/rails/commit/a437986f433a775c7c370ad3f0273938015699df
- `eval_gemfile` was later added to Bundler in 2012 in https://github.com/rubygems/rubygems/commit/84a3e2276c7a4926b361291be18f07747b06ed62

I do notice that regardless of the use of `eval_gemfile`, adding gems to `.Gemfile` locally means `Gemfile.lock` will be dirty. I wonder if there is a way to avoid this, perhaps by using a different lock file. Probably not worth spending much time on though.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~Tests are added or updated if you fix a bug or add a feature.~
* ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
