### PR TITLE
Rename `::normalize` to `::normalize_value_for`

### DIFF
--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -91,9 +91,9 @@ module ActiveRecord # :nodoc:
       #     normalizes :email, with: -> email { email.strip.downcase }
       #   end
       #
-      #   User.normalize(:email, " CRUISE-CONTROL@EXAMPLE.COM\n")
+      #   User.normalize_value_for(:email, " CRUISE-CONTROL@EXAMPLE.COM\n")
       #   # => "cruise-control@example.com"
-      def normalize(name, value)
+      def normalize_value_for(name, value)
         type_for_attribute(name).cast(value)
       end
     end

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -49,7 +49,11 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
   end
 
   test "normalizes value without record" do
-    assert_equal "Titlecase Me", NormalizedAircraft.normalize(:name, "titlecase ME")
+    assert_equal "Titlecase Me", NormalizedAircraft.normalize_value_for(:name, "titlecase ME")
+  end
+
+  test "casts value when no normalization is declared" do
+    assert_equal 6, NormalizedAircraft.normalize_value_for(:wheels_count, "6")
   end
 
   test "casts value before applying normalization" do
@@ -58,7 +62,7 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
   end
 
   test "ignores nil by default" do
-    assert_nil NormalizedAircraft.normalize(:name, nil)
+    assert_nil NormalizedAircraft.normalize_value_for(:name, nil)
   end
 
   test "normalizes nil if apply_to_nil" do
@@ -66,7 +70,7 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
       normalizes :name, with: -> name { name&.titlecase || "Untitled" }, apply_to_nil: true
     end
 
-    assert_equal "Untitled", including_nil.normalize(:name, nil)
+    assert_equal "Untitled", including_nil.normalize_value_for(:name, nil)
   end
 
   test "does not automatically normalize value from database" do
@@ -84,8 +88,8 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
       normalizes :name, with: -> name { name.reverse }
     end
 
-    assert_equal "eM esreveR nehT esaceltiT", titlecase_then_reverse.normalize(:name, "titlecase THEN reverse ME")
-    assert_equal "Only Titlecase Me", NormalizedAircraft.normalize(:name, "ONLY titlecase ME")
+    assert_equal "esreveR nehT esaceltiT", titlecase_then_reverse.normalize_value_for(:name, "titlecase THEN reverse")
+    assert_equal "Only Titlecase", NormalizedAircraft.normalize_value_for(:name, "ONLY titlecase")
   end
 
   test "minimizes number of times normalization is applied" do


### PR DESCRIPTION
The `::normalize` method accepts an attribute name and a value, and type casts the value, applying any declared normalizations for the attribute. Because of the way type casting works for most types, the type of the given value can be very different than the attribute type.  This allows for potential confusion between the `::normalize` method and the `::normalizes` method.  For example:

  ```ruby
  class Post < ActiveRecord::Base
    normalize :title, with: -> { _1.titlecase }
  end
  ```

In the above code, the user meant to call `::normalizes`, but called `::normalize` instead.  The `:with` kwarg is treated as a `Hash` value which is then type cast to a `String`.  The type cast silently succeeds, so the user does not realize why their normalization is not applied.

To prevent such confusion, this commit renames `::normalize` to `::normalize_value_for`.
