### PR TITLE
Support nested middleware stacks

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for nested middleware stacks
+
+    *Nick Hengeveld*
+
 *   Fix `Rails.application.reload_routes!` from clearing almost all routes.
 
     When calling `Rails.application.reload_routes!` inside a middleware of

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -21,6 +21,10 @@ module ActionDispatch
         @block = block
       end
 
+      def middleware_container?
+        false
+      end
+
       def name; klass.name; end
 
       def ==(middleware)
@@ -46,6 +50,32 @@ module ActionDispatch
 
       def build_instrumented(app)
         InstrumentationProxy.new(build(app), inspect)
+      end
+    end
+
+    class MiddlewareContainer
+      attr_reader :container
+
+      def initialize(container)
+        @container = container
+      end
+
+      def middleware_container?
+        true
+      end
+
+      def flattened_middlewares
+        middlewares.flat_map do |middleware|
+          if middleware.middleware_container?
+            middleware.flattened_middlewares
+          else
+            middleware
+          end
+        end
+      end
+
+      def middlewares
+        @middlewares ||= container.merge_into(MiddlewareStack.new).middlewares
       end
     end
 
@@ -163,8 +193,21 @@ module ActionDispatch
     end
     ruby2_keywords(:use)
 
+    def flatten_middleware!
+      @middlewares = middlewares.flat_map do |middleware|
+        if middleware.middleware_container?
+          middleware.flattened_middlewares
+        else
+          middleware
+        end
+      end
+    end
+
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)
+
+      flatten_middleware!
+
       middlewares.freeze.reverse.inject(app || block) do |a, e|
         if instrumenting
           e.build_instrumented(a)
@@ -182,12 +225,20 @@ module ActionDispatch
       end
 
       def build_middleware(klass, args, block)
-        Middleware.new(klass, args, block)
+        if klass.respond_to?(:merge_into)
+          MiddlewareContainer.new(klass)
+        else
+          Middleware.new(klass, args, block)
+        end
       end
 
       def index_of(klass)
         middlewares.index do |m|
-          m.name == klass.name
+          if klass.respond_to?(:merge_into)
+            m.middleware_container? && m.container == klass
+          else
+            !m.middleware_container? && m.name == klass.name
+          end
         end
       end
   end

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -49,6 +49,10 @@ module Rails
         @delete_operations = delete_operations
       end
 
+      def create_stack
+        self.class.new
+      end
+
       def insert_before(...)
         @operations << -> middleware { middleware.insert_before(...) }
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4319,6 +4319,34 @@ module ApplicationTests
       assert_nil Rails.application.config.middleware.map(&:name).index("3rd custom middleware")
     end
 
+    test "middleware can be added with a nested stack" do
+      app_file "config/initializers/add_custom_middleware.rb", <<~RUBY
+        class NestedMiddlewareBase
+          def initialize(app, *args); end
+          def new(app); self; end
+        end
+
+        class NestedMiddlewareOne < NestedMiddlewareBase ; end
+        class NestedMiddlewareTwo < NestedMiddlewareBase ; end
+        class NestedMiddlewareThree < NestedMiddlewareBase ; end
+
+        inner_nested_stack = Rails.application.config.middleware.create_stack
+        outer_nested_stack = Rails.application.config.middleware.create_stack
+        Rails.application.config.middleware.unshift(outer_nested_stack)
+        outer_nested_stack.use(NestedMiddlewareOne)
+        outer_nested_stack.use(NestedMiddlewareThree)
+        outer_nested_stack.insert_after(NestedMiddlewareOne, inner_nested_stack)
+        inner_nested_stack.use(NestedMiddlewareTwo)
+      RUBY
+
+      app "development"
+
+      built_middleware = Rails.application.config.middleware.map(&:klass)
+      assert_equal 0, built_middleware.index(NestedMiddlewareOne)
+      assert_equal 1, built_middleware.index(NestedMiddlewareTwo)
+      assert_equal 2, built_middleware.index(NestedMiddlewareThree)
+    end
+
     test "Rails.application.deprecators includes framework deprecators" do
       app "production"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because middleware configuration can be unwieldy/confusing when an application needs to add many middlewares in specific locations on the stack relative to the default stack.

For example, to add a list of app-specific middleware `A`, `B,` and `C` in order before the start of the default Rails middleware stack, one might use:

```ruby
config.middleware.insert_before ActionDispatch::HostAuthorization, A
config.middleware.insert_before ActionDispatch::HostAuthorization, B
config.middleware.insert_before ActionDispatch::HostAuthorization, C
```

This is slightly nonintuitive in that each successive middleware is being sandwiched between the last app-specific middleware and `ActionDispatch::HostAuthorization`, and is also more brittle with a dependency on the presence and location of `ActionDispatch::HostAuthorization`.

One could also use:

```ruby
config.middleware.unshift C
config.middleware.unshift B
config.middleware.unshift A
```

This ensures that the app-specific middleware is located before the Rails middleware, but must be added in reverse to get the desired order.


### Detail

This Pull Request changes middleware configuration to allow stacks to be nested. In the above example, the app-specific middleware could be configured in its own stack proxy, and then added to the Rails root stack proxy with one configuration directive:

```ruby
app_stack = config.middleware.create_stack
app_stack.use A
app_stack.use B
app_stack.use C

config.middleware.unshift app_stack
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

This change defers flattening of the nested middleware stacks until the top-level stack proxy is merged into a stack, so later changes to a nested stack are still included:

```ruby
app_stack = config.middleware.create_stack
app_stack.use A
app_stack.use B

config.middleware.unshift app_stack

# This middleware will be at the expected location in the app's middleware stack when it is built
app_stack.use C
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.