### PR TITLE
Make sure `ActiveRecord::Relation#sum` works with objects that implement #coerce without deprecation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -146,7 +146,7 @@ module ActiveRecord
     def sum(identity_or_column = nil, &block)
       if block_given?
         values = map(&block)
-        if identity_or_column.nil? && (values.first.is_a?(Numeric) || values.first(1) == [])
+        if identity_or_column.nil? && (values.first.is_a?(Numeric) || values.first(1) == [] || values.first.respond_to?(:coerce))
           identity_or_column = 0
         end
 


### PR DESCRIPTION
Same as https://github.com/rails/rails/commit/e9bc620f786d7da9afb82ec13ca3ec249f856c0c but for AR relations (not arrays).

cc @rafaelfranca 