### PR TITLE
Date and time/new date methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -530,4 +530,17 @@
 
     *Jean Boussier*
 
+*   New methods to check if current date is start of month or end of month, returns boolean.
+    ```
+    Time.zone.today.is_start_of_month?
+    Date.current.is_start_of_month?
+
+    Time.zone.today.is_beginning_of_month?    
+    Date.current.is_beginning_of_month?
+
+    Time.zone.today.is_end_of_month?
+    Date.current.is_end_of_month?
+    ```
+    *lordstingray*
+
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -530,7 +530,9 @@
 
     *Jean Boussier*
 
-*   New methods to check if current date is start of month or end of month, returns boolean.
+*   Add `DateAndTime::Calculations#is_start_of_month?`, `DateAndTime::Calculations#is_beginning_of_month?`, and `DateAndTime::Calculations#is_end_of_month?`
+    to check if current date is start or end of month.
+
     ```
     Time.zone.today.is_start_of_month?
     Date.current.is_start_of_month?
@@ -541,6 +543,7 @@
     Time.zone.today.is_end_of_month?
     Date.current.is_end_of_month?
     ```
+
     *lordstingray*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -535,7 +535,7 @@
     Time.zone.today.is_start_of_month?
     Date.current.is_start_of_month?
 
-    Time.zone.today.is_beginning_of_month?    
+    Time.zone.today.is_beginning_of_month?
     Date.current.is_beginning_of_month?
 
     Time.zone.today.is_end_of_month?

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -73,6 +73,17 @@ module DateAndTime
       self > date_or_time
     end
 
+    # Returns true if the current date is also start of the month.
+    def is_start_of_month?
+      beginning_of_month.to_date == ::Date.current
+    end
+    alias :is_beginning_of_month? :is_start_of_month?
+
+    # Returns true if the current date is also end of the month.
+    def is_end_of_month?
+      end_of_month.to_date == ::Date.current
+    end
+
     # Returns a new date/time the specified number of days ago.
     def days_ago(days)
       advance(days: -days)

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -563,7 +563,6 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
       assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59, Rational(-18000, 86400)).is_start_of_month?
       assert_equal true,  DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-18000, 86400)).is_start_of_month?
       assert_equal true,  DateTime.civil(2000, 1, 1, 23, 59, 59, Rational(-18000, 86400)).is_start_of_month?
-      assert_equal false, DateTime.civil(2000, 1, 2, 0, 0, 0, Rational(-18000, 86400)).is_start_of_month?
     end
   end
 
@@ -572,7 +571,6 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
       assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59, Rational(-18000, 86400)).is_end_of_month?
       assert_equal true,  DateTime.civil(2000, 1, 31, 0, 0, 0, Rational(-18000, 86400)).is_end_of_month?
       assert_equal true,  DateTime.civil(2000, 1, 31, 23, 59, 59, Rational(-18000, 86400)).is_end_of_month?
-      assert_equal false, DateTime.civil(2000, 1, 30, 0, 0, 0, Rational(-18000, 86400)).is_end_of_month?
     end
   end
 end

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -557,4 +557,22 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 0, DateTime.civil(2000).subsec
     assert_equal Rational(1, 2), DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 2)).subsec
   end
+
+  def test_is_start_of_month
+    Date.stub(:current, Date.new(2000, 1, 1)) do
+      assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59, Rational(-18000, 86400)).is_start_of_month?
+      assert_equal true,  DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-18000, 86400)).is_start_of_month?
+      assert_equal true,  DateTime.civil(2000, 1, 1, 23, 59, 59, Rational(-18000, 86400)).is_start_of_month?
+      assert_equal false, DateTime.civil(2000, 1, 2, 0, 0, 0, Rational(-18000, 86400)).is_start_of_month?
+    end
+  end
+
+  def test_is_end_of_month
+    Date.stub(:current, Date.new(2000, 1, 31)) do
+      assert_equal false, DateTime.civil(1999, 12, 31, 23, 59, 59, Rational(-18000, 86400)).is_end_of_month?
+      assert_equal true,  DateTime.civil(2000, 1, 31, 0, 0, 0, Rational(-18000, 86400)).is_end_of_month?
+      assert_equal true,  DateTime.civil(2000, 1, 31, 23, 59, 59, Rational(-18000, 86400)).is_end_of_month?
+      assert_equal false, DateTime.civil(2000, 1, 30, 0, 0, 0, Rational(-18000, 86400)).is_end_of_month?
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

I came across one particular check where it was required to validate if current date is also a start of the month or not. Which brings me to find any built-in methods and found nothing but there was one method `today?` which convinced me add these two methods as well.

### Detail

This pull request will add two different methods:
- `is_start_of_month?` with alias `is_beginning_of_month`.
- `is_end_of_month`, this method does not have any alias.

Both methods will help to verify if current date is also a start of the month or not, uses same approach for the second method as well to check if current date is also end of the month.  

### Additional information

You can use them like this:

```
Time.zone.today.is_start_of_month?
Time.zone.today.is_beginning_of_month?
Time.zone.today.is_end_of_month?

Date.current.is_start_of_month?
Date.current.is_beginning_of_month?
Date.current.is_end_of_month?
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ✔️  ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ✔️ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ✔️ ] Tests are added or updated if you fix a bug or add a feature.
* [✔️  ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
