### PR TITLE
refactor(numericality-validation): remove duplicate symbol call 

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -123,15 +123,15 @@ module ActiveModel
         return value if record_attribute_changed_in_place?(record, attr_name)
 
         came_from_user = :"#{attr_name}_came_from_user?"
+        before_type_cast = :"#{attr_name}_before_type_cast"
 
         if record.respond_to?(came_from_user)
           if record.public_send(came_from_user)
-            raw_value = record.public_send(:"#{attr_name}_before_type_cast")
+            raw_value = record.public_send(before_type_cast)
           elsif record.respond_to?(:read_attribute)
             raw_value = record.read_attribute(attr_name)
           end
         else
-          before_type_cast = :"#{attr_name}_before_type_cast"
           if record.respond_to?(before_type_cast)
             raw_value = record.public_send(before_type_cast)
           end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Hi everyone, this is a simple PR, which aims to remove the duplicate calls of the symbol `:"#{attr_name}_before_type_cast"` inside the `prepare_value_for_validation` 
