### PR TITLE
Fix spelling in Active Record CHANGELOG

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -30,7 +30,7 @@
     carefully crafted input.
 
     This commit makes the sanitization more robust by replacing any
-    occurrances of "/*" or "*/" with "/ *" or "* /". It also performs a
+    occurrences of "/*" or "*/" with "/ *" or "* /". It also performs a
     first pass to remove one surrounding comment to avoid compatibility
     issues for users relying on the existing removal.
 


### PR DESCRIPTION
Needs backport to `6-1-stable` and `6-0-stable`
