### PR TITLE
Update action_text_overview.md for libvips42 note

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -98,6 +98,10 @@ And finally, display the sanitized rich text on a page:
 <%= @message.content %>
 ```
 
+**Note:** if there's an attached resource within `content` field. It might not show properly unless
+have libvips/libvips42 package installed locally on your machine. Linux based users can run `apt install libvips42`
+to install it.
+
 To accept the rich text content, all you have to do is permit the referenced attribute:
 
 ```ruby

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -98,8 +98,8 @@ And finally, display the sanitized rich text on a page:
 <%= @message.content %>
 ```
 
-**Note:** if there's an attached resource within `content` field. It might not show properly unless
-have libvips/libvips42 package installed locally on your machine. Linux based users can run `apt install libvips42`
+**Note:** if there's an attached resource within `content` field. It might not show properly unless you
+have *libvips/libvips42* package installed locally on your machine. Linux based users can run `apt install libvips42`
 to install it.
 
 To accept the rich text content, all you have to do is permit the referenced attribute:


### PR DESCRIPTION
While following up the ActionText documentation [here](https://guides.rubyonrails.org/action_text_overview.html). I found my attached resource within rich_text_content doesn't render. On investigation, it comes out to be a package `libvips42` unavailability locally.
