### PR TITLE
Add test for HealthController

### DIFF
--- a/railties/test/rails_health_controller_test.rb
+++ b/railties/test/rails_health_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class HealthControllerTest < ActionController::TestCase
+  tests Rails::HealthController
+
+  def setup
+    Rails.application.routes.draw do
+      get "/up" => "rails/health#show"
+    end
+    @routes = Rails.application.routes
+  end
+
+  test "health controller renders green success page" do
+    get :show
+    assert_response :success
+    assert_match(/background-color: green/, @response.body)
+  end
+
+  test "health controller renders red internal server error page" do
+    @controller.instance_eval do
+      def render_up
+        raise Exception, "some exception"
+      end
+    end
+    get :show
+    assert_response :internal_server_error
+    assert_match(/background-color: red/, @response.body)
+  end
+end


### PR DESCRIPTION
### Motivation / Background

I tried to use `ActionController::Metal` for the `HealthController` and didn't notice I broke the implementation. That's when I noticed the missing tests for the `HealthController`.

### Detail

This Pull Request adds a simple test for the new `HealthController`, similar to the `InfoControllerTest`.