### PR TITLE
Improve matching of cookie assertions.

### DIFF
--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -313,12 +313,14 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     end
   end
 
+  include CookieAssertions
+
   test "response cookies are added to the cookie jar for the next request" do
     with_test_route_set do
       cookies["cookie_1"] = "sugar"
       cookies["cookie_2"] = "oatmeal"
       get "/cookie_monster"
-      assert_equal "cookie_1=; path=/\ncookie_3=chocolate; path=/", headers["Set-Cookie"]
+      assert_set_cookie_header "cookie_1=; path=/\ncookie_3=chocolate; path=/", headers["Set-Cookie"]
       assert_equal({ "cookie_1" => "", "cookie_2" => "oatmeal", "cookie_3" => "chocolate" }, cookies.to_hash)
     end
   end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1241,9 +1241,14 @@ class CookieCsrfTokenStorageStrategyControllerTest < ActionController::TestCase
     assert_match "SameSite=Lax", @response.headers["Set-Cookie"]
   end
 
+  include CookieAssertions
+
   def test_csrf_token_cookie_is_http_only
     get :cookie
-    assert_match "HttpOnly", @response.headers["Set-Cookie"]
+
+    cookies = parse_set_cookies_headers(@response.headers["Set-Cookie"])
+    csrf_token_cookie = cookies["csrf_token"]
+    assert csrf_token_cookie["httponly"]
   end
 
   def test_csrf_token_cookie_is_permanent

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -81,6 +81,8 @@ class CookieJarTest < ActiveSupport::TestCase
 end
 
 class CookiesTest < ActionController::TestCase
+  include CookieAssertions
+
   class CustomSerializer
     def self.load(value)
       value.to_s + " and loaded"
@@ -391,7 +393,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.cookies_same_site_protection"] = proc { :none }
 
     get :authenticate
-    assert_cookie_header "user_name=david; path=/; SameSite=None"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=None"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -401,7 +403,7 @@ class CookiesTest < ActionController::TestCase
     end
 
     get :authenticate
-    assert_cookie_header "user_name=david; path=/; SameSite=Strict"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=Strict"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -412,7 +414,7 @@ class CookiesTest < ActionController::TestCase
 
     request.user_agent = "spooky browser"
     get :authenticate
-    assert_cookie_header "user_name=david; path=/"
+    assert_set_cookie_header "user_name=david; path=/"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -429,7 +431,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.cookies_same_site_protection"] = proc { :strict }
 
     get :authenticate
-    assert_cookie_header "user_name=david; path=/; SameSite=Strict"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=Strict"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -437,7 +439,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.cookies_same_site_protection"] = proc { nil }
 
     get :authenticate
-    assert_cookie_header "user_name=david; path=/"
+    assert_set_cookie_header "user_name=david; path=/"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -445,7 +447,7 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.cookies_same_site_protection"] = proc { :lax }
 
     get :set_same_site_strict
-    assert_cookie_header "user_name=david; path=/; SameSite=Strict"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=Strict"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -453,13 +455,13 @@ class CookiesTest < ActionController::TestCase
     @request.env["action_dispatch.cookies_same_site_protection"] = proc { :lax }
 
     get :set_same_site_nil
-    assert_cookie_header "user_name=david; path=/"
+    assert_set_cookie_header "user_name=david; path=/"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie
     get :authenticate
-    assert_cookie_header "user_name=david; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -477,46 +479,46 @@ class CookiesTest < ActionController::TestCase
 
   def test_setting_with_escapable_characters
     get :set_with_with_escapable_characters
-    assert_cookie_header "that+%26+guy=foo+%26+bar+%3D%3E+baz; path=/; SameSite=Lax"
+    assert_set_cookie_header "that+%26+guy=foo+%26+bar+%3D%3E+baz; path=/; SameSite=Lax"
     assert_equal({ "that & guy" => "foo & bar => baz" }, @response.cookies)
   end
 
   def test_setting_cookie_for_fourteen_days
     get :authenticate_for_fourteen_days
-    assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie_for_fourteen_days_with_symbols
     get :authenticate_for_fourteen_days_with_symbols
-    assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie_with_http_only
     get :authenticate_with_http_only
-    assert_cookie_header "user_name=david; path=/; HttpOnly; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; HttpOnly; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie_with_secure
     @request.env["HTTPS"] = "on"
     get :authenticate_with_secure
-    assert_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie_with_secure_on_onion_address
     @request.host = "fake.onion"
     get :authenticate_with_secure
-    assert_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_setting_cookie_with_secure_when_always_write_cookie_is_true
     old_cookie, @request.cookie_jar.always_write_cookie = @request.cookie_jar.always_write_cookie, true
     get :authenticate_with_secure
-    assert_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   ensure
     @request.cookie_jar.always_write_cookie = old_cookie
@@ -524,14 +526,14 @@ class CookiesTest < ActionController::TestCase
 
   def test_not_setting_cookie_with_secure
     get :authenticate_with_secure
-    assert_not_cookie_header "user_name=david; path=/; secure"
+    assert_not_set_cookie_header("user_name")
     assert_not_equal({ "user_name" => "david" }, @response.cookies)
   end
 
   def test_multiple_cookies
     get :set_multiple_cookies
     assert_equal 2, @response.cookies.size
-    assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax\nlogin=XJ-122; path=/; SameSite=Lax"
+    assert_set_cookie_header ["user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax", "login=XJ-122; path=/; SameSite=Lax"]
     assert_equal({ "login" => "XJ-122", "user_name" => "david" }, @response.cookies)
   end
 
@@ -542,14 +544,14 @@ class CookiesTest < ActionController::TestCase
   def test_expiring_cookie
     request.cookies[:user_name] = "Joe"
     get :logout
-    assert_cookie_header "user_name=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
     assert_equal({ "user_name" => nil }, @response.cookies)
   end
 
   def test_delete_cookie_with_path
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_path
-    assert_cookie_header "user_name=; path=/beaten; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; path=/beaten; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_delete_unexisting_cookie
@@ -880,7 +882,7 @@ class CookiesTest < ActionController::TestCase
   def test_delete_and_set_cookie
     request.cookies[:user_name] = "Joe"
     get :delete_and_set_cookie
-    assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -1120,172 +1122,172 @@ class CookiesTest < ActionController::TestCase
   def test_cookie_with_all_domain_option
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_tld
     @request.host = "two.subdomains.nextangle.local"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_australian_style_tld
     @request.host = "nextangle.com.au"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_australian_style_tld_and_two_subdomains
     @request.host = "x.nextangle.com.au"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_uk_style_tld
     @request.host = "nextangle.co.uk"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_uk_style_tld_and_two_subdomains
     @request.host = "x.nextangle.co.uk"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_host_with_port
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_localhost
     @request.host = "localhost"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_ipv4_address
     @request.host = "192.168.1.1"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_ipv6_address
     @request.host = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
     get :set_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_all_domain_option
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domain
     assert_response :success
-    assert_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_and_tld_length
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_tld_and_tld_length
     @request.host = "two.subdomains.nextangle.local"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_2_letter_tld
     @request.host = "admin.lvh.me"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.lvh.me; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.lvh.me; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_host_with_port_and_tld_length
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_longer_tld_length
     @request.host = "x.y.z.t.com"
     get :set_cookie_with_domain_and_longer_tld
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.y.z.t.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.y.z.t.com; path=/; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_all_domain_option_and_tld_length
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domain_and_tld
     assert_response :success
-    assert_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_one_of_these_domains
     @request.host = "example1.com"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_subdomain
     @request.host = "subdomain.example1.com"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_similar_tld
     @request.host = "example1.com.au"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_similar_domain
     @request.host = "myexample1.com"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_other_domain
     @request.host = "other-domain.com"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_shared_domain
     @request.host = "example3.com"
     get :set_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=rizwanreza; domain=.example3.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=.example3.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_domain_proc
     get :set_cookie_with_domain_proc
     assert_response :success
-    assert_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_domain_proc_with_request
     get :set_cookie_with_domain_proc_with_request
     assert_response :success
-    assert_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=braindeaf; domain=.sub.www.nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_several_preset_domains_using_one_of_these_domains
@@ -1293,7 +1295,7 @@ class CookiesTest < ActionController::TestCase
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=; domain=example2.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; domain=example2.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_several_preset_domains_using_other_domain
@@ -1301,7 +1303,7 @@ class CookiesTest < ActionController::TestCase
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domains
     assert_response :success
-    assert_cookie_header "user_name=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_cookies_hash_is_indifferent_access
@@ -1327,7 +1329,7 @@ class CookiesTest < ActionController::TestCase
 
   def test_cookies_retained_across_requests
     get :symbol_key
-    assert_cookie_header "user_name=david; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=david; path=/; SameSite=Lax"
     assert_equal "david", cookies[:user_name]
 
     get :noop
@@ -1446,7 +1448,7 @@ class CookiesTest < ActionController::TestCase
   def test_vanilla_cookie_with_expires_set_relatively
     travel_to Time.utc(2017, 8, 15) do
       get :cookie_expires_in_two_hours
-      assert_cookie_header "user_name=assain; path=/; expires=Tue, 15 Aug 2017 02:00:00 GMT; SameSite=Lax"
+      assert_set_cookie_header "user_name=assain; path=/; expires=Tue, 15 Aug 2017 02:00:00 GMT; SameSite=Lax"
     end
   end
 
@@ -1574,23 +1576,4 @@ class CookiesTest < ActionController::TestCase
 
     assert_equal "5-2-Stable Choco Chip Cookie", cookies.signed[:favorite]
   end
-
-  private
-    def assert_cookie_header(expected)
-      header = @response.headers["Set-Cookie"]
-      if header.respond_to?(:to_str)
-        assert_equal expected.split("\n").sort, header.split("\n").sort
-      else
-        assert_equal expected.split("\n"), header
-      end
-    end
-
-    def assert_not_cookie_header(expected)
-      header = @response.headers["Set-Cookie"]
-      if header.respond_to?(:to_str)
-        assert_not_equal expected.split("\n").sort, header.split("\n").sort
-      else
-        assert_not_equal expected.split("\n"), header
-      end
-    end
 end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -227,10 +227,12 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal "OK", @response.message
   end
 
+  include CookieAssertions
+
   test "cookies" do
     @response.set_cookie("user_name", value: "david", path: "/")
     _status, headers, _body = @response.to_a
-    assert_equal "user_name=david; path=/", headers["Set-Cookie"]
+    assert_set_cookie_header "user_name=david; path=/", headers["Set-Cookie"]
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
@@ -238,7 +240,7 @@ class ResponseTest < ActiveSupport::TestCase
     @response.set_cookie("user_name", value: "david", path: "/")
     @response.set_cookie("login", value: "foo&bar", path: "/", expires: Time.utc(2005, 10, 10, 5))
     _status, headers, _body = @response.to_a
-    assert_equal "user_name=david; path=/\nlogin=foo%26bar; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT", headers["Set-Cookie"]
+    assert_set_cookie_header "user_name=david; path=/\nlogin=foo%26bar; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT", headers["Set-Cookie"]
     assert_equal({ "login" => "foo&bar", "user_name" => "david" }, @response.cookies)
   end
 


### PR DESCRIPTION
The current implementation makes assumptions about the order and case sensitivity of cookie attributes. Introduce methods to parse those fields and compare them semantically. Update the existing tests to take advantage of these new assertions.

This is in preparation for Rack 3 which requires these changes, since it generates cookies using lower case tokens, while Rack 2 used mixed case.
