### PR TITLE
Prefer a table than inline code comments, which are harder to read

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1139,14 +1139,14 @@ I18n.backend = I18n::Backend::Chain.new(I18n::Backend::ActiveRecord.new, I18n.ba
 
 The I18n API defines the following exceptions that will be raised by backends when the corresponding unexpected conditions occur:
 
-```ruby
-MissingTranslationData       # no translation was found for the requested key
-InvalidLocale                # the locale set to I18n.locale is invalid (e.g. nil)
-InvalidPluralizationData     # a count option was passed but the translation data is not suitable for pluralization
-MissingInterpolationArgument # the translation expects an interpolation argument that has not been passed
-ReservedInterpolationKey     # the translation contains a reserved interpolation variable name (i.e. one of: scope, default)
-UnknownFileType              # the backend does not know how to handle a file type that was added to I18n.load_path
-```
+| Exception  | Reason  |
+|---|---|
+| MissingTranslationData       | no translation was found for the requested key
+| InvalidLocale                | the locale set to I18n.locale is invalid (e.g. nil)
+| InvalidPluralizationData     | a count option was passed but the translation data is not suitable for | pluralization
+| MissingInterpolationArgument | the translation expects an interpolation argument that has not been passed
+| ReservedInterpolationKey     | the translation contains a reserved interpolation variable name (i.e. one of: | scope, default)
+| UnknownFileType              | the backend does not know how to handle a file type that was added to I18n.load_path
 
 The I18n API will catch all of these exceptions when they are thrown in the backend and pass them to the default_exception_handler method. This method will re-raise all exceptions except for `MissingTranslationData` exceptions. When a `MissingTranslationData` exception has been caught, it will return the exception's error message string containing the missing key/scope.
 


### PR DESCRIPTION
Stumbled on this when reviewing #47057.

Before

<img width="652" alt="Screenshot 2023-01-20 at 12 12 35" src="https://user-images.githubusercontent.com/277819/213610384-ed7db292-2182-45f5-9e3a-674d78b5646d.png">

After

![Screenshot 2023-01-20 at 12 12 31](https://user-images.githubusercontent.com/277819/213610404-7247500c-561a-465c-9645-51574255a11b.png)
