### PR TITLE
[ci-skip] Remove obsolete paragraph from form_helpers.md Guide for Rails 7

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -366,9 +366,6 @@ Rails works around this issue by emulating other methods over POST through a com
   <button type="submit" name="button">Update</button>
 </form>
 ```
-
-IMPORTANT: In Rails 6.0 and 5.2, all forms using `form_with` implement `remote: true` by default. These forms will submit data using an XHR (Ajax) request. To disable this include `local: true`. To dive deeper see [Working with JavaScript in Rails](working_with_javascript_in_rails.html#remote-elements) guide.
-
 [formmethod]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formmethod
 [button-name]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name
 [button-value]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-value


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we found an obsolete description in form_helpers.md guides for Rails 7 while translating working_with_javascript_in_rails.md for https://railsguides.jp/

### Detail

This Pull Request just removes the following obsolete paragraph:

> IMPORTANT: In Rails 6.0 and 5.2, all forms using `form_with` implement `remote: true` by default. These forms will submit data using an XHR (Ajax) request. To disable this include `local: true`. To dive deeper see [Working with JavaScript in Rails](working_with_javascript_in_rails.html#remote-elements) guide.

I suppose just removing it is OK for now. If some other descriptions should be added here, I'd just leave it to the working_with_javascript_in_rails.md writers or someone else🙏

### Additional information

I think the change finally should only be applied to 7_0_stable branch because the change is based upon the wide update of working_with_javascript_in_rails.md for Turbo in Rails 7.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

