### PR TITLE
Address `test_warnings_do_not_change_returned_value_of_exec_(update|delete)` failures

### DIFF
--- a/activerecord/test/fixtures/bad_posts.yml
+++ b/activerecord/test/fixtures/bad_posts.yml
@@ -4,6 +4,7 @@ _fixture:
   model_class: BadPostModel
 
 bad_welcome:
+  id: 1
   author_id: 1
   title: Welcome to the another weblog
   body: It's really nice today


### PR DESCRIPTION
### Motivation / Background

This pull request fixes #47064

### Detail

This pull request addresses `test_warnings_do_not_change_returned_value_of_exec_(update|delete)` failures
by setting `id: 1` of the `:bad_welcome` fixture.

After `SetFixtureClassPrevailsTest#test_uses_set_fixture_class` is executed, the maximum id value of `Posts` is 976518741 because `bad_welcome:` fixture does not have any explicit id.
Then the `test_warnings_do_not_change_returned_value_of_exec_(update|delete)` executed, they assume that the id is smaller than 42.

```ruby
$ ARCONN=mysql2 bin/test test/cases/fixtures_test.rb test/cases/adapters/mysql2/mysql2_adapter_test.rb -n "/^(?:SetFixtureClassPrevailsTest#(?:test_uses_set_fixture_class)|Mysql2AdapterTest#(?:test_warnings_do_not_change_returned_value_of_exec_delete|test_warnings_do_not_change_returned_value_of_exec_update))$/" --seed 42198
Using mysql2
Run options: -n "/^(?:SetFixtureClassPrevailsTest#(?:test_uses_set_fixture_class)|Mysql2AdapterTest#(?:test_warnings_do_not_change_returned_value_of_exec_delete|test_warnings_do_not_change_returned_value_of_exec_update))$/" --seed 42198

"/home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixture_set/table_row.rb:122:in `generate_primary_key'"
.F

Failure:
Mysql2AdapterTest#test_warnings_do_not_change_returned_value_of_exec_delete [/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb:437]:
Expected: 1
  Actual: 0

bin/test test/cases/adapters/mysql2/mysql2_adapter_test.rb:429

F

Failure:
Mysql2AdapterTest#test_warnings_do_not_change_returned_value_of_exec_update [/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb:424]:
Expected: 1
  Actual: 0

bin/test test/cases/adapters/mysql2/mysql2_adapter_test.rb:416

Finished in 0.043522s, 68.9302 runs/s, 68.9302 assertions/s.
3 runs, 3 assertions, 2 failures, 0 errors, 0 skips
$
```

### Additional information

There could be other options to set Mysql2AdapterTest `use_transactional_tests = false` or changing `test_warnings_do_not_change_returned_value_of_exec_(update|delete)` not to depending on the id value.
I think setting `id: 1` of `:bad_welcome` should not affect the purpose of `SetFixtureClassPrevailsTest#test_uses_set_fixture_class` .

Fix #47064

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
