### PR TITLE
Explicitly require `rack/server` as it may not be part of rack.

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -6,6 +6,7 @@ require "rails"
 require "active_support/core_ext/string/filters"
 require "rails/dev_caching"
 require "rails/command/environment_argument"
+require "rack/server"
 
 module Rails
   class Server < ::Rack::Server


### PR DESCRIPTION
Rack 3 separates this code into a separate gem, so autoloads from `rack` may not load it. Explicitly require it where needed.