### PR TITLE
Don't assume that `rack/chunked` exists.

### DIFF
--- a/actionpack/lib/action_controller/metal/streaming.rb
+++ b/actionpack/lib/action_controller/metal/streaming.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rack/chunked"
+require "rack"
 
 module ActionController # :nodoc:
   # Allows views to be streamed back to the client as they are rendered.


### PR DESCRIPTION
`Rack::Chunked` was a bad idea and has been deprecated in Rack 3.0 and will be removed in Rack 3.1. Therefore, don't require that file directly. In Rack 2, it will be autoloaded correctly.