### PR TITLE
Fix `#inspect` failures when dealing with requests with `method=nil`.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -450,7 +450,10 @@ module ActionDispatch
 
     private
       def check_method(name)
-        HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")
+        if name
+          HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")
+        end
+
         name
       end
 


### PR DESCRIPTION
When I was debugging `ActionDispatch::Request` instances in some tests, I noticed IRB complaining that the object did not support `#inspect`, as it was trying to print out the `method` which calls `check_method(nil)` which fails. Don't try to validate `nil` method as it will always fail and appears to be a valid state (when constructing an empty request as in some tests).