### PR TITLE
Don't assume these fields will be present in a rack env.

### DIFF
--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -20,12 +20,8 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal "0.0.0.0", env.delete("REMOTE_ADDR")
     assert_equal "Rails Testing", env.delete("HTTP_USER_AGENT")
 
-    assert_equal [1, 3], env.delete("rack.version")
     assert_equal "", env.delete("rack.input").string
     assert_kind_of StringIO, env.delete("rack.errors")
-    assert_equal true, env.delete("rack.multithread")
-    assert_equal true, env.delete("rack.multiprocess")
-    assert_equal false, env.delete("rack.run_once")
   end
 
   test "cookie jar" do


### PR DESCRIPTION
Rack 3 drops several of these fields as mandatory.