### PR TITLE
Don't assume the existance of `Rack::Utils::HeaderHash`.

### DIFF
--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -3,7 +3,7 @@
 require "abstract_unit"
 
 class SSLTest < ActionDispatch::IntegrationTest
-  HEADERS = Rack::Utils::HeaderHash.new "Content-Type" => "text/html"
+  HEADERS = { "Content-Type" => "text/html" }
 
   attr_accessor :app
 


### PR DESCRIPTION
In Rack 3, this was deprecated and replaced with `Rack::Headers`. Using a hash instance here appears to be sufficient.