### PR TITLE
Fix cookie domain for `domain: all` on two letter single level TLD

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -461,7 +461,7 @@ module ActionDispatch
             # Case where tld_length is not provided
             else
               # Regular TLDs
-              if !(/([^.]{2,3}\.[^.]{2})$/.match?(request.host))
+              if !(/\.[^.]{2,3}\.[^.]{2}\z/.match?(request.host))
                 cookie_domain = dot_splitted_host.last(2).join(".")
               # **.**, ***.** style TLDs like co.uk and com.au
               else

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1153,6 +1153,20 @@ class CookiesTest < ActionController::TestCase
     assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
   end
 
+  def test_cookie_with_all_domain_option_using_two_letter_one_level_tld
+    @request.host = "hawth.ca"
+    get :set_cookie_with_domain
+    assert_response :success
+    assert_set_cookie_header "user_name=rizwanreza; domain=.hawth.ca; path=/; SameSite=Lax"
+  end
+
+  def test_cookie_with_all_domain_option_using_two_letter_one_level_tld_and_subdomain
+    @request.host = "x.hawth.ca"
+    get :set_cookie_with_domain
+    assert_response :success
+    assert_set_cookie_header "user_name=rizwanreza; domain=.hawth.ca; path=/; SameSite=Lax"
+  end
+
   def test_cookie_with_all_domain_option_using_uk_style_tld_and_two_subdomains
     @request.host = "x.nextangle.co.uk"
     get :set_cookie_with_domain


### PR DESCRIPTION
Previously the regex wasn't checking for a `.` before the TLDs, so would incorrectly match on single-level two-letter TLDs.

This should (hopefully) fix #47055 and restore the previous behaviour (though possibly that behaviour isn't 1000% correct vs comparing against the public suffix list, but hopefully it's good enough™)