### PR TITLE
fix(autosave-association): 4 -> 4.1 number does not generate error messages in nested_attributes

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -67,6 +67,10 @@ module ActiveModel
       changed_from_assignment? || changed_in_place?
     end
 
+    def raw_changed?
+      value_before_type_cast != value
+    end
+
     def changed_in_place?
       has_been_read? && type.changed_in_place?(original_value_for_database, value)
     end

--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -41,10 +41,18 @@ module ActiveModel
       attr_names.any? { |attr| changed?(attr) }
     end
 
+    def any_raw_changes?
+      attr_names.any? { |attr| raw_changed?(attr) }
+    end
+
     def changed?(attr_name, from: OPTION_NOT_GIVEN, to: OPTION_NOT_GIVEN)
       attribute_changed?(attr_name) &&
         (OPTION_NOT_GIVEN == from || original_value(attr_name) == type_cast(attr_name, from)) &&
         (OPTION_NOT_GIVEN == to || fetch_value(attr_name) == type_cast(attr_name, to))
+    end
+
+    def raw_changed?(attr_name)
+      attributes[attr_name].raw_changed?
     end
 
     def changed_in_place?(attr_name)

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -123,7 +123,7 @@ module ActiveModel
     include ActiveModel::AttributeMethods
 
     included do
-      attribute_method_suffix "_previously_changed?", "_changed?", parameters: "**options"
+      attribute_method_suffix "_previously_changed?", "_changed?", "_raw_changed?", parameters: "**options"
       attribute_method_suffix "_change", "_will_change!", "_was", parameters: false
       attribute_method_suffix "_previous_change", "_previously_was", parameters: false
       attribute_method_affix prefix: "restore_", suffix: "!", parameters: false
@@ -177,6 +177,11 @@ module ActiveModel
     # Dispatch target for <tt>*_changed?</tt> attribute methods.
     def attribute_changed?(attr_name, **options) # :nodoc:
       mutations_from_database.changed?(attr_name.to_s, **options)
+    end
+
+    # Dispatch target for <tt>*_raw_changed?</tt> attribute methods.
+    def attribute_raw_changed?(attr_name) # :nodoc:
+      mutations_from_database.raw_changed?(attr_name.to_s)
     end
 
     # Dispatch target for <tt>*_was</tt> attribute methods.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -160,6 +160,11 @@ module ActiveRecord
         mutations_from_database.any_changes?
       end
 
+      # Returns an boolean if has records that will be changed for persistence or changed raw values that didn't persist
+      def has_changes_to_validate?
+        mutations_from_database.any_changes? || mutations_from_database.any_raw_changes?
+      end
+
       # Returns a hash containing all the changes that will be persisted during
       # the next save.
       def changes_to_save

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -285,7 +285,7 @@ module ActiveRecord
         if new_record || custom_validation_context?
           association && association.target
         elsif autosave
-          association.target.find_all(&:changed_for_autosave?)
+          association.target.find_all(&:changed_for_autosave?).presence || association.target.find_all(&:has_changes_to_validate?)
         else
           association.target.find_all(&:new_record?)
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR is just an initial idea of how to resolve issue #46509 where changes to nested_attributes do not generate error messages when the model has `only_integer` validation

The initial idea is to create a new attribute that detects when it hears changes before the type cast happens. With this, it is able to detect fractional changes such as 4 -> 4.1 and notify autosave that it needs to generate exceptions.

Please, this is my first Rails code change, so if there's any "dumb" code, forgive me, I'm still figuring out how things work 😅

### Detail

I think everything you need to know about the problem is in #46509

About PR also came two new attributes... I don't know if they really make sense to exist, I left it just for discussion

`comment.likes_count_raw_changed?`
`comment.has_changes_to_validate?`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
