### PR TITLE
Use Rack's own headers classes where appropriate.

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -40,6 +40,7 @@ module ActionDispatch
 
   class IllegalStateError < StandardError
   end
+  deprecate_constant :IllegalStateError
 
   class MissingController < NameError
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -1086,8 +1086,11 @@ class ResponseDefaultHeadersTest < ActionController::TestCase
   test "response contains default headers" do
     get :leave_alone
 
-    # Response headers start out with the defaults
-    assert_equal @defaults.merge("Content-Type" => "text/html"), response.headers
+    expected_headers = @defaults.merge("Content-Type" => "text/html")
+
+    expected_headers.each do |key, value|
+      assert_equal value, @response.headers[key]
+    end
   end
 
   test "response deletes a default header" do

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -24,8 +24,9 @@ module ActionController
           end
         end
 
-        header = r.new.header
-        assert_kind_of(ActionController::Live::Response::Header, header)
+        headers = r.create.headers
+        assert_kind_of(ActionController::Live::Response::Header, headers)
+        assert_equal "g", headers["omg"]
       end
 
       def test_parallel
@@ -98,11 +99,10 @@ module ActionController
 
         latch.wait
         assert_predicate @response.headers, :frozen?
-        e = assert_raises(ActionDispatch::IllegalStateError) do
+        assert_raises(FrozenError) do
           @response.headers["Content-Length"] = "zomg"
         end
 
-        assert_equal "header already sent", e.message
         @response.stream.close
         t.join
       end
@@ -112,10 +112,9 @@ module ActionController
         # we can add data until it's actually written, which happens on `each`
         @response.each { |x| }
 
-        e = assert_raises(ActionDispatch::IllegalStateError) do
+        assert_raises(FrozenError) do
           @response.headers["Content-Length"] = "zomg"
         end
-        assert_equal "header already sent", e.message
       end
     end
   end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -423,14 +423,12 @@ class ResponseHeadersTest < ActiveSupport::TestCase
 
   test "has_header?" do
     assert @response.has_header? "Foo"
-    assert_not @response.has_header? "foo"
-    assert_not @response.has_header? nil
+    assert @response.has_header? "foo"
   end
 
   test "get_header" do
     assert_equal "1", @response.get_header("Foo")
-    assert_nil @response.get_header("foo")
-    assert_nil @response.get_header(nil)
+    assert_equal "1", @response.get_header("foo")
   end
 
   test "set_header" do
@@ -444,11 +442,6 @@ class ResponseHeadersTest < ActiveSupport::TestCase
   end
 
   test "delete_header" do
-    assert_nil @response.delete_header(nil)
-
-    assert_nil @response.delete_header("foo")
-    assert @response.has_header?("Foo")
-
     assert_equal "1", @response.delete_header("Foo")
     assert_not @response.has_header?("Foo")
   end


### PR DESCRIPTION
Rack 3 response headers must be a mutable hash with lower-case keys. Rack provides `Rack::Headers` as a compatibility layer for existing systems which don't conform to this requirement. Prefer `Rack::Utils::HeaderHash` on Rack 2, and `Rack::Headers` on Rack 3.

Remove some of the response test cases which test `nil` header keys as these are considered invalid, and will fail with `Rack::Headers`.
