### PR TITLE
Update `ActionDispatch::Response` to support streaming bodies.

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -111,6 +111,10 @@ module ActionDispatch # :nodoc:
         @str_body = nil
       end
 
+      def to_ary
+        @buf.to_ary
+      end
+
       def body
         @str_body ||= begin
           buf = +""
@@ -486,10 +490,6 @@ module ActionDispatch # :nodoc:
         @response = response
       end
 
-      def each(*args, &block)
-        @response.each(*args, &block)
-      end
-
       def close
         # Rack "close" maps to Response#abort, and *not* Response#close
         # (which is used when the controller's finished writing)
@@ -500,12 +500,26 @@ module ActionDispatch # :nodoc:
         @response.body
       end
 
+      BODY_METHODS = { to_ary: true, each: true, call: true, to_path: true }
+
       def respond_to?(method, include_private = false)
-        if method.to_sym == :to_path
+        if BODY_METHODS.key?(method)
           @response.stream.respond_to?(method)
         else
           super
         end
+      end
+
+      def to_ary
+        @response.stream.to_ary
+      end
+
+      def each(*args, &block)
+        @response.each(*args, &block)
+      end
+
+      def call(*arguments, &block)
+        @response.stream.call(*arguments, &block)
       end
 
       def to_path

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -396,9 +396,9 @@ class ResponseTest < ActiveSupport::TestCase
   test "[response.to_a].flatten does not recurse infinitely" do
     Timeout.timeout(1) do # use a timeout to prevent it stalling indefinitely
       status, headers, body = [@response.to_a].flatten
-      assert_equal @response.status, status
-      assert_equal @response.headers, headers
-      assert_equal @response.body, body.each.to_a.join
+      assert_equal status, 200
+      assert_equal headers, @response.headers
+      assert_nil body
     end
   end
 


### PR DESCRIPTION
Rack 3 introduces streaming bodies, which don't respond to `#each` and MUST respond to `#call`. Ensure that the methods are correctly delegated.

`#to_ary` must also work correctly for enumerable bodies, and is used by middleware like `Rack::ETag` to buffer enumerable bodies correctly.