### PR TITLE
Remove changelog entry for bugfix [#46300]

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,9 +1,3 @@
-*   Fixed ingress controllers' ability to accept emails that contain no UTF-8 encoded parts.
-
-    Fixes #46297.
-
-    *Jan Honza Sterba*
-
 *   Add X-Forwarded-To addresses to recipients.
 
     *Andrew Stewart*


### PR DESCRIPTION
We usually only put features / major changes in the changelog

ref: https://github.com/rails/rails/pull/46879#issuecomment-1375676523

Also mentioned here:
https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#updating-the-changelog

> You should add an entry to the top of the CHANGELOG of the framework you modified if you're adding or removing a feature, or adding deprecation notices. Refactorings, minor bug fixes, and documentation changes generally should not go to the CHANGELOG.