### PR TITLE
Revert "Use `eval_gemfile` to read .Gemfile"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ end
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
-eval_gemfile local_gemfile if File.exist? local_gemfile
+instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
   gem "minitest-bisect"


### PR DESCRIPTION
Reverts rails/rails#47033

Based on the [feedback](https://github.com/rails/rails/pull/47033#issuecomment-1399056112) from @simi :

> ℹ️ `eval_gemfile` is not public API (not documented at https://bundler.io/v2.4/man/gemfile.5.html) and is not recommended to be used since there is no guarantee it will stay as is.
> 
> See [rubocop/rubocop#3903 (comment)](https://github.com/rubocop/rubocop/issues/3903#issuecomment-272712779) for reference. I have checked with other maintainers recently as well and the status is still the same.
