### PR TITLE
Gracefully degrade when `ActionMailer::Base#params` is nil

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Default `ActionMailer::Parameterized#params` to an empty `Hash`
+
+    *Sean Doyle*
+
 *   `assert_emails` now returns the emails that were sent.
 
     This makes it easier to do further analysis on those emails:

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -88,7 +88,11 @@ module ActionMailer
     extend ActiveSupport::Concern
 
     included do
-      attr_accessor :params
+      attr_writer :params
+
+      def params
+        @params ||= {}
+      end
     end
 
     module ClassMethods

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -37,6 +37,13 @@ class ParameterizedTest < ActiveSupport::TestCase
     assert_equal("So says david@basecamp.com", @mail.body.encoded)
   end
 
+  test "degrade gracefully when .with is not called" do
+    @mail = ParamsMailer.invitation
+
+    assert_nil(@mail.to)
+    assert_nil(@mail.from)
+  end
+
   test "enqueue the email with params" do
     args = [
       "ParamsMailer",


### PR DESCRIPTION
### Motivation / Background

Prior to this change, access to `params` on `ActionMailer::Base` instances prior to being decorated by `ActionMailer::Parameterized.with` calls results in a `NoMethodError`:

```
Error:
ParameterizedTest#test_degrade_gracefully_when_.with_is_not_called:
NoMethodError: undefined method `[]' for nil:NilClass

  before_action { @inviter, @invitee = params[:inviter], params[:invitee] }
                                             ^^^^^^^^^^
```

### Detail

This change modifies the `attr_accessor :params` to be an `attr_writer` paired with a `params` method that assigns `@params` to an empty `Hash` whenever it's accessed without being otherwise initialized.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
