### PR TITLE
Revert "Remove changelog entry for bugfix [#46300]"

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fixed ingress controllers' ability to accept emails that contain no UTF-8 encoded parts.
+
+    Fixes #46297.
+
+    *Jan Honza Sterba*
+
 *   Add X-Forwarded-To addresses to recipients.
 
     *Andrew Stewart*


### PR DESCRIPTION
Reverts rails/rails#47097 [ci-skip]
Any change to behaviour goes to the changelog.
The documentation for the Changelog needs to be updated.
cc @zzak