### PR TITLE
Make `raise_on_missing_translations` raise on any missing translation

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `config.i18n.raise_on_missing_translations = true` now raises on any missing translation.
+
+    Previously it would only raise when called in a view or controller. Now it will raise
+    anytime `I18n.t` is provided an unrecognised key.
+
+    If you do not want this behaviour, you can customise the i18n exception handler. See the
+    upgrading guide or i18n guide for more information.
+
+    *Alex Ghiculescu*
+
 *   `ActiveSupport::CurrentAttributes` now raises if a restricted attribute name is used.
 
     Attributes such as `set` and `reset` cannot be used as they clash with the

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -85,6 +85,15 @@ module I18n
       ActiveSupport.on_load(:action_controller) do
         AbstractController::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
       end
+
+      if app.config.i18n.raise_on_missing_translations &&
+          I18n.exception_handler.is_a?(I18n::ExceptionHandler) # Only override the i18n gem's default exception handler.
+
+        I18n.exception_handler = ->(exception, *) {
+          exception = exception.to_exception if exception.is_a?(I18n::MissingTranslation)
+          raise exception
+        }
+      end
     end
 
     def self.include_fallbacks_module

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -813,8 +813,7 @@ Sets the path Rails uses to look for locale files. Defaults to `config/locales/*
 
 #### `config.i18n.raise_on_missing_translations`
 
-Determines whether an error should be raised for missing translations
-in controllers and views. This defaults to `false`.
+Determines whether an error should be raised for missing translations. This defaults to `false`.
 
 #### `config.i18n.fallbacks`
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1148,47 +1148,34 @@ The I18n API defines the following exceptions that will be raised by backends wh
 | `I18n::ReservedInterpolationKey`     | the translation contains a reserved interpolation variable name (i.e. one of: `scope`, `default`) |
 | `I18n::UnknownFileType`              | the backend does not know how to handle a file type that was added to `I18n.load_path` |
 
-The I18n API will catch all of these exceptions when they are thrown in the backend and pass them to the default_exception_handler method. This method will re-raise all exceptions except for `MissingTranslationData` exceptions. When a `MissingTranslationData` exception has been caught, it will return the exception's error message string containing the missing key/scope.
+#### Customizing how `I18n::MissingTranslationData` is handled
 
-The reason for this is that during development you'd usually want your views to still render even though a translation is missing.
+If `config.i18n.raise_on_missing_translations` is `true`, `I18n::MissingTranslationData` errors will be raised. It's a good idea to turn this on in your test environment, so you can catch places where missing translations are requested.
 
-In other contexts you might want to change this behavior, though. E.g. the default exception handling does not allow to catch missing translations during automated tests easily. For this purpose a different exception handler can be specified. The specified exception handler must be a method on the I18n module or a class with a `call` method:
+If `config.i18n.raise_on_missing_translations` is `false` (the default in all environments), the exception's error message will be printed. This contains the missing key/scope so you can fix your code.
+
+If you want to customize this behaviour further, you should set `config.i18n.raise_on_missing_translations = false` and then implement a `I18n.exception_handler`. The custom exception handler can be a proc or a class with a `call` method:
 
 ```ruby
+# config/initializers/i18n.rb
 module I18n
-  class JustRaiseExceptionHandler < ExceptionHandler
+  class RaiseExceptForSpecificKeyExceptionHandler
     def call(exception, locale, key, options)
-      if exception.is_a?(MissingTranslation)
+      if key == "special.key"
+        "translation missing!" # return this, don't raise it
+      elsif exception.is_a?(MissingTranslation)
         raise exception.to_exception
       else
-        super
+        raise exception
       end
     end
   end
 end
 
-I18n.exception_handler = I18n::JustRaiseExceptionHandler.new
+I18n.exception_handler = I18n::RaiseExceptForSpecificKeyExceptionHandler.new
 ```
 
-This would re-raise only the `MissingTranslationData` exception, passing all other input to the default exception handler.
-
-However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use an additional check for the translation key:
-
-```ruby
-if exception.is_a?(MissingTranslation) && key.to_s != 'i18n.plural.rule'
-  raise exception.to_exception
-else
-  super
-end
-```
-
-Another example where the default behavior is less desirable is the Rails TranslationHelper which provides the method `#t` (as well as `#translate`). When a `MissingTranslationData` exception occurs in this context, the helper wraps the message into a span with the CSS class `translation_missing`.
-
-To do so, the helper forces `I18n#translate` to raise exceptions no matter what exception handler is defined by setting the `:raise` option:
-
-```ruby
-I18n.t :foo, raise: true # always re-raises exceptions from the backend
-```
+This would raise all exceptions the same way the default handler would, except in the case of `I18n.t("special.key")`.
 
 Translating Model Content
 -------------------------

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -297,6 +297,37 @@ Option `config.action_mailer.preview_path` is deprecated in favor of `config.act
 config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
 ```
 
+### `config.i18n.raise_on_missing_translations = true` now raises on any missing translation.
+
+Previously it would only raise when called in a view or controller. Now it will raise anytime `I18n.t` is provided an unrecognised key.
+
+```ruby
+# with config.i18n.raise_on_missing_translations = true
+
+# in a view or controller:
+t("missing.key") # raises in 7.0, raises in 7.1
+I18n.t("missing.key") # didn't raise in 7.0, raises in 7.1
+
+# anywhere:
+I18n.t("missing.key") # didn't raise in 7.0, raises in 7.1
+```
+
+If you don't want this behaviour, you can set `config.i18n.raise_on_missing_translations = false`:
+
+```ruby
+# with config.i18n.raise_on_missing_translations = false
+
+# in a view or controller:
+t("missing.key") # didn't raise in 7.0, doesn't raise in 7.1
+I18n.t("missing.key") # didn't raise in 7.0, doesn't raise in 7.1
+
+# anywhere:
+I18n.t("missing.key") # didn't raise in 7.0, doesn't raise in 7.1
+```
+
+Alternatively, you can customise the `I18n.exception_handler`.
+See the [i18n guide](https://guides.rubyonrails.org/v7.1/i18n.html#using-different-exception-handlers) for more information.
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.assets.quiet = true
   <%- end -%>
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -57,7 +57,7 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Raises error for missing translations in controllers and views.
+  # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because currently `config.i18n.raise_on_missing_translations = true` only works when calling `t('missing.key')` in a view or controller. But as noted in https://github.com/rails/rails/issues/47057 the name suggests it will raise anytime a key isn't recognised.

### Detail

This Pull Request implements an `I18n.exception_handler`, when `config.i18n.raise_on_missing_translations == true`. It slightly tweaks the default behaviour to raise on any exception.

The existing raise behaviour for `t` in views and controllers is left unchanged.

I've also upgraded the i18n guide to reflect this behaviour, as well as adding a note to the upgrade guide.

### Additional information

Fixes https://github.com/rails/rails/issues/47057.

We probably don't need  https://github.com/rails/rails/pull/45361 if this is merged.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
