### PR TITLE
Hard code serializer for `AS::EncryptedFile`

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -111,7 +111,7 @@ module ActiveSupport
       end
 
       def encryptor
-        @encryptor ||= ActiveSupport::MessageEncryptor.new([ key ].pack("H*"), cipher: CIPHER)
+        @encryptor ||= ActiveSupport::MessageEncryptor.new([ key ].pack("H*"), cipher: CIPHER, serializer: Marshal)
       end
 
 

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -144,6 +144,18 @@ class EncryptedFileTest < ActiveSupport::TestCase
     FileUtils.rm_rf symlink_path
   end
 
+  test "can read encrypted file after changing MessageEncryptor.default_message_encryptor_serializer" do
+    original_serializer = ActiveSupport::MessageEncryptor.default_message_encryptor_serializer
+
+    ActiveSupport::MessageEncryptor.default_message_encryptor_serializer = :marshal
+    encrypted_file(@content_path).write(@content)
+
+    ActiveSupport::MessageEncryptor.default_message_encryptor_serializer = :json
+    assert_equal @content, encrypted_file(@content_path).read
+  ensure
+    ActiveSupport::MessageEncryptor.default_message_encryptor_serializer = original_serializer
+  end
+
   private
     def encrypted_file(content_path, key_path: @key_path, env_key: "CONTENT_KEY")
       ActiveSupport::EncryptedFile.new(content_path: @content_path, key_path: key_path,


### PR DESCRIPTION
Follow-up to #42846.

Prior to this commit, `ActiveSupport::EncryptedFile` used the `ActiveSupport::MessageEncryptor` default serializer.  #42846 changed the default serializer to `JSON` when using `config.load_defaults 7.1`. Thus, encrypted files that were written with the previous default serializer (`Marshal`) could not be read by `Rails.application.encrypted`. That included files which were written with `bin/rails encrypted:edit` even when using the new default, because the `bin/rails encrypted:edit` command does not run the initializer that applies the configuration to `MessageEncryptor`:

  ```console
  $ bin/rails r 'puts ActiveSupport::MessageEncryptor.default_message_encryptor_serializer'
  json

  $ bin/rails encrypted:edit config/my_encrypted.yml.enc
  ...

  $ bin/rails encrypted:show config/my_encrypted.yml.enc
  foo: bar

  $ bin/rails r 'Rails.application.encrypted("config/my_encrypted.yml.enc").read'
  rails/activesupport/lib/active_support/message_encryptor.rb:241:in `rescue in _decrypt': ActiveSupport::MessageEncryptor::InvalidMessage (ActiveSupport::MessageEncryptor::InvalidMessage)
  ...
  ruby-3.2.0/lib/ruby/3.2.0/json/common.rb:216:in `parse': unexpected token at "foo: bar (JSON::ParserError)
  ```

This commit hard codes the serializer for `EncryptedFile` to `Marshal`.
