### PR TITLE
support lower case x-cascade headers in the router

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -47,16 +47,16 @@ module ActionDispatch
 
           req.path_parameters = tmp_params
 
-          _, headers, _ = response = route.app.serve(req)
+          response = Rack::Response[*route.app.serve(req)]
 
-          if "pass" == headers["X-Cascade"]
+          if "pass" == response.headers["X-Cascade"]
             req.script_name     = script_name
             req.path_info       = path_info
             req.path_parameters = set_params
             next
           end
 
-          return response
+          return response.to_a
         end
 
         [404, { "X-Cascade" => "pass" }, ["Not Found"]]

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -24,14 +24,14 @@ module ActionDispatch
     end
 
     def call(env)
-      _, headers, body = response = @app.call(env)
+      response = Rack::Response[*@app.call(env)]
 
-      if headers["X-Cascade"] == "pass"
-        body.close if body.respond_to?(:close)
+      if response.headers["X-Cascade"] == "pass"
+        response.close
         raise ActionController::RoutingError, "No route matches [#{env['REQUEST_METHOD']}] #{env['PATH_INFO'].inspect}"
       end
 
-      response
+      response.to_a
     rescue Exception => exception
       request = ActionDispatch::Request.new env
       backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -43,8 +43,8 @@ module ActionDispatch
         fallback_to_html_format_if_invalid_mime_type(request)
         request.path_info = "/#{status}"
         request.request_method = "GET"
-        response = @exceptions_app.call(request.env)
-        response[1]["X-Cascade"] == "pass" ? pass_response(status) : response
+        response = Rack::Response[*@exceptions_app.call(request.env)]
+        response.headers["X-Cascade"] == "pass" ? pass_response(status) : response.to_a
       rescue Exception => failsafe_error
         $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -783,6 +783,9 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     mount MountedApp => "/mounted", :as => "mounted"
     get "fooz" => proc { |env| [ 200, { "X-Cascade" => "pass" }, [ "omg" ] ] }, :anchor => false
     get "fooz", to: "application_integration_test/test#index"
+
+    get "fooz_lower" => proc { |env| [ 200, { "x-cascade" => "pass" }, [ "omg" ] ] }, :anchor => false
+    get "fooz_lower", to: "application_integration_test/test#index"
   end
 
   def app
@@ -803,6 +806,11 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     get "/fooz"
     assert_equal "index", response.body
     assert_equal "/fooz", path
+  end
+
+  test "cascade pass for lower case headers" do
+    get "/fooz_lower"
+    assert_equal "index", response.body
   end
 
   test "route helpers after controller access" do

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -62,6 +62,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       case req.path
       when "/pass"
         [404, { "X-Cascade" => "pass" }, self]
+      when "/pass_lower"
+        [404, { "x-cascade" => "pass" }, self]
       when "/not_found"
         controller = SimpleController.new
         raise AbstractController::ActionNotFound.new(nil, controller, :ello)
@@ -152,6 +154,13 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     @app = ProductionApp
     assert_raise ActionController::RoutingError do
       get "/pass", headers: { "action_dispatch.show_exceptions" => true }
+    end
+  end
+
+  test "raise an exception on lower cascade pass" do
+    @app = ProductionApp
+    assert_raise ActionController::RoutingError do
+      get "/pass_lower", headers: { "action_dispatch.show_exceptions" => true }
     end
   end
 

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -128,6 +128,17 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "", body
   end
 
+  test "returns an empty response if custom exceptions app returns lower case x-cascade pass" do
+    exceptions_app = lambda do |env|
+      [404, { "x-cascade" => "pass" }, []]
+    end
+
+    @app = ActionDispatch::ShowExceptions.new(Boomer.new, exceptions_app)
+    get "/method_not_allowed", env: { "action_dispatch.show_exceptions" => true }
+    assert_response 405
+    assert_equal "", body
+  end
+
   test "bad params exception is returned in the correct format" do
     @app = ProductionApp
 


### PR DESCRIPTION
### Motivation / Background

As part of the change in the spec for Rack for Rack 3.0 - the headers are now expected to be lower case.

This was updated in sprockets in https://github.com/rails/sprockets/pull/758, but when using the `X-Cascade` header we are currently checking a case sensitive version which causes the cascade to fail, as identified in https://github.com/rails/rails/issues/47096.

This PR updates the logic for detecting the cascade header to be case insensitive and fixes #47096.

### Detail

This Pull Request changes the detection of the `X-Cascade` header in the router to be case insensitive. 

### Additional information

The implementation may be able to be simplified using the `ActionDispatch::Response::Header` once #47091 is merged, but I am not sure of the timing for when that would be merged, and we may want to backport a fix for this issue without needing to backport #47091. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I think that this is a minor bug fix - so I have not included a CHANGELOG entry. I am happy to add one if you think it is required.