### PR TITLE
Remove old `raise_on_missing_translations` behaviour

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `AbstractController::Translation.raise_on_missing_translations` removed
+
+    This was a private API, and has been removed in favour of a more broadly applicable
+    `config.i18n.raise_on_missing_translations`. See the upgrading guide for more information.
+
+    *Alex Ghiculescu*
+
 *   Add `ActionController::Parameters#extract_value` method to allow extracting serialized values from params
 
     ```ruby

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -4,8 +4,6 @@ require "active_support/html_safe_translation"
 
 module AbstractController
   module Translation
-    mattr_accessor :raise_on_missing_translations, default: false
-
     # Delegates to <tt>I18n.translate</tt>.
     #
     # When the given key starts with a period, it will be scoped by the current
@@ -23,9 +21,7 @@ module AbstractController
         key = "#{path}.#{action_name}#{key}"
       end
 
-      i18n_raise = options.fetch(:raise, self.raise_on_missing_translations)
-
-      ActiveSupport::HtmlSafeTranslation.translate(key, **options, raise: i18n_raise)
+      ActiveSupport::HtmlSafeTranslation.translate(key, **options)
     end
     alias :t :translate
 

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -47,16 +47,6 @@ module AbstractController
         assert_respond_to @controller, :l
       end
 
-      def test_raises_missing_translation_message_with_raise_config_option
-        AbstractController::Translation.raise_on_missing_translations = true
-
-        assert_raise(I18n::MissingTranslationData) do
-          @controller.t("translations.missing")
-        end
-      ensure
-        AbstractController::Translation.raise_on_missing_translations = false
-      end
-
       def test_raises_missing_translation_message_with_raise_option
         assert_raise(I18n::MissingTranslationData) do
           @controller.t(:"translations.missing", raise: true)

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -117,25 +117,6 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal expected, translate(:"translations.missing", year: "2015", scope: %i(scoped))
   end
 
-  def test_raises_missing_translation_message_with_raise_config_option
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
-
-    assert_raise(I18n::MissingTranslationData) do
-      translate("translations.missing")
-    end
-  ensure
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
-  end
-
-  def test_raise_arg_overrides_raise_config_option
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
-
-    expected = /translation missing: en.translations.missing/i
-    assert_match expected, translate(:"translations.missing", raise: false)
-  ensure
-    ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
-  end
-
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", raise: true)

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -49,7 +49,7 @@ module I18n
         when :load_path
           I18n.load_path += value
         when :raise_on_missing_translations
-          forward_raise_on_missing_translations_config(app)
+          setup_raise_on_missing_translations_config(app)
         else
           I18n.public_send("#{setting}=", value)
         end
@@ -77,13 +77,9 @@ module I18n
       @i18n_inited = true
     end
 
-    def self.forward_raise_on_missing_translations_config(app)
+    def self.setup_raise_on_missing_translations_config(app)
       ActiveSupport.on_load(:action_view) do
         ActionView::Helpers::TranslationHelper.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
-      end
-
-      ActiveSupport.on_load(:action_controller) do
-        AbstractController::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
       end
 
       if app.config.i18n.raise_on_missing_translations &&

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -505,7 +505,7 @@ instance variables:
   @_action_has_layout  @_action_name    @_config  @_lookup_context                      @_request
   @_response           @_response_body  @_routes  @marked_for_same_origin_verification  @posts
   @rendered_format
-class variables: @@raise_on_missing_translations  @@raise_on_open_redirects
+class variables: @@raise_on_open_redirects
 ```
 
 ### Breakpoints

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -162,6 +162,9 @@ I18n.t("missing.key") # didn't raise in 7.0, doesn't raise in 7.1
 Alternatively, you can customise the `I18n.exception_handler`.
 See the [i18n guide](https://guides.rubyonrails.org/v7.1/i18n.html#using-different-exception-handlers) for more information.
 
+`AbstractController::Translation.raise_on_missing_translations` has been removed. This was a private API, if you were
+relying on it you should migrate to `config.i18n.raise_on_missing_translations` or to a custom exception handler.
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/47105#issuecomment-1400843060

Removes the old `raise_on_missing_translations` accessors, that used to live [here](https://github.com/rails/rails/blob/fee61e3abc878e4d4930a0be0accf8e4569009a8/actionpack/lib/abstract_controller/translation.rb#L7) ~~and [here](https://github.com/rails/rails/blob/5c835bd669ae996a30bcc914672c9941539a496e/actionview/lib/action_view/helpers/translation_helper.rb#L15)~~. I included notes in the changelog and upgrade guide if anyone was relying on these despite them being private API.

Closes https://github.com/rails/rails/pull/45361
