### PR TITLE
Fix SQLWarning + exec_delete and exec_update tests

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -414,29 +414,35 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_warnings_do_not_change_returned_value_of_exec_update
+    ActiveRecord.db_warnings_action = :log
+
     # Mysql2 will raise an error when attempting to perform an update that warns if the sql_mode is set to strict
     old_sql_mode = @conn.query_value("SELECT @@SESSION.sql_mode")
     @conn.execute("SET @@SESSION.sql_mode=''")
 
     @conn.execute("INSERT INTO posts (title, body) VALUES('Title', 'Body')")
-    result = @conn.update("UPDATE posts SET title = 'Updated' WHERE id < (42+'foo') LIMIT 1")
+    result = @conn.update("UPDATE posts SET title = 'Updated' WHERE id > (0+'foo') LIMIT 1")
 
     assert_equal 1, result
   ensure
     @conn.execute("SET @@SESSION.sql_mode='#{old_sql_mode}'")
+    ActiveRecord.db_warnings_action = @original_db_warnings_action
   end
 
   def test_warnings_do_not_change_returned_value_of_exec_delete
+    ActiveRecord.db_warnings_action = :log
+
     # Mysql2 will raise an error when attempting to perform a delete that warns if the sql_mode is set to strict
     old_sql_mode = @conn.query_value("SELECT @@SESSION.sql_mode")
     @conn.execute("SET @@SESSION.sql_mode=''")
 
     @conn.execute("INSERT INTO posts (title, body) VALUES('Title', 'Body')")
-    result = @conn.delete("DELETE FROM posts WHERE id < (42+'foo') LIMIT 1")
+    result = @conn.delete("DELETE FROM posts WHERE id > (0+'foo') LIMIT 1")
 
     assert_equal 1, result
   ensure
     @conn.execute("SET @@SESSION.sql_mode='#{old_sql_mode}'")
+    ActiveRecord.db_warnings_action = @original_db_warnings_action
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Closes: https://github.com/rails/rails/issues/47113

These tests were failing intermittently if the created `Post` had an id exceeding 42, because no Post would be targeted by the condition in either the `UPDATE` or `DELETE` statement. This was an error on my part -- I assumed Post ids would auto-increment from 1 onwards. (`42` was selected rather arbitrarily.)

### Detail

To address the issue, I think it's simplest to change the condition to ` WHERE id > (0+'foo')`, since we're guaranteed to have ids that are `> 0`.

Additionally, I realized that the tests weren't quite set up correctly, because warnings behaviour wasn't enabled 🤦‍♀️ I changed the `db_warnings_action` to `:log` so that we're actually asserting that capturing SQL warnings doesn't impact the affected row count for `exec_update` and `exec_delete`. (Otherwise, if the DB warnings action is nil, `#handle_warnings` will just return early)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @eileencodes @yahonda 