### PR TITLE
Address Selenium :capabilities deprecation warning

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -56,7 +56,7 @@ module ActionDispatch
         end
 
         def browser_options
-          @options.merge(capabilities: @browser.options).compact
+          @options.merge(options: @browser.options).compact
         end
 
         def register_selenium(app)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -175,7 +175,7 @@ class DriverTest < ActiveSupport::TestCase
 
   private
     def assert_driver_capabilities(driver, expected_capabilities)
-      capabilities = driver.__send__(:browser_options)[:capabilities].as_json
+      capabilities = driver.__send__(:browser_options)[:options].as_json
 
       assert_equal expected_capabilities, capabilities.slice(*expected_capabilities.keys)
     end


### PR DESCRIPTION
### Motivation / Background

This PR addresses the deprecation warning for Selenium `:capabilities` since [Selenium 4.8.0](https://github.com/SeleniumHQ/selenium/releases/tag/selenium-4.8.0) was released.

### Detail

This was previously changed in https://github.com/rails/rails/commit/7f2b89faef4d4fcf186e7ff940f395ae9ba7a0b5, however, the latest Selenium release has moved away from `:capabilities` in favor of `:options` (https://github.com/seleniumhq/selenium/commit/9dc5a1c9f0f1f24c7d038f0b6853836fdb7539fd).

Steps to reproduce:
1. gh repo clone ron-shinall/selenium-deprecation
2. cd selenium-deprecation
3. bundle install
4. bin/rails test:system
5. Notice the deprecation warning: `WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead.`
    _Note that the `:logger_info` WARN message is there only because of the aforementioned deprecation warning._

### Additional information

With the code changes in this PR the deprecation warning is eliminated.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.