### PR TITLE
use lower case for codespell ignore words

### DIFF
--- a/codespell.txt
+++ b/codespell.txt
@@ -41,5 +41,5 @@ vew
 wil
 wth
 yau
-nIn
+nin
 elemen


### PR DESCRIPTION
### Motivation / Background

PR builds are currently failing with 

```
Run codespell --ignore-words=codespell.txt --skip="./actionview/test/ujs/public/vendor/qunit.js" || exit 1
./codespell.txt:44: nIn ==> inn, min, bin, nine
./actiontext/app/assets/javascripts/trix.js:3862: nIn ==> inn, min, bin, nine
./actiontext/app/assets/javascripts/trix.js:3866: nIn ==> inn, min, bin, nine
./actiontext/app/assets/javascripts/trix.js:3897: nIn ==> inn, min, bin, nine
./actiontext/app/assets/javascripts/trix.js:3944: nIn ==> inn, min, bin, nine
Error: Process completed with exit code 1.
```

From https://github.com/codespell-project/codespell/issues/402 - it appears that the codespell ignore words are expected to be provided in lower case.

This Pull Request has been created so that the "Check spelling with codespell" step can be green again.