### PR TITLE
Revert "Address `test_warnings_do_not_change_returned_value_of_exec_(update|delete)` failures"

### DIFF
--- a/activerecord/test/fixtures/bad_posts.yml
+++ b/activerecord/test/fixtures/bad_posts.yml
@@ -4,7 +4,6 @@ _fixture:
   model_class: BadPostModel
 
 bad_welcome:
-  id: 1
   author_id: 1
   title: Welcome to the another weblog
   body: It's really nice today


### PR DESCRIPTION
Reverts rails/rails#47070

#47113 has been addressed via #47116, which does not depend on the Posts id value generated by the fixtures. This change should not exist anymore. 