### PR TITLE
Remove deprecation from template

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -169,10 +169,6 @@ module ActionView
       if handler.respond_to?(:translate_location)
         handler.translate_location(spot, backtrace_location, encode!)
       else
-        ActionView.deprecator.warn(<<-MSG.squish)
-          The templating engine being used does not define `translate_location`
-          so Rails is unable to highlight the source location inside the template.
-        MSG
         spot
       end
     end


### PR DESCRIPTION
This PR removes the deprecation added in #47005 because it is non-trivial for HAML and Slim to implement error highlighting for templates. If a template engine doesn't support `translate_location` then we can fallback to `spot` and the error will be displayed but we won't be able to automatically underline the column.
