### PR TITLE
Add --no-sandbox flag to chrome.

### DIFF
--- a/actiontext/test/application_system_test_case.rb
+++ b/actiontext/test/application_system_test_case.rb
@@ -3,7 +3,9 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
+  driven_by :selenium, using: :headless_chrome do |driver_option|
+    driver_option.add_argument("--no-sandbox")
+  end
 end
 
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
### Motivation / Background

Add --no-sandbox flag to integration tests that run on google chrome headless mode.

This Pull Request has been created because https://github.com/rails/rails/issues/46804

📝 I could not find any integration tests in any of the frameworks that use capybara and chrome headless except for these action text integration tests. ActionView uses yarn/karma for the ujs tests so does action cable.

PR to run the integration tests: https://github.com/rails/buildkite-config/pull/33

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
