### PR TITLE
Use Gemfile to manage Rack version for development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,10 @@ gem "webrick", require: false
 gem "jbuilder", require: false
 gem "web-console", require: false
 
+# Action Pack and railties
+rack_version = ENV.fetch("RACK", "~> 2.0") # Change to ~> 3 after #46594 is merged.
+gem "rack", rack_version
+
 # Active Job
 group :job do
   gem "resque", require: false

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0", ">= 2.2.4"
+  s.add_dependency "rack",      "< 4", ">= 2.2.4"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"


### PR DESCRIPTION
This is an alternative to #47120.

The downside to this approach is that anyone installing `actionpack` from the main branch will probably(?) get Rack v3, which isn't fully compatible yet. Depending on #46594. As well as, once this change is released, any new installs (or bundle update) will grab Rack 3 as well, which may have other side-effects. For example, if they're mounting another non Rack 3 compatible library such as Sinatra (TBD?), or depending on other Rack 2 specific middleware, etc.

An example build can be found here:
https://buildkite.com/rails/rails/builds/93029#0185e6dd-f7da-4149-b11a-fa1a29ef38f0

This depends on rails/buildkite-config#34 to actually test different Rack versions in CI.