### PR TITLE
Turn on static file server by default

### DIFF
--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -18,9 +18,8 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :terser

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -20,9 +20,8 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :terser

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -21,9 +21,8 @@ Rails.application.configure do
   # `config/secrets.yml.key`.
   config.read_encrypted_secrets = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -71,8 +71,7 @@ COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
 # Deployment options
-ENV RAILS_LOG_TO_STDOUT="1" \
-    RAILS_SERVE_STATIC_FILES="true"
+ENV RAILS_LOG_TO_STDOUT="1"
 
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -22,9 +22,8 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
+  config.public_file_server.enabled = true
 
   <%- unless skip_sprockets? -%>
   # Compress CSS using a preprocessor.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -616,23 +616,12 @@ module ApplicationTests
       assert_equal Pathname.new(app_path).join("somewhere"), Rails.public_path
     end
 
-    test "In production mode, config.public_file_server.enabled is off by default" do
+    test "In production mode, config.public_file_server.enabled is on by default" do
       restore_default_config
 
       with_rails_env "production" do
         app "production"
-        assert_not app.config.public_file_server.enabled
-      end
-    end
-
-    test "In production mode, config.public_file_server.enabled is enabled when RAILS_SERVE_STATIC_FILES is set" do
-      restore_default_config
-
-      with_rails_env "production" do
-        switch_env "RAILS_SERVE_STATIC_FILES", "1" do
-          app "production"
-          assert app.config.public_file_server.enabled
-        end
+        assert app.config.public_file_server.enabled
       end
     end
 
@@ -643,17 +632,6 @@ module ApplicationTests
         switch_env "RAILS_LOG_TO_STDOUT", "1" do
           app "production"
           assert ActiveSupport::Logger.logger_outputs_to?(app.config.logger, STDOUT)
-        end
-      end
-    end
-
-    test "In production mode, config.public_file_server.enabled is disabled when RAILS_SERVE_STATIC_FILES is blank" do
-      restore_default_config
-
-      with_rails_env "production" do
-        switch_env "RAILS_SERVE_STATIC_FILES", " " do
-          app "production"
-          assert_not app.config.public_file_server.enabled
         end
       end
     end


### PR DESCRIPTION
Modern deployments don't need NGINX/Apache when using CDNs or caching LBs in front. This means file serving works out of the box too.