### PR TITLE
Allow use of SSL-terminating reserve proxy that doesn't set headers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `ActionDispatch::AssumeSSL` middleware that can be turned on via `config.assume_ssl`.
+    It makes the application believe that all requests are arring over SSL. This is useful 
+    when proxying through a load balancer that terminates SSL, the forwarded request will appear
+    as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
+    security target HTTP instead of HTTPS. This middleware makes the server assume that the
+    proxy already terminated SSL, and that the request really is HTTPS.
+
+    *DHH*
+
 *   Only use HostAuthorization middleware if `config.hosts` is not empty
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -54,6 +54,7 @@ module ActionDispatch
   end
 
   autoload_under "middleware" do
+    autoload :AssumeSSL
     autoload :HostAuthorization
     autoload :RequestId
     autoload :Callbacks

--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # When proxying through a load balancer that terminates SSL, the forwarded request will appear
 # as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
 # security target HTTP instead of HTTPS. This middleware makes the server assume that the

--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -1,0 +1,20 @@
+# When proxying through a load balancer that terminates SSL, the forwarded request will appear
+# as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
+# security target HTTP instead of HTTPS. This middleware makes the server assume that the
+# proxy already terminated SSL, and that the request really is HTTPS.
+module ActionDispatch
+  class AssumeSSL
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      env["HTTPS"] = "on"
+      env["HTTP_X_FORWARDED_PORT"] = 443
+      env["HTTP_X_FORWARDED_PROTO"] = "https"
+      env["rack.url_scheme"] = "https"
+
+      @app.call(env)
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -194,6 +194,10 @@ be set to `false` if application code is not thread safe. Defaults to `true`.
 
 Sets the host for the assets. Useful when CDNs are used for hosting assets, or when you want to work around the concurrency constraints built-in in browsers using different domain aliases. Shorter version of `config.action_controller.asset_host`.
 
+#### `config.assume_ssl`
+
+Makes application believe that all requests are arring over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though its HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
+
 #### `config.autoflush_log`
 
 Enables writing log file output immediately instead of buffering. Defaults to

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -10,7 +10,7 @@ require "rails/source_annotation_extractor"
 module Rails
   class Application
     class Configuration < ::Rails::Engine::Configuration
-      attr_accessor :allow_concurrency, :asset_host, :autoflush_log,
+      attr_accessor :allow_concurrency, :asset_host, :assume_ssl, :autoflush_log,
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
@@ -43,6 +43,7 @@ module Rails
         @public_file_server                      = ActiveSupport::OrderedOptions.new
         @public_file_server.enabled              = true
         @public_file_server.index_name           = "index"
+        @assume_ssl                              = false
         @force_ssl                               = false
         @ssl_options                             = {}
         @session_store                           = nil

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -17,6 +17,10 @@ module Rails
             middleware.use ::ActionDispatch::HostAuthorization, config.hosts, **config.host_authorization
           end
 
+          if config.assume_ssl
+            middleware.use ::ActionDispatch::AssumeSSL
+          end
+
           if config.force_ssl
             middleware.use ::ActionDispatch::SSL, **config.ssl_options,
               ssl_default_redirect_status: config.action_dispatch.ssl_default_redirect_status

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -53,6 +53,10 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   <%- end -%>
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # config.assume_ssl = true
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -190,6 +190,12 @@ module ApplicationTests
       assert_includes middleware, "ActiveRecord::Migration::CheckPending"
     end
 
+    test "ActionDispatch::AssumeSSL is present when assume_ssl is set" do
+      add_to_config "config.assume_ssl = true"
+      boot!
+      assert_includes middleware, "ActionDispatch::AssumeSSL"
+    end
+
     test "ActionDispatch::SSL is present when force_ssl is set" do
       add_to_config "config.force_ssl = true"
       boot!


### PR DESCRIPTION
NGINX and other SSL-terminating reverse proxies can use HTTP headers to include forwarding information. If your stack includes SSL-termination through a network load balancer, that won't happen. You can use config.assume_ssl to address that.