### PR TITLE
Add rack upper bound back in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ PATH
     actionpack (7.1.0.alpha)
       actionview (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
-      rack (>= 2.2.4)
+      rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      ">= 2.2.4"
+  s.add_dependency "rack",      "~> 2.0", ">= 2.2.4"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"


### PR DESCRIPTION
### Motivation / Background

A [recent commit](https://github.com/rails/rails/commit/859b526c5b9f1e516df3fc1b388c949da3fa9c4e) removed the upper bound on actionpack's rack dependency, which caused primer/view_component's CI to upgrade rack to v3.0. This in turn caused CI to fail with the following message:

```
/home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/bundler/gems/rails-e8f481b924c7/actionpack/lib/action_controller/test_case.rb:3:in `require': cannot load such file -- rack/session/abstract/id (LoadError)
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/bundler/gems/rails-e8f481b924c7/actionpack/lib/action_controller/test_case.rb:3:in `<top (required)>'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/bundler/gems/rails-e8f481b924c7/railties/lib/rails/test_help.rb:9:in `require'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/bundler/gems/rails-e8f481b924c7/railties/lib/rails/test_help.rb:9:in `<top (required)>'
	from /home/runner/work/view_components/view_components/test/test_helper.rb:19:in `require'
	from /home/runner/work/view_components/view_components/test/test_helper.rb:19:in `<top (required)>'
	from /home/runner/work/view_components/view_components/test/components/test_helper.rb:3:in `require'
	from /home/runner/work/view_components/view_components/test/components/test_helper.rb:3:in `<top (required)>'
	from /home/runner/work/view_components/view_components/test/components/alpha/action_list_test.rb:3:in `require'
	from /home/runner/work/view_components/view_components/test/components/alpha/action_list_test.rb:3:in `<top (required)>'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/gems/rake-[13](https://github.com/primer/view_components/actions/runs/4008570494/jobs/6884250030#step:6:14).0.6/lib/rake/rake_test_loader.rb:[21](https://github.com/primer/view_components/actions/runs/4008570494/jobs/6884250030#step:6:22):in `require'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/runner/work/view_components/view_components/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
```

It appears Rails main (and earlier) are not compatible with rack >= 3.0. A comment added in [this commit](https://github.com/rails/rails/commit/896c7faedf01893c50d963aa4f7857b42373bd03) indicates Rails cannot support modern rack versions until [@ioquatix's PR](https://github.com/rails/rails/pull/46594) is merged.

### Detail

This PR reinstates the upper bound on the rack dependency to `~> 2.0`.

### Additional information

Until this is merged, those depending on Rails main can pin their rack version to `<~ 2.0` in their Gemfiles.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.