### PR TITLE
Control log level with RAILS_LOG_LEVEL in production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -67,9 +67,10 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  # Info include generic and useful information about system operation, but avoids logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII). Use "debug"
+  # for everything.
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1790,7 +1790,6 @@ module ApplicationTests
     test "config.log_level can be overwritten by ENV['RAILS_LOG_LEVEL'] in production" do
       restore_default_config
 
-      with_rails_env "production" do
       switch_env "RAILS_LOG_LEVEL", "debug" do
         app "production"
         assert_equal Logger::DEBUG, Rails.logger.level

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1789,7 +1789,6 @@ module ApplicationTests
 
     test "config.log_level can be overwritten by ENV['RAILS_LOG_LEVEL'] in production" do
       restore_default_config
-      app "production"
 
       with_rails_env "production" do
       switch_env "RAILS_LOG_LEVEL", "debug" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1787,6 +1787,17 @@ module ApplicationTests
       assert_equal Logger::INFO, Rails.logger.level
     end
 
+    test "config.log_level can be overwritten by ENV['RAILS_LOG_LEVEL'] in production" do
+      restore_default_config
+      app "production"
+
+      with_rails_env "production" do
+      switch_env "RAILS_LOG_LEVEL", "debug" do
+        app "production"
+        assert_equal Logger::DEBUG, Rails.logger.level
+      end
+    end
+
     test "config.log_level with custom logger" do
       make_basic_app do |application|
         application.config.logger = Logger.new(STDOUT)


### PR DESCRIPTION
Makes it easier to switch to debug mode when needed without changing code.