### PR TITLE
Refactor `EnvironmentArgument` to be automatic

### DIFF
--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -9,31 +9,47 @@ module Rails
       extend ActiveSupport::Concern
 
       included do
-        no_commands do
-          class_attribute :environment_desc, default: "Specifies the environment to run this #{self.command_name} under (test/development/production)."
+        class_option :environment, aliases: "-e", type: :string,
+          desc: "The environment to run `#{self.command_name}` in (e.g. test / development / production)."
+      end
+
+      def initialize(...)
+        super
+
+        @environment_specified = options[:environment].present?
+
+        if !@environment_specified
+          self.options = options.merge(environment: Rails::Command.environment)
+        elsif !available_environments.include?(options[:environment])
+          self.options = options.merge(environment: expand_environment_name(options[:environment]))
         end
-        class_option :environment, aliases: "-e", type: :string, desc: environment_desc
       end
 
       private
-        def extract_environment_option_from_argument(default_environment: Rails::Command.environment)
-          if options[:environment]
-            self.options = options.merge(environment: acceptable_environment(options[:environment]))
-          else
-            self.options = options.merge(environment: default_environment)
-          end
+        def require_application!
+          ENV["RAILS_ENV"] = environment
+          super
         end
 
-        def acceptable_environment(env = nil)
-          if available_environments.include? env
-            env
-          else
-            %w( production development test ).detect { |e| /^#{env}/.match?(e) } || env
-          end
+        def environment
+          @environment ||= options[:environment]
+        end
+
+        def environment=(environment)
+          @environment = environment
+        end
+
+        def environment_specified?
+          @environment_specified
         end
 
         def available_environments
-          Dir["config/environments/*.rb"].map { |fname| File.basename(fname, ".*") }
+          @available_environments ||=
+            Dir["config/environments/*.rb"].map { |filename| File.basename(filename, ".*") }
+        end
+
+        def expand_environment_name(name)
+          %w[production development test].find { |full_name| full_name.start_with?(name) } || name
         end
     end
   end

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -97,11 +97,6 @@ module Rails
       end
 
       def perform
-        extract_environment_option_from_argument
-
-        # RAILS_ENV needs to be set before config/application is required.
-        ENV["RAILS_ENV"] = options[:environment]
-
         require_application_and_environment!
         Rails::Console.start(Rails.application, options)
       end

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -89,11 +89,6 @@ module Rails
         desc: "Specifies the database to use."
 
       def perform
-        extract_environment_option_from_argument
-
-        # RAILS_ENV needs to be set before config/application is required.
-        ENV["RAILS_ENV"] = options[:environment]
-
         require_application_and_environment!
         Rails::DBConsole.start(options)
       end

--- a/railties/lib/rails/commands/initializers/initializers_command.rb
+++ b/railties/lib/rails/commands/initializers/initializers_command.rb
@@ -9,9 +9,6 @@ module Rails
 
       desc "initializers", "Print out all defined initializers in the order they are invoked by Rails."
       def perform
-        extract_environment_option_from_argument
-        ENV["RAILS_ENV"] = options[:environment]
-
         require_application_and_environment!
 
         Rails.application.initializers.tsort_each do |initializer|

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -7,8 +7,6 @@ module Rails
     class RunnerCommand < Base # :nodoc:
       include EnvironmentArgument
 
-      self.environment_desc = "The environment for the runner to operate under (test/development/production)"
-
       no_commands do
         def help
           super
@@ -22,14 +20,10 @@ module Rails
 
       desc "runner", "Runs Ruby code in the context of your application"
       def perform(code_or_file = nil, *command_argv)
-        extract_environment_option_from_argument
-
         unless code_or_file
           help
           exit 1
         end
-
-        ENV["RAILS_ENV"] = options[:environment]
 
         require_application_and_environment!
         Rails.application.load_runner

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -129,7 +129,6 @@ module Rails
       end
 
       def perform
-        extract_environment_option_from_argument
         set_application_directory!
         prepare_restart
 

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -184,8 +184,6 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     end
 
     def parse_arguments(args)
-      command = Rails::Command::ConsoleCommand.new([], args)
-      command.send(:extract_environment_option_from_argument)
-      command.options
+      Rails::Command::ConsoleCommand.new([], args).options
     end
 end

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -246,21 +246,6 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     end
 
     def parse_arguments(args)
-      Rails::Command::DbconsoleCommand.class_eval do
-        alias_method :old_perform, :perform
-        define_method(:perform) do
-          extract_environment_option_from_argument
-
-          options
-        end
-      end
-
-      Rails::Command.invoke(:dbconsole, args)
-    ensure
-      Rails::Command::DbconsoleCommand.class_eval do
-        undef_method :perform
-        alias_method :perform, :old_perform
-        undef_method :old_perform
-      end
+      Rails::Command::DbconsoleCommand.new([], args).options
     end
 end

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -303,8 +303,6 @@ class Rails::Command::ServerCommandTest < ActiveSupport::TestCase
     end
 
     def parse_arguments(args = [])
-      command = Rails::Command::ServerCommand.new([], args)
-      command.send(:extract_environment_option_from_argument)
-      command.server_options
+      Rails::Command::ServerCommand.new([], args).server_options
     end
 end


### PR DESCRIPTION
This commit refactors `Rails::Command::EnvironmentArgument` to automatically set an appropriate value for `options[:environment]`, even when the `--environment` option is omitted.  Additionally, `EnvironmentArgument` will automatically set `ENV["RAILS_ENV"]` when `require_application!` (or `require_application_and_environment!`) is called.
