### PR TITLE
Generate `Dockerfile` to exclude `test` Bundle group

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Change `Dockerfile` template to exclude _both_ `development` and `test` gem
+    groups
+
+    *Sean Doyle*
+
 *   Credentials commands (e.g. `bin/rails credentials:edit`) now respect
     `config.credentials.content_path` and `config.credentials.key_path` when set
     in `config/application.rb`.

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Set production environment
 ENV RAILS_ENV="production" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development:test"
 
 
 # Throw-away build stage to reduce size of final image

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1040,6 +1040,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Dockerfile" do |content|
+      assert_match(%(BUNDLE_WITHOUT="development:test"), content)
       assert_match(/assets:precompile/, content)
       assert_match(/libvips/, content)
       assert_no_match(/yarn/, content)


### PR DESCRIPTION
### Motivation / Background

The generated `Dockerfile` excludes the `development` group, but does not exclude the `test` group. Since it's `production`-focused, it should exclude both.

### Detail

According to the [Bundler Configuration][] documentation, you can specify a `--without` flag or `BUNDLE_WITHOUT` environment variable with the group names to omit from bundling, separated by a `:`

> without (BUNDLE_WITHOUT): A :-separated list of groups whose gems
> bundler should not install.

[Bundler Configuration]: https://bundler.io/v2.4/man/bundle-config.1.html#CONFIGURATION-KEYS

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
