### PR TITLE
Normalize usage of "Headers".

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -35,12 +35,15 @@ module ActionDispatch # :nodoc:
     begin
       # For `Rack::Headers` (Rack 3+):
       require "rack/headers"
-      Header = ::Rack::Headers
+      Headers = ::Rack::Headers
     rescue LoadError
       # For `Rack::Utils::HeaderHash`:
       require "rack/utils"
-      Header = ::Rack::Utils::HeaderHash
+      Headers = ::Rack::Utils::HeaderHash
     end
+
+    # To be deprecated:
+    Header = Headers
 
     # The request that the response is responding to.
     attr_accessor :request
@@ -60,11 +63,12 @@ module ActionDispatch # :nodoc:
     #   headers["Content-Type"] = "application/json"
     #   headers["Content-Type"] # => "application/json"
     #
-    attr_reader :header
+    # Also aliased as +header+ for compatibility.
+    attr_reader :headers
 
-    alias_method :headers,  :header
+    alias_method :header, :headers
 
-    delegate :[], :[]=, to: :@header
+    delegate :[], :[]=, to: :@headers
 
     def each(&block)
       sending!
@@ -143,9 +147,9 @@ module ActionDispatch # :nodoc:
         end
     end
 
-    def self.create(status = 200, header = {}, body = [], default_headers: self.default_headers)
-      header = merge_default_headers(header, default_headers)
-      new status, header, body
+    def self.create(status = 200, headers = {}, body = [], default_headers: self.default_headers)
+      headers = merge_default_headers(headers, default_headers)
+      new status, headers, body
     end
 
     def self.merge_default_headers(original, default)
@@ -155,13 +159,13 @@ module ActionDispatch # :nodoc:
     # The underlying body, as a streamable object.
     attr_reader :stream
 
-    def initialize(status = 200, header = nil, body = [])
+    def initialize(status = 200, headers = nil, body = [])
       super()
 
-      @header = Header.new
+      @headers = Headers.new
 
-      header&.each do |key, value|
-        @header[key] = value
+      headers&.each do |key, value|
+        @headers[key] = value
       end
 
       self.body, self.status = body, status
@@ -176,10 +180,10 @@ module ActionDispatch # :nodoc:
       yield self if block_given?
     end
 
-    def has_header?(key);   headers.key? key;   end
-    def get_header(key);    headers[key];       end
-    def set_header(key, v); headers[key] = v;   end
-    def delete_header(key); headers.delete key; end
+    def has_header?(key);   @headers.key? key;   end
+    def get_header(key);    @headers[key];       end
+    def set_header(key, v); @headers[key] = v;   end
+    def delete_header(key); @headers.delete key; end
 
     def await_commit
       synchronize do
@@ -385,7 +389,7 @@ module ActionDispatch # :nodoc:
     #   status, headers, body = *response
     def to_a
       commit!
-      rack_response @status, @header.to_hash
+      rack_response @status, @headers.to_hash
     end
     alias prepare! to_a
 
@@ -452,7 +456,7 @@ module ActionDispatch # :nodoc:
       # our last chance.
       commit! unless committed?
 
-      @header.freeze
+      @headers.freeze
       @request.commit_cookie_jar! unless committed?
     end
 
@@ -506,16 +510,16 @@ module ActionDispatch # :nodoc:
 
     def handle_no_content!
       if NO_CONTENT_CODES.include?(@status)
-        @header.delete CONTENT_TYPE
-        @header.delete "Content-Length"
+        @headers.delete CONTENT_TYPE
+        @headers.delete "Content-Length"
       end
     end
 
-    def rack_response(status, header)
+    def rack_response(status, headers)
       if NO_CONTENT_CODES.include?(status)
-        [status, header, []]
+        [status, headers, []]
       else
-        [status, header, RackBody.new(self)]
+        [status, headers, RackBody.new(self)]
       end
     end
   end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -854,20 +854,20 @@ class HeadRenderTest < ActionController::TestCase
   def test_head_created_with_application_json_content_type
     post :head_created_with_application_json_content_type
     assert_predicate @response.body, :blank?
-    assert_equal "application/json", @response.header["Content-Type"]
+    assert_equal "application/json", @response.headers["Content-Type"]
     assert_response :created
   end
 
   def test_head_ok_with_image_png_content_type
     post :head_ok_with_image_png_content_type
     assert_predicate @response.body, :blank?
-    assert_equal "image/png", @response.header["Content-Type"]
+    assert_equal "image/png", @response.headers["Content-Type"]
     assert_response :ok
   end
 
   def test_head_respect_string_content_type
     get :head_ok_with_string_key_content_type
-    assert_equal "application/pdf", @response.header["Content-Type"]
+    assert_equal "application/pdf", @response.headers["Content-Type"]
   end
 
   def test_head_with_location_header
@@ -967,7 +967,7 @@ class HeadRenderTest < ActionController::TestCase
 
   def test_head_default_content_type
     post :head_default_content_type
-    assert_equal "text/html", @response.header["Content-Type"]
+    assert_equal "text/html", @response.headers["Content-Type"]
   end
 end
 

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -12,9 +12,9 @@ module ActionController
       end
 
       def test_header_merge
-        header = @response.header.merge("Foo" => "Bar")
-        assert_kind_of(ActionController::Live::Response::Header, header)
-        assert_not_equal header, @response.header
+        headers = @response.headers.merge("Foo" => "Bar")
+        assert_kind_of(ActionController::Live::Response::Headers, headers)
+        assert_not_equal headers, @response.headers
       end
 
       def test_initialize_with_default_headers
@@ -25,7 +25,7 @@ module ActionController
         end
 
         headers = r.create.headers
-        assert_kind_of(ActionController::Live::Response::Header, headers)
+        assert_kind_of(ActionController::Live::Response::Headers, headers)
         assert_equal "g", headers["omg"]
       end
 


### PR DESCRIPTION
This is the terminology which is used in most modern specifications and code.

We have lots of places in the code which refer to "headers" and a few places that refer to it as "header". This normalises all instances to use "headers". It still retains compatibility with the existing usage.