### PR TITLE
Load environment config in credentials commands

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -266,7 +266,7 @@ Defaults to `config/credentials/#{Rails.env}.yml.enc` if it exists, or
 `config/credentials.yml.enc` otherwise.
 
 NOTE: In order for the `bin/rails credentials` commands to recognize this value,
-it must be set in `config/application.rb`.
+it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
 
 #### `config.credentials.key_path`
 
@@ -276,7 +276,7 @@ Defaults to `config/credentials/#{Rails.env}.key` if it exists, or
 `config/master.key` otherwise.
 
 NOTE: In order for the `bin/rails credentials` commands to recognize this value,
-it must be set in `config/application.rb`.
+it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
 
 #### `config.debug_exception_response_format`
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Credentials commands (e.g. `bin/rails credentials:edit`) now respect
     `config.credentials.content_path` and `config.credentials.key_path` when set
-    in `config/application.rb`.
+    in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
 
     Before:
 
@@ -21,19 +21,8 @@
         would load for the current `RAILS_ENV`.
 
       * `bin/rails credentials:edit` respects `config.credentials.content_path`
-        and `config.credentials.key_path` when set in `config/application.rb`.
-        Using `RAILS_ENV`, environment-specific paths can be set, such as:
-
-          ```ruby
-          # config/application.rb
-          module MyCoolApp
-            class Application < Rails::Application
-              config.credentials.content_path = "my_credentials/#{Rails.env}.yml.enc"
-
-              config.credentials.key_path = "path/to/production.key" if Rails.env.production?
-            end
-          end
-          ```
+        and `config.credentials.key_path` when set in `config/application.rb`
+        or `config/environments/#{Rails.env}.rb`.
 
       * `bin/rails credentials:edit --environment foo` will create and edit
         `config/credentials/foo.yml.enc` _if_ `config.credentials.content_path`

--- a/railties/lib/rails/command/actions.rb
+++ b/railties/lib/rails/command/actions.rb
@@ -10,23 +10,21 @@ module Rails
         Dir.chdir(File.expand_path("../..", APP_PATH)) unless File.exist?(File.expand_path("config.ru"))
       end
 
-      def require_application_and_environment!
-        require_application!
-        require_environment!
-      end
-
       def require_application!
         require ENGINE_PATH if defined?(ENGINE_PATH)
-
-        if defined?(APP_PATH)
-          require APP_PATH
-        end
+        require APP_PATH if defined?(APP_PATH)
       end
 
-      def require_environment!
-        if defined?(APP_PATH)
-          Rails.application.require_environment!
-        end
+      def boot_application!
+        require_application!
+        Rails.application.require_environment! if defined?(APP_PATH)
+      end
+
+      def load_environment_config!
+        require_application!
+        # Only run initializers that are in the :all group, which includes the
+        # :load_environment_config initializer.
+        Rails.application.initialize!(:_) if defined?(APP_PATH)
       end
 
       if defined?(ENGINE_PATH)

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -97,7 +97,7 @@ module Rails
       end
 
       def perform
-        require_application_and_environment!
+        boot_application!
         Rails::Console.start(Rails.application, options)
       end
     end

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -24,7 +24,7 @@ module Rails
 
       desc "edit", "Opens the decrypted credentials in `$EDITOR` for editing"
       def edit
-        require_application!
+        load_environment_config!
         load_generators
 
         if environment_specified?
@@ -41,7 +41,7 @@ module Rails
 
       desc "show", "Shows the decrypted credentials"
       def show
-        require_application!
+        load_environment_config!
 
         say credentials.read.presence || missing_credentials_message
       end
@@ -56,7 +56,7 @@ module Rails
       def diff(content_path = nil)
         if @content_path = content_path
           self.environment = extract_environment_from_path(content_path)
-          require_application!
+          load_environment_config!
 
           say credentials.read.presence || credentials.content_path.read
         else

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -89,7 +89,7 @@ module Rails
         desc: "Specifies the database to use."
 
       def perform
-        require_application_and_environment!
+        boot_application!
         Rails::DBConsole.start(options)
       end
     end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -7,7 +7,7 @@ module Rails
     class DestroyCommand < Base # :nodoc:
       no_commands do
         def help
-          require_application_and_environment!
+          boot_application!
           load_generators
 
           Rails::Generators.help self.class.command_name
@@ -19,7 +19,7 @@ module Rails
         generator = args.shift
         return help unless generator
 
-        require_application_and_environment!
+        boot_application!
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -22,7 +22,7 @@ module Rails
 
       desc "edit", "Opens the decrypted file in `$EDITOR` for editing"
       def edit(*)
-        require_application!
+        load_environment_config!
 
         ensure_encryption_key_has_been_added
         ensure_encrypted_configuration_has_been_added
@@ -32,7 +32,7 @@ module Rails
 
       desc "show", "Shows the decrypted contents of the file"
       def show(*)
-        require_application!
+        load_environment_config!
 
         say encrypted_configuration.read.presence || missing_encrypted_configuration_message
       end

--- a/railties/lib/rails/commands/generate/generate_command.rb
+++ b/railties/lib/rails/commands/generate/generate_command.rb
@@ -7,7 +7,7 @@ module Rails
     class GenerateCommand < Base # :nodoc:
       no_commands do
         def help
-          require_application_and_environment!
+          boot_application!
           load_generators
 
           Rails::Generators.help self.class.command_name
@@ -18,7 +18,7 @@ module Rails
         generator = args.shift
         return help unless generator
 
-        require_application_and_environment!
+        boot_application!
         load_generators
 
         ARGV.replace(args) # set up ARGV for third-party libraries

--- a/railties/lib/rails/commands/initializers/initializers_command.rb
+++ b/railties/lib/rails/commands/initializers/initializers_command.rb
@@ -9,7 +9,7 @@ module Rails
 
       desc "initializers", "Print out all defined initializers in the order they are invoked by Rails."
       def perform
-        require_application_and_environment!
+        boot_application!
 
         Rails.application.initializers.tsort_each do |initializer|
           say "#{initializer.context_class}.#{initializer.name}"

--- a/railties/lib/rails/commands/notes/notes_command.rb
+++ b/railties/lib/rails/commands/notes/notes_command.rb
@@ -9,7 +9,7 @@ module Rails
 
       desc "notes", "Shows comments in your code annotated with FIXME, OPTIMIZE, and TODO"
       def perform(*)
-        require_application_and_environment!
+        boot_application!
 
         display_annotations
       end

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -22,7 +22,7 @@ module Rails
 
       desc "routes", "Lists all the defined routes"
       def perform(*)
-        require_application_and_environment!
+        boot_application!
         require "action_dispatch/routing/inspector"
 
         say inspector.format(formatter, routes_filter)

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -25,7 +25,7 @@ module Rails
           exit 1
         end
 
-        require_application_and_environment!
+        boot_application!
         Rails.application.load_runner
 
         ARGV.replace(command_argv)

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -24,7 +24,7 @@ module Rails
 
       desc "edit", "Opens the secrets in `$EDITOR` for editing"
       def edit
-        require_application_and_environment!
+        boot_application!
 
         using_system_editor do
           Rails::Secrets.read_for_editing { |tmp_path| system_editor(tmp_path) }

--- a/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
+++ b/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
@@ -40,7 +40,7 @@ module Rails
       end
 
       def perform(*)
-        require_application_and_environment!
+        boot_application!
         require "action_dispatch/routing/inspector"
 
         say(inspector.format(formatter, routes_filter))

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -303,6 +303,28 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_credentials_paths "config/credentials/production.yml.enc", key_path, environment: "production"
   end
 
+  test "respects config.credentials.content_path when set in config/environments/*.rb" do
+    content_path = "my_secrets/credentials.yml.enc"
+    add_to_env_config "production", "config.credentials.content_path = #{content_path.inspect}"
+
+    with_rails_env "production" do
+      assert_credentials_paths content_path, "config/master.key"
+    end
+
+    assert_credentials_paths content_path, "config/credentials/production.key", environment: "production"
+  end
+
+  test "respects config.credentials.key_path when set in config/environments/*.rb" do
+    key_path = "my_secrets/master.key"
+    add_to_env_config "production", "config.credentials.key_path = #{key_path.inspect}"
+
+    with_rails_env "production" do
+      assert_credentials_paths "config/credentials.yml.enc", key_path
+    end
+
+    assert_credentials_paths "config/credentials/production.yml.enc", key_path, environment: "production"
+  end
+
   private
     DEFAULT_CREDENTIALS_PATTERN = /access_key_id: 123\n.*secret_key_base: \h{128}\n/m
 


### PR DESCRIPTION
This commit changes the credentials commands (e.g. `bin/rails credentials:edit`) to load `config/environments/#{Rails.env}.rb`.  Thus, `config.credentials.content_path` and `config.credentials.key_path` can be set in `config/environments/*.rb`, in addition to the currently supported `config/application.rb`.

The `load_environment_config` initializer, which is run via `Rails.application.initialize!`, is responsible for loading the appropriate `config/environments/*.rb` file.

Normally, when booting an app, `Rails.application.initialize!` is called without arguments by `config/environment.rb`, which is loaded via `Rails.application.require_environment!`.  Doing so runs all initializers.

Running all initializers is problematic for credentials commands because (1) initializers might try to access resources that aren't available (e.g. a production database), and (2) initializers might try to read credentials values that have not yet been set in the current environment's credentials (see #34789).

Thus, the credentials commands call `Rails.application.initialize!` directly with a dummy group argument, so that initializers in the `:all` group — including `load_environment_config` — are run, but not initializers in the default group, such as `active_record.initialize_database` and `load_config_initializers`.

Closes #40778.

---

/cc @brianthoman I've added you as a co-author for your work on #40778.
