### PR TITLE
Add `InheritableOptions#override?`

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -92,6 +92,12 @@ module ActiveSupport
       end
     end
 
+    # Returns true if the given +key+ has an associated value that is not
+    # inherited.
+    def override?(key)
+      key?(key.to_sym)
+    end
+
     def inheritable_copy
       self.class.new(self)
     end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -82,6 +82,20 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal :baz, child.foo
   end
 
+  def test_inheritable_options_override_predicate
+    parent = ActiveSupport::OrderedOptions.new
+    parent[:foo] = nil
+    parent[:bar] = nil
+
+    child = ActiveSupport::InheritableOptions.new(parent)
+    child[:bar] = nil
+    child[:baz] = nil
+
+    assert_not child.override?(:foo)
+    assert child.override?(:bar)
+    assert child.override?(:baz)
+  end
+
   def test_inheritable_options_inheritable_copy
     original = ActiveSupport::InheritableOptions.new
     copy     = original.inheritable_copy

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -28,8 +28,8 @@ module Rails
         load_generators
 
         if environment_specified?
-          @content_path = "config/credentials/#{environment}.yml.enc" unless config.key?(:content_path)
-          @key_path = "config/credentials/#{environment}.key" unless config.key?(:key_path)
+          @content_path = "config/credentials/#{environment}.yml.enc" unless config.override?(:content_path)
+          @key_path = "config/credentials/#{environment}.key" unless config.override?(:key_path)
         end
 
         ensure_encryption_key_has_been_added


### PR DESCRIPTION
`InheritableOptions#override?` returns true if a given key has an associated value that is not inherited.  This can be used, for example, to detect whether a `config.*` value was explicitly set by the user.
