### PR TITLE
Allow destroying active storage variants

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow destroying active storage variants
+
+    ```ruby
+    User.first.avatar.variant(resize_to_limit: [100, 100]).destroy
+    ```
+
+    *Shouichi Kamiya*, *Yuichiro NAKAGAWA*, *Ryohei UEDA*
+
 *   Add missing preview event to `ActiveStorage::LogSubscriber`
 
     A `preview` event is being instrumented in `ActiveStorage::Previewer`.

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -100,6 +100,11 @@ class ActiveStorage::Variant
     self
   end
 
+  # Deletes variant file from service.
+  def destroy
+    service.delete(key)
+  end
+
   private
     def processed?
       service.exist?(key)

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -27,6 +27,11 @@ class ActiveStorage::VariantWithRecord
     record&.image
   end
 
+  # Destroys record and deletes file from service.
+  def destroy
+    record&.destroy
+  end
+
   delegate :key, :url, :download, to: :image, allow_nil: true
 
   private

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -275,6 +275,15 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "destroy deletes file from service" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(resize_to_limit: [100, 100]).processed
+
+    assert_changes -> { blob.service.exist?(variant.key) }, from: true, to: false do
+      variant.destroy
+    end
+  end
+
   private
     def process_variants_with(processor)
       previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, processor


### PR DESCRIPTION
Background:

When creating active storage variants, `ActiveStorage::VariantRecord` is inserted, then a file is uploaded. Because upload can be failed, the file can be missing even though `ActiveStorage::VariantRecord` exists.

When a file is missing, we need to delete the corresponding `ActiveStorage::VariantRecord` but there's no API to delete just one variant e.g., `attachable.variant(resize_to_limit: [100, 100]).destroy`.