### PR TITLE
Fix test:units and test:functionals commands for a new application

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix running `test:units` and `test:functionals` when directories don't
+    exist.
+
+    When creating a new application the `test/unit` and `test/functional`
+    directories are no longer created. By using a glob pattern for the tests
+    the task will no longer fail when run.
+
+    *Petrik de Heus*
+
 *   Credentials commands (e.g. `bin/rails credentials:edit`) now respect
     `config.credentials.content_path` and `config.credentials.key_path` when set
     in `config/application.rb`.

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -45,11 +45,17 @@ namespace :test do
   end
 
   task units: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/models", "test/helpers", "test/unit"])
+    dirs = %w[models helpers unit].map do |name|
+      "test/#{name}/**"
+    end
+    Rails::TestUnit::Runner.rake_run(dirs)
   end
 
   task functionals: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/controllers", "test/mailers", "test/functional"])
+    dirs = %w[controllers mailers functional].map do |name|
+      "test/#{name}/**"
+    end
+    Rails::TestUnit::Runner.rake_run(dirs)
   end
 
   desc "Run system tests only"

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -98,6 +98,18 @@ module ApplicationTests
       end
     end
 
+    def test_run_units_with_missing_unit_directory
+      create_test_file :models, "foo"
+      create_test_file :helpers, "bar_helper"
+      create_test_file :controllers, "foobar_controller"
+
+      rails("test:units").tap do |output|
+        assert_match "FooTest", output
+        assert_match "BarHelperTest", output
+        assert_match "2 runs, 2 assertions, 0 failures", output
+      end
+    end
+
     def test_run_all_takes_options
       create_test_file :system, "foo"
       assert_match "FooTest", rails("test:all", "--verbose")
@@ -180,6 +192,18 @@ module ApplicationTests
         assert_match "BarControllerTest", output
         assert_match "BazFunctionalTest", output
         assert_match "3 runs, 3 assertions, 0 failures", output
+      end
+    end
+
+    def test_run_functionals_with_missing_functional_directory
+      create_test_file :mailers, "foo_mailer"
+      create_test_file :controllers, "bar_controller"
+      create_test_file :models, "foo"
+
+      rails("test:functionals").tap do |output|
+        assert_match "FooMailerTest", output
+        assert_match "BarControllerTest", output
+        assert_match "2 runs, 2 assertions, 0 failures", output
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

When creating a new application the `test/unit` and `test/functional` directories are no longer created. Running `bin/rails test:units` or `bin/rails test:functionals` tries to run tests in these directories but will fail when any of the directories are missing.

### Detail

By using a glob pattern for the tests the task will no longer fail when run.

### Additional information

Another option would be checking if the directories exist, or removing these test tasks altogether.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
