### PR TITLE
Visit all arel nodes when compiling a values list to SQL

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -103,7 +103,7 @@ module Arel # :nodoc: all
             row.each_with_index do |value, k|
               collector << ", " unless k == 0
               case value
-              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute
+              when Nodes::Node, Nodes::SqlLiteral, ActiveModel::Attribute
                 collector = visit(value, collector)
               else
                 collector << quote(value).to_s

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -30,6 +30,21 @@ module Arel
         _(sql).must_be_like "VALUES (?)"
       end
 
+      it "does not quote Nodes used as part of a ValuesList" do
+        bind_param = Nodes::BindParam.new(Time.now)
+        node = Nodes::NamedFunction.new("date_trunc", [Nodes.build_quoted("day"), bind_param])
+        values = Nodes::ValuesList.new([[node]])
+        sql = compile values
+        _(sql).must_be_like "VALUES (date_trunc('day', ?))"
+      end
+
+      it "does not quote SqlLiterals used as part of a ValuesList" do
+        node = Arel.sql("true")
+        values = Nodes::ValuesList.new([[node]])
+        sql = compile values
+        _(sql).must_be_like "VALUES (true)"
+      end
+
       it "can define a dispatch method" do
         visited = false
         viz = Class.new(Arel::Visitors::Visitor) {


### PR DESCRIPTION
### Detail

This pull request relaxes the requirements for a value inside a ValueList to be visited by the ToSql visitor. Previously, anything but Nodes::BindParam or Nodes::SqlLiteral would be quoted (which fails because nodes can't be quoted). This change makes sure that all types of nodes are visited. This makes it possible to use function calls or type casts or other computations (like summing to values) within a values list.

### Additional information 

A similar change has been suggested by @quentindemetz in #47187

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
