### PR TITLE
Adds support for `UPDATE ... FROM ...` syntax to Arel

### DIFF
--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,11 +3,12 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :from, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
 
       def initialize(relation = nil)
         super()
         @relation = relation
+        @from     = nil
         @wheres   = []
         @values   = []
         @groups   = []
@@ -25,12 +26,13 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @from, @wheres, @values, @orders, @limit, @offset, @key].hash
       end
 
       def eql?(other)
         self.class == other.class &&
           self.relation == other.relation &&
+          self.from == other.from &&
           self.wheres == other.wheres &&
           self.values == other.values &&
           self.groups == other.groups &&

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -15,6 +15,11 @@ module Arel # :nodoc: all
       self
     end
 
+    def from(table)
+      @ast.from = table
+      self
+    end
+
     def set(values)
       if String === values
         @ast.values = [values]

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -148,6 +148,7 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_UpdateStatement(o)
           visit_edge o, "relation"
+          visit_edge o, "from"
           visit_edge o, "wheres"
           visit_edge o, "values"
           visit_edge o, "orders"

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -43,6 +43,11 @@ module Arel # :nodoc: all
           collector = visit o.relation, collector
           collect_nodes_for o.values, collector, " SET "
 
+          if o.from
+            collector << " FROM "
+            visit(o.from, collector)
+          end
+
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector

--- a/activerecord/test/cases/arel/nodes/update_statement_test.rb
+++ b/activerecord/test/cases/arel/nodes/update_statement_test.rb
@@ -22,6 +22,7 @@ describe Arel::Nodes::UpdateStatement do
     it "is equal with equal ivars" do
       statement1 = Arel::Nodes::UpdateStatement.new
       statement1.relation = "zomg"
+      statement1.from     = "foo"
       statement1.wheres   = 2
       statement1.values   = false
       statement1.orders   = %w[x y z]
@@ -31,6 +32,7 @@ describe Arel::Nodes::UpdateStatement do
       statement1.havings  = []
       statement2 = Arel::Nodes::UpdateStatement.new
       statement2.relation = "zomg"
+      statement2.from     = "foo"
       statement2.wheres   = 2
       statement2.values   = false
       statement2.orders   = %w[x y z]

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -167,5 +167,25 @@ module Arel
         _(@um.key).must_equal @table[:foo]
       end
     end
+
+    describe "from" do
+      it "generates an update statement" do
+        users = Table.new(:users)
+        employees = Table.new(:employees)
+
+        um = Arel::UpdateManager.new
+        um.table users
+        um.from employees
+        um.set [[users[:name], employees[:name]]]
+        um.where users[:id].eq(employees[:id])
+
+        _(um.to_sql).must_be_like %{ UPDATE "users" SET "name" = "employees"."name" FROM "employees" WHERE "users"."id" = "employees"."id" }
+      end
+
+      it "chains" do
+        um = Arel::UpdateManager.new
+        _(um.from(Table.new(:users))).must_equal um
+      end
+    end
   end
 end

--- a/activerecord/test/cases/arel/visitors/dot_test.rb
+++ b/activerecord/test/cases/arel/visitors/dot_test.rb
@@ -224,6 +224,7 @@ module Arel
 
         assert_match '[label="<f0>Arel::Nodes::UpdateStatement"]', dot
         assert_edge("relation", dot)
+        assert_edge("from", dot)
         assert_edge("wheres", dot)
         assert_edge("values", dot)
         assert_edge("orders", dot)


### PR DESCRIPTION
### Motivation / Background

This Pull Request adds support for the `UPDATE ... FROM ...` syntax to Arel's `UpdateStatement` and `UpdateManager`. This syntax is particularly useful when updating records in bulk based on data in a different table or a subexpression. 

One example where this is useful is bulk updating counter cache columns in a single query. The following Ruby code creates an update statement that updates the comments_count columns of all users with the number of comments they posted. 

```ruby 
users = Arel::Table.new(:users)
comments = Arel::Table.new(:comments)

comments_count = comments
  .project(comments[:user_id], Arel.star.count)
  .group(comments[:user_id])
  .as("comments_count")

update_manager = Arel::UpdateManager.new
  .table(users)
  .from(comments_count)
  .set([[users[:comments_count], comments_count[:count]]])
  .where(users[:id].eq(comments_count[:user_id]))
```

This will generate a query like this:

```sql 
UPDATE
  "users"
SET
  "comments_count" = comments_count."count"
FROM
  (
    SELECT
      "comments"."user_id",
      COUNT(*)
    FROM
      "comments"
    GROUP BY
      "comments"."user_id"
  ) comments_count
WHERE
  "users"."id" = comments_count."user_id"
```

### Detail

To add support for `UPDATE ... FROM ...` this pull requests add a `#from` method to both `Arel::UpdateManager` and `Arel::Nodes::UpdateStatement`. It also modifies the `Arel::Visitor::ToSql` and `Arel::Visitors::Dot` visitors to generate the respective SQL snippet and graph edge. 

### Additional information

The `UPDATE ... FROM ...` syntax is supported in both [PostgreSQL](https://www.postgresql.org/docs/current/sql-update.html) and [Sqlite3](https://www.sqlite.org/lang_update.html). 

The syntax is not supported in MySQL at the moment. There's [a way of adding similar behavior](https://dev.mysql.com/doc/refman/8.0/en/update.html) by adding the `from` table to the list of tables to be updated. This pull request doesn't implement this, though.

Very similar work has been done by @quentindemetz in #47188 and @lazaronixon in #46487. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
