### PR TITLE
Allow passing Symbols as aliases in Arel

### DIFF
--- a/activerecord/lib/arel/alias_predication.rb
+++ b/activerecord/lib/arel/alias_predication.rb
@@ -3,6 +3,8 @@
 module Arel # :nodoc: all
   module AliasPredication
     def as(other)
+      other = other.name if other.is_a?(Symbol)
+
       Nodes::As.new self, Nodes::SqlLiteral.new(other, retryable: true)
     end
   end

--- a/activerecord/test/cases/arel/nodes/as_test.rb
+++ b/activerecord/test/cases/arel/nodes/as_test.rb
@@ -18,6 +18,12 @@ module Arel
           as = attr.as("foo")
           assert_kind_of Arel::Nodes::SqlLiteral, as.right
         end
+
+        it "converts right to SqlLiteral if a symbol" do
+          attr = Table.new(:users)[:id]
+          as = attr.as(:foo)
+          assert_kind_of Arel::Nodes::SqlLiteral, as.right
+        end
       end
 
       describe "equality" do


### PR DESCRIPTION
### Motivation / Background

The following parts of Arel allow both Strings and Symbols to name things: 

```ruby
# Tables 
users = Arel::Table.new('users')
users = Arel::Table.new(:users)

# Columns
users['name']
users[:name]

# Table Alias
admins = users.alias('admins')
admins = users.alias(:admins)

# As 
users[:name].as('first_name')
users[:name].as(:first_name) # Currently raises an exception that symbols can't be convered into strings
```

The mismatch in behavior is very surprising and I keep stumbling over this while working with Arel, especially as using symbols with these methods is pretty common, even across the Rails codebase itself. 

### Detail

This pull request converts symbols to strings before wrapping them with an `Arel::Nodes::SqlLiteral` (which is a subclass of `String`). 

### Additional information

In the past, there used to be a `.to_s` call that was always applied to whatever was passed as name, but that was [expliclty removed](https://github.com/rails/rails/commit/1f5ed8eb20231644525bdad9a94a91e810191186). To keep the spirit of this change, this pull request explicitly only converts symbols into strings.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
