### PR TITLE
`tag.attributes` accept variable number of `Hash`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `tag.attributes` accepts a variable number of `Hash` arguments, then merges
+    them from left to right:
+
+    ```erb
+    <input <%= tag.attributes({ id: "search" }, { type: :text }, { aria: { label: "Search" } }, aria: { disabled: true }) %> >
+    <%# => <input id="search" type="text" aria-label="Search" aria-disabled="true"> %>
+    ```
+
+    *Sean Doyle*
+
 *   Added validation for HTML tag names in the `tag` and `content_tag` helper method. The `tag` and
     `content_tag` method now checks that the provided tag name adheres to the HTML specification. If
     an invalid HTML tag name is provided, the method raises an `ArgumentError` with an appropriate error

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -56,10 +56,27 @@ module ActionView
         # Transforms a Hash into HTML Attributes, ready to be interpolated into
         # ERB.
         #
+        # === Passing a single Hash argument
+        #
         #   <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %> >
         #   # => <input type="text" aria-label="Search">
-        def attributes(attributes)
-          tag_options(attributes.to_h).to_s.strip.html_safe
+        #
+        # === Passing multiple Hash arguments
+        #
+        # Passing multiple Hash arguments will be deep merged from left to right into a single Hash:
+        #
+        #   <input <%= tag.attributes({ type: :text }, { id: "search" }, { aria: { label: "Search" } }) %> >
+        #   # => <input type="text" id="search" aria-label="Search">
+        #
+        # Hash arguments can be mixed with keyword arguments:
+        #
+        #   <input <%= tag.attributes({ type: :text }, { id: "search" }, { aria: { label: "Search" } }, aria: { disabled: true }) %> >
+        #   # => <input type="text" id="search" aria-label="Search" aria-disabled="true">
+        #
+        ruby2_keywords def attributes(*attributes)
+          attributes = attributes.tap(&:flatten!).tap(&:compact_blank!)
+
+          tag_options(attributes.reduce({}, :deep_merge!)).to_s.strip.html_safe
         end
 
         def p(*arguments, **options, &block)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -544,8 +544,22 @@ class TagHelperTest < ActionView::TestCase
     HTML
   end
 
-  def test_tag_attributes_nil
+  def test_tag_attributes_merges_arguments_from_left_to_right
+    assert_equal %(<input type="text" id="1" class="2" disabled="disabled" >), render_erb(%(<input type="text" <%= tag.attributes({ id: 1 }, { class: "2" }, disabled: true) %> >))
+    assert_equal %(<input type="text" id="1" class="2" disabled="disabled" >), render_erb(%(<input type="text" <%= tag.attributes([{ id: 1 }, { class: "2" }], disabled: true) %> >))
+  end
+
+  def test_tag_attributes_merges_overrides_from_left_to_right
+    assert_equal %(<input type="text" id="3" >), render_erb(%(<input type="text" <%= tag.attributes({ id: 1 }, { id: 2 }, id: 3) %> >))
+  end
+
+  def test_tag_attributes_deep_merges_nested_arguments_from_left_to_right
+    assert_equal %(<input type="text" aria-label="2" aria-disabled="true" aria-selected="false" >), render_erb(%(<input type="text" <%= tag.attributes({ aria: { label: 1 } }, { aria: { disabled: true, label: 2 } }, aria: { selected: false }) %> >))
+  end
+
+  def test_tag_attributes_ignores_nil
     assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes nil %>>))
+    assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes nil, {} %>>))
   end
 
   def test_tag_attributes_empty

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -5,6 +5,8 @@ Action View Helpers
 
 After reading this guide, you will know:
 
+* How to render HTML elements
+* How to merge HTML attributes and token lists
 * How to format dates, strings and numbers
 * How to link to images, videos, stylesheets, etc...
 * How to sanitize content
@@ -18,6 +20,62 @@ Overview of Helpers Provided by Action View
 WIP: Not all the helpers are listed here. For a full list see the [API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers.html)
 
 The following is only a brief overview summary of the helpers available in Action View. It's recommended that you review the [API Documentation](https://api.rubyonrails.org/classes/ActionView/Helpers.html), which covers all of the helpers in more detail, but this should serve as a good starting point.
+
+### TagHelper
+
+This module provides methods for generating HTML [elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element), [token lists] (https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList), and [attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).
+
+#### Rendering HTML Elements
+
+Call Action View's `tag` helper method to generate an HTML element based on the name of the method:
+
+```ruby
+tag.div("Content")
+# => <div>Content</div>
+
+tag.h1("Heading", id: "heading-1")
+# => <h1 id="heading-1">Heading</h1>
+
+tag.p(class: "font-sans") { "Content" }
+# => <p class="font-sans">Content</p>
+```
+
+#### Rendering token lists
+
+Call Action View's `class_names` helper to flatten `Array`, `Hash`, and `String` instances into a `String`:
+
+```ruby
+class_names("a", "b c", ["d"])
+# => "a b c d"
+
+class_names("a", "b c", d: false, e: true)
+# => "a b c e"
+```
+
+You can call either [`class_names`](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-class_names) or [`token_list`](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list).
+
+#### Rendering HTML attributes
+
+Call Action View's `tag.attributes` to transform `Hash` instances into HTML-ready attributes:
+
+```erb
+<input <%= tag.attributes({ id: "search" }, { type: :text }, { aria: { label: "Search" } }, aria: { disabled: true }) %> >
+<%# => <input id="search" type="text" aria-label="Search" aria-disabled="true"> %>
+```
+
+Calls to `tag.attributes` accept many `Hash` instances, and merge them left to right, and support nesting keys under `aria:` and `data:`:
+
+```ruby
+tag.attributes({ id: "search" }, { type: :text }, { aria: { label: "Search" } }, data: { value: "123" })
+# => "id=\"search\" type=\"text\" aria-label=\"Search\" data-value=\"123\""
+```
+
+Calls to `tag.attributes` will merge nested values:
+
+```ruby
+tag.attributes({ aria: { label: "Search" } }, aria: { disabled: true })
+# => "aria-label=\"Search\" aria-disabled=\"true\""
+```
 
 ### AssetTagHelper
 


### PR DESCRIPTION
### Motivation / Background

The `tag.attributes` helper introduced in `7.0` can currently only transform a single `Hash` into an HTML attribute string. If that `Hash` is sourced from multiple pre-defined `Hash` instances, callers are responsible for merging or deep-merging their contents ahead of the call.

### Detail

This commit extends `tag.attributes` to accept a variable number of `Hash` arguments, deep merging them from left to right.

Considering a hypothetical where the following key-value pairings are appropriate, calls prior to this commit would resemble something like:

```erb
<%# elsewhere, or maybe from a view helper %>
<% first  = {aria: {label: 1}} %>
<% second = {aria: {label: 2, disabled: true}} %>
<% third  = {aria: {selected: false}} %>

<%# the call site %>
<%= tag.attributes(first.deep_merge(second).deep_merge(third)) %>
<%# or, if they're feeling clever %>
<%= tag.attributes([first, second, third].reduce(:deep_merge)) %>
```

With this change, the caller isn't responsible for merging:

```erb
<%# elsewhere, or maybe from a view helper %>
<% first  = {aria: {label: 1}} %>
<% second = {aria: {label: 2, disabled: true}} %>
<% third  = {aria: {selected: false}} %>

<%# the call site %>
<%= tag.attributes(first, second, third) %>
```

### Additional notes

We're calling `Hash#deep_merge` here to support `aria: {...}` and `data: {...}` attributes. Without it, subsequent `Hash` instances with `aria:` or `data:` keys would entirely clobber the ones passed before them.

There's still some improvements to be made here, in cases where callers would want to handle merging the _values_ in addition to the _keys_.

Take, for example, the `class:` attribute. Calling `tag.attributes({class: "1"}, {class: "2"}, class: "3"})` would result in `class="3"`. Since the [class](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class) attribute is a [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList), there is an opportunity for Action View to know that ahead of time and resolve a merge conflict with a call to [token_list](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list):

```ruby
tag.attributes({class: "1"}, {class: "2"}, {class: "3"})
# => "class=\"1 2 3\""
```

In addition to `class`, there are other attributes known to be token lists, including [aria-labelledby](https://www.w3.org/TR/wai-aria/#aria-labelledby) (known as an [ID reference list](https://www.w3.org/TR/wai-aria/#valuetype_idref_list)). Action View could provide out-of-the-box token list support, and could also provide hooks to extend that to include other known token lists like [data-controller](https://stimulus.hotwired.dev/reference/controllers#multiple-controllers) and [data-action](https://stimulus.hotwired.dev/reference/actions#multiple-actions).

~I'm happy to explore this in a subsequent set of work if this style of `tag.attributes` invocation is accepted.~

I've opened https://github.com/rails/rails/pull/47163 to add this behavior.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
