### PR TITLE
Add support for `RETURNING` to `INSERT`/`UPDATE`/`DELETE` statements

### DIFF
--- a/activerecord/lib/arel/delete_manager.rb
+++ b/activerecord/lib/arel/delete_manager.rb
@@ -35,5 +35,10 @@ module Arel # :nodoc: all
       @ast.comment = value
       self
     end
+
+    def returning(returning)
+      @ast.returning << returning
+      self
+    end
   end
 end

--- a/activerecord/lib/arel/insert_manager.rb
+++ b/activerecord/lib/arel/insert_manager.rb
@@ -39,6 +39,11 @@ module Arel # :nodoc: all
       self
     end
 
+    def returning(returning)
+      @ast.returning << returning
+      self
+    end
+
     def create_values(values)
       Nodes::ValuesList.new([values])
     end

--- a/activerecord/lib/arel/nodes/delete_statement.rb
+++ b/activerecord/lib/arel/nodes/delete_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class DeleteStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :comment, :key
+      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :comment, :key, :returning
 
       def initialize(relation = nil, wheres = [])
         super()
@@ -16,16 +16,18 @@ module Arel # :nodoc: all
         @offset = nil
         @comment = nil
         @key = nil
+        @returning = []
       end
 
       def initialize_copy(other)
         super
         @relation = @relation.clone if @relation
         @wheres = @wheres.clone if @wheres
+        @returning = @returning.clone if @returning
       end
 
       def hash
-        [self.class, @relation, @wheres, @orders, @limit, @offset, @comment, @key].hash
+        [self.class, @relation, @wheres, @orders, @limit, @offset, @comment, @key, @returning].hash
       end
 
       def eql?(other)
@@ -38,7 +40,8 @@ module Arel # :nodoc: all
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.comment == other.comment &&
-          self.key == other.key
+          self.key == other.key &&
+          self.returning == other.returning
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/nodes/insert_statement.rb
+++ b/activerecord/lib/arel/nodes/insert_statement.rb
@@ -3,14 +3,15 @@
 module Arel # :nodoc: all
   module Nodes
     class InsertStatement < Arel::Nodes::Node
-      attr_accessor :relation, :columns, :values, :select
+      attr_accessor :relation, :columns, :values, :select, :returning
 
       def initialize(relation = nil)
         super()
-        @relation = relation
-        @columns  = []
-        @values   = nil
-        @select   = nil
+        @relation  = relation
+        @columns   = []
+        @values    = nil
+        @select    = nil
+        @returning = []
       end
 
       def initialize_copy(other)
@@ -18,10 +19,11 @@ module Arel # :nodoc: all
         @columns = @columns.clone
         @values =  @values.clone if @values
         @select =  @select.clone if @select
+        @returning = @returning.clone if @returning
       end
 
       def hash
-        [@relation, @columns, @values, @select].hash
+        [@relation, @columns, @values, @select, @returning].hash
       end
 
       def eql?(other)
@@ -29,7 +31,8 @@ module Arel # :nodoc: all
           self.relation == other.relation &&
           self.columns == other.columns &&
           self.select == other.select &&
-          self.values == other.values
+          self.values == other.values &&
+          self.returning == other.returning
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,30 +3,32 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :comment, :key
+      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :comment, :key, :returning
 
       def initialize(relation = nil)
         super()
-        @relation = relation
-        @wheres   = []
-        @values   = []
-        @groups   = []
-        @havings  = []
-        @orders   = []
-        @limit    = nil
-        @offset   = nil
-        @comment  = nil
-        @key      = nil
+        @relation  = relation
+        @wheres    = []
+        @values    = []
+        @groups    = []
+        @havings   = []
+        @orders    = []
+        @limit     = nil
+        @offset    = nil
+        @comment   = nil
+        @key       = nil
+        @returning = []
       end
 
       def initialize_copy(other)
         super
         @wheres = @wheres.clone
         @values = @values.clone
+        @returning = @returning.clone if @returning
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @comment, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @offset, @comment, @key, @returning].hash
       end
 
       def eql?(other)
@@ -40,7 +42,8 @@ module Arel # :nodoc: all
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.comment == other.comment &&
-          self.key == other.key
+          self.key == other.key &&
+          self.returning == other.returning
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -52,5 +52,10 @@ module Arel # :nodoc: all
       @ast.comment = value
       self
     end
+
+    def returning(returning)
+      @ast.returning << returning
+      self
+    end
   end
 end

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -120,6 +120,7 @@ module Arel # :nodoc: all
           visit_edge o, "columns"
           visit_edge o, "values"
           visit_edge o, "select"
+          visit_edge o, "returning"
         end
 
         def visit_Arel_Nodes_SelectCore(o)
@@ -152,6 +153,7 @@ module Arel # :nodoc: all
           visit_edge o, "offset"
           visit_edge o, "comment"
           visit_edge o, "key"
+          visit_edge o, "returning"
         end
 
         def visit_Arel_Nodes_DeleteStatement(o)
@@ -162,6 +164,7 @@ module Arel # :nodoc: all
           visit_edge o, "offset"
           visit_edge o, "comment"
           visit_edge o, "key"
+          visit_edge o, "returning"
         end
 
         def visit_Arel_Table(o)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -36,6 +36,13 @@ module Arel # :nodoc: all
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
           maybe_visit o.comment, collector
+
+          if o.returning.empty?
+            collector
+          else
+            collector << " RETURNING "
+            visit o.returning, collector
+          end
         end
 
         def visit_Arel_Nodes_UpdateStatement(o, collector)
@@ -50,6 +57,13 @@ module Arel # :nodoc: all
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
           maybe_visit o.comment, collector
+
+          if o.returning.empty?
+            collector
+          else
+            collector << " RETURNING "
+            visit o.returning, collector
+          end
         end
 
         def visit_Arel_Nodes_InsertStatement(o, collector)
@@ -70,8 +84,13 @@ module Arel # :nodoc: all
             maybe_visit o.values, collector
           elsif o.select
             maybe_visit o.select, collector
-          else
+          end
+
+          if o.returning.empty?
             collector
+          else
+            collector << " RETURNING "
+            visit o.returning, collector
           end
         end
 

--- a/activerecord/test/cases/arel/delete_manager_test.rb
+++ b/activerecord/test/cases/arel/delete_manager_test.rb
@@ -44,6 +44,35 @@ module Arel
       assert_equal dm, dm.where(table[:id].eq(10))
     end
 
+    test "#returning accepts a returning clause" do
+      users   = Table.new :users
+      manager = Arel::DeleteManager.new
+      manager.from users
+      manager.returning Arel.star
+
+      assert_like %{
+        DELETE FROM "users" RETURNING *
+      }, manager.to_sql
+    end
+
+    test "#returning accepts multiple values as returning clause" do
+      users   = Table.new :users
+      manager = Arel::DeleteManager.new
+      manager.from users
+      manager.returning Arel.star
+      manager.returning [users[:id], users[:name]]
+
+      assert_like %{
+        DELETE FROM "users" RETURNING *, "users"."id", "users"."name"
+      }, manager.to_sql
+    end
+
+    test "#returning chains" do
+      manager = Arel::UpdateManager.new
+
+      assert_equal manager, manager.returning(Arel.star)
+    end
+
     private
       def build_manager(table = nil)
         Arel::DeleteManager.new(table)

--- a/activerecord/test/cases/arel/insert_manager_test.rb
+++ b/activerecord/test/cases/arel/insert_manager_test.rb
@@ -233,6 +233,34 @@ module Arel
       }, manager.to_sql
     end
 
+    test "#returning accepts a returning clause" do
+      users   = Table.new :users
+      manager = Arel::InsertManager.new
+      manager.into users
+      manager.returning Arel.star
+
+      assert_like %{
+        INSERT INTO "users" RETURNING *
+      }, manager.to_sql
+    end
+
+    test "#returning accepts multiple values as returning clause" do
+      users   = Table.new :users
+      manager = Arel::InsertManager.new
+      manager.into users
+      manager.returning Arel.star
+      manager.returning [users[:id], users[:name]]
+
+      assert_like %{
+        INSERT INTO "users" RETURNING *, "users"."id", "users"."name"
+      }, manager.to_sql
+    end
+
+    test "#returning chains" do
+      manager = Arel::InsertManager.new
+      assert_equal manager, manager.returning(Arel.star)
+    end
+
     private
       def build_manager(table = nil)
         Arel::InsertManager.new(table)

--- a/activerecord/test/cases/arel/nodes/delete_statement_test.rb
+++ b/activerecord/test/cases/arel/nodes/delete_statement_test.rb
@@ -3,20 +3,25 @@
 require_relative "../helper"
 
 class Arel::Nodes::DeleteStatementTest < Arel::Test
-  test "#clone clones wheres" do
+  test "#clone clones wheres and returning" do
     statement = Arel::Nodes::DeleteStatement.new
-    statement.wheres = %w[a b c]
+    statement.wheres    = %w[a b c]
+    statement.returning = %w[1 2 3]
 
     dolly = statement.clone
     assert_equal statement.wheres, dolly.wheres
     assert_not_same statement.wheres, dolly.wheres
+    assert_equal statement.returning, dolly.returning
+    assert_not_same statement.returning, dolly.returning
   end
 
   test "equality is equal with equal ivars" do
     statement1 = Arel::Nodes::DeleteStatement.new
     statement1.wheres = %w[a b c]
+    statement1.returning = %w[1 2 3]
     statement2 = Arel::Nodes::DeleteStatement.new
     statement2.wheres = %w[a b c]
+    statement2.returning = %w[1 2 3]
     array = [statement1, statement2]
     assert_equal 1, array.uniq.size
   end
@@ -24,8 +29,10 @@ class Arel::Nodes::DeleteStatementTest < Arel::Test
   test "equality is not equal with different ivars" do
     statement1 = Arel::Nodes::DeleteStatement.new
     statement1.wheres = %w[a b c]
+    statement1.returning = %w[1 2 3]
     statement2 = Arel::Nodes::DeleteStatement.new
     statement2.wheres = %w[1 2 3]
+    statement2.returning = %w[a b c]
     array = [statement1, statement2]
     assert_equal 2, array.uniq.size
   end

--- a/activerecord/test/cases/arel/nodes/insert_statement_test.rb
+++ b/activerecord/test/cases/arel/nodes/insert_statement_test.rb
@@ -5,35 +5,42 @@ require_relative "../helper"
 class Arel::Nodes::InsertStatementTest < Arel::Test
   test "#clone clones columns and values" do
     statement = Arel::Nodes::InsertStatement.new
-    statement.columns = %w[a b c]
-    statement.values  = %w[x y z]
+    statement.columns    = %w[a b c]
+    statement.values     = %w[x y z]
+    statement.returning  = %w[1 2 3]
 
     dolly = statement.clone
     assert_equal statement.columns, dolly.columns
     assert_equal statement.values, dolly.values
+    assert_equal statement.returning, dolly.returning
 
     assert_not_same statement.columns, dolly.columns
     assert_not_same statement.values, dolly.values
+    assert_not_same statement.returning, dolly.returning
   end
 
   test "equality is equal with equal ivars" do
     statement1 = Arel::Nodes::InsertStatement.new
-    statement1.columns = %w[a b c]
-    statement1.values  = %w[x y z]
+    statement1.columns    = %w[a b c]
+    statement1.values     = %w[x y z]
+    statement1.returning  = %w[1 2 3]
     statement2 = Arel::Nodes::InsertStatement.new
-    statement2.columns = %w[a b c]
-    statement2.values  = %w[x y z]
+    statement2.columns    = %w[a b c]
+    statement2.values     = %w[x y z]
+    statement2.returning  = %w[1 2 3]
     array = [statement1, statement2]
     assert_equal 1, array.uniq.size
   end
 
   test "equality is not equal with different ivars" do
     statement1 = Arel::Nodes::InsertStatement.new
-    statement1.columns = %w[a b c]
-    statement1.values  = %w[x y z]
+    statement1.columns    = %w[a b c]
+    statement1.values     = %w[x y z]
+    statement1.returning  = %w[1 2 3]
     statement2 = Arel::Nodes::InsertStatement.new
-    statement2.columns = %w[a b c]
-    statement2.values  = %w[1 2 3]
+    statement2.columns    = %w[a b c]
+    statement2.values     = %w[1 2 3]
+    statement2.returning  = %w[1 2 3]
     array = [statement1, statement2]
     assert_equal 2, array.uniq.size
   end

--- a/activerecord/test/cases/arel/nodes/update_statement_test.rb
+++ b/activerecord/test/cases/arel/nodes/update_statement_test.rb
@@ -3,10 +3,11 @@
 require_relative "../helper"
 
 class Arel::Nodes::UpdateStatementTest < Arel::Test
-  test "#clone clones wheres and values" do
+  test "#clone clones wheres, values, and returning" do
     statement = Arel::Nodes::UpdateStatement.new
-    statement.wheres = %w[a b c]
-    statement.values = %w[x y z]
+    statement.wheres    = %w[a b c]
+    statement.values    = %w[x y z]
+    statement.returning = %w[1 2 3]
 
     dolly = statement.clone
     assert_equal statement.wheres, dolly.wheres
@@ -14,46 +15,54 @@ class Arel::Nodes::UpdateStatementTest < Arel::Test
 
     assert_equal statement.values, dolly.values
     assert_not_same statement.values, dolly.values
+
+    assert_equal statement.returning, dolly.returning
+    assert_not_same statement.returning, dolly.returning
   end
 
   test "equality is equal with equal ivars" do
     statement1 = Arel::Nodes::UpdateStatement.new
-    statement1.relation = "zomg"
-    statement1.wheres   = 2
-    statement1.values   = false
-    statement1.orders   = %w[x y z]
-    statement1.limit    = 42
-    statement1.key      = "zomg"
-    statement1.groups   = ["foo"]
-    statement1.havings  = []
+    statement1.relation  = "zomg"
+    statement1.wheres    = 2
+    statement1.values    = false
+    statement1.orders    = %w[x y z]
+    statement1.limit     = 42
+    statement1.key       = "zomg"
+    statement1.groups    = ["foo"]
+    statement1.havings   = []
+    statement1.returning = %w[1 2 3]
     statement2 = Arel::Nodes::UpdateStatement.new
-    statement2.relation = "zomg"
-    statement2.wheres   = 2
-    statement2.values   = false
-    statement2.orders   = %w[x y z]
-    statement2.limit    = 42
-    statement2.key      = "zomg"
-    statement2.groups   = ["foo"]
-    statement2.havings  = []
+    statement2.relation  = "zomg"
+    statement2.wheres    = 2
+    statement2.values    = false
+    statement2.orders    = %w[x y z]
+    statement2.limit     = 42
+    statement2.key       = "zomg"
+    statement2.groups    = ["foo"]
+    statement2.havings   = []
+    statement2.returning = %w[1 2 3]
+
     array = [statement1, statement2]
     assert_equal 1, array.uniq.size
   end
 
   test "equality is not equal with different ivars" do
     statement1 = Arel::Nodes::UpdateStatement.new
-    statement1.relation = "zomg"
-    statement1.wheres   = 2
-    statement1.values   = false
-    statement1.orders   = %w[x y z]
-    statement1.limit    = 42
-    statement1.key      = "zomg"
+    statement1.relation  = "zomg"
+    statement1.wheres    = 2
+    statement1.values    = false
+    statement1.orders    = %w[x y z]
+    statement1.limit     = 42
+    statement1.key       = "zomg"
+    statement1.returning = %w[1 2 3]
     statement2 = Arel::Nodes::UpdateStatement.new
-    statement2.relation = "zomg"
-    statement2.wheres   = 2
-    statement2.values   = false
-    statement2.orders   = %w[x y z]
-    statement2.limit    = 42
-    statement2.key      = "wth"
+    statement2.relation  = "zomg"
+    statement2.wheres    = 2
+    statement2.values    = false
+    statement2.orders    = %w[x y z]
+    statement2.limit     = 42
+    statement2.key       = "wth"
+    statement2.returning = %w[1 2 3]
     array = [statement1, statement2]
     assert_equal 2, array.uniq.size
   end

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -159,6 +159,34 @@ module Arel
       assert_equal table[:foo], um.key
     end
 
+    test "#returning accepts a returning clause" do
+      users   = Table.new :users
+      manager = Arel::UpdateManager.new
+      manager.table users
+      manager.returning Arel.star
+
+      assert_like %{
+          UPDATE "users" RETURNING *
+        }, manager.to_sql
+    end
+
+    test "#returning accepts multiple values as returning clause" do
+      users   = Table.new :users
+      manager = Arel::UpdateManager.new
+      manager.table users
+      manager.returning Arel.star
+      manager.returning [users[:id], users[:name]]
+
+      assert_like %{
+          UPDATE "users" RETURNING *, "users"."id", "users"."name"
+        }, manager.to_sql
+    end
+
+    test "#returning chains" do
+      manager = Arel::UpdateManager.new
+      assert_equal manager, manager.returning(Arel.star)
+    end
+
     private
       def build_manager(table = nil)
         Arel::UpdateManager.new(table)

--- a/activerecord/test/cases/arel/visitors/dot_test.rb
+++ b/activerecord/test/cases/arel/visitors/dot_test.rb
@@ -229,6 +229,7 @@ module Arel
         assert_edge("columns", dot)
         assert_edge("values", dot)
         assert_edge("select", dot)
+        assert_edge("returning", dot)
       end
 
       def test_Arel_Nodes_UpdateStatement
@@ -244,6 +245,7 @@ module Arel
         assert_edge("limit", dot)
         assert_edge("offset", dot)
         assert_edge("key", dot)
+        assert_edge("returning", dot)
       end
 
       def test_Arel_Nodes_DeleteStatement
@@ -258,6 +260,7 @@ module Arel
         assert_edge("limit", dot)
         assert_edge("offset", dot)
         assert_edge("key", dot)
+        assert_edge("returning", dot)
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

This pull request adds support for `RETURNING` clauses to `INSERT`/`UPDATE`/`DELETE` statements in Arel. This is useful to build queries that modify data and return it (or something else) in the same query. 

The following example builds a query that deletes all data from a counter queue table and returns the aggregated counter delta values. 

```ruby 
counter_queue = Arel::Table.new(:counter_queue)
flush = Arel::Table.new(:flush)

delete_manager = Arel::DeleteManager.new 
  .from(counter_queue)
  .returning([counter_queue[:post_id], counter_queue[:delta]])

select_manager = Arel::SelectManager.new 
  .with(Arel::Nodes::TableAlias.new(Arel::Nodes::Grouping.new(delete_manager.ast), flush.name))
  .from(flush)
  .project(flush[:post_id], flush[:delta].sum) 
  .group(flush[:post_id])
```

```sql 
WITH "flush" AS (
  DELETE FROM
    "counter_queue" 
  RETURNING 
    "counter_queue"."post_id",
    "counter_queue"."delta"
)
SELECT
  "flush"."post_id",
  SUM("flush"."delta")
FROM
  "flush"
GROUP BY
  "flush"."post_id"
```


### Detail

To add support for `RETURNING`, this pull request adds a returning method to the sStatement and manager classes for insert, upsert, and delete. It also modifies the ToSql and Dot visitors to incorporate the returning statement (should there be one) into their output. 

### Additional information

The `RETURNING` syntax is supported in both PostgreSQL ([INSERT](https://www.postgresql.org/docs/current/sql-insert.html), [UPDATE](https://www.postgresql.org/docs/current/sql-update.html), [DELETE](https://www.postgresql.org/docs/current/sql-delete.html)) and Sqlite3 ([INSERT](https://www.sqlite.org/lang_insert.html), [UPDATE](https://www.sqlite.org/lang_update.html), [DELETE](https://www.sqlite.org/lang_delete.html)). MySQL does not support `RETURNING` on any of these statements at the moment. 

This pull request does not add `RETURNING` support to ActiveRecord itself (as discussed in #39968 and #42955). Nonetheless, I think this change to just Arel is useful in its own right to build more complex queries when needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
