### PR TITLE
Document exceptions app error handling

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -201,10 +201,10 @@ module Mime
       end
 
       # For an input of <tt>'text'</tt>, returns <tt>[Mime[:json], Mime[:xml], Mime[:ics],
-      # Mime[:html], Mime[:css], Mime[:csv], Mime[:js], Mime[:yaml], Mime[:text]</tt>.
+      # Mime[:html], Mime[:css], Mime[:csv], Mime[:js], Mime[:yaml], Mime[:text]]</tt>.
       #
       # For an input of <tt>'application'</tt>, returns <tt>[Mime[:html], Mime[:js],
-      # Mime[:xml], Mime[:yaml], Mime[:atom], Mime[:json], Mime[:rss], Mime[:url_encoded_form]</tt>.
+      # Mime[:xml], Mime[:yaml], Mime[:atom], Mime[:json], Mime[:rss], Mime[:url_encoded_form]]</tt>.
       def parse_data_with_trailing_star(type)
         Mime::SET.select { |m| m.match?(type) }
       end

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1239,6 +1239,14 @@ Existing applications can opt in to this new behavior by setting [`config.active
 
 [`config.active_storage.replace_on_assign_to_many`]: configuring.html#config-active-storage-replace-on-assign-to-many
 
+### Custom exception handling applications
+
+Invalid `Accept` or `Content-Type` request headers will now raise an exception.
+The default [`config.exceptions_app`][] specifically handles that error and compensates for it.
+Custom exceptions applications will need to handle that error as well, or such requests will cause Rails to use the fallback exceptions application, which returns a `500 Internal Server Error`.
+
+[`config.exceptions_app`]: configuring.html#config-exceptions-app
+
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request documents a change to Rails' exception handling application (`config.exceptions_app`). The change in behavior was first introduced in 6.0, changed slightly in 6.1, and persists today in 7.1/main.

### Details

Full details, including previous discussion and context, can be found in [#35766](https://github.com/rails/rails/pull/35766#issuecomment-1406591854).

[skip ci]