### PR TITLE
Fix typo in `assume_ssl` configuration guide

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -3,7 +3,7 @@
     *Joel Hawksley*, *Kate Higa*
 
 *   Add `ActionDispatch::AssumeSSL` middleware that can be turned on via `config.assume_ssl`.
-    It makes the application believe that all requests are arring over SSL. This is useful
+    It makes the application believe that all requests are arriving over SSL. This is useful
     when proxying through a load balancer that terminates SSL, the forwarded request will appear
     as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
     security target HTTP instead of HTTPS. This middleware makes the server assume that the

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -196,7 +196,7 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets, or w
 
 #### `config.assume_ssl`
 
-Makes application believe that all requests are arring over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though its HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
+Makes application believe that all requests are arriving over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though its HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
 
 #### `config.autoflush_log`
 


### PR DESCRIPTION
Just a quick typo fix in the Action Pack changelog and related guide. Looks like "arring" should be "arriving".