### PR TITLE
Revert "Add nodoc to `Mail` module [ci-skip]"

### DIFF
--- a/actionmailbox/lib/action_mailbox/mail_ext/address_equality.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/address_equality.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Mail # :nodoc: all
-  class Address # :nodoc: all
+module Mail
+  class Address
     def ==(other_address)
       other_address.is_a?(Mail::Address) && to_s == other_address.to_s
     end

--- a/actionmailbox/lib/action_mailbox/mail_ext/address_wrapping.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/address_wrapping.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Mail # :nodoc: all
+module Mail
   class Address
     def self.wrap(address)
       address.is_a?(Mail::Address) ? address : Mail::Address.new(address)

--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Mail # :nodoc: all
-  class Message # :nodoc: all
+module Mail
+  class Message
     def from_address
       address_list(header[:from])&.addresses&.first
     end

--- a/actionmailbox/lib/action_mailbox/mail_ext/from_source.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/from_source.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Mail # :nodoc: all
+module Mail
   def self.from_source(source)
     Mail.new Mail::Utilities.binary_unsafe_to_crlf(source.to_s)
   end

--- a/actionmailbox/lib/action_mailbox/mail_ext/recipients.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/recipients.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Mail # :nodoc: all
+module Mail
   class Message
     def recipients
       Array(to) + Array(cc) + Array(bcc) + Array(header[:x_original_to]).map(&:to_s) +


### PR DESCRIPTION
Reverts rails/rails#46723. That PR says, ”The extension for `mail` gem seems private.” That is not correct. These extensions are intended for use in applications, and applications do use them. Where they are lacking documentation, documentation can be added.

The presence of these methods in documentation for the current stable version of Rails makes them public API. Removing them properly would require a deprecation cycle, but there is no reason to remove them.