### PR TITLE
Revert "Prefer README.md over railties/RDOC_MAIN"

### DIFF
--- a/railties/RDOC_MAIN.rdoc
+++ b/railties/RDOC_MAIN.rdoc
@@ -1,0 +1,97 @@
+= Welcome to \Rails
+
+== What's \Rails
+
+\Rails is a web-application framework that includes everything needed to
+create database-backed web applications according to the
+{Model-View-Controller (MVC)}[https://en.wikipedia.org/wiki/Model-view-controller]
+pattern.
+
+Understanding the MVC pattern is key to understanding \Rails. MVC divides your
+application into three layers: Model, View, and Controller, each with a specific responsibility.
+
+== Model layer
+
+The <em><b>Model layer</b></em> represents the domain model (such as Account, Product,
+Person, Post, etc.) and encapsulates the business logic specific to
+your application. In \Rails, database-backed model classes are derived from
+<tt>ActiveRecord::Base</tt>. {Active Record}[link:/files/activerecord/README_rdoc.html] allows you to present the data from
+database rows as objects and embellish these data objects with business logic
+methods. Although most \Rails models are backed by a database, models can also be ordinary
+Ruby classes, or Ruby classes that implement a set of interfaces as provided by
+the {Active Model}[link:/files/activemodel/README_rdoc.html] module.
+
+== Controller layer
+
+The <em><b>Controller layer</b></em> is responsible for handling incoming HTTP requests and
+providing a suitable response. Usually, this means returning \HTML, but \Rails controllers
+can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
+manipulate models and render view templates in order to generate the appropriate HTTP response.
+In \Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
+controller classes are derived from <tt>ActionController::Base</tt>. Action Dispatch and Action Controller
+are bundled together in {Action Pack}[link:/files/actionpack/README_rdoc.html].
+
+== View layer
+
+The <em><b>View layer</b></em> is composed of "templates" that are responsible for providing
+appropriate representations of your application's resources. Templates can
+come in a variety of formats, but most view templates are \HTML with embedded
+Ruby code (ERB files). Views are typically rendered to generate a controller response,
+or to generate the body of an email. In \Rails, View generation is handled by {Action View}[link:/files/actionview/README_rdoc.html].
+
+== Frameworks and libraries
+
+{Active Record}[link:/files/activerecord/README_rdoc.html], {Active Model}[link:/files/activemodel/README_rdoc.html],
+{Action Pack}[link:/files/actionpack/README_rdoc.html], and {Action View}[link:/files/actionview/README_rdoc.html] can each be used independently outside \Rails.
+In addition to that, \Rails also comes with {Action Mailer}[link:/files/actionmailer/README_rdoc.html], a library
+to generate and send emails; {Action Mailbox}[link:/files/actionmailbox/README_md.html], a library to receive emails within a Rails application;
+{Active Job}[link:/files/activejob/README_md.html], a framework for declaring jobs and making them run on a variety of queueing
+backends; {Action Cable}[link:/files/actioncable/README_md.html], a framework to
+integrate WebSockets with a \Rails application; {Active Storage}[link:/files/activestorage/README_md.html],
+a library to attach cloud and local files to \Rails applications; {Action Text}[link:/files/actiontext/README_md.html], a library to handle rich text content;
+and {Active Support}[link:/files/activesupport/README_rdoc.html], a collection
+of utility classes and standard library extensions that are useful for \Rails,
+and may also be used independently outside \Rails.
+
+== Getting Started
+
+1. Install \Rails at the command prompt if you haven't yet:
+
+    $ gem install rails
+
+2. At the command prompt, create a new \Rails application:
+
+    $ rails new myapp
+
+   where "myapp" is the application name.
+
+3. Change directory to +myapp+ and start the web server:
+
+    $ cd myapp
+    $ bin/rails server
+
+   Run with <tt>--help</tt> or <tt>-h</tt> for options.
+
+4. Go to <tt>http://localhost:3000</tt>, and you'll see: "Yay! You’re on \Rails!"
+
+5. Follow the guidelines to start developing your application. You may find the following resources handy:
+
+   * The \README file created within your application.
+   * {Getting Started with \Rails}[https://guides.rubyonrails.org/getting_started.html].
+   * {Ruby on \Rails Guides}[https://guides.rubyonrails.org].
+   * {The API Documentation}[link:/files/railties/RDOC_MAIN_rdoc.html].
+
+== Contributing
+
+We encourage you to contribute to Ruby on \Rails! Please check out the
+{Contributing to Ruby on \Rails guide}[https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html] for guidelines about how to proceed. {Join us!}[http://contributors.rubyonrails.org]
+
+Trying to report a possible security vulnerability in \Rails? Please
+check out our {security policy}[https://rubyonrails.org/security] for
+guidelines about how to proceed.
+
+Everyone interacting in \Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the \Rails {code of conduct}[http://rubyonrails.org/conduct].
+
+== License
+
+Ruby on \Rails is released under the {MIT License}[https://opensource.org/licenses/MIT].

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -170,7 +170,7 @@ module Rails
       end
 
       def api_main
-        "README.md"
+        component_root_dir("railties") + "/RDOC_MAIN.rdoc"
       end
     end
 

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.email    = "david@loudthinking.com"
   s.homepage = "https://rubyonrails.org"
 
-  s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "exe/**/*", "lib/**/{*,.[a-z]*}"]
+  s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "RDOC_MAIN.rdoc", "exe/**/*", "lib/**/{*,.[a-z]*}"]
   s.require_path = "lib"
 
   s.bindir      = "exe"


### PR DESCRIPTION
Reverts rails/rails#47176

Ok, now I remember the other reason we have two files.

Links to the gems READMEs like will be different.

* GitHub: `[Active Record](activerecord/README.rdoc)` creates a relative link to the readme for AR
* api.: `{Active Record}[link:/files/activerecord/README_rdoc.html]` creates a relative link to the _file_ from RDoc

I can't think of a way to fix this now, so reverting.