### PR TITLE
Arel::Nodes::ValuesList supports InfixOperation, NamedFunction and Quoted

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -103,7 +103,7 @@ module Arel # :nodoc: all
             row.each_with_index do |value, k|
               collector << ", " unless k == 0
               case value
-              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute, Nodes::Quoted, Nodes::InfixOperation
+              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute, Nodes::Quoted, Nodes::InfixOperation, Nodes::NamedFunction
                 collector = visit(value, collector)
               else
                 collector << quote(value).to_s

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -103,7 +103,7 @@ module Arel # :nodoc: all
             row.each_with_index do |value, k|
               collector << ", " unless k == 0
               case value
-              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute
+              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute, Nodes::Quoted, Nodes::InfixOperation
                 collector = visit(value, collector)
               else
                 collector << quote(value).to_s

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -749,7 +749,7 @@ module Arel
           quoted = Arel::Nodes.build_quoted("foo")
           node = Arel::Nodes::ValuesList.new([[quoted]])
 
-          _(compile(node)).must_be like %{
+          _(compile(node)).must_be_like %{
             VALUES ('foo')
           }
         end
@@ -761,7 +761,7 @@ module Arel
           infix_operation = Arel::Nodes::InfixOperation.new("::", quoted, type)
           node = Arel::Nodes::ValuesList.new([[infix_operation]])
 
-          _(compile(node)).must_be like %{
+          _(compile(node)).must_be_like %{
             VALUES ('foo' :: character varying)
           }
         end
@@ -772,7 +772,7 @@ module Arel
           named_function = Arel::Nodes::NamedFunction.new("CAST", [quoted.as("text")])
           node = Arel::Nodes::ValuesList.new([[named_function]])
 
-          _(compile(node)).must_be like %{
+          _(compile(node)).must_be_like %{
             VALUES (CAST('foo' AS text))
           }
         end

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -744,6 +744,29 @@ module Arel
         end
       end
 
+      describe 'Nodes::ValuesList' do
+        it 'works with Quoted' do
+          quoted = Arel::Nodes.build_quoted("foo")
+          node = Arel::Nodes::ValuesList.new([[quoted]])
+
+          _(compile(node)).must_be like %{
+            VALUES ('foo')
+          }
+        end
+
+        it 'works with InfixOperation' do
+          quoted = Arel::Nodes.build_quoted("foo")
+          type = Arel::Nodes::SqlLiteral.new('character varying')
+
+          infix_operation = Arel::Nodes::InfixOperation.new('::', quoted, type)
+          node = Arel::Nodes::ValuesList.new([[infix_operation]])
+
+          _(compile(node)).must_be like %{
+            VALUES ('foo' :: character varying)
+          }
+        end
+      end
+
       describe "Nodes::With" do
         it "handles table aliases" do
           manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr2"))

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -770,7 +770,7 @@ module Arel
           quoted = Arel::Nodes.build_quoted("foo")
 
           named_function = Arel::Nodes::NamedFunction.new("CAST", [quoted.as("text")])
-          node = Arel::Nodes::ValuesList.new([[infix_operation]])
+          node = Arel::Nodes::ValuesList.new([[named_function]])
 
           _(compile(node)).must_be like %{
             VALUES (CAST('foo' AS text))

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -765,6 +765,17 @@ module Arel
             VALUES ('foo' :: character varying)
           }
         end
+
+        it 'works with InfixOperation' do
+          quoted = Arel::Nodes.build_quoted("foo")
+
+          named_function = Arel::Nodes::NamedFunction.new('CAST', [quoted.as('text')])
+          node = Arel::Nodes::ValuesList.new([[infix_operation]])
+
+          _(compile(node)).must_be like %{
+            VALUES (CAST('foo' AS text))
+          }
+        end
       end
 
       describe "Nodes::With" do

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -744,8 +744,8 @@ module Arel
         end
       end
 
-      describe 'Nodes::ValuesList' do
-        it 'works with Quoted' do
+      describe "Nodes::ValuesList" do
+        it "works with Quoted" do
           quoted = Arel::Nodes.build_quoted("foo")
           node = Arel::Nodes::ValuesList.new([[quoted]])
 
@@ -754,11 +754,11 @@ module Arel
           }
         end
 
-        it 'works with InfixOperation' do
+        it "works with InfixOperation" do
           quoted = Arel::Nodes.build_quoted("foo")
-          type = Arel::Nodes::SqlLiteral.new('character varying')
+          type = Arel::Nodes::SqlLiteral.new("character varying")
 
-          infix_operation = Arel::Nodes::InfixOperation.new('::', quoted, type)
+          infix_operation = Arel::Nodes::InfixOperation.new("::", quoted, type)
           node = Arel::Nodes::ValuesList.new([[infix_operation]])
 
           _(compile(node)).must_be like %{
@@ -766,10 +766,10 @@ module Arel
           }
         end
 
-        it 'works with InfixOperation' do
+        it "works with InfixOperation" do
           quoted = Arel::Nodes.build_quoted("foo")
 
-          named_function = Arel::Nodes::NamedFunction.new('CAST', [quoted.as('text')])
+          named_function = Arel::Nodes::NamedFunction.new("CAST", [quoted.as("text")])
           node = Arel::Nodes::ValuesList.new([[infix_operation]])
 
           _(compile(node)).must_be like %{


### PR DESCRIPTION
<!--
The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes the following "can't quote" errors
```
> Arel::Nodes::ValuesList.new([[Arel::Nodes.build_quoted("hello")]]).to_sql
TypeError: can't quote Arel::Nodes::Quoted

> Arel::Nodes::ValuesList.new([[Arel::Nodes::InfixOperation.new('::', Arel::Nodes.build_quoted("hello"), Arel.sql('timestamp'))]]).to_sql
TypeError: can't quote Arel::Nodes::InfixOperation

> Arel::Nodes::ValuesList.new([[Arel::Nodes::NamedFunction.new('CAST', [Arel::Nodes.build_quoted("hello").as('text')])]]).to_sql
TypeError: can't quote Arel::Nodes::NamedFunction
```

This Pull Request has been created because it's currently impossible to create a `Arel::Nodes::ValuesList` with many different node types.

QUESTION: Thoughts on removing the `case ... when` statement entirely and replacing it by the following? This would open up even more possibilities instead of just scratching my specific itch.
```ruby
collector = visit(value, collector)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
