### PR TITLE
Arel::Nodes::UpdateStatement supports FROM

### DIFF
--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :from, :limit, :offset, :key
 
       def initialize(relation = nil)
         super()
@@ -13,6 +13,7 @@ module Arel # :nodoc: all
         @groups   = []
         @havings  = []
         @orders   = []
+        @from     = nil
         @limit    = nil
         @offset   = nil
         @key      = nil
@@ -25,7 +26,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @wheres, @values, @orders, @from, @limit, @offset, @key].hash
       end
 
       def eql?(other)
@@ -36,6 +37,7 @@ module Arel # :nodoc: all
           self.groups == other.groups &&
           self.havings == other.havings &&
           self.orders == other.orders &&
+          self.from == other.from &&
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.key == other.key

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -42,7 +42,7 @@ module Arel # :nodoc: all
           collector << "UPDATE "
           collector = visit o.relation, collector
           collect_nodes_for o.values, collector, " SET "
-          collect_nodes_for o.from, collector, " FROM "
+          maybe_visit o.from, collector, " FROM "
 
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -42,6 +42,7 @@ module Arel # :nodoc: all
           collector << "UPDATE "
           collector = visit o.relation, collector
           collect_nodes_for o.values, collector, " SET "
+          collect_nodes_for o.from, collector, " FROM "
 
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "

--- a/activerecord/test/cases/arel/nodes/update_statement_test.rb
+++ b/activerecord/test/cases/arel/nodes/update_statement_test.rb
@@ -25,6 +25,7 @@ describe Arel::Nodes::UpdateStatement do
       statement1.wheres   = 2
       statement1.values   = false
       statement1.orders   = %w[x y z]
+      statement1.from     = "bar"
       statement1.limit    = 42
       statement1.key      = "zomg"
       statement1.groups   = ["foo"]
@@ -34,6 +35,7 @@ describe Arel::Nodes::UpdateStatement do
       statement2.wheres   = 2
       statement2.values   = false
       statement2.orders   = %w[x y z]
+      statement2.from     = "bar"
       statement2.limit    = 42
       statement2.key      = "zomg"
       statement2.groups   = ["foo"]
@@ -48,6 +50,7 @@ describe Arel::Nodes::UpdateStatement do
       statement1.wheres   = 2
       statement1.values   = false
       statement1.orders   = %w[x y z]
+      statement1.from     = "bar"
       statement1.limit    = 42
       statement1.key      = "zomg"
       statement2 = Arel::Nodes::UpdateStatement.new
@@ -55,6 +58,7 @@ describe Arel::Nodes::UpdateStatement do
       statement2.wheres   = 2
       statement2.values   = false
       statement2.orders   = %w[x y z]
+      statement1.from     = "baz"
       statement2.limit    = 42
       statement2.key      = "wth"
       array = [statement1, statement2]

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -129,7 +129,7 @@ module Arel
           }
         end
 
-        it "works with an from attribute" do
+        it "works with a from attribute" do
           table = Table.new(:users)
           from = Table.new(:customers)
 


### PR DESCRIPTION
### Motivation / Background

In PostgreSQL, [UPDATE supports the **FROM** keyword](https://www.postgresql.org/docs/current/sql-update.html) but this isn't currently supported in Arel. Similar functionality is supported in MySQL but with different syntax ([ref](https://www.mysqltutorial.org/mysql-update-join/)). This PR adds supports for FROM:

in SQL
```SQL
UPDATE users
SET name = customers.name
FROM customers
WHERE users.id = customer.id
```

with Arel
```ruby
users = Arel::Table.new('users')
customers = Arel::Table.new('customers')

Arel::Nodes::UpdateStatement.new(users).tap do |us|
  us.values = [
    Arel::Nodes::Assignment.new(
      Arel::Nodes::UnqualifiedColumn.new(users[:name]),
      customers[:name],
   ),
  ]
  us.wheres = [users[:id].eq(customers[:id])]
  us.from = [customers]
end.to_sql
=> "UPDATE \"users\" SET \"name\" = \"customers\".\"name\" FROM \"customers\" WHERE \"users\".\"id\" = \"customers\".\"id\""
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
