### PR TITLE
Adds `#as` helper method to create aliases to all Arel managers

### DIFF
--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -45,10 +45,6 @@ module Arel # :nodoc: all
       Arel::Nodes::Exists.new @ast
     end
 
-    def as(other)
-      create_table_alias grouping(@ast), Nodes::SqlLiteral.new(other)
-    end
-
     def lock(locking = Arel.sql("FOR UPDATE"))
       case locking
       when true

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -52,6 +52,12 @@ module Arel # :nodoc: all
       collector.value
     end
 
+    def as(other)
+      other = other.to_s if other.is_a?(Symbol)
+
+      create_table_alias grouping(@ast), Nodes::SqlLiteral.new(other)
+    end
+
     def initialize_copy(other)
       super
       @ast = @ast.clone

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -59,6 +59,12 @@ module Arel
           assert_kind_of Arel::Nodes::SqlLiteral, as.right
         end
 
+        it "converts right to SqlLiteral if a symbol" do
+          manager = Arel::SelectManager.new
+          as = manager.as(:foo)
+          assert_kind_of Arel::Nodes::SqlLiteral, as.right
+        end
+
         it "can make a subselect" do
           manager = Arel::SelectManager.new
           manager.project Arel.star

--- a/activerecord/test/cases/arel/update_manager_test.rb
+++ b/activerecord/test/cases/arel/update_manager_test.rb
@@ -167,5 +167,38 @@ module Arel
         _(@um.key).must_equal @table[:foo]
       end
     end
+
+    describe "as" do
+      it "makes an AS node by grouping the AST" do
+        manager = Arel::UpdateManager.new
+        as = manager.as(Arel.sql("foo"))
+        assert_kind_of Arel::Nodes::Grouping, as.left
+        assert_equal manager.ast, as.left.expr
+        assert_equal "foo", as.right
+      end
+
+      it "converts right to SqlLiteral if a string" do
+        manager = Arel::UpdateManager.new
+        as = manager.as("foo")
+        assert_kind_of Arel::Nodes::SqlLiteral, as.right
+      end
+
+      it "converts right to SqlLiteral if a symbol" do
+        manager = Arel::UpdateManager.new
+        as = manager.as(:foo)
+        assert_kind_of Arel::Nodes::SqlLiteral, as.right
+      end
+
+      it "can make a subselect" do
+        manager = Arel::UpdateManager.new
+        manager.table Arel.sql("zomg")
+        as = manager.as(Arel.sql("foo"))
+
+        manager = Arel::SelectManager.new
+        manager.project Arel.sql("name")
+        manager.from as
+        _(manager.to_sql).must_be_like "SELECT name FROM (UPDATE zomg) foo"
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Creating an alias for a (sub-)query is pretty involved right now. It requires a `Arel::Nodes::TableAlias` that wraps a `Arel::Nodes::Grouping` that wraps the query statement and a `Arel::Nodes::SqlLiteral` for the alias name. 

```ruby 
query = Arel::Table.new(:users).project(:name).ast

Arel::Nodes::TableAlias.new(
  Arel::Nodes::Grouping.new(query),
  Arel::Nodes::SqlLiteral.new("query_alias")
)
```

```sql 
"(SELECT name FROM \"users\") query_alias"
```

Luckily, `Arel::SelectManager` implements a handy `#as` helper method that makes very convenient and easy: 

```ruby 
Arel::Table.new(:users).project(:name).as('query_alias')
```

```sql 
"(SELECT name FROM \"users\") query_alias"
```

Unfortunately, there's no such helper method for `Arel::InsertManager`, `Arel::UpdateManager`, and `Arel::DeleteManager`. So to alias one of those still requires the rather cumbersome code from above. 


### Detail

This pull request moves the `#as` helper method from `Arel::SelectManager` into it's parent `Arel::TreeManager` class. This way it's also available on all other manager classes. In the spirit of #47158, it also allows symbols as aliases. 

```ruby 
users = Arel::Table.new(:users) 

manager = Arel::InsertManager.new
  .insert([[users[:name], 'Testing']])

# Previously 
Arel::Nodes::TableAlias.new(
  Arel::Nodes::Grouping.new(manager.ast),
  Arel::Nodes::SqlLiteral.new("query_alias")
)

# Now
manager.as(:query_alias)
```

```sql 
"(INSERT INTO \"users\" (\"name\") VALUES ('Testing')) query_alias"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
