### PR TITLE
Respect Column default in Type::Serialized

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -127,7 +127,7 @@ module ActiveRecord
             end
 
             cast_type = cast_type.subtype if Type::Serialized === cast_type
-            Type::Serialized.new(cast_type, coder)
+            Type::Serialized.new(cast_type, coder, default: columns_hash[attr_name.to_s]&.default)
           end
         end
 

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -9,9 +9,10 @@ module ActiveRecord
 
       attr_reader :subtype, :coder
 
-      def initialize(subtype, coder)
+      def initialize(subtype, coder, default: nil)
         @subtype = subtype
         @coder = coder
+        @default = default
         super(subtype)
       end
 
@@ -25,7 +26,7 @@ module ActiveRecord
 
       def serialize(value)
         return if value.nil?
-        unless default_value?(value)
+        unless default_value?(value) && @default.nil?
           super coder.dump(value)
         end
       end


### PR DESCRIPTION
### Motivation / Background

Original issue was mentioned in issue #46351
There was a bug with serialize and its defaults.

### Detail

This PR fixes issue with updating a column using serialize if it uses a default and adds additional test which covers the case mentioned in #46351

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
