### PR TITLE
Rm unused load_error core_ext in Action Controller

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -61,7 +61,6 @@ end
 
 # Common Active Support usage in Action Controller
 require "active_support/core_ext/module/attribute_accessors"
-require "active_support/core_ext/load_error"
 require "active_support/core_ext/module/attr_internal"
 require "active_support/core_ext/name_error"
 require "active_support/inflector"


### PR DESCRIPTION
### Motivation / Background

It was moved from action_controller/base/helpers.rb to its current location in 28508d444e36dc8b5819f011f0a2398f44d8d3e3. At that time, there were only two instances of is_missing being used: one in action_controller/base/helpers and one in action_mailer/base/helpers.rb.

The action_mailer usage was moved to abstract_controller/helpers in 684c2dc20801b7fcc941ec9478d33d3bf7c74551, and the action_controller usage moved in 0e063f435ce31a091d1097156172d551bd9d9d37. This last usage was later removed in 5b28a0e972da31da570ed24be505ef7958ab4b5e, leaving the require now unused.

### Detail

Remove unused load_error core_ext in Action Controller

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
