### PR TITLE
Deprecate AbstractController MissingHelperError

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `AbstractController::Helpers::MissingHelperError`
+
+    *Hartley McGuire*
+
 *   Change `ActionDispatch::Testing::TestResponse#parsed_body` to parse HTML as
     a Nokogiri document
 

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/name_error"
 
 module AbstractController
   module Helpers
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
     extend ActiveSupport::Concern
 
     included do
@@ -23,7 +24,7 @@ module AbstractController
       self._helpers = define_helpers_module(self)
     end
 
-    class MissingHelperError < LoadError
+    class DeprecatedMissingHelperError < LoadError
       def initialize(error, path)
         @error = error
         @path  = "helpers/#{path}.rb"
@@ -36,6 +37,9 @@ module AbstractController
         end
       end
     end
+    deprecate_constant "MissingHelperError", "AbstractController::Helpers::DeprecatedMissingHelperError",
+      message: "AbstractController::Helpers::MissingHelperError has been deprecated. If a Helper is not present, a NameError will be raised instead.",
+      deprecator: AbstractController.deprecator
 
     def _helpers
       self.class._helpers

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -264,6 +264,12 @@ class HelperTest < ActiveSupport::TestCase
     assert_equal "smth", AllHelpersController.helpers.config.my_var
   end
 
+  def test_missing_helper_error_is_deprecated
+    assert_deprecated(AbstractController.deprecator) do
+      AbstractController::Helpers::MissingHelperError
+    end
+  end
+
   private
     def expected_helper_methods
       TestHelper.instance_methods

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -52,6 +52,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 ### Deprecations
 
+*   Deprecate `AbstractController::Helpers::MissingHelperError`
+
 *   Deprecate `ActionDispatch::IllegalStateError`.
 
 ### Notable changes


### PR DESCRIPTION
### Motivation / Background

This error used to be a wrapper for a LoadError raised when require_dependency was used to load helpers for controllers.

Since Zeitwerk does not use require_dependency, the only usage of the error was removed in 5b28a0e972da31da570ed24be505ef7958ab4b5e.

### Detail

Deprecate AbstractController::Helpers::MissingHelperError

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
