### PR TITLE
Use AD.deprecator for IllegalStateError

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -36,11 +36,14 @@ module Rack
 end
 
 module ActionDispatch
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
   extend ActiveSupport::Autoload
 
-  class IllegalStateError < StandardError
+  class DeprecatedIllegalStateError < StandardError
   end
-  deprecate_constant :IllegalStateError
+  deprecate_constant "IllegalStateError", "ActionDispatch::DeprecatedIllegalStateError",
+    message: "ActionDispatch::IllegalStateError is deprecated without replacement.",
+    deprecator: ActionDispatch.deprecator
 
   class MissingController < NameError
   end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -10,6 +10,12 @@ class ResponseTest < ActiveSupport::TestCase
     @response.request = ActionDispatch::Request.empty
   end
 
+  def test_illegal_state_error_is_deprecated
+    assert_deprecated(ActionDispatch.deprecator) do
+      ActionDispatch::IllegalStateError
+    end
+  end
+
   def test_can_wait_until_commit
     t = Thread.new {
       @response.await_commit


### PR DESCRIPTION
### Motivation / Background

Previously, ActionDispatch::IllegalStateError was deprecated using Module#deprecate_constant in https://github.com/rails/rails/commit/0b4b4c6b96a41ef649f15e1a3df26e28ef95ff24. This requires the -w flag to be used to actually see the deprecation
warning, and it can not be controlled using ActiveSupport::Deprecator configuration.

### Detail

This commit changes the deprecation to use #deprecate_constant from ActiveSupport::Deprecation::DeprecatedConstantAccessor. This ensures that the deprecation warning will be printed even without -w, and the warning can be controlled by configuring ActionDispatch.deprecator

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
