### PR TITLE
feat: improve `assert_broadcast_on` error message

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Display broadcasted messages on error message when using `assert_broadcast_on`
+
+    *Stéphane Robino*
+
 *   The Action Cable client now supports subprotocols to allow passing arbitrary data
     to the server.
 

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -116,7 +116,17 @@ module ActionCable
 
       message = new_messages.find { |msg| ActiveSupport::JSON.decode(msg) == serialized_msg }
 
-      assert message, "No messages sent with #{data} to #{stream}"
+      error_message = "No messages sent with #{data} to #{stream}"
+
+      if new_messages.any?
+        error_message = new_messages.inject("#{error_message}\nMessage(s) found:\n") do |error_message, new_message|
+          error_message + "#{ActiveSupport::JSON.decode(new_message)}\n"
+        end
+      else
+        error_message = "#{error_message}\nNo message found for #{stream}"
+      end
+
+      assert message, error_message
     end
 
     def pubsub_adapter # :nodoc:

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -112,5 +112,15 @@ class TransmittedDataTest < ActionCable::TestCase
     end
 
     assert_match(/No messages sent/, error.message)
+    assert_match(/Message\(s\) found:\nhello/, error.message)
+  end
+
+  def test_assert_broadcast_on_message_with_empty_channel
+    error = assert_raises Minitest::Assertion do
+      assert_broadcast_on("test", "world")
+    end
+
+    assert_match(/No messages sent/, error.message)
+    assert_match(/No message found for test/, error.message)
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to improve error message when using `assert_broadcast_on`. Indeed it easier to debug if the error message contains messages that have been broadcasted (or information that there is no message at all)
See #47202 

### Detail

This Pull Request changes the `assert_broadcast_on` error message to display messages that have been broadcasted to a given channel

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
