### PR TITLE
Add "Did you mean?" for unrecognized CLI commands

### DIFF
--- a/codespell.txt
+++ b/codespell.txt
@@ -37,6 +37,7 @@ ue
 unqiue
 upto
 varius
+vershen
 vew
 wil
 wth

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -16,24 +16,6 @@ module Rails
       class Error < Thor::Error # :nodoc:
       end
 
-      class CorrectableError < Error # :nodoc:
-        attr_reader :key, :options
-
-        def initialize(message, key, options)
-          @key     = key
-          @options = options
-          super(message)
-        end
-
-        if defined?(DidYouMean::SpellChecker) && defined?(DidYouMean::Correctable)
-          include DidYouMean::Correctable
-
-          def corrections
-            @corrections ||= DidYouMean::SpellChecker.new(dictionary: options).correct(key)
-          end
-        end
-      end
-
       include Actions
 
       class_attribute :bin, instance_accessor: false, default: "bin/rails"

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -271,14 +271,9 @@ module Rails
               Run `#{executable} --help` for more options.
             MSG
           else
-            error = CorrectableError.new("Could not find server '#{server}'.", server, RACK_SERVERS)
-            if error.respond_to?(:detailed_message)
-              formatted_message = error.detailed_message
-            else
-              formatted_message = error.message
-            end
+            error = CorrectableNameError.new("Could not find server '#{server}'.", server, RACK_SERVERS)
             <<~MSG
-              #{formatted_message}
+              #{error.detailed_message}
               Run `#{executable} --help` for more options.
             MSG
           end

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -65,8 +65,10 @@ module Rails
       private
         def run_prepare_task(args)
           if @force_prepare || args.empty?
-            Rails::Command::RakeCommand.perform("test:prepare", nil, {}, optional: true)
+            Rails::Command::RakeCommand.perform("test:prepare", [], {})
           end
+        rescue UnrecognizedCommandError => error
+          raise unless error.name == "test:prepare"
         end
     end
   end

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -261,16 +261,10 @@ module Rails
           run_after_generate_callback if config[:behavior] == :invoke
         else
           options = sorted_groups.flat_map(&:last)
-          error   = Command::Base::CorrectableError.new("Could not find generator '#{namespace}'.", namespace, options)
-
-          if error.respond_to?(:detailed_message)
-            formatted_message = error.detailed_message
-          else
-            formatted_message = error.message
-          end
+          error = Command::CorrectableNameError.new("Could not find generator '#{namespace}'.", namespace, options)
 
           puts <<~MSG
-            #{formatted_message}
+            #{error.detailed_message}
             Run `bin/rails generate --help` for more options.
           MSG
         end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -1235,7 +1235,7 @@ module ApplicationTests
           error = assert_raises do
             rails "db:migrate:animals" ### Task not defined
           end
-          assert_includes error.message, "See the list of available tasks"
+          assert_includes error.message, "Unrecognized command"
 
           rails "db:schema:dump"
           assert_not File.exist?("db/animals_schema.yml")

--- a/railties/test/command/application_test.rb
+++ b/railties/test/command/application_test.rb
@@ -16,4 +16,14 @@ class Rails::Command::ApplicationTest < ActiveSupport::TestCase
     assert output.include?("The `rails new` command creates a new Rails application with a default
     directory structure and configuration at the path you specify.")
   end
+
+  test "prints helpful error on unrecognized command" do
+    output = capture(:stdout) do
+      Rails::Command.invoke("vershen")
+    rescue SystemExit
+    end
+
+    assert_match %(Unrecognized command "vershen"), output
+    assert_match "Did you mean?  version", output
+  end
 end


### PR DESCRIPTION
This commit improves the error message that is displayed when a user specifies an unrecognized `bin/rails` command by offering "Did you mean?" suggestions.  The suggestions cover all visible commands, and supersede any incomplete (Rake-task-only) suggestions that Rake might display.

__Before (example)__

  ```console
  $ bin/rails credentails:edit
  rails aborted!
  Don't know how to build task 'credentails:edit' (See the list of available tasks with `rails --tasks`)

  (See full trace by running task with --trace)

  $ bin/rails --tasks
  ...
  rails cache_digests:dependencies         # Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)
  rails cache_digests:nested_dependencies  # Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)
  rails db:create                          # Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use ...
  rails db:drop                            # Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db...
  ...

  $ bin/rails credentails -h
  # no output

  $ bin/rails credentials -h
  # no output

  $ bin/rails versoin
  rails aborted!
  Don't know how to build task 'versoin' (See the list of available tasks with `rails --tasks`)
  Did you mean?  db:version

  (See full trace by running task with --trace)
  ```

__After (example)__

  ```console
  $ bin/rails credentails:edit
  Unrecognized command "credentails:edit" (Rails::Command::UnrecognizedCommandError)
  Did you mean?  credentials:edit

  $ bin/rails credentails -h
  Unrecognized command "credentails" (Rails::Command::UnrecognizedCommandError)
  Did you mean?  credentials:diff

  $ bin/rails credentials -h
  Unrecognized command "credentials" (Rails::Command::UnrecognizedCommandError)
  Did you mean?  credentials:diff

  $ bin/rails versoin
  Unrecognized command "versoin" (Rails::Command::UnrecognizedCommandError)
  Did you mean?  version
  ```
