### PR TITLE
Show help for bare namespace CLI commands

### DIFF
--- a/railties/test/command/application_test.rb
+++ b/railties/test/command/application_test.rb
@@ -26,4 +26,17 @@ class Rails::Command::ApplicationTest < ActiveSupport::TestCase
     assert_match %(Unrecognized command "vershen"), output
     assert_match "Did you mean?  version", output
   end
+
+  test "prints help via `X:help` command when running `X` and `X:X` command is not defined" do
+    help = capture(:stdout) do
+      Rails::Command.invoke("dev:help")
+    end
+
+    output = capture(:stdout) do
+      Rails::Command.invoke("dev")
+    rescue SystemExit
+    end
+
+    assert_equal help, output
+  end
 end


### PR DESCRIPTION
This commit changes `bin/rails` to run the `X:help` command when the user runs `bin/rails X` and no `X:X` command is defined.

__Before (example)__

  ```console
  $ bin/rails credentials -h
  Unrecognized command "credentials" (Rails::Command::UnrecognizedCommandError)
  Did you mean?  credentials:diff
  ```

__After (example)__

  ```console
  $ bin/rails credentials -h
  Usage:
    bin/rails credentials [options]

  === Storing Encrypted Credentials in Source Control

  The Rails `credentials` commands provide access to encrypted credentials,
  ...
  ```
