### PR TITLE
Remove unused sequel gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ group :job do
   gem "sneakers", require: false
   gem "backburner", require: false
   gem "delayed_job_active_record", require: false
-  gem "sequel", require: false
 end
 
 # Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sequel (5.64.0)
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.0.3)
@@ -583,7 +582,6 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sdoc (>= 2.6.0)
   selenium-webdriver (>= 4.0.0)
-  sequel
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)


### PR DESCRIPTION
### Motivation / Background

It was originally added in 175ba6666453684bba3c24d03b75580a1f8e68bb as the database driver for Que in the Active Job integration tests.

However, the gem is now unused since the Que adapter and its integration tests were removed in cb22eb2b3628de428171175063371155d70a136c

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
