### PR TITLE
ActiveRecord::QueryLogs: handle invalid encoding

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `ActiveRecord::QueryLogs` better handle broken encoding.
+
+    It's not uncommon when building queries with BLOB fields to contain
+    binary data. Unless the call carefully encode the string in ASCII-8BIT
+    it generally end up being encoded in `UTF-8`, and `QueryLogs` would
+    end up failing on it.
+
+    `ActiveRecord::QueryLogs` now longer depend on the query to be properly encoded.
+
+    *Jean Boussier*
+
 *   `ActiveRecord::Relation#explain` now accepts options.
 
     For databases and adapters which support them (currently PostgreSQL

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -80,11 +80,13 @@ module ActiveRecord
 
     class << self
       def call(sql) # :nodoc:
-        if prepend_comment
+        if comment.blank?
+          sql
+        elsif prepend_comment
           "#{self.comment} #{sql}"
         else
           "#{sql} #{self.comment}"
-        end.strip
+        end
       end
 
       def clear_cache # :nodoc:


### PR DESCRIPTION
It can sometimes happen that `sql` is encoded in UTF-8 but contains some invalid binary data of some sort.

When this happens `strip` end up raising an EncodingError.

Overall I think this strip is quite wasteful, so we might as well just skip it.
