### PR TITLE
Fix preview variants in ActiveStorage proxy mode

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -48,9 +48,9 @@ class ActiveStorage::Preview
     self
   end
 
-  # Returns the blob's attached preview image.
+  # Returns the blob's attached preview image with applied variations.
   def image
-    blob.preview_image
+    variant.image
   end
 
   # Returns the URL of the preview's variant on the service. Raises ActiveStorage::Preview::UnprocessedError if the
@@ -89,22 +89,23 @@ class ActiveStorage::Preview
   end
 
   private
+    delegate :preview_image, to: :blob
+
     def processed?
-      image.attached?
+      preview_image.attached?
     end
 
     def process
       previewer.preview(service_name: blob.service_name) do |attachable|
         ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role) do
-          image.attach(attachable)
+          preview_image.attach(attachable)
         end
       end
     end
 
     def variant
-      image.variant(variation).processed
+      preview_image.variant(variation).processed
     end
-
 
     def previewer
       previewer_class.new(blob)

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -13,8 +13,8 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     assert_equal "image/png", preview.image.content_type
 
     image = read_image(preview.image)
-    assert_equal 612, image.width
-    assert_equal 792, image.height
+    assert_equal 216, image.width
+    assert_equal 280, image.height
   end
 
   test "previewing a cropped PDF" do
@@ -39,8 +39,8 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     assert_equal "image/jpeg", preview.image.content_type
 
     image = read_image(preview.image)
-    assert_equal 640, image.width
-    assert_equal 480, image.height
+    assert_equal 373, image.width
+    assert_equal 280, image.height
   end
 
   test "previewing an unpreviewable blob" do

--- a/activestorage/test/models/representation_test.rb
+++ b/activestorage/test/models/representation_test.rb
@@ -18,8 +18,8 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
     representation = blob.representation(resize_to_limit: [640, 280]).processed
 
     image = read_image(representation.image)
-    assert_equal 612, image.width
-    assert_equal 792, image.height
+    assert_equal 216, image.width
+    assert_equal 280, image.height
   end
 
   test "representing an MP4 video" do
@@ -27,8 +27,8 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
     representation = blob.representation(resize_to_limit: [640, 280]).processed
 
     image = read_image(representation.image)
-    assert_equal 640, image.width
-    assert_equal 480, image.height
+    assert_equal 373, image.width
+    assert_equal 280, image.height
   end
 
   test "representing an unrepresentable blob" do


### PR DESCRIPTION
Fixes #47071

Before this commit, when using ActiveStorage proxy mode, it was impossible to apply variations to the generated preview of a video or a PDF. This is because `ActiveStorage::Preview#image` (which is called in the `ActiveStorage::Representations::ProxyController`) always returned the blob's preview image without applying any variations.

This commit fixes the issue by changing `ActiveStorage::Preview#image` so that it takes into account the variations.