### PR TITLE
Pass the connection to query transformers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -31,12 +31,22 @@ module ActiveRecord
     class NullPool # :nodoc:
       include ConnectionAdapters::AbstractPool
 
+      class NullConfig # :nodoc:
+        def method_missing(*)
+          nil
+        end
+      end
+      NULL_CONFIG = NullConfig.new # :nodoc:
+
       attr_accessor :schema_cache
 
       def connection_class; end
       def checkin(_); end
       def remove(_); end
       def async_executor; end
+      def db_config
+        NULL_CONFIG
+      end
     end
 
     # Connection pool base class for managing Active Record database

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1113,7 +1113,7 @@ module ActiveRecord
 
         def transform_query(sql)
           ActiveRecord.query_transformers.each do |transformer|
-            sql = transformer.call(sql)
+            sql = transformer.call(sql, self)
           end
           sql
         end

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -80,12 +80,14 @@ module ActiveRecord
 
     class << self
       def call(sql) # :nodoc:
+        comment = self.comment
+
         if comment.blank?
           sql
         elsif prepend_comment
-          "#{self.comment} #{sql}"
+          "#{comment} #{sql}"
         else
-          "#{sql} #{self.comment}"
+          "#{sql} #{comment}"
         end
       end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -391,9 +391,9 @@ To keep using the current cache store, you can turn off cache versioning entirel
           ActiveRecord::QueryLogs.taggings.merge!(
             application:  Rails.application.class.name.split("::").first,
             pid:          -> { Process.pid.to_s },
-            socket:       -> { ActiveRecord::Base.connection_db_config.socket },
-            db_host:      -> { ActiveRecord::Base.connection_db_config.host },
-            database:     -> { ActiveRecord::Base.connection_db_config.database }
+            socket:       ->(context) { context[:connection].pool.db_config.socket },
+            db_host:      ->(context) { context[:connection].pool.db_config.host },
+            database:     ->(context) { context[:connection].pool.db_config.database }
           )
 
           if app.config.active_record.query_log_tags.present?

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -6,10 +6,6 @@ require "models/dashboard"
 class QueryLogsTest < ActiveRecord::TestCase
   fixtures :dashboards
 
-  ActiveRecord::QueryLogs.taggings[:application] = -> {
-    "active_record"
-  }
-
   def setup
     # ActiveSupport::ExecutionContext context is automatically reset in Rails app via an executor hooks set in railtie
     # But not in Active Record's own test suite.
@@ -19,16 +15,21 @@ class QueryLogsTest < ActiveRecord::TestCase
     @original_transformers = ActiveRecord.query_transformers
     @original_prepend = ActiveRecord::QueryLogs.prepend_comment
     @original_tags = ActiveRecord::QueryLogs.tags
+    @original_taggings = ActiveRecord::QueryLogs.taggings
     ActiveRecord.query_transformers += [ActiveRecord::QueryLogs]
     ActiveRecord::QueryLogs.prepend_comment = false
     ActiveRecord::QueryLogs.cache_query_log_tags = false
     ActiveRecord::QueryLogs.cached_comment = nil
+    ActiveRecord::QueryLogs.taggings[:application] = -> {
+      "active_record"
+    }
   end
 
   def teardown
     ActiveRecord.query_transformers = @original_transformers
     ActiveRecord::QueryLogs.prepend_comment = @original_prepend
     ActiveRecord::QueryLogs.tags = @original_tags
+    ActiveRecord::QueryLogs.taggings = @original_taggings
     ActiveRecord::QueryLogs.prepend_comment = false
     ActiveRecord::QueryLogs.cache_query_log_tags = false
     ActiveRecord::QueryLogs.cached_comment = nil

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -18,7 +18,7 @@ module ApplicationTests
       app_file "app/controllers/users_controller.rb", <<-RUBY
         class UsersController < ApplicationController
           def index
-            render inline: ActiveRecord::QueryLogs.call("")
+            render inline: ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
           end
 
           def dynamic_content
@@ -30,7 +30,7 @@ module ApplicationTests
       app_file "app/controllers/name_spaced/users_controller.rb", <<-RUBY
         class NameSpaced::UsersController < ApplicationController
           def index
-            render inline: ActiveRecord::QueryLogs.call("")
+            render inline: ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
           end
         end
       RUBY
@@ -38,7 +38,7 @@ module ApplicationTests
       app_file "app/jobs/user_job.rb", <<-RUBY
         class UserJob < ActiveJob::Base
           def perform
-            ActiveRecord::QueryLogs.call("")
+            ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
           end
 
           def dynamic_content

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -9,7 +9,8 @@ module ApplicationTests
     include Rack::Test::Methods
 
     def setup
-      build_app
+      build_app(multi_db: true)
+      rails("generate", "scaffold", "Pet", "name:string", "--database=animals")
       app_file "app/models/user.rb", <<-RUBY
         class User < ActiveRecord::Base
         end
@@ -18,7 +19,7 @@ module ApplicationTests
       app_file "app/controllers/users_controller.rb", <<-RUBY
         class UsersController < ApplicationController
           def index
-            render inline: ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
+            render inline: ActiveRecord::QueryLogs.call("", Pet.connection)
           end
 
           def dynamic_content
@@ -122,6 +123,18 @@ module ApplicationTests
       comment = last_response.body.strip
 
       assert_not_includes comment, "controller:users"
+    end
+
+    test "database information works with multiple database applications" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags = [ :socket, :db_host, :database ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+
+      assert_equal("/*action='index',controller='users',database='storage%2Fproduction_animals.sqlite3'*/", comment)
     end
 
     test "controller tags are not doubled up if already configured" do


### PR DESCRIPTION
Sometimes we need to tag the queries with information that are in the database connection that is making the query.

Exposing the connection in the `context` parameter for the tagging procs we can read the information we need.

This also allow us to fix the default tagging for database information that were always using the `ActiveRecord::Base` connection, to use the right connection.