### PR TITLE
Bump rubocop from 1.43.0 to 1.44.1 and fix offenses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
       connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
-    regexp_parser (2.6.1)
+    regexp_parser (2.6.2)
     reline (0.3.2)
       io-console (~> 0.5)
     representable (3.2.0)
@@ -394,7 +394,7 @@ GEM
     retriable (3.1.2)
     rexml (3.2.5)
     rouge (4.0.1)
-    rubocop (1.43.0)
+    rubocop (1.44.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -403,7 +403,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_delete_association
-    assert_queries(2) { posts(:welcome); people(:michael); }
+    assert_queries(2) { posts(:welcome); people(:michael) }
 
     assert_queries(1) do
       posts(:welcome).people.delete(people(:michael))

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -401,7 +401,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_cache_is_flat
     Task.cache do
-      assert_queries(1) { Topic.find(1); Topic.find(1); }
+      assert_queries(1) { Topic.find(1); Topic.find(1) }
     end
 
     ActiveRecord::Base.cache do


### PR DESCRIPTION
Ran into this when running `rubocop-md` on my branch (zzak/rails#8).