### PR TITLE
fixed typos in s3 cors policy example for active storage

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1012,7 +1012,7 @@ No CORS configuration is required for the Disk service since it shares your appâ
     "AllowedOrigins": [
       "https://www.example.com"
     ],
-    "ExposeHeaders": [
+    "ExposedHeaders": [
       "Origin",
       "Content-Type",
       "Content-MD5",

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1018,7 +1018,7 @@ No CORS configuration is required for the Disk service since it shares your appâ
       "Content-MD5",
       "Content-Disposition"
     ],
-    "MaxAgeSeconds": 3600
+    "MaxAge": 3600
   }
 ]
 ```


### PR DESCRIPTION
This is just a quick fix for a typo in the ActiveStorage guide where a key in the example Cloudformation template for S3 Bucket CORS policy is misspelt as per the [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors-corsrule.html#cfn-s3-bucket-cors-corsrule-maxage). 

It also changes the name of MaxAgeSeconds to MaxAge as per the same documentation.