### PR TITLE
Support composite foreign key association assignments

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -119,10 +119,13 @@ module ActiveRecord
         end
 
         def replace_keys(record, force: false)
-          target_key = record ? record._read_attribute(primary_key(record.class)) : nil
+          target_key_values = record ? Array(primary_key(record.class)).map { |key| record._read_attribute(key) } : []
+          reflection_fk = Array(reflection.foreign_key)
 
-          if force || owner._read_attribute(reflection.foreign_key) != target_key
-            owner[reflection.foreign_key] = target_key
+          if force || reflection_fk.map { |fk| owner._read_attribute(fk) } != target_key_values
+            reflection_fk.zip(target_key_values).each do |key, value|
+              owner[key] = value
+            end
           end
         end
 

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -22,8 +22,15 @@ module ActiveRecord::Associations
       def set_owner_attributes(record)
         return if options[:through]
 
-        key = owner._read_attribute(reflection.join_foreign_key)
-        record._write_attribute(reflection.join_primary_key, key)
+        primary_key_attribute_names = Array(reflection.join_primary_key)
+        foreign_key_attribute_names = Array(reflection.join_foreign_key)
+
+        primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
+
+        primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
+          value = owner._read_attribute(foreign_key)
+          record._write_attribute(primary_key, value)
+        end
 
         if reflection.type
           record._write_attribute(reflection.type, owner.class.polymorphic_name)

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -505,8 +505,14 @@ module ActiveRecord
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
-              association_id = record.public_send(reflection.options[:primary_key] || :id)
-              self[reflection.foreign_key] = association_id unless self[reflection.foreign_key] == association_id
+              primary_key = Array(reflection.options[:primary_key] || record.class.query_constraints_list)
+              foreign_key = Array(reflection.foreign_key)
+
+              primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
+              primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
+                association_id = record.public_send(primary_key)
+                self[foreign_key] = association_id unless self[foreign_key] == association_id
+              end
               association.loaded!
             end
 


### PR DESCRIPTION
This PR is built on top of https://github.com/rails/rails/pull/46962 and adds support for association assignments for Active Record models that use composite foreign and primary keys.

The high-level approach is pretty simple: Prepare code for the `primary_key` and the `foreign_key` to always be an array by temporarily wrapping it using `Array()` and assign all foreign key columns accordingly 

### What reviewers should focus on

You may have noticed that implementation has some duplication that can possibly be extracted into it's own concept and reused to avoid repetition. The logic goes the following way: "Given an array of `foreign_key` column names and an array of `primary_key` column names create a mapping of foreign key column names to the primary key column names, or vice-versa. For example:
```ruby
primary_key = [:blog_id, :id]
foreign_key = [:blog_id, :blog_post_id]
# create a mapping like 
# { blog_id: :blog_id, id: :blog_post_id }
# which is currently achieved through "zipping" the values
primary_key.zip(foreign_key) # => [[:blog_id, :blog_id], [:id, :blog_post_id]]
# [[:blog_id, :blog_id], [:id, :blog_post_id]] is basically a mapping, it's just unnecessary to turn it into an actual Hash for our use-cases
```

However I'm afraid of DRYing it up prematurely and either coming up with a wrongly named concept or placing the abstraction in a wrong place. Though most likely it will end up being a `Reflection` concept. Let me know if you think it is a good time to avoid duplication but I would prefer to wait for more usage examples to have a bigger picture
