### PR TITLE
Integrate Thor help features

### DIFF
--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -9,7 +9,7 @@ module Rails
 
       no_commands do
         def help
-          super
+          super("runner")
           say self.class.desc
         end
       end

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -189,14 +189,14 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     stdout = capture(:stdout) do
       Rails::Command.invoke(:dbconsole, ["-h"])
     end
-    assert_match(/rails dbconsole \[options\]/, stdout)
+    assert_match %r"bin/rails dbconsole", stdout
   end
 
   def test_print_help_long
     stdout = capture(:stdout) do
       Rails::Command.invoke(:dbconsole, ["--help"])
     end
-    assert_match(/rails dbconsole \[options\]/, stdout)
+    assert_match %r"bin/rails dbconsole", stdout
   end
 
   attr_reader :aborted, :output


### PR DESCRIPTION
This commit refactors `Rails::Command::Base` to more closely integrate with Thor's help features, and to improve the base usage banner format. With these improvements, subclasses can generally rely on Thor to display nicely-formatted help.

__Before (example)__

  ```console
  $ bin/rails db:system:change -h
  Usage:
    bin/rails change [options]

  Options:
    [--to=TO]  # The database system to switch to.

  Change `config/database.yml` and your database gem to the target database
  ```

__After (example)__

  ```console
  $ bin/rails db:system:change -h
  Usage:
    bin/rails db:system:change

  Options:
    [--to=TO]  # The database system to switch to.

  Change `config/database.yml` and your database gem to the target database
  ```

__Diff__

  ```diff
  @@ -1,6 +1,6 @@
   $ bin/rails db:system:change -h
   Usage:
  -  bin/rails change [options]
  +  bin/rails db:system:change

   Options:
     [--to=TO]  # The database system to switch to.
  ```
