### PR TITLE
Rely on Thor for credentials command help

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -14,14 +14,6 @@ module Rails
       require_relative "credentials_command/diffing"
       include Diffing
 
-      no_commands do
-        def help
-          say "Usage:\n  #{self.class.banner}"
-          say ""
-          say self.class.desc
-        end
-      end
-
       desc "edit", "Open the decrypted credentials in `$EDITOR` for editing"
       def edit
         require_application!
@@ -46,13 +38,11 @@ module Rails
         say credentials.read.presence || missing_credentials_message
       end
 
+      desc "diff", "Enroll/disenroll in decrypted diffs of credentials using git"
       option :enroll, type: :boolean, default: false,
         desc: "Enrolls project in credentials file diffing with `git diff`"
-
       option :disenroll, type: :boolean, default: false,
         desc: "Disenrolls project from credentials file diffing"
-
-      desc "diff", "Enroll/disenroll in decrypted diffs of credentials using git"
       def diff(content_path = nil)
         if @content_path = content_path
           self.environment = extract_environment_from_path(content_path)


### PR DESCRIPTION
This removes the custom `help` implementation from `CredentialsCommand` in favor of Thor's `help` implementation.

__Before__

  ```console
  $ bin/rails credentials --help
  Usage:
    bin/rails credentials

  === Storing Encrypted Credentials in Source Control

  The Rails `credentials` commands provide access to encrypted credentials,
  ...

  $ bin/rails credentials:edit --help
  Usage:
    bin/rails credentials

  === Storing Encrypted Credentials in Source Control

  The Rails `credentials` commands provide access to encrypted credentials,
  ...

  $ bin/rails credentials:diff --help
  Usage:
    bin/rails credentials

  === Storing Encrypted Credentials in Source Control

  The Rails `credentials` commands provide access to encrypted credentials,
  ...
  ```

__After__

  ```console
  $ bin/rails credentials --help
  Commands:
    bin/rails credentials:diff            # Enroll/disenroll in decrypted diffs of credentials using git
    bin/rails credentials:edit            # Open the decrypted credentials in `$EDITOR` for editing
    bin/rails credentials:help [COMMAND]  # Describe available commands or one specific command
    bin/rails credentials:show            # Show the decrypted credentials

  Options:
    -e, [--environment=ENVIRONMENT]  # The environment to run `credentials` in (e.g. test / development / production).

  === Storing Encrypted Credentials in Source Control

  The Rails `credentials` commands provide access to encrypted credentials,
  ...

  $ bin/rails credentials:edit --help # OR bin/rails credentials:help edit
  Usage:
    bin/rails credentials:edit

  Options:
    -e, [--environment=ENVIRONMENT]  # The environment to run `credentials` in (e.g. test / development / production).

  Open the decrypted credentials in `$EDITOR` for editing

  $ bin/rails credentials:diff --help # OR bin/rails credentials:help diff
  Usage:
    bin/rails credentials:diff

  Options:
        [--enroll], [--no-enroll]        # Enrolls project in credentials file diffing with `git diff`
        [--disenroll], [--no-disenroll]  # Disenrolls project from credentials file diffing
    -e, [--environment=ENVIRONMENT]      # The environment to run `credentials` in (e.g. test / development / production).

  Enroll/disenroll in decrypted diffs of credentials using git
  ```
