### PR TITLE
Rely on Thor for encrypted command help

### DIFF
--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -12,14 +12,6 @@ module Rails
       class_option :key, aliases: "-k", type: :string,
         default: "config/master.key", desc: "The Rails.root relative path to the encryption key"
 
-      no_commands do
-        def help
-          say "Usage:\n  #{self.class.banner}"
-          say ""
-          say self.class.desc
-        end
-      end
-
       desc "edit", "Open the decrypted file in `$EDITOR` for editing"
       def edit(*)
         require_application!


### PR DESCRIPTION
This removes the custom `help` implementation from `EncryptedCommand` in favor of Thor's `help` implementation.

__Before__

  ```console
  $ bin/rails encrypted --help
  Usage:
    bin/rails encrypted

  === Storing Encrypted Files in Source Control

  The Rails `encrypted` commands provide access to encrypted files or configurations.
  ...

  $ bin/rails encrypted:edit --help
  Usage:
    bin/rails encrypted

  === Storing Encrypted Files in Source Control

  The Rails `encrypted` commands provide access to encrypted files or configurations.
  ...
  ```

__After__

  ```console
  $ bin/rails encrypted --help
  Commands:
    bin/rails encrypted:edit            # Open the decrypted file in `$EDITOR` for editing
    bin/rails encrypted:help [COMMAND]  # Describe available commands or one specific command
    bin/rails encrypted:show            # Show the decrypted contents of the file

  Options:
    -k, [--key=KEY]  # The Rails.root relative path to the encryption key
                     # Default: config/master.key

  === Storing Encrypted Files in Source Control

  The Rails `encrypted` commands provide access to encrypted files or configurations.
  ...

  $ bin/rails encrypted:edit --help # OR bin/rails encrypted:help edit
  Usage:
    bin/rails encrypted:edit

  Options:
    -k, [--key=KEY]  # The Rails.root relative path to the encryption key
                     # Default: config/master.key

  Open the decrypted file in `$EDITOR` for editing
  ```
