### PR TITLE
Rely on Thor for secrets command help

### DIFF
--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -9,14 +9,6 @@ module Rails
     class SecretsCommand < Rails::Command::Base # :nodoc:
       include Helpers::Editor
 
-      no_commands do
-        def help
-          say "Usage:\n  #{self.class.banner}"
-          say ""
-          say self.class.desc
-        end
-      end
-
       desc "setup", "Deprecated in favor of credentials -- run `bin/rails credentials:help`"
       def setup
         deprecate_in_favor_of_credentials_and_exit
@@ -40,7 +32,7 @@ module Rails
         end
       end
 
-      desc "edit", "Show the decrypted secrets"
+      desc "show", "Show the decrypted secrets"
       def show
         say Rails::Secrets.read
       end


### PR DESCRIPTION
This removes the custom `help` implementation from `SecretsCommand` in favor of Thor's `help` implementation.

__Before__

  ```console
  $ bin/rails secrets --help
  Usage:
    bin/rails secrets

  === ** DEPRECATED **

  Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
  ...

  $ bin/rails secrets:setup --help
  Usage:
    bin/rails secrets

  === ** DEPRECATED **

  Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
  ...

  $ bin/rails secrets:edit --help
  Usage:
    bin/rails secrets

  === ** DEPRECATED **

  Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
  ...
  ```

__After__

  ```console
  $ bin/rails secrets --help
  Commands:
    bin/rails secrets:edit            # Open the secrets in `$EDITOR` for editing
    bin/rails secrets:help [COMMAND]  # Describe available commands or one specific command
    bin/rails secrets:setup           # Deprecated in favor of credentials -- run `bin/rails credentials:help`
    bin/rails secrets:show            # Show the decrypted secrets

  === ** DEPRECATED **

  Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
  ...

  $ bin/rails secrets:setup --help # OR bin/rails secrets:help setup
  Usage:
    bin/rails secrets:setup

  Deprecated in favor of credentials -- run `bin/rails credentials:help`

  $ bin/rails secrets:edit --help # OR bin/rails secrets:edit setup
  Usage:
    bin/rails secrets:edit

  Open the secrets in `$EDITOR` for editing
  ```
