### PR TITLE
Set test reporter default executable to bin/rails

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -6,7 +6,7 @@ require "minitest"
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
     class_attribute :app_root
-    class_attribute :executable, default: "rails test"
+    class_attribute :executable, default: "bin/rails test"
 
     def record(result)
       super

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -27,7 +27,7 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
     create_test_file "post", pass: false
 
     output = run_test_command("test/post_test.rb")
-    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[[^\]]+test/post_test\.rb:6\]:\nwups!\n\nrails test test/post_test\.rb:4}
+    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[[^\]]+test/post_test\.rb:6\]:\nwups!\n\nbin/rails test test/post_test\.rb:4}
     assert_match expect, output
   end
 

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -18,7 +18,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(failed_test)
     @reporter.report
 
-    assert_match %r{^rails test .*test/test_unit/reporter_test\.rb:\d+$}, @output.string
+    assert_match %r{^bin/rails test .*test/test_unit/reporter_test\.rb:\d+$}, @output.string
     assert_rerun_snippet_count 1
   end
 
@@ -64,7 +64,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(failed_test)
     @reporter.report
 
-    expect = %r{\AF\n\nFailure:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nboo\n\nrails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\AF\n\nFailure:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nboo\n\nbin/rails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -72,7 +72,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(errored_test)
     @reporter.report
 
-    expect = %r{\AE\n\nError:\nTestUnitReporterTest::ExampleTest#woot:\nArgumentError: wups\n    some_test.rb:4\n\nrails test .*test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\AE\n\nError:\nTestUnitReporterTest::ExampleTest#woot:\nArgumentError: wups\n    some_test.rb:4\n\nbin/rails test .*test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -81,7 +81,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     verbose.record(skipped_test)
     verbose.report
 
-    expect = %r{\ATestUnitReporterTest::ExampleTest#woot = 10\.00 s = S\n\n\nSkipped:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nskipchurches, misstemples\n\nrails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\ATestUnitReporterTest::ExampleTest#woot = 10\.00 s = S\n\n\nSkipped:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nskipchurches, misstemples\n\nbin/rails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -152,7 +152,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
       colored = Rails::TestUnitReporter.new @output, color: true, output_inline: true
       colored.record(failed_test)
 
-      expected = %r{\e\[31mF\e\[0m\n\n\e\[31mFailure:\nTestUnitReporterTest::ExampleTest#woot \[test/test_unit/reporter_test.rb:\d+\]:\nboo\n\e\[0m\n\nrails test .*test/test_unit/reporter_test.rb:\d+\n\n}
+      expected = %r{\e\[31mF\e\[0m\n\n\e\[31mFailure:\nTestUnitReporterTest::ExampleTest#woot \[test/test_unit/reporter_test.rb:\d+\]:\nboo\n\e\[0m\n\nbin/rails test .*test/test_unit/reporter_test.rb:\d+\n\n}
       assert_match expected, @output.string
     end
   end
@@ -169,7 +169,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
 
   private
     def assert_rerun_snippet_count(snippet_count)
-      assert_equal snippet_count, @output.string.scan(%r{^rails test }).size
+      assert_equal snippet_count, @output.string.scan(%r{^bin/rails test }).size
     end
 
     def failed_test


### PR DESCRIPTION
This sets the default executable for the test reporter to `bin/rails` instead of just `rails`.  This only affects command output messages.

__Before__

  ```console
  $ bin/rails test --help
  Usage: rails test [options] [files or directories]

  You can run a single test by appending a line number to a filename:

      rails test test/models/user_test.rb:27

  You can run multiple files and directories at the same time:

      rails test test/controllers test/integration/login_test.rb

  By default test failures and errors are reported inline during a run.

  minitest options:
  ...

  $ bin/rails test test/my_failing_test.rb
  Running 1 tests in a single process (parallelization threshold is 50)
  Run options: --seed 20964

  # Running:

  F

  Failure:
  MyFailingTest#test_it_fails [.../test/my_failing_test.rb:5]:
  Epic Fail!

  rails test test/my_failing_test.rb:4

  Finished in 0.185761s, 5.3833 runs/s, 5.3833 assertions/s.
  1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
  ```

__After__

  ```console
  $ bin/rails test --help
  Usage: bin/rails test [options] [files or directories]

  You can run a single test by appending a line number to a filename:

      bin/rails test test/models/user_test.rb:27

  You can run multiple files and directories at the same time:

      bin/rails test test/controllers test/integration/login_test.rb

  By default test failures and errors are reported inline during a run.

  minitest options:
  ...

  $ bin/rails test test/my_failing_test.rb
  Running 1 tests in a single process (parallelization threshold is 50)
  Run options: --seed 34270

  # Running:

  F

  Failure:
  MyFailingTest#test_it_fails [.../test/my_failing_test.rb:5]:
  Epic Fail!

  bin/rails test test/my_failing_test.rb:4

  Finished in 0.228461s, 4.3771 runs/s, 4.3771 assertions/s.
  1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
  ```

__Diff__

  ```diff
  @@ -1,13 +1,13 @@
   $ bin/rails test --help
  -Usage: rails test [options] [files or directories]
  +Usage: bin/rails test [options] [files or directories]

   You can run a single test by appending a line number to a filename:

  -    rails test test/models/user_test.rb:27
  +    bin/rails test test/models/user_test.rb:27

   You can run multiple files and directories at the same time:

  -    rails test test/controllers test/integration/login_test.rb
  +    bin/rails test test/controllers test/integration/login_test.rb

   By default test failures and errors are reported inline during a run.

  @@ -26,7 +26,7 @@
   MyFailingTest#test_it_fails [.../test/my_failing_test.rb:5]:
   Epic Fail!

  -rails test test/my_failing_test.rb:4
  +bin/rails test test/my_failing_test.rb:4

   Finished in 0.185761s, 5.3833 runs/s, 5.3833 assertions/s.
   1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
  ```
