### PR TITLE
Incorporate Thor help into test command help

### DIFF
--- a/railties/lib/rails/commands/test/USAGE
+++ b/railties/lib/rails/commands/test/USAGE
@@ -1,0 +1,9 @@
+You can run a single test by appending a line number to a filename:
+
+  <%= executable %> test/models/user_test.rb:27
+
+You can run multiple files and directories at the same time:
+
+  <%= executable %> test/controllers test/integration/login_test.rb
+
+By default test failures and errors are reported inline during a run.

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -8,25 +8,23 @@ require "rails/test_unit/reporter"
 module Rails
   module Command
     class TestCommand < Base # :nodoc:
-      no_commands do
-        def help
-          say "Usage: #{Rails::TestUnitReporter.executable} [options] [files or directories]"
-          say ""
-          say "You can run a single test by appending a line number to a filename:"
-          say ""
-          say "    #{Rails::TestUnitReporter.executable} test/models/user_test.rb:27"
-          say ""
-          say "You can run multiple files and directories at the same time:"
-          say ""
-          say "    #{Rails::TestUnitReporter.executable} test/controllers test/integration/login_test.rb"
-          say ""
-          say "By default test failures and errors are reported inline during a run."
-          say ""
+      def self.executable(*args)
+        args.empty? ? Rails::TestUnitReporter.executable : super
+      end
 
+      no_commands do
+        def help(command_name = nil, *)
+          super
+          if command_name == "test"
+            say ""
+            say self.class.class_usage
+          end
+          say ""
           Minitest.run(%w(--help))
         end
       end
 
+      desc "test [PATHS...]", "Run tests except system tests"
       def perform(*args)
         $LOAD_PATH << Rails::Command.root.join("test").to_s
 


### PR DESCRIPTION
This incorporates Thor's help output into the help output of the test command.

__Before__

  ```console
  $ bin/rails test:help
  Usage: bin/rails test [options] [files or directories]

  You can run a single test by appending a line number to a filename:

      bin/rails test test/models/user_test.rb:27
  ...
  minitest options:
  ...

  $ bin/rails test --help
  Usage: bin/rails test [options] [files or directories]

  You can run a single test by appending a line number to a filename:

      bin/rails test test/models/user_test.rb:27
  ...
  minitest options:
  ...

  $ bin/rails test:all --help
  Usage: bin/rails test [options] [files or directories]

  You can run a single test by appending a line number to a filename:

      bin/rails test test/models/user_test.rb:27
  ...
  minitest options:
  ...
  ```

__After__

  ```console
  $ bin/rails test:help
  Commands:
    bin/rails test [PATHS...]      # Run tests except system tests
    bin/rails test:all             # Run all tests, including system tests
    bin/rails test:channels        # Run tests in test/channels
    bin/rails test:controllers     # Run tests in test/controllers
    bin/rails test:functionals     # Run tests in test/controllers, test/mailers, and test/functional
    bin/rails test:generators      # Run tests in test/lib/generators
    bin/rails test:help [COMMAND]  # Describe available commands or one specific command
    bin/rails test:helpers         # Run tests in test/helpers
    bin/rails test:integration     # Run tests in test/integration
    bin/rails test:jobs            # Run tests in test/jobs
    bin/rails test:mailboxes       # Run tests in test/mailboxes
    bin/rails test:mailers         # Run tests in test/mailers
    bin/rails test:models          # Run tests in test/models
    bin/rails test:system          # Run system tests only
    bin/rails test:units           # Run tests in test/models, test/helpers, and test/unit

  You can run a single test by appending a line number to a filename:

    bin/rails test test/models/user_test.rb:27
  ...
  minitest options:
  ...

  $ bin/rails test --help
  Usage:
    bin/rails test [PATHS...]

  Run tests except system tests

  You can run a single test by appending a line number to a filename:

    bin/rails test test/models/user_test.rb:27
  ...
  minitest options:
  ...

  $ bin/rails test:all --help # OR bin/rails test:help all
  Usage:
    bin/rails test:all

  Run all tests, including system tests

  minitest options:
  ...
  ```
