### PR TITLE
Rely on Thor for dev command help

### DIFF
--- a/railties/lib/rails/commands/dev/dev_command.rb
+++ b/railties/lib/rails/commands/dev/dev_command.rb
@@ -5,12 +5,6 @@ require "rails/dev_caching"
 module Rails
   module Command
     class DevCommand < Base # :nodoc:
-      no_commands do
-        def help
-          say "#{executable(:cache)} # Toggle development mode caching on/off."
-        end
-      end
-
       desc "cache", "Toggle development mode caching on/off"
       def cache
         Rails::DevCaching.enable_by_file


### PR DESCRIPTION
This removes the custom `help` implementation from `DevCommand` in favor of Thor's `help` implementation.

__Before__

  ```console
  $ bin/rails dev --help
  bin/rails dev:cache # Toggle development mode caching on/off.

  $ bin/rails dev:cache --help
  bin/rails dev:cache # Toggle development mode caching on/off.
  ```

__After__

  ```console
  $ bin/rails dev --help
  Commands:
    bin/rails dev:cache           # Toggle development mode caching on/off
    bin/rails dev:help [COMMAND]  # Describe available commands or one specific command

  $ bin/rails dev:cache --help
  Usage:
    bin/rails dev:cache

  Toggle development mode caching on/off
  ```
