### PR TITLE
Remove unneeded require in plugin application.rb

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -124,10 +124,6 @@ module Rails
     def test_dummy_config
       template "rails/boot.rb", "#{dummy_path}/config/boot.rb", force: true
 
-      insert_into_file "#{dummy_path}/config/application.rb", <<~RUBY, after: /^Bundler\.require.+\n/
-        require #{namespaced_name.inspect}
-      RUBY
-
       if mountable?
         template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       end

--- a/railties/test/engine/test_test.rb
+++ b/railties/test/engine/test_test.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "plugin_helpers"
 
 class Rails::Engine::TestTest < ActiveSupport::TestCase
+  include PluginHelpers
+
   setup do
     @destination_root = Dir.mktmpdir("bukkits")
-    Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+    generate_plugin("#{@destination_root}/bukkits", "--mountable")
   end
 
   teardown do
@@ -13,7 +16,7 @@ class Rails::Engine::TestTest < ActiveSupport::TestCase
   end
 
   test "automatically synchronize test schema" do
-    Dir.chdir(plugin_path) do
+    in_plugin_context(plugin_path) do
       # In order to confirm that migration files are loaded, generate multiple migration files.
       `bin/rails generate model user name:string;
        bin/rails generate model todo name:string;

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "plugin_helpers"
 require "generators/generators_test_helper"
 require "rails/generators/rails/plugin/plugin_generator"
 require "generators/shared_generator_tests"
@@ -22,6 +23,7 @@ DEFAULT_PLUGIN_FILES = %w(
 )
 
 class PluginGeneratorTest < Rails::Generators::TestCase
+  include PluginHelpers
   include GeneratorsTestHelper
   destination File.join(destination_root, "bukkits")
   arguments [destination_root]
@@ -282,10 +284,13 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
   def test_ensure_that_migration_tasks_work_with_mountable_option
     run_generator [destination_root, "--mountable"]
-    FileUtils.cd destination_root
-    quietly { system "bundle install" }
-    output = `bin/rails db:migrate 2>&1`
-    assert $?.success?, "Command failed: #{output}"
+    prepare_plugin(destination_root)
+
+    in_plugin_context(destination_root) do
+      quietly { system "bundle install" }
+      output = `bin/rails db:migrate 2>&1`
+      assert $?.success?, "Command failed: #{output}"
+    end
   end
 
   def test_creating_engine_in_full_mode
@@ -554,10 +559,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_dummy_application_loads_plugin
+  def test_plugin_passes_generated_test
     run_generator
+    prepare_plugin(destination_root)
 
-    assert_file "test/dummy/config/application.rb", /^require "bukkits"/
+    in_plugin_context(destination_root) do
+      output = `bin/test 2>&1`
+      assert $?.success?, "Command failed: #{output}"
+    end
   end
 
   def test_dummy_application_sets_include_all_helpers_to_false_for_mountable

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "plugin_helpers"
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold_controller/scaffold_controller_generator"
 
@@ -9,6 +10,7 @@ module Unknown
 end
 
 class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
+  include PluginHelpers
   include GeneratorsTestHelper
   arguments %w(User name:string age:integer)
 
@@ -270,11 +272,9 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_controller_tests_pass_by_default_inside_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--mountable") do
       quietly { `bin/rails g controller dashboard foo` }
       quietly { `bin/rails db:migrate RAILS_ENV=test` }
       assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
@@ -282,11 +282,9 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_controller_tests_pass_by_default_inside_full_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--full") do
       quietly { `bin/rails g controller dashboard foo` }
       quietly { `bin/rails db:migrate RAILS_ENV=test` }
       assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "plugin_helpers"
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
+  include PluginHelpers
   include GeneratorsTestHelper
   arguments %w(product_line title:string approved:boolean product:belongs_to user:references)
 
@@ -565,11 +567,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_tests_pass_by_default_inside_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--mountable") do
       quietly do
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
@@ -579,11 +579,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_tests_pass_by_default_inside_namespaced_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits-admin --mountable` }
-
     engine_path = File.join(destination_root, "bukkits-admin")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--mountable") do
       quietly do
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
@@ -599,11 +597,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_tests_pass_by_default_inside_full_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--full") do
       quietly do
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
@@ -613,11 +609,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_tests_pass_by_default_inside_api_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable --api` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--mountable", "--api") do
       quietly do
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
@@ -627,11 +621,9 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_tests_pass_by_default_inside_api_full_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --full --api` }
-
     engine_path = File.join(destination_root, "bukkits")
 
-    Dir.chdir(engine_path) do
+    with_new_plugin(engine_path, "--full", "--api") do
       quietly do
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`

--- a/railties/test/plugin_helpers.rb
+++ b/railties/test/plugin_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PluginHelpers
+  def generate_plugin(plugin_path, *args)
+    system(*%w[bundle exec rails plugin new], plugin_path, *args, out: File::NULL, exception: true)
+    prepare_plugin(plugin_path)
+  end
+
+  def prepare_plugin(plugin_path)
+    # Fill placeholders in gemspec to prevent Gem::InvalidSpecificationException
+    # from being raised. (Some fields require a valid URL, so use one for all.)
+    gemspec_path = "#{plugin_path}/#{File.basename(plugin_path)}.gemspec"
+    gemspec = File.read(gemspec_path).gsub(/"TODO.*"/, "http://example.com".inspect)
+    File.write(gemspec_path, gemspec)
+
+    # Resolve `rails` gem to this repo so that Bundler doesn't search for a
+    # version of Rails that hasn't been released yet.
+    gemfile_path = "#{plugin_path}/Gemfile"
+    gemfile = <<~RUBY
+      #{File.read(gemfile_path).sub(/gem "rails".*/, "")}
+      gem "rails", path: #{File.expand_path("../..", __dir__).inspect}
+    RUBY
+    File.write(gemfile_path, gemfile)
+  end
+
+  def in_plugin_context(plugin_path, &block)
+    # Run with `Bundler.with_unbundled_env` so that Bundler uses the plugin's
+    # Gemfile instead of this repo's Gemfile.
+    Dir.chdir(plugin_path) { Bundler.with_unbundled_env(&block) }
+  end
+
+  def with_new_plugin(plugin_path, *args, &block)
+    generate_plugin(plugin_path, *args)
+    in_plugin_context(plugin_path, &block)
+  end
+end


### PR DESCRIPTION
This require was added in cfcea1d53ae5ce38a7cbeb41e05958dc009988b0, but at that time the generated Gemfile did not resolve using the gemspec. gemspec was added to the plugin's generated Gemfile later in a74e4736f95befa7a22c208019bf11a155ff7543. Since then, the Bundler.require in the plugin's generated config/application.rb will require the plugin and the extra require is unneeded.

The replaced test was added in adfa417fbbf6f670c3d10ed2c32c58bc1dc92c2e when the plugin generator's application.rb was replaced with the app generator's. Since the test is only concerned with the file content and not whether that content is useful, the test was replaced with an attempt to run the plugin's test, since this would verify that the plugin can be loaded within the dummy app.

The plugin helpers are added because the generated Gemfile is now used for resolution instead of Rails'. This makes the tests more accurate because real plugins will be resolving against their own Gemfiles. However, this also leads to a few issues solved by the new helpers:
- gemspecs are generated with TODOs that have to be fixed
- commands run in the plugin must have their Bundler environment reset because processes spawned in Rails' tests inherit BUNDLE_GEMFILE

Co-authored-by: Jonathan Hefner <jonathan@hefner.pro>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
