### PR TITLE
Fix double blank lines in generated production.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -95,7 +95,6 @@ Rails.application.configure do
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
-
   <%- unless options.skip_active_record? -%>
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
### Motivation / Background

The change in 2b1fa89e442ecb99e262a34eb11bc1110912cd49 left a blank line above the skip_active_record check, while previously the check was immediately after the previous line.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
