### PR TITLE
Support joins for associations with composite foreign keys

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -199,10 +199,14 @@ module ActiveRecord
 
         scope_chain_items.inject(klass_scope, &:merge!)
 
-        primary_key = join_primary_key
-        foreign_key = join_foreign_key
+        primary_key_column_names = Array(join_primary_key)
+        foreign_key_column_names = Array(join_foreign_key)
 
-        klass_scope.where!(table[primary_key].eq(foreign_table[foreign_key]))
+        primary_foreign_key_pairs = primary_key_column_names.zip(foreign_key_column_names)
+
+        primary_foreign_key_pairs.each do |primary_key_column_name, foreign_key_column_name|
+          klass_scope.where!(table[primary_key_column_name].eq(foreign_table[foreign_key_column_name]))
+        end
 
         if klass.finder_needs_type_condition?
           klass_scope.where!(klass.send(:type_condition, table))

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -131,7 +131,7 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_belongs_to_a_model_with_composite_foreign_key_finds_associated_record
     comment = sharded_comments(:great_comment_blog_post_one)
-    blog_post = sharded_blog_posts(:great_post_blog_one)
+    blog_post = sharded_blog_posts(:great_blog_post_one)
 
     assert_equal(blog_post, comment.blog_post)
   end
@@ -148,7 +148,7 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_association_with_composite_foreign_key_loads_records
-    blog_post = sharded_blog_posts(:great_post_blog_one)
+    blog_post = sharded_blog_posts(:great_blog_post_one)
 
     comments = blog_post.comments.to_a
     assert_includes(comments, sharded_comments(:wow_comment_blog_post_one))
@@ -156,7 +156,7 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_model_with_composite_query_constraints_has_many_association_sql
-    blog_post = sharded_blog_posts(:great_post_blog_one)
+    blog_post = sharded_blog_posts(:great_blog_post_one)
 
     sql = capture_sql do
       blog_post.comments.to_a
@@ -167,7 +167,7 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_append_composite_foreign_key_has_many_association
-    blog_post = sharded_blog_posts(:great_post_blog_one)
+    blog_post = sharded_blog_posts(:great_blog_post_one)
     comment = Sharded::Comment.new(body: "Great post! :clap:")
     comment.save
     blog_post.comments << comment
@@ -206,7 +206,7 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_append_composite_foreign_key_has_many_association_with_autosave
-    blog_post = sharded_blog_posts(:great_post_blog_one)
+    blog_post = sharded_blog_posts(:great_blog_post_one)
     comment = Sharded::Comment.new(body: "Great post! :clap:")
     blog_post.comments << comment
 

--- a/activerecord/test/fixtures/sharded_blog_posts.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts.yml
@@ -1,10 +1,10 @@
 _fixture:
   model_class: Sharded::BlogPost
 
-great_post_blog_one:
+great_blog_post_one:
   title: "My first post!"
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
-great_post_blog_two:
-  title: "My first post!"
+great_blog_post_two:
+  title: "My second post!"
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/fixtures/sharded_comments.yml
+++ b/activerecord/test/fixtures/sharded_comments.yml
@@ -3,15 +3,20 @@ _fixture:
 
 great_comment_blog_post_one:
   body: "I really enjoyed the post!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
 wow_comment_blog_post_one:
   body: "Wow!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+unique_comment_blog_post_one:
+  body: "Your first blog post is great!"
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
 great_comment_blog_post_two:
   body: "I really enjoyed the post!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_two) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>


### PR DESCRIPTION
This PR adds `joins` support for associations with a composite foreign key, foundations of which were introduced in https://github.com/rails/rails/pull/46962

### What reviewers should be focusing on

- Once again we are duplicating the `primary_foreign_key_pairs` concept. Eventually we are hoping to extract it into it's own thing that will be reused, however we are gathering use-cases to properly name it and make sure the concept is placed correctly. Most likely this will end up being a `Hash` on `Reflection` instances called `primary_by_foreign_keys_mapping`
-  See the comment about `klass_scope.where!` approach 
- Tests location. I decided to put the tests in `InnerJoinAssociationTest` however these test may also fit into the `associations_test` or specific `belongs_to_association_test`, `has_many_association_test`. Let me know if you think there is a better place to put the tests in.