### PR TITLE
Bring back quote_bound_value & deprecate instead

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -47,10 +47,25 @@ module ActiveRecord
         end
       end
 
+      # Quote a value to be used as a bound parameter of unknown type. For example,
+      # MySQL might perform dangerous castings when comparing a string to a number,
+      # so this method will cast numbers to string.
+      #
+      # Deprecated: Consider `Arel.sql("... ? ...", value)` or
+      # +sanitize_sql+ instead.
+      def quote_bound_value(value)
+        ActiveRecord.deprecator.warn(<<~MSG.squish)
+          #quote_bound_value is deprecated and will be removed in Rails 7.2.
+          Consider Arel.sql(".. ? ..", value) or #sanitize_sql instead.
+        MSG
+
+        quote(cast_bound_value(value))
+      end
+
       # Cast a value to be used as a bound parameter of unknown type. For example,
       # MySQL might perform dangerous castings when comparing a string to a number,
       # so this method will cast numbers to string.
-      def cast_bound_value(value)
+      def cast_bound_value(value) # :nodoc:
         value
       end
 

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -32,4 +32,34 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
   def test_cast_bound_false
     assert_equal "0", @conn.cast_bound_value(false)
   end
+
+  def test_quote_bound_integer
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(42) }
+    assert_equal "'42'", expected
+  end
+
+  def test_quote_bound_big_decimal
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(BigDecimal("4.2")) }
+    assert_equal "'4.2'", expected
+  end
+
+  def test_quote_bound_rational
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(Rational(3, 4)) }
+    assert_equal "'0.75'", expected
+  end
+
+  def test_quote_bound_duration
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(42.seconds) }
+    assert_equal "'42'", expected
+  end
+
+  def test_quote_bound_true
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(true) }
+    assert_equal "'1'", expected
+  end
+
+  def test_quote_bound_false
+    expected = assert_deprecated(ActiveRecord.deprecator) { @conn.quote_bound_value(false) }
+    assert_equal "'0'", expected
+  end
 end


### PR DESCRIPTION
@rafaelfranca pointed out that I misread the module scoping in #46600 / 2f08e611d3fe3c20403b39399b8db68cf961a205; it's not actually nodoc.

I don't think people should need to reach for this type of quoting directly, so I'm adding an explicit `:nodoc:` to the new `cast_bound_value`, and consequently pointing elsewhere in the deprecation.