### PR TITLE
Add `binstubs:change` command

### DIFF
--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -14,9 +14,8 @@ case ARGV.first
 when Rails::Command::HELP_MAPPINGS, "help", nil
   ARGV.shift
   Rails::Command.invoke :gem_help, ARGV
-when "plugin"
-  ARGV.shift
-  Rails::Command.invoke :plugin, ARGV
+when "plugin", "binstubs:change"
+  Rails::Command.invoke ARGV.shift, ARGV
 else
   Rails::Command.invoke :application, ARGV
 end

--- a/railties/lib/rails/commands/binstubs/binstubs_command.rb
+++ b/railties/lib/rails/commands/binstubs/binstubs_command.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module Rails
+  module Command
+    class BinstubsCommand < Base # :nodoc:
+      self.bin = "rails"
+
+      desc "change [PATHS...]",
+        "Change binstubs to have a specific shebang, Unix-style line endings, and execute permission"
+      option :pattern, type: :string, default: "ruby",
+        desc: "Change binstubs with a shebang matching this pattern (regex)."
+      option :interpreter, type: :string, default: "/usr/bin/env #{File.basename Thor::Util.ruby_command}",
+        desc: "The new shebang interpreter."
+      def change(*paths)
+        @shebang_pattern = /#{options[:pattern]}/
+        @shebang = "#!#{options[:interpreter]}"
+        paths = ["bin"] if paths.empty?
+
+        each_file(*paths) { |path| change_binstub(path) }
+      end
+
+      private
+        def each_file(*paths, &block)
+          paths.each do |path|
+            path = Pathname(path)
+
+            if path.file?
+              block.call(path)
+            else
+              each_file(*path.children, &block)
+            end
+          end
+        end
+
+        def change_binstub(path)
+          path.open("r+") do |file|
+            shebang = file.read(2)
+
+            if shebang == "#!"
+              shebang << file.gets.chomp!
+              shebang = @shebang if @shebang_pattern.match?(shebang)
+
+              content = file.read
+              content.delete!("\r")
+
+              file.rewind
+              file.truncate(file.write(shebang, "\n", content))
+              path.chmod(0755 & ~File.umask)
+            end
+          end
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -470,35 +470,6 @@ module Rails
         "latest"
       end
 
-      def dockerfile_binfile_fixups
-        # binfiles may have OS specific paths to ruby.  Normalize them.
-        shebangs = Dir["bin/*"].map { |file| IO.read(file).lines.first }.join
-        rubies = shebangs.scan(%r{#!/usr/bin/env (ruby.*)}).flatten.uniq
-
-        binfixups = (rubies - %w(ruby)).map do |ruby|
-          "sed -i 's/#{Regexp.quote(ruby)}$/ruby/' bin/*"
-        end
-
-        # Windows line endings will cause scripts to fail.  If any
-        # or found OR this generation is run on a windows platform
-        # and there are other binfixups required, then convert
-        # line endings.  This avoids adding unnecessary fixups if
-        # none are required, but prepares for the need to do the
-        # fix line endings if other fixups are required.
-        has_cr = Dir["bin/*"].any? { |file| IO.read(file).include? "\r" }
-        if has_cr || (Gem.win_platform? && !binfixups.empty?)
-          binfixups.unshift 'sed -i "s/\r$//g" bin/*'
-        end
-
-        # Windows file systems may not have the concept of executable.
-        # In such cases, fix up during the build.
-        unless Dir["bin/*"].all? { |file| File.executable? file }
-          binfixups.unshift "chmod +x bin/*"
-        end
-
-        binfixups
-      end
-
       def dockerfile_build_packages
         # start with the essentials
         packages = %w(build-essential git)

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -48,9 +48,9 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 <% end -%>
-<% unless dockerfile_binfile_fixups.empty? -%>
+<% if Gem.win_platform? -%>
 # Adjust binfiles to be executable on Linux
-<%= "RUN " + dockerfile_binfile_fixups.join(" && \\\n    ") %>
+RUN bundle exec rails binstubs:change
 
 <% end -%>
 <% unless options.api? -%>

--- a/railties/test/commands/binstubs_test.rb
+++ b/railties/test/commands/binstubs_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+require "rails/commands/notes/notes_command"
+
+class Rails::Command::BinstubsTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  test "binstubs:change can be run using the global rails command" do
+    original_content = read_file("bin/rails")
+    remove_file "bin/rails"
+    windows_content = original_content.sub(/\A(#!.*ruby)$/, '\1.exe').gsub("\n", "\r\n")
+    app_file "bin/rails", windows_content
+
+    assert_match %r/\A#!.*ruby\.exe/, windows_content
+    assert_match "\r", windows_content
+    assert_not File.executable?(app_path("bin/rails"))
+
+    Dir.chdir(app_path) do
+      quietly do
+        system("#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails binstubs:change", exception: true)
+      end
+    end
+
+    assert_equal original_content, read_file("bin/rails")
+    assert File.executable?(app_path("bin/rails"))
+  end
+
+  test "binstubs:change without args changes all binstubs in bin/ (recursively)" do
+    create_windows_binstubs "bin/foo", "bin/bar/baz"
+
+    run_change_command
+
+    assert_binstub "bin/foo"
+    assert_binstub "bin/bar/baz"
+  end
+
+  test "binstubs:change can target a specified file" do
+    create_windows_binstubs "foo", "bin/foo"
+
+    assert_no_changes -> { read_file "bin/foo" } do
+      run_change_command "foo"
+    end
+
+    assert_binstub "foo"
+  end
+
+  test "binstubs:change can target a specified directory" do
+    create_windows_binstubs "dir/foo", "bin/foo"
+
+    assert_no_changes -> { read_file "bin/foo" } do
+      run_change_command "dir"
+    end
+
+    assert_binstub "dir/foo"
+  end
+
+  test "binstubs:change can target multiple specified files and directories" do
+    create_windows_binstubs "bin/foo", "bin/subdir/foo", "bin/other"
+
+    assert_no_changes -> { read_file "bin/other" } do
+      run_change_command "bin/foo", "bin/subdir"
+    end
+
+    assert_binstub "bin/foo"
+    assert_binstub "bin/subdir/foo"
+  end
+
+  test "binstubs:change does not replace non-Ruby shebangs by default" do
+    create_windows_binstubs "bin/foo", interpreter: "rooby"
+
+    run_change_command
+
+    assert_binstub "bin/foo", interpreter: "rooby"
+  end
+
+  test "binstubs:change --pattern specifies the pattern to match for shebang replacement" do
+    create_windows_binstubs "bin/foo", interpreter: "rooby"
+
+    run_change_command pattern: "r[ou]+by"
+
+    assert_binstub "bin/foo"
+  end
+
+  test "binstubs:change --interpreter specifies the desired interpreter for shebang replacement" do
+    create_windows_binstubs "bin/foo"
+
+    run_change_command interpreter: "rooby"
+
+    assert_binstub "bin/foo", interpreter: "rooby"
+  end
+
+  test "binstubs:change ignores non-shebang files" do
+    content = binstub("bin/foo", line_endings: "\r\n").delete_prefix("#")
+    app_file "bin/foo", content
+
+    run_change_command
+
+    assert_equal content, read_file("bin/foo")
+    assert_not File.executable?(app_path("bin/foo"))
+  end
+
+  private
+    DEFAULT_INTERPRETER = "/usr/bin/env ruby"
+
+    def run_change_command(*args, pattern: nil, interpreter: nil)
+      args.push("--pattern", pattern) if pattern
+      args.push("--interpreter", interpreter) if interpreter
+
+      # Use #rails helper method because it's much faster than launching a new
+      # process for each call.
+      rails "binstubs:change", args
+    end
+
+    def binstub(path, interpreter: DEFAULT_INTERPRETER, line_endings: "\n")
+      ["#!#{interpreter}", "", "# #{path}", ""].join(line_endings)
+    end
+
+    def create_binstubs(*paths, permission: true, **binstub_options)
+      paths.each do |path|
+        app_file path, binstub(path, **binstub_options)
+        File.chmod(app_path(path), 0755) if permission
+      end
+    end
+
+    def create_windows_binstubs(*paths, **binstub_options)
+      create_binstubs(
+        *paths,
+        interpreter: DEFAULT_INTERPRETER + ".exe",
+        line_endings: "\r\n",
+        **binstub_options,
+        permission: false,
+      )
+    end
+
+    def read_file(relative)
+      File.read(app_path(relative))
+    end
+
+    def assert_binstub(path, **binstub_options)
+      assert_equal binstub(path, **binstub_options), read_file(path)
+      assert File.executable?(app_path(path))
+    end
+end


### PR DESCRIPTION
The `binstubs:change` command changes binstubs to have a specific shebang, Unix-style line endings, and execute permission.  For example, Windows users can use `binstubs:change` to update their app's binstubs to target a Unix-like platform.  In particular, this can be used when copying binstubs from a Windows system to a Docker image.

  ```console
  $ cd my_cool_app

  $ stat --printf="%A  %n\n" bin/*
  -rw-r--r--  bin/bundle
  -rw-r--r--  bin/docker-entrypoint
  -rw-r--r--  bin/importmap
  -rw-r--r--  bin/rails
  -rw-r--r--  bin/rake
  -rw-r--r--  bin/setup

  $ cat -v bin/rails
  #!/usr/bin/env ruby.exe^M
  APP_PATH = File.expand_path("../config/application", __dir__)^M
  require_relative "../config/boot"^M
  require "rails/commands"^M

  $ bundle exec rails binstubs:change
  .../ruby-3.1.2/bin/ruby: warning: shebang line ending with \r may cause problems

  $ stat --printf="%A  %n\n" bin/*
  -rwxr-xr-x  bin/bundle
  -rwxr-xr-x  bin/docker-entrypoint
  -rwxr-xr-x  bin/importmap
  -rwxr-xr-x  bin/rails
  -rwxr-xr-x  bin/rake
  -rwxr-xr-x  bin/setup

  $ cat -v bin/rails
  #!/usr/bin/env ruby
  APP_PATH = File.expand_path("../config/application", __dir__)
  require_relative "../config/boot"
  require "rails/commands"
  ```
