### PR TITLE
Missing end to code block in 7_0_release_notes.md

### DIFF
--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -213,6 +213,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
     # Rails 7.0 (same behavior with IN clause, mergee side condition is consistently replaced)
     Author.where(id: [david.id, mary.id]).merge(Author.where(id: bob)) # => [bob]
     Author.where(id: david.id..mary.id).merge(Author.where(id: bob)) # => [bob]
+    ```
 
 Active Storage
 --------------


### PR DESCRIPTION
I think because of the un-indent, this parses fine with most markdown libraries, but I'm not 100%.