### PR TITLE
Move comment to out of codeblock to note

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -315,7 +315,6 @@ To add a new value (before or after an existing one) or to rename a value you sh
 
 ```ruby
 # db/migrate/20150720144913_add_new_state_to_articles.rb
-# NOTE: ALTER TYPE ... ADD VALUE cannot be executed inside of a transaction block so here we are using disable_ddl_transaction!
 disable_ddl_transaction!
 
 def up
@@ -325,6 +324,8 @@ def up
   SQL
 end
 ```
+
+NOTE: `ALTER TYPE ... ADD VALUE` cannot be executed inside of a transaction block so here we are using `disable_ddl_transaction!`
 
 NOTE: Enum values [can't be dropped or reordered](https://www.postgresql.org/docs/current/datatype-enum.html). Adding a value is not easily reversed.
 


### PR DESCRIPTION
Notes are better served for comments, it's too easy to skip over them or have them scroll past.

If it's important it should be called out in the note block.

**Before**

![Screenshot 2023-02-04 at 19 01 01](https://user-images.githubusercontent.com/277819/216761095-5777f3c6-97ed-45a9-9bf1-f65f67617d36.png)

**After**

![Screenshot 2023-02-04 at 19 01 06](https://user-images.githubusercontent.com/277819/216761112-32269c15-3a28-4888-8738-b587737438e2.png)
