### PR TITLE
Object#presence_if? returns object when block is truthy

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `Object#presence_if?(&block)` will return the object only if present and
+    block is truthy.
+
+    *trevorrjohn*
+
 *   `config.i18n.raise_on_missing_translations = true` now raises on any missing translation.
 
     Previously it would only raise when called in a view or controller. Now it will raise

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -45,6 +45,27 @@ class Object
   def presence
     self if present?
   end
+
+  # Returns the receiver if it's present and arg or block is truthy otherwise returns +nil+.
+  # <tt>object.presence_if?(block)</tt> is equivalent to
+  #
+  #    object.present? && block.call ? object : nil
+  #
+  # For example, something like
+  #
+  #   model = Model.new
+  #   model.valid? ? model : nil
+  #
+  # becomes
+  #
+  #   Model.new.presence_if?(&:valid?)
+  #
+  # @return [Object]
+  def presence_if?
+    raise ArgumentError, "Missing block" unless block_given?
+
+    self if presence && yield(self).presence
+  end
 end
 
 class NilClass

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -31,6 +31,17 @@ class BlankTest < ActiveSupport::TestCase
 
   def test_presence
     BLANK.each { |v| assert_nil v.presence, "#{v.inspect}.presence should return nil" }
-    NOT.each   { |v| assert_equal v,   v.presence, "#{v.inspect}.presence should return self" }
+    NOT.each   { |v| assert_equal v, v.presence, "#{v.inspect}.presence should return self" }
+  end
+
+  def test_presence_if
+    assert_raises(ArgumentError, "Missing block") do
+      Object.new.presence_if?
+    end
+    BLANK.each { |v| assert_nil v.presence_if?(lambda { flunk "Block should not be called" }), "#{v.inspect}.presence_if? should return nil" }
+    NOT.each do |v|
+      assert_equal v, v.presence_if?(lambda { |x| x == v }), "#{v.inspect}.presence_if? should return self"
+      assert_nil v.presence_if?(lambda { BLANK.sample }), "#{v.inspect}.presence_if? should return nil when block returns falsy"
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This method would allow me and hopefully others to simplify their codebases. I find a lot of logic in my code that this method would simplify

```ruby
object = SomeObject.new(args: args)
return object if object.valid?
```

This helper method would make this code a lot simpler and easier to follow IMO.

```ruby
object = SomeObject.new(args: args)
return object.presence_if?(&:valid?)
```

### Detail

I've added this method to core_ext/blank alongside `Object#presence`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
