### PR TITLE
Prefer a simple counter-based lock.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ PATH
       marcel (~> 1.0)
       mini_mime (>= 1.1.0)
     activesupport (7.1.0.alpha)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.2)
       connection_pool (>= 2.2.5)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -159,7 +159,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.3.6)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     connection_pool (2.3.0)
     crack (0.4.5)
       rexml

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -41,6 +41,10 @@ module ActionView
       # any threads waiting on a write lock will be woken up.
       def release_read_lock
         @guard.synchronize do
+          if @exclusive_count.value.zero?
+            raise "Attempted to release a read lock when none were held."
+          end
+
           @read_count -= 1
           @exclusive_count.value -= 1
         end

--- a/actionview/test/unit/cache_expiry_test.rb
+++ b/actionview/test/unit/cache_expiry_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class ActionViewCacheExpiryTest < ActiveSupport::TestCase
+  def test_execution_lock_can_be_acquired_and_released
+    execution_lock = ActionView::CacheExpiry::ExecutionLock.new
+
+    # It can acquire read lock:
+    execution_lock.acquire_read_lock
+    assert_equal 1, execution_lock.read_count
+    execution_lock.release_read_lock
+    assert_equal 0, execution_lock.read_count
+
+    # It can acquire write lock:
+    execution_lock.with_write_lock do
+      assert_equal 1, execution_lock.write_count
+    end
+    assert_equal 0, execution_lock.write_count
+  end
+
+  def test_execution_lock_multiple_read_locks
+    execution_lock = ActionView::CacheExpiry::ExecutionLock.new
+
+    execution_lock.acquire_read_lock
+    assert_equal 1, execution_lock.read_count
+
+    execution_lock.acquire_read_lock
+    assert_equal 2, execution_lock.read_count
+
+    execution_lock.release_read_lock
+    assert_equal 1, execution_lock.read_count
+
+    execution_lock.release_read_lock
+    assert_equal 0, execution_lock.read_count
+  end
+
+  def test_execution_lock_read_lock_upgraded_to_write_lock
+    execution_lock = ActionView::CacheExpiry::ExecutionLock.new
+
+    execution_lock.acquire_read_lock
+    assert_equal 1, execution_lock.read_count
+
+    execution_lock.with_write_lock do
+      assert_equal 1, execution_lock.write_count
+      assert_equal 1, execution_lock.read_count
+    end
+
+    assert_equal 1, execution_lock.read_count
+    execution_lock.release_read_lock
+
+    assert_equal 0, execution_lock.read_count
+  end
+
+  def test_execution_lock_write_lock_priority
+    execution_lock = ActionView::CacheExpiry::ExecutionLock.new
+    sequence = Thread::Queue.new
+
+    execution_lock.acquire_read_lock
+    assert_equal 1, execution_lock.read_count
+
+    writer = Thread.new do
+      execution_lock.acquire_read_lock
+
+      execution_lock.with_write_lock do
+        sequence << :write_lock_acquired
+        assert_equal 1, execution_lock.write_count
+        assert_equal 1, execution_lock.read_count
+      end
+
+      execution_lock.release_read_lock
+    end
+
+    reader = Thread.new do
+      execution_lock.acquire_read_lock
+      sequence << :read_lock_acquired
+      assert_equal 1, execution_lock.read_count
+      execution_lock.release_read_lock
+      assert_equal 0, execution_lock.read_count
+    end
+
+    # Wait for both the threads to be waiting for the lock:
+    Thread.pass until reader.status == "sleep" && writer.status == "sleep"
+
+    # After releasing this read lock, the writer thread should take priority over the reader:
+    execution_lock.release_read_lock
+    assert_equal :write_lock_acquired, sequence.pop
+    assert_equal :read_lock_acquired, sequence.pop
+
+    reader.join
+    writer.join
+
+    assert_equal 0, execution_lock.read_count
+    assert_equal 0, execution_lock.write_count
+  end
+
+  class EmptyWatcher
+    def initialize(*)
+    end
+
+    def execute
+    end
+
+    def execute_if_updated
+    end
+  end
+
+  def test_invoke_cache_expiry_on_different_threads
+    executor = ActionView::CacheExpiry::Executor.new(watcher: EmptyWatcher)
+    state = executor.run
+
+    assert_nothing_raised do
+      Thread.new do
+        executor.complete(state)
+      end.value
+    end
+  end
+
+  def test_invoke_cache_expiry_on_different_fibers
+    executor = ActionView::CacheExpiry::Executor.new(watcher: EmptyWatcher)
+    state = executor.run
+
+    assert_nothing_raised do
+      Fiber.new do
+        executor.complete(state)
+      end.resume
+    end
+  end
+end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "i18n",            ">= 1.6", "< 2"
   s.add_dependency "tzinfo",          "~> 2.0"
-  s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
+  s.add_dependency "concurrent-ruby", "~> 1.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
   s.add_dependency "minitest",        ">= 5.1"
 end


### PR DESCRIPTION
This allows `acquire_read_lock` and `release_read_lock` to be called from different fibers/threads (which can be the case for falcon).

See https://github.com/rails/rails/commit/9a4c1e205ee5c4facef3c391e2a63bc3cff7d7f8 which introduced the current implementation.

### Motivation / Background

This is causing problems as outlined in detail here: https://github.com/socketry/falcon/issues/166

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
