### PR TITLE
Configure RDoc in Task#new

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -105,15 +105,16 @@ module Rails
       }
 
       def initialize(name)
-        super
-
         # Every time rake runs this task is instantiated as all the rest.
         # Be lazy computing stuff to have as light impact as possible to
         # the rest of tasks.
         before_running_rdoc do
-          configure_sdoc
           configure_rdoc_files
           setup_horo_variables
+        end
+
+        super do
+          configure_sdoc
         end
       end
 


### PR DESCRIPTION
Because we're subclassing `RDoc::Task` here, we want to make sure `rdoc_dir` is set before tasks are defined. [ref](https://github.com/ruby/rdoc/blob/31ea1c030ab67128269c12090f2bcc49f3c0be90/lib/rdoc/task.rb#L154-L168)

Before

```
$ bundle exec rake clobber
rm -r html

$ bundle exec rake clobber_rdoc
rm -r html
```

After

```
$ bundle exec rake clobber
rm -r doc/rdoc
```

This time the clobber tasks know about where to clean rdoc files.