### PR TITLE
Revert "Configure RDoc in Task#new"

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -105,16 +105,15 @@ module Rails
       }
 
       def initialize(name)
+        super
+
         # Every time rake runs this task is instantiated as all the rest.
         # Be lazy computing stuff to have as light impact as possible to
         # the rest of tasks.
         before_running_rdoc do
+          configure_sdoc
           configure_rdoc_files
           setup_horo_variables
-        end
-
-        super do
-          configure_sdoc
         end
       end
 


### PR DESCRIPTION
Reverts rails/rails#47261

I think this broke edgeapi.rubyonrails.org because we're using an older ruby (2.7) to generate the docs, and need more time to investigate.

Sorry for the noise :bow: