### PR TITLE
Clearer core dev deps title

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -1,7 +1,7 @@
 **DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
-Development Dependencies Install
-================================
+Installing Rails Core Development Dependencies
+==============================================
 
 This guide covers how to set up an environment for Ruby on Rails core development.
 

--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -306,6 +306,9 @@
       name: Guides Guidelines
       url: ruby_on_rails_guides_guidelines.html
       description: This guide documents the Ruby on Rails guides guidelines.
+    - name: Installing Rails Core Development Dependencies
+      url: development_dependencies_install.html
+      description: This guide covers how to set up an environment for Ruby on Rails core development.
 -
   name: Policies
   documents:


### PR DESCRIPTION
The title of this guide might lead to confusion that it's for general development dependencies of a Rails app, and not only for core development of the framework.

Also added this document to the index.

cc #47062