### PR TITLE
Bump RDoc dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 
 group :doc do
   gem "sdoc", ">= 2.6.0"
+  gem "rdoc", "~> 6.5"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,6 +567,7 @@ DEPENDENCIES
   rack-cache (~> 1.2)
   rails!
   rake (>= 13)
+  rdoc (~> 6.5)
   redcarpet (~> 3.2.3)
   redis (>= 4.0.1)
   redis-namespace


### PR DESCRIPTION
While we depend on rdoc through the sdoc gem, it only requires a minimum version.

This may be the cause for #47261 broke edgeapi.rubyonrails.org, those docs are generated with Ruby 2.6 or 2.7, and so it's defaulting to the older RDoc.

I'd also like to investigate increasing the Ruby version on the doc server, but I feel that has bigger impact.