### PR TITLE
Prefer table for mapping included API controller modules

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -400,24 +400,21 @@ Choosing Controller Modules
 An API application (using `ActionController::API`) comes with the following
 controller modules by default:
 
-- `ActionController::UrlFor`: Makes `url_for` and similar helpers available.
-- `ActionController::Redirecting`: Support for `redirect_to`.
-- `AbstractController::Rendering` and `ActionController::ApiRendering`: Basic support for rendering.
-- `ActionController::Renderers::All`: Support for `render :json` and friends.
-- `ActionController::ConditionalGet`: Support for `stale?`.
-- `ActionController::BasicImplicitRender`: Makes sure to return an empty response, if there isn't an explicit one.
-- `ActionController::StrongParameters`: Support for parameters filtering in combination with Active Model mass assignment.
-- `ActionController::DataStreaming`: Support for `send_file` and `send_data`.
-- `AbstractController::Callbacks`: Support for `before_action` and
-  similar helpers.
-- `ActionController::Rescue`: Support for `rescue_from`.
-- `ActionController::Instrumentation`: Support for the instrumentation
-  hooks defined by Action Controller (see [the instrumentation
-  guide](active_support_instrumentation.html#action-controller) for
-more information regarding this).
-- `ActionController::ParamsWrapper`: Wraps the parameters hash into a nested hash,
-  so that you don't have to specify root elements sending POST requests for instance.
-- `ActionController::Head`: Support for returning a response with no content, only headers.
+|   |   |
+|---|---|
+| `ActionController::UrlFor` | Makes `url_for` and similar helpers available. |
+| `ActionController::Redirecting` | Support for `redirect_to`. |
+| `AbstractController::Rendering` and `ActionController::ApiRendering` | Basic support for rendering. |
+| `ActionController::Renderers::All` | Support for `render :json` and friends. |
+| `ActionController::ConditionalGet` | Support for `stale?`. |
+| `ActionController::BasicImplicitRender` | Makes sure to return an empty response, if there isn't an explicit one. |
+| `ActionController::StrongParameters` | Support for parameters filtering in combination with Active Model mass assignment. |
+| `ActionController::DataStreaming` | Support for `send_file` and `send_data`. |
+| `AbstractController::Callbacks` | Support for `before_action` and similar helpers. |
+| `ActionController::Rescue` | Support for `rescue_from`. |
+| `ActionController::Instrumentation` | Support for the instrumentation hooks defined by Action Controller (see [the instrumentation guide](active_support_instrumentation.html#action-controller) for more information regarding this). |
+| `ActionController::ParamsWrapper` | Wraps the parameters hash into a nested hash, so that you don't have to specify root elements sending POST requests for instance.
+| `ActionController::Head` | Support for returning a response with no content, only headers. |
 
 Other plugins may add additional modules. You can get a list of all modules
 included into `ActionController::API` in the rails console:


### PR DESCRIPTION
Before

![Screenshot 2023-02-06 at 18 19 01](https://user-images.githubusercontent.com/277819/216933944-7eed0cee-7171-4e75-ba24-d526ea0c0587.png)

After

![Screenshot 2023-02-06 at 18 19 06](https://user-images.githubusercontent.com/277819/216933983-9c48ada0-c5db-42c5-879b-e7c5a7db9fe6.png)

While longer on the page, this is less jumbled mess, if we increase the max-width on the guides (my dream) would make this even easier on the eyes.