### PR TITLE
Fix NOTE notation

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -258,7 +258,7 @@ class Dog < AnimalsRecord
 end
 ```
 
-Note: Since Rails doesn't know which database is the replica for your writer you will need to
+NOTE: Since Rails doesn't know which database is the replica for your writer you will need to
 add this to the abstract class after you're done.
 
 Rails will only generate the new class once. It will not be overwritten by new scaffolds

--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -66,7 +66,7 @@ Rails.error.subscribe(ErrorSubscriber.new)
 
 You can register as many subscribers as you wish. Rails will call them in turn, in the order in which they were registered.
 
-Note: The Rails error-reporter will always call registered subscribers, regardless of your environment. However, many error-reporting services only report errors in production by default. You should configure and test your setup across environments as needed.
+NOTE: The Rails error-reporter will always call registered subscribers, regardless of your environment. However, many error-reporting services only report errors in production by default. You should configure and test your setup across environments as needed.
 
 ### Using the Error Reporter
 


### PR DESCRIPTION
### Motivation / Background

Almost all notes start from "NOTE:" because "NOTE:" is compiled to the special format for notes.
But there are only two notes that start from "Note:" and are not compiled to the format.
This Pull Request has been created to fix this issue.

### Detail

This Pull Request changes from "Note:" to "NOTE:".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
