### PR TITLE
Fixes encoding/decoding Data object via as_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -65,6 +65,14 @@ class Object
   end
 end
 
+if RUBY_VERSION >= "3.2"
+  class Data # :nodoc:
+    def as_json(options = nil)
+      Hash[members.zip(deconstruct)].as_json(options)
+    end
+  end
+end
+
 class Struct # :nodoc:
   def as_json(options = nil)
     Hash[members.zip(values)].as_json(options)

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -334,6 +334,17 @@ class TestJSONEncoding < ActiveSupport::TestCase
                  ActiveSupport::JSON.decode(json_string_and_date))
   end
 
+  if RUBY_VERSION >= "3.2"
+    def test_data_encoding
+      data = Data.define(:name, :email).new("test", "test@example.com")
+
+      assert_nothing_raised { data.to_json }
+
+      assert_equal({ "name" => "test", "email" => "test@example.com" },
+        ActiveSupport::JSON.decode(data.to_json))
+    end
+  end
+
   def test_nil_true_and_false_represented_as_themselves
     assert_nil nil.as_json
     assert_equal true,  true.as_json


### PR DESCRIPTION
### Motivation / Background

Add as_json method for the new Data object introduced in Ruby 3.2 so Data objects can be encoded/decoded.

```
data = Data.define(:name).new(:test)
data.as_json
```

This Pull Request has been created because https://github.com/rails/rails/issues/47267

cc/ @eileencodes 

### Additional information

Run the tests in Ruby 3.2 only.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
