### PR TITLE
Fix warnings that appear on CI that relate to Rack::Chunked deprecation

### DIFF
--- a/railties/test/commands/unused_routes_test.rb
+++ b/railties/test/commands/unused_routes_test.rb
@@ -15,7 +15,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command
+    assert_includes <<~OUTPUT, run_unused_routes_command
       No unused routes found.
     OUTPUT
   end
@@ -27,7 +27,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
       Found 1 unused route:
 
         Prefix Verb URI Pattern Controller#Action
@@ -47,7 +47,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
       Found 1 unused route:
 
         Prefix Verb URI Pattern Controller#Action
@@ -71,7 +71,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command
+    assert_includes <<~OUTPUT, run_unused_routes_command
       No unused routes found.
     OUTPUT
   end
@@ -84,7 +84,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
       Found 2 unused routes:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -101,7 +101,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(["-g", "one"], allow_failure: true)
+    assert_includes <<~OUTPUT, run_unused_routes_command(["-g", "one"], allow_failure: true)
       Found 1 unused route:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -115,7 +115,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(["-g", "one"])
+    assert_includes <<~OUTPUT, run_unused_routes_command(["-g", "one"])
       No unused routes found for this grep pattern.
     OUTPUT
   end
@@ -128,7 +128,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(["-c", "posts"], allow_failure: true)
+    assert_includes <<~OUTPUT, run_unused_routes_command(["-c", "posts"], allow_failure: true)
       Found 1 unused route:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -142,7 +142,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_equal <<~OUTPUT, run_unused_routes_command(["-c", "posts"])
+    assert_includes <<~OUTPUT, run_unused_routes_command(["-c", "posts"])
       No unused routes found for this controller.
     OUTPUT
   end


### PR DESCRIPTION
### Motivation / Background

Rack 3 is emitting a deprecation warning for Rack 3. The said warning is breaking some tests which is evaluating the output from the `bin/rails unused_routes` command.

`assert_equal` has been changed to `assert_include` which fixes the test and it's a viable solution beyond ignoring those deprecation warnings.

Output:
```
F
 
Failure:
Rails::Command::UnusedRoutesTest#test_filter_by_controller [test/commands/unused_routes_test.rb:131]:
--- expected
+++ actual
@@ -1,4 +1,5 @@
-"Found 1 unused route:
+"/usr/local/bundle/gems/rack-3.0.4.1/lib/rack/chunked.rb:6: warning: Rack::Chunked is deprecated and will be removed in Rack 3.1
+Found 1 unused route:
 
 Prefix Verb URI Pattern    Controller#Action
    one GET  /one(.:format) posts#one
 
 
bin/rails test test/commands/unused_routes_test.rb:123
```

Source: https://buildkite.com/rails/rails/builds/93460#018625a3-8aea-430b-b72a-acc04f1c23fd

### Additional information

Related comment https://github.com/rails/rails/pull/47078#issuecomment-1407095325

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
