### PR TITLE
Fix wrong order for assert_includes in railties test

### DIFF
--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -377,7 +377,7 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
 
     output = run_routes_command([ "--unused" ])
 
-    assert_equal(output, "No unused routes found.\n")
+    assert_includes(output, "No unused routes found.")
   end
 
   private

--- a/railties/test/commands/unused_routes_test.rb
+++ b/railties/test/commands/unused_routes_test.rb
@@ -15,9 +15,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command
-      No unused routes found.
-    OUTPUT
+    assert_includes run_unused_routes_command, "No unused routes found."
   end
 
   test "no controller" do
@@ -27,7 +25,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes run_unused_routes_command(allow_failure: true), <<~OUTPUT
       Found 1 unused route:
 
         Prefix Verb URI Pattern Controller#Action
@@ -47,7 +45,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes run_unused_routes_command(allow_failure: true), <<~OUTPUT
       Found 1 unused route:
 
         Prefix Verb URI Pattern Controller#Action
@@ -71,9 +69,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command
-      No unused routes found.
-    OUTPUT
+    assert_includes run_unused_routes_command, "No unused routes found."
   end
 
   test "multiple unused routes" do
@@ -84,7 +80,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(allow_failure: true)
+    assert_includes run_unused_routes_command(allow_failure: true), <<~OUTPUT
       Found 2 unused routes:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -101,7 +97,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(["-g", "one"], allow_failure: true)
+    assert_includes run_unused_routes_command(["-g", "one"], allow_failure: true), <<~OUTPUT
       Found 1 unused route:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -115,7 +111,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(["-g", "one"])
+    assert_includes run_unused_routes_command(["-g", "one"]), <<~OUTPUT
       No unused routes found for this grep pattern.
     OUTPUT
   end
@@ -128,7 +124,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(["-c", "posts"], allow_failure: true)
+    assert_includes run_unused_routes_command(["-c", "posts"], allow_failure: true), <<~OUTPUT
       Found 1 unused route:
 
       Prefix Verb URI Pattern    Controller#Action
@@ -142,7 +138,7 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
       end
     RUBY
 
-    assert_includes <<~OUTPUT, run_unused_routes_command(["-c", "posts"])
+    assert_includes run_unused_routes_command(["-c", "posts"]), <<~OUTPUT
       No unused routes found for this controller.
     OUTPUT
   end


### PR DESCRIPTION
### Motivation / Background

I accidentally mixed up the order for the params for the method `assert_includes` 😅.

Follow up to https://github.com/rails/rails/pull/47274

Build failure from that PR https://buildkite.com/rails/rails/builds/93477#01862746-f8b8-422f-bc8b-708acbb1d052/1401-1409

To repro:

```
cd railties
RACK="~> 3" bin/test test/commands/unused_routes_test.rb -w
RACK="~> 3" bin/test test/commands/routes_test.rb-w
```

Sorry about that, cc/ @eileencodes 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
