### PR TITLE
Add configuration to use string enum as default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Allow setting string as the default database mapping strategy for enums.
+
+    By default enum is mapped to database as integer, this change introduces
+    a new configuration variable that makes possible to use string
+    as the default mapping strategy.
+
+    ```ruby
+    config.active_record.use_string_database_mapping_for_enum = true
+    ```
+
+    ```ruby
+    # Before
+    enum status: { proposed: "proposed", written: "written", published: "published" }
+
+    # After
+    enum status: [:proposed, :written, :published]
+    ```
+
+    *Lázaro Nixon*
+
 *   `ActiveRecord::QueryLogs` better handle broken encoding.
 
     It's not uncommon when building queries with BLOB fields to contain

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -311,6 +311,9 @@ module ActiveRecord
   singleton_class.attr_accessor :before_committed_on_all_records
   self.before_committed_on_all_records = false
 
+  singleton_class.attr_accessor :use_string_database_mapping_for_enum
+  self.use_string_database_mapping_for_enum = false
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -222,7 +222,7 @@ module ActiveRecord
             suffix == true ? "_#{name}" : "_#{suffix}"
           end
 
-          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+          pairs = values.respond_to?(:each_pair) ? values.each_pair : default_pairs(name, values)
           pairs.each do |label, value|
             enum_values[label] = value
             label = label.to_s
@@ -271,6 +271,14 @@ module ActiveRecord
               # scope :not_active, -> { where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
               klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+            end
+          end
+
+          def default_pairs(name, values)
+            if ActiveRecord.use_string_database_mapping_for_enum
+              values.index_with { |v| v.to_s }.each_pair
+            else
+              values.each_with_index
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1031,4 +1031,19 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { instance.proposed? }
     assert_raises(NoMethodError) { instance.proposed! }
   end
+
+  test "string database mapping for enum configuration" do
+    original_value = ActiveRecord.use_string_database_mapping_for_enum
+    ActiveRecord.use_string_database_mapping_for_enum = true
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :cover, [:hard, :soft]
+    end
+
+    book = klass.create(cover: :soft)
+    assert_equal "soft", book.cover
+  ensure
+    ActiveRecord.use_string_database_mapping_for_enum = original_value
+  end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1065,6 +1065,10 @@ Controls the format of the timestamp value in the cache key. Default is `:usec`.
 
 Is a boolean value which controls whether or not timestamping of `create` and `update` operations on a model occur. The default value is `true`.
 
+#### `config.active_record.use_string_database_mapping_for_enum`
+
+Allow setting string as the default database mapping strategy for enums. The default value is `false`.
+
 #### `config.active_record.partial_inserts`
 
 Is a boolean value and controls whether or not partial writes are used when creating new records (i.e. whether inserts only set attributes that are different from the default).


### PR DESCRIPTION
This PR introduces a new configuration variable that allows setting string as the default strategy to enum attributes. Many people argue that string enums are more readable and easier to maintain.

```ruby
config.active_record.use_string_database_mapping_for_enum = true
```

```ruby
# Before
enum status: { proposed: "proposed", written: "written", published: "published" }

# After
enum status: [:proposed, :written, :published]
```

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
