### PR TITLE
[ci skip] Fix "Note:" to "NOTE:"

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -78,7 +78,7 @@ or add rich text field while creating a new model using:
 bin/rails generate model Message content:rich_text
 ```
 
-**Note:** you don't need to add a `content` field to your `messages` table.
+NOTE: you don't need to add a `content` field to your `messages` table.
 
 Then use [`rich_text_area`] to refer to this field in the form for the model:
 

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -578,7 +578,7 @@ initializers (like building the middleware stack) are run last. The `railtie`
 initializers are the initializers which have been defined on the `Rails::Application`
 itself and are run between the `bootstrap` and `finishers`.
 
-*Note:* Do not confuse Railtie initializers overall with the [load_config_initializers](configuring.html#using-initializer-files)
+NOTE: Do not confuse Railtie initializers overall with the [load_config_initializers](configuring.html#using-initializer-files)
 initializer instance or its associated config initializers in `config/initializers`.
 
 After this is done we go back to `Rack::Server`.


### PR DESCRIPTION
### Motivation / Background

ref: https://github.com/rails/rails/pull/47271

This Pull Request has been created because I'd like to fix some more "NOTE: " notation for consistency.


### Detail

This Pull Request changes "Note:" with some asterisk `*` to "NOTE:"

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
