### PR TITLE
Backport #44967: Improve upgrade guide section on cookies rotator

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -203,22 +203,27 @@ encrypted cookies.
 In order to be able to read messages using the old digest class it is necessary
 to register a rotator.
 
-The following is an example for rotator for the encrypted cookies.
+The following is an example for rotator for the encrypted and the signed cookies.
 
 ```ruby
 # config/initializers/cookie_rotator.rb
 Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-    salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
+    authenticated_encrypted_cookie_salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
+    signed_cookie_salt = Rails.application.config.action_dispatch.signed_cookie_salt
+
     secret_key_base = Rails.application.secret_key_base
 
     key_generator = ActiveSupport::KeyGenerator.new(
       secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
     )
     key_len = ActiveSupport::MessageEncryptor.key_len
-    secret = key_generator.generate_key(salt, key_len)
 
-    cookies.rotate :encrypted, secret
+    old_encrypted_secret = key_generator.generate_key(authenticated_encrypted_cookie_salt, key_len)
+    old_signed_secret = key_generator.generate_key(signed_cookie_salt)
+
+    cookies.rotate :encrypted, old_encrypted_secret
+    cookies.rotate :signed, old_signed_secret
   end
 end
 ```


### PR DESCRIPTION
#44967

I was surprised that this information isn't part of the current stable upgrade guide. Rails 7.1 is more imminent than at the time the PR was originally made, but I believe this still makes sense to do now.