### PR TITLE
Remove unparsed :method: directive

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -36,7 +36,6 @@ module ActiveModel
 
     module ClassMethods
       ##
-      # :method: attribute
       # :call-seq: attribute(name, cast_type = nil, default: nil, **options)
       #
       # Defines a model attribute. In addition to the attribute name, a cast


### PR DESCRIPTION
RDoc doesn't parse this directive since the method is defined below. It's only useful for metaprogrammed methods.

https://github.com/ruby/rdoc/blob/v6.5.0/lib/rdoc/parser/ruby.rb#L138-L139

Before:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/3535/217260291-6f38af46-71cc-41c3-ab8f-749945a3d80e.png">

After:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/3535/217260439-39820c92-cb79-40fd-921e-a6e87b20d247.png">
