### PR TITLE
Exception is raised when using dependent: :restrict_with_error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveRecord::RecordNotDestroyed` is no longer raised when using `dependent: :restrict_with_error`.
+
+    When the destruction of a record is prevented because one of its association's
+    destruction is itself prevented by a `dependent: :restrict_with_error`, an error
+    is added to the initial record begin targeted for destruction instead of raising
+    an `ActiveRecord::RecordNotDestroyed` error.
+
+    *Younes Serraj*
+
 *   Allow composite primary key to be derived from schema
 
     Booting an application with a schema that contains composite primary keys

--- a/activerecord/test/models/answer.rb
+++ b/activerecord/test/models/answer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Answer < ActiveRecord::Base
+  belongs_to :choice
+end

--- a/activerecord/test/models/choice.rb
+++ b/activerecord/test/models/choice.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Choice < ActiveRecord::Base
+  belongs_to :question
+end
+
+class ChoiceWithErrorRestriction < Choice
+  has_many :answers,
+           foreign_key: :choice_id,
+           dependent: :restrict_with_error
+end
+
+class ChoiceWithExceptionRestriction < Choice
+  has_many :answers,
+           foreign_key: :choice_id,
+           dependent: :restrict_with_exception
+end

--- a/activerecord/test/models/question.rb
+++ b/activerecord/test/models/question.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Question < ActiveRecord::Base
+  has_many :choice_with_error_restrictions,
+           dependent: :destroy
+  has_many :choice_with_exception_restrictions,
+           dependent: :destroy
+
+  accepts_nested_attributes_for :choice_with_error_restrictions,
+                                :choice_with_exception_restrictions,
+                                allow_destroy: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1416,6 +1416,21 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
+
+  create_table :questions, force: :true do |t|
+    t.string :title
+    t.timestamps null: true
+  end
+
+  create_table :choices, force: :true do |t|
+    t.integer :question_id, null: false
+    t.timestamps null: true
+  end
+
+  create_table :answers, force: :true do |t|
+    t.integer :choice_id, null: false
+    t.timestamps null: true
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is a behavior in ActiveRecord that does not seem logical IMO. `dependent: :restrict_with_error` promises that failures will be handled using errors, not exceptions, but `ActiveRecord::RecordNotDestroyed` is raised.

### Detail

I wrote a test to reproduce the behavior. I am more than willing to propose a patch if the maintainers consider it to be a bug, however I'd be grateful for any guidance as ActiveRecord's source code is a bit overwhelming at first.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
