### PR TITLE
Fix envelope provider DEK decrypting after previous scheme

### DIFF
--- a/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/envelope_encryption_key_provider.rb
@@ -39,6 +39,9 @@ module ActiveRecord
 
         def decrypt_data_key(encrypted_message)
           encrypted_data_key = encrypted_message.headers.encrypted_data_key
+
+          raise Errors::Decryption if encrypted_data_key.nil?
+
           key = primary_key_provider.decryption_keys(encrypted_message)&.collect(&:secret)
           ActiveRecord::Encryption.cipher.decrypt encrypted_data_key, key: key if key
         end

--- a/activerecord/test/models/author_encrypted.rb
+++ b/activerecord/test/models/author_encrypted.rb
@@ -14,3 +14,11 @@ class EncryptedAuthorWithKey < Author
 
   encrypts :name, key: "some secret key!"
 end
+
+class EnvelopeEncryptedAuthor < Author
+  self.table_name = "authors"
+
+  encrypts :name,
+           key_provider: ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider.new,
+           previous: { key: "some secret key!" }
+end


### PR DESCRIPTION
DEK decrypting was failing if you tried to decrypt ciphertext which was previously encrypted with a different scheme without using envelope/DEK approach at all

### Detail

If your data is encrypted with non-envelope provider (for example with `DerivedSecretKeyProvider`) and now you want to change it to `EnvelopeEncryptionKeyProvider` using _previous scheme approach_:
  ```
    encrypts :phone, key_provider: ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider.new,
                     previous: { key_provider: ActiveRecord::Encryption.key_provider }
  ```

you won't succeed because `EnvelopeEncryptionKeyProvider` expects DEK to be always present and decryption fails because of that:
```
NoMethodError: undefined method `payload' for nil:NilClass

          encrypted_data = encrypted_message.payload
                                            ^^^^^^^^
from ... activerecord-7.0.3.1/lib/active_record/encryption/cipher/aes256_gcm.rb:57:in `decrypt'
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
