### PR TITLE
[Rails7] Old ruby syntax with index_exists? causing migrations to fail with ruby-3.x

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -662,8 +662,8 @@ module ActiveRecord
       #  end
       #
       # See {connection.index_exists?}[rdoc-ref:SchemaStatements#index_exists?]
-      def index_exists?(column_name, options = {})
-        @base.index_exists?(name, column_name, options)
+      def index_exists?(column_name, **options)
+        @base.index_exists?(name, column_name, **options)
       end
 
       # Renames the given index on the table.

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -188,7 +188,7 @@ module ActiveRecord
 
       def test_index_exists
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
+          @connection.expect :index_exists?, nil, [:delete_me, :bar]
           t.index_exists?(:bar)
         end
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the Rails6/7 migration failing at index_exists? due to the old ruby syntax with Rails 6.1 & 7.0.
https://github.com/rails/rails/blob/v7.0.4.2/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L664-L666
Below is an example of migration :
```
class TestMigrationWithIndex < ActiveRecord::Migration[6.0]

  def up
    change_table :test_table do |t|
      t.index [:name, :category_type], name: :index_account_categories_ref unless t.index_exists? :index_account_categories_ref
    end

end
```
For more details please refer https://github.com/rails/rails/issues/47291

### Detail

We have observed that the column method `index_exists?` is throwing an error due to old ruby syntax. More details can be found [here](https://github.com/rails/rails/issues/47291).

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
