### PR TITLE
use filtered_path in action_controller event payloads instead of fullpath

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Change `ActionController::Instrumentation` to pass `filtered_path` instead of `fullpath` in the event payload to filter sensitive query params
+
+    ```ruby
+    get "/posts?password=test"
+    request.full_path         # => "/posts?password=test"
+    response.filtered_path    # => "/posts?password=[FILTERED]"
+    ```
+
+    *Ritikesh G*
+
 *   Deprecate `AbstractController::Helpers::MissingHelperError`
 
     *Hartley McGuire*

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -63,7 +63,7 @@ module ActionController
           headers: request.headers,
           format: request.format.ref,
           method: request.request_method,
-          path: request.fullpath
+          path: request.filtered_path
         }
 
         ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload)

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -194,6 +194,13 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_match(/Completed 200 OK in \d+ms/, logs[1])
   end
 
+  def test_process_action_with_path
+    @request.env["action_dispatch.parameter_filter"] = [:password]
+    get :show, params: { password: "test" }
+    wait
+    assert_match(/\/show\?password=\[FILTERED\]/, @controller.last_payload[:path])
+  end
+
   def test_process_action_with_throw
     catch(:halt) do
       get :with_throw


### PR DESCRIPTION
### Motivation / Background

For applications relying on the event payload from action_controller's instrumentation for custom logging, the `params` are filtered, however, the path isn't filtered.

Before - 
```
> event.payload[:path]
> "/resource?hello=1&password=notsosecure"
```
After - 
```
> event.payload[:path]
> "/resource?hello=1&password=[FILTERED]"`
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
