### PR TITLE
Add config.form_with_generates_local_forms

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -474,7 +474,7 @@ module ActionView
       end
       private :apply_form_for_options!
 
-      mattr_accessor :form_with_generates_remote_forms, default: true
+      mattr_accessor :form_with_generates_local_forms, default: false
 
       mattr_accessor :form_with_generates_ids, default: false
 
@@ -619,12 +619,8 @@ module ActionView
       #   When set to <tt>true</tt>, the form is submitted via standard HTTP.
       #   When set to <tt>false</tt>, the form is submitted as a "remote form", which
       #   is handled by Rails UJS as an XHR. When unspecified, the behavior is derived
-      #   from <tt>config.action_view.form_with_generates_remote_forms</tt> where the
-      #   config's value is actually the inverse of what <tt>local</tt>'s value would be.
-      #   As of Rails 6.1, that configuration option defaults to <tt>false</tt>
-      #   (which has the equivalent effect of passing <tt>local: true</tt>).
-      #   In previous versions of Rails, that configuration option defaults to
-      #   <tt>true</tt> (the equivalent of passing <tt>local: false</tt>).
+      #   from <tt>config.action_view.form_with_generates_local_forms</tt> where the
+      #   default is <tt>true</tt>.
       # * <tt>:skip_enforcing_utf8</tt> - If set to true, a hidden input with name
       #   utf8 is not output.
       # * <tt>:builder</tt> - Override the object used to build the form.
@@ -1585,7 +1581,7 @@ module ActionView
       end
 
       private
-        def html_options_for_form_with(url_for_options = nil, model = nil, html: {}, local: !form_with_generates_remote_forms,
+        def html_options_for_form_with(url_for_options = nil, model = nil, html: {}, local: generate_local_forms,
           skip_enforcing_utf8: nil, **options)
           html_options = options.slice(:id, :class, :multipart, :method, :data, :authenticity_token).merge!(html)
           html_options[:remote] = html.delete(:remote) || !local
@@ -1617,6 +1613,10 @@ module ActionView
         def default_form_builder_class
           builder = default_form_builder || ActionView::Base.default_form_builder
           builder.respond_to?(:constantize) ? builder.constantize : builder
+        end
+
+        def generate_local_forms
+          form_with_generates_local_forms
         end
     end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -23,8 +23,10 @@ module ActionView
     end
 
     config.after_initialize do |app|
-      form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
-      ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
+      app.config.action_view.delete(:form_with_generates_remote_forms)
+
+      form_with_generates_local_forms = app.config.action_view.delete(:form_with_generates_local_forms)
+      ActionView::Helpers::FormHelper.form_with_generates_local_forms = form_with_generates_local_forms
     end
 
     config.after_initialize do |app|
@@ -68,7 +70,14 @@ module ActionView
     config.after_initialize do |app|
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
-          send "#{k}=", v
+          if k == "form_with_generates_remote_forms"
+            ActionView.deprecator.warn(<<-MSG.squish)
+              config.action_view.form_with_generates_remote_forms is deprecated and will be removed in Rails 7.2.
+              It no longer has any effect and should be replaced with config.action_view.form_with_generates_local_forms instead.
+            MSG
+          else
+            send "#{k}=", v
+          end
         end
       end
     end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -883,9 +883,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_is_not_remote_by_default_if_form_with_generates_remote_forms_is_false
-    old_value = ActionView::Helpers::FormHelper.form_with_generates_remote_forms
-    ActionView::Helpers::FormHelper.form_with_generates_remote_forms = false
+  def test_form_is_not_remote_by_default_if_form_with_generates_local_forms_is_true
+    old_value = ActionView::Helpers::FormHelper.form_with_generates_local_forms
+    ActionView::Helpers::FormHelper.form_with_generates_local_forms = true
 
     form_with(model: @post, url: "/", id: "create-post", method: :patch) do |f|
       concat f.text_field(:title)
@@ -902,7 +902,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     assert_dom_equal expected, @rendered
   ensure
-    ActionView::Helpers::FormHelper.form_with_generates_remote_forms = old_value
+    ActionView::Helpers::FormHelper.form_with_generates_local_forms = old_value
   end
 
   def test_form_with_skip_enforcing_utf8_true

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -109,7 +109,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_mailbox.queues.incineration`](#config-action-mailbox-queues-incineration): `nil`
 - [`config.action_mailbox.queues.routing`](#config-action-mailbox-queues-routing): `nil`
 - [`config.action_mailer.deliver_later_queue_name`](#config-action-mailer-deliver-later-queue-name): `nil`
-- [`config.action_view.form_with_generates_remote_forms`](#config-action-view-form-with-generates-remote-forms): `false`
+- [`config.action_view.form_with_generates_local_forms`](#config-action-view-form-with-generates-local-forms): `true`
 - [`config.action_view.preload_links_header`](#config-action-view-preload-links-header): `true`
 - [`config.active_job.retry_jitter`](#config-active-job-retry-jitter): `0.15`
 - [`config.active_record.has_many_inversing`](#config-active-record-has-many-inversing): `true`
@@ -137,7 +137,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 5.1
 
-- [`config.action_view.form_with_generates_remote_forms`](#config-action-view-form-with-generates-remote-forms): `true`
+- [`config.action_view.form_with_generates_local_forms`](#config-action-view-form-with-generates-local-forms): `false`
 - [`config.assets.unknown_asset_fallback`](#config-assets-unknown-asset-fallback): `false`
 
 #### Default Values for Target Version 5.0
@@ -1882,16 +1882,16 @@ defaults to `true`.
 
 Determines whether to wrap the missing translations key in a `<span>` tag or not. This defaults to `true`.
 
-#### `config.action_view.form_with_generates_remote_forms`
+#### `config.action_view.form_with_generates_local_forms`
 
-Determines whether `form_with` generates remote forms or not.
+Determines whether `form_with` generates local forms or not.
 
 The default value depends on the `config.load_defaults` target version:
 
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
-| 5.1                   | `true`               |
-| 6.1                   | `false`              |
+| 5.1                   | `false`              |
+| 6.1                   | `true`               |
 
 #### `config.action_view.form_with_generates_ids`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -126,7 +126,7 @@ module Rails
           end
 
           if respond_to?(:action_view)
-            action_view.form_with_generates_remote_forms = true
+            action_view.form_with_generates_local_forms = false
           end
         when "5.2"
           load_defaults "5.1"
@@ -191,7 +191,7 @@ module Rails
           end
 
           if respond_to?(:action_view)
-            action_view.form_with_generates_remote_forms = false
+            action_view.form_with_generates_local_forms = true
             action_view.preload_links_header = true
           end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1039,9 +1039,9 @@ module ApplicationTests
       assert_match(/id=('|")post_name('|")/, last_response.body)
     end
 
-    test "form_with can be configured with form_with_generates_remote_forms" do
+    test "form_with can be configured with form_with_generates_local_forms" do
       app_file "config/initializers/form_builder.rb", <<-RUBY
-      Rails.configuration.action_view.form_with_generates_remote_forms = true
+      Rails.configuration.action_view.form_with_generates_local_forms = false
       RUBY
 
       app_file "app/models/post.rb", <<-RUBY


### PR DESCRIPTION
Deprecates config.form_with_generates_remote_forms

cc #41276

The idea is that `form_with_generates_remote_forms` is confusing, and to introduce a new config option to avoid having to understand the inverse logic.
