### PR TITLE
RDoc should go next to the declared module

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# When proxying through a load balancer that terminates SSL, the forwarded request will appear
-# as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
-# security target HTTP instead of HTTPS. This middleware makes the server assume that the
-# proxy already terminated SSL, and that the request really is HTTPS.
 module ActionDispatch
+  # When proxying through a load balancer that terminates SSL, the forwarded request will appear
+  # as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
+  # security target HTTP instead of HTTPS. This middleware makes the server assume that the
+  # proxy already terminated SSL, and that the request really is HTTPS.
   class AssumeSSL
     def initialize(app)
       @app = app


### PR DESCRIPTION
This accidentally documents `ActionDispatch` here:
https://edgeapi.rubyonrails.org/classes/ActionDispatch.html

Moving this should fix it under the `AssumeSSL` class.