### PR TITLE
Follow up to HTTP::Request#route_uri_pattern

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -146,7 +146,7 @@ module ActionDispatch
     end
 
     # Returns the URI pattern of the matched route for the request,
-    # using the same format as `bin/rails routes`:
+    # using the same format as <tt>bin/rails routes</tt>:
     #
     #   request.route_uri_pattern # => "/:controller(/:action(/:id))(.:format)"
     def route_uri_pattern

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -360,6 +360,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       "/:controller(/:action(/:id))(.:format)",
       controller.request.route_uri_pattern
     )
+
+    assert_equal(
+      "/:controller(/:action(/:id))(.:format)",
+      controller.request.get_header("action_dispatch.route_uri_pattern")
+    )
   end
 
   def test_route_with_colon_first


### PR DESCRIPTION
My goal is to add some more coverage for #47129.

Also, spotted a tiny RDoc style bug in f38c21b.

Even though `route_uri_pattern=` is private, I thought we should add a test for it?
I'm still thinking about how to test it.