### PR TITLE
:nail_care: use ENV.fetch(name, default) form

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -70,7 +70,7 @@ Rails.application.configure do
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). Use "debug"
   # for everything.
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Follow up to #47143, prefers the `ENV.fetch(name, default)` form instead of block form.

Block form is only useful if we want to yield the name, I think.

[[ref](https://docs.ruby-lang.org/en/master/ENV.html#method-c-fetch)]