### PR TITLE
Use infinitive form for all task descriptions verbs

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -40,9 +40,9 @@ module Rails
 
       desc "diff", "Enroll/disenroll in decrypted diffs of credentials using git"
       option :enroll, type: :boolean, default: false,
-        desc: "Enrolls project in credentials file diffing with `git diff`"
+        desc: "Enroll project in credentials file diffing with `git diff`"
       option :disenroll, type: :boolean, default: false,
-        desc: "Disenrolls project from credentials file diffing"
+        desc: "Disenroll project from credentials file diffing"
       def diff(content_path = nil)
         if @content_path = content_path
           self.environment = extract_environment_from_path(content_path)

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -86,7 +86,7 @@ module Rails
       class_option :header, type: :boolean
 
       class_option :database, aliases: "--db", type: :string,
-        desc: "Specifies the database to use."
+        desc: "Specify the database to use."
 
       desc "dbconsole", "Start a console for the database specified in config/database.yml"
       def perform

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -103,22 +103,22 @@ module Rails
       DEFAULT_PIDFILE = "tmp/pids/server.pid"
 
       class_option :port, aliases: "-p", type: :numeric,
-        desc: "Runs Rails on the specified port - defaults to 3000.", banner: :port
+        desc: "Run Rails on the specified port - defaults to 3000.", banner: :port
       class_option :binding, aliases: "-b", type: :string,
-        desc: "Binds Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
+        desc: "Bind Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
         banner: :IP
       class_option :config, aliases: "-c", type: :string, default: "config.ru",
-        desc: "Uses a custom rackup configuration.", banner: :file
+        desc: "Use a custom rackup configuration.", banner: :file
       class_option :daemon, aliases: "-d", type: :boolean, default: false,
-        desc: "Runs server as a Daemon."
+        desc: "Run server as a Daemon."
       class_option :using, aliases: "-u", type: :string,
-        desc: "Specifies the Rack server used to run the application (thin/puma/webrick).", banner: :name
+        desc: "Specify the Rack server used to run the application (thin/puma/webrick).", banner: :name
       class_option :pid, aliases: "-P", type: :string,
-        desc: "Specifies the PID file - defaults to #{DEFAULT_PIDFILE}."
+        desc: "Specify the PID file - defaults to #{DEFAULT_PIDFILE}."
       class_option :dev_caching, aliases: "-C", type: :boolean, default: nil,
-        desc: "Specifies whether to perform caching in development."
+        desc: "Specify whether to perform caching in development."
       class_option :restart, type: :boolean, default: nil, hide: true
-      class_option :early_hints, type: :boolean, default: nil, desc: "Enables HTTP/2 early hints."
+      class_option :early_hints, type: :boolean, default: nil, desc: "Enable HTTP/2 early hints."
       class_option :log_to_stdout, type: :boolean, default: nil, optional: true,
         desc: "Whether to log to stdout. Enabled by default in development when not daemonized."
 

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -13,7 +13,7 @@ module Rails
       class_option :orm, banner: "NAME", type: :string, required: true,
                          desc: "ORM to generate the controller for"
       class_option :api, type: :boolean,
-                         desc: "Generates API controller"
+                         desc: "Generate API controller"
 
       class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
 

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -11,7 +11,7 @@ module TestUnit # :nodoc:
       check_class_collision suffix: "ControllerTest"
 
       class_option :api, type: :boolean,
-                         desc: "Generates API functional tests"
+                         desc: "Generate API functional tests"
 
       class_option :system_tests, type: :string,
                          desc: "Skip system test files"


### PR DESCRIPTION
### Motivation / Background

The previous pull request changed to infinitive form.
The infinitive form has used some commands.
So fixed it in this pull request.

#### previous pull request

> All the common rails commands and some extended commands use the infinitive form for the verb in the description:
"Generate ...", "Start ...", "Run ...", instead of "Generates ...", "Starts ...", "Runs ...".
This changes the remaining tasks to use the infinitive form for the verb as well, for consistency.

https://github.com/rails/rails/pull/47215

#### before
```sh
$ git grep "desc: \S*s "
railties/lib/rails/commands/credentials/credentials_command.rb:        desc: "Enrolls project in credentials file diffing with `git diff`"
railties/lib/rails/commands/credentials/credentials_command.rb:        desc: "Disenrolls project from credentials file diffing"
railties/lib/rails/commands/dbconsole/dbconsole_command.rb:        desc: "Specifies the database to use."
railties/lib/rails/commands/server/server_command.rb:        desc: "Runs Rails on the specified port - defaults to 3000.", banner: :port
railties/lib/rails/commands/server/server_command.rb:        desc: "Binds Rails to the specified IP - defaults to 'localhost' in development and '0.0.0.0' in other environments'.",
railties/lib/rails/commands/server/server_command.rb:        desc: "Uses a custom rackup configuration.", banner: :file
railties/lib/rails/commands/server/server_command.rb:        desc: "Runs server as a Daemon."
railties/lib/rails/commands/server/server_command.rb:        desc: "Specifies the Rack server used to run the application (thin/puma/webrick).", banner: :name
railties/lib/rails/commands/server/server_command.rb:        desc: "Specifies the PID file - defaults to #{DEFAULT_PIDFILE}."
railties/lib/rails/commands/server/server_command.rb:        desc: "Specifies whether to perform caching in development."
railties/lib/rails/commands/server/server_command.rb:      class_option :early_hints, type: :boolean, default: nil, desc: "Enables HTTP/2 early hints."
railties/lib/rails/generators/rails/resource/resource_generator.rb:                             desc: "Actions for the resource controller"
railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb:                         desc: "Generates API controller"
railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb:                         desc: "Generates API functional tests"
```

#### after

```sh
$ git grep "desc: \S*s "
NONE
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
