### PR TITLE
Fix regression in ActionDispatch::Routing::RouteSet#recognize_path

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -884,7 +884,7 @@ module ActionDispatch
 
       def recognize_path(path, environment = {})
         method = (environment[:method] || "GET").to_s.upcase
-        path = Journey::Router::Utils.normalize_path(path) unless path.include?("://")
+        path = Journey::Router::Utils.normalize_path(path) unless path&.include?("://")
         extras = environment[:extras] || {}
 
         begin

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2129,6 +2129,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     assert_equal({ controller: "geocode", action: "show", postalcode: "12345" }, @routes.recognize_path("/extended/geocode/12345"))
 
     assert_equal({ controller: "news", action: "index" }, @routes.recognize_path("/", method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(nil))
     assert_equal({ controller: "news", action: "index", format: "rss" }, @routes.recognize_path("/news.rss", method: :get))
 
     assert_raise(ActionController::RoutingError) { @routes.recognize_path("/none", method: :get) }


### PR DESCRIPTION
### Motivation / Background

#47262 includes a subtle change to `ActionDispatch::Routing::RouteSet#recognize_path`: If given `nil`, it will now fail like

```
NoMethodError: undefined method `include?' for nil:NilClass
    /workspaces/rails/actionpack/lib/action_dispatch/routing/route_set.rb:887:in `recognize_path'
```

instead of providing the root path.

### Detail

This Pull Request brings back the previous behaviour, so that `recognize_path(nil)` gives the root path.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
