### PR TITLE
move directory existence check for code statistics task inside of the…

### DIFF
--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -26,12 +26,13 @@ STATS_DIRECTORIES ||= [
   %w(Channel\ tests     test/channels),
   %w(Integration\ tests test/integration),
   %w(System\ tests      test/system),
-].collect do |name, dir|
-  [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
-end.select { |name, dir| File.directory?(dir) }
+]
 
 desc "Report code statistics (KLOCs, etc) from the application or engine"
 task :stats do
   require "rails/code_statistics"
-  CodeStatistics.new(*STATS_DIRECTORIES).to_s
+  stat_directories = STATS_DIRECTORIES.collect do |name, dir|
+    [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
+  end.select { |name, dir| File.directory?(dir) }
+  CodeStatistics.new(*stat_directories).to_s
 end

--- a/railties/test/commands/statistics_test.rb
+++ b/railties/test/commands/statistics_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::DevTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  test "`bin/rails stats` handles non-existing directories added by third parties" do
+    Dir.chdir(app_path) do
+      app_file("lib/tasks/custom.rake", <<~CODE
+        task stats: "custom:statsetup"
+        namespace :custom do
+          task statsetup: :environment do
+            require "rails/code_statistics"
+            ::STATS_DIRECTORIES << ["app/non_existing"]
+          end
+        end
+      CODE
+      )
+      assert rails "stats"
+    end
+  end
+end


### PR DESCRIPTION
… task

otherwise, if a gem appends to the constant, we can end up with an error.
Such an example is the `view_component` gem:  
https://github.com/ViewComponent/view_component/blob/main/lib/view_component/rails/tasks/view_component.rake#L3

It is a dependency of one of my dependencies, so I don't have the `app/components` directory inside my app, and when running `rails stats`, it fails due to that:

```
rails stats                  
rails aborted!
Errno::ENOENT: No such file or directory @ dir_initialize - app/components

Tasks: TOP => stats
(See full trace by running task with --trace)
```
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
