### PR TITLE
PoC: Cache Extended Collection Proxies

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -30,9 +30,6 @@ module ActiveRecord
       def initialize(klass, association, **) # :nodoc:
         @association = association
         super klass
-
-        extensions = association.extensions
-        extend(*extensions) if extensions.any?
       end
 
       def target

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -10,6 +10,12 @@ module ActiveRecord
         @relation_delegate_cache[klass]
       end
 
+      def relation_extended_class(klass, extensions)
+        @relation_delegate_cache[[klass, extensions]] ||= begin
+          Class.new(@relation_delegate_cache[klass]).include(*extensions)
+        end
+      end
+
       def initialize_relation_delegate_cache
         @relation_delegate_cache = cache = {}
         [
@@ -115,13 +121,12 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       def create(klass, *args, **kwargs)
-        relation_class_for(klass).new(klass, *args, **kwargs)
+        klass.relation_delegate_class(self).new(klass, *args, **kwargs)
       end
 
-      private
-        def relation_class_for(klass)
-          klass.relation_delegate_class(self)
-        end
+      def create_extended_class(klass, extensions, *args, **kwargs)
+        klass.relation_extended_class(self, extensions).new(klass, *args, **kwargs)
+      end
     end
 
     private


### PR DESCRIPTION
### Problem

If you use `Relation#extending` or `has_many extend:`, the provided modules are extended onto the proxy instance.

This means that every single instance has a different class and this is terrible for many reasons.

First it will make method caches for the extended methods miss every time.

Second, the method cache will hold onto the singleton_class making the instance immortal until the method is called again (Ref: https://bugs.ruby-lang.org/issues/19436), e.g.

```ruby
obj = Object.new
module Foo
  def bar
  end
end

obj.extend(Foo)

def call_bar(obj)
  # Here MRI keeps a call cache that holds
  # onto `obj.singleton_class` and `obj`.
  # It won't be cleared until that method is
  # called again with another `obj` instance.
  obj.bar
end
call_bar(obj)

obj = nil
```

The above means that any extended method on a CollectionProxy may cause that collection to no longer be garbage collectable.

At best another collection will replace it on a future call.

Because of this, Rails applications using `extend:` or `extending` can end up with large amount of Active Record data sticking around for a long time.

In this PR I tried to use (and re-use) anonymous classes instead to avoid this problem, however the test suite shows that we expect associations to be serializable.

`Marshal`, quite surprisingly, is able to serialize extended objects just fine. However, less surprisingly, it can't serialize an instance of an anonymous class...

It's unclear to me what a solution could be here, at least not without the existing API. Which begs the question of wether we really want this very late bound API, or if we wouldn't be better of with a more "static" API that would require to define your extensions when the model is defined so that we can include them in a named class.

cc @rafaelfranca @tenderlove @jhawthorn I wonder if any of you have any thoughts about this.