### PR TITLE
`token_list`: Guard Stimulus' `data-action` from multiple escapes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Guard `token_list` calls from escaping HTML too often
+
+    *Sean Doyle*
+
 *   `select` can now be called with a single hash containing options and some HTML options
 
     Previously this would not work as expected:

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -363,7 +363,7 @@ module ActionView
       #   token_list(nil, false, 123, "", "foo", { bar: true })
       #    # => "123 foo bar"
       def token_list(*args)
-        tokens = build_tag_values(*args).flat_map { |value| value.to_s.split(/\s+/) }.uniq
+        tokens = build_tag_values(*args).flat_map { |value| CGI.unescape_html(value.to_s).split(/\s+/) }.uniq
 
         safe_join(tokens, " ")
       end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -448,6 +448,29 @@ class TagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_token_list_and_class_names_returns_an_html_safe_string
+    assert_predicate token_list("a value"), :html_safe?
+    assert_predicate class_names("a value"), :html_safe?
+  end
+
+  def test_token_list_and_class_names_only_html_escape_once
+    [:token_list, :class_names].each do |helper_method|
+      helper = ->(*arguments) { public_send(helper_method, *arguments) }
+
+      tokens = %w[
+        click->controller#action1
+        click->controller#action2
+        click->controller#action3
+        click->controller#action4
+      ]
+
+      token_list = tokens.reduce(&helper)
+
+      assert_predicate token_list, :html_safe?
+      assert_equal tokens, (CGI.unescape_html(token_list)).split
+    end
+  end
+
   def test_content_tag_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       content_tag("p", "limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, chaining more than one `token_list` calls with a [data-action][] attribute value would result in one too many HTML escapes. Additional subsequent calls would compound the problem.

For example, the following calls would result in an invalid descriptor that's escaped too many times to be parsed.

```ruby
first   = "click->controller#action1"
second  = "click->controller#action2"
third   = "click->controller#action3"
fourth  = "click->controller#action4"

value = token_list(first, token_list(second, token_list(third)))

CGI.unescape_html value.to_s
 # => "click->controller#action1 click-&gt;controller#action2 click-&amp;gt;controller#action3 click-&amp;amp;gt;controller#action4"
```

### Detail

By [CGI.unescape_html][] each `String` value before passing it to [token_list][] (which re-escapes the value), we can preserve a lossless concatenation process while also preserving the HTML safety.

After this commit, the previous example works as expected:

```ruby
first   = "click->controller#action1"
second  = "click->controller#action2"
third   = "click->controller#action3"
fourth  = "click->controller#action4"

value = token_list(first, token_list(second, token_list(third)))

CGI.unescape_html value.to_s
 # => "click->controller#action1 click->controller#action2 click->controller#action3 click->controller#action4"
```

[CGI.unescape_html]: https://ruby-doc.org/stdlib-2.5.3/libdoc/cgi/rdoc/CGI/Util.html#method-i-unescape_html
[token_list]:
https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list
[data-action]: https://stimulus.hotwired.dev/reference/actions

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
