### PR TITLE
Fix state leakage between tests

### DIFF
--- a/activerecord/test/support/ddl_helper.rb
+++ b/activerecord/test/support/ddl_helper.rb
@@ -5,6 +5,6 @@ module DdlHelper
     connection.execute("CREATE TABLE #{table_name}(#{definition})")
     yield
   ensure
-    connection.execute("DROP TABLE #{table_name}")
+    connection.drop_table(table_name)
   end
 end


### PR DESCRIPTION
### Motivation / Background
Fixes https://github.com/rails/rails/issues/47203

### Detail

The issue was about a test failing when executed in a particular order as part a series of tests described as below:
```
ARCONN=postgresql bin/test test/cases/validations/uniqueness_validation_test.rb test/cases/adapters/postgresql/postgresql_adapter_test.rb -n "/^(?:UniquenessValidationTest#(?:test_validate_case_insensitive_uniqueness)|ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#(?:test_unparsed_defaults_are_at_least_set_when_saving|test_only_check_for_insensitive_comparison_capability_once))$/" --seed 21290 -v
```

This test command runs the following tests in that order:

1. UniquenessValidationTest#test_validate_case_insensitive_uniqueness
2. ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_unparsed_defaults_are_at_least_set_when_saving
3. ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_only_check_for_insensitive_comparison_capability_once

The 1st and 2nd tests passes but the last one fails.

The below assertion is where the test fails because it's expecting queries to be run when `case_insensitive_comparison` is called but no queries are executed. 
```
assert_queries :any, ignore_none: true do
  @connection.case_insensitive_comparison(attribute, "foo")
end
```

This is happening for two reasons: 
**1) Schema cache not being cleared between tests**

 The purpose of the `case_insensitive_comparison` method is to perform a case insensitive comparison for the given attribute against a value. But the method needs to know if a comparison is possible based on the column type of the attribute being compared. To find out if it is capable of doing it, it run queries against Postgres which will return a boolean result. `true` if case insensitive comparison is possible for the column type of the attribute, otherwise `false`.

However, querying the database every time the method `case_insensitive_comparison` is called is not optimal for performance. So, a prior [PR](https://github.com/rails/rails/commit/b39050e8d574b814d3580688276e933a3d08aca8) tackled this issue by introducing a local cache layer aka `@case_insensitive_cache`, so that queries to the database are only done once.

So when debugging the 3rd test, we noticed that the `case_insensitive_comparison` method was looking up the column type `integer` in the cache `@case_insensitive_cache` when it should have been looking up  `example_type` based on the table created in the test. ![first_screenshot](https://user-images.githubusercontent.com/13633237/217651038-3e29ef54-39a8-45bd-bb4a-2f96baacd36a.jpg)

We noticed that both the failing test and the second test ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_unparsed_defaults_are_at_least_set_when_saving both create a table called "ex" but with different column_types for the `number` attribute. When we skip the second test, the failing test now passes because it now looks up `example_type` in the `@case_insensitive_cache`.  We printed out the logs when debugging to see exactly what was happening behind the scenes and we saw that both tests were properly creating and dropping the tables during their lifecycle. We confirmed this by checking the postgres database. 

This led us to discover that Rails has a schema cache for performance reasons. We realized that the column_type used by the failing test was coming from the schema cache and NOT from what was defined in the table creation within the test. 
The third test (failing one) is  loading the  column_type for `number` from the schema cache populated by the table creation in the second test because both tests have the same table name e.g. "ex" and column name e.g. "number". 

To fix that, we clear the schema cache using `clear_data_source_cache!` on the table "ex". 

**2) `@case_insensitive_cache` not being cleared between tests**

The `case_insensitive_comparison` method uses a local cache between successive calls and the failing test was testing the functionality of that cache, and asserting that the queries against postgres were only performed once assuming that the cache was empty. But we found that the cache was not empty when the 3rd test executes because the 1st test also calls the `case_insensitive_comparison` method which populated the cache for column type `integer`. 
The 3rd test already passes by just clearing the schema cache. So why do we clear the `@case_insensitive_cache` again?
If another test is added that also calls the `case_insensitive_comparison` method with an attribute of the same column type e.g. `integer` or even `example_type`, then the 3rd test will fail because the cache knows about those column types. So, clearing `@case_insensitive_cache` ensures that the 3rd test will never fail the `assert_queries :any`.

You can see the cache being populated by the first test in the top section of this screenshot:
![latest](https://user-images.githubusercontent.com/13633237/217660251-59ced012-2747-4961-8c0d-6b4624e9027d.jpg)

### Additional information

- Is force clearing the schema cache the right approach? We would have expected the schema cache to be destroyed as part of the table drop 🤔 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
