### PR TITLE
Include nil when serializing ActiveModel to include a singular association that is nil

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   When serializing a record, include keys for singular associations that are nil
+
+    ```ruby
+    user.as_json(include: :phone)
+    # => {name: 'Ben Ehmke', email_address: 'ben.ehmke@email.com', phone: nil}
+    ```
+
+    *Ben Ehmke*
+
 *   Raise `NoMethodError` in `ActiveModel::Type::Value#as_json` to avoid unpredictable
     results.
 

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -140,8 +140,10 @@ module ActiveModel
       serializable_add_includes(options) do |association, records, opts|
         hash[association.to_s] = if records.respond_to?(:to_ary)
           records.to_ary.map { |a| a.serializable_hash(opts) }
-        else
+        elsif records.respond_to?(:serializable_hash)
           records.serializable_hash(opts)
+        else
+          records
         end
       end
 
@@ -189,9 +191,7 @@ module ActiveModel
         end
 
         includes.each do |association, opts|
-          if records = send(association)
-            yield association, records, opts
-          end
+          yield association, send(association), opts
         end
       end
   end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -7,7 +7,7 @@ class SerializationTest < ActiveModel::TestCase
   class User
     include ActiveModel::Serialization
 
-    attr_accessor :name, :email, :gender, :address, :friends
+    attr_accessor :name, :email, :gender, :address, :friends, :phone
 
     def initialize(name, email, gender)
       @name, @email, @gender = name, email, gender
@@ -15,7 +15,7 @@ class SerializationTest < ActiveModel::TestCase
     end
 
     def attributes
-      instance_values.except("address", "friends")
+      instance_values.except("address", "friends", "phone")
     end
 
     def method_missing(method_name, *args)
@@ -112,6 +112,11 @@ class SerializationTest < ActiveModel::TestCase
     @user.friends = []
     expected = { "email" => "david@example.com", "gender" => "male", "name" => "David", "friends" => [] }
     assert_equal expected, @user.serializable_hash(include: :friends)
+  end
+
+  def test_include_option_with_nil_association
+    expected = { "name" => "David", "gender" => "male", "email" => "david@example.com", "phone" => nil }
+    assert_equal expected, @user.serializable_hash(include: :phone)
   end
 
   class FriendList


### PR DESCRIPTION
### Motivation / Background

For my specific use case, we need to inject all the data for a record and it's sub-resources into HTML. When including a `belongs_to` or `has_one` association, if the association is nil, the key is simply not included in the data. For reasons, this is problematic because it triggers our client-side code to request that resource. It would be ideal if it knew it didn't need to make the request.

### Detail

This change allows nil values for `record.send(...)` to be included in the serialization of associations.

```ruby
 user.as_json(include: :phone)
 # => {name: 'Ben Ehmke', email_address: 'ben.ehmke@email.com', phone: nil}
```
