### PR TITLE
Use `throw` for message error handling control flow

### DIFF
--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -164,7 +164,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     end
 
     def assert_not_verified(value)
-      assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do
         @encryptor.decrypt_and_verify(value)
       end
     end

--- a/activesupport/test/message_encryptors_test.rb
+++ b/activesupport/test/message_encryptors_test.rb
@@ -48,7 +48,7 @@ class MessageEncryptorsTest < ActiveSupport::TestCase
 
     def roundtrip(message, encryptor, decryptor = encryptor)
       decryptor.decrypt_and_verify(encryptor.encrypt_and_sign(message))
-    rescue ActiveSupport::MessageVerifier::InvalidSignature
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
       nil
     end
 end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -38,6 +38,12 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_equal @data, @verifier.verify(message)
   end
 
+  def test_round_tripping_nil
+    message = @verifier.generate(nil)
+    assert_nil @verifier.verified(message)
+    assert_nil @verifier.verify(message)
+  end
+
   def test_verified_returns_false_on_invalid_message
     assert_not @verifier.verified("purejunk")
   end

--- a/activesupport/test/messages/message_encryptor_rotator_test.rb
+++ b/activesupport/test/messages/message_encryptor_rotator_test.rb
@@ -10,14 +10,6 @@ class MessageEncryptorRotatorTest < ActiveSupport::TestCase
     assert_rotate [cipher: "aes-256-gcm"], [cipher: "aes-256-cbc"]
   end
 
-  test "rotate serializer" do
-    assert_rotate [serializer: JSON], [serializer: Marshal]
-  end
-
-  test "rotate serializer when message has purpose" do
-    assert_rotate [serializer: JSON], [serializer: Marshal], purpose: "purpose"
-  end
-
   test "rotate verifier secret when using non-authenticated encryption" do
     with_authenticated_encryption(false) do
       assert_rotate \
@@ -49,7 +41,7 @@ class MessageEncryptorRotatorTest < ActiveSupport::TestCase
 
     def decode(message, encryptor, **options)
       encryptor.decrypt_and_verify(message, **options)
-    rescue ActiveSupport::MessageVerifier::InvalidSignature
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
       nil
     end
 

--- a/activesupport/test/messages/message_rotator_tests.rb
+++ b/activesupport/test/messages/message_rotator_tests.rb
@@ -18,6 +18,23 @@ module MessageRotatorTests
       assert_rotate [url_safe: true], [url_safe: false]
     end
 
+    test "rotate serializer" do
+      assert_rotate [serializer: JSON], [serializer: Marshal]
+    end
+
+    test "rotate serializer when message has purpose" do
+      assert_rotate [serializer: JSON], [serializer: Marshal], purpose: "purpose"
+    end
+
+    test "rotate serializer that raises a custom deserialization error" do
+      serializer = Class.new do
+        def self.dump(*); ""; end
+        def self.load(*); raise Class.new(StandardError); end
+      end
+
+      assert_rotate [serializer: serializer], [serializer: JSON], [serializer: Marshal]
+    end
+
     test "rotate secret and options" do
       assert_rotate [secret("new"), url_safe: true], [secret("old"), url_safe: false]
     end


### PR DESCRIPTION
There are multiple points of failure when processing a message with `MessageEncryptor` or `MessageVerifier`, and there several ways we might want to handle those failures.  For example, swallowing a failure with `MessageVerifier#verified`, or raising a specific exception with `MessageVerifier#verify`, or conditionally ignoring a failure when rotations are configured.

Prior to this commit, the _internal_ logic of handling failures was implemented using a mix of `nil` return values and raised exceptions. This commit reimplements the internal logic using `throw` and a few precisely targeted `rescue`s.  This accomplishes several things:

* Allow rotation of serializers for `MessageVerifier`.  Previously, errors from a `MessageVerifier`'s initial serializer were never rescued.  Thus, the serializer could not be rotated:

    ```ruby
    old_verifier = ActiveSupport::MessageVerifier.new("secret", serializer: Marshal)
    new_verifier = ActiveSupport::MessageVerifier.new("secret", serializer: JSON)
    new_verifier.rotate(serializer: Marshal)

    message = old_verifier.generate("message")

    new_verifier.verify(message)
    # BEFORE:
    # => raises JSON::ParserError
    # AFTER:
    # => "message"
    ```

* Allow rotation of serializers for `MessageEncryptor` when using a non-standard initial serializer.  Similar to `MessageVerifier`, the serializer could not be rotated when the initial serializer raised an error other than `TypeError` and `JSON::ParserError`, such as `Psych::SyntaxError` or a custom error.

* Raise `MessageEncryptor::InvalidMessage` from `decrypt_and_verify` regardless of cipher.  Previously, when a `MessageEncryptor` was using a non-AEAD cipher such as AES-256-CBC, a corrupt or tampered message would raise `MessageVerifier::InvalidSignature` due to reliance on `MessageVerifier` for verification.  Now, the verification mechanism is transparent to the user:

    ```ruby
    encryptor = ActiveSupport::MessageEncryptor.new("x" * 32, cipher: "aes-256-gcm")
    message = encryptor.encrypt_and_sign("message")
    encryptor.decrypt_and_verify(message.next)
    # => raises ActiveSupport::MessageEncryptor::InvalidMessage

    encryptor = ActiveSupport::MessageEncryptor.new("x" * 32, cipher: "aes-256-cbc")
    message = encryptor.encrypt_and_sign("message")
    encryptor.decrypt_and_verify(message.next)
    # BEFORE:
    # => raises ActiveSupport::MessageVerifier::InvalidSignature
    # AFTER:
    # => raises ActiveSupport::MessageEncryptor::InvalidMessage
    ```

* Support `nil` original value when using `MessageVerifier#verify`. Previously, `MessageVerifier#verify` did not work with `nil` original values, though both `MessageVerifier#verified` and `MessageEncryptor#decrypt_and_verify` do:

    ```ruby
    encryptor = ActiveSupport::MessageEncryptor.new("x" * 32)
    message = encryptor.encrypt_and_sign(nil)

    encryptor.decrypt_and_verify(message)
    # => nil

    verifier = ActiveSupport::MessageVerifier.new("secret")
    message = verifier.generate(nil)

    verifier.verified(message)
    # => nil

    verifier.verify(message)
    # BEFORE:
    # => raises ActiveSupport::MessageVerifier::InvalidSignature
    # AFTER:
    # => nil
    ```

* Improve performance of verifying a message when it has expired and one or more rotations have been configured:

    ```ruby
    # frozen_string_literal: true
    require "benchmark/ips"
    require "active_support/all"

    verifier = ActiveSupport::MessageVerifier.new("new secret")
    verifier.rotate("old secret")

    message = verifier.generate({ "data" => "x" * 100 }, expires_at: 1.day.ago)

    Benchmark.ips do |x|
      x.report("expired message") do
        verifier.verified(message)
      end
    end
    ```

  __Before__

    ```
    Warming up --------------------------------------
         expired message     1.442k i/100ms
    Calculating -------------------------------------
         expired message     14.403k (± 1.7%) i/s -     72.100k in   5.007382s
    ```

  __After__

    ```
    Warming up --------------------------------------
         expired message     1.995k i/100ms
    Calculating -------------------------------------
         expired message     19.992k (± 2.0%) i/s -    101.745k in   5.091421s
    ```

Fixes #47185.
