### PR TITLE
Enable Style/RedundantFetchBlock and autocorrect-all

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -343,3 +343,6 @@ Minitest/SkipEnsure:
 
 Minitest/UnreachableAssertion:
   Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -26,7 +26,7 @@ module ActionCable
       # If the adapter cannot be found, this will default to the Redis adapter.
       # Also makes sure proper dependencies are required.
       def pubsub_adapter
-        adapter = (cable.fetch("adapter") { "redis" })
+        adapter = (cable.fetch("adapter", "redis"))
 
         # Require the adapter itself and give useful feedback about
         #   1. Missing adapter gems and

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -268,12 +268,12 @@ class ParametersPermitTest < ActiveSupport::TestCase
 
   test "fetch doesn't raise ParameterMissing exception if there is a default" do
     assert_equal "monkey", @params.fetch(:foo, "monkey")
-    assert_equal "monkey", @params.fetch(:foo) { "monkey" }
+    assert_equal "monkey", @params.fetch(:foo, "monkey")
   end
 
   test "fetch doesn't raise ParameterMissing exception if there is a default that is nil" do
     assert_nil @params.fetch(:foo, nil)
-    assert_nil @params.fetch(:foo) { nil }
+    assert_nil @params.fetch(:foo, nil)
   end
 
   test "KeyError in fetch block should not be covered up" do

--- a/actionpack/test/dispatch/header_test.rb
+++ b/actionpack/test/dispatch/header_test.rb
@@ -84,7 +84,7 @@ class HeaderTest < ActiveSupport::TestCase
   end
 
   test "fetch with block" do
-    assert_equal "omg", @headers.fetch("notthere") { "omg" }
+    assert_equal "omg", @headers.fetch("notthere", "omg")
   end
 
   test "accessing http header" do

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -280,7 +280,7 @@ module ActiveRecord
               name,
               value,
               type,
-              _default_attributes.fetch(name.to_s) { nil },
+              _default_attributes.fetch(name.to_s, nil),
             )
           else
             default_attribute = ActiveModel::Attribute.from_database(name, value, type)

--- a/activerecord/test/cases/type/type_map_test.rb
+++ b/activerecord/test/cases/type/type_map_test.rb
@@ -23,8 +23,8 @@ module ActiveRecord
         mapping = klass.new
         mapping.register_type(1, "string")
 
-        assert_equal "string", mapping.fetch(1) { "int" }
-        assert_equal "int", mapping.fetch(2) { "int" }
+        assert_equal "string", mapping.fetch(1, "int")
+        assert_equal "int", mapping.fetch(2, "int")
       end
 
       def test_fetch_memoizes

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -22,14 +22,14 @@ module CacheStoreBehavior
     key = SecureRandom.uuid
     @cache.write(key, "bar")
     assert_not_called(@cache, :write) do
-      assert_equal "bar", @cache.fetch(key) { "baz" }
+      assert_equal "bar", @cache.fetch(key, "baz")
     end
   end
 
   def test_fetch_with_cache_miss
     key = SecureRandom.uuid
     assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch(key) { "baz" }
+      assert_equal "baz", @cache.fetch(key, "baz")
     end
   end
 
@@ -86,7 +86,7 @@ module CacheStoreBehavior
     key = SecureRandom.uuid
     @cache.write(key, nil)
     assert_not_called(@cache, :write) do
-      assert_nil @cache.fetch(key) { "baz" }
+      assert_nil @cache.fetch(key, "baz")
     end
   end
 
@@ -735,7 +735,7 @@ module CacheStoreBehavior
     ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
       @events << ActiveSupport::Notifications::Event.new(*args)
     end
-    assert_not @cache.fetch(SecureRandom.uuid) { }
+    assert_not @cache.fetch(SecureRandom.uuid, nil)
     assert_equal 3, @events.length
     assert_equal "cache_read.active_support", @events[0].name
     assert_equal "cache_generate.active_support", @events[1].name

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -16,7 +16,7 @@ module FailureSafetyBehavior
     @cache.write(key, value)
 
     emulating_unavailability do |cache|
-      val = cache.fetch(key) { "1" }
+      val = cache.fetch(key, "1")
 
       ##
       # Though the `write` part of fetch fails for the same reason

--- a/activesupport/test/cache/cache_store_logger_test.rb
+++ b/activesupport/test/cache/cache_store_logger_test.rb
@@ -12,7 +12,7 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
   end
 
   def test_logging
-    @cache.fetch("foo") { "bar" }
+    @cache.fetch("foo", "bar")
     assert_predicate @buffer.string, :present?
   end
 
@@ -30,7 +30,7 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
   end
 
   def test_mute_logging
-    @cache.mute { @cache.fetch("foo") { "bar" } }
+    @cache.mute { @cache.fetch("foo", "bar") }
     assert_predicate @buffer.string, :blank?
   end
 end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -206,12 +206,12 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
   def test_dalli_cache_nils
     cache = lookup_store(cache_nils: false)
-    cache.fetch("nil_foo") { nil }
-    assert_equal "bar", cache.fetch("nil_foo") { "bar" }
+    cache.fetch("nil_foo", nil)
+    assert_equal "bar", cache.fetch("nil_foo", "bar")
 
     cache1 = lookup_store(cache_nils: true)
-    cache1.fetch("not_nil_foo") { nil }
-    assert_nil cache.fetch("not_nil_foo") { "bar" }
+    cache1.fetch("not_nil_foo", nil)
+    assert_nil cache.fetch("not_nil_foo", "bar")
   end
 
   def test_local_cache_raw_values_with_marshal
@@ -320,7 +320,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
     @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), "value", 0, compress: false) }
     assert_nil @cache.read(key)
-    assert_equal "value", @cache.fetch(key) { "value" }
+    assert_equal "value", @cache.fetch(key, "value")
   end
 
   def test_can_load_raw_falsey_values_from_dalli_store
@@ -328,7 +328,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
     @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), false, 0, compress: false) }
     assert_nil @cache.read(key)
-    assert_equal false, @cache.fetch(key) { false }
+    assert_equal false, @cache.fetch(key, false)
   end
 
   def test_can_load_raw_values_from_dalli_store_with_local_cache
@@ -337,7 +337,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), "value", 0, compress: false) }
     @cache.with_local_cache do
       assert_nil @cache.read(key)
-      assert_equal "value", @cache.fetch(key) { "value" }
+      assert_equal "value", @cache.fetch(key, "value")
     end
   end
 
@@ -347,7 +347,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), false, 0, compress: false) }
     @cache.with_local_cache do
       assert_nil @cache.read(key)
-      assert_equal false, @cache.fetch(key) { false }
+      assert_equal false, @cache.fetch(key, false)
     end
   end
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -210,14 +210,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     test "fetch caches nil" do
       @cache.write("foo", nil)
       assert_not_called(@cache, :write) do
-        assert_nil @cache.fetch("foo") { "baz" }
+        assert_nil @cache.fetch("foo", "baz")
       end
     end
 
     test "skip_nil is passed to ActiveSupport::Cache" do
       @cache = lookup_store(skip_nil: true)
       assert_not_called(@cache, :write) do
-        assert_nil @cache.fetch("foo") { nil }
+        assert_nil @cache.fetch("foo", nil)
         assert_equal false, @cache.exist?("foo")
       end
     end


### PR DESCRIPTION
As @natematykiewicz pointed out in #47307 there is a rubocop rule for this.