### PR TITLE
Fix raw_post empty bug when when Transfer-Encoding: chunked

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -290,6 +290,7 @@ module ActionDispatch
 
     # Returns the content length of the request as an integer.
     def content_length
+      return raw_post.bytesize if headers.key?("Transfer-Encoding")
       super.to_i
     end
 
@@ -344,9 +345,8 @@ module ActionDispatch
     # work with raw requests directly.
     def raw_post
       unless has_header? "RAW_POST_DATA"
-        raw_post_body = body
-        set_header("RAW_POST_DATA", raw_post_body.read(content_length))
-        raw_post_body.rewind if raw_post_body.respond_to?(:rewind)
+        set_header("RAW_POST_DATA", read_body_stream)
+        body_stream.rewind if body_stream.respond_to?(:rewind)
       end
       get_header "RAW_POST_DATA"
     end
@@ -471,6 +471,11 @@ module ActionDispatch
 
       def default_session
         Session.disabled(self)
+      end
+
+      def read_body_stream
+        return body_stream.read if headers.key?("Transfer-Encoding") # Read body stream until EOF if "Transfer-Encoding" is present
+        body_stream.read(content_length)
       end
   end
 end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -474,6 +474,7 @@ module ActionDispatch
       end
 
       def read_body_stream
+        body_stream.rewind if body_stream.respond_to?(:rewind)
         return body_stream.read if headers.key?("Transfer-Encoding") # Read body stream until EOF if "Transfer-Encoding" is present
         body_stream.read(content_length)
       end

--- a/railties/test/railties/http_request_test.rb
+++ b/railties/test/railties/http_request_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "stringio"
+require "rack/test"
+require "active_support/core_ext/module/delegation"
+
+module RailtiesTest
+  class HttpRequestTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    def setup
+      build_app
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          post "posts", to: "posts#create"
+        end
+      RUBY
+
+      controller "posts", <<-RUBY
+        class PostsController < ApplicationController
+          def create
+            render json: {
+              raw_post: request.raw_post,
+              content_length: request.content_length
+            }
+          end
+        end
+      RUBY
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    class TestInput < StringIO
+      undef_method :size
+    end
+
+    test "parses request raw_post correctly when request has Transfer-Encoding header without a Content-Length value" do
+      require "#{app_path}/config/environment"
+
+      header "Transfer-Encoding", "gzip, chunked;foo=bar"
+      post "/posts", TestInput.new("foo=bar") # prevents Rack::MockRequest from adding a Content-Length
+
+      json_response = JSON.parse(last_response.body)
+      assert_equal 7, json_response["content_length"]
+      assert_equal "foo=bar", json_response["raw_post"]
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This PR fixes the [issue](https://github.com/rails/rails/issues/46784) with `request.raw_post` property being empty for chunked requests. (Transfer-Encoding header present and without a Content-Length value). It was inspired from this previous [PR](https://github.com/rails/rails/pull/37423), but without the need of doing a second `rewind` of the request body.

A similar fix was done on [Puma webserver](https://github.com/puma/puma/pull/2287), but with this fix, `raw_post` will work as expected for any Rack based http server.

### Detail

This pull request changes `ActionDispatch::Request#raw_post` and `ActionDispatch::Request#content_length` methods, to take into account the presence of `Transfer-Encoding` header or not.

According to [HTTP/1.1](https://httpwg.org/specs/rfc9112.html#rfc.section.6.2) RFC, when `Transfer-Encoding` is present, a sender must not send a `Content-Length` header field on a request, so because of that we can't rely on that field when reading the raw request body stream and calculating its content length for the upstream app.

So what this change does is to read the entire requests's `body_stream` for `raw_post` instead of using `content_length` as its length when `Transfer-Encoding` header is present.

And it uses the `raw_post#bytesize` value to calculate the request's `content_length` instead of reading this value from the `Content-Length` header, when `Transfer-Encoding` header is present.

### Additional information

To test this case an integration railties test `http_request_test.rb` was used, in order for it to be similar to real use cases.

It is also recommended to test this change manually with a real Rails app running on different Rack servers (e.g. Puma, Unicorn, Webrick or Thin)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
