### PR TITLE
Deprecate initialize memcache store with dalli client

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecated initializing a `ActiveSupport::Cache::MemCacheStore` with an instance of `Dalli::Client`.
+
+    Deprecate the undocumented option of providing an already-initialized instance of `Dalli::Client` to `ActiveSupport::Cache::MemCacheStore`. Such clients could be configured with unrecognized options, which could lead to unexpected behavior. Instead, provide addresses as documented.
+
+    *aledustet*
+
 *   Stub `Time.new()` in `TimeHelpers#travel_to`
 
       ```ruby

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -28,6 +28,10 @@ module ActiveSupport
     # MemCacheStore implements the Strategy::LocalCache strategy which implements
     # an in-memory cache inside of a block.
     class MemCacheStore < Store
+      # These options represent behavior overridden by this implementation and should
+      # not be allowed to get down to the Dalli client
+      OVERRIDDEN_OPTIONS = UNIVERSAL_OPTIONS
+
       # Advertise cache versioning support.
       def self.supports_cache_versioning?
         true
@@ -108,6 +112,7 @@ module ActiveSupport
       #
       # If no addresses are provided, but <tt>ENV['MEMCACHE_SERVERS']</tt> is defined, it will be used instead. Otherwise,
       # MemCacheStore will connect to localhost:11211 (the default memcached port).
+      # Passing a +Dalli::Client+ instance is deprecated and will be removed. Please pass an address instead.
       def initialize(*addresses)
         addresses = addresses.flatten
         options = addresses.extract_options!
@@ -117,15 +122,19 @@ module ActiveSupport
         super(options)
 
         unless [String, Dalli::Client, NilClass].include?(addresses.first.class)
-          raise ArgumentError, "First argument must be an empty array, an array of hosts or a Dalli::Client instance."
+          raise ArgumentError, "First argument must be an empty array, address, or array of addresses."
         end
         if addresses.first.is_a?(Dalli::Client)
+          ActiveSupport.deprecator.warn(<<~MSG)
+            Initializing MemCacheStore with a Dalli::Client is deprecated and will be removed in Rails 7.2.
+            Use memcached server addresses instead.
+          MSG
           @data = addresses.first
         else
           mem_cache_options = options.dup
           # The value "compress: false" prevents duplicate compression within Dalli.
           mem_cache_options[:compress] = false
-          (UNIVERSAL_OPTIONS - %i(compress)).each { |name| mem_cache_options.delete(name) }
+          (OVERRIDDEN_OPTIONS - %i(compress)).each { |name| mem_cache_options.delete(name) }
           @data = self.class.build_mem_cache(*(addresses + [mem_cache_options]))
         end
       end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -271,9 +271,11 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def test_uses_provided_dalli_client_if_present
-    cache = lookup_store(Dalli::Client.new("custom_host"))
-
-    assert_equal ["custom_host"], servers(cache)
+    assert_deprecated(ActiveSupport.deprecator) do
+      host = "custom_host"
+      cache = lookup_store(Dalli::Client.new(host))
+      assert_equal [host], servers(cache)
+    end
   end
 
   def test_forwards_string_addresses_if_present


### PR DESCRIPTION
Part of #47323
The full fix will be to remove support for the `Dalli::Client` option when initializing a `MemCacheStore`

### Motivation / Background

Following up on [#47323](https://github.com/rails/rails/issues/47323). Many options are not forwarded to the Dalli client when it is initialized from the `ActiveSupport::Cache::MemCacheStore`. This is to support a broader set of features powered by the implementation. When an instance of a client is passed on the initializer, it takes precedence, and we have no control over which attributes will be overridden or re-processed on the client side; this is by design and should remain as such to allow both projects to progress independently. 
Having this option introduces several potential bugs that are difficult to pinpoint and get multiplied by which version of the tool is used and how each evolves.
During the conversation on the issue, the `Dalli` client maintainer supports [deprecating](https://github.com/rails/rails/issues/47323#issuecomment-1424292456) this option.

### Detail

This Pull Request adds a deprecation warning any time the `ActiveSupport::Cache::MemCacheStore` is initialized with an instance of a `Dalli::Client` instead of providing the address(es) of the memcache server(s) and any additional options to let the `MemCacheStore` implementation handle the provisioning of the client.

Removing this implicit dependency will ensure each library can evolve separately and cements the usage of `Dalli::Client` as an [implementation detail](https://github.com/rails/rails/issues/21595#issuecomment-139815433)

We can not remove a supported feature overnight, so we should add a deprecation warning for the next minor release(7.2 at this time).

A constant on the `Cache` namespace was only used to restrict options passed to the `Dalli::Client` initializer that now lives on the `MemCacheStore` class.

### Additional information

The main issue with allowing this approach is regarding potential misbehaviors and bugs because of both implementations' different strategies when dealing with keys, namespaces, and compression.
One example of functionality has already diverged between the two and how [fixing it](https://github.com/aledustet/rails/pull/1/files) would further increase the coupling between both libraries.
A follow-up to this would still be an attempt to include the key truncation recovery mechanism on `ActiveSupport` to the `Dalli` client, but this will not be the only time both libraries stray, and it will be up to maintainers to catch up.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
