### PR TITLE
maintain html_safe? on sliced HTML safe strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Maintain `html_safe?` on html_safe strings when sliced with `slice`, `slice!`, or `chr` method.
+
+    Previously, `html_safe?` was only maintained when the html_safe strings were sliced
+    with `[]` method. Now, `slice`, `slice!`, and `chr` methods will maintain `html_safe?` like `[]` method.
+
+    ```ruby
+    string = "<div>test</div>".html_safe
+    string.slice(0, 1).html_safe? # => true
+    string.slice!(0, 1).html_safe? # => true
+    # maintain html_safe? after the slice!
+    string.html_safe? # => true
+    string.chr # => true
+    ```
+
+    *Michael Go*
+
 *   `config.i18n.raise_on_missing_translations = true` now raises on any missing translation.
 
     Previously it would only raise when called in a view or controller. Now it will raise

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -90,7 +90,6 @@ class SafeBufferTest < ActiveSupport::TestCase
     reverse: nil,
     rstrip: nil,
     scrub: nil,
-    slice: "foo",
     squeeze: nil,
     strip: nil,
     sub: ["foo", "bar"],
@@ -212,28 +211,59 @@ class SafeBufferTest < ActiveSupport::TestCase
   end
 
   test "Should continue unsafe on slice" do
-    x = "foo".html_safe.gsub!("f", '<script>alert("lolpwnd");</script>')
+    safe_string = "foo".html_safe.gsub!("f", '<script>alert("lolpwnd");</script>')
 
     # calling gsub! makes the dirty flag true
-    assert_not x.html_safe?, "should not be safe"
-
-    # getting a slice of it
-    y = x[0..-1]
+    assert_not safe_string.html_safe?, "should not be safe"
 
     # should still be unsafe
-    assert_not y.html_safe?, "should not be safe"
+    assert_not safe_string[0..-1].html_safe?, "should not be safe"
+    assert_not safe_string.slice(0..-1).html_safe?, "should not be safe"
+    assert_not safe_string.slice!(0..-1).html_safe?, "should not be safe"
+    # even after slice! safe_string is still unsafe
+    assert_not safe_string.html_safe?, "should not be safe"
   end
 
   test "Should continue safe on slice" do
-    x = "<div>foo</div>".html_safe
+    safe_string = "<div>foo</div>".html_safe
 
-    assert_predicate x, :html_safe?
-
-    # getting a slice of it
-    y = x[0..-1]
+    assert_predicate safe_string, :html_safe?
 
     # should still be safe
-    assert_predicate y, :html_safe?
+    assert_predicate safe_string[0..-1], :html_safe?
+    assert_predicate safe_string.slice(0..-1), :html_safe?
+    assert_predicate safe_string.slice!(0...1), :html_safe?
+
+    # even after slice! safe_string is still safe
+    assert_predicate safe_string, :html_safe?
+  end
+
+  test "Should continue safe on chr" do
+    safe_string = "<div>foo</div>".html_safe
+
+    assert_predicate safe_string, :html_safe?
+    assert_predicate safe_string.chr, :html_safe?
+  end
+
+  test "Should continue unsafe on chr" do
+    safe_string = "<div>foo</div>"
+
+    assert_not safe_string.html_safe?, "should not be safe"
+    assert_not safe_string.chr.html_safe?, "should not be safe"
+  end
+
+  test "Should return a SafeBuffer on slice! if original value was safe" do
+    safe_string = "<div>foo</div>".html_safe
+
+    assert safe_string.slice!(0...1).is_a?(ActiveSupport::SafeBuffer)
+  end
+
+  test "Should return a String on slice! if original value was not safe" do
+    unsafe_string = +'<script>alert("XSS");</script>'
+
+    sliced_string = unsafe_string.slice!(0...1)
+    assert_not sliced_string.is_a?(ActiveSupport::SafeBuffer)
+    assert sliced_string.is_a?(String)
   end
 
   test "Should work with interpolation (array argument)" do


### PR DESCRIPTION
### Motivation / Background

Closes https://github.com/rails/rails/issues/47343

I have found inconsistent behaviour with `SafeBuffer`'s `slice`, `chr`, and `[]` functions.

```ruby
buffer = ActiveSupport::SafeBuffer.new
buffer.concat("<html>")

buffer[0..0].html_safe? # true
buffer.slice(0, 1).html_safe? # false

buffer[0].html_safe? # true
buffer.chr.html_safe? # false
```

This behaviour was introduced in this [PR](https://github.com/rails/rails/pull/33808), and this has been included in Rails 6.0.0.
Also, the behaviour of persistently keeping the `html_safe` flag from the `[]` function was introduced in this [commit](https://github.com/rails/rails/commit/8ccaa34103f1c37f7549f7f6c47a21dba21624db) from 2012.  

### Detail

Since `String#slice` is an alias method of `String#[]`, I believe `SafeBuffer`'s `slice` and `[]` functions should also have the same parity. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @flavorjones 
