### PR TITLE
Add test case for Arel condition exclusive open-ended range 

### DIFF
--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -658,6 +658,16 @@ module Arel
           )
         end
 
+        it "can be constructed with an exclusive range implicitly ending at Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0...)
+
+          _(node).must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Casted.new(0, attribute)
+          )
+        end
+
         it "can be constructed with a quoted range ending at Infinity" do
           attribute = Attribute.new nil, nil
           node = attribute.between(quoted_range(0, ::Float::INFINITY, false))


### PR DESCRIPTION
This corrects an apparent bug in Arel when handling open-ended exclusive (`...`) ranges with an implied infinity upper bound.

```ruby
# current behavior

irb(main):002:0> User.where(created_at: ..time).to_sql
=> "SELECT `users`.* FROM `users` WHERE `users`.`created_at` <= '2000-01-01 00:00:00'"

irb(main):003:0> User.where(created_at: ...time).to_sql
=> "SELECT `users`.* FROM `users` WHERE `users`.`created_at` < '2000-01-01 00:00:00'"

irb(main):004:0> User.where(created_at: time..).to_sql
=> "SELECT `users`.* FROM `users` WHERE `users`.`created_at` >= '2000-01-01 00:00:00'"

irb(main):005:0> User.where(created_at: time...).to_sql  # this should probably generate a `>`
=> "SELECT `users`.* FROM `users` WHERE `users`.`created_at` >= '2000-01-01 00:00:00'"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
