### PR TITLE
Fix querying of serialized `Class` attributes

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -115,13 +115,17 @@ module ActiveModel
     def ==(other)
       self.class == other.class &&
         name == other.name &&
-        value_before_type_cast == other.value_before_type_cast &&
+        identifier_value == other.identifier_value &&
         type == other.type
     end
     alias eql? ==
 
     def hash
-      [self.class, name, value_before_type_cast, type].hash
+      [self.class, name, identifier_value, type].hash
+    end
+
+    def identifier_value
+      value_before_type_cast
     end
 
     def init_with(coder)

--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -4,10 +4,6 @@ module ActiveModel
   module Type
     module Helpers # :nodoc: all
       module Mutable
-        def immutable_value(value)
-          value.deep_dup.freeze
-        end
-
         def cast(value)
           deserialize(serialize(value))
         end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix error when querying serialized Class attributes.
+
+    *Jorge Manrubia*
+
 *   The deferrable foreign key can be passed to `t.references`.
 
     *Hiroyuki Ishii*

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -66,7 +66,7 @@ module ActiveRecord
 
     def build_bind_attribute(column_name, value)
       type = table.type(column_name)
-      Relation::QueryAttribute.new(column_name, type.immutable_value(value), type)
+      Relation::QueryAttribute.new(column_name, value, type)
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)

--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -36,9 +36,23 @@ module ActiveRecord
         @_unboundable
       end
 
+      def identifier_value
+        if unboundable?
+          super
+        else
+          # Override to define equality based on frozen casted values to prevent caching
+          # issues with mutable database query values.
+          value_for_database
+        end
+      end
+
       private
         def infinity?(value)
           value.respond_to?(:infinite?) && value.infinite?
+        end
+
+        def _value_for_database
+          super.deep_dup.freeze
         end
     end
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -9,6 +9,11 @@ require "models/binary_field"
 class SerializedAttributeTest < ActiveRecord::TestCase
   def setup
     ActiveRecord.use_yaml_unsafe_load = true
+    @yaml_column_permitted_classes_default = ActiveRecord.yaml_column_permitted_classes
+  end
+
+  def teardown
+    ActiveRecord.yaml_column_permitted_classes = @yaml_column_permitted_classes_default
   end
 
   fixtures :topics, :posts
@@ -21,6 +26,10 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   class ImportantTopic < Topic
     serialize :important, type: Hash
+  end
+
+  class ClassifiedTopic < Topic
+    serialize :important, type: Class
   end
 
   teardown do
@@ -164,6 +173,14 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     myobj = "Yes"
     topic = Topic.create("content" => myobj).reload
     assert_equal(myobj, topic.content)
+  end
+
+  def test_serialized_class_attribute
+    ActiveRecord.yaml_column_permitted_classes += [Class]
+
+    topic = ClassifiedTopic.create(important: Symbol).reload
+    assert_equal(Symbol, topic.important)
+    assert_not_empty ClassifiedTopic.where(important: Symbol)
   end
 
   def test_nil_serialized_attribute_without_class_constraint
@@ -551,6 +568,7 @@ end
 
 class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   def setup
+    super
     ActiveRecord.use_yaml_unsafe_load = false
   end
 


### PR DESCRIPTION
This fixes [a problem](https://github.com/rails/rails/issues/47338) where Active Record failed to query serialized `Class` attributes. 

The problem was introduced in [this commit](https://github.com/rails/rails/commit/5abb45d53ae32f9d80fac5a21fe4cda9b83412a1#diff-7743ab95b8e15581f432206245c691434a3993d1a751b9d451170956d59457a9R8). Duplicating a `Class` argument generates an anonymous class that can't be serialized as YAML. This change defines the identity of query attributes based on their frozen casted values to prevent the problem.

This is based on [this idea](https://github.com/rails/rails/issues/47338#issuecomment-1424402777) by @matthewd.

Fixes #47338

