### PR TITLE
Fix retrieving foreign keys referencing tables named like keywords in PostgreSQL and MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -491,7 +491,7 @@ module ActiveRecord
 
         fk_info.map do |row|
           options = {
-            column: row["column"],
+            column: unquote_identifier(row["column"]),
             name: row["name"],
             primary_key: row["primary_key"]
           }
@@ -499,7 +499,7 @@ module ActiveRecord
           options[:on_update] = extract_foreign_key_action(row["on_update"])
           options[:on_delete] = extract_foreign_key_action(row["on_delete"])
 
-          ForeignKeyDefinition.new(table_name, row["to_table"], options)
+          ForeignKeyDefinition.new(table_name, unquote_identifier(row["to_table"]), options)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -54,6 +54,14 @@ module ActiveRecord
           "x'#{value.hex}'"
         end
 
+        def unquote_identifier(identifier)
+          if identifier && identifier.start_with?("`")
+            identifier[1..-2]
+          else
+            identifier
+          end
+        end
+
         # Override +type_cast+ we pass to mysql2 Date and Time objects instead
         # of Strings since mysql2 is able to handle those classes more efficiently.
         def type_cast(value) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -531,7 +531,7 @@ module ActiveRecord
 
           fk_info.map do |row|
             options = {
-              column: row["column"],
+              column: Utils.unquote_identifier(row["column"]),
               name: row["name"],
               primary_key: row["primary_key"]
             }
@@ -541,8 +541,9 @@ module ActiveRecord
             options[:deferrable] = extract_foreign_key_deferrable(row["deferrable"], row["deferred"])
 
             options[:validate] = row["valid"]
+            to_table = Utils.unquote_identifier(row["to_table"])
 
-            ForeignKeyDefinition.new(table_name, row["to_table"], options)
+            ForeignKeyDefinition.new(table_name, to_table, options)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/utils.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         attr_reader :schema, :identifier
 
         def initialize(schema, identifier)
-          @schema, @identifier = unquote(schema), unquote(identifier)
+          @schema, @identifier = Utils.unquote_identifier(schema), Utils.unquote_identifier(identifier)
         end
 
         def to_s
@@ -40,15 +40,6 @@ module ActiveRecord
           def parts
             @parts ||= [@schema, @identifier].compact
           end
-
-        private
-          def unquote(part)
-            if part && part.start_with?('"')
-              part[1..-2]
-            else
-              part
-            end
-          end
       end
 
       module Utils # :nodoc:
@@ -73,6 +64,14 @@ module ActiveRecord
             schema = nil
           end
           PostgreSQL::Name.new(schema, table)
+        end
+
+        def unquote_identifier(identifier)
+          if identifier && identifier.start_with?('"')
+            identifier[1..-2]
+          else
+            identifier
+          end
         end
       end
     end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -340,6 +340,16 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           assert_not @connection.foreign_key_exists?(:astronauts, :stars)
         end
 
+        def test_foreign_key_exists_referencing_table_having_keyword_as_name
+          @connection.create_table :user, force: true
+          @connection.add_column :rockets, :user_id, :bigint
+          @connection.add_foreign_key :rockets, :user
+          assert @connection.foreign_key_exists?(:rockets, :user)
+        ensure
+          @connection.remove_foreign_key :rockets, :user
+          @connection.drop_table :user
+        end
+
         def test_foreign_key_exists_by_column
           @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id"
 


### PR DESCRIPTION
Fixes #47346.

In PostgreSQL, `user` is a reserved word, so when creating a foreign key referencing a table named `user`, it additionally quotes it. And when retrieving foreign keys for a table, PostgreSQL returns `"user"` as to_table, and we need to remove this double quotes.