### PR TITLE
Respect `unscoped` for update & delete operations

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -627,7 +627,7 @@ module ActiveRecord
         # to build `where` clause from default scopes.
         # Skips empty scopes.
         def build_default_constraint
-          return unless default_scopes?(all_queries: true)
+          return if current_scope || default_scopes?(all_queries: true).blank?
 
           default_where_clause = default_scoped(all_queries: true).where_clause
           default_where_clause.ast unless default_where_clause.empty?

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -569,11 +569,8 @@ module ActiveRecord
       def _update_record(values, constraints) # :nodoc:
         constraints = constraints.map { |name, value| predicate_builder[name, value] }
 
-        default_constraint = build_default_constraint
-        constraints << default_constraint if default_constraint
-
-        if current_scope = self.global_current_scope
-          constraints << current_scope.where_clause.ast
+        if scope_constraints = build_scope_constraints
+          constraints << scope_constraints
         end
 
         um = Arel::UpdateManager.new(arel_table)
@@ -586,11 +583,8 @@ module ActiveRecord
       def _delete_record(constraints) # :nodoc:
         constraints = constraints.map { |name, value| predicate_builder[name, value] }
 
-        default_constraint = build_default_constraint
-        constraints << default_constraint if default_constraint
-
-        if current_scope = self.global_current_scope
-          constraints << current_scope.where_clause.ast
+        if scope_constraints = build_scope_constraints
+          constraints << scope_constraints
         end
 
         dm = Arel::DeleteManager.new(arel_table)
@@ -623,14 +617,17 @@ module ActiveRecord
           self
         end
 
-        # Called by +_update_record+ and +_delete_record+
-        # to build `where` clause from default scopes.
+        # Called by +_update_record+ and +_delete_record+ to build `where`
+        # clause from scopes, default or from +scoping+
         # Skips empty scopes.
-        def build_default_constraint
-          return if current_scope || default_scopes?(all_queries: true).blank?
+        def build_scope_constraints
+          scope_constraints = if current_scope = global_current_scope
+            current_scope.where_clause
+          elsif default_scopes?(all_queries: true)
+            default_scoped(all_queries: true).where_clause
+          end
 
-          default_where_clause = default_scoped(all_queries: true).where_clause
-          default_where_clause.ast unless default_where_clause.empty?
+          scope_constraints.ast if scope_constraints&.any?
         end
 
         # This is a fallback method that is used to determine the query_constraints_list

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -48,7 +48,7 @@ module ActiveRecord
         #     Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
         #   }
         def unscoped(&block)
-          block_given? ? relation.scoping(&block) : relation
+          block_given? ? relation.scoping(all_queries: true, &block) : relation
         end
 
         # Are there attributes associated with this scope?

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -179,6 +179,15 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, update_sql)
   end
 
+  def test_default_scope_with_all_queries_is_applied_once_on_update_columns
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    relation = DeveloperWithDefaultMentorScopeAllQueries.where("1=1")
+    update_sql = capture_sql { relation.scoping(all_queries: true) { dev.update_columns(name: "Not Eileen") } }.first
+
+    assert_match(/WHERE .\w+.\..id. = \S+ AND .\w+.\..mentor_id. = \S+ AND \(1=1\)\Z/, update_sql)
+  end
+
   def test_default_scope_with_all_queries_doesnt_run_on_update_columns_when_unscoped
     Mentor.create!
     dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
@@ -208,6 +217,15 @@ class DefaultScopingTest < ActiveRecord::TestCase
     destroy_sql = capture_sql { dev.destroy }.first
 
     assert_match(/mentor_id/, destroy_sql)
+  end
+
+  def test_default_scope_with_all_queries_is_applied_once_on_destroy
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    relation = DeveloperWithDefaultMentorScopeAllQueries.where("1=1")
+    update_sql = capture_sql { relation.scoping(all_queries: true) { dev.destroy } }.first
+
+    assert_match(/WHERE .\w+.\..id. = \S+ AND .\w+.\..mentor_id. = \S+ AND \(1=1\)\Z/, update_sql)
   end
 
   def test_default_scope_with_all_queries_doesnt_run_on_destroy_when_unscoped

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -179,6 +179,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, update_sql)
   end
 
+  def test_default_scope_with_all_queries_doesnt_run_on_update_columns_when_unscoped
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    update_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.unscoped { dev.update_columns(name: "Not Eileen") } }.first
+
+    assert_no_match(/mentor_id/, update_sql)
+  end
+
   def test_nilable_default_scope_with_all_queries_runs_on_update_columns
     dev = DeveloperWithDefaultNilableFirmScopeAllQueries.create!(name: "Nikita")
     update_sql = capture_sql { dev.update_columns(name: "Not Nikita") }.first
@@ -200,6 +208,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
     destroy_sql = capture_sql { dev.destroy }.first
 
     assert_match(/mentor_id/, destroy_sql)
+  end
+
+  def test_default_scope_with_all_queries_doesnt_run_on_destroy_when_unscoped
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    destroy_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.unscoped { dev.destroy } }.first
+
+    assert_no_match(/mentor_id/, destroy_sql)
   end
 
   def test_nilable_default_scope_with_all_queries_runs_on_destroy
@@ -241,7 +257,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_no_match(/AND$/, reload_sql)
   end
 
-  def test_default_scope_with_all_queries_doesnt_run_on_destroy_when_unscoped
+  def test_default_scope_with_all_queries_doesnt_run_on_reload_when_unscoped
     dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen", mentor_id: 2)
     reload_sql = capture_sql { dev.reload({ unscoped: true }) }.first
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Calling `.unscoped` around an update or delete operation, such as `#update` or `#destroy` is currently a no-op and does not ignore scopes marked with `all_queries: true`.

This feels like an issue as other methods, such as `#reload` respect the scoping rules set by calling `.unscoped`, i.e. assuming a default_scope on `Comment` for `where(post_id: 1)`,  `Comment.unscoped { comment.reload }` will only use the primary key in the `WHERE` clause and not include the `AND post_id = 1` piece.

Additionally, without the change in this PR, there is no "escape hatch" (or at least no obvious ones), once a model has defined a default scope with `all_queries: true`, there is no way to opt out of it, which is now possible with `Comment.unscoped { comment.touch }`.

Related issue: #44823

<details>
  <summary>Executable test case</summary>
  
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
    t.timestamps
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
  default_scope -> { where(post_id: 1) }, all_queries: true
end

class BugTest < Minitest::Test
  def test_association_stuff
    post1 = Post.create!
    comment1 = post1.comments.create!

    post2 = Post.create!
    comment2 = post2.comments.create!

    assert comment1.touch # query includes WHERE post_id = 1

    comment2.touch # query includes WHERE post_id = 1, returns nothing and is a no-op
    # confirm that the value in the DB is different than what the in-memory instance has, since nothing was persisted
    # see https://github.com/rails/rails/issues/44823 for the "ignored update" issue
    refute_equal Comment.unscoped.find(comment2.id).updated_at, comment2.updated_at

    # I would expect the following to _actually_ perform the update, thanks to `unscoped`, but it doesn't
    Comment.unscoped { comment2.touch } # query includes WHERE post_id = 1, returns nothing and is a no-op
    assert_equal Comment.unscoped.find(comment2.id).updated_at, comment2.updated_at # Fails on main, not on this branch
  end
end
```
</details>


### Detail

There are two commits in this PR, only the first one fixes the issue, the second one is a small refactor after I realized that in some cases the default scope could be applied twice. They could be squashed, but I kept them separate, at least for now, since the second one doesn't change any _real_ behavior.

The fix I used in the first commit was to return early from `Persistence#build_default_constraint` if `current_scope` returns anything. I am still not sure if it's the best approach, but this is the only way I found to detect that `.uncoped` was called earlier and to prevent applying the default scopes to the current operation.

In the second commit I refactored what used to be a two step process in both `_update_record` & `_delete_record`, first apply the default constraints with `build_constraints`, if any, and then apply `global_current_scope`, if any.

The issue there was that if you had a model with a default scope and `all_queries: true`, and you also created an explicit scope with `all_queries: true`, something like `Comment.where("1=1").scoping(all_queries: true)`, then the default scope was applied twice, once from `build_default_constraint` and once from `global_current_scope`.

So I opted to consolidate the logic in a new method, which also has the added benefit to remove some duplication.

Additionally, I changed the behavior of `Default::ClassMethods#unscoped` to pass `all_queries: true` to `.scoping`, so that in the new `build_scope_constraints` method we can start checking for the presence of `global_current_scope`, which would be true in the `Comment.where("1=1").scoping(all_queries: true)` example, and would contain both the default scope and the explicit one with `scoping`.


### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

cc @nvasilevski since you worked on #42517

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. _not yet, figured I would add it in case it's decided that this PR makes sense)_
