### PR TITLE
Adjust guide to explain you *should* disable the ActiveStorage default routes when implementing authenticated routes [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -734,7 +734,7 @@ end
 <%= image_tag account_logo_path %>
 ```
 
-And then you might want to disable the Active Storage default routes with:
+And then you should disable the Active Storage default routes with:
 
 ```ruby
 config.active_storage.draw_routes = false


### PR DESCRIPTION
Small update to https://github.com/rails/rails/pull/42593

I think the language needs to make it explicit you **should** make 

```
config.active_storage.draw_routes = false
```

Previous language makes it sound like you don't have to.  

(When we implemented Authenticated Controllers we didn't do this; then a pentest & review picked up we should!)

