### PR TITLE
Use current scope for `CounterCache::ClassMethods#update_counters`

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -446,7 +446,7 @@ module ActiveRecord
       _run_touch_callbacks { super }
     end
 
-    def increment!(attribute, by = 1, touch: nil) # :nodoc:
+    def increment!(attribute, by = 1, touch: nil, unscoped: nil) # :nodoc:
       touch ? _run_touch_callbacks { super } : super
     end
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -112,7 +112,7 @@ module ActiveRecord
       #   #    `updated_at` = '2016-10-13T09:59:23-05:00'
       #   #  WHERE id IN (10, 15)
       def update_counters(id, counters)
-        unscoped.where!(primary_key => id).update_counters(counters)
+        all.where!(primary_key => id).update_counters(counters)
       end
 
       # Increment a numeric field by one, via a direct SQL update.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -951,10 +951,14 @@ module ActiveRecord
     # Validations and callbacks are skipped. Supports the +touch+ option from
     # +update_counters+, see that for more.
     # Returns +self+.
-    def increment!(attribute, by = 1, touch: nil)
+    def increment!(attribute, by = 1, touch: nil, unscoped: nil)
       increment(attribute, by)
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
-      self.class.update_counters(id, attribute => change, touch: touch)
+
+      with_scoping_rules({ unscoped: unscoped }) do |_apply_scoping|
+        self.class.update_counters(id, attribute => change, touch: touch)
+      end
+
       public_send(:"clear_#{attribute}_change")
       self
     end
@@ -972,8 +976,8 @@ module ActiveRecord
     # Validations and callbacks are skipped. Supports the +touch+ option from
     # +update_counters+, see that for more.
     # Returns +self+.
-    def decrement!(attribute, by = 1, touch: nil)
-      increment!(attribute, -by, touch: touch)
+    def decrement!(attribute, by = 1, touch: nil, unscoped: nil)
+      increment!(attribute, -by, touch: touch, unscoped: unscoped)
     end
 
     # Assigns to +attribute+ the boolean opposite of <tt>attribute?</tt>. So
@@ -1052,10 +1056,9 @@ module ActiveRecord
     def reload(options = nil)
       self.class.connection.clear_query_cache
 
-      fresh_object = if apply_scoping?(options)
-        _find_record((options || {}).merge(all_queries: true))
-      else
-        self.class.unscoped { _find_record(options) }
+      fresh_object = with_scoping_rules(options) do |apply_scoping|
+        options = (options || {}).merge(all_queries: true) if apply_scoping
+        _find_record(options)
       end
 
       @association_cache = fresh_object.instance_variable_get(:@association_cache)
@@ -1152,6 +1155,16 @@ module ActiveRecord
     def apply_scoping?(options)
       !(options && options[:unscoped]) &&
         (self.class.default_scopes?(all_queries: true) || self.class.global_current_scope)
+    end
+
+    def with_scoping_rules(options, &block)
+      if apply_scoping?(options)
+        yield true
+      else
+        self.class.unscoped do
+          yield false
+        end
+      end
     end
 
     def _query_constraints_hash

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -375,6 +375,54 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "update counters based on the current scope" do
+    t1, t2 = topics(:first, :second)
+
+    assert_no_difference -> { t1.reload.replies_count } do
+      assert_difference -> { t2.reload.replies_count }, -3 do
+        Topic.where(author_name: t2.author_name).scoping do
+          Topic.update_counters([t1.id, t2.id], replies_count: -3)
+        end
+      end
+    end
+  end
+
+  test "update counters based on the default scope" do
+    approved_topic = DefaultRejectedTopic.create(approved: true)
+    rejected_topic = DefaultRejectedTopic.create(approved: false, author_name: "Alice")
+    rejected_topic2 = DefaultRejectedTopic.create(approved: false, author_name: "Bob")
+    topic_ids = [approved_topic.id, rejected_topic.id, rejected_topic2.id]
+
+    assert_no_difference -> { approved_topic.reload.replies_count } do
+      assert_no_difference -> { rejected_topic2.reload.replies_count } do
+        assert_difference -> { rejected_topic.reload.replies_count }, -3 do
+          DefaultRejectedTopic.where(author_name: rejected_topic.author_name).scoping do
+            DefaultRejectedTopic.update_counters(topic_ids, replies_count: -3)
+          end
+        end
+      end
+    end
+  end
+
+  test "update counters can be unscoped" do
+    approved_topic = DefaultRejectedTopic.create(approved: true)
+    rejected_topic = DefaultRejectedTopic.create(approved: false, author_name: "Alice")
+    rejected_topic2 = DefaultRejectedTopic.create(approved: false, author_name: "Bob")
+    topic_ids = [approved_topic.id, rejected_topic.id, rejected_topic2.id]
+
+    assert_difference -> { approved_topic.reload.replies_count }, -3 do
+      assert_difference -> { rejected_topic2.reload.replies_count }, -3 do
+        assert_difference -> { rejected_topic.reload.replies_count }, -3 do
+          DefaultRejectedTopic.where(author_name: rejected_topic.author_name).scoping do
+            DefaultRejectedTopic.unscoped do
+              DefaultRejectedTopic.update_counters(topic_ids, replies_count: -3)
+            end
+          end
+        end
+      end
+    end
+  end
+
   private
     def assert_touching(record, *attributes)
       record.update_columns attributes.index_with(5.minutes.ago)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -271,6 +271,72 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raises(ArgumentError) { topic.increment! }
   end
 
+  def test_increment_applies_default_scope_with_all_queries
+    topic = DefaultApprovedTopic.create(approved: true)
+    assert topic.class.default_scopes?(all_queries: true)
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      update_sql = capture_sql { topic.increment!(:replies_count) }.first
+      assert_match(/approved/, update_sql)
+    end
+  end
+
+  def test_increment_applies_scopes_with_all_queries
+    topic = topics(:first)
+    assert_not topic.class.default_scopes?(all_queries: true)
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      Topic.where(author_name: topic.author_name).scoping(all_queries: true) do
+        update_sql = capture_sql { topic.increment!(:replies_count) }.first
+        assert_match(/author_name/, update_sql)
+      end
+    end
+  end
+
+  def test_increment_ignores_default_scopes_without_all_queries
+    topic = DefaultRejectedTopic.create(author_name: "Pierre")
+    assert topic.class.default_scopes?
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      update_sql = capture_sql { topic.increment!(:replies_count) }.first
+      assert_no_match(/author_name/, update_sql)
+    end
+  end
+
+  def test_increment_ignores_scopes_without_all_queries
+    topic = topics(:first)
+    assert_not topic.class.default_scopes?
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      Topic.where(author_name: "Pierre").scoping do
+        update_sql = capture_sql { topic.increment!(:replies_count) }.first
+        assert_no_match(/author_name/, update_sql)
+      end
+    end
+  end
+
+  def test_increment_ignores_default_scopes_with_unscoped
+    topic = DefaultApprovedTopic.create(approved: true)
+    assert topic.class.default_scopes?(all_queries: true)
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      update_sql = capture_sql { topic.increment!(:replies_count, unscoped: true) }.first
+      assert_no_match(/approved/, update_sql)
+    end
+  end
+
+  def test_increment_ignores_scopes_with_unscoped
+    topic = topics(:first)
+    assert_not topic.class.default_scopes?
+
+    assert_difference -> { topic.reload.replies_count }, 1 do
+      Topic.where("1=2").scoping(all_queries: true) do
+        update_sql = capture_sql { topic.increment!(:replies_count, unscoped: true) }.first
+        assert_no_match(/approved/, update_sql)
+      end
+    end
+  end
+
   def test_destroy_many
     clients = Client.find([2, 3])
 

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -135,6 +135,10 @@ class DefaultRejectedTopic < Topic
   default_scope -> { where(approved: false) }
 end
 
+class DefaultApprovedTopic < Topic
+  default_scope -> { where(approved: true) }, all_queries: true
+end
+
 class BlankTopic < Topic
   # declared here to make sure that dynamic finder with a bang can find a model that responds to `blank?`
   def blank?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Prior to this change, calling `.update_counters` on an ActiveRecord class would use `unscoped` and therefore ignore existing scopes, both default scopes set in the model, or dynamic scopes set with `.scoping`.

With this change, `update_counters` is more consistent with similar methods such as `.update_all` and use existing scopes before applying the update.

Because `#increment!` & `#decrement!` use `update_counters` internally, I ended up changing their behaviors as well, but if it's preferable, we could totally keep this PR focused on `update_counters` only, and keep the `increment!`/`decrement!` behaviors the same, and address that in a separate PR.

### Detail

Assuming this `Comment` class

```ruby
class Comment < ActiveRecord::Base
  default_scope -> { where(post_id: 1) }
end
```

The current behavior on main is:

```ruby
Comment.where("1=1").scoping { Comment.update_counters(1, views_count: 0) }
 # UPDATE "comments" SET "views_count" = COALESCE("views_count", 0) + ? WHERE "comments"."id" = ?
```

And the behavior on this branch is:

```ruby
Comment.where("1=1").scoping { Comment.update_counters(1, views_count: 0) }
 # UPDATE "comments" SET "views_count" = COALESCE("views_count", 0) + ? WHERE "comments"."post_id" = ? AND (1=1) AND "comments"."id" = ?
```

For reference, here is how `update_all` behaves:

```ruby
Comment.where("1=1").scoping { Comment.update_all("updated_at=CURRENT_TIMESTAMP") }
 # UPDATE "comments" SET updated_at=CURRENT_TIMESTAMP WHERE (1=1)
```

The changes to `#increment!` were made to keep the behavior consistent with `#reload`, as in, "regular" scopes, the ones without `all_queries: true` are ignored, whether explicit with `.scoping` or default, and the scopes with `all_queries: true` are applied.

Quoting @eileencodes from [a previous PR](https://github.com/rails/rails/pull/40805#issuecomment-743353343):

> all_queries should mean all_queries so it makes sense to add reload to this if you have that option set.

### Additional information

Note that there seems to be a bug with `#reload`, and therefore this new version of `#increment!` since they now match, when using `.scoping` around an operation, all scopes, even the ones without `all_queries: true` end up applied.

See this issue: #47357

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. _Not yet, I thought I would add it once it's decided that this PR makes sense_
