### PR TITLE
Add `#update_if` to perform optimistic updates

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -99,6 +99,7 @@ module ActiveRecord
     autoload :FutureResult
     autoload :LegacyYamlAdapter
     autoload :NullRelation
+    autoload :OptimisticUpdate
     autoload :Promise
     autoload :Relation
     autoload :Result

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -311,6 +311,7 @@ module ActiveRecord # :nodoc:
     include Attributes
     include Locking::Optimistic
     include Locking::Pessimistic
+    include OptimisticUpdate
     include Encryption::EncryptableRecord
     include AttributeMethods
     include Callbacks

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -337,6 +337,24 @@ module ActiveRecord
     end
   end
 
+  class UnexpectedValueInDatabase < ActiveRecordError
+    attr_reader :record, :attempted_action, :constraints
+
+    def initialize(record = nil, attempted_action = nil, constraints = nil)
+      if record && attempted_action && constraints
+        @record = record
+        @attempted_action = attempted_action
+        @constraints = constraints
+
+        super("Failed to #{attempted_action} an object: #{record.class.name}. No rows matching [#{constraints}]")
+      elsif constraints
+        super("Failed to find records. No rows matching [#{constraints}]")
+      else
+        super("Failed to find records.")
+      end
+    end
+  end
+
   # Raised when association is being configured improperly or user tries to use
   # offset and limit together with
   # {ActiveRecord::Base.has_many}[rdoc-ref:Associations::ClassMethods#has_many] or

--- a/activerecord/lib/active_record/optimistic_update.rb
+++ b/activerecord/lib/active_record/optimistic_update.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module OptimisticUpdate
+    def update_if(*args, &block)
+      @_optimistic_update_constraints << args
+
+      if block_given?
+        begin
+          yield
+        ensure
+          clear_update_conditions
+        end
+      else
+        self
+      end
+    end
+
+    def clear_update_conditions
+      @_optimistic_update_constraints = []
+    end
+
+    def decrement!(...)
+      super(...)
+    rescue ActiveRecord::UnexpectedValueInDatabase => e
+      raise ActiveRecord::UnexpectedValueInDatabase.new(self, "decrement!", e.constraints)
+    end
+
+    def update_columns(attributes)
+      return super if @_optimistic_update_constraints.empty?
+
+      _with_scope do |scope|
+        super.tap do |success|
+          raise ActiveRecord::UnexpectedValueInDatabase.new(self, "update", scope.arel.where_sql) unless success
+        end
+      end
+    end
+
+    private
+      def init_internals
+        super
+        @_optimistic_update_constraints = []
+      end
+
+      def _update_row(attribute_names, attempted_action = "update")
+        return super if @_optimistic_update_constraints.empty?
+
+        _with_scope do |scope|
+          super.tap do |affected_rows|
+            if affected_rows != 1
+              raise ActiveRecord::UnexpectedValueInDatabase.new(self, attempted_action, scope.arel.where_sql)
+            end
+          end
+        rescue ActiveRecord::StaleObjectError => e
+          # To make things more explicit for developers, append the optimistic lock condition to the error message:
+          locking_column = self.class.locking_column
+          full_constraints = scope.arel.where_sql.to_s + " AND #{locking_column} = #{_lock_value_for_database(locking_column)}"
+          raise ActiveRecord::UnexpectedValueInDatabase.new(e.record, e.attempted_action, full_constraints)
+        end
+      end
+
+      def _combine_constraints(relation = self.class.all)
+        return if @_optimistic_update_constraints.empty?
+
+        @_optimistic_update_constraints.reduce(relation) do |relation, constraint|
+          relation.where(*constraint)
+        end
+      end
+
+      def _with_scope(&block)
+        scoped_relation = _combine_constraints(self.class.unscoped)
+        scoped_relation.scoping(all_queries: true) do
+          yield scoped_relation
+        end
+      end
+
+      def _increment(id, counters)
+        return super if @_optimistic_update_constraints.empty?
+
+        _with_scope do |scope|
+          # Ideally we could use self.class.update_counters(id, counters), but it uses `unscoped` so we can't
+          # See: https://github.com/rails/rails/pull/47358
+          self.class.all.where!(self.class.primary_key => id).update_counters(counters).tap do |affected_rows|
+            if affected_rows != 1
+              raise ActiveRecord::UnexpectedValueInDatabase.new(self, "increment!", scope.arel.where_sql)
+            end
+          end
+        end
+      end
+  end
+end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -954,7 +954,7 @@ module ActiveRecord
     def increment!(attribute, by = 1, touch: nil)
       increment(attribute, by)
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
-      self.class.update_counters(id, attribute => change, touch: touch)
+      _increment(id, attribute => change, touch: touch)
       public_send(:"clear_#{attribute}_change")
       self
     end
@@ -1256,6 +1256,12 @@ module ActiveRecord
         Cannot touch on a new or destroyed record object. Consider using
         persisted?, new_record?, or destroyed? before touching.
       MSG
+    end
+
+    def _increment(id, counters)
+      # This is nececessary because OptimisticUpdate needs to have access to the
+      # result of this call, to raise an exception if affected_rows == 0
+      self.class.update_counters(id, counters)
     end
   end
 end

--- a/activerecord/test/cases/optimistic_update_test.rb
+++ b/activerecord/test/cases/optimistic_update_test.rb
@@ -1,0 +1,352 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/computer"
+require "models/person"
+require "models/reader"
+require "models/sharded/blog_post"
+require "models/sharded/comment"
+
+class OptimisticUpdateTest < ActiveRecord::TestCase
+  fixtures :people, :sharded_blog_posts, :sharded_comments, :computers, :readers
+
+  def test_it_works_with_block_syntax_and_optimistic_locking
+    person = people(:michael)
+
+    update_sql = capture_sql { person.update_if(primary_contact_id: 2) { person.update!(first_name: "Pierre") } }.first
+
+    assert_match(/WHERE .*.lock_version. = .{1,2}.*.primary_contact_id. = .{1,2}/i, update_sql)
+    assert_equal "Pierre", person.first_name
+    assert_equal(%w(first_name lock_version updated_at), person.previous_changes.keys.sort)
+  end
+
+  def test_it_works_with_block_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    update_sql = capture_sql { post.update_if(title: post.title) { post.update!(title: "New Title!") } }.first
+
+    assert_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_it_does_not_update_with_block_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+    sql_log = []
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      capture_sql(sql_log) do
+        post.update_if(title: "Not the current title") { post.update!(title: "New Title!") }
+      end
+    end
+    update_sql = sql_log.first
+
+    regexp = error_message_regexp(Sharded::BlogPost, ["sharded_blog_posts.title"])
+    assert_match(regexp, error.message)
+    assert_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal({}, post.previous_changes)
+  end
+
+  def test_it_does_not_update_if_stale
+    michael = people(:michael)
+    Person.find(michael.id).touch
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      michael.update_if(primary_contact_id: 2) do
+        michael.update!(first_name: "Pierre")
+      end
+    end
+
+    regexp = error_message_regexp(Person, ["people.primary_contact_id", /lock_version = 0/])
+    assert_match regexp, error.message
+  end
+
+  def test_it_works_with_inline_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    post.update_if(title: post.title)
+    update_sql = capture_sql { post.update!(title: "New Title!") }.first
+
+    assert_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_it_works_with_chained_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    update_sql = capture_sql { post.update_if(title: post.title).update!(title: "New Title!") }.first
+
+    assert_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_it_does_not_update_with_inline_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      post.update_if(title: "Not the current title")
+      post.update_if(id: 123)
+      post.update_if("id = ?", "456")
+      post.update!(title: "New Title!")
+    end
+
+    regexp = error_message_regexp(Sharded::BlogPost, ["sharded_blog_posts.title", "sharded_blog_posts.id", /\(id = '456'\)/])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_does_not_update_with_chained_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      post.update_if(title: "").update!(title: "New Title!")
+    end
+
+    regexp = error_message_regexp(Sharded::BlogPost, ["sharded_blog_posts.title"])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_can_clear_conditions
+    post = sharded_blog_posts(:great_post_blog_one)
+    post.update_if(title: post.title)
+    post.update!(title: "New Title!")
+    assert_equal "New Title!", post.title
+
+    post.clear_update_conditions
+    update_sql = capture_sql { post.update!(title: "Latest Title!") }.first
+
+    assert_no_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal "Latest Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_block_syntax_automatically_clear_conditions
+    post = sharded_blog_posts(:great_post_blog_one)
+    post.update_if(title: post.title) { post.update!(title: "New Title!") }
+    assert_equal "New Title!", post.title
+
+    update_sql = capture_sql { post.update!(title: "Latest Title!") }.first
+
+    assert_no_match(/WHERE .*.title. = .{1,2}/i, update_sql)
+    assert_equal "Latest Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_supports_where_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    update_sql = capture_sql { post.update_if("title = ?", post.title) { post.update!(title: "New Title!") } }.first
+
+    assert_match(/WHERE .*\(title = 'My first post!'\)/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_it_can_stack_conditions
+    comment = sharded_comments(:great_comment_blog_post_one)
+
+    update_sql = capture_sql do
+      comment.update_if("blog_post_id = ?", comment.blog_post_id.to_s) do
+        comment.update_if(body: comment.body) { comment.update!(body: "New Body!") }
+      end
+    end.first
+
+    assert_match(/WHERE .*blog_post_id = '#{comment.blog_post_id}'.*.body. = .{1,2}/i, update_sql)
+    assert_equal "New Body!", comment.body
+    assert_equal(%w(body), comment.previous_changes.keys)
+  end
+
+  def test_like_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    update_sql = capture_sql { post.update_if("title LIKE ?", "%first%") { post.update!(title: "New Title!") } }.first
+
+    assert_match(/WHERE .*title LIKE '%first%'/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_interpolation_with_hash_syntax
+    post = sharded_blog_posts(:great_post_blog_one)
+
+    update_sql = capture_sql { post.update_if("title = :title", title: post.title) { post.update!(title: "New Title!") } }.first
+
+    assert_match(/WHERE .*\(title = 'My first post!'\)/i, update_sql)
+    assert_equal "New Title!", post.title
+    assert_equal(%w(title), post.previous_changes.keys)
+  end
+
+  def test_like_syntax_no_update
+    post = sharded_blog_posts(:great_post_blog_one)
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      post.update_if("title LIKE ?", "%no match%") do
+        post.update!(title: "New Title!")
+      end
+    end
+
+    regexp = error_message_regexp(Sharded::BlogPost, [/\(title LIKE '%no match%'\)/i])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_touch
+    computer = computers(:workstation)
+    original_updated_at = computer.updated_at
+
+    update_sql = capture_sql { computer.update_if(system: computer.system) { computer.touch } }.first
+
+    assert_match(/WHERE .*.system. = .{1,2}/i, update_sql)
+    assert_not_equal original_updated_at, computer.reload.updated_at
+  end
+
+  def test_it_raises_when_not_matching_with_touch
+    computer = computers(:workstation)
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      computer.update_if(system: "macOS") do
+        computer.touch
+      end
+    end
+
+    regexp = error_message_regexp(Computer, ["computers.system"], "touch")
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_increment!
+    computer = computers(:workstation)
+    original_timezone = computer.timezone
+
+    update_sql = capture_sql { computer.update_if(system: computer.system) { computer.increment!(:timezone) } }.first
+
+    assert_match(/WHERE .*.system. = .{1,2}/i, update_sql)
+    assert_not_equal original_timezone, computer.timezone
+  end
+
+
+  def test_it_raises_when_not_matching_with_increment!
+    computer = computers(:workstation)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      computer.update_if(system: "macOS") { computer.increment!(:timezone) }
+    end
+
+    regexp = error_message_regexp(Computer, ["computers.system"], "increment!")
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_decrement!
+    computer = computers(:workstation)
+    original_timezone = computer.timezone
+
+    update_sql = capture_sql { computer.update_if(system: computer.system) { computer.decrement!(:timezone) } }.first
+
+    assert_match(/WHERE .*.system. = .{1,2}/i, update_sql)
+    assert_not_equal original_timezone, computer.timezone
+  end
+
+
+  def test_it_raises_when_not_matching_with_decrement!
+    computer = computers(:workstation)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      computer.update_if(system: "macOS") { computer.decrement!(:timezone) }
+    end
+
+    regexp = error_message_regexp(Computer, ["computers.system"], "decrement!")
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_toggle!
+    reader = readers(:michael_welcome)
+
+    update_sql = capture_sql { reader.update_if(person_id: reader.person_id) { reader.toggle!(:skimmer) } }.first
+
+    assert_match(/WHERE .*.person_id. = .{1,2}/i, update_sql)
+    assert reader.skimmer
+  end
+
+  def test_it_raises_when_not_matching_with_toggle!
+    reader = readers(:michael_welcome)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      reader.update_if(person_id: -1) { reader.toggle!(:skimmer) }
+    end
+
+    regexp = error_message_regexp(Reader, ["readers.person_id"])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_update_attribute
+    reader = readers(:michael_welcome)
+
+    update_sql = capture_sql { reader.update_if(person_id: reader.person_id) { reader.update_attribute(:skimmer, true) } }.first
+
+    assert_match(/WHERE .*.person_id. = .{1,2}/i, update_sql)
+    assert reader.skimmer
+  end
+
+  def test_it_raises_when_not_matching_with_update_attribute
+    reader = readers(:michael_welcome)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      reader.update_if(person_id: -1) { reader.update_attribute(:skimmer, true) }
+    end
+
+    regexp = error_message_regexp(Reader, ["readers.person_id"])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_update_column
+    reader = readers(:michael_welcome)
+
+    update_sql = capture_sql { reader.update_if(person_id: reader.person_id) { reader.update_column(:skimmer, true) } }.first
+
+    assert_match(/WHERE .*.person_id. = .{1,2}/i, update_sql)
+    assert reader.skimmer
+  end
+
+  def test_it_raises_when_not_matching_with_update_column
+    reader = readers(:michael_welcome)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      reader.update_if(person_id: -1) { reader.update_column(:skimmer, true) }
+    end
+
+    regexp = error_message_regexp(Reader, ["readers.person_id"])
+    assert_match(regexp, error.message)
+  end
+
+  def test_it_updates_with_update_columns
+    reader = readers(:michael_welcome)
+
+    update_sql = capture_sql { reader.update_if(person_id: reader.person_id) { reader.update_columns(skimmer: true) } }.first
+
+    assert_match(/WHERE .*.person_id. = .{1,2}/i, update_sql)
+    assert reader.skimmer
+  end
+
+  def test_it_raises_when_not_matching_with_update_columns
+    reader = readers(:michael_welcome)
+
+    error = assert_raises(ActiveRecord::UnexpectedValueInDatabase) do
+      reader.update_if(person_id: -1) { reader.update_columns(skimmer: true) }
+    end
+
+    regexp = error_message_regexp(Reader, ["readers.person_id"])
+    assert_match(regexp, error.message)
+  end
+
+  private
+    def error_message_regexp(model, where_columns, operation = "update")
+      connection = model.connection
+      quoted_where_columns = where_columns.map do |where|
+        if where.is_a?(Regexp)
+          where
+        else
+          quoted_column_name = quote_column_name(connection, where)
+          "#{quoted_column_name} = .*"
+        end
+      end.join(" AND ")
+
+      /Failed to #{operation} an object: #{model}\. No rows matching \[WHERE #{quoted_where_columns}\]/
+    end
+
+    def quote_column_name(connection, column)
+      Regexp.escape(connection.quote_table_name(column))
+    end
+end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -39,11 +39,13 @@ module ActiveRecord
       SQLCounter.clear_log
     end
 
-    def capture_sql
+    def capture_sql(output = nil)
       ActiveRecord::Base.connection.materialize_transactions
       SQLCounter.clear_log
       yield
-      SQLCounter.log.dup
+      sql_logs = SQLCounter.log.dup
+    ensure
+      output.concat(sql_logs || SQLCounter.log.dup) if output
     end
 
     def assert_sql(*patterns_to_match, &block)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

SQL Optimistic updates are a convenient way to perform an `UPDATE` while confirming that the current values in the database match some expectation. I've used this pattern extensively in the past with tables having a lifecycle following a determined state machine. For instance, with the following model:

```ruby
class Charge < ActiveRecord::Base
  validates :status, inclusion: ["pending", "success", "failure"]
end
```

A charge status can be updated from `"pending"` to `"success"` or from `"pending"` to `"failure"` but never from `"failure"` to `"success"` and vice versa. With optimistic updates, the following is now possible:

```ruby
charge.update_if(status: "pending") { charge.update!(status: "success") }
# UPDATE charges SET status = 'success' WHERE id = ? AND status = 'pending'
# UnexpectedValueInDatabase will be raised if charge.status == "failure"
```

### Details

Introduce the method `update_if` for instance of `ActiveRecord::Base`.
The method is used to perform optimistic updates. This is similar to
`Locking::Optimistic`, but does not require a integer version to store the
version of the records.

We can now do the following:

```ruby
charge.update_if(status: "pending") do
  charge.update!(status: "success")
  # UPDATE "charges" SET "charges"."status" = 'success' WHERE "charges"."id" = ? AND "charges"."status" = 'pending'
end
```

If the `UPDATE` statement does not match any queries, because the value
of the `status` column in the DB was not `'pending'`, an exception is raised:

```ruby
charge.update!(status: "success")

charge.update_if(status: "pending") do
  charge.update!(status: "success") # raises an ActiveRecord::UnexpectedValueInDatabase
end
```

A version without block is available, but requires developers to clear
the conditions manually (the block version automatically clears them):

```ruby
charge.update_if(status: "pending")
charge.update!(status: "success")
charge.clear_update_conditions
```

Conditions can be stacked:

```ruby
charge.update_if(status: "pending") do
  charge.update_if(deleted_at: nil) do
    charge.update!(status: "success", deleted_at: Time.now)
    # UPDATE "charges" SET "charges"."status" = 'success', "charges"."deleted_at" = ? WHERE "charges"."id" = ? AND "charges"."status" = 'pending' AND "charges"."deleted_at" IS NULL
  end
end

charge.update_if(status: "pending") do
charge.update_if(deleted_at: nil) do
charge.update!(status: "success", deleted_at: Time.now)
 # UPDATE "charges" SET "charges"."status" = 'success', "charges"."deleted_at" = ? WHERE "charges"."id" = ? AND "charges"."status" = 'pending' AND "charges"."deleted_at" IS NULL
charge.clear_update_conditions
```

`update_if` can be used similarly to `where`, so for instance the
following options are possible:

```ruby
charge.update_if("status LIKE ?", "pend%")
charge.update_if("status = :status", status: "pending")
charge.update!(status: "success")
 # UPDATE "charges" SET "charges"."status" = 'success' WHERE "charges"."id" = ? AND "charges"."status" LIKE 'pend%' AND "charges"."status" = 'pending'
```

### Additional information

Some of the comments were added as a way to facilitate review, and explain some of the decisions, and would likely be removed if the feature is approved.

Similarly, I didn't write any public facing API documentation. I figured I would take the time to do it if the feature is approved

The first commit is a small refactor of the `capture_sql` test helper, so that logs can be captured even if the underlying operation throws an exception.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. _Not yet, as mentioned earlier, I figured I would take the time to do that only if the feature is approved_
