### PR TITLE
Duplicate default attributes when they are mutable non-procs

### DIFF
--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -18,7 +18,7 @@ module ActiveModel
         if user_provided_value.is_a?(Proc)
           @memoized_value_before_type_cast ||= user_provided_value.call
         else
-          @user_provided_value
+          @user_provided_value.frozen? ? @user_provided_value : @user_provided_value.deep_dup
         end
       end
 

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -14,6 +14,9 @@ module ActiveModel
       attribute :string_with_default, :string, default: "default string"
       attribute :date_field, :date, default: -> { Date.new(2016, 1, 1) }
       attribute :boolean_field, :boolean
+      attribute :hash_with_mutable_default, default: {}
+      attribute :array_with_mutable_default, default: []
+      attribute :array_with_nested_mutable_default, default: [[42]]
     end
 
     class ChildModelForAttributesTest < ModelForAttributesTest
@@ -89,7 +92,10 @@ module ActiveModel
         decimal_field: BigDecimal("1.1"),
         string_with_default: "default string",
         date_field: Date.new(2016, 1, 1),
-        boolean_field: true
+        boolean_field: true,
+        hash_with_mutable_default: {},
+        array_with_mutable_default: [],
+        array_with_nested_mutable_default: [[42]],
       }.stringify_keys
 
       assert_equal expected_attributes, data.attributes
@@ -102,7 +108,10 @@ module ActiveModel
         "decimal_field",
         "string_with_default",
         "date_field",
-        "boolean_field"
+        "boolean_field",
+        "hash_with_mutable_default",
+        "array_with_mutable_default",
+        "array_with_nested_mutable_default",
       ]
 
       assert_equal names, ModelForAttributesTest.attribute_names
@@ -174,6 +183,33 @@ module ActiveModel
       assert_raise(ArgumentError) do
         ModelForAttributesTest.attribute :foo, :unknown
       end
+    end
+
+    test "mutable hash default attribute should be isolated" do
+      data1 = ModelForAttributesTest.new
+      data2 = ModelForAttributesTest.new
+
+      data1.hash_with_mutable_default[:key] = "value"
+      assert_equal({ key: "value" }, data1.hash_with_mutable_default)
+      assert_equal({}, data2.hash_with_mutable_default)
+    end
+
+    test "mutable array default attribute should be isolated" do
+      data1 = ModelForAttributesTest.new
+      data2 = ModelForAttributesTest.new
+
+      data1.array_with_mutable_default << "value"
+      assert_equal(["value"], data1.array_with_mutable_default)
+      assert_equal([], data2.array_with_mutable_default)
+    end
+
+    test "nested mutable array default attribute should be isolated" do
+      data1 = ModelForAttributesTest.new
+      data2 = ModelForAttributesTest.new
+
+      data1.array_with_nested_mutable_default[0] << 54
+      assert_equal([42, 54], data1.array_with_nested_mutable_default[0])
+      assert_equal([42], data2.array_with_nested_mutable_default[0])
     end
   end
 end


### PR DESCRIPTION
Fixes #42959
Fixes #41854

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because when default attributes are mutable, they are shared between ActiveModel instances. See #41854 #42959 #42977

### Detail

This Pull Request changes default attributes so that if they are mutable non-procs they `deep_dup` is called to copy the default rather than return a reference to shared state.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
- Alternative solution: it was proposed to deprecate non-proc default attributes. I think the current PR is preferable because it works as expected with minimal changes.
- Alternative solution: use this approach but perhaps locate it elsewhere. I started with a modification of `attribute_registration.rb` then switched to `user_provided_default` which seemed more appropriate.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
