### PR TITLE
[ci-skip] fix sample code for *bytes methods in Active Support Guide

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1950,7 +1950,7 @@ They return the corresponding amount of bytes, using a conversion factor of 1024
 ```ruby
 2.kilobytes   # => 2048
 3.megabytes   # => 3145728
-3.5.gigabytes # => 3758096384
+3.5.gigabytes # => 3758096384.0
 -4.exabytes   # => -4611686018427387904
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found an incorrect result from a sample code in active_support_core_extensions.md.

### Detail

This Pull Request changes: 

```ruby
# before
2.kilobytes   # => 2048
3.megabytes   # => 3145728
3.5.gigabytes # => 3758096384
-4.exabytes   # => -4611686018427387904
```

```ruby
# after
2.kilobytes   # => 2048
3.megabytes   # => 3145728
3.5.gigabytes # => 3758096384.0.  # 3.5.class is `Float`
-4.exabytes   # => -4611686018427387904
```

### Additional information

The behavior has been checked in M1 Macbook Pro.
At least, I got the same result in the following:

* Ruby 2.6.8 and Active Support 6.1.7.2
* Ruby 3.2.1 and Active Support 7.0.4.2

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
