### PR TITLE
Fix S3 CORS example

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1012,13 +1012,13 @@ No CORS configuration is required for the Disk service since it shares your appâ
     "AllowedOrigins": [
       "https://www.example.com"
     ],
-    "ExposedHeaders": [
+    "ExposeHeaders": [
       "Origin",
       "Content-Type",
       "Content-MD5",
       "Content-Disposition"
     ],
-    "MaxAge": 3600
+    "MaxAgeSeconds": 3600
   }
 ]
 ```


### PR DESCRIPTION
Update S3 CORS example keys to match latest AWS documentation.

Doc ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html#cors-example-2

AWS example:
```json
[
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "PUT",
            "POST",
            "DELETE"
        ],
        "AllowedOrigins": [
            "http://www.example.com"
        ],
        "ExposeHeaders": [
            "x-amz-server-side-encryption",
            "x-amz-request-id",
            "x-amz-id-2"
        ],
        "MaxAgeSeconds": 3000
    }
]
```

----

Errors while trying to edit cross-origin resource sharing (CORS) using the old keys:

> There were 2 validation errors: * UnexpectedParameter: Unexpected key 'ExposedHeaders' found in params.CORSConfiguration.CORSRules[0] * UnexpectedParameter: Unexpected key 'MaxAge' found in params.CORSConfiguration.CORSRules[0]
