### PR TITLE
Fix all missing $ signs in all bash commands in guides

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -75,7 +75,7 @@ end
 or add rich text field while creating a new model using:
 
 ```bash
-bin/rails generate model Message content:rich_text
+$ bin/rails generate model Message content:rich_text
 ```
 
 NOTE: you don't need to add a `content` field to your `messages` table.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -467,7 +467,7 @@ Known extensions: rails, pride
 To run all tests in a CI environment, there's just one command you need:
 
 ```bash
-bin/rails test
+$ bin/rails test
 ```
 
 If you are using [System Tests](#system-testing), `bin/rails test` will not run them, since


### PR DESCRIPTION
Followup of https://github.com/rails/rails/pull/47298

This PR only fixes missing $ on  main guides.

I left out old upgrade guides as I was not sure whether they should be done too right now