### PR TITLE
Fix variants not included when eager loading multiple records containing a single attachment

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix variants not included when eager loading multiple records containing a single attachment
+
+    When using the `with_attached_#{name}` scope for a `has_one_attached` relation,
+    attachment variants were not eagerly loaded.
+
+    *Russell Porter*
+
 *   Allow an ActiveStorage attachment to be removed via a form post
 
     Attachments can already be removed by updating the attachment to be nil such as:

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -72,7 +72,13 @@ module ActiveStorage
         has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
         has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
-        scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
+        scope :"with_attached_#{name}", -> {
+          if ActiveStorage.track_variants
+            includes("#{name}_attachment": { blob: { variant_records: { image_attachment: :blob } } })
+          else
+            includes("#{name}_attachment": :blob)
+          end
+        }
 
         after_save { attachment_changes[name.to_s]&.save }
 

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -59,7 +59,69 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     assert_equal "local_public", variant.image.blob.service_name
   end
 
-  test "eager loading" do
+  test "eager loading has_one_attached record" do
+    user1 = User.create!(name: "Josh")
+    user2 = User.create!(name: "John")
+
+    blob1 = directly_upload_file_blob(filename: "racecar.jpg")
+    assert_difference -> { ActiveStorage::VariantRecord.count }, +1 do
+      blob1.representation(resize_to_limit: [100, 100]).process
+    end
+
+    blob2 = directly_upload_file_blob(filename: "racecar_rotated.jpg")
+    assert_difference -> { ActiveStorage::VariantRecord.count }, +1 do
+      blob2.representation(resize_to_limit: [100, 100]).process
+    end
+
+    assert_no_difference -> { ActiveStorage::VariantRecord.count } do
+      user1.cover_photo.attach(blob1)
+      user2.cover_photo.attach(blob2)
+    end
+
+    users = User.where(id: [user1.id, user2.id])
+
+    users.reset
+
+    assert_no_difference -> { ActiveStorage::VariantRecord.count } do
+      assert_queries(11) do
+        # 11 queries:
+        # users x 1
+        # attachment (cover photo) x 2
+        # blob for the cover photo x 2
+        # variant record x 1 per blob
+        # attachment x 1 per variant record
+        # variant record x 1 per variant record attachment
+        users.each do |u|
+          rep = u.cover_photo.representation(resize_to_limit: [100, 100])
+          rep.processed
+          rep.key
+          rep.url
+        end
+      end
+    end
+
+    users.reset
+
+    assert_no_difference -> { ActiveStorage::VariantRecord.count } do
+      assert_queries(6) do
+        # 6 queries:
+        # users x 1
+        # attachment (cover photos) x 1
+        # blob for the cover photo x 1
+        # variant record x 1
+        # attachment x 1
+        # variant record x 1
+        users.with_attached_cover_photo.each do |u|
+          rep = u.cover_photo.representation(resize_to_limit: [100, 100])
+          rep.processed
+          rep.key
+          rep.url
+        end
+      end
+    end
+  end
+
+  test "eager loading has_many_attached records" do
     user = User.create!(name: "Josh")
 
     blob1 = directly_upload_file_blob(filename: "racecar.jpg")


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

When using the `with_attached_#{name}` scope for a `has_one_attached` relation, attachment variants were not eagerly loaded.

This fix is important to ensure good performance when using Active Storage variants.

This Pull Request has been created because I encountered this performance issue when developing my project.

Fixes #46770

### Detail

The scope implementation is now the same as when used with `has_many_attached`.

### Additional information

I'm very inexperienced with Ruby, so I tried follow the existing implementation and testing approach.

In particular, it would be good to remove the duplication between `has_one_attached` and `has_many_attached` that led to this bug but I am not sure the best way to achieve that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
