### PR TITLE
Add linter for framework defaults and Rails config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,22 +6,23 @@ permissions:
   contents: read
 
 jobs:
-  changelog-formatting:
-    name: Check CHANGELOGs formatting
+  rails-bin:
+    name: Check rails-bin lints
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         repository: skipkayhil/rails-bin
-        ref: ba349066e1ce0c6e8d5b2c5e92dc71802237adbd
+        ref: 748f4673a5fe5686b5859e89f814166280e51781
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
+        ruby-version: 3.2
         bundler-cache: true
     - uses: actions/checkout@v3
       with:
         path: rails
     - run: bin/check-changelogs ./rails
+    - run: bin/check-config-docs ./rails
   codespell:
     name: Check spelling all files with codespell
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation / Background

Ref: #45784
Ref: #45787
Ref: #46355
Ref: #46356
Ref: #46732
Ref: #47330
etc.

### Detail

This linter parses the Rails::Application::Configuration file and ensures that
- all configurations are listed alphabetically in Configuring guide
- all framework defaults are listed alphabetically in Configuring guide
- all framework defaults are included in the new_framework_defaults_x_x
  template

### Additional information

Example failing run:
skipkayhil/rails#2
https://github.com/skipkayhil/rails/actions/runs/4157986301/jobs/7192876941

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
