### PR TITLE
Add test coverage for `Object#with_options` with `Hash`-like argument

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/with_options.rb
+++ b/activesupport/lib/active_support/core_ext/object/with_options.rb
@@ -5,9 +5,9 @@ require "active_support/option_merger"
 class Object
   # An elegant way to factor duplication out of options passed to a series of
   # method calls. Each method called in the block, with the block variable as
-  # the receiver, will have its options merged with the default +options+ hash
-  # provided. Each method called on the block variable must take an options
-  # hash as its final argument.
+  # the receiver, will have its options merged with the default +options+
+  # <tt>Hash</tt> or <tt>Hash</tt>-like object provided. Each method called on
+  # the block variable must take an options hash as its final argument.
   #
   # Without <tt>with_options</tt>, this code contains duplication:
   #

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -114,6 +114,21 @@ class OptionMergerTest < ActiveSupport::TestCase
     assert_equal expected, @options
   end
 
+  def test_with_options_hash_like
+    hash_like = Class.new do
+      delegate :to_hash, :deep_merge, to: :@hash
+
+      def initialize(hash)
+        @hash = hash
+      end
+    end
+    local_options = { "cool" => true }
+    scope = with_options(hash_like.new(@options))
+
+    assert_equal local_options, method_with_options(local_options)
+    assert_equal @options.merge(local_options), scope.method_with_options(local_options)
+  end
+
   def test_with_options_no_block
     local_options = { "cool" => true }
     scope = with_options(@options)


### PR DESCRIPTION
### Motivation / Background

Add test coverage for existing `Object#with_options` support for `Hash`-like objects.

### Detail

The current implementation expects "Hash-like" to mean that the argument implements both `Hash#deep_merge` and `#to_hash` (to be called explicitly with `#to_hash` and implicitly with `**`).

This coverage is an explicit commitment to (what has so far been implicit) support for objects that do not descend from `Hash`, but implement `Hash` methods. This includes classes like [ActionController::Parameters](https://edgeapi.rubyonrails.org/classes/ActionController/Parameters.html) (which inherits from `Object`) and others like it that return instances of a class other than `Hash` when calling `deep_merge`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
