### PR TITLE
Refactor query constraints feature set

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -19,7 +19,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     self.extensions = []
 
     VALID_OPTIONS = [
-      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading
+      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints
     ].freeze # :nodoc:
 
     def self.build(model, name, scope, options, &block)

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -505,7 +505,7 @@ module ActiveRecord
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
-              primary_key = Array(reflection.options[:primary_key] || record.class.query_constraints_list)
+              primary_key = Array(compute_primary_key(reflection, record))
               foreign_key = Array(reflection.foreign_key)
 
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
@@ -518,6 +518,16 @@ module ActiveRecord
 
             saved if autosave
           end
+        end
+      end
+
+      def compute_primary_key(reflection, record)
+        if primary_key_options = reflection.options[:primary_key]
+          primary_key_options
+        elsif query_constraints = record.class.query_constraints_list
+          query_constraints
+        else
+          :id
         end
       end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -490,9 +490,9 @@ module ActiveRecord
       end
 
       def foreign_key
-        @foreign_key ||= if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+        @foreign_key ||= if options[:query_constraints]
           # composite foreign keys support
-          options[:foreign_key].map { |fk| fk.to_s.freeze }.freeze
+          options[:query_constraints].map { |fk| fk.to_s.freeze }.freeze
         else
           -(options[:foreign_key]&.to_s || derive_foreign_key)
         end
@@ -507,7 +507,7 @@ module ActiveRecord
       end
 
       def active_record_primary_key
-        @active_record_primary_key ||= if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+        @active_record_primary_key ||= if options[:query_constraints]
           active_record.query_constraints_list
         else
           -(options[:primary_key]&.to_s || primary_key(active_record))
@@ -775,7 +775,7 @@ module ActiveRecord
 
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
-        if options[:foreign_key] && options[:foreign_key].is_a?(Array)
+        if options[:query_constraints]
           (klass || self.klass).query_constraints_list
         elsif primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1439,13 +1439,13 @@ class QueryConstraintsTest < ActiveRecord::TestCase
     assert_equal("id", ClothingItem.primary_key)
   end
 
-  def test_query_constraints_list_is_an_empty_array_if_primary_key_is_nil
+  def test_query_constraints_list_is_nil_if_primary_key_is_nil
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "developers_projects"
     end
 
     assert_nil klass.primary_key
-    assert_empty klass.query_constraints_list
+    assert_nil klass.query_constraints_list
   end
 
   def test_query_constraints_uses_primary_key_by_default

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -6,6 +6,6 @@ module Sharded
     query_constraints :blog_id, :id
 
     belongs_to :blog
-    has_many :comments, foreign_key: [:blog_id, :blog_post_id]
+    has_many :comments, query_constraints: [:blog_id, :blog_post_id]
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_comments
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post, foreign_key: [:blog_id, :blog_post_id]
+    belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
     belongs_to :blog
   end
 end


### PR DESCRIPTION
I worked on this last week and shared with @nvasilevski as well. The main thing I'm doing here is walking the composite keys / query constraints feature back a bit so that we know when we have query constraints vs a primary rather than trying to make primary key into query constraints. Eventually we'll want to remove the branching but that's not required to implement the feature and we can't change the meaning of `primary_key` in the process (we can do it later as a separate implementation).

---

Commit message:

This PR refactors the query constraints feature to be more contained and have less implicit behavior. Eventually we'll want `primary_key` to flow through query constraints and return `["id"]` when we have a single column and internally Rails will use an array for all `primary_key` and `foreign_key` calls, falling back to query constraints. At the moment however, this is a large change in Rails and one that could break current expected behavior. In order to implement the feature and not break compatibility I think we should walk back the feature a little bit. The changes are:

* Only return `query_constraints_list` if `query_constraints` was set by the model, otherwise return nil.
* Re-implement `primary_key` calls where we only have a single ID
* Update the `foreign_key` option on associations to use a `query_constraints` option instead so we don't need to check `is_a?(Array)`.

These changes will ensure that the changes are contained to `query_constraints` rather than having to make decisions about whether we want to treat `primary_key` as an array. For now we will call everything `query_constraints` which makes it easy to see the line when we want an array vs single column. Later we can change the meaning of `primary_key` if necessary.