### PR TITLE
Remove deprecated Capybara drivers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated drivers for system testing, poltergeist and capybara-webkit.
+
+    *Yusuke Iwaki*
+
 *   Change `ActionController::Instrumentation` to pass `filtered_path` instead of `fullpath` in the event payload to filter sensitive query params
 
     ```ruby

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -12,14 +12,6 @@ module ActionDispatch
         @name = @options.delete(:name) || driver_type
         @capabilities = capabilities
 
-        if [:poltergeist, :webkit].include?(driver_type)
-          ActionDispatch.deprecator.warn <<~MSG.squish
-            Poltergeist and capybara-webkit are not maintained already.
-            Driver registration of :poltergeist or :webkit is deprecated and will be removed in Rails 7.1.
-            You can still use :selenium, and also :cuprite is available for alternative to Poltergeist.
-          MSG
-        end
-
         if driver_type == :selenium
           gem "selenium-webdriver", ">= 4.0.0"
           require "selenium/webdriver"
@@ -38,7 +30,7 @@ module ActionDispatch
 
       private
         def registerable?
-          [:selenium, :poltergeist, :webkit, :cuprite, :rack_test].include?(@driver_type)
+          [:selenium, :cuprite, :rack_test].include?(@driver_type)
         end
 
         def register
@@ -47,8 +39,6 @@ module ActionDispatch
           Capybara.register_driver name do |app|
             case @driver_type
             when :selenium then register_selenium(app)
-            when :poltergeist then register_poltergeist(app)
-            when :webkit then register_webkit(app)
             when :cuprite then register_cuprite(app)
             when :rack_test then register_rack_test(app)
             end
@@ -62,16 +52,6 @@ module ActionDispatch
         def register_selenium(app)
           Capybara::Selenium::Driver.new(app, browser: @browser.type, **browser_options).tap do |driver|
             driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
-          end
-        end
-
-        def register_poltergeist(app)
-          Capybara::Poltergeist::Driver.new(app, @options.merge(window_size: @screen_size))
-        end
-
-        def register_webkit(app)
-          Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
-            driver.resize_window_to(driver.current_window_handle, *@screen_size)
           end
         end
 

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -37,24 +37,6 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
-  test "initializing the driver with a poltergeist" do
-    driver = assert_deprecated(ActionDispatch.deprecator) do
-      ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
-    end
-    assert_equal :poltergeist, driver.instance_variable_get(:@driver_type)
-    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
-    assert_equal ({ js_errors: false }), driver.instance_variable_get(:@options)
-  end
-
-  test "initializing the driver with a webkit" do
-    driver = assert_deprecated(ActionDispatch.deprecator) do
-      ActionDispatch::SystemTesting::Driver.new(:webkit, screen_size: [1400, 1400], options: { skip_image_loading: true })
-    end
-    assert_equal :webkit, driver.instance_variable_get(:@driver_type)
-    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
-    assert_equal ({ skip_image_loading: true }), driver.instance_variable_get(:@options)
-  end
-
   test "initializing the driver with a cuprite" do
     driver = ActionDispatch::SystemTesting::Driver.new(:cuprite, screen_size: [1400, 1400], options: { js_errors: false })
     assert_equal :cuprite, driver.instance_variable_get(:@driver_type)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In Rails 7.0, poltergeist and capybara-webkit are marked as deprecated. #42790
This PR completely remove them.

### Detail

This Pull Request removes deprecated Capybara drivers (poltergeist and webkit).

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
