### PR TITLE
Fixes issue: Link to SQL Reference guide #47369

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -45,7 +45,7 @@ overall database access code.
 
 NOTE: Basic knowledge of relational database management systems (RDBMS) and
 structured query language (SQL) is helpful in order to fully understand Active
-Record. Please refer to [this tutorial][w3sql] (or [this one][sqlcourse]) or
+Record. Please refer to [this tutorial][sqlcourse] (or [this one][rdbmsinfo]) or
 study them by other means if you would like to learn more.
 
 ### Active Record as an ORM Framework
@@ -62,8 +62,8 @@ to:
 [MVC]: https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller
 [MFAR]: https://www.martinfowler.com/eaaCatalog/activeRecord.html
 [ORM]: https://en.wikipedia.org/wiki/Object-relational_mapping
-[w3sql]: https://www.w3schools.com/sql/default.asp
-[sqlcourse]: https://www.sqlcourse.com
+[sqlcourse]: https://www.khanacademy.org/computing/computer-programming/sql
+[rdbmsinfo]: https://www.devart.com/what-is-rdbms/
 
 Convention over Configuration in Active Record
 ----------------------------------------------


### PR DESCRIPTION
### Motivation / Background
Fixes #47369 
Change link for sql tutorial to Khan Academy course. Added link to devart page which explains RDBMS. Both sites do not contain ads, tracking software, or other subscription related inceptives.

### Detail

This Pull Request removes w3sql and sqlcourse links due to advertisements, and adds link to Khan Academy Introduction to SQL course and devart.com page on RDBMS.

### Checklist

Before submitting the PR make sure the following are checked:

* [ x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a ] Tests are added or updated if you fix a bug or add a feature.
* [n/a ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
