### PR TITLE
Update TimeHelpers#travel_to docs after stubbing Time.new

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,12 @@
 *   Stub `Time.new()` in `TimeHelpers#travel_to`
 
+      ```ruby
+      travel_to Time.new(2004, 11, 24) do
+        # Inside the `travel_to` block `Time.new` is stubbed
+        assert_equal Time.new.year, 2004
+      end
+      ```
+
     *fatkodima*
 
 *   Raise `ActiveSupport::MessageEncryptor::InvalidMessage` from

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -98,7 +98,7 @@ module ActiveSupport
         travel_to Time.now + duration, with_usec: with_usec, &block
       end
 
-      # Changes current time to the given time by stubbing +Time.now+,
+      # Changes current time to the given time by stubbing +Time.now+, +Time.new+,
       # +Date.today+, and +DateTime.now+ to return the time or date passed into this method.
       # The stubs are automatically removed at the end of the test.
       #

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2156,18 +2156,24 @@ Additional Testing Resources
 
 Rails provides built-in helper methods that enable you to assert that your time-sensitive code works as expected.
 
-Here is an example using the [`travel_to`](https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel_to) helper:
+The following example uses the [`travel_to`][travel_to] helper:
 
 ```ruby
-# Lets say that a user is eligible for gifting a month after they register.
+# Given a user is eligible for gifting a month after they register.
 user = User.create(name: "Gaurish", activation_date: Date.new(2004, 10, 24))
 assert_not user.applicable_for_gifting?
+
 travel_to Date.new(2004, 11, 24) do
-  assert_equal Date.new(2004, 10, 24), user.activation_date # inside the `travel_to` block `Date.current` is mocked
+  # Inside the `travel_to` block `Date.current` is stubbed
+  assert_equal Date.new(2004, 10, 24), user.activation_date
   assert user.applicable_for_gifting?
 end
-assert_equal Date.new(2004, 10, 24), user.activation_date # The change was visible only inside the `travel_to` block.
+
+# The change was visible only inside the `travel_to` block.
+assert_equal Date.new(2004, 10, 24), user.activation_date
 ```
 
-Please see [`ActiveSupport::Testing::TimeHelpers` API Documentation](https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html)
-for in-depth information about the available time helpers.
+Please see [`ActiveSupport::Testing::TimeHelpers`][time_helpers_api] API reference for more information about the available time helpers.
+
+[travel_to]: https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel_to
+[time_helpers_api]: https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html


### PR DESCRIPTION
Follow up to #47315

* Adds an example to the changelog
* Updates API doc to include `Time.new` in list of stubbed methods
* Some minor style changes to "Testing Time-Dependent Code" guide

cc @fatkodima 