### PR TITLE
[Railties iso tests] Replace redundant double-dots with a constant

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -539,6 +539,9 @@ Module.new do
 
   assets_path = "#{RAILS_FRAMEWORK_ROOT}/railties/test/isolation/assets"
   unless Dir.exist?("#{assets_path}/node_modules")
+    contents = File.read("#{assets_path}/package.json")
+    contents.gsub!(/RAILS_FRAMEWORK_ROOT/, RAILS_FRAMEWORK_ROOT)
+
     Dir.chdir(assets_path) do
       sh "yarn install"
     end

--- a/railties/test/isolation/assets/package.json
+++ b/railties/test/isolation/assets/package.json
@@ -2,9 +2,9 @@
   "name": "dummy",
   "private": true,
   "dependencies": {
-    "@rails/actioncable": "file:../../../../actioncable",
-    "@rails/activestorage": "file:../../../../activestorage",
-    "@rails/ujs": "file:../../../../actionview",
-    "@rails/webpacker": "^6.0.0-rc.5"
+    "@rails/actioncable": "file:RAILS_FRAMEWORK_ROOT/actioncable",
+    "@rails/activestorage": "file:RAILS_FRAMEWORK_ROOT/activestorage",
+    "@rails/ujs": "file:RAILS_FRAMEWORK_ROOT/actionview",
+    "@rails/webpacker": "^6.0.0-rc.6"
   }
 }


### PR DESCRIPTION
Found this honestly looking to see if we had any tests for #39351, then felt it should be updated.

There's also a change to bump `@rails/webpacker` to the latest version, that I'd like to see the result of. :pray:

ℹ️ This requires rails/buildkite-config#35 in order to pass, you can see an [example build here](https://buildkite.com/rails/rails/builds/93881).

---

💭 I'm not 100% this is better, it was interesting to find out the connection in CI however. So sharing this at least has some value IMO. My instincts are that a non-templated file like this should behave as it normally would without pre-parsing, otherwise to use a file-extension suffix like `package.json.tt` or something and use the **same** method for preprocessing.

That said, this PR is here if anyone else discovers this and says "that's weird". :joy: