### PR TITLE
SchemaCache#init_with skip deduplicate if specified

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -67,13 +67,16 @@ module ActiveRecord
 
       def init_with(coder)
         @columns          = coder["columns"]
+        @columns_hash     = coder["columns_hash"]
         @primary_keys     = coder["primary_keys"]
         @data_sources     = coder["data_sources"]
         @indexes          = coder["indexes"] || {}
         @version          = coder["version"]
         @database_version = coder["database_version"]
 
-        derive_columns_hash_and_deduplicate_values
+        unless coder["deduplicated"]
+          derive_columns_hash_and_deduplicate_values
+        end
       end
 
       def primary_keys(table_name)

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -375,6 +375,17 @@ module ActiveRecord
         end
       end
 
+      test "#init_with skips deduplication if told to" do
+        coder = {
+          "columns" => [].freeze,
+          "deduplicated" => true,
+        }
+
+        schema_cache = SchemaCache.allocate
+        schema_cache.init_with(coder)
+        assert_same coder["columns"], schema_cache.instance_variable_get(:@columns)
+      end
+
       private
         def schema_dump_path
           "#{ASSETS_ROOT}/schema_dump_5_1.yml"


### PR DESCRIPTION
This is a very advanced API for people who use a custom Schema Cache serializer.

The custom serializer might already deduplicate data, in which case going through deduplication again would be very wasteful.
