### PR TITLE
Remove unnecessary calls to `establish_connection`

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -73,7 +73,6 @@ module ActiveRecord
           assert_raises(ArgumentError) { setup_shared_connection_pool }
         ensure
           ActiveRecord::Base.connection_handler = connection_handler
-          ActiveRecord::Base.establish_connection :arunit
         end
 
         def test_fixtures_dont_raise_if_theres_no_writing_pool_config
@@ -90,7 +89,6 @@ module ActiveRecord
           assert_equal rw_conn, ro_conn
         ensure
           ActiveRecord::Base.connection_handler = connection_handler
-          ActiveRecord::Base.establish_connection :arunit
         end
 
         def test_setting_writing_role_while_using_another_named_role_does_not_raise
@@ -104,7 +102,6 @@ module ActiveRecord
         ensure
           ActiveRecord.writing_role = old_role
           ActiveRecord::Base.connection_handler = connection_handler
-          ActiveRecord::Base.establish_connection :arunit
         end
 
         def test_establish_connection_with_primary_works_without_deprecation

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -43,7 +43,6 @@ module ActiveRecord
           assert_equal default_pool, @handler.retrieve_connection_pool("primary")
         ensure
           ActiveRecord::Base.configurations = @prev_configs
-          ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
         end
 
@@ -68,7 +67,6 @@ module ActiveRecord
           assert_not_nil @handler.retrieve_connection_pool("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
-          ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
         end
 
@@ -94,7 +92,6 @@ module ActiveRecord
           assert_not @handler.connected?("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
-          ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
         end
       end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -14,7 +14,6 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
       assert_predicate ActiveRecord::Base.configurations, :blank?
     ensure
       ActiveRecord::Base.configurations = old_config
-      ActiveRecord::Base.establish_connection :arunit
     end
   end
 

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -227,13 +227,12 @@ class DefaultsTestWithoutTransactionalFixtures < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
     def using_strict(strict)
-      connection = ActiveRecord::Base.remove_connection
-      conn_hash = connection.configuration_hash
+      db_config = ActiveRecord::Base.connection_pool.db_config
+      conn_hash = db_config.configuration_hash
       ActiveRecord::Base.establish_connection conn_hash.merge(strict: strict)
       yield
     ensure
-      ActiveRecord::Base.remove_connection
-      ActiveRecord::Base.establish_connection connection
+      ActiveRecord::Base.establish_connection db_config
     end
 
     # Strict mode controls how MySQL handles invalid or missing values

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -14,9 +14,6 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
 
   teardown do
     return if in_memory_db?
-    db_config = ActiveRecord::Base.connection_db_config
-    ActiveRecord::Base.remove_connection
-    ActiveRecord::Base.establish_connection(db_config)
   end
 
   unless in_memory_db?


### PR DESCRIPTION
* Remove/establish_connection is not needed in the `disconnected_test` teardown
* Remove `establish_connection` in ensure blocks that are already using a custom handler (therefore we don't need to set the connection back)
* Remove `establish_connection` in ensure blocks where we don't ever swap out base.
* Remove `remove_connection` from `defaults_test` - it was only being used to get the configuration hash, which we can do without removing the conn