### PR TITLE
Test Deprecation skipping caller locations

### DIFF
--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -707,7 +707,18 @@ class DeprecationTest < ActiveSupport::TestCase
     end
   end
 
+  test "warn deprecation skips the internal caller locations" do
+    @deprecator.behavior = ->(_, callstack, *) { @callstack = callstack }
+    method_that_emits_deprecation(@deprecator)
+    assert_equal __FILE__, @callstack.first.absolute_path
+    assert_equal __LINE__ - 2, @callstack.first.lineno
+  end
+
   private
+    def method_that_emits_deprecation(deprecator)
+      deprecator.warn
+    end
+
     def deprecator_with_messages
       klass = Class.new(ActiveSupport::Deprecation)
       deprecator = klass.new


### PR DESCRIPTION
ActiveSupport::Deprecation warn uses `caller_locations(2)` to skip the current backtrace (in `warn`), and the one above (in the deprecated method) so that the backtrace starts in the application code. It's a very useful feature that's not specifically tested, this adds a test.

https://github.com/rails/rails/blob/ae3abb760cf98f71dacf6a2f908b3f18c12042b0/activesupport/lib/active_support/deprecation/reporting.rb#L21

Extracted from #47354