### PR TITLE
Remove test that's not useful

### DIFF
--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -411,20 +411,6 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_deprecated(/this is the old way/, @deprecator) { klass.new.fubar }
   end
 
-  test "delegating to ActiveSupport::Deprecation" do
-    messages = []
-
-    klass = Class.new do
-      delegate :warn, :behavior=, to: ActiveSupport::Deprecation
-    end
-
-    o = klass.new
-    o.behavior = Proc.new { |message, callstack| messages << message }
-    assert_difference("messages.size") do
-      o.warn("warning")
-    end
-  end
-
   test "overriding deprecated_method_warning" do
     deprecator = deprecator_with_messages
 


### PR DESCRIPTION
This test was originally added when ActiveSupport::Deprecation was a Module in 2c690a0f5b36896da9b003d4e24159a27ebd7f71. It was testing that including the module and changing the behavior would not impact the global deprecation behavior.

When ActiveSupport::Deprecation was changed to be a Class in 71993c6f9770b1350aa41fe8c68f1dd2c7800403, it started to mutate the global state, changing the behavior of the singleton. And the test lost its meaning, it wasn't testing anymore that one Deprecation object wouldn't impact another.

I didn't add such a test because it's default behavior that changing one object doesn't impact another.

Extracted from #47354 