### PR TITLE
Document that only application deprecators are disabled by `report_deprecations`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2240,7 +2240,7 @@ Configures deprecation warnings that the Application considers disallowed. This 
 
 #### `config.active_support.report_deprecations`
 
-When `false`, disables all deprecation warnings, including disallowed deprecations, making `ActiveSupport::Deprecation.warn` a no-op.
+When `false`, disables all deprecation warnings, including disallowed deprecations, from the [application’s deprecators](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-deprecators). This includes all the deprecations from Rails and other gems that may add their deprecator to the collection of deprecators, but may not prevent all deprecation warnings emitted from ActiveSupport::Deprecation.
 
 In the default generated `config/environments` files, this is set to `false` for production.
 


### PR DESCRIPTION
I'm just worried the original wording may lead people to believe no deprecations will be emitted at all.

Extracted from #47354