### PR TITLE
Remove deprecation warning without a deprecator

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -28,9 +28,6 @@ module ActiveJob
     end
 
     included do
-      cattr_accessor :skip_after_callbacks_if_terminated, instance_accessor: false, default: false
-      singleton_class.deprecate :skip_after_callbacks_if_terminated, :skip_after_callbacks_if_terminated=
-
       define_callbacks :perform, skip_after_callbacks_if_terminated: true
       define_callbacks :enqueue, skip_after_callbacks_if_terminated: true
     end


### PR DESCRIPTION
The initial deprecation was introduced in 6.1: bbfab0b33abd7481b8a801b672d7b2316609315a

The configuration stayed with a deprecation in 7.0 but was not preserving the behavior, so it's no longer that useful: 10bd5e59c3291bb2034869e97cca30634a559afb

This removes the configuration and deprecation.

Extracted from #47354
