### PR TITLE
Allow mailer classes to customize the deliver_later queue name

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   The `deliver_later_queue_name` used by the default mailer job can now be
+    configured on a per-mailer basis. Previously this was only configurable
+    for all mailers via `ActionMailer::Base`.
+
+    Example:
+
+    ```ruby
+    class EventsMailer < ApplicationMailer
+      self.deliver_later_queue_name = :throttled_mailer
+    end
+    ```
+
+    *Jeffrey Hardy*
+
 *   Email previews now include an expandable section to show all headers.
 
     Headers like `Message-ID` for threading or email service provider specific

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -53,6 +53,7 @@ module ActionMailer
   autoload :TestHelper
   autoload :MessageDelivery
   autoload :MailDeliveryJob
+  autoload :QueuedDelivery
 
   def self.eager_load!
     super

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -460,12 +460,14 @@ module ActionMailer
   # * <tt>deliveries</tt> - Keeps an array of all the emails sent out through the Action Mailer with
   #   <tt>delivery_method :test</tt>. Most useful for unit and functional testing.
   #
-  # * <tt>delivery_job</tt> - The job class used with <tt>deliver_later</tt>. Defaults to
-  #   +ActionMailer::MailDeliveryJob+.
+  # * <tt>delivery_job</tt> - The job class used with <tt>deliver_later</tt>. Mailers can set this to use a
+  #   custom delivery job. Defaults to +ActionMailer::MailDeliveryJob+.
   #
-  # * <tt>deliver_later_queue_name</tt> - The name of the queue used with <tt>deliver_later</tt>.
+  # * <tt>deliver_later_queue_name</tt> - The queue name used by <tt>deliver_later</tt> with the default
+  #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue. Defaults to <tt>:mailers</tt>.
   class Base < AbstractController::Base
     include DeliveryMethods
+    include QueuedDelivery
     include Rescuable
     include Parameterized
     include Previews
@@ -487,7 +489,6 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -12,7 +12,6 @@ module ActionMailer
       # Do not make this inheritable, because we always want it to propagate
       cattr_accessor :raise_delivery_errors, default: true
       cattr_accessor :perform_deliveries, default: true
-      cattr_accessor :deliver_later_queue_name, default: :mailers
 
       class_attribute :delivery_methods, default: {}.freeze
       class_attribute :delivery_method, default: :smtp

--- a/actionmailer/lib/action_mailer/mail_delivery_job.rb
+++ b/actionmailer/lib/action_mailer/mail_delivery_job.rb
@@ -9,7 +9,10 @@ module ActionMailer
   #
   # Exceptions are rescued and handled by the mailer class.
   class MailDeliveryJob < ActiveJob::Base # :nodoc:
-    queue_as { ActionMailer::Base.deliver_later_queue_name }
+    queue_as do
+      mailer_class = arguments.first.constantize
+      mailer_class.deliver_later_queue_name
+    end
 
     rescue_from StandardError, with: :handle_exception_with_mailer_class
 

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -62,9 +62,10 @@ module ActionMailer
     # * <tt>:queue</tt> - Enqueue the email on the specified queue
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
-    # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt>. Each
-    # ActionMailer::Base class can specify the job to use by setting the class variable
-    # +delivery_job+.
+    # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt> on
+    # the +:mailers+ queue. Mailer classes can customize the queue name used for the default
+    # job by assigning a +deliver_later_queue_name+ class variable, or provide a custom job
+    # by assigning a +delivery_job+. When a custom job is used, it controls the queue name.
     #
     #   class AccountRegistrationMailer < ApplicationMailer
     #     self.delivery_job = RegistrationDeliveryJob
@@ -88,9 +89,10 @@ module ActionMailer
     # * <tt>:queue</tt> - Enqueue the email on the specified queue.
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
-    # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt>. Each
-    # ActionMailer::Base class can specify the job to use by setting the class variable
-    # +delivery_job+.
+    # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt> on
+    # the +:mailers+ queue. Mailer classes can customize the queue name used for the default
+    # job by assigning a +deliver_later_queue_name+ class variable, or provide a custom job
+    # by assigning a +delivery_job+. When a custom job is used, it controls the queue name.
     #
     #   class AccountRegistrationMailer < ApplicationMailer
     #     self.delivery_job = RegistrationDeliveryJob

--- a/actionmailer/lib/action_mailer/queued_delivery.rb
+++ b/actionmailer/lib/action_mailer/queued_delivery.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActionMailer
+  module QueuedDelivery
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
+      class_attribute :deliver_later_queue_name, default: :mailers
+    end
+  end
+end

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -170,11 +170,14 @@ module ActionMailer
     #       ContactMailer.with(email: 'user@example.com').welcome.deliver_later
     #     end
     #   end
-    def assert_enqueued_email_with(mailer, method, params: nil, args: nil, queue: ActionMailer::Base.deliver_later_queue_name || "default", &block)
+    def assert_enqueued_email_with(mailer, method, params: nil, args: nil, queue: nil, &block)
       if mailer.is_a? ActionMailer::Parameterized::Mailer
         params = mailer.instance_variable_get(:@params)
         mailer = mailer.instance_variable_get(:@mailer)
       end
+
+      queue ||= mailer.deliver_later_queue_name || ActiveJob::Base.default_queue_name
+
       args = if args.is_a?(Hash)
         [mailer.to_s, method.to_s, "deliver_now", params: args, args: []]
       elsif params.present?
@@ -182,6 +185,7 @@ module ActionMailer
       else
         [mailer.to_s, method.to_s, "deliver_now", args: Array(args)]
       end
+
       assert_enqueued_with(job: mailer.delivery_job, args: args, queue: queue.to_s, &block)
     end
 

--- a/actionmailer/test/mailers/delayed_mailer.rb
+++ b/actionmailer/test/mailers/delayed_mailer.rb
@@ -5,6 +5,8 @@ require "active_job/arguments"
 class DelayedMailerError < StandardError; end
 
 class DelayedMailer < ActionMailer::Base
+  self.deliver_later_queue_name = :delayed_mailers
+
   cattr_accessor :last_error
   cattr_accessor :last_rescue_from_instance
 

--- a/actionmailer/test/parameterized_test.rb
+++ b/actionmailer/test/parameterized_test.rb
@@ -17,18 +17,13 @@ class ParameterizedTest < ActiveSupport::TestCase
     @previous_delivery_method = ActionMailer::Base.delivery_method
     ActionMailer::Base.delivery_method = :test
 
-    @previous_deliver_later_queue_name = ActionMailer::Base.deliver_later_queue_name
-    ActionMailer::Base.deliver_later_queue_name = :test_queue
-
     @mail = ParamsMailer.with(inviter: "david@basecamp.com", invitee: "jason@basecamp.com").invitation
   end
 
   teardown do
     ActiveJob::Base.logger = @previous_logger
     ParamsMailer.deliveries.clear
-
     ActionMailer::Base.delivery_method = @previous_delivery_method
-    ActionMailer::Base.deliver_later_queue_name = @previous_deliver_later_queue_name
   end
 
   test "parameterized headers" do

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -38,6 +38,10 @@ class CustomDeliveryMailer < TestHelperMailer
   self.delivery_job = CustomDeliveryJob
 end
 
+class CustomQueueMailer < TestHelperMailer
+  self.deliver_later_queue_name = :custom_queue
+end
+
 class TestHelperMailerTest < ActionMailer::TestCase
   include ActiveSupport::Testing::Stream
 
@@ -366,6 +370,22 @@ class TestHelperMailerTest < ActionMailer::TestCase
       assert_enqueued_email_with TestHelperMailer, :test, queue: :mailers do
         silence_stream($stdout) do
           TestHelperMailer.test.deliver_later
+        end
+      end
+    end
+  end
+
+  def test_assert_enqueued_email_with_when_mailer_has_custom_deliver_later_queue
+    assert_nothing_raised do
+      assert_enqueued_email_with CustomQueueMailer, :test do
+        silence_stream($stdout) do
+          CustomQueueMailer.test.deliver_later
+        end
+      end
+
+      assert_enqueued_email_with CustomQueueMailer, :test, queue: :custom_queue do
+        silence_stream($stdout) do
+          CustomQueueMailer.test.deliver_later
         end
       end
     end

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -818,7 +818,7 @@ files (environment.rb, production.rb, etc...)
 |`perform_deliveries`|Determines whether deliveries are actually carried out when the `deliver` method is invoked on the Mail message. By default they are, but this can be turned off to help functional testing. If this value is `false`, `deliveries` array will not be populated even if `delivery_method` is `:test`.|
 |`deliveries`|Keeps an array of all the emails sent out through the Action Mailer with delivery_method :test. Most useful for unit and functional testing.|
 |`delivery_job`|The job class used with `deliver_later`. Defaults to `ActionMailer::MailDeliveryJob`.|
-|`deliver_later_queue_name`|The name of the queue used with `deliver_later`.|
+|`deliver_later_queue_name`|The name of the queue used with the default `delivery_job`. Defaults to `:mailers|
 |`default_options`|Allows you to set default values for the `mail` method options (`:from`, `:reply_to`, etc.).|
 
 For a complete writeup of possible configurations see the

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2112,9 +2112,18 @@ Enable or disable mailer previews. By default this is `true` in development.
 config.action_mailer.show_previews = false
 ```
 
+#### `config.action_mailer.perform_caching`
+
+Specifies whether the mailer templates should perform fragment caching or not. If it's not specified, the default will be `true`.
+
 #### `config.action_mailer.deliver_later_queue_name`
 
-Specifies the Active Job queue to use for delivery jobs. When this option is set to `nil`, delivery jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`). Make sure that your Active Job adapter is also configured to process the specified queue, otherwise delivery jobs may be silently ignored.
+Specifies the Active Job queue to use for the default delivery job (see `config.action_mailer.delivery_job`). When this option is set to `nil`, delivery jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
+
+Mailer classes can override this to use a different queue. Note that this only applies when using the default delivery job. If your mailer is using a custom
+job, its queue will be used.
+
+Ensure that your Active Job adapter is also configured to process the specified queue, otherwise delivery jobs may be silently ignored.
 
 The default value depends on the `config.load_defaults` target version:
 
@@ -2122,10 +2131,6 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `:mailers`           |
 | 6.1                   | `nil`                |
-
-#### `config.action_mailer.perform_caching`
-
-Specifies whether the mailer templates should perform fragment caching or not. If it's not specified, the default will be `true`.
 
 #### `config.action_mailer.delivery_job`
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1281,7 +1281,7 @@ module ApplicationTests
       require "mail"
       _ = ActionMailer::Base
 
-      assert_equal "test_default", ActionMailer::Base.class_variable_get(:@@deliver_later_queue_name)
+      assert_equal "test_default", ActionMailer::Base.deliver_later_queue_name
     end
 
     test "ActionMailer::DeliveryJob queue name is :mailers without the Rails defaults" do
@@ -1292,7 +1292,7 @@ module ApplicationTests
       require "mail"
       _ = ActionMailer::Base
 
-      assert_equal :mailers, ActionMailer::Base.class_variable_get(:@@deliver_later_queue_name)
+      assert_equal :mailers, ActionMailer::Base.deliver_later_queue_name
     end
 
     test "ActionMailer::DeliveryJob queue name is nil by default in 6.1" do
@@ -1304,7 +1304,7 @@ module ApplicationTests
       require "mail"
       _ = ActionMailer::Base
 
-      assert_nil ActionMailer::Base.class_variable_get(:@@deliver_later_queue_name)
+      assert_nil ActionMailer::Base.deliver_later_queue_name
     end
 
     test "valid timezone is setup correctly" do


### PR DESCRIPTION
The `deliver_later_queue_name` is already configurable on `ActionMailer::Base`, however [the value is inherited by all subclasses](https://github.com/rails/rails/blob/51e9fa9bf9701672bc45ab6da4f39212af39db59/actionmailer/lib/action_mailer/delivery_methods.rb#L15). Use a class-inheritable attribute instead, so that subclasses can override.

This can be handy if you're using named queues for concurrency control. For example, a queue being processed by many workers can deliver a lot of mail concurrently, which may not be desirable. With a high-volume mailer, too much concurrency can lead to rate-limiting and blocking at mail providers. Using a queue that's assigned fewer workers (or a single worker) is one way to prevent this.

To make this easier, this PR allows the queue used by the default delivery job to be configured on a per-mailer basis.

Example:

```ruby
class AnnouncementsMailer < ApplicationMailer
  self.deliver_later_queue_name = :throttled_mailer
end
```

References:
- https://github.com/rails/rails/pull/18587#issuecomment-324975192