### PR TITLE
Fix rubocop issue for action cable -- ostruct

### DIFF
--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -1,18 +1,28 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 class TestServer
   include ActionCable::Server::Connections
   include ActionCable::Server::Broadcasting
 
   attr_reader :logger, :config, :mutex
 
+  class FakeConfiguration < ActionCable::Server::Configuration
+    attr_accessor :subscription_adapter, :log_tags, :filter_parameters
+
+    def initialize(subscription_adapter:)
+      @log_tags = []
+      @filter_parameters = []
+      @subscription_adapter = subscription_adapter
+    end
+
+    def pubsub_adapter
+      @subscription_adapter
+    end
+  end
+
   def initialize(subscription_adapter: SuccessAdapter)
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
-
-    @config = OpenStruct.new(log_tags: [], subscription_adapter: subscription_adapter, filter_parameters: [])
-
+    @config = FakeConfiguration.new(subscription_adapter: subscription_adapter)
     @mutex = Monitor.new
   end
 


### PR DESCRIPTION
### Motivation / Background

~~Action cable is breaking when creating a simple test like below, because of an error `NameError: uninitialized constant ActionCable::Channel::ConnectionStub::TestServer`. The test_server is now inside the lib folder, alongside a the success_adapter which it depends on.~~

```
require "test_helper"

class RandomChannelTest < ActionCable::Channel::TestCase
  test "subscribes" do
    subscribe
    assert subscription.confirmed?
  end
end
```

~~This Pull Request has been created because https://github.com/rails/rails/issues/47377 which relates to a change merged in https://github.com/rails/rails/pull/47300~~

The second commit addresses the rubocop performance issue where I added a fake config class that inherits from `ActionCable::Server::Configuration`. The `subscription_adapter` is added so it can be overridden in tests, this seems like a a better option than using a struct in which a whole bunch of vars need to be assigned/overridden. 

### Detail

Fix rubocop issue with using ostruct.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
