### PR TITLE
`Associations::Preloader` supports preloading associations with composite keys

### DIFF
--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -216,8 +216,8 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   end
 
   test "joins a belongs_to association with a composite foreign key" do
-    first_post_comments = Sharded::Comment.joins(:blog_post).where(blog_post: { title: "My first post!" }).to_a
-    expected_blog_post = sharded_blog_posts(:great_blog_post_one)
+    first_post_comments = Sharded::Comment.joins(:blog_post).where(blog_post: { title: "My first post in my Blog1!" }).to_a
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
 
     assert_not_empty comments
     assert_equal(expected_blog_post.comments.to_a.sort, first_post_comments.sort)

--- a/activerecord/test/fixtures/sharded_blog_posts.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts.yml
@@ -1,10 +1,14 @@
 _fixture:
   model_class: Sharded::BlogPost
 
-great_blog_post_one:
-  title: "My first post!"
+great_post_blog_one:
+  title: "My first post in my Blog1!"
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
-great_blog_post_two:
-  title: "My second post!"
+second_post_blog_one:
+  title: "This is my second post in my Blog1!"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+great_post_blog_two:
+  title: "My first post in my Blog2!"
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/fixtures/sharded_comments.yml
+++ b/activerecord/test/fixtures/sharded_comments.yml
@@ -3,17 +3,17 @@ _fixture:
 
 great_comment_blog_post_one:
   body: "I really enjoyed the post!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
 wow_comment_blog_post_one:
   body: "Wow!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
 unique_comment_blog_post_one:
   body: "Your first blog post is great!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
 
 great_comment_blog_post_two:


### PR DESCRIPTION
This PR adds support for `Associations::Preloader` to be able to preload associations associated by a composite foreign key (`query_constraints`) and by implication adds support for `includes()` relations.

The fundamental requirement for querying cross-tenant records in bulk is to be able to specify sets/tuples of column names and values. The most effective SQL clause would use a row constructor like:
```sql
select * from comments where (blog_id, blog_post_id) IN ((1,2), (1,3))
```
However, since Rails currently doesn't support row-constructor clauses, we are using a series of OR clauses like this:
```sql
select * from comments where (blog_id=1 and blog_post_id=2) OR (blog_id=1 and blog_post_id=3)
```

This is less effective approach as the query grows quicker with the number of values being queries. However still a valid equivalent.

In a tenant-based application, we anticipate most of the queries to be performed in scope a single tenant (line in the examples above) and Rails (Arel?) is smart enough to turn the OR query from above into:
```sql
select * from comments where blog_id=1 AND (blog_post_id=2 OR blog_post_id=3)
```

### Potential optimization

I don't think it would be suitable to do that in this PR, however the query above can potentially be optimized even further and turned into:
```sql
select * from comments where blog_id=1 AND blog_post_id IN (2,3)
```
making the sql clause as short as possible. I haven't explored this option yet but I expect us to implement this implementation at either `load_records_for_keys` level or inside Arel, if possible.


### Further steps

Ideally we would love Rails to eventually support row-constructor clauses allowing `load_records_for_keys` to stay unchanged and be as simple as `resulting_scope.where(association_key_name => keys)` where `association_key_name` refers to either a single column or a set of columns.