### PR TITLE
Bump timeout gem to 0.3.2 and fix CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     tilt (2.0.11)
-    timeout (0.3.1)
+    timeout (0.3.2)
     trailblazer-option (0.1.2)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)


### PR DESCRIPTION
This was causing one bug report template to fail:
https://buildkite.com/rails/rails/builds/93873#018657ce-2c40-4dcb-8f38-dd1dd0af6279

```
/Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated timeout 0.3.1, but your Gemfile requires timeout 0.3.2. Since timeout is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports timeout as a default gem. (Gem::LoadError)
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/runtime.rb:25:in `block in setup'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/spec_set.rb:155:in `each'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/spec_set.rb:155:in `each'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/runtime.rb:24:in `map'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/runtime.rb:24:in `setup'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/inline.rb:66:in `block in gemfile'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/settings.rb:131:in `temporary'
        from /Users/zzak/.gem/ruby/3.3.0/gems/bundler-2.3.22/lib/bundler/inline.rb:50:in `gemfile'
        from bug_report_templates/action_controller_gem.rb:5:in `<main>'
```