### PR TITLE
Need absolute path to this test file

### DIFF
--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -706,7 +706,7 @@ class DeprecationTest < ActiveSupport::TestCase
   test "warn deprecation skips the internal caller locations" do
     @deprecator.behavior = ->(_, callstack, *) { @callstack = callstack }
     method_that_emits_deprecation(@deprecator)
-    assert_equal __FILE__, @callstack.first.absolute_path
+    assert_equal File.expand_path(__FILE__), @callstack.first.absolute_path
     assert_equal __LINE__ - 2, @callstack.first.lineno
   end
 


### PR DESCRIPTION
Follow up to #47398 which results in the following failure:
https://buildkite.com/rails/rails/builds/93883#01865907-dfaa-4bd3-82ce-2c14cc9bb918

```
Failure:
--
  | DeprecationTest#test_warn_deprecation_skips_the_internal_caller_locations [test/deprecation_test.rb:709]:
  | --- expected
  | +++ actual
  | @@ -1 +1 @@
  | -"test/deprecation_test.rb"
  | +"/rails/activesupport/test/deprecation_test.rb"
  |  
  |  
  |  
  | bin/rails test test/deprecation_test.rb:706
```