### PR TITLE
Specify when to generate `has_secure_token`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Specify callback in `has_secure_token`
+
+    ```ruby
+    class User < ApplicationRecord
+      has_secure_token on: :initialize
+    end
+
+    User.new.token # => "abc123...."
+    ```
+
+    *Sean Doyle*
+
 *   Fix incrementation of in memory counter caches when associations overlap
 
     When two associations had a similarly named counter cache column, Active Record

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -29,7 +29,20 @@ module ActiveRecord
       # Note that it's still possible to generate a race condition in the database in the same way that
       # {validates_uniqueness_of}[rdoc-ref:Validations::ClassMethods#validates_uniqueness_of] can.
       # You're encouraged to add a unique index in the database to deal with this even more unlikely scenario.
-      def has_secure_token(attribute = :token, length: MINIMUM_TOKEN_LENGTH)
+      #
+      # === Options
+      #
+      # [:length]
+      #   Length of the Secure Random, with a minimum of 24 characters. It will
+      #   default to 24.
+      #
+      # [:on]
+      #   The callback when the value is generated. When called with <tt>on:
+      #   :initialize</tt>, the value is generated in an
+      #   <tt>after_initialize</tt> callback, otherwise the value will be used
+      #   in a <tt>before_</tt> callback. It will default to <tt>:create</tt>.
+      #
+      def has_secure_token(attribute = :token, length: MINIMUM_TOKEN_LENGTH, on: :create)
         if length < MINIMUM_TOKEN_LENGTH
           raise MinimumLengthError, "Token requires a minimum length of #{MINIMUM_TOKEN_LENGTH} characters."
         end
@@ -37,7 +50,9 @@ module ActiveRecord
         # Load securerandom only when has_secure_token is used.
         require "active_support/core_ext/securerandom"
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(length: length) }
-        before_create { send("#{attribute}=", self.class.generate_unique_secure_token(length: length)) unless send("#{attribute}?") }
+        set_callback on, on == :initialize ? :after : :before do
+          send("#{attribute}=", self.class.generate_unique_secure_token(length: length)) unless send("#{attribute}?")
+        end
       end
 
       def generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -44,4 +44,16 @@ class SecureTokenTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_token_on_callback
+    User.class_eval do
+      undef regenerate_token
+
+      has_secure_token on: :initialize
+    end
+
+    model = User.new
+
+    assert_predicate model.token, :present?
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When a model defines `has_secure_token`, that value isn't available at initialization-time.


### Detail

Extend `has_secure_token` to accept an `on:` option to specify the callback. Continues to default to `before_create`.

The callback when the value is generated. When called with `on: :initialize`, the value is generated in an `after_initialize` callback, otherwise the value will be used in a `before_` callback. It will default to `:create`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
