### PR TITLE
Stop serializing columns as YAML by default

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     # Abstract representation of an index definition on a table. Instances of

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -66,6 +66,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
 - [`config.active_record.before_committed_on_all_records`](#config-active-record-before-committed-on-all-records): `true`
 - [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
+- [`config.active_record.default_column_serializer`](#config-active-record-default-column-serializer): `nil`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
 - [`config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`](#config-active-record-run-commit-callbacks-on-first-saved-instances-in-transaction): `false`
@@ -1273,16 +1274,23 @@ The default value depends on the `config.load_defaults` target version:
 The serializer implementation to use if none is explicitly specified for a given
 column.
 
-`serialize` and `store` while allowing to use alternative serializer
-implementations, use `YAML` by default, but it's not a very efficient format
+Historically `serialize` and `store` while allowing to use alternative serializer
+implementations, would use `YAML` by default, but it's not a very efficient format
 and can be the source of security vulnerabilities if not carefully employed.
 
 As such it is recommended to prefer stricter, more limited formats for database
 serialization.
 
+Unfortunately there isn't really any suitable defaults available in Ruby's standard
+library. `JSON` could work as a format, but the `json` gems will cast unsupported
+types to strings which may lead to bugs.
+
+The default value depends on the `config.load_defaults` target version:
+
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
 | (original)            | `YAML`               |
+| 7.1                   | `nil`                |
 
 #### `config.active_record.query_log_tags_enabled`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -287,6 +287,7 @@ module Rails
             active_record.raise_on_assign_to_attr_readonly = true
             active_record.belongs_to_required_validates_foreign_key = false
             active_record.before_committed_on_all_records = true
+            active_record.default_column_serializer = nil
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -137,3 +137,9 @@
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 # Rails.application.config.active_record.before_committed_on_all_records = true
+
+# Disable automatic column serialization into YAML.
+# To keep the historic behavior, you can set it to `YAML`, however it is
+# recommended to explicitly define the serialization method for each column
+# rather than to rely on a global default.
+# Rails.application.config.active_record.default_column_serializer = nil


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/47463

YAML is great for configuration and such, but for serializing arbitrary data it has many problem, both in term of performance and efficiency but also in term of security.

As such, we shouldn't let it be the default.

The open question is wether we should provide another default, or just let users chose what they want based on their own tradeoffs.

Many people would probably suggest JSON as the new default, unfortunately I don't think it's a good fit either because the parsers available in Ruby have some wonky behaviors:

```ruby
>> ActiveSupport::JSON.decode(ActiveSupport::JSON.encode(Object.new))
=> {}
>> JSON.load(JSON.dump(Object.new))
=> "#<Object:0x000000012b61a068>"
```

If we were to select another default, I beleive it would need several properties:

  - It should only serialized a safe list of primitive types.
  - It should explictly raise if attempting to serialize complex types.

NB: I have quite a lot of documentation to update, but making sure CI passes first.