### PR TITLE
Support string or symbol for owner_name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -127,7 +127,7 @@ module ActiveRecord
       end
 
       def establish_connection(config, owner_name: Base, role: ActiveRecord::Base.current_role, shard: Base.current_shard)
-        owner_name = StringConnectionName.new(config.to_s) if config.is_a?(Symbol)
+        owner_name = determine_owner_name(owner_name, config)
 
         pool_config = resolve_pool_config(config, owner_name, role, shard)
         db_config = pool_config.db_config
@@ -348,6 +348,16 @@ module ActiveRecord
           end
 
           ConnectionAdapters::PoolConfig.new(connection_name, db_config, role, shard)
+        end
+
+        def determine_owner_name(owner_name, config)
+          if owner_name.is_a?(String) || owner_name.is_a?(Symbol)
+            StringConnectionName.new(owner_name.to_s)
+          elsif config.is_a?(Symbol)
+            StringConnectionName.new(config.to_s)
+          else
+            owner_name
+          end
         end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -195,6 +195,22 @@ module ActiveRecord
         ActiveRecord::Base.configurations = @prev_configs
       end
 
+      def test_establish_connection_with_string_owner_name
+        config = {
+          "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+          "development_readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" }
+        }
+        @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+        @handler.establish_connection(:development_readonly, owner_name: "custom_connection")
+
+        assert_not_nil pool = @handler.retrieve_connection_pool("custom_connection")
+        assert_not_predicate pool.connection, :preventing_writes?
+        assert_equal "test/db/readonly.sqlite3", pool.db_config.database
+      ensure
+        ActiveRecord::Base.configurations = @prev_configs
+      end
+
       def test_symbolized_configurations_assignment
         @prev_configs = ActiveRecord::Base.configurations
         config = {


### PR DESCRIPTION
In legacy systems the `owner_name` didn't have to be a class so it's possible that connections are using a string as an identifier. I think this should be allowed since we turn it into a class that defines the necessary methods that are called on the connection class object (like `primary_class?` and `preventing_writes?`.

Before, `owner_name` had to be a class so any application wanting to use a special identifier would be forced to use `ActiveRecord::Base` or ensure their `config` was a `Symbol`. With this change, you can pass a `db_config` object and a string to use for the owner OR you can pass a symbol and still define a custom owner. In some cases you might not want the name to default to the symbol version of your config name.