### PR TITLE
Ensure `AUTOINCREMENT` declaration is preserved when altering SQLite tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class Column < ConnectionAdapters::Column # :nodoc:
+        def initialize(*, auto_increment: nil, **)
+          super
+          @auto_increment = auto_increment
+        end
+
+        def auto_increment?
+          @auto_increment
+        end
+
+        def init_with(coder)
+          @auto_increment = coder["auto_increment"]
+          super
+        end
+
+        def encode_with(coder)
+          coder["auto_increment"] = @auto_increment
+          super
+        end
+
+        def ==(other)
+          other.is_a?(Column) &&
+            super &&
+            auto_increment? == other.auto_increment?
+        end
+        alias :eql? :==
+
+        def hash
+          Column.hash ^
+            super.hash ^
+            auto_increment?.hash
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -145,7 +145,8 @@ module ActiveRecord
               type_metadata,
               field["notnull"].to_i == 0,
               default_function,
-              collation: field["collation"]
+              collation: field["collation"],
+              auto_increment: field["auto_increment"],
             )
           end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -2,6 +2,7 @@
 
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
+require "active_record/connection_adapters/sqlite3/column"
 require "active_record/connection_adapters/sqlite3/explain_pretty_printer"
 require "active_record/connection_adapters/sqlite3/quoting"
 require "active_record/connection_adapters/sqlite3/database_statements"
@@ -527,13 +528,21 @@ module ActiveRecord
                 default = type.deserialize(column.default)
               end
 
-              column_type = column.bigint? ? :bigint : column.type
-              @definition.column(column_name, column_type,
-                limit: column.limit, default: default,
-                precision: column.precision, scale: column.scale,
-                null: column.null, collation: column.collation,
+              column_options = {
+                limit: column.limit,
+                precision: column.precision,
+                scale: column.scale,
+                null: column.null,
+                collation: column.collation,
                 primary_key: column_name == from_primary_key
-              )
+              }
+
+              unless column.auto_increment?
+                column_options[:default] = default
+              end
+
+              column_type = column.bigint? ? :bigint : column.type
+              @definition.column(column_name, column_type, **column_options)
             end
 
             yield @definition if block_given?
@@ -603,10 +612,12 @@ module ActiveRecord
           end
         end
 
-        COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i.freeze
+        COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i
+        PRIMARY_KEY_AUTOINCREMENT_REGEX = /.*"(\w+)".+PRIMARY KEY AUTOINCREMENT/i
 
         def table_structure_with_collation(table_name, basic_structure)
           collation_hash = {}
+          auto_increments = {}
           sql = <<~SQL
             SELECT sql FROM
               (SELECT * FROM sqlite_master UNION ALL
@@ -628,6 +639,7 @@ module ActiveRecord
               # This regex will match the column name and collation type and will save
               # the value in $1 and $2 respectively.
               collation_hash[$1] = $2 if COLLATE_REGEX =~ column_string
+              auto_increments[$1] = true if PRIMARY_KEY_AUTOINCREMENT_REGEX =~ column_string
             end
 
             basic_structure.map do |column|
@@ -635,6 +647,10 @@ module ActiveRecord
 
               if collation_hash.has_key? column_name
                 column["collation"] = collation_hash[column_name]
+              end
+
+              if auto_increments.has_key?(column_name)
+                column["auto_increment"] = true
               end
 
               column

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -262,6 +262,9 @@ module ApplicationTests
       RUBY
 
       switch_env("DATABASE_URL", "mysql2://127.0.0.1:1") do
+        # The existing schema cache dump will contain ActiveRecord::ConnectionAdapters::SQLite3::Column objects
+        require "active_record/connection_adapters/sqlite3/column"
+
         require "#{app_path}/config/environment"
 
         assert_nil ActiveRecord::Base.connection_pool.schema_cache
@@ -294,6 +297,9 @@ module ApplicationTests
       RUBY
 
       switch_env("DATABASE_URL", "mysql2://127.0.0.1:1") do
+        # The existing schema cache dump will contain ActiveRecord::ConnectionAdapters::SQLite3::Column objects
+        require "active_record/connection_adapters/sqlite3/column"
+
         require "#{app_path}/config/environment"
 
         assert ActiveRecord::Base.connection_pool.schema_cache.data_sources("posts")


### PR DESCRIPTION
### Motivation / Background

Closes: https://github.com/rails/rails/issues/47400

Previously, when copying a table as a result of an `ALTER TABLE` statement, the `AUTOINCREMENT` declaration on the PK column was dictated by the absence of a `:default` option on that column. However, we were always passing `default` when copying the columns to the new table, regardless of whether the column originally had a default. This led to the `AUTOINCREMENT` declaration being lost.

### Detail

This commit fixes the issue by tracking a column's `auto_increment` value, and only passing the `default` option in `#copy_table` when the column does not have the `auto_increment` option set.

I've added a test that ensure that both storing `auto_increment` on `SQLite3::Column` works as intended, and that the `AUTOINCREMENT` declaration is preserved on the table itself.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
