### PR TITLE
Optimize `SchemaDumper`s check for ignored tables

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -306,6 +306,10 @@ module ActiveRecord
       end
 
       def remove_prefix_and_suffix(table)
+        # This method appears at the top when profiling active_record test cases run.
+        # Avoid costly calculation when there are no prefix and suffix.
+        return table if @options[:table_name_prefix].blank? && @options[:table_name_suffix].blank?
+
         prefix = Regexp.escape(@options[:table_name_prefix].to_s)
         suffix = Regexp.escape(@options[:table_name_suffix].to_s)
         table.sub(/\A#{prefix}(.+)#{suffix}\z/, "\\1")


### PR DESCRIPTION
I made a simpler profiling of active record test cases run.

### Before
`Finished in 453.372258s, 19.5138 runs/s, 75.4193 assertions/s`

```
==================================
  Mode: wall(1000)
  Samples: 1499413 (4.46% miss rate)
  GC: 76085 (5.07%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    481406  (32.1%)      467917  (31.2%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#query
    176795  (11.8%)      153412  (10.2%)     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
==> 135606   (9.0%)      135606   (9.0%)     ActiveRecord::SchemaDumper#remove_prefix_and_suffix
    133807   (8.9%)      126421   (8.4%)     PG::Connection#cancel
    104187   (6.9%)       94969   (6.3%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute
     59032   (3.9%)       59032   (3.9%)     (sweeping)
     99266   (6.6%)       54476   (3.6%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#internal_execute
     25010   (1.7%)       24980   (1.7%)     PessimisticLockingTest#duel
     16892   (1.1%)       16892   (1.1%)     (marking)
     12092   (0.8%)       12092   (0.8%)     ActiveSupport::IsolatedExecutionState.context
```

### After
`Finished in 428.776452s, 20.6331 runs/s, 79.7758 assertions/s.`

```
==================================
  Mode: wall(1000)
  Samples: 1704476 (8.08% miss rate)
  GC: 43384 (2.55%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    234865  (13.8%)      213458  (12.5%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#query
    244014  (14.3%)      202178  (11.9%)     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
    201250  (11.8%)      188281  (11.0%)     PG::Connection#cancel
    159645   (9.4%)      141461   (8.3%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute
    188537  (11.1%)      108396   (6.4%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#internal_execute
     79636   (4.7%)       79636   (4.7%)     MonitorMixin::ConditionVariable#wait
     39509   (2.3%)       33152   (1.9%)     Logger::LogDevice#write
     28570   (1.7%)       28570   (1.7%)     (sweeping)
     26823   (1.6%)       26823   (1.6%)     ActiveSupport::IsolatedExecutionState.context
     24990   (1.5%)       24980   (1.5%)     PessimisticLockingTest#duel
     18590   (1.1%)       18590   (1.1%)     Concurrent::Collection::NonConcurrentMapBackend#[]
     15747   (0.9%)       15442   (0.9%)     PG::Connection#async_connect_or_reset
```

I also saw a ~30s decrease in time when using the unfamous PostgreSQL unlogged tables, introduced in https://github.com/rails/rails/pull/34221.