### PR TITLE
Add response fields to request.action_dispatch

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include response status and headers in request.action_dispatch payload
+
+    *Hartley McGuire*
+
 *   Add `without` as an alias of `except` on `ActiveController::Parameters`.
 
     *Hidde-Jan Jongsma*

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -281,7 +281,9 @@ INFO. Additional keys may be added by the caller.
 
 | Key         | Value                         |
 | ----------- | ----------------------------- |
+| `:headers`  | Response headers              |
 | `:request`  | The `ActionDispatch::Request` |
+| `:status`   | HTTP response code            |
 
 ### Action View
 

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -30,11 +30,14 @@ module Rails
       private
         def call_app(request, env) # :doc:
           instrumenter = ActiveSupport::Notifications.instrumenter
-          handle = instrumenter.build_handle("request.action_dispatch", { request: request })
+          payload = { request: request }
+          handle = instrumenter.build_handle("request.action_dispatch", payload)
           handle.start
 
           logger.info { started_request_message(request) }
           status, headers, body = response = @app.call(env)
+          payload[:status] = status
+          payload[:headers] = headers
           body = ::Rack::BodyProxy.new(body, &handle.method(:finish))
 
           if response.frozen?

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -90,6 +90,17 @@ module Rails
           end
         end
       end
+
+      def test_payload_includes_status_and_headers
+        app = TestApp.new([304, { "last-modified" => "Wed, 21 Oct 2015 07:28:00 GMT" }, []])
+        logger = TestLogger.new(app: app)
+
+        logger.call("REQUEST_METHOD" => "GET")
+
+        event_payload = subscriber.starts.first[2]
+        assert_equal 304, event_payload[:status]
+        assert_includes event_payload[:headers], "last-modified"
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Ref: #46869 

An issue was opened about Rails logging a 200 status when the actual status returned to the client was a 304 (because it was changed by Rack::ConditionalGet). This is due to requests being logged from the process_action.action_controller instrumentation, which is at the very bottom of the Rack middleware stack.

### Detail

To help fix this issue, request.action_dispatch has been improved to include response status and headers. This makes the instrumentation more usable for request logging, as the payload now contains references to almost all of the data provided in process_action.action_controller. In addition, its much higher position in the middleware stack means that it will return a "more accurate" status than  is available in process_action.action_controller.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
