### PR TITLE
Allow 3-tier shared config in database.yml

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -417,8 +417,14 @@ module Rails
           if (shared = loaded_yaml.delete("shared"))
             loaded_yaml.each do |env, config|
               if config.is_a?(Hash) && config.values.all?(Hash)
-                config.map do |name, sub_config|
-                  sub_config.reverse_merge!(shared)
+                if shared.is_a?(Hash) && shared.values.all?(Hash)
+                  config.map do |name, sub_config|
+                    sub_config.reverse_merge!(shared[name])
+                  end
+                else
+                  config.map do |name, sub_config|
+                    sub_config.reverse_merge!(shared)
+                  end
                 end
               else
                 config.reverse_merge!(shared)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2180,6 +2180,28 @@ module ApplicationTests
       assert_equal "dev_db",  ar_config["development"]["primary"]["database"]
     end
 
+    test "loads database.yml using 3-tier shared keys with a 3-tier config" do
+      app_file "config/database.yml", <<-YAML
+        shared:
+          one:
+            migrations_path: "db/one"
+          two:
+            migrations_path: "db/two"
+
+        development:
+          one:
+            adapter: sqlite3
+          two:
+            adapter: sqlite3
+      YAML
+
+      app "development"
+
+      ar_config = Rails.configuration.database_configuration
+      assert_equal "db/one", ar_config["development"]["one"]["migrations_path"]
+      assert_equal "db/two", ar_config["development"]["two"]["migrations_path"]
+    end
+
     test "config.action_mailer.show_previews defaults to true in development" do
       app "development"
 


### PR DESCRIPTION
### Motivation / Background

Previously, the shared config hash would be merged with all database configurations defined in database.yml.

### Detail

This commit makes the shared hash 3-tier aware so that it can be used to share configuration across environments but only with matching configuration names.

For example:

```yaml
shared:
  one:
    migrations_path: "db/one"
  two:
    migrations_path: "db/two"

development:
  one:
    adapter: sqlite3
  two:
    adapter: sqlite3

production:
  one:
    adapter: mysql2
  two:
    adapter: mysql2
```

Will now properly set the migration_path for the one and two configurations in both development and production.

### Additional information

Fixes #47367

cc @eileencodes 
cc @matthewd because I saw you had previous thoughts about this https://github.com/rails/rails/pull/28896#issuecomment-299939288

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ 
 
I didn't add a changelog based on #45309, but can if one is wanted
