### PR TITLE
Remove too many closing parentheses

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -733,7 +733,7 @@ SELECT * FROM customers WHERE (customers.last_name = 'Smith' OR customers.orders
 `AND` conditions can be built by chaining `where` conditions.
 
 ```ruby
-Customer.where(last_name: 'Smith').where(orders_count: [1,3,5]))
+Customer.where(last_name: 'Smith').where(orders_count: [1,3,5])
 ```
 
 ```sql


### PR DESCRIPTION
Fixed typo in Active Record Query Interface.
Remove too many closing parentheses.