### PR TITLE
Don't double-encode nested `field_id` and `field_name` index

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Don't double-encode nested `field_id` and `field_name` index values
+
+    Pass `index: @options` as a default keyword argument to `field_id` and
+    `field_name` view helper methods.
+
+    *Sean Doyle*
+
 *   Stop generating `Link preload` headers once it has reached 1KB.
 
     Some proxies have trouble handling large headers, but more importantly preload links

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1767,7 +1767,7 @@ module ActionView
       # <tt>aria-describedby</tt> attribute referencing the <tt><span></tt>
       # element, sharing a common <tt>id</tt> root (<tt>post_title</tt>, in this
       # case).
-      def field_id(method, *suffixes, namespace: @options[:namespace], index: @index)
+      def field_id(method, *suffixes, namespace: @options[:namespace], index: @options[:index])
         @template.field_id(@object_name, method, *suffixes, namespace: namespace, index: index)
       end
 
@@ -1787,7 +1787,7 @@ module ActionView
       #     <%# => <input type="text" name="post[tag][]">
       #   <% end %>
       #
-      def field_name(method, *methods, multiple: false, index: @index)
+      def field_name(method, *methods, multiple: false, index: @options[:index])
         object_name = @options.fetch(:as) { @object_name }
 
         @template.field_name(object_name, method, *methods, index: index, multiple: multiple)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1894,6 +1894,57 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_form_for_with_nested_attributes_field_id
+    post, comment, tag = Post.new, Comment.new, Tag.new
+    comment.relevances = [tag]
+    post.comments = [comment]
+    form_for(post) do |form|
+      form.fields_for(:comments) do |comment_form|
+        concat comment_form.field_id :relevances_attributes
+      end
+    end
+
+    expected = whole_form("/posts", "new_post", "new_post") do
+      "post_comments_attributes_0_relevances_attributes"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_for_with_nested_attributes_field_name
+    post, comment, tag = Post.new, Comment.new, Tag.new
+    comment.relevances = [tag]
+    post.comments = [comment]
+    form_for(post) do |form|
+      form.fields_for(:comments) do |comment_form|
+        concat comment_form.field_name :relevances_attributes
+      end
+    end
+
+    expected = whole_form("/posts", "new_post", "new_post") do
+      "post[comments_attributes][0][relevances_attributes]"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_for_with_nested_attributes_field_name_multiple
+    post, comment, tag = Post.new, Comment.new, Tag.new
+    comment.relevances = [tag]
+    post.comments = [comment]
+    form_for(post) do |form|
+      form.fields_for(:comments) do |comment_form|
+        concat comment_form.field_name :relevances_attributes, multiple: true
+      end
+    end
+
+    expected = whole_form("/posts", "new_post", "new_post") do
+      "post[comments_attributes][0][relevances_attributes][]"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_form_for_with_collection_radio_buttons
     post = Post.new
     def post.active; false; end


### PR DESCRIPTION
### Motivation / Background

Closes https://github.com/rails/rails/issues/45483
Closes https://github.com/rails/rails/pull/45523

To quote #45483:

> `field_name` is adding an extra index parameter, the extra `[0]` in
> `parent[children_attributes][0][0][grandchildren_attributes][]`

### Detail

To resolve that issue, this commit reads its default `field_id` and `field_name` method's `index:` option directly from the `@options`. Prior to this commit, that value was read from the `@index` instance variable.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
