### PR TITLE
Add test for Gemfile.lock after 'bundle install' finishes

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -682,6 +682,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     assert_equal 1, @bundle_commands.count("install")
+    assert_file "#{destination_root}/Gemfile.lock"
   end
 
   def test_generation_use_original_bundle_environment


### PR DESCRIPTION
This test produces the following output (but passes) on my local machine:

```
/Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:293:in `raise_not_found!': Could not find gem 'rails (~> 7.1.0.alpha)' in locally installed gems. (Bundler::GemNotFound)
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:346:in `block in prepare_dependencies'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:331:in `each'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:331:in `map'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:331:in `prepare_dependencies'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:51:in `setup_solver'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/resolver.rb:28:in `start'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/definition.rb:554:in `start_resolution'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/definition.rb:289:in `resolve'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/definition.rb:507:in `materialize'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/definition.rb:197:in `specs'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/definition.rb:254:in `specs_for'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/runtime.rb:18:in `setup'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler.rb:170:in `setup'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/setup.rb:20:in `block in <top (required)>'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/ui/shell.rb:159:in `with_level'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/ui/shell.rb:111:in `silence'
	from /Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/bundler/setup.rb:20:in `<top (required)>'
	from <internal:/Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from <internal:/Users/zzak/.rubies/ruby-3.3.0/lib/ruby/3.3.0+0/rubygems/core_ext/kernel_require.rb>:88:in `require'
```

I'd like to verify bundle install finishes in CI.