### PR TITLE
Make irb a railties dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PATH
     railties (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
+      irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -23,6 +23,13 @@
 
     *Xavier Noria*
 
+*   Railties now requires the irb gem as a dependency, which means when you install Rails, irb will also
+    be installed as a gem. Rails will then use the installed version of irb for its console instead of
+    relying on Ruby's built-in version.
+    This ensures that Rails has access to the most up-to-date and reliable version of irb for its console.
+
+    *Stan Lo*
+
 *   Use infinitive form for all rails command descriptions verbs.
 
     *Petrik de Heus*

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0"
   s.add_dependency "zeitwerk", "~> 2.6"
+  s.add_dependency "irb"
 
   s.add_development_dependency "actionview", version
 end


### PR DESCRIPTION
### Motivation / Background

This PR proposes adding irb to the dependencies of railties for the following reasons:

- Firstly, including irb as a dependency allows users with older versions of Ruby to benefit from the latest version of irb, instead of being limited to the version bundled with their Ruby installation.

- Additionally, there is an [ongoing discussion](https://bugs.ruby-lang.org/issues/19351) to move irb to bundled gems. If this change is implemented, users may need to declare irb in their Gemfile in order to use it for Rails console. By adding irb as a dependency, users can avoid the extra effort of manually specifying irb in their Gemfile.


(**Old Description**)
<details><summary>Details</summary>
<p>

This PR updates app generator's template to add `gem "irb"` to new Rails applications' Gemfile. This is for several reasons:

1. irb constantly receives improvements and bug fixes, so differences between 2 Ruby versions' irb could be significant. For example, Ruby 3.2's irb (v1.6.2), has 10+ new commands than Ruby 3.1's irb (v1.4.1). 
    By installing irb as a gem, Ruby 3.1's Rails users can get the same features Ruby 3.2 users get when they run `rails console`.
1. Having irb in Gemfile means `dependabot` users can get irb updated automatically.
1. It makes users aware of that they can control the version of irb they use.

(BTW, there's a (still under discussion) [plan](https://bugs.ruby-lang.org/issues/19351) to move `irb` to bundled gems.)

</p>
</details> 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
