### PR TITLE
Fix `rails new --dev APP_PATH` command crashing

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -629,7 +629,8 @@ module Rails
 
           run_bundle
 
-          @argv[0] = destination_root
+          @argv.delete_at(@argv.index(app_path))
+          @argv.unshift(destination_root)
           require "shellwords"
           bundle_command("exec rails #{self_command} #{Shellwords.join(@argv)}")
           exit


### PR DESCRIPTION
ref: https://github.com/rails/rails/issues/47435#issuecomment-1436530001

- `rails new APP_PATH --dev` works fine.
- `rails new --dev APP_PATH` does not work.

For most other flags, putting the APP_PATH before or after the flags has the same effect. It's just the prelease ones that have issues, because we have to rengerate the command so as to call `bundle exec rails new ...` a second time.

Prior to this PR, the command that was being called was `bundle exec rails new APP_PATH APP_PATH`, and that doesn't work. Now it will get called as `bundle exec rails new APP_PATH --dev APP_PATH` which is fine.

I haven't been able to find a way to write an automated test for this, but you can use the replication steps in https://github.com/rails/rails/issues/47435 to verify that the issue is fixed.
