### PR TITLE
Revert "Change dockerfile from using Node 19 to match dev environment…"

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -522,13 +522,4 @@
 
     *Harun Sabljaković*
 
-*   Add .node-version files for Rails apps that use Node.js
-
-    Node version managers that make use of this file:
-      https://github.com/shadowspawn/node-version-usage#node-version-file-usage
-
-    The generated Dockerfile will use the same node version.
-
-    *Sam Ruby*
-
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -458,18 +458,6 @@ module Rails
         options[:javascript] && options[:javascript] != "importmap"
       end
 
-      def dockerfile_node_version
-        using_node? and `node --version`[/\d+\.\d+\.\d+/]
-      rescue
-        "lts"
-      end
-
-      def dockerfile_yarn_version
-        using_node? and `yarn --version`[/\d+\.\d+\.\d+/]
-      rescue
-        "latest"
-      end
-
       def dockerfile_binfile_fixups
         # binfiles may have OS specific paths to ruby.  Normalize them.
         shebangs = Dir["bin/*"].map { |file| IO.read(file).lines.first }.join

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -54,10 +54,6 @@ module Rails
       template "ruby-version", ".ruby-version"
     end
 
-    def node_version
-      template "node-version", ".node-version"
-    end
-
     def gemfile
       template "Gemfile"
     end
@@ -329,7 +325,6 @@ module Rails
       def create_root_files
         build(:readme)
         build(:rakefile)
-        build(:node_version) if using_node?
         build(:ruby_version)
         build(:configru)
 

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -20,14 +20,32 @@ RUN apt-get update -qq && \
     apt-get install -y <%= dockerfile_build_packages.join(" ") %>
 
 <% if using_node? -%>
-# Install JavaScript dependencies
-ARG NODE_VERSION=<%= dockerfile_node_version %>
-ARG YARN_VERSION=<%= dockerfile_yarn_version %>
-ENV VOLTA_HOME="/usr/local"
-RUN curl https://get.volta.sh | bash && \
-    volta install node@$NODE_VERSION yarn@$YARN_VERSION
+# Install JavaScript dependencies and libvips for Active Storage
+ ARG NODE_MAJOR_VERSION=19
+ RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR_VERSION.x | bash -
+ RUN apt-get update -qq && \
+     apt-get install -y build-essential libvips nodejs && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man && \
+     npm install -g yarn
+
+<% elsif !skip_active_storage? -%>
+# Install libvips for Active Storage preview support
+RUN apt-get update -qq && \
+    apt-get install -y build-essential libvips && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man
 
 <% end -%>
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV RAILS_LOG_TO_STDOUT="1" \
+    RAILS_SERVE_STATIC_FILES="true" \
+    RAILS_ENV="production" \
+    BUNDLE_WITHOUT="development"
+
 # Install application gems
 COPY Gemfile Gemfile.lock ./
 RUN bundle install<% if depend_on_bootsnap? -%> && \

--- a/railties/lib/rails/generators/rails/app/templates/node-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/node-version.tt
@@ -1,1 +1,0 @@
-<%= ENV["NODE_VERSION"] || dockerfile_node_version %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -748,8 +748,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".gitattributes" do |content|
       assert_no_match(/yarn\.lock/, content)
     end
-
-    assert_no_file ".node-version"
   end
 
   def test_webpack_option
@@ -772,15 +770,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Dockerfile" do |content|
       assert_match(/yarn/, content)
-      assert_match(/node-gyp/, content)
-    end
-
-    assert_file ".node-version" do |content|
-      if ENV["NODE_VERSION"]
-        assert_match(/#{ENV["NODE_VERSION"]}/, content)
-      else
-        assert_match(/\d+\.\d+\.\d+/, content)
-      end
     end
   end
 


### PR DESCRIPTION
Reverts #46794 and part of commit ecc7491bc567a0a9484756855b686c3a68b9d9c6.

Keeps some tests from `railties/test/generators/app_generator_test.rb`,
since they should still apply in either case, and adds coverage.

Fixes #47441

/cc @dhh