### PR TITLE
Add config.hosts and config.host_authorization to new app templates

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -100,4 +100,12 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
   <%- end -%>
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  # config.hosts = [
+  #   "example.com",     # Allow requests from example.com
+  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  # ]
+  # Skip DNS rebinding protection for the default health check endpoint.
+  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
5c830a8a5ccd7e5fda8205c37c04ca12529e2a42 adds an "/up" endpoint to help LB and uptime monitors. DNS rebindings sometimes get in the way of it. Suggesting settings for both `hosts` and` host_authorization` help reduce this friction.