### PR TITLE
Support has_many through associations with composite query_constraints

### DIFF
--- a/activerecord/test/fixtures/sharded_blog_posts_tags.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts_tags.yml
@@ -1,0 +1,27 @@
+_fixture:
+  model_class: Sharded::BlogPostTag
+
+short_read_first_post_blog_one:
+  tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+technical_content_first_post_blog_one:
+  tag_id: <%= ActiveRecord::FixtureSet.identify(:technical_blog_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+short_read_second_post_blog_one:
+  tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:second_post_blog_one) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+beginner_content_first_post_blog_two:
+  tag_id: <%= ActiveRecord::FixtureSet.identify(:beginner_blog_two) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+
+short_read_first_post_blog_two:
+  tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_two) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/fixtures/sharded_tags.yml
+++ b/activerecord/test/fixtures/sharded_tags.yml
@@ -1,0 +1,34 @@
+_fixture:
+  model_class: Sharded::Tag
+
+short_read_blog_one:
+  name: "short read"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+long_read_blog_one:
+  name: "long read"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+technical_blog_one:
+  name: "tech"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+time_management_blog_one:
+  name: "time management"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+
+beginner_blog_two:
+  name: "for beginners"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+
+intermediate_blog_two:
+  name: "for intermediate"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+
+short_read_blog_two:
+  name: "short read"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+
+breaking_news_blog_2:
+  name: "breaking news"
+  blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>

--- a/activerecord/test/models/sharded.rb
+++ b/activerecord/test/models/sharded.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "sharded/blog"
+require_relative "sharded/blog_post"
+require_relative "sharded/comment"
+require_relative "sharded/tag"
+require_relative "sharded/blog_post_tag"

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -7,5 +7,8 @@ module Sharded
 
     belongs_to :blog
     has_many :comments, query_constraints: [:blog_id, :blog_post_id]
+
+    has_many :blog_post_tags, query_constraints: [:blog_id, :blog_post_id]
+    has_many :tags, through: :blog_post_tags
   end
 end

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Sharded
+  class BlogPostTag < ActiveRecord::Base
+    self.table_name = :sharded_blog_posts_tags
+
+    belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
+    belongs_to :tag, query_constraints: [:blog_id, :tag_id]
+  end
+end

--- a/activerecord/test/models/sharded/tag.rb
+++ b/activerecord/test/models/sharded/tag.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sharded
+  class Tag < ActiveRecord::Base
+    self.table_name = :sharded_tags
+    query_constraints :blog_id, :id
+
+    has_many :blog_post_tags, query_constraints: [:blog_id, :tag_id]
+    has_many :blog_posts, through: :blog_post_tags
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -258,6 +258,17 @@ ActiveRecord::Schema.define do
     t.integer :blog_id
   end
 
+  create_table :sharded_tags, force: true do |t|
+    t.string :name
+    t.integer :blog_id
+  end
+
+  create_table :sharded_blog_posts_tags, force: true do |t|
+    t.integer :blog_id
+    t.integer :blog_post_id
+    t.integer :tag_id
+  end
+
   create_table :clubs, force: true do |t|
     t.string :name
     t.integer :category_id


### PR DESCRIPTION
This PR adds support for `has_many :items, through: :association` associations defined with composite `query_constraints` 

The change is similar to other ones. Since `reflection.join_primary_key` and `reflection.join_foreign_key` can both be Arrays 
https://github.com/rails/rails/blob/4085395f41f8c9c712f39ea6bec64ae6161bfbc9/activerecord/lib/active_record/reflection.rb#L512-L515
https://github.com/rails/rails/blob/4085395f41f8c9c712f39ea6bec64ae6161bfbc9/activerecord/lib/active_record/reflection.rb#L496-L499

`next_chain_scope` should be ready to process them as arrays. 

Then we iterate over pairis of primary & foreign keys, building `Equality` arel nodes and joining them with `AND` if we have more than one `eq` condition.

For tests `Sharded` models were extended with the `Tag` models that is associated with `BlogPost` through `blog_posts_tags` joining table
