### PR TITLE
Set ORIGINAL_FULLPATH header in controller tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -127,6 +127,9 @@ module ActionController
       fetch_header("PATH_INFO") do |k|
         set_header k, generated_path
       end
+      fetch_header("ORIGINAL_FULLPATH") do |k|
+        set_header k, fullpath
+      end
       path_parameters[:controller] = controller_path
       path_parameters[:action] = action
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -82,34 +82,34 @@ class TestCaseTest < ActionController::TestCase
     end
 
     def test_html_output
-      render plain: <<HTML
-<html>
-  <body>
-    <a href="/"><img src="/images/button.png" /></a>
-    <div id="foo">
-      <ul>
-        <li class="item">hello</li>
-        <li class="item">goodbye</li>
-      </ul>
-    </div>
-    <div id="bar">
-      <form action="/somewhere">
-        Name: <input type="text" name="person[name]" id="person_name" />
-      </form>
-    </div>
-  </body>
-</html>
-HTML
+      render plain: <<~HTML
+        <html>
+          <body>
+            <a href="/"><img src="/images/button.png" /></a>
+            <div id="foo">
+              <ul>
+                <li class="item">hello</li>
+                <li class="item">goodbye</li>
+              </ul>
+            </div>
+            <div id="bar">
+              <form action="/somewhere">
+                Name: <input type="text" name="person[name]" id="person_name" />
+              </form>
+            </div>
+          </body>
+        </html>
+      HTML
     end
 
     def test_xml_output
       response.content_type = params[:response_as]
-      render plain: <<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<root>
-  <area><p>area is an empty tag in HTML, so it won't contain this content</p></area>
-</root>
-XML
+      render plain: <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <root>
+          <area><p>area is an empty tag in HTML, so it won't contain this content</p></area>
+        </root>
+      XML
     end
 
     def test_only_one_param
@@ -169,6 +169,11 @@ XML
       @counter ||= 0
       @counter += 1
       render plain: @counter
+    end
+
+    def original_fullpath
+      request.set_header("PATH_INFO", "/new")
+      render plain: request.original_fullpath
     end
 
     private
@@ -1043,6 +1048,11 @@ XML
     get :increment_count
     assert_equal "1", response.body
     assert_equal 1, @controller.instance_variable_get(:@counter)
+  end
+
+  def test_original_fullpath_doesnt_change_when_path_is_changed
+    get :original_fullpath
+    assert_equal "/test_case_test/test/original_fullpath", response.body
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Since rails/rails#47296, nothing sets the fullpath early, so changing the path of a request, and then calling original_fullpath returns the updated fullpath. This is a controller testing specific bug as integration tests and real requests always have this header set, so I think controller tests should too.

### Detail

This Pull Request changes the behaviour of `ActionController::TestCase` to pass `ORIGINAL_FULLPATH` headers with requests.

### Additional information

It is my assumption that changing `PATH_INFO` should not change `ORIGINAL_FULLPATH`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
