### PR TITLE
Fix ruby:master re: ruby/feature/18285

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -340,7 +340,7 @@ module RenderTestCases
 
   def test_undefined_method_error_references_named_class
     e = assert_raises(ActionView::Template::Error) { @view.render(inline: "<%= undefined %>") }
-    assert_match(/`undefined' for #<ActionView::Base:0x[0-9a-f]+>/, e.message)
+    assert_match(/undefined local variable or method `undefined'/, e.message)
   end
 
   def test_render_renderable_object

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1095,7 +1095,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }
-    assert_match "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:ActiveSupport::TimeWithZone", e.message
+    assert_match(/undefined method `this_method_does_not_exist' for.*ActiveSupport::TimeWithZone/, e.message)
     assert_no_match "rescue", e.backtrace.first
   end
 end

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -243,7 +243,7 @@ module RailtiesTest
         Foo.instance.abc
       end
 
-      assert_equal("undefined method `abc' for #<RailtiesTest::RailtieTest::Foo>", error.original_message)
+      assert_match(/undefined method `abc' for.*RailtiesTest::RailtieTest::Foo/, error.original_message)
     end
   end
 end


### PR DESCRIPTION
Behavior was changed in ruby/ruby#6950.

https://bugs.ruby-lang.org/issues/18285

Before

```
Failure:
TimeWithZoneTest#test_no_method_error_has_proper_context [/Users/zzak/code/rails/activesupport/test/core_ext/time_with_zone_test.rb:1098]:
Expected /undefined\ method\ `this_method_does_not_exist'\ for\ Fri,\ 31\ Dec\ 1999\ 19:00:00\.000000000\ EST\ \-05:00:ActiveSupport::TimeWithZone/ to match # encoding: US-ASCII
#    valid: true
"undefined method `this_method_does_not_exist' for an instance of ActiveSupport::TimeWithZone".
```

```
Failure:
LazyViewRenderTest#test_undefined_method_error_references_named_class [/Users/zzak/code/rails/actionview/test/template/render_test.rb:343]:
Expected /`undefined' for #<ActionView::Base:0x[0-9a-f]+>/ to match # encoding: US-ASCII
#    valid: true
"undefined local variable or method `undefined' for an instance of #<Class:0x000000010a330508>".
```