### PR TITLE
Don't use a full blown version manager to install nodejs

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -23,9 +23,11 @@ RUN apt-get update -qq && \
 # Install JavaScript dependencies
 ARG NODE_VERSION=<%= dockerfile_node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
-ENV VOLTA_HOME="/usr/local"
-RUN curl https://get.volta.sh | bash && \
-    volta install node@$NODE_VERSION yarn@$YARN_VERSION
+
+RUN git clone https://github.com/nodenv/node-build.git /tmp/node-build/ && \
+    /tmp/node-build/bin/node-build "${NODE_VERSION}" /usr/local && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build
 
 <% end -%>
 # Install application gems


### PR DESCRIPTION
Closes: https://github.com/rails/rails/pull/47450
Fix: https://github.com/rails/rails/issues/47441

`node-build` will do just fine and doesn't require modifying PATH or anything. We also avoid a `curl | bash`, I somehow trust `git clone` a bit more as there is one less indirection.

We could also just directly download the binary from nodejs.org but `node-build` has the added security of verifying the checksum which doesn't hurt.

cc @dhh, @rubys, @zzak 