### PR TITLE
Download node-build via GitHub archives

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -24,8 +24,9 @@ RUN apt-get update -qq && \
 ARG NODE_VERSION=<%= dockerfile_node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
 
+ENV PATH=$PATH:/usr/local/node/bin
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
-    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     npm install -g yarn@$YARN_VERSION && \
     rm -rf /tmp/node-build-master
 

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -24,10 +24,10 @@ RUN apt-get update -qq && \
 ARG NODE_VERSION=<%= dockerfile_node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
 
-RUN git clone https://github.com/nodenv/node-build.git /tmp/node-build/ && \
-    /tmp/node-build/bin/node-build "${NODE_VERSION}" /usr/local && \
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local && \
     npm install -g yarn@$YARN_VERSION && \
-    rm -rf /tmp/node-build
+    rm -rf /tmp/node-build-master
 
 <% end -%>
 # Install application gems


### PR DESCRIPTION
Should be faster than a full clone. We don't need the history or anything anyway.

The downside is that if node-env rename it's default branch, it might break.
