### PR TITLE
Use an actual version in .node-version

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -15,6 +15,8 @@ module Rails
       include Database
       include AppName
 
+      NODE_TLS_VERSION = "18.15.0"
+
       attr_accessor :rails_template
       add_shebang_option!
 
@@ -458,10 +460,14 @@ module Rails
         options[:javascript] && options[:javascript] != "importmap"
       end
 
-      def dockerfile_node_version
-        using_node? and `node --version`[/\d+\.\d+\.\d+/]
-      rescue
-        "lts"
+      def node_version
+        if using_node?
+          ENV.fetch("NODE_VERSION") do
+            `node --version`[/\d+\.\d+\.\d+/]
+          rescue
+            NODE_TLS_VERSION
+          end
+        end
       end
 
       def dockerfile_yarn_version

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -23,7 +23,7 @@ RUN apt-get update -qq && \
 
 <% if using_node? -%>
 # Install JavaScript dependencies
-ARG NODE_VERSION=<%= dockerfile_node_version %>
+ARG NODE_VERSION=<%= node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
 ENV PATH=/usr/local/node/bin:$PATH
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \

--- a/railties/lib/rails/generators/rails/app/templates/node-version.tt
+++ b/railties/lib/rails/generators/rails/app/templates/node-version.tt
@@ -1,1 +1,1 @@
-<%= ENV["NODE_VERSION"] || dockerfile_node_version %>
+<%= node_version %>


### PR DESCRIPTION
`"lts"` isn't supported by all version managers, and even if it was, it's a moving target, so it might build differently on different machines based on how the version manager refresh it's definition list.
