### PR TITLE
Allow to define the default column serializer

### DIFF
--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -8,7 +8,7 @@ module ActionText
   class RichText < Record
     self.table_name = "action_text_rich_texts"
 
-    serialize :body, ActionText::Content
+    serialize :body, coder: ActionText::Content
     delegate :to_s, :nil?, to: :body
 
     belongs_to :record, polymorphic: true, touch: true

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -118,6 +118,7 @@ module ActiveRecord
   end
 
   module Coders
+    autoload :ColumnSerializer, "active_record/coders/column_serializer"
     autoload :JSON, "active_record/coders/json"
     autoload :YAMLColumn, "active_record/coders/yaml_column"
   end

--- a/activerecord/lib/active_record/coders/column_serializer.rb
+++ b/activerecord/lib/active_record/coders/column_serializer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Coders # :nodoc:
+    class ColumnSerializer # :nodoc:
+      attr_reader :object_class
+      attr_reader :coder
+
+      def initialize(attr_name, coder, object_class = Object)
+        @attr_name = attr_name
+        @object_class = object_class
+        @coder = coder
+        check_arity_of_constructor
+      end
+
+      def init_with(coder) # :nodoc:
+        @attr_name = coder["attr_name"]
+        @object_class = coder["object_class"]
+        @coder = coder["coder"]
+      end
+
+      def dump(object)
+        return if object.nil?
+
+        assert_valid_value(object, action: "dump")
+        coder.dump(object)
+      end
+
+      def load(payload)
+        if payload.nil?
+          if @object_class != ::Object
+            return @object_class.new
+          end
+          return nil
+        end
+
+        object = coder.load(payload)
+
+        assert_valid_value(object, action: "load")
+        object ||= object_class.new if object_class != Object
+
+        object
+      end
+
+      # Public because it's called by Type::Serialized
+      def assert_valid_value(object, action:)
+        unless object.nil? || object_class === object
+          raise SerializationTypeMismatch,
+            "can't #{action} `#{@attr_name}`: was supposed to be a #{object_class}, but was a #{object.class}. -- #{object.inspect}"
+        end
+      end
+
+      private
+        def check_arity_of_constructor
+          load(nil)
+        rescue ArgumentError
+          raise ArgumentError, "Cannot serialize #{object_class}. Classes passed to `serialize` must have a 0 argument constructor."
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Coders # :nodoc:
-    class JSON # :nodoc:
+    module JSON # :nodoc:
       def self.dump(obj)
         ActiveSupport::JSON.encode(obj)
       end

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -4,109 +4,91 @@ require "yaml"
 
 module ActiveRecord
   module Coders # :nodoc:
-    class YAMLColumn # :nodoc:
-      attr_accessor :object_class
+    class YAMLColumn < ColumnSerializer # :nodoc:
+      class SafeCoder
+        def initialize(permitted_classes: [], unsafe_load: nil)
+          @permitted_classes = permitted_classes
+          @unsafe_load = unsafe_load
+        end
+
+        if Gem::Version.new(Psych::VERSION) >= "5.1"
+          def dump(object)
+            if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
+              ::YAML.dump(object)
+            else
+              ::YAML.safe_dump(
+                object,
+                permitted_classes: @permitted_classes + ActiveRecord.yaml_column_permitted_classes,
+                aliases: true,
+              )
+            end
+          end
+        else
+          def dump(object)
+            YAML.dump(object)
+          end
+        end
+
+        if YAML.respond_to?(:unsafe_load)
+          def load(payload)
+            if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
+              YAML.unsafe_load(payload)
+            else
+              YAML.safe_load(
+                payload,
+                permitted_classes: @permitted_classes + ActiveRecord.yaml_column_permitted_classes,
+                aliases: true,
+              )
+            end
+          end
+        else
+          def load(payload)
+            if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
+              YAML.load(payload)
+            else
+              YAML.safe_load(
+                payload,
+                permitted_classes: @permitted_classes + ActiveRecord.yaml_column_permitted_classes,
+                aliases: true,
+              )
+            end
+          end
+        end
+      end
 
       def initialize(attr_name, object_class = Object, permitted_classes: [], unsafe_load: nil)
-        @attr_name = attr_name
-        @object_class = object_class
-        @permitted_classes = permitted_classes
-        @unsafe_load = unsafe_load
+        super(
+          attr_name,
+          SafeCoder.new(permitted_classes: permitted_classes || [], unsafe_load: unsafe_load),
+          object_class,
+        )
         check_arity_of_constructor
       end
 
       def init_with(coder) # :nodoc:
-        # This is just to avoid the warning about trying to use instance variables before defining them
-        # when loading from an YAML generated in a Rails version before 7.1.
-        #
-        # This method can be removed when we drop support to Ruby 2.7.
-        @attr_name = coder["attr_name"]
-        @object_class = coder["object_class"]
-        @permitted_classes = coder["permitted_classes"] || []
-        @unsafe_load = coder["unsafe_load"]
-      end
-
-      if Gem::Version.new(Psych::VERSION) >= "5.1"
-        def dump(obj)
-          return if obj.nil?
-
-          assert_valid_value(obj, action: "dump")
-          if unsafe_load?
-            YAML.dump(obj)
-          else
-            YAML.safe_dump(obj, permitted_classes: permitted_classes, aliases: true)
-          end
+        unless coder["coder"]
+          permitted_classes = coder["permitted_classes"] || []
+          unsafe_load = coder["unsafe_load"] || false
+          coder["coder"] = SafeCoder.new(permitted_classes: permitted_classes, unsafe_load: unsafe_load)
         end
-      else
-        def dump(obj)
-          return if obj.nil?
-
-          assert_valid_value(obj, action: "dump")
-          YAML.dump obj
-        end
+        super(coder)
       end
 
-      def load(yaml)
-        return object_class.new if object_class != Object && yaml.nil?
-        return yaml unless yaml.is_a?(String) && yaml.start_with?("---")
-        obj = yaml_load(yaml)
-
-        assert_valid_value(obj, action: "load")
-        obj ||= object_class.new if object_class != Object
-
-        obj
-      end
-
-      def assert_valid_value(obj, action:)
-        unless obj.nil? || obj.is_a?(object_class)
-          raise SerializationTypeMismatch,
-            "can't #{action} `#{@attr_name}`: was supposed to be a #{object_class}, but was a #{obj.class}. -- #{obj.inspect}"
+      def coder
+        # This is to retain forward compatibility when loading records serialized with Marshal
+        # from a previous version of Rails.
+        @coder ||= begin
+          permitted_classes = defined?(@permitted_classes) ? @permitted_classes : []
+          unsafe_load = defined?(@unsafe_load) && @unsafe_load.nil?
+          SafeCoder.new(permitted_classes: permitted_classes, unsafe_load: unsafe_load)
         end
       end
 
       private
-        def permitted_classes
-          # This `defined?` check is just to avoid the warning about trying to use instance variables before defining
-          # them when loading from an Marshal object generated in a Rails version before 7.1.
-          #
-          # The `defined?` can be removed when we drop support to Ruby 2.7.
-          if defined?(@permitted_classes)
-            ActiveRecord.yaml_column_permitted_classes + @permitted_classes
-          else
-            ActiveRecord.yaml_column_permitted_classes
-          end
-        end
-
-        def unsafe_load?
-          # This `defined?` check is just to avoid the warning about trying to use instance variables before defining
-          # them when loading from an Marshal object generated in a Rails version before 7.1.
-          #
-          # The `defined?` can be removed when we drop support to Ruby 2.7.
-          defined?(@unsafe_load) && !@unsafe_load.nil? ? @unsafe_load : ActiveRecord.use_yaml_unsafe_load
-        end
-
         def check_arity_of_constructor
           load(nil)
         rescue ArgumentError
           raise ArgumentError, "Cannot serialize #{object_class}. Classes passed to `serialize` must have a 0 argument constructor."
-        end
-
-        if YAML.respond_to?(:unsafe_load)
-          def yaml_load(payload)
-            if unsafe_load?
-              YAML.unsafe_load(payload)
-            else
-              YAML.safe_load(payload, permitted_classes: permitted_classes, aliases: true)
-            end
-          end
-        else
-          def yaml_load(payload)
-            if unsafe_load?
-              YAML.load(payload)
-            else
-              YAML.safe_load(payload, permitted_classes: permitted_classes, aliases: true)
-            end
-          end
         end
     end
   end

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -102,7 +102,8 @@ module ActiveRecord
 
     module ClassMethods
       def store(store_attribute, options = {})
-        serialize store_attribute, IndifferentCoder.new(store_attribute, options[:coder])
+        coder = build_column_serializer(store_attribute, options[:coder], Object, options[:yaml])
+        serialize store_attribute, coder: IndifferentCoder.new(store_attribute, coder)
         store_accessor(store_attribute, options[:accessors], **options.slice(:prefix, :suffix)) if options.has_key? :accessors
       end
 

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -49,7 +49,7 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
 
   def test_not_compatible_with_serialize_array
     new_klass = Class.new(PgArray) do
-      serialize :tags, Array
+      serialize :tags, type: Array
     end
     assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
       new_klass.new
@@ -65,7 +65,7 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
 
   def test_array_with_serialized_attributes
     new_klass = Class.new(PgArray) do
-      serialize :tags, MyTags
+      serialize :tags, coder: MyTags
     end
 
     new_klass.create!(tags: MyTags.new(["one", "two"]))

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -118,7 +118,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
 
   def test_serialize
     klass = Class.new(ByteaDataType) {
-      serialize :serialized, Serializer.new
+      serialize :serialized, coder: Serializer.new
     }
     obj = klass.new
     obj.serialized = "hello world"

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -320,7 +320,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
   end
 
   class HstoreWithSerialize < Hstore
-    serialize :tags, TagCollection
+    serialize :tags, coder: TagCollection
   end
 
   def test_hstore_with_serialized_attributes

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -230,10 +230,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic.content = { "one" => 1, "two" => 2 }
 
     db_attributes = Topic.instantiate(topic.attributes_for_database).attributes
-    before_type_cast_attributes = Topic.instantiate(topic.attributes_before_type_cast).attributes
-
     assert_equal topic.attributes, db_attributes
-    assert_not_equal topic.attributes, before_type_cast_attributes
   end
 
   test "read attributes after type cast on a date" do

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -50,9 +50,11 @@ module ActiveRecord
         assert_equal "foo", coder.load("foo")
       end
 
-      def test_load_handles_other_classes
+      def test_load_raises_on_other_classes
         coder = YAMLColumn.new("attr_name")
-        assert_equal [], coder.load([])
+        assert_raises TypeError do
+          coder.load([])
+        end
       end
 
       def test_load_doesnt_swallow_yaml_exceptions

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -220,7 +220,7 @@ module JSONSharedTestCases
 
   def test_not_compatible_with_serialize_json
     new_klass = Class.new(klass) do
-      serialize :payload, JSON
+      serialize :payload, coder: JSON
     end
     assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
       new_klass.new
@@ -236,7 +236,7 @@ module JSONSharedTestCases
 
   def test_json_with_serialized_attributes
     new_klass = Class.new(klass) do
-      serialize :settings, MySettings
+      serialize :settings, coder: MySettings
     end
 
     new_klass.create!(settings: MySettings.new("one" => "two"))

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -20,7 +20,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   class ImportantTopic < Topic
-    serialize :important, Hash
+    serialize :important, type: Hash
   end
 
   teardown do
@@ -35,7 +35,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attribute
-    Topic.serialize("content", MyObject)
+    Topic.serialize("content", type: MyObject)
 
     myobj = MyObject.new("value1", "value2")
     topic = Topic.create("content" => myobj)
@@ -49,7 +49,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
       alias_attribute :object, :content
-      serialize :object, MyObject
+      serialize :object, type: MyObject
     end
 
     myobj = MyObject.new("value1", "value2")
@@ -63,7 +63,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   def test_serialized_attribute_with_default
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
-      serialize(:content, Hash, default: { key: "value" })
+      serialize(:content, type: Hash, default: { key: "value" })
     end
 
     t = klass.new
@@ -74,7 +74,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
       attribute :content, default: { key: "value" }
-      serialize :content, Hash
+      serialize :content, type: Hash
     end
 
     t = klass.new
@@ -82,7 +82,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attribute_in_base_class
-    Topic.serialize("content", Hash)
+    Topic.serialize("content", type: Hash)
 
     hash = { "content1" => "value1", "content2" => "value2" }
     important_topic = ImportantTopic.create("content" => hash)
@@ -93,7 +93,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attributes_from_database_on_subclass
-    Topic.serialize :content, Hash
+    Topic.serialize :content, type: Hash
 
     t = ImportantTopic.new(content: { foo: :bar })
     assert_equal({ foo: :bar }, t.content)
@@ -103,7 +103,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_attribute_calling_dup_method
-    Topic.serialize :content, JSON
+    Topic.serialize :content, coder: JSON
 
     orig = Topic.new(content: { foo: :bar })
     clone = orig.dup
@@ -111,7 +111,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_serialized_json_attribute_returns_unserialized_value
-    Topic.serialize :content, JSON
+    Topic.serialize :content, coder: JSON
     my_post = posts(:welcome)
 
     t = Topic.new(content: my_post)
@@ -124,7 +124,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_json_read_legacy_null
-    Topic.serialize :content, JSON
+    Topic.serialize :content, coder: JSON
 
     # Force a row to have a JSON "null" instead of a database NULL (this is how
     # null values are saved on 4.1 and before)
@@ -135,7 +135,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_json_read_db_null
-    Topic.serialize :content, JSON
+    Topic.serialize :content, coder: JSON
 
     # Force a row to have a database NULL instead of a JSON "null"
     id = Topic.connection.insert "INSERT INTO topics (content) VALUES(NULL)"
@@ -177,13 +177,13 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_nil_not_serialized_with_class_constraint
-    Topic.serialize :content, Hash
+    Topic.serialize :content, type: Hash
     assert Topic.new(content: nil).save
     assert_equal 1, Topic.where(content: nil).count
   end
 
   def test_serialized_attribute_should_raise_exception_on_assignment_with_wrong_type
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     assert_raise(ActiveRecord::SerializationTypeMismatch) do
       Topic.new(content: "string")
     end
@@ -193,13 +193,13 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     myobj = MyObject.new("value1", "value2")
     topic = Topic.new(content: myobj)
     assert topic.save
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     assert_raise(ActiveRecord::SerializationTypeMismatch) { Topic.find(topic.id).content }
   end
 
   def test_serialized_attribute_with_class_constraint
     settings = { "color" => "blue" }
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.new(content: settings)
     assert topic.save
     assert_equal(settings, Topic.find(topic.id).content)
@@ -207,27 +207,27 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   def test_where_by_serialized_attribute_with_array
     settings = [ "color" => "green" ]
-    Topic.serialize(:content, Array)
+    Topic.serialize(:content, type: Array)
     topic = Topic.create!(content: settings)
     assert_equal topic, Topic.where(content: settings).take
   end
 
   def test_where_by_serialized_attribute_with_hash
     settings = { "color" => "green" }
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.create!(content: settings)
     assert_equal topic, Topic.where(content: settings).take
   end
 
   def test_where_by_serialized_attribute_with_hash_in_array
     settings = { "color" => "green" }
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.create!(content: settings)
     assert_equal topic, Topic.where(content: [settings]).take
   end
 
   def test_serialized_default_class
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.new
     assert_equal Hash, topic.content.class
     assert_equal Hash, topic.read_attribute(:content).class
@@ -268,7 +268,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       end
     end
 
-    Topic.serialize(:content, some_class)
+    Topic.serialize(:content, coder: some_class)
     topic = Topic.new(content: some_class.new("my value"))
     topic.save!
     topic.reload
@@ -278,7 +278,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   def test_serialize_attribute_via_select_method_when_time_zone_available
     with_timezone_config aware_attributes: true do
-      Topic.serialize(:content, MyObject)
+      Topic.serialize(:content, type: MyObject)
 
       myobj = MyObject.new("value1", "value2")
       topic = Topic.create(content: myobj)
@@ -303,10 +303,10 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_unexpected_serialized_type
-    Topic.serialize :content, Hash
+    Topic.serialize :content, type: Hash
     topic = Topic.create!(content: { zomg: true })
 
-    Topic.serialize :content, Array
+    Topic.serialize :content, type: Array
 
     topic.reload
     error = assert_raise(ActiveRecord::SerializationTypeMismatch) do
@@ -335,7 +335,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_nil_is_not_changed_when_serialized_with_a_class
-    Topic.serialize(:content, Array)
+    Topic.serialize(:content, type: Array)
 
     topic = Topic.new(content: nil)
 
@@ -344,12 +344,12 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
   def test_classes_without_no_arg_constructors_are_not_supported
     assert_raises(ArgumentError) do
-      Topic.serialize(:content, Regexp)
+      Topic.serialize(:content, type: Regexp)
     end
   end
 
   def test_newly_emptied_serialized_hash_is_changed
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.create(content: { "things" => "stuff" })
     topic.content.delete("things")
     topic.save!
@@ -396,7 +396,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     #
     # model.attribute = value
     # assert_equal model.attribute, model.tap(&:save).reload.attribute
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
     topic = Topic.create!(content: {})
     topic2 = Topic.create!(content: nil)
 
@@ -451,7 +451,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_nil_is_always_persisted_as_null
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
 
     topic = Topic.create!(content: { foo: "bar" })
     topic.update_attribute :content, nil
@@ -545,7 +545,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     end.new
     model = Class.new(Topic) do
       attribute :foo, type
-      serialize :foo, coder
+      serialize :foo, coder: coder
     end
 
     topic = model.create!(foo: "bar")
@@ -559,7 +559,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     topic = model.create!
     topic.update group: "1"
 
-    model.serialize :group, JSON
+    model.serialize :group, coder: JSON
     model.reset_column_information
 
     # This isn't strictly necessary for the test, but a little bit of
@@ -588,7 +588,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   end
 
   def test_serialized_attribute
-    Topic.serialize("content", String)
+    Topic.serialize("content", type: String)
 
     myobj = String.new("value1")
     topic = Topic.create("content" => myobj)
@@ -602,7 +602,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
       attribute :content, default: { "key" => "value" }
-      serialize :content, Hash
+      serialize :content, type: Hash
     end
 
     t = klass.new
@@ -610,7 +610,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   end
 
   def test_nil_is_always_persisted_as_null
-    Topic.serialize(:content, Hash)
+    Topic.serialize(:content, type: Hash)
 
     topic = Topic.create!(content: { "foo" => "bar" })
     topic.update_attribute :content, nil
@@ -620,7 +620,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   def test_serialized_attribute_with_default
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
-      serialize(:content, Hash, default: { "key" => "value" })
+      serialize(:content, type: Hash, default: { "key" => "value" })
     end
 
     t = klass.new
@@ -628,7 +628,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   end
 
   def test_serialized_attributes_from_database_on_subclass
-    Topic.serialize :content, Hash
+    Topic.serialize :content, type: Hash
 
     t = ImportantTopic.new(content: { "foo" => "bar" })
     assert_equal({ "foo" => "bar" }, t.content)
@@ -641,7 +641,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
       alias_attribute :object, :content
-      serialize :object, Hash
+      serialize :object, type: Hash
     end
 
     myobj = { "somevalue" => "thevalue" }
@@ -653,10 +653,10 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   end
 
   def test_unexpected_serialized_type
-    Topic.serialize :content, Hash
+    Topic.serialize :content, type: Hash
     topic = Topic.create!(content: { "zomg" => true })
 
-    Topic.serialize :content, Array
+    Topic.serialize :content, type: Array
 
     topic.reload
     error = assert_raise(ActiveRecord::SerializationTypeMismatch) do
@@ -668,7 +668,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
 
   def test_serialize_attribute_via_select_method_when_time_zone_available
     with_timezone_config aware_attributes: true do
-      Topic.serialize(:content, Hash)
+      Topic.serialize(:content, type: Hash)
 
       myobj = { "somevalue" => "thevalue" }
       topic = Topic.create(content: myobj)
@@ -682,7 +682,7 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     myobj = { "somevalue" => "thevalue" }
     topic = Topic.new(content: myobj)
     assert topic.save
-    Topic.serialize(:content, String)
+    Topic.serialize(:content, type: String)
     assert_raise(ActiveRecord::SerializationTypeMismatch) { Topic.find(topic.id).content }
   end
 

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -127,7 +127,7 @@ class NestedPerson < ActiveRecord::Base
   end
 end
 
-class Insure
+module Insure
   INSURES = %W{life annuality}
 
   def self.load(mask)
@@ -145,5 +145,5 @@ end
 class SerializedPerson < ActiveRecord::Base
   self.table_name = "people"
 
-  serialize :insures, Insure
+  serialize :insures, coder: Insure
 end

--- a/activerecord/test/models/traffic_light.rb
+++ b/activerecord/test/models/traffic_light.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class TrafficLight < ActiveRecord::Base
-  serialize :state, Array
-  serialize :long_state, Array
+  serialize :state, type: Array
+  serialize :long_state, type: Array
 end

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -144,14 +144,14 @@ If you need to support a custom type, the recommended way is using a [serialized
 ```ruby
 # CORRECT
 class Article < ApplicationRecord
-  serialize :title, Title
+  serialize :title, type: Title
   encrypts :title
 end
 
 # INCORRECT
 class Article < ApplicationRecord
   encrypts :title
-  serialize :title, Title
+  serialize :title, type: Title
 end
 ```
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1268,6 +1268,22 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `true`               |
 | 7.1                   | `false`              |
 
+#### `config.active_record.default_column_serializer`
+
+The serializer implementation to use if none is explicitly specified for a given
+column.
+
+`serialize` and `store` while allowing to use alternative serializer
+implementations, use `YAML` by default, but it's not a very efficient format
+and can be the source of security vulnerability if not carefully employeed.
+
+As such it is recommended to prefer stricter, more limited formats for database
+serialization.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `YAML`               |
+
 #### `config.active_record.query_log_tags_enabled`
 
 Specifies whether or not to enable adapter-level query comments. Defaults to


### PR DESCRIPTION
YAML has quite a bit of footguns, as such it's desirable to be able to substitute it for something else or even simply to force users to define a serializer explictly for every serialized columns.

This is a scaled back version of https://github.com/rails/rails/pull/47422. This make the default configurable, and we can have a discussion on whether or not we wish to change the default (and what it should be) in a followup.
