### PR TITLE
Return record ids additionally to the relation in `Batches#in_batches`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Return record ids additionally to the relation in `Batches#in_batches`.
+
+    ```ruby
+    User.in_batches do |relation, ids|
+      SomeWorker.perform_async(ids)
+    end
+    ```
+
+    This helps to avoid calling `relation.pluck(:id)` inside the block,
+    which produces additional SQL queries.
+
+    *fatkodima*
+
 *   YAML columns use `YAML.safe_dump` is available.
 
     As of `psych 5.1.0`, `YAML.safe_dump` can now apply the same permitted

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -257,7 +257,7 @@ module ActiveRecord
         primary_key_offset = ids.last
         raise ArgumentError.new("Primary key not included in the custom select clause") unless primary_key_offset
 
-        yield yielded_relation
+        yield yielded_relation, ids
 
         break if ids.length < batch_limit
 

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -63,7 +63,9 @@ module ActiveRecord
       #
       # See Relation#delete_all for details of how each batch is deleted.
       def delete_all
-        sum(&:delete_all)
+        sum do |relation, _ids|
+          relation.delete_all
+        end
       end
 
       # Updates records in batches. Returns the total number of rows affected.
@@ -72,7 +74,7 @@ module ActiveRecord
       #
       # See Relation#update_all for details of how each batch is updated.
       def update_all(updates)
-        sum do |relation|
+        sum do |relation, _ids|
           relation.update_all(updates)
         end
       end
@@ -83,7 +85,9 @@ module ActiveRecord
       #
       # See Relation#destroy_all for details of how each batch is destroyed.
       def destroy_all
-        each(&:destroy_all)
+        each do |relation, _ids|
+          relation.destroy_all
+        end
       end
 
       # Yields an ActiveRecord::Relation object for each batch of records.


### PR DESCRIPTION
Relevant - https://github.com/rails/rails/issues/47462.

Currently, `in_batches` yields only relations, but people often use something like `relation.pluck(:ids)` to get record ids inside the block to schedule a worker with ids, for example.

```ruby
# Before
User.in_batches do |relation|
  ids = relation.pluck(:id) # will perform additional SQL query
  SomeWorker.perform_async(ids)
end

# After
User.in_batches do |relation, ids|
  SomeWorker.perform_async(ids)
end
```

There was a discussion about this some time ago - https://discuss.rubyonrails.org/t/yield-record-ids-to-in-batches-block/81102.

Note: I had a need to change a few tests a bit, because `in_batches` now yields 2 values. Is this OK?

cc @nvasilevski (since you were at that discussion)