### PR TITLE
Only require irb if console is unconfigured

### DIFF
--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "irb"
-require "irb/completion"
-
 require "rails/command/environment_argument"
 
 module Rails
@@ -34,14 +31,17 @@ module Rails
 
       app.load_console
 
-      @console = app.config.console || IRB
+      @console = app.config.console || begin
+        require "irb"
+        require "irb/completion"
 
-      if @console == IRB
         IRB::WorkSpace.prepend(BacktraceCleaner)
 
         if Rails.env.production?
           ENV["IRB_USE_AUTOCOMPLETE"] ||= "false"
         end
+
+        IRB
       end
     end
 

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -55,7 +55,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
   def test_console_defaults_to_IRB
     app = build_app(nil)
-    assert_equal IRB, Rails::Console.new(app).console
+    assert_equal "IRB", Rails::Console.new(app).console.name
   end
 
   def test_console_disables_IRB_auto_completion_in_production
@@ -64,7 +64,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
     with_rack_env "production" do
       app = build_app(nil)
-      assert_equal IRB, Rails::Console.new(app).console
+      assert_equal "IRB", Rails::Console.new(app).console.name
       assert_equal "false", ENV["IRB_USE_AUTOCOMPLETE"]
     end
   ensure
@@ -77,7 +77,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
     with_rack_env "production" do
       app = build_app(nil)
-      assert_equal IRB, Rails::Console.new(app).console
+      assert_equal "IRB", Rails::Console.new(app).console.name
       assert_equal "true", ENV["IRB_USE_AUTOCOMPLETE"]
     end
   ensure
@@ -90,7 +90,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
 
     with_rails_env nil do
       app = build_app(nil)
-      assert_equal IRB, Rails::Console.new(app).console
+      assert_equal "IRB", Rails::Console.new(app).console.name
       assert_nil ENV["IRB_USE_AUTOCOMPLETE"]
     end
   ensure


### PR DESCRIPTION
### Motivation / Background

Previously, irb would be required by the console whether or not another console was configured. While this is not a huge issue at the moment, it will become an issue if irb is removed as a default gem (which has been proposed for Ruby 3.3).

### Detail

This commit changes the console command to only require irb if it was not previously configured, preventing potential issues with it not being included in an application's dependencies.

### Additional information

Ref: #47442 

There is currently an open discussion about whether irb should be added to generated Gemfiles. This change is beneficial whether or not that PR is merged:
- if irb is added to Gemfiles, then this change will prevent errors running the rails console for apps that use other consoles
- if irb is added to railties dependencies, then this change will result in less libraries required for apps that use other consoles

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
