### PR TITLE
Fix parsing ruby version for Dockerfile packages

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -520,11 +520,11 @@ module Rails
           # how python is installed with the bullseye release.  Below
           # is based on debian release included with the Ruby images on
           # Dockerhub.
-          case Gem.ruby_version
-          when /^2.7/
-            bullseye = ruby_version >= "2.7.4"
-          when /^3.0/
-            bullseye = ruby_version >= "3.0.2"
+          case Gem.ruby_version.to_s
+          when /^2\.7/
+            bullseye = Gem.ruby_version >= "2.7.4"
+          when /^3\.0/
+            bullseye = Gem.ruby_version >= "3.0.2"
           else
             bullseye = true
           end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1047,6 +1047,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_old_rubies_do_not_use_bullseye_python
+    Gem.stub(:ruby_version, Gem::Version.new("2.7.0")) do
+      run_generator [destination_root, "--js=esbuild"]
+    end
+
+    assert_file "Dockerfile" do |content|
+      assert_match(/python/, content)
+      assert_no_match(/python-is-python3/, content)
+    end
+  end
+
   def test_skip_docker
     run_generator [destination_root, "--skip-docker"]
 


### PR DESCRIPTION
### Motivation / Background

Previously, the version regular expressions never matched Gem.ruby_version because Gem::Version is not a string. In addition, ruby_version was undefined and this was not caught before because the case statement never evaluated those branches.

### Detail

This commit fixes both of those issues, so that ruby versions like 2.7.0 will correctly install "python" instead of "python-is-python3"

### Additional information

Fixes #47415 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
