### PR TITLE
Dir.glob result must be sorted

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1090,7 +1090,7 @@ module MyApp
     Rails.autoloaders.main.ignore(overrides)
 
     config.to_prepare do
-      Dir.glob("#{overrides}/**/*_override.rb").each do |override|
+      Dir.glob("#{overrides}/**/*_override.rb").sort.each do |override|
         load override
       end
     end


### PR DESCRIPTION
Otherwise it is non-deterministic.

Just ran into a problem in local development where this non-determinism may have changed the load order of my overrides, and things did break.

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
