### PR TITLE
Disable Joins UUID support

### DIFF
--- a/activerecord/lib/active_record/disable_joins_association_relation.rb
+++ b/activerecord/lib/active_record/disable_joins_association_relation.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         record[key]
       end
 
-      records = ids.flat_map { |id| records_by_id[id.to_i] }
+      records = ids.flat_map { |id| records_by_id[id] }
       records.compact!
 
       @records = records


### PR DESCRIPTION
### Motivation / Background

We're using `disable_joins` very successfully — thank you! — but discovered a bug when using non-integer primary keys. Some combinations of non-integer primary keys, has many through associations and order clauses invokes a disable-joins specific association cache which returns nil records. I discovered it's due to a rogue `#to_i`.

This PR uses the attribute type to cast values when reaching into the cache instead of presuming ids are always integers and causes appropriate records to be returned. Existing tests continue to pass.

I've added a test which demonstrates the issue, but it's pretty heavy and I'm not sure is the most appropriate place. Please advise if this test belongs somewhere else.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.~ **Minor bug fixes** and documentation changes should not be included.
