### PR TITLE
Rack 3 static lowercase headers.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -31,7 +31,7 @@ module ActionDispatch
   #
   # Precompressed versions of these files are checked first. Brotli (.br)
   # and gzip (.gz) files are supported. If +path+.br exists, this
-  # endpoint returns that file with a <tt>Content-Encoding: br</tt> header.
+  # endpoint returns that file with a <tt>content-encoding: br</tt> header.
   #
   # If no matching file is found, this endpoint responds <tt>404 Not Found</tt>.
   #
@@ -76,7 +76,7 @@ module ActionDispatch
           request.path_info, ::Rack::Utils.escape_path(filepath).b
 
         @file_server.call(request.env).tap do |status, headers, body|
-          # Omit Content-Encoding/Type/etc headers for 304 Not Modified
+          # Omit content-encoding/type/etc headers for 304 Not Modified
           if status != 304
             headers.update(content_headers)
           end
@@ -104,7 +104,7 @@ module ActionDispatch
       end
 
       def try_files(filepath, content_type, accept_encoding:)
-        headers = { "Content-Type" => content_type }
+        headers = { "content-type" => content_type }
 
         if compressible? content_type
           try_precompressed_files filepath, headers, accept_encoding: accept_encoding
@@ -124,10 +124,10 @@ module ActionDispatch
             if content_encoding == "identity"
               return precompressed_filepath, headers
             else
-              headers["Vary"] = "Accept-Encoding"
+              headers["vary"] = "accept-encoding"
 
               if accept_encoding.any? { |enc, _| /\b#{content_encoding}\b/i.match?(enc) }
-                headers["Content-Encoding"] = content_encoding
+                headers["content-encoding"] = content_encoding
                 return precompressed_filepath, headers
               end
             end

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -79,7 +79,7 @@ module StaticTests
 
     assert_gzip  "/foo/さようなら.html", response
     assert_equal "text/html",          response.headers["Content-Type"]
-    assert_equal "Accept-Encoding",    response.headers["Vary"]
+    assert_equal "accept-encoding",    response.headers["Vary"]
     assert_equal "gzip",               response.headers["Content-Encoding"]
   end
 
@@ -151,7 +151,7 @@ module StaticTests
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")
     assert_gzip  file_name, response
     assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "Accept-Encoding",        response.headers["Vary"]
+    assert_equal "accept-encoding",        response.headers["Vary"]
     assert_equal "gzip",                   response.headers["Content-Encoding"]
 
     response = get(file_name, "HTTP_ACCEPT_ENCODING" => "Gzip")
@@ -170,14 +170,14 @@ module StaticTests
   def test_set_vary_when_origin_compressed_but_client_cant_accept
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "None")
-    assert_equal "Accept-Encoding", response.headers["Vary"]
+    assert_equal "accept-encoding", response.headers["Vary"]
   end
 
   def test_serves_brotli_files_when_header_set
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "br")
     assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "Accept-Encoding",        response.headers["Vary"]
+    assert_equal "accept-encoding",        response.headers["Vary"]
     assert_equal "br",                     response.headers["Content-Encoding"]
 
     response = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")
@@ -188,7 +188,7 @@ module StaticTests
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip, deflate, sdch, br")
     assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "Accept-Encoding",        response.headers["Vary"]
+    assert_equal "accept-encoding",        response.headers["Vary"]
     assert_equal "br",                     response.headers["Content-Encoding"]
   end
 


### PR DESCRIPTION
`ActionDispatch::Static` uses mixed-case headers and merges them with lower case headers. This produces duplicate headers. Prefer lowercase headers to avoid this situation.

Fixes <https://github.com/rails/rails/issues/47456>.