### PR TITLE
Fix deprecation warnings emitted by serialized

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -416,7 +416,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       end
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "tmp_posts"
-        serialize(:content, Hash)
+        serialize(:content, type: Hash)
       end
 
       t = klass.create!(content: { "other_key" => "new_value" })
@@ -439,7 +439,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       end
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "tmp_posts"
-        serialize(:content, Hash)
+        serialize(:content, type: Hash)
       end
 
       t = klass.create!(content: { foo: "bar" })


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/47463

I forgot I rebased on another PR that added two new serialization tests.

cc @yahonda 