### PR TITLE
Dockerfile: Improve bundle install

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -9,6 +9,8 @@ WORKDIR /rails
 
 # Set production environment
 ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
 
@@ -33,7 +35,8 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 <% end -%>
 # Install application gems
 COPY Gemfile Gemfile.lock ./
-RUN bundle install<% if depend_on_bootsnap? -%> && \
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile
 <% end %>
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47465

We enable `BUNDLE_DEPLOYMENT` so that bundler won't take the liberty to upgrade any gems. See: https://www.bundler.cn/man/bundle-install.1.html#DEPLOYMENT-MODE

We delete several cache directories to reduce the layer sizes.

FYI @dhh @rubys 