### PR TITLE
Avoid "comparison of Gem::Version..." error in Ruby < 3.1

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           @unsafe_load = unsafe_load
         end
 
-        if Gem::Version.new(Psych::VERSION) >= "5.1"
+        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("5.1")
           def dump(object)
             if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
               ::YAML.dump(object)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Commit [185f2d7](https://github.com/rails/rails/commit/185f2d718d4) errors out with Ruby < 3.1 in this way:
```
/activerecord/lib/active_record/coders/yaml_column.rb:14:in `>=': comparison of Gem::Version with String failed (ArgumentError)
```

This Pull Request has been created to update the Psych gem version check in `activerecord/lib/active_record/coders/yaml_column.rb` in order to remedy this issue.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
