### PR TITLE
Serialized attribute should be able to be defined in abstract classes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -219,7 +219,7 @@ module ActiveRecord
             end
 
             cast_type = cast_type.subtype if Type::Serialized === cast_type
-            Type::Serialized.new(cast_type, column_serializer, default: columns_hash[attr_name.to_s]&.default)
+            Type::Serialized.new(cast_type, column_serializer)
           end
         end
 

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -9,10 +9,9 @@ module ActiveRecord
 
       attr_reader :subtype, :coder
 
-      def initialize(subtype, coder, default: nil)
+      def initialize(subtype, coder)
         @subtype = subtype
         @coder = coder
-        @default = default
         super(subtype)
       end
 
@@ -26,7 +25,7 @@ module ActiveRecord
 
       def serialize(value)
         return if value.nil?
-        unless default_value?(value) && @default.nil?
+        unless default_value?(value)
           super coder.dump(value)
         end
       end


### PR DESCRIPTION
Reverts: https://github.com/rails/rails/pull/47191

Also adds a regression test.

This feature recently regressed when https://github.com/rails/rails/pull/47191
was merged to handle column defaults.

The `attribute` definition callback is set on the parent class and
is triggered when the child class schema is loaded.

It may be fixable, but it took me several hours to reduce a repro already. So I'd rather revert for now, but I may try to find a solution another day.

@serg-kovalev FYI I'll merge this on green. You are welcome to look for a better implementation if you feel like it. Sorry I didn't notice this during review, it was quite subtle.