### PR TITLE
Fix using TestServer in ConnectionStub

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -286,7 +286,7 @@ module ActionCable
         end
 
         def parameter_filter
-          @parameter_filter ||= ActiveSupport::ParameterFilter.new(connection.server.config.filter_parameters)
+          @parameter_filter ||= ActiveSupport::ParameterFilter.new(connection.config.filter_parameters)
         end
 
         def transmit_subscription_confirmation

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -45,7 +45,7 @@ module ActionCable
     end
 
     class ConnectionStub
-      attr_reader :transmissions, :identifiers, :subscriptions, :logger, :server
+      attr_reader :transmissions, :identifiers, :subscriptions, :logger, :config
 
       def initialize(identifiers = {})
         @transmissions = []
@@ -57,7 +57,7 @@ module ActionCable
         @subscriptions = ActionCable::Connection::Subscriptions.new(self)
         @identifiers = identifiers.keys
         @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
-        @server = TestServer.new
+        @config = ActionCable::Server::Configuration.new
       end
 
       def transmit(cable_message)

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -51,7 +51,7 @@ module ActionCable
       include ActiveSupport::Rescuable
 
       attr_reader :server, :env, :subscriptions, :logger, :worker_pool, :protocol
-      delegate :event_loop, :pubsub, to: :server
+      delegate :event_loop, :pubsub, :config, to: :server
 
       def initialize(server, env, coder: ActiveSupport::JSON)
         @server, @env, @coder = server, env, coder

--- a/actioncable/test/stubs/test_connection.rb
+++ b/actioncable/test/stubs/test_connection.rb
@@ -5,7 +5,7 @@ require "stubs/user"
 class TestConnection
   attr_reader :identifiers, :logger, :current_user, :server, :subscriptions, :transmissions
 
-  delegate :pubsub, to: :server
+  delegate :pubsub, :config, to: :server
 
   def initialize(user = User.new("lifo"), coder: ActiveSupport::JSON, subscription_adapter: SuccessAdapter)
     @coder = coder


### PR DESCRIPTION
### Motivation / Background

Closes https://github.com/rails/rails/issues/47377.

### Detail

It's an alternative implementation to #47409.

The solution in #47409 suggest promoting TestServer to be an official part of the Action Cable, which, I believe, isn't a good idea. The whole purpose of Channels/Connections testing it to make it possible to test logic in isolation from any kind of a server.

This PR fixes the original _server leakage_ by making channel dependent on the configuration (which is fine, it's a part of the abstraction, not implementation), without directly depending on a server.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
