### PR TITLE
Suppress output from mail parser warnings

### DIFF
--- a/actionmailbox/test/test_helper.rb
+++ b/actionmailbox/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/testing/strict_warnings"
+
 ENV["RAILS_ENV"] = "test"
 ENV["RAILS_INBOUND_EMAIL_PASSWORD"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
 

--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/testing/strict_warnings"
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -12,7 +12,16 @@ module RaiseWarnings
     /Ignoring .*\.yml because it has expired/,
     /Failed to validate the schema cache because/,
   )
+
+  SUPPRESSED_WARNINGS = Regexp.union(
+    # TODO: remove if https://github.com/mikel/mail/pull/1557 or similar fix
+    %r{/lib/mail/parsers/.*statement not reached},
+    %r{/lib/mail/parsers/.*assigned but unused variable - testEof}
+  )
+
   def warn(message, *)
+    return if SUPPRESSED_WARNINGS.match?(message)
+
     super
 
     return unless message.include?(PROJECT_ROOT)


### PR DESCRIPTION
### Motivation / Background

Previously, requiring any of the ragel generated parsers in mail would output tons of warnings in tests, making output much harder to read (especially in Railties).

### Detail

This commit extends the RaiseWarnings patch to suppress output from these mail parsers.

The suppression can be removed once mikel/mail#1557 or mikel/mail#1551 or any other PR fixes the issue

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
