### PR TITLE
Fix has_many through association assginments with custom scope and custom joining association name

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -70,7 +70,7 @@ module ActiveRecord
 
         def through_scope_attributes
           scope = through_scope || self.scope
-          attributes = scope.where_values_hash(through_association.reflection.name.to_s)
+          attributes = scope.where_values_hash(through_association.reflection.klass.table_name)
           except_keys = [
             *Array(through_association.reflection.foreign_key),
             through_association.reflection.klass.inheritance_column

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1359,6 +1359,18 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal [member], club.favorites
   end
 
+  def test_insert_records_via_has_many_through_association_with_scope_and_association_name_different_from_the_joining_table_name
+    club = Club.create!
+    member = Member.create!
+    Membership.create!(club: club, member: member)
+
+    club.custom_favorites << member
+    assert_equal [member], club.custom_favorites
+
+    club.reload
+    assert_equal [member], club.custom_favorites
+  end
+
   def test_has_many_through_unscope_default_scope
     post = Post.create!(title: "Beaches", body: "I like beaches!")
     Reader.create! person: people(:david), post: post

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -10,6 +10,9 @@ class Club < ActiveRecord::Base
 
   has_many :favorites, -> { where(memberships: { favorite: true }) }, through: :memberships, source: :member
 
+  has_many :custom_memberships, class_name: "Membership"
+  has_many :custom_favorites, -> { where(memberships: { favorite: true }) }, through: :custom_memberships, source: :member
+
   scope :general, -> { left_joins(:category).where(categories: { name: "General" }).unscope(:limit) }
 
   accepts_nested_attributes_for :membership


### PR DESCRIPTION
The issue was introduced in https://github.com/rails/rails/pull/12829

`where_values_hash` method signature accepts `table_name` which is not always the same as the association name.
So passing `through_association.reflection.name.to_s` as `table_name` in `through_scope_attributes` wasn't accurate for every case. This commit fixes the issue by passing the `table_name` taken from `through_association.reflection.klass.table_name` instead.

To reveal this bug we need to have a set of models associated with each other using a `has_many through` association where the joining association name and it's table name do not match. There are two ways to achieve this: either by changing the table name to a non-conventional name or by changing the association name itself.

In our case it was either to extend existing `Club` model with `memberships` joining association/table and change the association name to `custom_memberships` leading to `custom_memberships` being passed as a `table_name` argument to the `where_values_hash` and not matching the `memberships` table name used in the underlying sql clause.
https://github.com/rails/rails/blob/b0dd7c7ae21d692b6e38428e8abe0e9538b75711/activerecord/lib/active_record/associations/has_many_through_association.rb#L72
