### PR TITLE
feat: Allow configuration to specify threadsafe Dalli client

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -96,7 +96,7 @@ module ActiveSupport
         if pool_options.empty?
           Dalli::Client.new(addresses, options)
         else
-          ConnectionPool.new(pool_options) { Dalli::Client.new(addresses, options.merge(threadsafe: false)) }
+          ConnectionPool.new(pool_options) { Dalli::Client.new(addresses, options.reverse_merge(threadsafe: false)) }
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

We sometimes  get thread-related memcached errors in our app using the mem_cache_store store. 

This Pull Request has been created because I'd like to explicitly pass in `threadsafe: true` to our cache configuration so as to override the default of 'false' (when connection pool is present).

### Detail

This Pull Request changes mem_cache_store to respect the configuration variable `:threadsafe`

### Additional information

Always setting `threadsafe: false` in a connection pool was introduced in https://github.com/rails/rails/commit/4ac143d1937e8d6f33162863a17c1b1db57687c1 (four years ago now) without a specific comment.  I recognize I probably don't need this change and perhaps there's something somewhere else in our app which is bananas, but I haven't found it yet, and being able to opt in to my own setting here seems fair to do.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
