### PR TITLE
Refactor ViewPath::Registry into path ActionView::PathRegistry

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -245,7 +245,7 @@ module ActionDispatch
       def build_backtrace
         built_methods = {}
 
-        ActionView::ViewPaths::Registry.all_resolvers.each do |resolver|
+        ActionView::PathRegistry.all_resolvers.each do |resolver|
           resolver.built_templates.each do |template|
             built_methods[template.method_name] = template
           end

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -40,6 +40,7 @@ module ActionView
     autoload :Helpers
     autoload :LookupContext
     autoload :Layouts
+    autoload :PathRegistry
     autoload :PathSet
     autoload :RecordIdentifier
     autoload :Rendering

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -13,7 +13,7 @@ module ActionView
         rebuild_watcher
 
         _self = self
-        ActionView::ViewPaths::Registry.singleton_class.set_callback(:build_file_system_resolver, :after) do
+        ActionView::PathRegistry.singleton_class.set_callback(:build_file_system_resolver, :after) do
           _self.send(:rebuild_watcher)
         end
       end
@@ -59,7 +59,7 @@ module ActionView
         end
 
         def all_view_paths
-          ActionView::ViewPaths::Registry.all_file_system_resolvers.map(&:path)
+          ActionView::PathRegistry.all_file_system_resolvers.map(&:path)
         end
     end
   end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -71,7 +71,7 @@ module ActionView
       end
 
       def self.clear
-        ActionView::ViewPaths::Registry.all_resolvers.each do |resolver|
+        ActionView::PathRegistry.all_resolvers.each do |resolver|
           resolver.clear_cache
         end
         @view_context_class = nil

--- a/actionview/lib/action_view/path_registry.rb
+++ b/actionview/lib/action_view/path_registry.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ActionView # :nodoc:
+  module PathRegistry # :nodoc:
+    @view_paths_by_class = {}
+    @file_system_resolvers = Concurrent::Map.new
+
+    class << self
+      include ActiveSupport::Callbacks
+      define_callbacks :build_file_system_resolver
+    end
+
+    def self.get_view_paths(klass)
+      @view_paths_by_class[klass] || get_view_paths(klass.superclass)
+    end
+
+    def self.set_view_paths(klass, paths)
+      @view_paths_by_class[klass] = paths
+    end
+
+    def self.file_system_resolver(path)
+      path = File.expand_path(path)
+      resolver = @file_system_resolvers[path]
+      unless resolver
+        run_callbacks(:build_file_system_resolver) do
+          resolver = @file_system_resolvers.fetch_or_store(path) do
+            FileSystemResolver.new(path)
+          end
+        end
+      end
+      resolver
+    end
+
+    def self.all_resolvers
+      resolvers = [all_file_system_resolvers]
+      resolvers.concat @view_paths_by_class.values.map(&:to_a)
+      resolvers.flatten.uniq
+    end
+
+    def self.all_file_system_resolvers
+      @file_system_resolvers.values
+    end
+  end
+end

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -67,7 +67,7 @@ module ActionView # :nodoc:
         paths.map do |path|
           case path
           when Pathname, String
-            ViewPaths::Registry.file_system_resolver(path.to_s)
+            ActionView::PathRegistry.file_system_resolver(path.to_s)
           when Resolver
             path
           else


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

In https://github.com/rails/rails/pull/47347 `ActionView::ViewPath::Registry` was introduced. In a recent upgrade to rails, we found that this change conflicted with a top level module called `Registry`. Instead of fixing the changes locally, it was suggested by @matthewd that we fix the namespace conflicts upstream instead.

### Detail

This moves the `Registry` module under `ViewPath` into its own module under `ActionView` called `PathRegistry`. Functionally there should be no change in the changes introduced in https://github.com/rails/rails/pull/47347. 

