### PR TITLE
Fix docs about the return value of authenticate_with_http_token [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -431,8 +431,9 @@ module ActionController
           authenticate_with_http_token(&login_procedure) || request_http_token_authentication(realm, message)
         end
 
-        # Authenticate using an HTTP Bearer token. Returns true if
-        # authentication is successful, false otherwise.
+        # Authenticate using an HTTP Bearer token.
+        # Returns the return value of <tt>login_procedure</tt> if a
+        # token is found. Returns <tt>nil</tt> if no token is found.
         def authenticate_with_http_token(&login_procedure)
           Token.authenticate(self, &login_procedure)
         end


### PR DESCRIPTION
### Motivation / Background
The current documentation says it returns boolean, which reads contradictory with [this sample](https://github.com/rails/rails/blob/v7.0.4.2/actionpack/lib/action_controller/metal/http_authentication.rb#L387). Shall we fix it with the wordings borrowed straight from [Token.authenticate](https://github.com/rails/rails/blob/v7.0.4.2/actionpack/lib/action_controller/metal/http_authentication.rb#L450-L451)?
