### PR TITLE
Enhance has_secure_password to also generate a password_salt method

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   `has_secure_password` now generates an `#{attribute}_salt` method that returns the salt
+    used to compute the password digest. The salt will change whenever the password is changed,
+    so it can be used to create single-use password reset tokens with `generates_token_for`:
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_secure_password
+
+      generates_token_for :password_reset, expires_in: 15.minutes do
+        password_salt&.last(10)
+      end
+    end
+    ```
+
+    *Lázaro Nixon*
+
 *   Improve typography of user facing error messages. In English contractions,
     the Unicode APOSTROPHE (`U+0027`) is now RIGHT SINGLE QUOTATION MARK
     (`U+2019`). For example, "can't be blank" is now "can’t be blank".

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -170,6 +170,12 @@ module ActiveModel
           attribute_digest.present? && BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
         end
 
+        # Returns the salt, a small chunk of random data added to the password before it's hashed.
+        define_method("#{attribute}_salt") do
+          attribute_digest = public_send("#{attribute}_digest")
+          attribute_digest.present? ? BCrypt::Password.new(attribute_digest).salt : nil
+        end
+
         alias_method :authenticate, :authenticate_password if attribute == :password
       end
     end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -265,6 +265,21 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal false, @user.authenticate(" ")
   end
 
+  test "password_salt" do
+    @user.password = "secret"
+    assert_equal @user.password_digest.salt, @user.password_salt
+  end
+
+  test "password_salt should return nil when password is nil" do
+    @user.password = nil
+    assert_nil @user.password_salt
+  end
+
+  test "password_salt should return nil when password digest is nil" do
+    @user.password_digest = nil
+    assert_nil @user.password_salt
+  end
+
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 

--- a/activerecord/lib/active_record/token_for.rb
+++ b/activerecord/lib/active_record/token_for.rb
@@ -67,7 +67,7 @@ module ActiveRecord
       #
       #     generates_token_for :password_reset, expires_in: 15.minutes do
       #       # Last 10 characters of password salt, which changes when password is updated:
-      #       BCrypt::Password.new(password_digest).salt[-10..]
+      #       password_salt&.last(10)
       #     end
       #   end
       #


### PR DESCRIPTION
### Motivation / Background

As mentioned [here](https://github.com/rails/rails/pull/44189) there's an additional task to be done in order to simplify the token generation for password hashes.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/2651240/221092335-ffc4f773-0456-4524-811f-83d03cf23c43.png">

Before: 
```ruby
class User < ActiveRecord::Base
  has_secure_password
  
  generates_token_for :password_reset, expires_in: 15.minutes do
    BCrypt::Password.new(password_digest).salt[-10..]
  end
end
```

After:
```ruby
class User < ActiveRecord::Base
  has_secure_password
  
  generates_token_for :password_reset, expires_in: 15.minutes do
    password_salt[-10..]
  end
end
```
