### PR TITLE
Update Asset Pipeline Guideline reference to Sass gem

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -33,8 +33,7 @@ passing the `--skip-asset-pipeline` option.
 $ rails new appname --skip-asset-pipeline
 ```
 
-Rails can easily work with Sass by adding the [`dartsass-rails`](https://github.com/rails/dartsass-rails)
-gem to your `Gemfile`, which is used by Sprockets for [Sass](https://sass-lang.com) compilation:
+Rails can easily work with [Sass](https://sass-lang.com) by adding the [`dartsass-rails`](https://github.com/rails/dartsass-rails) gem to your `Gemfile`:
 
 ```ruby
 gem 'dartsass-rails'
@@ -54,9 +53,6 @@ in `production.rb` - [`config.assets.css_compressor`][] for your CSS and
 config.assets.css_compressor = :yui
 config.assets.js_compressor = :terser
 ```
-
-NOTE: The `sassc-rails` gem is automatically used for CSS compression if included
-in the `Gemfile` and no `config.assets.css_compressor` option is set.
 
 [`config.assets.css_compressor`]: configuring.html#config-assets-css-compressor
 [`config.assets.js_compressor`]: configuring.html#config-assets-js-compressor

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -33,11 +33,17 @@ passing the `--skip-asset-pipeline` option.
 $ rails new appname --skip-asset-pipeline
 ```
 
-Rails can easily work with Sass by adding the [`sassc-rails`](https://github.com/sass/sassc-rails)
+Rails can easily work with Sass by adding the [`dartsass-rails`](https://github.com/rails/dartsass-rails)
 gem to your `Gemfile`, which is used by Sprockets for [Sass](https://sass-lang.com) compilation:
 
 ```ruby
-gem 'sassc-rails'
+gem 'dartsass-rails'
+```
+
+After bundling the gem, run the following to complete the installation:
+
+```bash
+$ rails dartsass:install
 ```
 
 To set asset compression methods, set the appropriate configuration options


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is a reference in the guides to `sassc-rails` gem which is no longer maintained. The new `dartsass-rails` gem wraps the standalone release of the Dart version of Sass and works in Rails 7.

### Detail

This Pull Request changes updates/replaces the reference to `sassc-rails` gem with the updated `dartsass-rails` gem, including installation reference.