### PR TITLE
rails new: add x86_64-linux and aarch64-linux platforms by default

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -644,7 +644,17 @@ module Rails
       end
 
       def run_bundle
-        bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
+        if bundle_install?
+          bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1")
+
+          # The vast majority of Rails apps will be deployed on `x86_64-linux`.
+          platform = ["--add-platform=x86_64-linux"]
+
+          # Users that develop on M1 mac may use docker and would need `aarch64-linux` as well.
+          platform << "--add-platform=aarch64-linux" if RUBY_PLATFORM.start_with?("arm64")
+
+          bundle_command("lock #{platform.join(" ")}", "BUNDLE_IGNORE_MESSAGES" => "1")
+        end
       end
 
       def run_javascript

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -366,9 +366,11 @@ module SharedGeneratorTests
 
       assert_file File.expand_path("Gemfile", project_path) do |gemfile|
         assert_equal "install", @bundle_commands[0]
+        assert_match "lock --add-platform", @bundle_commands[1]
+
         assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[0]
 
-        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", @bundle_commands[1]
+        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", @bundle_commands[2]
         assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[1]
       end
     end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47479

The vast majority of apps will be deployed on Linux, so might as well initialize the Gemfile.lock with these platforms. This will save users from having to do it themselves when they push to GitHub Actions or similar platforms.

FYI: @rafaelfranca @zzak @rubys @dhh 