### PR TITLE
Backport (#45169): Allow all available locales for template lookups.

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -17,9 +17,11 @@ module ActionView
       ParsedPath = Struct.new(:path, :details)
 
       def build_path_regex
-        handlers = Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
-        formats = Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
-        locales = "[a-z]{2}(?:[-_][A-Z]{2})?"
+        handlers = Regexp.union(Template::Handlers.extensions.map(&:to_s))
+        formats = Regexp.union(Template::Types.symbols.map(&:to_s))
+        available_locales = I18n.available_locales.map(&:to_s)
+        regular_locales = [/[a-z]{2}(?:[-_][A-Z]{2})?/]
+        locales = Regexp.union(available_locales + regular_locales)
         variants = "[^.]*"
 
         %r{

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -242,4 +242,16 @@ module ResolverSharedTests
 
     assert_equal "Texto simple!", es_ar[0].source
   end
+
+  def test_finds_template_with_arbitrarily_formatted_locale
+    I18n.backend.store_translations(:en_customer1, { hello: "hello" })
+    with_file "test/hello_world.en_customer1.text.erb", "Good day, world."
+
+    templates = context.find_all("hello_world", "test", false, [], locale: [:en_customer1])
+
+    assert_equal 1, templates.size
+    assert_equal "Good day, world.", templates[0].source
+  ensure
+    I18n.reload!
+  end
 end


### PR DESCRIPTION
This is a proposed backport of #45169 to v7.0, cherry-picking @oneiros's commit below. Our use case of per-tenant locales is pretty much identical and we'd greatly appreciate the backport while we're waiting for v7.1 to be released.

Following the discussion here:
https://github.com/rails/rails/pull/44174/files#r785160819

Background: The `i18n` gem is relatively lax when it comes to naming locales. It does not enforce any standard. Thus it is possible to have e.g. per tenant locales (think `en_tenant1`, `en_tenant2` etc.). This also worked for translated templates up until rails 6.1.

Rails 7 changed the template lookup and enforced a naming scheme for locales. This poses a problem for legacy apps that use non-standard locale names.

This commit changes the way locale names are detected in template file names. In addition to the previously used regexp it also allows all known locales from
`I18n.available_locales`.

This makes it backwards compatible to rails 7.0
behavior while also allowing non-standard locale names. Thanks to jvillarejo for the great idea.

Also introduce the usage of `Regexp.union`, a wonderful suggestion by casperisfine.

(cherry picked from commit 12c12899df560d65c03eb10f0ddd46d6ce418bc6)

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
