### PR TITLE
Use same rules for bindings in BoundSqlLiteral as in ActiveRecord

### DIFF
--- a/activerecord/lib/arel/nodes/bound_sql_literal.rb
+++ b/activerecord/lib/arel/nodes/bound_sql_literal.rb
@@ -13,7 +13,7 @@ module Arel # :nodoc: all
             raise BindError.new("wrong number of bind variables (#{positional_binds.size} for #{expected})", sql_with_placeholders)
           end
         elsif !named_binds.empty?
-          tokens_in_string = sql_with_placeholders.scan(/:(?<!::)(\w+)/).flatten.map(&:to_sym).uniq
+          tokens_in_string = sql_with_placeholders.scan(/:(?<!::)([a-zA-Z]\w*)/).flatten.map(&:to_sym).uniq
           tokens_in_hash = named_binds.keys.map(&:to_sym).uniq
 
           if !(missing = (tokens_in_string - tokens_in_hash)).empty?

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -782,7 +782,7 @@ module Arel # :nodoc: all
               end
             end
           else
-            o.sql_with_placeholders.scan(/:(?<!::)(\w+)|([^:]+|.)/) do
+            o.sql_with_placeholders.scan(/:(?<!::)([a-zA-Z]\w*)|([^:]+|.)/) do
               if $2
                 collector << $2
               else

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -659,6 +659,13 @@ module Arel
           }
         end
 
+        it "will only consider named binds starting with a letter" do
+          node = Nodes::BoundSqlLiteral.new("id = :0abc", [], { "0abc": 1 })
+          _(compile(node)).must_be_like %{
+            id = :0abc
+          }
+        end
+
         it "works with array values" do
           node = Nodes::BoundSqlLiteral.new("id IN (?)", [[1, 2, 3]], {})
           _(compile(node)).must_be_like %{


### PR DESCRIPTION
### Motivation / Background

The [newly introduced](https://github.com/rails/rails/pull/46600) `BoundSqlLiteral` accepts a string with binding variables that will be substituted, exactly like you can do in ActiveRecord queries. However, the behaviour differs a tiny bit from ActiveRecord, in that binding parameters with names starting with e.g. numbers are accepted.

This pull request changes that, so the rules are the same as for ActiveRecord (see [`replace_named_bind_variables`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/sanitization.rb#L202-L212)).

### Detail

This Pull Request simply changes `\w+` to `[a-zA-Z]\w*` in the relevant regular expressions to require the binding variables to start with a letter.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
