### PR TITLE
Batch custom orders

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Custom ordering for `ActiveRecord::Batches#in_batches`
+
+    Adds extra order options for in_batches, so we can order by non primary
+    key columns.
+
+    This allows you to specific orders like:
+
+    ```
+    Comments.in_batches(order: :post_id)
+    Comments.in_batches(order: [:post_id, :parent_id])
+    Comments.in_batches(order: {post_id :asc, parent_id: desc})
+    Comments.joins(:post).in_batches(order: [:"posts.id", :parent_id])
+    ```
+
+    To ensure that the sort key always returns unique values the primary key
+    is appended to the sort order if it is not already included.
+
+    *Donal McBreen*
+
 *   `ActiveRecord::Base.serialize` no longer uses YAML by default.
 
     YAML isn't particularly performant and can lead to security issues

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -573,6 +573,10 @@ module ActiveRecord
         true
       end
 
+      def sorts_nulls_first?
+        raise NotImplementedError
+      end
+
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
           !ActiveRecord.async_query_executor.nil? && !pool.async_executor.nil?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -168,6 +168,10 @@ module ActiveRecord
         true
       end
 
+      def sorts_nulls_first?
+        true
+      end
+
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -434,6 +434,10 @@ module ActiveRecord
         true
       end
 
+      def sorts_nulls_first?
+        false
+      end
+
       def get_advisory_lock(lock_id) # :nodoc:
         unless lock_id.is_a?(Integer) && lock_id.bit_length <= 63
           raise(ArgumentError, "PostgreSQL requires advisory lock ids to be a signed 64 bit integer")

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -224,6 +224,10 @@ module ActiveRecord
         true
       end
 
+      def sorts_nulls_first?
+        true
+      end
+
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity # :nodoc:

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -206,76 +206,21 @@ module ActiveRecord
     #
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil)
-      relation = self
-
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block)
       unless [:asc, :desc].include?(order)
         raise ArgumentError, ":order must be :asc or :desc, got #{order.inspect}"
       end
 
-      unless block_given?
-        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, order: order, use_ranges: use_ranges)
-      end
+      enumerator = BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, order: order, use_ranges: use_ranges)
 
-      if arel.orders.present?
-        act_on_ignored_order(error_on_ignore)
-      end
-
-      batch_limit = of
-      if limit_value
-        remaining   = limit_value
-        batch_limit = remaining if remaining < batch_limit
-      end
-
-      relation = relation.reorder(batch_order(order)).limit(batch_limit)
-      relation = apply_limits(relation, start, finish, order)
-      relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
-      batch_relation = relation
-      empty_scope = to_sql == klass.unscoped.all.to_sql
-
-      loop do
-        if load
-          records = batch_relation.records
-          ids = records.map(&:id)
-          yielded_relation = where(primary_key => ids)
-          yielded_relation.load_records(records)
-        elsif (empty_scope && use_ranges != false) || use_ranges
-          ids = batch_relation.pluck(primary_key)
-          finish = ids.last
-          if finish
-            yielded_relation = apply_finish_limit(batch_relation, finish, order)
-            yielded_relation = yielded_relation.except(:limit, :order)
-            yielded_relation.skip_query_cache!(false)
-          end
-        else
-          ids = batch_relation.pluck(primary_key)
-          yielded_relation = where(primary_key => ids)
+      if block
+        if arel.orders.present?
+          act_on_ignored_order(error_on_ignore)
         end
 
-        break if ids.empty?
-
-        primary_key_offset = ids.last
-        raise ArgumentError.new("Primary key not included in the custom select clause") unless primary_key_offset
-
-        yield yielded_relation
-
-        break if ids.length < batch_limit
-
-        if limit_value
-          remaining -= ids.length
-
-          if remaining == 0
-            # Saves a useless iteration when the limit is a multiple of the
-            # batch size.
-            break
-          elsif remaining < batch_limit
-            relation = relation.limit(remaining)
-          end
-        end
-
-        batch_relation = relation.where(
-          predicate_builder[primary_key, primary_key_offset, order == :desc ? :lt : :gt]
-        )
+        enumerator.each(load: load, error_on_ignore: error_on_ignore, &block)
+      else
+        enumerator
       end
     end
 
@@ -292,10 +237,6 @@ module ActiveRecord
 
       def apply_finish_limit(relation, finish, order)
         relation.where(predicate_builder[primary_key, finish, order == :desc ? :gteq : :lteq])
-      end
-
-      def batch_order(order)
-        table[primary_key].public_send(order)
       end
 
       def act_on_ignored_order(error_on_ignore)

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -218,7 +218,7 @@ module ActiveRecord
           act_on_ignored_order(error_on_ignore)
         end
 
-        enumerator.each(load: load, error_on_ignore: error_on_ignore, &block)
+        enumerator.each(load: load, &block)
       else
         enumerator
       end

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -5,6 +5,8 @@ module ActiveRecord
     class BatchEnumerator
       include Enumerable
 
+      delegate :arel, :limit_value, :table, :primary_key, :to_sql, :klass, :predicate_builder, :where, to: :relation
+
       def initialize(of: 1000, start: nil, finish: nil, relation:, order: :asc, use_ranges: nil) # :nodoc:
         @of       = of
         @relation = relation
@@ -52,7 +54,7 @@ module ActiveRecord
       def each_record(&block)
         return to_enum(:each_record) unless block_given?
 
-        @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: true, order: @order).each do |relation|
+        each(load: true) do |relation|
           relation.records.each(&block)
         end
       end
@@ -91,11 +93,71 @@ module ActiveRecord
       #   Person.in_batches.each do |relation|
       #     relation.update_all(awesome: true)
       #   end
-      def each(&block)
-        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false, order: @order, use_ranges: @use_ranges)
-        return enum.each(&block) if block_given?
-        enum
+      def each(load: false, error_on_ignore: nil)
+        return to_enum(:each) unless block_given?
+
+        batch_limit = batch_size
+        if limit_value
+          remaining   = limit_value
+          batch_limit = remaining if remaining < batch_limit
+        end
+
+        relation = @relation.reorder(batch_order(@order)).limit(batch_limit)
+        relation = relation.send(:apply_limits, relation, start, finish, @order)
+        relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
+        batch_relation = relation
+        empty_scope = to_sql == klass.unscoped.all.to_sql
+
+        loop do
+          if load
+            records = batch_relation.records
+            ids = records.map(&:id)
+            yielded_relation = where(primary_key => ids)
+            yielded_relation.send(:load_records, records)
+          elsif (empty_scope && @use_ranges != false) || @use_ranges
+            ids = batch_relation.pluck(primary_key)
+            finish = ids.last
+            if finish
+              yielded_relation = relation.send(:apply_finish_limit, batch_relation, finish, @order)
+              yielded_relation = yielded_relation.except(:limit, :order)
+              yielded_relation.skip_query_cache!(false)
+            end
+          else
+            ids = batch_relation.pluck(primary_key)
+            yielded_relation = where(primary_key => ids)
+          end
+
+          break if ids.empty?
+
+          primary_key_offset = ids.last
+          raise ArgumentError.new("Primary key not included in the custom select clause") unless primary_key_offset
+
+          yield yielded_relation
+
+          break if ids.length < batch_limit
+
+          if limit_value
+            remaining -= ids.length
+
+            if remaining == 0
+              # Saves a useless iteration when the limit is a multiple of the
+              # batch size.
+              break
+            elsif remaining < batch_limit
+              relation = relation.limit(remaining)
+            end
+          end
+
+          batch_relation = relation.where(
+            predicate_builder[primary_key, primary_key_offset, @order == :desc ? :lt : :gt]
+          )
+        end
       end
+
+      private
+        def batch_order(order)
+          table[primary_key].public_send(order)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/relation/batches/batch_relations.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_relations.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Batches
+    class BatchRelations
+      include Enumerable
+
+      attr_reader :relation, :batch_limit, :order, :limited_relation, :iterate_by
+      attr_reader :remaining, :ids, :yielded_relation
+
+      delegate :primary_key, :where, :limit_value, :table, :to_sql, :klass, :predicate_builder, to: :relation
+
+      def initialize(of:, start:, finish:, relation:, order:, use_ranges:, load:)
+        @relation = relation
+        @batch_limit = [of, limit_value].compact.min
+        @order = order
+
+        @limited_relation = relation.reorder(batch_order).limit(batch_limit)
+        @limited_relation = relation.send(:apply_limits, limited_relation, start, finish, order)
+        @limited_relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
+
+        empty_scope = to_sql == klass.unscoped.all.to_sql
+
+        if load
+          @iterate_by = :loading_records
+        elsif (empty_scope && use_ranges != false) || use_ranges
+          @iterate_by = :using_ranges
+        else
+          @iterate_by = :default
+        end
+
+        @remaining = limit_value
+        @ids = nil
+        @yielded_relation = nil
+      end
+
+      def each
+        loop do
+          next_iteration
+
+          yield yielded_relation if yielded_relation
+
+          break if finished?
+        end
+      end
+
+      private
+        def next_iteration
+          @ids, @yielded_relation = iterate
+
+          unless ids.empty? || primary_key_offset
+            raise ArgumentError.new("Primary key not included in the custom select clause")
+          end
+
+          @remaining -= ids.size if remaining
+        end
+
+        def iterate
+          case iterate_by
+          when :loading_records
+            iterate_loading_records(next_batch_relation)
+          when :using_ranges
+            iterate_using_ranges(next_batch_relation)
+          else
+            iterate_default(next_batch_relation)
+          end
+        end
+
+        def iterate_loading_records(batch_relation)
+          records = batch_relation.records
+          ids = records.map(&:id)
+          unless ids.empty?
+            yielded_relation = batch_relation.where(primary_key => ids)
+            yielded_relation.send(:load_records, records)
+          end
+
+          [ids, yielded_relation]
+        end
+
+        def iterate_using_ranges(batch_relation)
+          ids = batch_relation.pluck(primary_key)
+          finish = ids.last
+          if finish
+            yielded_relation = relation.send(:apply_finish_limit, batch_relation, finish, order)
+            yielded_relation = yielded_relation.except(:limit, :order)
+            yielded_relation.skip_query_cache!(false)
+          end
+
+          [ids, yielded_relation]
+        end
+
+        def iterate_default(batch_relation)
+          ids = batch_relation.pluck(primary_key)
+          yielded_relation = where(primary_key => ids) if ids.any?
+
+          [ids, yielded_relation]
+        end
+
+        def batch_order
+          table[primary_key].public_send(order)
+        end
+
+        def next_batch_relation
+          batch_relation = limited_relation
+          batch_relation = batch_relation.limit(remaining) if remaining_below_batch_limit?
+          batch_relation = batch_relation.where(offset_from_previous_batch) if primary_key_offset
+
+          batch_relation
+        end
+
+        def remaining_below_batch_limit?
+          remaining && remaining < batch_limit
+        end
+
+        def primary_key_offset
+          ids&.last
+        end
+
+        def finished?
+          ids.size < batch_limit || remaining&.zero?
+        end
+
+        def offset_from_previous_batch
+          predicate_builder[primary_key, primary_key_offset, order == :desc ? :lt : :gt]
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/batches/batch_relations.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_relations.rb
@@ -5,33 +5,41 @@ module ActiveRecord
     class BatchRelations
       include Enumerable
 
-      attr_reader :relation, :batch_limit, :order, :limited_relation, :iterate_by
-      attr_reader :remaining, :ids, :yielded_relation
+      attr_reader :relation, :batch_limit, :orderings, :order_columns, :limited_relation, :iterate_by
+      attr_reader :primary_key_column, :primary_key_order_only, :primary_key_position
+      attr_reader :remaining, :ids, :yielded_relation, :offsets
 
-      delegate :primary_key, :where, :limit_value, :table, :to_sql, :klass, :predicate_builder, to: :relation
+      delegate :primary_key, :where, :limit_value, :table, :to_sql, :klass, :predicate_builder, :connection, :arel_table, to: :relation
 
       def initialize(of:, start:, finish:, relation:, order:, use_ranges:, load:)
         @relation = relation
         @batch_limit = [of, limit_value].compact.min
-        @order = order
+        @orderings = order
+        @order_columns = order.map(&:expr)
 
-        @limited_relation = relation.reorder(batch_order).limit(batch_limit)
-        @limited_relation = relation.send(:apply_limits, limited_relation, start, finish, order)
+        @limited_relation = relation.reorder(orderings).limit(batch_limit)
+        @limited_relation = relation.send(:apply_limits, limited_relation, start, finish, orderings)
         @limited_relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
 
         empty_scope = to_sql == klass.unscoped.all.to_sql
 
+        @primary_key_column = relation.send(:arel_column, primary_key)
+        @primary_key_order_only = order_columns == [primary_key_column]
+        @primary_key_position = order_columns.index(primary_key_column)
+
         if load
           @iterate_by = :loading_records
-        elsif (empty_scope && use_ranges != false) || use_ranges
+        elsif primary_key_order_only && (empty_scope && use_ranges != false) || use_ranges
           @iterate_by = :using_ranges
         else
           @iterate_by = :default
         end
 
+        # Mutated as we iterate
         @remaining = limit_value
         @ids = nil
         @yielded_relation = nil
+        @offsets = nil
       end
 
       def each
@@ -46,9 +54,9 @@ module ActiveRecord
 
       private
         def next_iteration
-          @ids, @yielded_relation = iterate
+          @ids, @yielded_relation, @offsets = iterate
 
-          unless ids.empty? || primary_key_offset
+          if ids.present? && ids.last.nil?
             raise ArgumentError.new("Primary key not included in the custom select clause")
           end
 
@@ -69,41 +77,47 @@ module ActiveRecord
         def iterate_loading_records(batch_relation)
           records = batch_relation.records
           ids = records.map(&:id)
-          unless ids.empty?
+          if ids.present?
+            if primary_key_order_only
+              offsets = [records.last.id]
+            else
+              offsets = Array(batch_relation.where(primary_key => ids.last).pick(*order_columns))
+            end
             yielded_relation = batch_relation.where(primary_key => ids)
             yielded_relation.send(:load_records, records)
           end
 
-          [ids, yielded_relation]
+          [ids, yielded_relation, offsets]
         end
 
         def iterate_using_ranges(batch_relation)
           ids = batch_relation.pluck(primary_key)
           finish = ids.last
           if finish
-            yielded_relation = relation.send(:apply_finish_limit, batch_relation, finish, order)
+            yielded_relation = relation.send(:apply_finish_limit, batch_relation, finish, orderings)
             yielded_relation = yielded_relation.except(:limit, :order)
             yielded_relation.skip_query_cache!(false)
           end
+          offsets = [*ids.last]
 
-          [ids, yielded_relation]
+          [ids, yielded_relation, offsets]
         end
 
         def iterate_default(batch_relation)
-          ids = batch_relation.pluck(primary_key)
-          yielded_relation = where(primary_key => ids) if ids.any?
+          order_value_rows = batch_relation.pluck(*order_columns)
+          ids = primary_key_order_only ? order_value_rows : order_value_rows.map { |row| row[primary_key_position] }
+          if order_value_rows.present?
+            offsets = Array(order_value_rows.last)
+            yielded_relation = where(primary_key => ids)
+          end
 
-          [ids, yielded_relation]
-        end
-
-        def batch_order
-          table[primary_key].public_send(order)
+          [ids, yielded_relation, offsets]
         end
 
         def next_batch_relation
           batch_relation = limited_relation
           batch_relation = batch_relation.limit(remaining) if remaining_below_batch_limit?
-          batch_relation = batch_relation.where(offset_from_previous_batch) if primary_key_offset
+          batch_relation = batch_relation.where(offset_clause) if offsets
 
           batch_relation
         end
@@ -112,16 +126,104 @@ module ActiveRecord
           remaining && remaining < batch_limit
         end
 
-        def primary_key_offset
-          ids&.last
-        end
-
         def finished?
           ids.size < batch_limit || remaining&.zero?
         end
 
-        def offset_from_previous_batch
-          predicate_builder[primary_key, primary_key_offset, order == :desc ? :lt : :gt]
+        def offset_clause
+          if orderings.size == 1
+            offset_from_single_column(orderings.first, offsets.first)
+          else
+            offset_from_multiple_columns
+          end
+        end
+
+        def offset_from_single_column(ordering, offset)
+          predicate_builder[ordering.expr.name, offset, ordering.ascending? ? :gt : :lt]
+        end
+
+        def offset_from_multiple_columns
+          OffsetFromMany.new(orderings, offsets, primary_key_column, connection.sorts_nulls_first?, arel_table, predicate_builder).clause
+        end
+
+        class OffsetFromMany
+          attr_reader :order_offsets, :primary_key_column, :arel_table, :predicate_builder
+
+          def initialize(orderings, offsets, primary_key_column, sorts_nulls_first, arel_table, predicate_builder)
+            @order_offsets = orderings.zip(offsets)
+            @primary_key_column = primary_key_column
+            @sorts_nulls_first = sorts_nulls_first
+            @arel_table = arel_table
+            @predicate_builder = predicate_builder
+          end
+
+          def clause
+            order_offsets.size.times \
+              .filter_map { |index| subsequent_to_many(index) } \
+              .reduce(&:or)
+          end
+
+          private
+            def subsequent_to_many(index)
+              subsequent_clause = subsequent_to(*order_offsets[index])
+
+              if subsequent_clause.nil?
+                nil
+              elsif index == 0
+                subsequent_clause
+              else
+                equal_clauses = order_offsets[0..index - 1].map { |order_offset| equal_to(*order_offset) }
+                arel_table.grouping([*equal_clauses, *subsequent_clause].reduce(&:and))
+              end
+            end
+
+            def sorts_nulls_first?
+              @sorts_nulls_first
+            end
+
+            def equal_to(ordering, offset)
+              column = ordering.expr
+              if offset
+                predicate_builder_for(column)[column.name, offset, :eq]
+              else
+                column.eq(offset)
+              end
+            end
+
+            def subsequent_to(ordering, offset)
+              if offset.nil?
+                subsequent_to_nil(ordering)
+              else
+                subsequent_to_value(ordering, offset)
+              end
+            end
+
+            def subsequent_to_nil(ordering)
+              if sorts_nulls_first? == ordering.ascending?
+                # after null == NOT NULL
+                ordering.expr.not_eq(nil)
+              else
+                # after null is an empty set, so the whole clause is redundant
+                nil
+              end
+            end
+
+            def subsequent_to_value(ordering, value)
+              column = ordering.expr
+
+              next_values = predicate_builder_for(column)[column.name, value, ordering.ascending? ? :gt : :lt]
+
+              if column == primary_key_column || sorts_nulls_first? == ordering.ascending?
+                next_values
+              else
+                # nulls are after our value, so we also need to match them
+                arel_table.grouping(next_values.or(column.eq(nil)))
+              end
+            end
+
+            def predicate_builder_for(column)
+              column.relation.instance_variable_get("@klass").predicate_builder
+            end
         end
     end
   end


### PR DESCRIPTION

### Motivation / Background

Adds extra order options for in_batches, so we can order by non primary key columns.

This allows you to specific orders like:

```
Comments.in_batches(order: :post_id)
Comments.in_batches(order: [:post_id, :parent_id])
Comments.in_batches(order: {post_id :asc, parent_id: desc})
Comments.joins(:post).in_batches(order: [:"posts.id", :parent_id])
```

Ordering by primary key can be inefficient if the database needs to examine all the matched rows and sort them. Allowing custom ordering can lead to much more efficient batching queries.

### Detail

`ActiveRecord::Batches#in_batches` was fairly complicated and just plugging these changes into it would have made it a lot worse, so I've implemented this in three commits to fix that and make review easier.

1. Move most of the `in_batches` code into `ActiveRecord::Batches::BatchEnumerator`
2. Extract it from there into `ActiveRecord::Batches::BatchRelations`
3. Add the ability to custom sort orders.

**Preventing missed rows due to sort key duplication**
If the sort key provided is not unique then we may start missing rows between batches. To prevent this the primary key is appended to the end of key if it is not included in it. We could provide an argument to indicate that we know the sort by is unique to allow the caller to control this behaviour, but I haven't implemented this at the moment.

**Handling nulls**
Except for the primary key, we assume that any column listed in the orders could be NULL. We could I guess check the metadata and only do it for those that are? The batch queries are designed to correctly batch through the NULLs.

The adapter has been updated to report whether nulls are sorted first or not so we can correctly batch through them. We could instead force the order with `nulls_first` but ignoring the natural database sort order might reduce the performance benefit of the custom ordering.

**Batching queries**
When sorting just by primary key, we'll use the exact same queries as before, so there shouldn't be any change there.

When sorting by a custom order, there is an additional pluck query to grab the sort column values for the last row from the previous batch. We then construct a where statement that will continue on from the previous batch.

Assuming we are sorting by `a`, `b`, `id` (all ascending), the where clause (ignoring null handling for now) will look like this:

Given values for the last batch of a = 4, b = 6, id = 10
```
WHERE (a > 4) OR (a = 4 AND b > 6) OR (a = 4 AND b = 6 AND id > 10)
```

We can pick sorting ascending and descending, with the same example but sorting `b` descending we would have:

```
WHERE (a > 4) OR (a = 4 AND b < 6) OR (a = 4 AND b = 6 AND id > 10)
```

Null handling leads to more complicated queries. Assuming nulls are sorted first, then with a = 4, b = 6, id = 10, all sorted ascending we would get the same query as before. If however we had the values a = 4, b = NULL, id = 10, we would have

```
WHERE (a > 4) OR (a = 4 AND b IS NOT NULL) OR (a = 4 AND b IS NULL AND id > 10)
```

If b was sorted descended and we have a = 4, b = NULL, id = 10, then the query would be:

```
WHERE (a > 4) OR (a = 4 AND b IS NULL AND id > 10)
```
The second clause was removed here, since there's not going to be anything "before" NULL.

Finally if we have a sorted descending, b and id ascending and the values a = 4, b = NULL, id = 10, we'll have:

```
WHERE (a < 4 OR a IS NULL) OR (a = 4 AND b IS NOT NULL) OR (a = 4 AND b IS NULL AND id > 10)
```

### Additional information

I've benchmarked sorting by `:asc` to ensure that batching performance hasn't changed for that.

Here's the script:
```
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  if ENV["BATCH_CUSTOM_ORDERS"]
    gem "rails", github: "djmb/rails", branch: "batch-custom-orders"
  else
    gem "rails", github: "rails/rails", branch: "main"
  end
  gem "sqlite3"
  gem "benchmark-ips"
  gem "stackprof"
end

require "active_record"
require "minitest/autorun"
require "logger"
require "stackprof"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :text
    t.integer :number
    t.boolean :bool
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

10000.times.map do |i|
  Post.create!(text: Digest::SHA256.base64digest(i.to_s), number: i, bool: i.even?)
end

tests = {
  "in-batches": Post.in_batches,
  "in-batches-no-use-ranges": Post.in_batches(use_ranges: false),
  "in-batches-small": Post.in_batches(of: 10),
  "in-batches-condition": Post.where(bool: true).in_batches,
  "find-each": Post.find_each,
  "find-each-small": Post.find_each(batch_size: 10),
  "find-each-condition": Post.where(bool: true).find_each,
  "find-in-batches": Post.find_in_batches,
  "find-in-batches-small": Post.find_in_batches(batch_size: 10),
  "find-in-batches-condition": Post.where(bool: true).find_each
}

branch = ENV["BATCH_CUSTOM_ORDERS"] ? "branch" : "main"
results_dir = "/tmp/custom_order_benchmarks"
FileUtils.mkdir_p(results_dir)

tests.each do |name, relation|
  Benchmark.ips do |x|
    x.time = 10
    x.report("#{name}-#{branch}") { relation.map { |batch| Array(batch).map(&:id) } }
    x.save!("#{results_dir}/#{name}")
    x.compare!
  end
end
```

And the output (from a 16GB 2021 M1 MacBook Pro):
```
$ ruby custom_batch_order_benchmark.rb && BATCH_CUSTOM_ORDERS=true ruby custom_batch_order_benchmark.rb
<SNIP>
Warming up --------------------------------------
   in-batches-branch     2.000  i/100ms
Calculating -------------------------------------
   in-batches-branch     29.347  (± 3.4%) i/s -    294.000  in  10.021589s

Comparison:
   in-batches-branch:       29.3 i/s
     in-batches-main:       29.1 i/s - same-ish: difference falls within error

Warming up --------------------------------------
in-batches-no-use-ranges-branch
                         1.000  i/100ms
Calculating -------------------------------------
in-batches-no-use-ranges-branch
                         17.206  (± 0.0%) i/s -    172.000  in  10.002446s

Comparison:
in-batches-no-use-ranges-branch:       17.2 i/s
in-batches-no-use-ranges-main:       17.2 i/s - 1.00x  slower

Warming up --------------------------------------
in-batches-small-branch
                         1.000  i/100ms
Calculating -------------------------------------
in-batches-small-branch
                          6.902  (± 0.0%) i/s -     69.000  in  10.000174s

Comparison:
in-batches-small-branch:        6.9 i/s
in-batches-small-main:        6.9 i/s - 1.00x  slower

Warming up --------------------------------------
in-batches-condition-branch
                         3.000  i/100ms
Calculating -------------------------------------
in-batches-condition-branch
                         33.527  (± 3.0%) i/s -    336.000  in  10.024163s

Comparison:
in-batches-condition-branch:       33.5 i/s
in-batches-condition-main:       33.5 i/s - same-ish: difference falls within error

Warming up --------------------------------------
    find-each-branch     2.000  i/100ms
Calculating -------------------------------------
    find-each-branch     22.541  (± 4.4%) i/s -    226.000  in  10.058540s

Comparison:
    find-each-branch:       22.5 i/s
      find-each-main:       22.5 i/s - same-ish: difference falls within error

Warming up --------------------------------------
find-each-small-branch
                         1.000  i/100ms
Calculating -------------------------------------
find-each-small-branch
                          7.641  (± 0.0%) i/s -     77.000  in  10.080318s

Comparison:
find-each-small-main:        7.7 i/s
find-each-small-branch:        7.6 i/s - 1.00x  slower

Warming up --------------------------------------
find-each-condition-branch
                         4.000  i/100ms
Calculating -------------------------------------
find-each-condition-branch
                         44.563  (± 4.5%) i/s -    448.000  in  10.089475s

Comparison:
find-each-condition-main:       44.6 i/s
find-each-condition-branch:       44.6 i/s - same-ish: difference falls within error

Warming up --------------------------------------
find-in-batches-branch
                         3.000  i/100ms
Calculating -------------------------------------
find-in-batches-branch
                         29.801  (± 6.7%) i/s -    300.000  in  10.109160s

Comparison:
find-in-batches-main:       29.9 i/s
find-in-batches-branch:       29.8 i/s - same-ish: difference falls within error

Warming up --------------------------------------
find-in-batches-small-branch
                         1.000  i/100ms
Calculating -------------------------------------
find-in-batches-small-branch
                          8.552  (± 0.0%) i/s -     86.000  in  10.059261s

Comparison:
find-in-batches-small-main:        8.6 i/s
find-in-batches-small-branch:        8.6 i/s - 1.00x  slower

Warming up --------------------------------------
find-in-batches-condition-branch
                         4.000  i/100ms
Calculating -------------------------------------
find-in-batches-condition-branch
                         44.743  (± 4.5%) i/s -    448.000  in  10.045859s

Comparison:
find-in-batches-condition-branch:       44.7 i/s
find-in-batches-condition-main:       44.6 i/s - same-ish: difference falls within error
```

