### PR TITLE
Speedup activerecord tests

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -160,8 +160,12 @@ module ActiveRecord
         end
 
         private
+          IDLE_TRANSACTION_STATUSES = [PG::PQTRANS_IDLE, PG::PQTRANS_INTRANS, PG::PQTRANS_INERROR]
+          private_constant :IDLE_TRANSACTION_STATUSES
+
           def cancel_any_running_query
-            return unless @raw_connection && @raw_connection.transaction_status != PG::PQTRANS_IDLE
+            return if @raw_connection.nil? || IDLE_TRANSACTION_STATUSES.include?(@raw_connection.transaction_status)
+
             @raw_connection.cancel
             @raw_connection.block
           rescue PG::Error

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -65,6 +65,11 @@ module ActiveRecord
         @connection = connection
         @version = connection.migration_context.current_version rescue nil
         @options = options
+        @ignore_tables = [
+          ActiveRecord::Base.schema_migrations_table_name,
+          ActiveRecord::Base.internal_metadata_table_name,
+          self.class.ignore_tables
+        ].flatten
       end
 
       # turns 20170404131909 into "2017_04_04_131909"
@@ -317,7 +322,7 @@ module ActiveRecord
       end
 
       def ignored?(table_name)
-        [ActiveRecord::Base.schema_migrations_table_name, ActiveRecord::Base.internal_metadata_table_name, ignore_tables].flatten.any? do |ignored|
+        @ignore_tables.any? do |ignored|
           ignored === remove_prefix_and_suffix(table_name)
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -414,6 +414,8 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_warnings_do_not_change_returned_value_of_exec_update
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
     ActiveRecord.db_warnings_action = :log
 
     # Mysql2 will raise an error when attempting to perform an update that warns if the sql_mode is set to strict
@@ -426,10 +428,13 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     assert_equal 1, result
   ensure
     @conn.execute("SET @@SESSION.sql_mode='#{old_sql_mode}'")
+    ActiveRecord::Base.logger = previous_logger
     ActiveRecord.db_warnings_action = @original_db_warnings_action
   end
 
   def test_warnings_do_not_change_returned_value_of_exec_delete
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
     ActiveRecord.db_warnings_action = :log
 
     # Mysql2 will raise an error when attempting to perform a delete that warns if the sql_mode is set to strict
@@ -442,6 +447,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     assert_equal 1, result
   ensure
     @conn.execute("SET @@SESSION.sql_mode='#{old_sql_mode}'")
+    ActiveRecord::Base.logger = previous_logger
     ActiveRecord.db_warnings_action = @original_db_warnings_action
   end
 

--- a/activerecord/test/cases/adapters/postgresql/create_unlogged_tables_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/create_unlogged_tables_test.rb
@@ -18,13 +18,14 @@ class UnloggedTablesTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
+    @previous_unlogged_tables = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
     @connection = ActiveRecord::Base.connection
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
   end
 
   teardown do
     @connection.drop_table TABLE_NAME, if_exists: true
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = @previous_unlogged_tables
   end
 
   def test_logged_by_default

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -101,7 +101,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   def test_schema_dump
     @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy", null: false
 
-    output = dump_all_table_schema
+    output = dump_table_schema("postgresql_enums")
 
     assert_includes output, "# Note that some types may not work with other database engines. Be careful if changing database."
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -92,9 +92,14 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_warn_if_order_scope_is_set
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
+
     assert_called(ActiveRecord::Base.logger, :warn) do
       Post.order("title").find_each { |post| post }
     end
+  ensure
+    ActiveRecord::Base.logger = previous_logger
   end
 
   def test_logger_not_required

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -440,9 +440,14 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_logger_level_invariant
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
+
     level = ActiveRecord::Base.logger.level
     create_fixtures("topics")
     assert_equal level, ActiveRecord::Base.logger.level
+  ensure
+    ActiveRecord::Base.logger = previous_logger
   end
 
   def test_instantiation

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -11,6 +11,10 @@ require "active_support/logger"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/kernel/singleton_class"
 
+if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = true
+end
+
 # TODO: Move all these random hacks into the ARTest namespace and into the support/ dir
 
 Thread.abort_on_exception = true

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -21,7 +21,11 @@ module ARTest
   def self.connect
     ActiveRecord.async_query_executor = :global_thread_pool
     puts "Using #{connection_name}"
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 1, 100 * 1024 * 1024)
+    if ENV["CI"]
+      ActiveRecord::Base.logger = nil
+    else
+      ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 1, 100 * 1024 * 1024)
+    end
     ActiveRecord::Base.configurations = test_configuration_hashes
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module SchemaDumpingHelper
-  def dump_table_schema(table)
+  def dump_table_schema(*tables)
     connection = ActiveRecord::Base.connection
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
-    ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - [table]
+    ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - tables
     stream = StringIO.new
 
     ActiveRecord::SchemaDumper.dump(connection, stream)


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/47428.

activerecord tests are the slowest across all the CI, from what I see, especially for PostgreSQL and MySQL. Speeding up them would improve the whole CI time.

Tested on PostgreSQL, but this should improve the time for MySQL too.

### Before
`Finished in 428.776452s, 20.6331 runs/s, 79.7758 assertions/s.`

```
==================================
  Mode: wall(1000)
  Samples: 1704476 (8.08% miss rate)
  GC: 43384 (2.55%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    234865  (13.8%)      213458  (12.5%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#query
    244014  (14.3%)      202178  (11.9%)     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache
    201250  (11.8%)      188281  (11.0%)     PG::Connection#cancel
    159645   (9.4%)      141461   (8.3%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#execute
    188537  (11.1%)      108396   (6.4%)     ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#internal_execute
     79636   (4.7%)       79636   (4.7%)     MonitorMixin::ConditionVariable#wait
     39509   (2.3%)       33152   (1.9%)     Logger::LogDevice#write
     28570   (1.7%)       28570   (1.7%)     (sweeping)
     26823   (1.6%)       26823   (1.6%)     ActiveSupport::IsolatedExecutionState.context
     24990   (1.5%)       24980   (1.5%)     PessimisticLockingTest#duel
     18590   (1.1%)       18590   (1.1%)     Concurrent::Collection::NonConcurrentMapBackend#[]
     15747   (0.9%)       15442   (0.9%)     PG::Connection#async_connect_or_reset
```

### After
`Finished in 219.472868s, 40.3740 runs/s, 155.9373 assertions/s.` 🔥 🔥 🔥 
```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     24432   (9.7%)       24428   (9.7%)     PG::Connection#exec_params
      8950   (3.5%)        8950   (3.5%)     Thread#join
      5199   (2.1%)        5199   (2.1%)     (sweeping)
      4833   (1.9%)        4833   (1.9%)     (marking)
      4159   (1.6%)        4159   (1.6%)     PG::Connection#exec
      2944   (1.2%)        2944   (1.2%)     IO#wait
      2779   (1.1%)        2778   (1.1%)     PG::Connection#exec_prepared
      2760   (1.1%)        2760   (1.1%)     Kernel#sleep
     79635  (31.5%)        2202   (0.9%)     Thread.handle_interrupt
      2036   (0.8%)        2036   (0.8%)     BCrypt::Engine.__bc_crypt
      1866   (0.7%)        1866   (0.7%)     String#match?
      2261   (0.9%)        1762   (0.7%)     Kernel#require
      2955   (1.2%)        1642   (0.6%)     Psych::Parser#_native_parse
      1628   (0.6%)        1628   (0.6%)     String#sub!
      1852   (0.7%)        1461   (0.6%)     ActiveRecord::SchemaDumper#remove_prefix_and_suffix
      1308   (0.5%)        1308   (0.5%)     Process.waitpid
    225525  (89.2%)        1201   (0.5%)     Array#each
     10404   (4.1%)         904   (0.4%)     Hash#each_value
      1261   (0.5%)         900   (0.4%)     Module#class_eval
    131830  (52.2%)         763   (0.3%)     ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection
       750   (0.3%)         750   (0.3%)     SQLite3::Statement#initialize
       968   (0.4%)         748   (0.3%)     Concurrent::Collection::NonConcurrentMapBackend#[]
     17567   (7.0%)         676   (0.3%)     Hash#fetch
      9449   (3.7%)         639   (0.3%)     ActiveRecord::ConnectionAdapters::ConnectionHandler#each_connection_pool
       733   (0.3%)         618   (0.2%)     Module#module_eval
      3309   (1.3%)         611   (0.2%)     ActiveSupport::Notifications::Fanout::BaseTimeGroup#finish
      2855   (1.1%)         582   (0.2%)     ActiveRecord::SchemaDumper#ignored?
      2427   (1.0%)         581   (0.2%)     Kernel#require_relative
      7773   (3.1%)         576   (0.2%)     ActiveRecord::ConnectionHandling#clear_query_caches_for_current_thread
       567   (0.2%)         567   (0.2%)     Regexp#match?
```

Concrete optimizations used in this PR:

1. For each activerecord test fixtures are setup/teardown in a transaction, and after the test finished - transaction is rolledback. For this we need to cancel the running query (if any; extra additional call to the database) on the current connection and issue a `ROLLBACK`. There is an existing optimization in `cancel_any_running_query` (see PR changes) to ignore cancelling a query if there are no ones, but it accounts only for idle connections (outside of transactions). But there are 2 more "idle" statuses https://github.com/ged/ruby-pg/blob/ff42e3bca2675254762be08def0d1130f9a880b4/ext/pg_connection.c#L782-L787, one of them is "idle in transaction", which accounts for `~100%` of the cases.
2. `SchemaDumper` tests are heavy, because in many cases they unnecessary dump the whole db, where just one table would be enough.
3. Debug log items are generated (IO + generation of lines), which are not necessary on CI.
4. PostgreSQL unlogged tables - PostgreSQL spends less time managing these tables and more in responding to queries.