### PR TITLE
Address `Passing the coder as positional argument` deprecation warning

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -377,7 +377,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
           super&.freeze
         end
       end
-      serialize :normal_blob, FrozenCoder.new(:normal_blob, Array)
+      serialize(:normal_blob, coder: FrozenCoder.new(:normal_blob, Array))
     end
 
     def test_is_not_changed_when_stored_in_mysql_blob_frozen_payload


### PR DESCRIPTION
This pull request addresses the `Passing the coder as positional argument` deprecation warning.

### Motivation / Background

Follow-up #47463

### Detail

```ruby
$ ARCONN=mysql2 bin/test test/cases/serialized_attribute_test.rb -n test_is_not_changed_when_stored_in_mysql_blob_frozen_payload
Using mysql2
DEPRECATION WARNING:                 Passing the coder as positional argument is deprecated and will be remove in Rails 7.2.

                Please pass the coder as a keyword argument:

                  serialize :normal_blob, coder: #<SerializedAttributeTest::FrozenBinaryField::FrozenCoder:0x00007f59ebdcaf40>
 (called from <class:FrozenBinaryField> at /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/serialized_attribute_test.rb:380)
/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/serialized_attribute_test.rb:380:in `<class:FrozenBinaryField>'
  /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/serialized_attribute_test.rb:374:in `<class:SerializedAttributeTest>'
  /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/serialized_attribute_test.rb:9:in `<top (required)>'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:50:in `require'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:50:in `each'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:50:in `load_tests'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:42:in `run'
  /home/yahonda/src/github.com/rails/rails/activerecord/test/support/tools.rb:37:in `<top (required)>'
  bin/test:11:in `require_relative'
  bin/test:11:in `<main>'
Run options: -n test_is_not_changed_when_stored_in_mysql_blob_frozen_payload --seed 33922

..

Finished in 0.067710s, 29.5376 runs/s, 29.5376 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
