### PR TITLE
Add docs for `data-turbo-method` and `data-turbo-confirm` for `link_to`

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -173,6 +173,28 @@ module ActionView
       #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
       #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
       #
+      # ==== Turbo
+      #
+      # Rails 7 ships with Turbo enabled by default. Turbo provides the following +:data+ options:
+      #
+      # * <tt>turbo_method: symbol of HTTP verb</tt> - Performs a Turbo link visit
+      #   with the given HTTP verb. Forms are recommended when performing non-+GET+ requests.
+      #   Only use <tt>data-turbo-method</tt> where a form is not possible.
+      #
+      # * <tt>turbo_confirm: "question?"</tt> - Adds a confirmation dialog to the link with the
+      #   given value.
+      #
+      # {Consult the Turbo Handbook for more information on the options
+      # above.}[https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method]
+      #
+      # ===== \Examples
+      #
+      #   link_to "Delete profile", @profile, data: { turbo_method: :delete }
+      #   # => <a href="/profiles/1" data-turbo-method="delete">Delete profile</a>
+      #
+      #   link_to "Visit Other Site", "https://rubyonrails.org/", data: { turbo_confirm: "Are you sure?" }
+      #   # => <a href="https://rubyonrails.org/" data-turbo-confirm="Are you sure?">Visit Other Site</a>
+      #
       # ==== Deprecated: \Rails UJS Attributes
       #
       # Prior to \Rails 7, \Rails shipped with a JavaScript library called <tt>@rails/ujs</tt> on by default. Following \Rails 7,
@@ -224,9 +246,6 @@ module ActionView
       # Generates a form containing a single button that submits to the URL created
       # by the set of +options+. This is the safest method to ensure links that
       # cause changes to your data are not triggered by search bots or accelerators.
-      # If the HTML button does not work with your layout, you can also consider
-      # using the +link_to+ method with the <tt>:method</tt> modifier as described in
-      # the +link_to+ documentation.
       #
       # You can control the form and button behavior with +html_options+. Most
       # values in +html_options+ are passed through to the button element. For
@@ -239,6 +258,10 @@ module ActionView
       #
       # The form submits a POST request by default. You can specify a different
       # HTTP verb via the +:method+ option within +html_options+.
+      #
+      # If the HTML button generated from +button_to+ does not work with your layout, you can
+      # consider using the +link_to+ method with the +data-turbo-method+
+      # attribute as described in the +link_to+ documentation.
       #
       # ==== Options
       # The +options+ hash accepts the same options as +url_for+. To generate a


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Rails 7 ships with Turbo enabled by default. Instead of using `data-method` and `data-confirm`, Turbo now uses `data-turbo-method` and `data-turbo-confirm` to perform a link visit with the specified HTTP method and show confirmation dialog respectively.

The deprecated legacy options are documented **but the new options are not.**

### Detail

This commit documents the `data-turbo-method` and `data-turbo-confirm` for the `link_to` method. The `button_to` documentation has also been updated to reference the new `link_to` options.

### Additional information

There is an argument that this change is unrelated to Rails, since it is a [Turbo-specific behavior](https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method). 

However, I feel it needs to be documented because:

1) Turbo is enabled by default so people who were used to the legacy `data-method` and `data-confirm` may not be aware of it when upgrading or starting a new Rails 7 project.
2) The new options are referenced in the [getting started guide](https://guides.rubyonrails.org/getting_started.html#deleting-an-article), so it makes sense to reference it in the API documentation as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
