### PR TITLE
Use squiggly heredoc to remove extra spaces after `DEPRECATION WARNING:`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         def serialize(attr_name, class_name_or_coder = nil, coder: nil, type: Object, yaml: {}, **options)
           unless class_name_or_coder.nil?
             if class_name_or_coder.respond_to?(:new)
-              ActiveRecord.deprecator.warn(<<-MSG)
+              ActiveRecord.deprecator.warn(<<~MSG)
                 Passing the class as positional argument is deprecated and will be remove in Rails 7.2.
 
                 Please pass the class as a keyword argument:
@@ -191,7 +191,7 @@ module ActiveRecord
               MSG
               type = class_name_or_coder
             else
-              ActiveRecord.deprecator.warn(<<-MSG)
+              ActiveRecord.deprecator.warn(<<~MSG)
                 Passing the coder as positional argument is deprecated and will be remove in Rails 7.2.
 
                 Please pass the coder as a keyword argument:


### PR DESCRIPTION
### Detail

This pull request uses squiggly heredoc to remove extra spaces after `DEPRECATION WARNING:`

### Additional information
Run this script to see how it works.

- rep.rb
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  # gem "rails", path: "/home/yahonda/src/github.com/rails/rails"
end

require "active_record"
require "logger"

ActiveRecord::Base.logger = Logger.new(STDOUT)

class User < ActiveRecord::Base
  serialize :foo, JSON
  serialize :bar, Hash
end
```

- Without this commit

```ruby
DEPRECATION WARNING:                 Passing the coder as positional argument is deprecated and will be remove in Rails 7.2.

                Please pass the coder as a keyword argument:

                  serialize :foo, coder: JSON
 (called from <class:User> at rep.rb:20)
DEPRECATION WARNING:                 Passing the class as positional argument is deprecated and will be remove in Rails 7.2.

                Please pass the class as a keyword argument:

                  serialize :bar, type: Hash
 (called from <class:User> at rep.rb:21)

```

- With this commit

```ruby
DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be remove in Rails 7.2.

Please pass the coder as a keyword argument:

  serialize :foo, coder: JSON
 (called from <class:User> at rep.rb:20)
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be remove in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :bar, type: Hash
 (called from <class:User> at rep.rb:21)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
