### PR TITLE
Apply rails 3.2 patch for activemodel attribute access 

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -426,7 +426,7 @@ module ActiveModel
             @prefix = prefix
             @suffix = suffix
             @parameters = parameters.nil? ? FORWARD_PARAMETERS : parameters
-            @regex = /^(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})$/
+            @regex = /\A(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})\z/
             @proxy_target = "#{@prefix}attribute#{@suffix}"
             @method_name = "#{prefix}%s#{suffix}"
           end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the fix for CVE-2013-0276 was never applied fully to Rails 4 and later.
It is a cherry-pick adjusted for the current state of the code to give proper authorship credits.

[Original commit](https://github.com/rails/rails/commit/060bb7250b963609a0d8a5d0559e36b99d2402c6):
```
Fix issue with attr_protected where malformed input could circumvent protection

Fixes: CVE-2013-0276
```

### Detail

This Pull Request changes the attribute matching in activemodel. Newlines will now be seen as part of the attribute name, thus making injections harder.

### Additional information

This was originally easy to exploit but the switch to strong parameters should make it a non-issue in most cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
