### PR TITLE
Optimize slow tests in activerecord

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -6,14 +6,15 @@ module ActiveRecord
   module ConnectionAdapters
     class SchemaCacheTest < ActiveRecord::TestCase
       def setup
-        @connection       = ActiveRecord::Base.connection
+        @connection       = ARUnit2Model.connection
         @cache            = SchemaCache.new @connection
         @database_version = @connection.get_database_version
       end
 
       def test_yaml_dump_and_load
+        connection = ActiveRecord::Base.connection
         # Create an empty cache.
-        cache = SchemaCache.new @connection
+        cache = SchemaCache.new connection
 
         tempfile = Tempfile.new(["schema_cache-", ".yml"])
         # Dump it. It should get populated before dumping.
@@ -25,7 +26,7 @@ module ActiveRecord
         # Give it a connection. Usually the connection
         # would get set on the cache when it's retrieved
         # from the pool.
-        cache.connection = @connection
+        cache.connection = connection
 
         assert_no_queries do
           assert_equal 12, cache.columns("posts").size
@@ -70,11 +71,11 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
 
@@ -85,11 +86,11 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -98,7 +99,7 @@ module ActiveRecord
 
       def test_yaml_loads_5_1_dump
         cache = SchemaCache.load_from(schema_dump_path)
-        cache.connection = @connection
+        cache.connection = ActiveRecord::Base.connection
 
         assert_no_queries do
           assert_equal 11, cache.columns("posts").size
@@ -110,7 +111,7 @@ module ActiveRecord
 
       def test_yaml_loads_5_1_dump_without_indexes_still_queries_for_indexes
         cache = SchemaCache.load_from(schema_dump_path)
-        cache.connection = @connection
+        cache.connection = ActiveRecord::Base.connection
 
         assert_queries :any, ignore_none: true do
           assert_equal 1, cache.indexes("posts").size
@@ -119,7 +120,7 @@ module ActiveRecord
 
       def test_yaml_loads_5_1_dump_without_database_version_still_queries_for_database_version
         cache = SchemaCache.load_from(schema_dump_path)
-        cache.connection = @connection
+        cache.connection = ActiveRecord::Base.connection
 
         # We can't verify queries get executed because the database version gets
         # cached in both MySQL and PostgreSQL outside of the schema cache.
@@ -128,7 +129,7 @@ module ActiveRecord
       end
 
       def test_primary_key_for_existent_table
-        assert_equal "id", @cache.primary_keys("posts")
+        assert_equal "id", @cache.primary_keys("courses")
       end
 
       def test_primary_key_for_non_existent_table
@@ -136,7 +137,7 @@ module ActiveRecord
       end
 
       def test_columns_for_existent_table
-        assert_equal 12, @cache.columns("posts").size
+        assert_equal 3, @cache.columns("courses").size
       end
 
       def test_columns_for_non_existent_table
@@ -146,7 +147,7 @@ module ActiveRecord
       end
 
       def test_columns_hash_for_existent_table
-        assert_equal 12, @cache.columns_hash("posts").size
+        assert_equal 3, @cache.columns_hash("courses").size
       end
 
       def test_columns_hash_for_non_existent_table
@@ -156,7 +157,7 @@ module ActiveRecord
       end
 
       def test_indexes_for_existent_table
-        assert_equal 1, @cache.indexes("posts").size
+        assert_equal 1, @cache.indexes("courses").size
       end
 
       def test_indexes_for_non_existent_table
@@ -176,11 +177,11 @@ module ActiveRecord
       end
 
       def test_clearing
-        @cache.columns("posts")
-        @cache.columns_hash("posts")
-        @cache.data_sources("posts")
-        @cache.primary_keys("posts")
-        @cache.indexes("posts")
+        @cache.columns("courses")
+        @cache.columns_hash("courses")
+        @cache.data_sources("courses")
+        @cache.primary_keys("courses")
+        @cache.indexes("courses")
 
         @cache.clear!
 
@@ -193,17 +194,17 @@ module ActiveRecord
         cache = SchemaCache.new @connection
 
         # Populate it.
-        cache.add("posts")
+        cache.add("courses")
 
         # Create a new cache by marshal dumping / loading.
         cache = Marshal.load(Marshal.dump(cache))
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       end
@@ -221,11 +222,11 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -234,7 +235,7 @@ module ActiveRecord
 
       def test_marshal_dump_and_load_with_ignored_tables
         old_ignore = ActiveRecord.schema_cache_ignored_tables
-        ActiveRecord.schema_cache_ignored_tables = ["p_schema_migrations"]
+        ActiveRecord.schema_cache_ignored_tables = ["professors"]
         # Create an empty cache.
         cache = SchemaCache.new @connection
 
@@ -247,23 +248,23 @@ module ActiveRecord
         cache.connection = @connection
 
         # Assert a table in the cache
-        assert cache.data_sources("posts"), "expected posts to be in the cached data_sources"
-        assert_equal 12, cache.columns("posts").size
-        assert_equal 12, cache.columns_hash("posts").size
-        assert cache.data_sources("posts")
-        assert_equal "id", cache.primary_keys("posts")
-        assert_equal 1, cache.indexes("posts").size
+        assert cache.data_sources("courses"), "expected courses to be in the cached data_sources"
+        assert_equal 3, cache.columns("courses").size
+        assert_equal 3, cache.columns_hash("courses").size
+        assert cache.data_sources("courses")
+        assert_equal "id", cache.primary_keys("courses")
+        assert_equal 1, cache.indexes("courses").size
 
         # Assert ignored table. Behavior should match non-existent table.
-        assert_nil cache.data_sources("p_schema_migrations"), "expected comments to not be in the cached data_sources"
+        assert_nil cache.data_sources("professors"), "expected professors to not be in the cached data_sources"
         assert_raises ActiveRecord::StatementInvalid do
-          cache.columns("p_schema_migrations")
+          cache.columns("professors")
         end
         assert_raises ActiveRecord::StatementInvalid do
-          cache.columns_hash("p_schema_migrations").size
+          cache.columns_hash("professors").size
         end
-        assert_nil cache.primary_keys("p_schema_migrations")
-        assert_equal [], cache.indexes("p_schema_migrations")
+        assert_nil cache.primary_keys("professors")
+        assert_equal [], cache.indexes("professors")
       ensure
         tempfile.unlink
         ActiveRecord.schema_cache_ignored_tables = old_ignore
@@ -282,11 +283,11 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
 
@@ -295,11 +296,11 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
-          assert cache.data_sources("posts")
-          assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 3, cache.columns("courses").size
+          assert_equal 3, cache.columns_hash("courses").size
+          assert cache.data_sources("courses")
+          assert_equal "id", cache.primary_keys("courses")
+          assert_equal 1, cache.indexes("courses").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -307,34 +308,34 @@ module ActiveRecord
       end
 
       def test_data_source_exist
-        assert @cache.data_source_exists?("posts")
+        assert @cache.data_source_exists?("courses")
         assert_not @cache.data_source_exists?("foo")
       end
 
       def test_clear_data_source_cache
-        @cache.clear_data_source_cache!("posts")
+        @cache.clear_data_source_cache!("courses")
       end
 
       test "#columns_hash? is populated by #columns_hash" do
-        assert_not @cache.columns_hash?("posts")
+        assert_not @cache.columns_hash?("courses")
 
-        @cache.columns_hash("posts")
+        @cache.columns_hash("courses")
 
-        assert @cache.columns_hash?("posts")
+        assert @cache.columns_hash?("courses")
       end
 
       test "#columns_hash? is not populated by #data_source_exists?" do
-        assert_not @cache.columns_hash?("posts")
+        assert_not @cache.columns_hash?("courses")
 
-        @cache.data_source_exists?("posts")
+        @cache.data_source_exists?("courses")
 
-        assert_not @cache.columns_hash?("posts")
+        assert_not @cache.columns_hash?("courses")
       end
 
       unless in_memory_db?
         def test_when_lazily_load_schema_cache_is_set_cache_is_lazily_populated_when_est_connection
           tempfile = Tempfile.new(["schema_cache-", ".yml"])
-          original_config = ActiveRecord::Base.connection_db_config
+          original_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit2", name: "primary")
           new_config = original_config.configuration_hash.merge(schema_cache_path: tempfile.path)
 
           ActiveRecord::Base.establish_connection(new_config)

--- a/activerecord/test/cases/encryption/concurrency_test.rb
+++ b/activerecord/test/cases/encryption/concurrency_test.rb
@@ -13,7 +13,8 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
   end
 
   def thread_encrypting_and_decrypting(thread_label)
-    posts = 200.times.collect { |index| EncryptedPost.create! title: "Article #{index} (#{thread_label})", body: "Body #{index} (#{thread_label})" }
+    EncryptedPost.insert_all 100.times.collect { |index| { title: "Article #{index} (#{thread_label})", body: "Body #{index} (#{thread_label})" } }
+    posts = EncryptedPost.last(100)
 
     Thread.new do
       posts.each.with_index do |article, index|

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -4,7 +4,8 @@ require "cases/helper"
 require "models/author"
 require "models/categorization"
 require "models/post"
-require "models/citation"
+require "models/book"
+require "models/paragraph"
 
 module ActiveRecord
   class OrTest < ActiveRecord::TestCase
@@ -180,14 +181,14 @@ module ActiveRecord
   # https://www.sqlite.org/limits.html#max_expr_depth
   class TooManyOrTest < ActiveRecord::TestCase
     unless current_adapter?(:SQLite3Adapter)
-      fixtures :citations
+      fixtures :paragraphs
 
       def test_too_many_or
-        citations = 6000.times.map do |i|
-          Citation.where(id: i, book2_id: i * i)
+        paragraphs = 1001.times.map do |i|
+          Paragraph.where(id: i, book_id: i * i)
         end
 
-        assert_equal 6000, citations.inject(&:or).count
+        assert_equal 1001, paragraphs.inject(&:or).count
       end
     end
   end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -2,7 +2,8 @@
 
 require "cases/helper"
 require "active_record/tasks/database_tasks"
-require "models/author"
+require "models/course"
+require "models/college"
 
 module ActiveRecord
   module DatabaseTasksSetupper
@@ -1270,14 +1271,15 @@ module ActiveRecord
     unless in_memory_db?
       self.use_transactional_tests = false
 
-      fixtures :authors, :author_addresses
+      fixtures :courses, :colleges
 
       def setup
-        @schema_migration = ActiveRecord::Base.connection.schema_migration
+        connection = ARUnit2Model.connection
+        @schema_migration = connection.schema_migration
         @schema_migration.create_table
         @schema_migration.create_version(@schema_migration.table_name)
 
-        @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+        @internal_metadata = connection.internal_metadata
         @internal_metadata.create_table
         @internal_metadata[@internal_metadata.table_name] = nil
 
@@ -1294,10 +1296,10 @@ module ActiveRecord
       def test_truncate_tables
         assert_operator @schema_migration.count, :>, 0
         assert_operator @internal_metadata.count, :>, 0
-        assert_operator Author.count, :>, 0
-        assert_operator AuthorAddress.count, :>, 0
+        assert_operator Course.count, :>, 0
+        assert_operator College.count, :>, 0
 
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit2", name: "primary")
         configurations = { development: db_config.configuration_hash }
         ActiveRecord::Base.configurations = configurations
 
@@ -1309,8 +1311,8 @@ module ActiveRecord
 
         assert_operator @schema_migration.count, :>, 0
         assert_operator @internal_metadata.count, :>, 0
-        assert_equal 0, Author.count
-        assert_equal 0, AuthorAddress.count
+        assert_equal 0, Course.count
+        assert_equal 0, College.count
       end
     end
 

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1346,8 +1346,11 @@ class TransactionsWithTransactionalFixturesTest < ActiveRecord::TestCase
   end
 end if Topic.connection.supports_savepoints?
 
-class ConcurrentTransactionTest < TransactionTest
+class ConcurrentTransactionTest < ActiveRecord::TestCase
   if ActiveRecord::Base.connection.supports_transaction_isolation? && !current_adapter?(:SQLite3Adapter)
+    self.use_transactional_tests = false
+    fixtures :topics, :developers
+
     # This will cause transactions to overlap and fail unless they are performed on
     # separate database connections.
     def test_transaction_per_thread

--- a/activerecord/test/fixtures/paragraphs.yml
+++ b/activerecord/test/fixtures/paragraphs.yml
@@ -1,0 +1,5 @@
+<% 1001.times do |i| %>
+fixture_no_<%= i %>:
+  id: <%= i %>
+  book_id: <%= i*i %>
+<% end %>

--- a/activerecord/test/models/paragraph.rb
+++ b/activerecord/test/models/paragraph.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Paragraph < ActiveRecord::Base
+  belongs_to :book
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -252,6 +252,10 @@ ActiveRecord::Schema.define do
     t.string :status
   end
 
+  create_table :paragraphs, force: true do |t|
+    t.references :book
+  end
+
   create_table :clothing_items, force: true do |t|
     t.string :clothing_type
     t.string :color
@@ -1390,7 +1394,7 @@ end
 
 Course.connection.create_table :courses, force: true do |t|
   t.column :name, :string, null: false
-  t.column :college_id, :integer
+  t.column :college_id, :integer, index: true
 end
 
 College.connection.create_table :colleges, force: true do |t|

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -13,10 +13,10 @@ module SchemaDumpingHelper
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
   end
 
-  def dump_all_table_schema(ignore_tables = [])
+  def dump_all_table_schema(ignore_tables = [], connection: ActiveRecord::Base.connection)
     old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, ignore_tables
     stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
+    ActiveRecord::SchemaDumper.dump(connection, stream)
     stream.string
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/47499.

Was able to substantially speedup active record tests even further (this is probably the last time) by working out through the slowest tests.

The main offenders are schema dumping and schema cache tests, which dump/load a lot of tables from the [schema.rb file](https://github.com/rails/rails/blob/main/activerecord/test/schema/schema.rb) connected to `:arunit` connections, where we can work with a much smaller `:arunit2` connections' tables.

`$ CI=1 SEED=1 rake test:postgresql`

### Timings
Before: `Finished in 199.307319s, 44.0476 runs/s, 170.5808 assertions/s.`
After: `Finished in 162.104721s, 54.1563 runs/s, 160.5629 assertions/s.` 🔥 

### Slowest tests
Used https://github.com/y-yagi/minitest-test_profile for detection.

#### Before
```
Top 30 slowest tests (79.700740 seconds, 40.2% of total time):
PooledConnectionsTest#test_pooled_connection_checkin_one
  20.23 seconds
ActiveRecord::TooManyOrTest#test_too_many_or
  6.80 seconds
EagerLoadingTooManyIdsTest#test_eager_loading_too_many_ids
  5.12 seconds
PessimisticLockingTest#test_no_locks_no_wait
  5.03 seconds
ActiveRecord::Encryption::ConcurrencyTest#test_models_can_be_encrypted_and_decrypted_in_different_threads_concurrently
  3.25 seconds
SecurePasswordTest#test_authenticate_by_takes_the_same_amount_of_time_regardless_of_whether_record_is_found
  2.91 seconds
SchemaDumperTest#test_schema_dump_with_table_name_prefix_and_ignoring_tables
  2.19 seconds
ActiveRecord::DatabaseTasksDumpSchemaTest#test_db_dir_ignored_if_included_in_schema_dump
  2.17 seconds
ActiveRecord::DatabaseTasksDumpSchemaTest#test_ensure_db_dir
  2.16 seconds
SchemaDumperTest#test_schema_dump_keeps_id_false_when_id_is_false_and_unique_not_null_column_added
  2.14 seconds
SchemaDumperTest#test_schema_dump_with_regexp_ignored_table
  2.14 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_yaml_dump_and_load
  1.92 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_when_lazily_load_schema_cache_is_set_cache_is_lazily_populated_when_est_connection
  1.71 seconds
EagerLoadingTooManyIdsTest#test_preloading_too_many_ids
  1.66 seconds
PostgresqlHstoreTest#test_disable_enable_hstore
  1.63 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_yaml_dump_and_load_with_gzip
  1.61 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_cache_path_can_be_in_directory
  1.44 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_with_ignored_tables
  1.42 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_with_gzip
  1.39 seconds
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_via_disk
  1.39 seconds
ActiveRecord::DatabaseTasksDumpSchemaCacheTest#test_dump_schema_cache
  1.37 seconds
ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_disconnect_and_clear_reloadable_connections_attempt_to_wait_for_threads_to_return_their_conns
  1.26 seconds
ActiveRecord::BindParameterTest#test_too_many_binds_with_query_cache
  1.19 seconds
ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_checkout_fairness
  1.19 seconds
ActiveRecord::PostgresqlTransactionNestedTest#test_deadlock_raises_Deadlocked_inside_nested_SavepointTransaction
  1.17 seconds
ActiveRecord::PostgresqlTransactionNestedTest#test_deadlock_inside_nested_SavepointTransaction_is_recoverable
  1.13 seconds
ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::StatementPoolTest#test_cache_is_per_pid
  1.11 seconds
ActiveRecord::PostgresqlTransactionTest#test_raises_Deadlocked_when_a_deadlock_is_encountered
  1.06 seconds
ActiveRecord::DatabaseTasksTruncateAllTest#test_truncate_tables
  0.99 seconds
ActiveRecord::BindParameterTest#test_too_many_binds
  0.91 seconds
```

#### After
```
Top 30 slowest tests (53.339880 seconds, 33.1% of total time):
PooledConnectionsTest#test_pooled_connection_checkin_one
  20.24 seconds
EagerLoadingTooManyIdsTest#test_eager_loading_too_many_ids
  5.58 seconds
PessimisticLockingTest#test_no_locks_no_wait
  5.02 seconds
SecurePasswordTest#test_authenticate_by_takes_the_same_amount_of_time_regardless_of_whether_record_is_found
  2.96 seconds
SchemaDumperTest#test_schema_dump_keeps_id_false_when_id_is_false_and_unique_not_null_column_added
  2.18 seconds
PostgresqlHstoreTest#test_disable_enable_hstore
  1.62 seconds
EagerLoadingTooManyIdsTest#test_preloading_too_many_ids
  1.51 seconds
ActiveRecord::BindParameterTest#test_too_many_binds_with_query_cache
  1.36 seconds
ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_disconnect_and_clear_reloadable_connections_attempt_to_wait_for_threads_to_return_their_conns
  1.25 seconds
ActiveRecord::ConnectionAdapters::ConnectionPoolThreadTest#test_checkout_fairness
  1.20 seconds
ActiveRecord::BindParameterTest#test_too_many_binds
  1.11 seconds
ActiveRecord::PostgresqlTransactionNestedTest#test_deadlock_inside_nested_SavepointTransaction_is_recoverable
  1.04 seconds
ActiveRecord::PostgresqlTransactionNestedTest#test_deadlock_raises_Deadlocked_inside_nested_SavepointTransaction
  1.04 seconds
ActiveRecord::PostgresqlTransactionTest#test_raises_Deadlocked_when_a_deadlock_is_encountered
  1.03 seconds
ConcurrentTransactionTest#test_transaction_isolation__read_committed
  0.58 seconds
ActiveRecord::PostgresqlTransactionTest#test_raises_QueryCanceled_when_canceling_statement_due_to_user_request
  0.53 seconds
ActiveRecord::Encryption::KeyGeneratorTest#test_derive_key_derives_a_key_with_from_the_provided_password_with_the_cipher_key_length_by_default
  0.53 seconds
ActiveRecord::PostgresqlTransactionTest#test_raises_Interrupt_when_canceling_statement_via_interrupt
  0.51 seconds
ActiveRecord::Encryption::DerivedSecretKeyProviderTest#test_will_derive_a_key_with_the_right_length_from_the_given_password
  0.42 seconds
EagerLoadPolyAssocsTest#test_include_query
  0.40 seconds
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_forked_child_recovers_from_disconnected_parent
  0.37 seconds
ActiveRecord::Encryption::KeyProviderTest#test_work_with_multiple_keys_when_config.store_key_references_is_false
  0.32 seconds
ActiveRecord::Encryption::SchemeTest#test_validates_config_options_when_declaring_encrypted_attributes
  0.32 seconds
ActiveRecord::Encryption::DerivedSecretKeyProviderTest#test_work_with_multiple_keys_when_config.store_key_references_is_true
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_when_the_message_does_not_contain_any_key_reference,_it_returns_all_the_keys
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_when_store_key_references_is_true,_the_encryption_key_contains_a_reference_to_the_key_itself
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_when_the_message_to_decrypt_contains_a_reference_to_the_key_id,_it_will_return_an_array_only_with_that_message
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_work_with_multiple_keys_when_config.store_key_references_is_true
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_when_store_key_references_is_false,_the_encryption_key_contains_a_reference_to_the_key_itself
  0.32 seconds
ActiveRecord::Encryption::KeyProviderTest#test_serves_the_last_key_for_encrypting
  0.32 seconds
```

Note: There is an offender with 20s runtime at the top (😱), so someone else with the skills can try to get rid of that, if they wish.