### PR TITLE
Add `required_rubygems_version` to all modules

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Structure many real-time application concerns into channels over a single WebSocket connection."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Receive and process incoming emails in Rails applications."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license  = "MIT"
 

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Email on Rails. Compose, deliver, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Edit and display rich text in Rails applications."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license  = "MIT"
 

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Simple, battle-tested conventions and helpers for building web pages."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Declare job classes that can be run by a variety of queuing backends."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Attach cloud and local files in Rails applications."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Rails internals: application bootup, plugins, generators, and rake tasks."
 
   s.required_ruby_version = ">= 2.7.0"
+  s.required_rubygems_version = ">= 3.3.13"
 
   s.license = "MIT"
 


### PR DESCRIPTION
### Motivation / Background

This pull request adds `required_rubygems_version` to all modules that have been added to the `rails.gemspec` via https://github.com/rails/rails/pull/46817

When 3rd party gems or applications that require some modules of Rails, `required_rubygems_version` in the `rails.gemspec` is not considered.

i.e.
https://github.com/rails/rails/pull/47480 reported this error "`>=': comparison of Gem::Version with String failed (ArgumentError)" that syntax is available since RubyGems 3.3.6 higher than `required_rubygems_version = ">= 3.3.13"` https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#336--2022-01-26

### Detail

- Ruby 3.0.5 and RubyGems 3.2.33 that does not satisfy `required_rubygems_version = ">= 3.3.13"`

```
$ ruby -v
ruby 3.0.5p211 (2022-11-24 revision ba5cf0f7c5) [x86_64-linux]
$ gem -v
3.2.33
```

Prepare two gemfiles to install entire rails and install all submodules separately.
- `gemfile_rails`

```ruby

source "https://rubygems.org"
gem "rails", git: "https://github.com/rails/rails", branch: "main"
```

- `gemfile_submodules`
```ruby

source 'https://rubygems.org'

%w[ actioncable actionmailbox actionmailer actionpack actiontext
    actionview activejob activemodel activerecord activestorage
    activesupport railties].each do |submodule|
      gem submodule, git: 'https://github.com/rails/rails', branch: 'main'
end
```

- Installing entire `rails` shows `rails-7.1.0.alpha requires rubygems version >= 3.3.13` as expected.

```ruby
$ BUNDLE_GEMFILEg=gemfile_rails bundle install
Fetching https://github.com/rails/rails
Resolving dependencies...Fetching gem metadata from https://rubygems.org/.......
............
rails-7.1.0.alpha requires rubygems version >= 3.3.13, which is incompatible with the current version, 3.2.33
$
```

- Without this commit Installing each submodule install them unexpectedly.`required_rubygems_version = ">= 3.3.13"`

```ruby
$ BUNDLE_GEMFILE=gemfile_submodules bundle install
Fetching https://github.com/rails/rails
Resolving dependencies...Fetching gem metadata from https://rubygems.org/.......
.................................
... snip ...
Using actionview 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using activemodel 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using actionpack 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using activejob 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using actioncable 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using activerecord 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using actionmailer 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using railties 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using activestorage 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using actiontext 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Using actionmailbox 7.1.0.alpha from https://github.com/rails/rails (at main@0eaa58e)
Bundle complete! 12 Gemfile dependencies, 47 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$
```

- With this commit, Installing each submodule install fails as expected.

```ruby
$ BUNDLE_GEMFILE=gemfile_test bundle install
Resolving dependencies...Fetching gem metadata from https://rubygems.org/.......
.
Bundler found conflicting requirements for the RubyGems version:
  In gemfile_test:
    RubyGems (= 3.2.33)

    actioncable was resolved to 7.1.0.alpha, which depends on
      RubyGems (>= 3.3.13)

RubyGems (>= 3.3.13), which is required by gem 'actioncable', is not available in the local ruby installation
$
```

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
