### PR TITLE
Remove sentence about the namespace of deprecation notification events

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -760,8 +760,6 @@ INFO. The only ActiveStorage service that provides this hook so far is GCS.
 | `:gem_name`            | Name of the gem reporting the deprecation             |
 | `:deprecation_horizon` | Version where the deprecated behavior will be removed |
 
-NOTE: Each framework will also emit their own namespaced `deprecation` events.
-
 Exceptions
 ----------
 


### PR DESCRIPTION
Follow-up to #47305

All Rails frameworks deprecators have "Rails" as their `gem_name`, and the `:notify` behavior emits events based on that, so all frameworks emit their deprecations under the `rails` namespace.

For example: https://github.com/rails/rails/blob/5d7b6d823f50d9cc10f22c4380218e697f6e03bb/activesupport/lib/active_support/deprecator.rb#L5
https://github.com/rails/rails/blob/5d7b6d823f50d9cc10f22c4380218e697f6e03bb/activesupport/lib/active_support/deprecation.rb#L42
https://github.com/rails/rails/blob/5d7b6d823f50d9cc10f22c4380218e697f6e03bb/activesupport/lib/active_support/deprecation/behaviors.rb#L39

cc @skipkayhil @p8 