### PR TITLE
Add rails new and docker build smoke tests to CI

### DIFF
--- a/.github/workflows/rails-new.yml
+++ b/.github/workflows/rails-new.yml
@@ -1,0 +1,17 @@
+name: Rails new smoke tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+    - run: mkdir -p integration/vendor/rails
+    - run: git archive --format tar HEAD | tar x -C integration/vendor/rails
+    - run: RAILS_DEV_PATH=vendor/rails bundle exec railties/exe/rails new integration --dev --javascript=esbuild
+    - run: docker build integration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -603,4 +603,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.3.22
+   2.4.6

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -397,6 +397,10 @@ module Rails
         end
       end
 
+      def rails_dev?
+        options.dev?
+      end
+
       def rails_prerelease?
         options.dev? || options.edge? || options.main?
       end
@@ -504,7 +508,7 @@ module Rails
         packages = %w(build-essential git)
 
         # add databases: sqlite3, postgres, mysql
-        packages += %w(pkg-config libpq-dev default-libmysqlclient-dev)
+        packages += %w(pkg-config libpq-dev default-libmysqlclient-dev libxml2-dev)
 
         # ActiveStorage preview support
         packages << "libvips" unless skip_active_storage?
@@ -538,7 +542,7 @@ module Rails
 
       def dockerfile_deploy_packages
         # start with databases: sqlite3, postgres, mysql
-        packages = %w(libsqlite3-0 postgresql-client default-mysql-client)
+        packages = %w(libsqlite3-0 postgresql-client default-mysql-client libxml2-dev)
 
         # ActiveStorage preview support
         packages << "libvips" unless skip_active_storage?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -266,7 +266,7 @@ module Rails
   module Generators
     # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
     # can change in Ruby 1.8.7 when we FileUtils.cd.
-    RAILS_DEV_PATH = File.expand_path("../../../../../..", __dir__)
+    RAILS_DEV_PATH = ENV.fetch("RAILS_DEV_PATH", File.expand_path("../../../../../..", __dir__))
 
     class AppGenerator < AppBase
       # :stopdoc:

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -35,6 +35,9 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 <% end -%>
 # Install application gems
 COPY Gemfile Gemfile.lock ./
+<% if rails_dev? %>
+COPY vendor/rails vendor/rails
+<% end %>
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -32,13 +32,6 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 <%- end -%>
-<% if RUBY_ENGINE == "ruby" -%>
-
-group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
-end
-<% end -%>
 
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>


### PR DESCRIPTION
It's very basic for now, we simply run `rails new` and then `docker build`.

- I had to hack `--dev` a bit and to copy the current Rails in `vendor/rails` so that it can be copied in the image.
- Somehow we were missing `libxml2-dev` for nokogiri?
- I think the proper solution for `debug` is just to remove it from the Gemfile. It now ship with Ruby, so I don't really see a need to add it. If users want the latest version they can add it themselves.

In a followup I'd like to try booting the docker image and `curl /up` to ensure it boots.

FYI: @dhh @rubys @zzak 