### PR TITLE
Remove `debug` from the default Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -32,13 +32,6 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 <%- end -%>
-<% if RUBY_ENGINE == "ruby" -%>
-
-group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
-end
-<% end -%>
 
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -600,15 +600,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "jbuilder"
   end
 
-  def test_inclusion_of_a_debugger
-    run_generator
-    if defined?(JRUBY_VERSION)
-      assert_no_gem "debug"
-    else
-      assert_gem "debug"
-    end
-  end
-
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
It's baked in Ruby 3.1+ so not needed in most case.

It also ship with a sligthly broken gemspec, so cause issues when bundling with `BUNDLE_DEPLOYMENT=1`.

Ref: https://github.com/rubygems/rubygems/issues/6082#issuecomment-1329756343

FYI: @dhh @matthewd @zzak @rubys 