### PR TITLE
Add one platform at the time

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -642,12 +642,14 @@ module Rails
           bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1")
 
           # The vast majority of Rails apps will be deployed on `x86_64-linux`.
-          platform = ["--add-platform=x86_64-linux"]
+          platforms = ["--add-platform=x86_64-linux"]
 
           # Users that develop on M1 mac may use docker and would need `aarch64-linux` as well.
-          platform << "--add-platform=aarch64-linux" if RUBY_PLATFORM.start_with?("arm64")
+          platforms << "--add-platform=aarch64-linux" if RUBY_PLATFORM.start_with?("arm64")
 
-          bundle_command("lock #{platform.join(" ")}", "BUNDLE_IGNORE_MESSAGES" => "1")
+          platforms.each do |platform|
+            bundle_command("lock #{platform}", "BUNDLE_IGNORE_MESSAGES" => "1")
+          end
         end
       end
 


### PR DESCRIPTION
Bundler won't process adding two platforms at the same time using identically named cli parameters (think it's a Thor limitation). So just do it one at the time.