### PR TITLE
Dockerfile: run yarn install with --frozen-lockfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -43,7 +43,7 @@ RUN bundle install && \
 <% if using_node? -%>
 # Install node modules
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 <% end -%>
 # Copy application code


### PR DESCRIPTION
Similar to BUNDLE_DEPLOYMENT, this flag make sure no package is upgraded or downgraded in the lockfile.

Ref: https://classic.yarnpkg.com/lang/en/docs/cli/install/

> If you need reproducible dependencies, which is usually the
> case with the continuous integration systems, you
> should pass `--frozen-lockfile` flag.

FYI: @rubys @zzak @dhh @matthewd 