### PR TITLE
Avoid setting notice receiver on PG connection when ignoring SQL warnings

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -189,8 +189,6 @@ module ActiveRecord
           end
 
           def handle_warnings(sql)
-            return if ActiveRecord.db_warnings_action.nil?
-
             @notice_receiver_sql_warnings.each do |warning|
               next if warning_ignored?(warning)
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -950,11 +950,13 @@ module ActiveRecord
           self.client_min_messages = @config[:min_messages] || "warning"
           self.schema_search_path = @config[:schema_search_path] || @config[:schema_order]
 
-          @raw_connection.set_notice_receiver do |result|
-            message = result.error_field(PG::Result::PG_DIAG_MESSAGE_PRIMARY)
-            code = result.error_field(PG::Result::PG_DIAG_SQLSTATE)
-            level = result.error_field(PG::Result::PG_DIAG_SEVERITY)
-            @notice_receiver_sql_warnings << SQLWarning.new(message, code, level)
+          unless ActiveRecord.db_warnings_action.nil?
+            @raw_connection.set_notice_receiver do |result|
+              message = result.error_field(PG::Result::PG_DIAG_MESSAGE_PRIMARY)
+              code = result.error_field(PG::Result::PG_DIAG_SQLSTATE)
+              level = result.error_field(PG::Result::PG_DIAG_SEVERITY)
+              @notice_receiver_sql_warnings << SQLWarning.new(message, code, level)
+            end
           end
 
           # Use standard-conforming strings so we don't have to do the E'...' dance.


### PR DESCRIPTION
### Motivation / Background

See https://github.com/rails/rails/pull/46690#discussion_r1117952202.

We should avoid setting the notice processor on the Postgres connection if SQL warnings are ignored.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @yogeshjain999 @byroot 
