### PR TITLE
Update Action Mailer's deliver_later_queue_name documentation with current defaults

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -464,7 +464,7 @@ module ActionMailer
   #   custom delivery job. Defaults to +ActionMailer::MailDeliveryJob+.
   #
   # * <tt>deliver_later_queue_name</tt> - The queue name used by <tt>deliver_later</tt> with the default
-  #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue. Defaults to <tt>:mailers</tt>.
+  #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue name.
   class Base < AbstractController::Base
     include DeliveryMethods
     include QueuedDelivery

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -63,7 +63,7 @@ module ActionMailer
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
     # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt> on
-    # the +:mailers+ queue. Mailer classes can customize the queue name used for the default
+    # the default queue. Mailer classes can customize the queue name used for the default
     # job by assigning a +deliver_later_queue_name+ class variable, or provide a custom job
     # by assigning a +delivery_job+. When a custom job is used, it controls the queue name.
     #
@@ -90,7 +90,7 @@ module ActionMailer
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
     # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt> on
-    # the +:mailers+ queue. Mailer classes can customize the queue name used for the default
+    # the default queue. Mailer classes can customize the queue name used for the default
     # job by assigning a +deliver_later_queue_name+ class variable, or provide a custom job
     # by assigning a +delivery_job+. When a custom job is used, it controls the queue name.
     #

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -818,7 +818,7 @@ files (environment.rb, production.rb, etc...)
 |`perform_deliveries`|Determines whether deliveries are actually carried out when the `deliver` method is invoked on the Mail message. By default they are, but this can be turned off to help functional testing. If this value is `false`, `deliveries` array will not be populated even if `delivery_method` is `:test`.|
 |`deliveries`|Keeps an array of all the emails sent out through the Action Mailer with delivery_method :test. Most useful for unit and functional testing.|
 |`delivery_job`|The job class used with `deliver_later`. Defaults to `ActionMailer::MailDeliveryJob`.|
-|`deliver_later_queue_name`|The name of the queue used with the default `delivery_job`. Defaults to `:mailers`|
+|`deliver_later_queue_name`|The name of the queue used with the default `delivery_job`. Defaults to the default Active Job queue.|
 |`default_options`|Allows you to set default values for the `mail` method options (`:from`, `:reply_to`, etc.).|
 
 For a complete writeup of possible configurations see the


### PR DESCRIPTION
Since Rails 6.1 the default application configuration has been to use Active Job's default queue, achieved by setting the queue name to `nil`:

https://github.com/rails/rails/blob/c15093c8561618a7673d1373293e6ff58a05cd65/railties/lib/rails/application/configuration.rb#L212-L214

Update the incorrect documentation introduced in #47408 with current defaults.

Refs:
- https://github.com/rails/rails/pull/47408#discussion_r1118672914
