### PR TITLE
Revert "Support prerelease rubies in Gemfile template"

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "\"#{Gem.ruby_version}\"" -%>
+ruby <%= "\"#{RUBY_VERSION}\"" -%>
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -922,7 +922,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby "#{Gem.ruby_version}"/, content)
+      assert_match(/ruby "#{RUBY_VERSION}"/, content)
     end
     assert_file ".ruby-version" do |content|
       if ENV["RBENV_VERSION"]


### PR DESCRIPTION
Reverts rails/rails#45979

Because this pull request requires RubyGems 3.3.13, which requires `gem update --system` for Ruby 2.7 and Ruby 3.0.

https://github.com/rails/rails/pull/47511#issuecomment-1447269468