### PR TITLE
Revert "Merge pull request #46817 from yahonda/bump_required_rubygems_version_to_3313"

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration."
 
   s.required_ruby_version     = ">= 2.7.0"
-  s.required_rubygems_version = ">= 3.3.13"
+  s.required_rubygems_version = ">= 1.8.11"
 
   s.license = "MIT"
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -81,12 +81,6 @@
 
     *DHH*
 
-*   Bump `required_rubygems_version` from 1.8.11 to 3.3.13 or higher in order to
-    support pre-release versions of Ruby when generating a new Rails app
-    Gemfile.
-
-    *Yasuo Honda*
-
 *   Add Docker files by default to new apps: Dockerfile, .dockerignore, bin/docker-entrypoint.
     These files can be skipped with `--skip-docker`. They're intended as a starting point for
     a production deploy of the application. Not intended for development (see Docked Rails for that).


### PR DESCRIPTION
This pull request reverts #46817 as discussed https://github.com/rails/rails/pull/47511#issuecomment-1447269468

This reverts commit c14b8c7323e84ebd0f8646c5ecc242e6256278b7, reversing changes made to 85bc6ca9d2c0768796bbd6e496b2b3206853127f.
