### PR TITLE
Ensure app generator works on Ruby 2.7 rubygems

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -519,9 +519,9 @@ module Rails
           # Dockerhub.
           case Gem.ruby_version.to_s
           when /^2\.7/
-            bullseye = Gem.ruby_version >= "2.7.4"
+            bullseye = Gem.ruby_version >= Gem::Version.new("2.7.4")
           when /^3\.0/
-            bullseye = Gem.ruby_version >= "3.0.2"
+            bullseye = Gem.ruby_version >= Gem::Version.new("3.0.2")
           else
             bullseye = true
           end


### PR DESCRIPTION
### Motivation / Background

Ref: #47525 

Previously, this method compared Gem::Versions with Strings, which isn't supported until Rubygems 3.3.6.

### Detail

Now, it correctly only compares Gem::Versions with Gem::Versions.

### Additional information

An alternative approach could be to use Gem::Version.new(RUBY_VERSION), however there doesn't appear to be a benefit in this case and the downside is that testing becomes much harder.

I tested this locally on a fresh install of Ruby 2.7.0 and tests are passing for me.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
