### PR TITLE
Add test:arel task to run only Arel tests

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -38,6 +38,14 @@ namespace :test do
       %w(isolated_test_mysql2 isolated_test_sqlite3 isolated_test_postgresql)
     run_without_aborting(*tasks)
   end
+
+  Rake::TestTask.new(:arel) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/cases/arel/**/*_test.rb"]
+
+    t.warning = true
+    t.verbose = true
+  end
 end
 
 namespace :db do


### PR DESCRIPTION
### Motivation / Background

Previously, all of the Arel tests would be run with every database adapter. This is not necessarily a problem, but these tests end up getting run along with every adapter's tests in CI even though none of them require a database.

### Detail

This commit starts the process of testing Arel separately from database adapters by adding a new task to run Arel's tests. The next step will be to add the test:arel task to Buildkite, and then the Arel tests can be filtered from the list of adapter tests so that they are only run once.

### Additional information

Ref: https://github.com/rails/rails/pull/47523#issuecomment-1447270767

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
