### PR TITLE
Revert "Use cached instance of ruby_version"

### DIFF
--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -2,7 +2,7 @@
 
 # :stopdoc:
 
-if Gem.ruby_version < "2.7.0" && RUBY_ENGINE == "ruby"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0") && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 


### PR DESCRIPTION
This reverts commit d247f491a4e4e76b8930484a94e5055b30d9db0c.

### Motivation / Background

Because Rails 7.1.0.alpha no longer requires RubyGems 3.3.13 so that Ruby 2.7 and Ruby 3.0 users can use Rails without bumping RubyGems version as discussed at https://github.com/rails/rails/pull/47511#issuecomment-1447269468

### Detail

### Additional information
Related pull requests:

https://github.com/rails/rails/pull/47526
https://github.com/rails/rails/pull/47525
https://github.com/rails/rails/pull/47524

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
