### PR TITLE
Fix regressions in recent `serialize` API changes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -230,7 +230,7 @@ module ActiveRecord
             # using the #as_json hook.
             coder = Coders::JSON if coder == ::JSON
 
-            if coder == ::YAML
+            if coder == ::YAML || coder == Coders::YAMLColumn
               Coders::YAMLColumn.new(attr_name, type, **(yaml || {}))
             elsif coder.respond_to?(:new) && !coder.respond_to?(:load)
               coder.new(attr_name, type)

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -181,24 +181,24 @@ module ActiveRecord
         #
         def serialize(attr_name, class_name_or_coder = nil, coder: nil, type: Object, yaml: {}, **options)
           unless class_name_or_coder.nil?
-            if class_name_or_coder.respond_to?(:new)
+            if class_name_or_coder == ::JSON || [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
               ActiveRecord.deprecator.warn(<<~MSG)
-                Passing the class as positional argument is deprecated and will be remove in Rails 7.2.
-
-                Please pass the class as a keyword argument:
-
-                  serialize #{attr_name.inspect}, type: #{class_name_or_coder.name}
-              MSG
-              type = class_name_or_coder
-            else
-              ActiveRecord.deprecator.warn(<<~MSG)
-                Passing the coder as positional argument is deprecated and will be remove in Rails 7.2.
+                Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.
 
                 Please pass the coder as a keyword argument:
 
                   serialize #{attr_name.inspect}, coder: #{class_name_or_coder}
               MSG
               coder = class_name_or_coder
+            else
+              ActiveRecord.deprecator.warn(<<~MSG)
+                Passing the class as positional argument is deprecated and will be removed in Rails 7.2.
+
+                Please pass the class as a keyword argument:
+
+                  serialize #{attr_name.inspect}, type: #{class_name_or_coder.name}
+              MSG
+              type = class_name_or_coder
             end
           end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -657,6 +657,12 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     skip "Time is a DisallowedClass in Psych safe_load()."
   end
 
+  def test_supports_permitted_classes_for_default_column_serializer
+    Topic.serialize(:content, yaml: { permitted_classes: [Time] })
+    topic = Topic.new(content: Time.now)
+    assert topic.save
+  end
+
   def test_recognizes_coder_as_deprecated_positional_argument
     some_coder = Struct.new(:foo) do
       def self.dump(value)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -656,4 +656,26 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
   def test_serialized_time_attribute
     skip "Time is a DisallowedClass in Psych safe_load()."
   end
+
+  def test_recognizes_coder_as_deprecated_positional_argument
+    some_coder = Struct.new(:foo) do
+      def self.dump(value)
+        value.foo
+      end
+
+      def self.load(value)
+        new(value)
+      end
+    end
+
+    assert_deprecated(/Please pass the coder as a keyword argument/, ActiveRecord.deprecator) do
+      Topic.serialize(:content, some_coder)
+    end
+  end
+
+  def test_recognizes_type_as_deprecated_positional_argument
+    assert_deprecated(/Please pass the class as a keyword argument/, ActiveRecord.deprecator) do
+      Topic.serialize(:content, Hash)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

With the changes in `serialize` in #47463, it is now expected that you explicitly pass either a coder or a type through the `coder:` or `type:` options, respectively. A deprecation warning is issued if this is not done.

However:

* The logic that determines whether the `class_name_or_coder` argument is a class name or a coder is different than it used to be, breaking some code. Rails applications can explicitly set `coder:` and `type:` everywhere - and they should! - but still, this was not supposed to be a breaking change.
* `serialize` no longer respects the `permitted_classes` YAML option when using the default YAML column serializer (i.e., not specifying a coder).

Oh, and there's a small typo in the deprecation warning: `will be remove in Rails 7.2`.

### Detail

First of all, this PR uses the same heuristic as previously (i.e., pre- #47463) when determining whether the second positional parameter to `serialize` is a class or a coder.

Secondly, the default coder (`Coders::YAMLColumn`) is taken into account when instantiating a new `Coders::YAMLColumn`, which in turn ensures that `**(yaml || {})` is passed to the constructor. This ensures that the `permitted_classes` option is passed along.

Co-authored with @matthewd.

CC @casperisfine.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
