### PR TITLE
Expand rails route search to all table content

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**
+
+    *Jason Kotchoff*
+
 *   Remove deprecated `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -1,4 +1,8 @@
 <% content_for :style do %>
+  h2, p {
+    padding-left: 30px;
+  }
+
   #route_table {
     margin: 0;
     border-collapse: collapse;
@@ -25,8 +29,13 @@
     line-height: 15px;
   }
 
-  #route_table thead tr.bottom th input#search {
+  #route_table #search_container {
+    padding: 7px 30px;
+  }
+
+  #route_table thead tr th input#search {
     -webkit-appearance: textfield;
+    width:100%;
   }
 
   #route_table thead th.http-verb {
@@ -57,11 +66,6 @@
     padding: 4px 30px;
   }
 
-  #path_search {
-    width: 80%;
-    font-size: inherit;
-  }
-
   @media (prefers-color-scheme: dark) {
     #route_table tbody tr:nth-child(odd) {
       background: #282828;
@@ -74,28 +78,21 @@
   }
 <% end %>
 
-<table id='route_table' class='route_table'>
+<table id='route_table'>
   <thead>
     <tr>
-      <th>Helper</th>
+      <th>Helper
+        (<%= link_to "Path", "#", 'data-route-helper' => '_path',
+                    title: "Returns a relative path (without the http or domain)" %> /
+        <%= link_to "Url", "#", 'data-route-helper' => '_url',
+                    title: "Returns an absolute URL (with the http and domain)"   %>)
+      </th>
       <th class="http-verb">HTTP Verb</th>
       <th>Path</th>
       <th>Controller#Action</th>
     </tr>
-    <tr class='bottom'>
-      <th><%# Helper %>
-        <%= link_to "Path", "#", 'data-route-helper' => '_path',
-                    title: "Returns a relative path (without the http or domain)" %> /
-        <%= link_to "Url", "#", 'data-route-helper' => '_url',
-                    title: "Returns an absolute URL (with the http and domain)"   %>
-      </th>
-      <th><%# HTTP Verb %>
-      </th>
-      <th><%# Path %>
-        <%= search_field(:path, nil, id: 'search', placeholder: "Path Match") %>
-      </th>
-      <th><%# Controller#action %>
-      </th>
+    <tr>
+      <th colspan="4" id="search_container"><%= search_field(:query, nil, id: 'search', placeholder: "Search") %></th>
     </tr>
   </thead>
   <tbody class='exact_matches' id='exact_matches'>
@@ -111,8 +108,8 @@
   // support forEach iterator on NodeList
   NodeList.prototype.forEach = Array.prototype.forEach;
 
-  // Enables path search functionality
-  function setupMatchPaths() {
+  // Enables query search functionality
+  function setupMatchingRoutes() {
     // Check if there are any matched results in a section
     function checkNoMatch(section, trElement) {
       if (section.children.length <= 1) {
@@ -140,8 +137,8 @@
     }
 
     // remove params or fragments
-    function sanitizePath(path) {
-      return path.replace(/[#?].*/, '');
+    function sanitizeQuery(query) {
+      return query.replace(/[#?].*/, '');
     }
 
     var pathElements = document.querySelectorAll('#route_table [data-route-path]'),
@@ -168,16 +165,16 @@
 
     // On key press perform a search for matching paths
     delayedKeyup(searchElem, function() {
-      var path = sanitizePath(searchElem.value),
-          defaultExactMatch = buildTr('Paths Matching (' + path + '):'),
-          defaultFuzzyMatch = buildTr('Paths Containing (' + path +'):'),
-          noExactMatch      = buildTr('No Exact Matches Found'),
-          noFuzzyMatch      = buildTr('No Fuzzy Matches Found');
+      var query = sanitizeQuery(searchElem.value),
+          defaultExactMatch = buildTr("Routes matching '" + query + "':"),
+          defaultFuzzyMatch = buildTr("Routes containing '" + query + "':"),
+          noExactMatch      = buildTr('No exact matches found'),
+          noFuzzyMatch      = buildTr('No fuzzy matches found');
 
-      if (!path)
+      if (!query)
         return searchElem.onblur();
 
-      getJSON('/rails/info/routes?path=' + path, function(matches){
+      getJSON('/rails/info/routes?query=' + query, function(matches){
         // Clear out results section
         exactSection.replaceChildren(defaultExactMatch);
         fuzzySection.replaceChildren(defaultFuzzyMatch);
@@ -185,7 +182,6 @@
         // Display exact matches and fuzzy matches
         pathElements.forEach(function(elem) {
           var elemPath = elem.getAttribute('data-route-path');
-
           if (matches['exact'].indexOf(elemPath) != -1)
             exactSection.appendChild(elem.parentNode.cloneNode(true));
 
@@ -227,7 +223,7 @@
     });
   }
 
-  setupMatchPaths();
+  setupMatchingRoutes();
   setupRouteToggleHelperLinks();
 
   // Focus the search input after page has loaded

--- a/codespell.txt
+++ b/codespell.txt
@@ -24,6 +24,7 @@ objekt
 optin
 ot
 overthere
+propertie
 reenable
 rouge
 searchin

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -19,12 +19,12 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
   end
 
   def routes
-    if path = params[:path]
-      path = URI::DEFAULT_PARSER.escape path
-      normalized_path = with_leading_slash path
+    if query = params[:query]
+      query = URI::DEFAULT_PARSER.escape query
+
       render json: {
-        exact: match_route { |it| it.match normalized_path },
-        fuzzy: match_route { |it| it.spec.to_s.match path }
+        exact: matching_routes(query: query, exact_match: true),
+        fuzzy: matching_routes(query: query, exact_match: false)
       }
     else
       @routes_inspector = ActionDispatch::Routing::RoutesInspector.new(_routes.routes)
@@ -33,11 +33,31 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
   end
 
   private
-    def match_route
-      _routes.routes.filter_map { |route| route.path.spec.to_s if yield route.path }
-    end
+    def matching_routes(query:, exact_match:)
+      return [] if query.blank?
 
-    def with_leading_slash(path)
-      ("/" + path).squeeze("/")
+      normalized_path = ("/" + query).squeeze("/")
+      query_without_url_or_path_suffix = query.gsub(/(\w)(_path$)/, '\1').gsub(/(\w)(_url$)/, '\1')
+
+      _routes.routes.filter_map do |route|
+        route_wrapper = ActionDispatch::Routing::RouteWrapper.new(route)
+
+        if exact_match
+          match = route.path.match(normalized_path)
+          match ||= (query_without_url_or_path_suffix === route_wrapper.name)
+        else
+          match = route_wrapper.path.match(query)
+          match ||= route_wrapper.name.include?(query_without_url_or_path_suffix)
+        end
+
+        match ||= (query === route_wrapper.verb)
+
+        unless match
+          controller_action = URI::DEFAULT_PARSER.escape(route_wrapper.reqs)
+          match = exact_match ? (query === controller_action) : controller_action.include?(query)
+        end
+
+        route_wrapper.path if match
+      end
     end
 end

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -14,14 +14,27 @@ class InfoControllerTest < ActionController::TestCase
 
   def setup
     Rails.application.routes.draw do
+      namespace :test do
+        get :nested_route, to: "test#show"
+      end
       get "/rails/info/properties" => "rails/info#properties"
-      get "/rails/info/routes"     => "rails/info#routes"
+      get "/rails/info/routes" => "rails/info#routes"
+      post "/rails/:test/properties" => "rails/info#properties"
+      put "/rails/:test/named_properties" => "rails/info#properties", as: "named_rails_info_properties"
     end
     @routes = Rails.application.routes
 
     Rails::InfoController.include(@routes.url_helpers)
 
     @request.env["REMOTE_ADDR"] = "127.0.0.1"
+  end
+
+  def exact_results
+    JSON(response.body)["exact"]
+  end
+
+  def fuzzy_results
+    JSON(response.body)["fuzzy"]
   end
 
   test "info controller does not allow remote requests" do
@@ -56,30 +69,123 @@ class InfoControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "info controller returns exact matches" do
-    exact_count = -> { JSON(response.body)["exact"].size }
+  test "info controller search returns exact matches for route names" do
+    get :routes, params: { query: "rails_info_" }
+    assert exact_results.size == 0, "should not match incomplete route names"
 
-    get :routes, params: { path: "rails/info/route" }
-    assert exact_count.call == 0, "should not match incomplete routes"
+    get :routes, params: { query: "" }
+    assert exact_results.size == 0, "should not match unnamed routes"
 
-    get :routes, params: { path: "rails/info/routes" }
-    assert exact_count.call == 1, "should match complete routes"
+    get :routes, params: { query: "rails_info_properties" }
+    assert exact_results.size == 1, "should match complete route names"
+    assert exact_results.include? "/rails/info/properties(.:format)"
 
-    get :routes, params: { path: "rails/info/routes.html" }
-    assert exact_count.call == 1, "should match complete routes with optional parts"
+    get :routes, params: { query: "rails_info_properties_path" }
+    assert exact_results.size == 1, "should match complete route paths"
+    assert exact_results.include? "/rails/info/properties(.:format)"
+
+    get :routes, params: { query: "rails_info_properties_url" }
+    assert exact_results.size == 1, "should match complete route urls"
+    assert exact_results.include? "/rails/info/properties(.:format)"
   end
 
-  test "info controller returns fuzzy matches" do
-    fuzzy_count = -> { JSON(response.body)["fuzzy"].size }
+  test "info controller search returns exact matches for route paths" do
+    get :routes, params: { query: "rails/info/route" }
+    assert exact_results.size == 0, "should not match incomplete route paths"
 
-    get :routes, params: { path: "rails/info" }
-    assert fuzzy_count.call == 2, "should match incomplete routes"
+    get :routes, params: { query: "/rails/info/routes" }
+    assert exact_results.size == 1, "should match complete route paths prefixed with /"
+    assert exact_results.include? "/rails/info/routes(.:format)"
 
-    get :routes, params: { path: "rails/info/routes" }
-    assert fuzzy_count.call == 1, "should match complete routes"
+    get :routes, params: { query: "rails/info/routes" }
+    assert exact_results.size == 1, "should match complete route paths NOT prefixed with /"
+    assert exact_results.include? "/rails/info/routes(.:format)"
 
-    get :routes, params: { path: "rails/info/routes.html" }
-    assert fuzzy_count.call == 0, "should match optional parts of route literally"
+    get :routes, params: { query: "rails/info/routes.html" }
+    assert exact_results.size == 1, "should match complete route paths with optional parts"
+    assert exact_results.include? "/rails/info/routes(.:format)"
+
+    get :routes, params: { query: "test/nested_route" }
+    assert exact_results.size == 1, "should match complete route paths that are nested in a namespace"
+    assert exact_results.include? "/test/nested_route(.:format)"
+  end
+
+  test "info controller search returns case-sensitive exact matches for HTTP Verb methods" do
+    get :routes, params: { query: "GE" }
+    assert exact_results.size == 0, "should not match incomplete HTTP Verb methods"
+
+    get :routes, params: { query: "get" }
+    assert exact_results.size == 0, "should not case-insensitive match HTTP Verb methods"
+
+    get :routes, params: { query: "GET" }
+    assert exact_results.size == 3, "should match complete HTTP Verb methods"
+    assert exact_results.include? "/test/nested_route(.:format)"
+    assert exact_results.include? "/rails/info/properties(.:format)"
+    assert exact_results.include? "/rails/info/routes(.:format)"
+  end
+
+  test "info controller search returns exact matches for route Controller#Action(s)" do
+    get :routes, params: { query: "rails/info#propertie" }
+    assert exact_results.size == 0, "should not match incomplete route Controller#Action(s)"
+
+    get :routes, params: { query: "rails/info#properties" }
+    assert exact_results.size == 3, "should match complete route Controller#Action(s)"
+    assert exact_results.include? "/rails/info/properties(.:format)"
+    assert exact_results.include? "/rails/:test/properties(.:format)"
+    assert exact_results.include? "/rails/:test/named_properties(.:format)"
+  end
+
+  test "info controller returns fuzzy matches for route names" do
+    get :routes, params: { query: "" }
+    assert exact_results.size == 0, "should not match unnamed routes"
+
+    get :routes, params: { query: "rails_info" }
+    assert fuzzy_results.size == 3, "should match incomplete route names"
+    assert fuzzy_results.include? "/rails/info/properties(.:format)"
+    assert fuzzy_results.include? "/rails/info/routes(.:format)"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
+
+    get :routes, params: { query: "/rails/info/routes" }
+    assert fuzzy_results.size == 1, "should match complete route names"
+    assert fuzzy_results.include? "/rails/info/routes(.:format)"
+
+    get :routes, params: { query: "named_rails_info_properties_path" }
+    assert fuzzy_results.size == 1, "should match complete route paths"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
+
+    get :routes, params: { query: "named_rails_info_properties_url" }
+    assert fuzzy_results.size == 1, "should match complete route urls"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
+  end
+
+  test "info controller returns fuzzy matches for route paths" do
+    get :routes, params: { query: "rails/:test" }
+    assert fuzzy_results.size == 2, "should match incomplete routes"
+    assert fuzzy_results.include? "/rails/:test/properties(.:format)"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
+
+    get :routes, params: { query: "/rails/info/routes" }
+    assert fuzzy_results.size == 1, "should match complete routes"
+    assert fuzzy_results.include? "/rails/info/routes(.:format)"
+
+    get :routes, params: { query: "rails/info/routes.html" }
+    assert fuzzy_results.size == 0, "should match optional parts of route literally"
+  end
+
+  # Intentionally ignoring fuzzy match of HTTP Verb methods. There's not much value to 'GE' returning 'GET' results.
+
+  test "info controller search returns fuzzy matches for route Controller#Action(s)" do
+    get :routes, params: { query: "rails/info#propertie" }
+    assert fuzzy_results.size == 3, "should match incomplete routes"
+    assert fuzzy_results.include? "/rails/info/properties(.:format)"
+    assert fuzzy_results.include? "/rails/:test/properties(.:format)"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
+
+    get :routes, params: { query: "rails/info#properties" }
+    assert fuzzy_results.size == 3, "should match complete route Controller#Action(s)"
+    assert fuzzy_results.include? "/rails/info/properties(.:format)"
+    assert fuzzy_results.include? "/rails/:test/properties(.:format)"
+    assert fuzzy_results.include? "/rails/:test/named_properties(.:format)"
   end
 
   test "internal routes do not have a default params[:internal] value" do


### PR DESCRIPTION
Expands the search field on the rails/info/routes page to also search:
* Route name (with or without a _path and _url extension)
* HTTP Verb (eg. GET/POST/PUT etc.)
* Controller#Action

because it's not obvious that the search field is currently only restricted to the route paths.

### Motivation / Background

Many rails projects define lots of routes and the rails/info/routes page is very helpful for discovering routes when page building.

However, because it only currently matches route paths, searching for route names (eg. `ios_subscriptions_admin_dashboard_index_path`) or specific controller/action paths yields no results.

This can be confusing because even though the search field is located under the **Path** heading, it's not intuitively obvious that it's path-specific.

Being able to search for route names and controller#action combos (and HTTP Verbs) is very useful when trying to understand how a particular piece of code is routed.

### Detail

This Pull Request changes the search endpoint for the rails/info/routes page to consider more data when filtering the routes table.

### Additional information

I looked to add Seleminum system test coverage for the JavaScript behaviour of this page however this gem didn't have obvious precedent for this. If assistance is available to identify best practise for introducing a draft selenium test for this rails/info/routes screen, I'd be more than happy to flesh it out.

This change should also merge nicely with https://github.com/rails/rails/pull/47488.

https://user-images.githubusercontent.com/58198/221837987-26466799-413c-4758-ac5e-944fd3941236.mov