### PR TITLE
add --home and --shell to rails user in Dockerfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -73,7 +73,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Run and own the application files as a non-root user for security
-RUN useradd rails
+RUN useradd rails --home /rails --shell /bin/bash
 USER rails:rails
 
 # Copy built artifacts: gems, application


### PR DESCRIPTION
### Motivation / Background

This modest change can improve developer experience when using `docker run -i -t` and after deploying to a data center or cloud that support some form of secure shell.

### Detail

This Pull Request adds `--home` and `--shell` to the adduser command in the generated Dockerfile.

cc: @dhh @zzak 