### PR TITLE
Fix assigning through records when using polymorphic has many through association

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -59,9 +59,10 @@ module ActiveRecord
 
             attributes = through_scope_attributes
             attributes[source_reflection.name] = record
-            attributes[source_reflection.foreign_type] = options[:source_type] if options[:source_type]
 
-            through_association.build(attributes)
+            through_association.build(attributes).tap do |new_record|
+              new_record.send("#{source_reflection.foreign_type}=", options[:source_type]) if options[:source_type]
+            end
           end
         end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -27,6 +27,7 @@ require "models/cake_designer"
 require "models/drink_designer"
 require "models/recipe"
 require "models/user_with_invalid_relation"
+require "models/hardback"
 
 class ReflectionTest < ActiveRecord::TestCase
   include ActiveRecord::Reflection
@@ -324,7 +325,7 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal 2, hotel.chefs.count
   end
 
-  def test_scope_chain_does_not_interfere_with_hmt_with_polymorphic_case_and_sti
+  def test_scope_chain_does_not_interfere_with_hmt_with_polymorphic_case_and_subclass_source
     hotel = Hotel.create!
     hotel.mocktail_designers << MocktailDesigner.create!
 
@@ -339,6 +340,20 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal 0, hotel.mocktail_designers.count
     assert_equal 0, hotel.chef_lists.size
     assert_equal 0, hotel.chef_lists.count
+  end
+
+  def test_scope_chain_does_not_interfere_with_hmt_with_polymorphic_and_subclass_source_2
+    author = Author.create!(name: "John Doe")
+    hardback = BestHardback.create!
+    author.best_hardbacks << hardback
+
+    assert_equal [hardback], author.best_hardbacks
+    assert_equal [hardback], author.reload.best_hardbacks
+
+    author.best_hardbacks = []
+
+    assert_empty author.best_hardbacks
+    assert_empty author.reload.best_hardbacks
   end
 
   def test_scope_chain_of_polymorphic_association_does_not_leak_into_other_hmt_associations

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -168,6 +168,7 @@ class Author < ActiveRecord::Base
   has_many :tags_with_primary_key, through: :posts
 
   has_many :books
+  has_many :best_hardbacks, through: :books, source: :format_record, source_type: "BestHardback"
   has_many :published_books, class_name: "PublishedBook"
   has_many :unpublished_books, -> { where(status: [:proposed, :written]) }, class_name: "Book"
   has_many :subscriptions,        through: :books

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -2,6 +2,7 @@
 
 class Book < ActiveRecord::Base
   belongs_to :author
+  belongs_to :format_record, polymorphic: true
 
   has_many :citations, foreign_key: "book1_id", inverse_of: :book
   has_many :references, -> { distinct }, through: :citations, source: :reference_of

--- a/activerecord/test/models/hardback.rb
+++ b/activerecord/test/models/hardback.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Hardback < ActiveRecord::Base
+end
+
+class BestHardback < Hardback
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -125,6 +125,8 @@ ActiveRecord::Schema.define do
     default_zero = { default: 0 }
     t.references :author
     t.string :format
+    t.integer :format_record_id
+    t.string :format_record_type
     t.column :name, :string
     t.column :status, :integer, **default_zero
     t.column :last_read, :integer, **default_zero
@@ -163,6 +165,9 @@ ActiveRecord::Schema.define do
 
     t.datetime :created_at
     t.datetime :updated_at
+  end
+
+  create_table :hardbacks, force: true do |t|
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
The bug appeared on https://github.com/rails/rails/pull/47485 CI so fixing it will unblock another PR.

The reproduction setup is similar to https://github.com/rails/rails/issues/23209
 
The proposed fix partially reverts https://github.com/rails/rails/pull/35799 and brings back the original implementation - https://github.com/rails/rails/pull/23221

### About reverting https://github.com/rails/rails/pull/35799

By "partially reverts" I mean that we still keep the intended behaviour of the fix while reverting some of the changes. To be specific, the intention of the PR was to make sure `record` is being passed along with other `attributes` to the build method. We keep it but only change the way how the `source_type` is being assigned. 

### About the added test case

Added test is almost a copy of https://github.com/rails/rails/blob/a389c011c87c3bb305842d17906f526d55b9c7fa/activerecord/test/cases/reflection_test.rb#L328
With the only difference, in our setup the `through` association name and underlying `table_name` are the same while in the existing tests those values are different which hides the bug. Specifically:

```
# in the existing test
`chef_lists` - association name
`chefs` - table name


# in our added test
`books` -  both association & the table name

```

This difference results in `through_scope_attributes` method returning different result because of a different value passed to `where_values_hash` which reveals the bug under this setup.

https://github.com/rails/rails/blob/a389c011c87c3bb305842d17906f526d55b9c7fa/activerecord/lib/active_record/associations/has_many_through_association.rb#L70


I have also removed the `_sti` part from the test name as I consider this misleading as both `MocktailDesigner` and `BestHardback` models are not STI models as there is no `type` column in retrospective tables. The test context is less about STI but more about a has many through association with a custom `source_type` where `source_type` points to a subclass.


The association semantics I used for the test were partially taken from the guides - https://guides.rubyonrails.org/association_basics.html#options-for-has-one-source-type


### About the bug itself

The bug is happening because currently we are passing both `record` and the `source_type` values to the `build` method and the outcome depends on a very implicit thing - Hash key order. In other words, for most cases, `source_reflection.foreign_type` key is being added to the `attributes` hash after `source_reflection.name` which makes the association builder to favour explicit `source_type` value and not the one derived from the record (it uses `polymorphic_name` by default). Though it behaves differently if `source_reflection.foreign_type` key was added to the `attributes` hash earlier than `source_reflection.name` - the resulting object won't have the `source_reflection.foreign_type` value set-up as it will be overridden by the one derived from the record. 

Hopefully an example will clarify it:

<details>
  <summary>Full reproduction script</summary>
  
  
  ```ruby
  # frozen_string_literal: true

  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    git_source(:github) { |repo| "https://github.com/#{repo}.git" }

    # Activate the gem you are reporting the issue against.
    gem "activerecord", "~> 7.0.0"
    gem "sqlite3"
  end

  require "active_record"
  require "minitest/autorun"
  require "logger"

  # This connection will do for database-independent bug reports.
  ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
  ActiveRecord::Base.logger = Logger.new(STDOUT)

  ActiveRecord::Schema.define do
    create_table :owners, force: true do |t|
    end

    create_table :pets, force: true do |t|
      t.integer :owner_id
      t.string :owner_type
    end
  end

  class Owner < ActiveRecord::Base
  end

  class BestOwner < Owner
  end

  class Pet < ActiveRecord::Base
    belongs_to :owner, polymorphic: true
  end

  class BugTest < Minitest::Test
    def test_association_stuff
      best_owner = BestOwner.create!
      record_first_hash = { owner: best_owner, owner_type: "BestOwner" }
      pet = Pet.new(record_first_hash)
      assert_equal("BestOwner", pet.owner_type) # passes

      record_last_hash = { owner_type: "BestOwner", owner: best_owner }

      # those are identical hashes,
      # it is very unexpected (but explainable) for them to produce different results
      assert_equal(record_first_hash, record_last_hash)
      pet = Pet.new(record_last_hash)
      assert_equal("BestOwner", pet.owner_type) # fails
    end
  end
  ```
  
</details>

Exactly the same happens in our case, the bug appears if our manually set `_type` key gets added to the `attributes` hash from. So we are fixing it by explicitly setting the `_type` column to `source_type` after building a record. This way we can ensure the value is exactly the one we want it to be.

### Alternative fixes:

1. There is a whole group of possible fixes that will ensure that the `_type` key is being added to the `attributes` hash after the `record` but I don't consider these as valid solutions as relying on any specific order of `Hash` keys is fundamentally wrong, I just want to mention them to be open. 
  1.1 - Exclude the `_type` key from `through_scope_attributes`, this way we ensure that `_type` key will be added by us in `build_through_record` in a correct order.
  1.2 - Delete the `_type` key from `attributes` hash and re-insert it

2. What we could do is to make sure that the association builder always respects the manually passed `_type` column or basically everything that was explicitly passed along with the association object itself. However I don't feel confident about it. I don't see a reason for someone to path both record and manually provided values to the association builder, we should either supply everything explicitly or pass the record and let the values to be derived from the record. It brings us to the point #3

3. This one I actually like even more but it is a riskier one so I would prefer to explore the possibility of it in a separate PR. Technically we shouldn't even need to explicitly supply the `source_type` because it should be derivable from the `record.class` by the association builder. However this is not what is happening right now as the builder derives the value from the `base_class`: 
https://github.com/rails/rails/blob/c12a77da4083e195d233e3f156e38f4871e6a5dc/activerecord/lib/active_record/inheritance.rb#L199
So I think we should be able to completely remove the manual `source_type` value logic if we address an issue described in - https://github.com/rails/rails/issues/32912
