### PR TITLE
Allow configs_for to accept a custom hash key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Remove the `:include_replicas` argument from `configs_for`. Use `:include_hidden` argument instead.
+
+    *Eileen M. Uchitelle*
+
+*   Allow applications to lookup a config via a custom hash key.
+
+    If you have registered a custom config or want to find configs where the hash matches a specific key, now you can pass `config_key` to `configs_for`. For example if you have a `db_config` with the key `vitess` you can look up a database configuration hash by  matching that key.
+
+    ```ruby
+    ActiveRecord::Base.configurations.configs_for(env_name: "development", name: "primary", config_key: :vitess)
+    ActiveRecord::Base.configurations.configs_for(env_name: "development", config_key: :vitess)
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Allow applications to register a custom database configuration handler.
 
     Adds a mechanism for registering a custom handler for cases where you want database configurations to respond to custom methods. This is useful for non-Rails database adapters or tools like Vitess that you may want to configure differently from a standard `HashConfig` or `UrlConfig`.

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -82,26 +82,26 @@ module ActiveRecord
     # * <tt>name:</tt> The db config name (i.e. primary, animals, etc.). Defaults
     #   to +nil+. If no +env_name+ is specified the config for the default env and the
     #   passed +name+ will be returned.
-    # * <tt>include_replicas:</tt> Deprecated. Determines whether to include replicas in
-    #   the returned list. Most of the time we're only iterating over the write
-    #   connection (i.e. migrations don't need to run for the write and read connection).
-    #   Defaults to +false+.
+    # * <tt>config_key:</tt> Selects configs that contain a particular key in the configuration
+    #   hash. Useful for selecting configs that use a custom db config handler or finding
+    #   configs with hashes that contain a particular key.
     # * <tt>include_hidden:</tt> Determines whether to include replicas and configurations
     #   hidden by +database_tasks: false+ in the returned list. Most of the time we're only
     #   iterating over the primary connections (i.e. migrations don't need to run for the
     #   write and read connection). Defaults to +false+.
-    def configs_for(env_name: nil, name: nil, include_replicas: false, include_hidden: false)
-      if include_replicas
-        include_hidden = include_replicas
-        ActiveRecord.deprecator.warn("The kwarg `include_replicas` is deprecated in favor of `include_hidden`. When `include_hidden` is passed, configurations with `replica: true` or `database_tasks: false` will be returned. `include_replicas` will be removed in Rails 7.1.")
-      end
-
+    def configs_for(env_name: nil, name: nil, config_key: nil, include_hidden: false)
       env_name ||= default_env if name
       configs = env_with_configs(env_name)
 
       unless include_hidden
         configs = configs.select do |db_config|
           db_config.database_tasks?
+        end
+      end
+
+      if config_key
+        configs = configs.select do |db_config|
+          db_config.configuration_hash.key?(config_key)
         end
       end
 

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -89,6 +89,8 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 * Remove support for `ActiveRecord.legacy_connection_handling`.
 
+* Remove support for `:include_replicas` on `configs_for`. Use `:include_hidden` instead.
+
 ### Deprecations
 
 ### Notable changes


### PR DESCRIPTION
Now that we support a way to register custom configurations we need to allow applications to find those configurations. This change adds a `config_key` option to `configs_for` to find db configs where the configuration_hash contains a particular key.

I have also removed the deprecation for `include_replicas` while I was in here to make the method signature cleaner. I've updated the upgrade guide with the removal.