### PR TITLE
Always write to debug.log in activerecord tests

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -21,11 +21,7 @@ module ARTest
   def self.connect
     ActiveRecord.async_query_executor = :global_thread_pool
     puts "Using #{connection_name}"
-    if ENV["CI"]
-      ActiveRecord::Base.logger = nil
-    else
-      ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 1, 100 * 1024 * 1024)
-    end
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 1, 100 * 1024 * 1024)
     ActiveRecord::Base.configurations = test_configuration_hashes
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2


### PR DESCRIPTION
After merging #47499, sqlite3_mem tests became flaky (see https://github.com/rails/rails/pull/47499#issuecomment-1447459343 for the details).

I was able to periodically see such errors when running tests locally, but they were not reproducible with the same `SEED`s. I iteratively reverted parts of that PR and reran tests many times and seems like the logger was the problem. After running tests with the changes from this PR ~100 times, that errors hasn't appeared again. I have no idea why. 

Also, writing `ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)` did not help, as that error still appeared. 

