### PR TITLE
Support assignments for composite key has_many through associations

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -69,9 +69,12 @@ module ActiveRecord
 
         def through_scope_attributes
           scope = through_scope || self.scope
-          scope.where_values_hash(through_association.reflection.name.to_s).
-            except!(through_association.reflection.foreign_key,
-                    through_association.reflection.klass.inheritance_column)
+          attributes = scope.where_values_hash(through_association.reflection.name.to_s)
+          except_keys = [
+            *Array(through_association.reflection.foreign_key),
+            through_association.reflection.klass.inheritance_column
+          ]
+          attributes.except!(*except_keys)
         end
 
         def save_through_record(record)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -231,6 +231,27 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(another_blog.id, comment.blog_id)
     assert_equal(comment.blog_post_id, blog_post.id)
   end
+
+  def test_append_composite_has_many_through_association
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    tag = Sharded::Tag.new(name: "Ruby on Rails", blog_id: blog_post.blog_id)
+    tag.save
+
+    blog_post.tags << tag
+
+    assert_includes(blog_post.reload.tags, tag)
+    assert_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id, tag_id: tag.id), :exists?
+  end
+
+  def test_append_composite_has_many_through_association_with_autosave
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    tag = Sharded::Tag.new(name: "Ruby on Rails", blog_id: blog_post.blog_id)
+
+    blog_post.tags << tag
+
+    assert_includes(blog_post.reload.tags, tag)
+    assert_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id, tag_id: tag.id), :exists?
+  end
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase


### PR DESCRIPTION
Similarly to https://github.com/rails/rails/pull/47230 this PR adds support for assigning `has_many :items, through: :items_source` associations that use composite `query_constraints` config 

The fix is almost the same to work we are doing in scope of the `query_constraints` changes - make code that still expects `foreign_key` being a single-value item work in cases when `foreign_key` is an Array. 
In this particular case we are changing `through_scope_attributes` to exclude all parts of the composite `query_constraints` from the attributes list.

### Added test

Added test covers the broken use-case, however it passes on `main` right now because the broken logic is hidden by another bug - https://github.com/rails/rails/pull/47485 which is also dependent on https://github.com/rails/rails/pull/47534

So I would appreciate the two PRs mentioned above to be reviewed first so we can actually get the test from this PR failing on main and passing with the suggested fix.
As an alternative I can come up with a test that fails on `main` despite of the bug mentioned above, however this will involve setting up a set of new models and I prefer not to spawn test models without a necessity and fix the bug instead