### PR TITLE
Install dartsass-rails when generating app with sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "jsbundling-rails"
 gem "cssbundling-rails"
 gem "importmap-rails"
 gem "tailwindcss-rails"
+gem "dartsass-rails"
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
       railties (>= 6.0.0)
     dalli (3.2.3)
     dante (0.2.0)
+    dartsass-rails (0.4.1)
+      railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -540,6 +542,7 @@ DEPENDENCIES
   connection_pool
   cssbundling-rails
   dalli (>= 3.0.1)
+  dartsass-rails
   debug (>= 1.1.0)
   delayed_job
   delayed_job_active_record

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -135,7 +135,7 @@ that you should choose a traditional bundler include:
 [tree-shaking](https://webpack.js.org/guides/tree-shaking/).
 * If you will install Bootstrap, Bulma, PostCSS, or Dart CSS through the
 [cssbundling-rails gem](https://github.com/rails/cssbundling-rails). All options provided by this
-gem except Tailwind will automatically install `esbuild` for you if you do not specify a different
+gem except Tailwind and Sass will automatically install `esbuild` for you if you do not specify a different
 option in `rails new`.
 
 Turbo

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -546,10 +546,10 @@ module Rails
         packages.sort
       end
 
-      # CSS processors other than Tailwind require a node-based JavaScript environment. So overwrite the normal JS default
+      # CSS processors other than Tailwind and Sass require a node-based JavaScript environment. So overwrite the normal JS default
       # if one such processor has been specified.
       def adjusted_javascript_option
-        if options[:css] && options[:css] != "tailwind" && options[:javascript] == "importmap"
+        if options[:css] && options[:css] != "tailwind" && options[:css] != "sass" && options[:javascript] == "importmap"
           "esbuild"
         else
           options[:javascript]
@@ -561,6 +561,8 @@ module Rails
 
         if !using_node? && options[:css] == "tailwind"
           GemfileEntry.floats "tailwindcss-rails", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]"
+        elsif !using_node? && options[:css] == "sass"
+          GemfileEntry.floats "dartsass-rails", "Use Dart SASS [https://github.com/rails/dartsass-rails]"
         else
           GemfileEntry.floats "cssbundling-rails", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]"
         end
@@ -673,6 +675,8 @@ module Rails
 
         if !using_node? && options[:css] == "tailwind"
           rails_command "tailwindcss:install"
+        elsif !using_node? && options[:css] == "sass"
+          rails_command "dartsass:install"
         else
           rails_command "css:install:#{options[:css]}"
         end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -868,6 +868,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_css_option_with_asset_pipeline_sass
+    run_generator_and_bundler [destination_root, "--css=sass"]
+    assert_gem "dartsass-rails"
+    assert_file "app/assets/stylesheets/application.scss"
+  end
+
   def test_css_option_with_cssbundling_gem
     run_generator_and_bundler [destination_root, "--css=postcss"]
     assert_gem "cssbundling-rails"


### PR DESCRIPTION
### Motivation / Background

When we generate an app using `--css sass` it always uses `css-bundling`, since nowadays we have `dartsass-rails`, would be great to use it without node, the same way as we do with `--css tailwind`, that in this case adds `tailwindcss-rails`.

### Additional information

https://github.com/rails/rails/commit/023940101012e16ee0acd9a6b4dd3636169e59ef


