### PR TITLE
Revert "Use `COPY --link` in Dockerfile"

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -34,7 +34,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 
 <% end -%>
 # Install application gems
-COPY --link Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile
@@ -42,12 +42,12 @@ RUN bundle install && \
 
 <% if using_node? -%>
 # Install node modules
-COPY --link package.json yarn.lock ./
+COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 <% end -%>
 # Copy application code
-COPY --link . .
+COPY . .
 
 <% if depend_on_bootsnap? -%>
 # Precompile bootsnap code for faster boot times


### PR DESCRIPTION
Reverts rails/rails#47500

For reasons that I will explain soon, in a separate PR, I'm using [Red Hat's buildah](https://www.redhat.com/en/topics/containers/what-is-buildah) to build my Rails containers. It doesn't yet support `COPY --link`, so I would like to postpone this optimization until then (see containers/buildah#4325).