### PR TITLE
Fix dockerfile syntax version

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1
+# syntax = docker/dockerfile:1.4
 
 # Make sure it matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=<%= Gem.ruby_version %>


### PR DESCRIPTION
### Motivation / Background

`COPY --link` is add in `docker/dockerfile:1.4`

https://docs.docker.com/engine/reference/builder/#copy---link

