### PR TITLE
Add a drop shadow to the boot screen

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -50,6 +50,7 @@
       border-radius: 100%;
       display: flex;
       transition: background 0.25s cubic-bezier(0.33, 1, 0.68, 1);
+      filter: drop-shadow(0 20px 13px rgb(0 0 0 / 0.03)) drop-shadow(0 8px 5px rgb(0 0 0 / 0.08));
     }
 
     nav a:hover {


### PR DESCRIPTION
[This tweet](https://twitter.com/bradgessler/status/1630655637096108032) inspired a long conversation on Discord. A lot of it re-hashed the conversation at https://github.com/rails/rails/pull/43802 so I don't want to repeat it. But one takeaway was that not everyone realises the Rails logo is also a link.

This PR adds a drop shadow, which I think makes the logo look a bit more clickable at a glance. I would say the drop shadow is least noticable in these screenshots; if you do a `rails new` with this PR, I think it stands out better.

| Before | After |
|--------|------|
| <img width="1036" alt="image" src="https://user-images.githubusercontent.com/509837/222292719-7ebde962-d640-4d2d-a9f0-8dce58631839.png"> | <img width="1018" alt="image" src="https://user-images.githubusercontent.com/509837/222292742-177018e0-b4e7-4c09-9a3c-35d130f27358.png"> |