### PR TITLE
CI workflow to build and test --dev image

### DIFF
--- a/.github/workflows/build-and-test-dev-image.yml
+++ b/.github/workflows/build-and-test-dev-image.yml
@@ -1,0 +1,33 @@
+name: Build and test --dev image
+on: [push]
+
+env:
+  APP_NAME: devrails
+  APP_PATH: dev/devrails
+
+jobs:
+  build-and-test-dev-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+    - name: Generate --dev app
+      run: |
+        bundle exec railties/exe/rails new $APP_PATH --dev
+    - name: Build image
+      run: |
+        podman build -t $APP_NAME \
+        -v $(pwd):$(pwd) \
+        -f ./$APP_PATH/Dockerfile \
+        ./$APP_PATH
+    - name: Run container
+      run: |
+        podman run --name $APP_NAME \
+        -v $(pwd):$(pwd) \
+        -e SECRET_KEY_BASE_DUMMY=1 \
+        -p 3000:3000 $APP_NAME &
+    - name: Test container
+      run: ruby -r ./.github/workflows/scripts/test-container.rb

--- a/.github/workflows/scripts/test-container.rb
+++ b/.github/workflows/scripts/test-container.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Based on Sam Ruby's system test from dockerfile-rails:
+# https://github.com/rubys/dockerfile-rails/pull/21
+
+require "net/http"
+require "socket"
+
+LOCALHOST = Socket.gethostname
+PORT = 3000
+
+60.times do |i|
+  sleep 0.5
+  begin
+    response = Net::HTTP.get_response(LOCALHOST, "/up", PORT)
+
+    if %w(404 500).include? response.code
+      status = response.code.to_i
+    end
+
+    puts response.body
+    exit status || 0
+  rescue SystemCallError, IOError
+    puts "#{i}/60 Connection to #{LOCALHOST}:#{PORT} refused or timed out, retrying..."
+  end
+end
+
+exit 999


### PR DESCRIPTION
Adds a new GitHub Actions workflow "Build and test --dev image".

Which has a single job `build-and-test-dev-image`, that:

1. Runs `rails new --dev`
2. Builds a docker image from the generated app (using podman CLI)
3. Boots a container with that image (also using podman CLI)
4. Runs a ruby script to fetch the `/up` health-check from that running app.

If the application fails to boot or the network requests fail, it will retry for up to 30 seconds. In either pass/fail scenario the entire response body is printed to the console for further inspection under the "Test container" step, and the container logs are visible in the "Run container" step.

Example scenarios are linked below with more explanation.

### Motivation / Background

Rails generates a Dockerfile when running `rails new`, this feature is being actively developed and changes rapidly.

We want to be able to ensure that changes do not break the most basic use-case.

We also want to avoid making any changes to the framework in order to test this feature.

### Detail

When using `rails new --dev`, Rails will generate an application which points the Gemfile to install rails to the absolute path on the developer's machine.

Since the generated Dockerfile assumes the build context is within the generated context (e.g. `$HOME/code/myapp`), we cannot access the Rails checkout (e.g. `$HOME/source/rails`). For example, the step to copy the application's Gemfile uses `COPY Gemfile ./`.

Due to contraints of Docker, we are not able to easily mount arbitrary volumes into the build context, which makes building the generated Dockerfile difficult. This means we need to change the Dockerfile to `COPY` the entire contents of the Rails directory, and update the Gemfile to point to that if we want to build a `--dev` Rails application inside Docker.

Alternatively, we can use [buildah](https://www.redhat.com/en/topics/containers/what-is-buildah) which is able to generate containers compatible with Docker, but also let's us mount volumes into the build container -- so `bundle install` will work at build time without modiciation.

This technique allows us to build an image of a freshly generated Rails `--dev` application, and boot up the container without any modification to Rails itself.

### Blockers

This PR is currently blocked by #47546, as `COPY --link` is not supported by buildah (containers/buildah#4325).

### Examples

Here are a couple example scenarios, so we know what to expect when debugging this in the future.

* :green_circle: After reverting #47546: [success](https://github.com/zzak/rails/actions/runs/4309543713/jobs/7517053891#step:7:8)
* :red_circle: Container fails to start due to missing `secret_key_base` env var: [failed](https://github.com/zzak/rails/actions/runs/4309620139/jobs/7517217586#step:6:11)
* :red_circle: Connection refused from test script via wrong port: [failed](https://github.com/zzak/rails/actions/runs/4309624069/jobs/7517226712#step:7:68)
* :red_circle: Test container received 404 from Rails: [failed](https://github.com/zzak/rails/actions/runs/4309626764/jobs/7517232054#step:7:75)

### Notes

Previously, #47514 was opened to address the need for a CI test of the generated Dockerfile, but ran into the same issues as me which I initially tried to solve with #47453.

cc @byroot @dhh @jonathanhefner @matthewd @rubys