### PR TITLE
Allow both include and where on PostgreSQL add_index

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
         :options_include_default?, :supports_indexes_in_create?, :use_foreign_keys?,
         :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?,
-        :supports_exclusion_constraints?, to: :@conn, private: true
+        :supports_index_include?, :supports_exclusion_constraints?, to: :@conn, private: true
 
       private
         def visit_AlterTable(o)
@@ -104,6 +104,7 @@ module ActiveRecord
           sql << "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
           sql << "USING #{index.using}" if supports_index_using? && index.using
           sql << "(#{quoted_columns(index)})"
+          sql << "INCLUDE (#{quoted_include_columns(o.index.include)})" if supports_index_include? && o.index.include
           sql << "WHERE #{index.where}" if supports_partial_index? && index.where
 
           sql.join(" ")

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -5,8 +5,7 @@ module ActiveRecord
     module PostgreSQL
       class SchemaCreation < SchemaCreation # :nodoc:
         private
-          delegate :quoted_include_columns_for_index, :supports_index_include?,
-          to: :@conn
+          delegate :quoted_include_columns_for_index, to: :@conn
 
           def visit_AlterTable(o)
             sql = super
@@ -28,12 +27,6 @@ module ActiveRecord
 
           def visit_CheckConstraintDefinition(o)
             super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
-          end
-
-          def visit_CreateIndexDefinition(o)
-            super.dup.tap do |sql|
-              sql << " INCLUDE (#{quoted_include_columns(o.index.include)})" if supports_index_include? && o.index.include
-            end
           end
 
           def visit_ValidateConstraint(name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -108,7 +108,7 @@ module ActiveRecord
             oid = row[4]
             comment = row[5]
             valid = row[6]
-            using, expressions, where, include = inddef.scan(/ USING (\w+?) \((.+?)\)(?: NULLS(?: NOT)? DISTINCT)?(?: WHERE (.+?))?(?: INCLUDE \((.+)\))?\z/m).flatten
+            using, expressions, include, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: NULLS(?: NOT)? DISTINCT)?(?: INCLUDE \((.+?)\))?(?: WHERE (.+))?\z/m).flatten
 
             orders = {}
             opclasses = {}

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -286,6 +286,14 @@ module ActiveRecord
           connection.remove_index("testings", "last_name")
           assert_not connection.index_exists?("testings", "last_name")
         end
+
+        def test_add_index_with_included_column_and_where_clause
+          connection.add_index("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+          assert connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+
+          connection.remove_index("testings", "last_name")
+          assert_not connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+        end
       end
 
       private


### PR DESCRIPTION
### Motivation / Background

In #44803, support was added for the `include` option when creating a index in PostgreSQL.

However, when using this option in conjunction with the `where` option - the INCLUDE and WHERE segments where in the incorrect order causing the migration to error.

```
Error:
ActiveRecord::Migration::IndexTest#test_add_index_with_included_column_and_where_clause:
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near "INCLUDE"
LINE 1: ...ings" ("last_name") WHERE first_name = 'john doe' INCLUDE ("...
```

As specified at https://www.postgresql.org/docs/current/sql-createindex.html, the INCLUDE segment should occur before the WHERE segment. 

This Pull Request has been created to allow INCLUDE and WHERE options to be used on the same index.

### Detail

This Pull Request changes there order of the INCLUDE and WHERE segments when adding an index so that the query is valid.

It also updates the order they are expected in the create index statement when dumping the schema.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (No changelog entry as this is a bug in an unreleased feature)
