### PR TITLE
Make delayed job display_name failsafe

### DIFF
--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -50,6 +50,8 @@ module ActiveJob
         private
           def log_arguments?
             job_data["job_class"].constantize.log_arguments?
+          rescue NameError
+            false
           end
       end
     end

--- a/activejob/test/cases/delayed_job_adapter_test.rb
+++ b/activejob/test/cases/delayed_job_adapter_test.rb
@@ -30,4 +30,17 @@ class DelayedJobAdapterTest < ActiveSupport::TestCase
     assert_equal "HelloJob [#{job_id}] from DelayedJob(default) with arguments: #{arguments}",
                  job_wrapper.display_name
   end
+
+  test "shows name for invalid job class" do
+    job_id = SecureRandom.uuid
+
+    job_wrapper = ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(
+      "job_class" => "NotExistingJob",
+      "queue_name" => "default",
+      "job_id" => job_id,
+      "arguments" => { "some" => { "job" => "arguments" } }
+    )
+
+    assert_equal "NotExistingJob [#{job_id}] from DelayedJob(default)", job_wrapper.display_name
+  end
 end


### PR DESCRIPTION
### Motivation / Background

The display_name method is used by delayed job to log information about a certain job, including failure messages. Whenever a job class is moved or deleted, the instances still scheduled cannot be constantized anymore, causing display_name and hence the log method to raise an exception. In certain cases, e.g. when logging happens in a rescue block, this may terminate the entire delayed job worker. With the failsafe method, the worker handles failed jobs gracefully and continues work, all with appropriate log output.

### Additional information

Steps to reproduce the issue:

1. Schedule a job in the far future using the delayed job backend, e.g. `MyJob.set(wait_until: Date.tomorrow).perform_later`
2. Rename or delete the job class `MyJob`.
3. Run delayed jobs: `rake jobs:work`
4. The job fails with "NameError: uninitialized constant MyJob"

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
