### PR TITLE
Fix cascading through association empty loaded association

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -74,7 +74,14 @@ module ActiveRecord
           end
 
           def middle_records
-            through_preloaders.flat_map(&:preloaded_records)
+            middle_records = owners.flat_map do |owner|
+              association = owner.association(through_reflection.name)
+              break unless association.loaded?
+
+              Array.wrap(association.target)
+            end
+
+            middle_records || through_preloaders.flat_map(&:preloaded_records)
           end
 
           def through_preloaders

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -105,6 +105,7 @@ class Author < ActiveRecord::Base
 
   has_many :hello_posts, -> { where "posts.body = 'hello'" }, class_name: "Post"
   has_many :hello_post_comments, through: :hello_posts, source: :comments
+  has_many :hello_post_comments_ratings, through: :hello_post_comments, source: :ratings
   has_many :posts_with_no_comments, -> { where("comments.id" => nil).includes(:comments) }, class_name: "Post"
   has_many :posts_with_no_comments_2, -> { left_joins(:comments).where("comments.id": nil) }, class_name: "Post"
 


### PR DESCRIPTION
### Motivation / Background
To fix preloader bug
Fixes #45056

### Detail

This Pull Request changes `ActiveRecord::Associations::Preloader::ThroughAssociation#middle_records` method 
When through association is based on another through association the middle_records are loaded twice and cannot be matched using `compare_by_identity` Hash
That leads to loaded empty association as described in the issue
The fix uses already loaded records as middle_records

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
