### PR TITLE
Fix nullifying association with composite query constraints

### DIFF
--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -12,7 +12,7 @@ module ActiveRecord::Associations
 
     def nullified_owner_attributes
       Hash.new.tap do |attrs|
-        attrs[reflection.foreign_key] = nil
+        Array(reflection.foreign_key).each { |foreign_key| attrs[foreign_key] = nil }
         attrs[reflection.type] = nil if reflection.type.present?
       end
     end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -177,6 +177,21 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(blog_post.blog_id, comment.blog_id)
   end
 
+  def test_nullify_composite_foreign_key_has_many_association
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    comment = sharded_comments(:great_comment_blog_post_one)
+
+    assert_not_empty(blog_post.comments)
+    blog_post.comments = []
+
+    comment = Sharded::Comment.find(comment.id)
+    assert_nil(comment.blog_post_id)
+    assert_nil(comment.blog_id)
+
+    assert_empty(blog_post.comments)
+    assert_empty(blog_post.reload.comments)
+  end
+
   def test_assign_persisted_composite_foreign_key_belongs_to_association
     comment = sharded_comments(:great_comment_blog_post_one)
     another_blog = sharded_blogs(:sharded_blog_two)
@@ -190,6 +205,19 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(comment.blog_id, blog_post.blog_id)
     assert_equal(another_blog.id, comment.blog_id)
     assert_equal(comment.blog_post_id, blog_post.id)
+  end
+
+  def test_nullify_composite_foreign_key_belongs_to_association
+    comment = sharded_comments(:great_comment_blog_post_one)
+    assert_not_nil(comment.blog_post)
+
+    comment.blog_post = nil
+    assert_nil(comment.blog_id)
+    assert_nil(comment.blog_post_id)
+
+    comment.save
+    assert_nil(comment.blog_post)
+    assert_nil(comment.reload.blog_post)
   end
 
   def test_assign_composite_foreign_key_belongs_to_association


### PR DESCRIPTION
Given a models setup like:
```ruby
class BlogPost < ApplicationRecord
  query_constraints :blog_id, :id

  has_many :comments, query_constraints: [:blog_id, :blog_post_id]
end

class Comment < ApplicationRecord
  query_constraints :blog_id, :blog_post_id

  belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
end
```

It should be possible to nullify both `blog_post.comments = []` and `comment.blog_post = nil` association which should result in nullification of all parts of the composite query constraints, meaning `blog_id` and `blog_post_id` being nil on the affected comments.


The solution is the simplest from the ones we use in work with `query_constraints` - repeat what used to be done for a single-value `foreign_key` once for each element of a composite `foreign_key` Which for our use-case translates to "nullify every part of the `query_constraints` foreign key