### PR TITLE
Do not use `query_constraints` if association doesn't explicitly specifies it

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -524,7 +524,7 @@ module ActiveRecord
       def compute_primary_key(reflection, record)
         if primary_key_options = reflection.options[:primary_key]
           primary_key_options
-        elsif query_constraints = record.class.query_constraints_list
+        elsif reflection.options[:query_constraints] && (query_constraints = record.class.query_constraints_list)
           query_constraints
         else
           :id

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -166,6 +166,18 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_match(/#{Regexp.escape(Sharded::Comment.connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
   end
 
+  def test_belongs_to_association_does_not_use_parent_query_constraints_if_not_configured_to
+    comment = sharded_comments(:great_comment_blog_post_one)
+    blog_post = Sharded::BlogPost.new(blog_id: comment.blog_id, title: "Following best practices")
+
+    comment.blog_post_by_id = blog_post
+
+    comment.save
+
+    assert_predicate blog_post, :persisted?
+    assert_equal(blog_post, comment.blog_post_by_id)
+  end
+
   def test_append_composite_foreign_key_has_many_association
     blog_post = sharded_blog_posts(:great_post_blog_one)
     comment = Sharded::Comment.new(body: "Great post! :clap:")

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -6,6 +6,7 @@ module Sharded
     query_constraints :blog_id, :id
 
     belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
+    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id
     belongs_to :blog
   end
 end


### PR DESCRIPTION
Similar and an extension of https://github.com/rails/rails/pull/47378

Since we made a decision to make `query_constraints` feature more contained and only be used when explicitly configured, in `compute_primary_key` we shouldn't be using parent's `query_constraints` if the association doesn't specify it's own `query_constraints` as it leads to primary key and foreign key have different sizes. 

It should allow with gradually adding `query_constraints` to an existing model. For example if an existing `Sharded::BlogPost` model wants to start utilizing `query_constraints`,  existing associations like `belongs_to : blog_post_by_id`  that point to `Sharded::BlogPost` shouldn't immediately require `:query_constraints` argument and continue work assuming that there was a single-valued `foreign_key` that we can keep using