### PR TITLE
Add class name to ActiveModel::MissingAttributeError error message

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add class to ActiveModel::MissingAttributeError error message.
+
+    Show which class is missing the attribute in the error message:
+
+    ```ruby
+    user = User.first
+    user.pets.select(:id).first.user_id
+    # => ActiveModel::MissingAttributeError: missing attribute 'user_id' for Pet
+    ```
+
+    *Petrik de Heus*
+
 *   Raise `NoMethodError` in `ActiveModel::Type::Value#as_json` to avoid unpredictable
     results.
 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -11,7 +11,7 @@ module ActiveModel
   #
   #   user = User.first
   #   user.pets.select(:id).first.user_id
-  #   # => ActiveModel::MissingAttributeError: missing attribute: user_id
+  #   # => ActiveModel::MissingAttributeError: missing attribute 'user_id' for Pet
   class MissingAttributeError < NoMethodError
   end
 
@@ -501,7 +501,7 @@ module ActiveModel
       end
 
       def missing_attribute(attr_name, stack)
-        raise ActiveModel::MissingAttributeError, "missing attribute: #{attr_name}", stack
+        raise ActiveModel::MissingAttributeError, "missing attribute '#{attr_name}' for #{self.class}", stack
       end
 
       def _read_attribute(attr)

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -94,7 +94,7 @@ module ActiveRecord
       # receive:
       #
       #   person.pets.select(:name).first.person_id
-      #   # => ActiveModel::MissingAttributeError: missing attribute: person_id
+      #   # => ActiveModel::MissingAttributeError: missing attribute 'person_id' for Pet
       #
       # *Second:* You can pass a block so it can be used just like Array#select.
       # This builds an array of objects from the database for the scope,

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -332,8 +332,8 @@ module ActiveRecord
     #
     #   person = Person.select(:name).first
     #   person[:name]            # => "Francesco"
-    #   person[:date_of_birth]   # => ActiveModel::MissingAttributeError: missing attribute: date_of_birth
-    #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute: organization_id
+    #   person[:date_of_birth]   # => ActiveModel::MissingAttributeError: missing attribute 'date_of_birth' for Person
+    #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute 'organization_id' for Person
     #   person[:id]              # => nil
     def [](attr_name)
       read_attribute(attr_name) { |n| missing_attribute(n, caller) }

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -106,7 +106,7 @@ module ActiveRecord
           timestamp.utc.to_fs(cache_timestamp_format)
         end
       elsif self.class.has_attribute?("updated_at")
-        raise ActiveModel::MissingAttributeError, "missing attribute: updated_at"
+        raise ActiveModel::MissingAttributeError, "missing attribute 'updated_at' for #{self.class}"
       end
     end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -370,7 +370,7 @@ module ActiveRecord
     # except +id+ will throw ActiveModel::MissingAttributeError:
     #
     #   Model.select(:field).first.other_field
-    #   # => ActiveModel::MissingAttributeError: missing attribute: other_field
+    #   # => ActiveModel::MissingAttributeError: missing attribute 'other_field' for Model
     def select(*fields)
       if block_given?
         if fields.any?

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -377,7 +377,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "read_attribute raises ActiveModel::MissingAttributeError when the attribute isn't selected" do
     computer = Computer.select(:id, :extendedWarranty).first
-    assert_raises(ActiveModel::MissingAttributeError) { computer[:developer] }
+    assert_raises(ActiveModel::MissingAttributeError, match: /attribute 'developer' for Computer/) do
+      computer[:developer]
+    end
     assert_nothing_raised { computer[:extendedWarranty] }
     assert_nothing_raised { computer[:no_column_exists] }
   end

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -123,7 +123,7 @@ module ActiveRecord
     test "updated_at on class but not on instance raises an error" do
       record = CacheMeWithVersion.create
       record_from_db = CacheMeWithVersion.where(id: record.id).select(:id).first
-      assert_raises(ActiveModel::MissingAttributeError) do
+      assert_raises(ActiveModel::MissingAttributeError, match: /'updated_at' for .*CacheMeWithVersion/) do
         record_from_db.cache_version
       end
     end

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
     def assert_non_select_columns_wont_be_loaded(post)
       assert_equal "WELCOME TO THE WEBLOG", post.title
-      assert_raise(ActiveModel::MissingAttributeError) do
+      assert_raise(ActiveModel::MissingAttributeError, match: /attribute 'body' for Post/) do
         post.body
       end
     end

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -824,7 +824,7 @@ SELECT isbn, out_of_print FROM books
 Be careful because this also means you're initializing a model object with only the fields that you've selected. If you attempt to access a field that is not in the initialized record you'll receive:
 
 ```
-ActiveModel::MissingAttributeError: missing attribute: <attribute>
+ActiveModel::MissingAttributeError: missing attribute '<attribute>' for Book
 ```
 
 Where `<attribute>` is the attribute you asked for. The `id` method will not raise the `ActiveRecord::MissingAttributeError`, so just be careful when working with associations because they need the `id` method to function properly.


### PR DESCRIPTION
### Motivation / Background

When an attribute is missing the current message is unclear about which class is missing the attribute, especially when there are multiple classes that could miss the attribute.

By adding the class name to the error message it is easier to debug:

```ruby
user = User.first
user.pets.select(:id).first.user_id
=> ActiveModel::MissingAttributeError: missing attribute 'user_id' for Pet
```

This also makes the error message more inline with the UnknownAttributeError message:

```ruby
=> ActiveModel::UnknownAttributeError: unknown attribute 'name' for Person
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
