### PR TITLE
Fixes TimeWithZone ArgumentError #47572

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -535,8 +535,8 @@ module ActiveSupport
 
     # Send the missing method to +time+ instance, and wrap result in a new
     # TimeWithZone with the existing +time_zone+.
-    def method_missing(sym, *args, &block)
-      wrap_with_time_zone time.__send__(sym, *args, &block)
+    def method_missing(...)
+      wrap_with_time_zone time.__send__(...)
     rescue NoMethodError => e
       raise e, e.message.sub(time.inspect, inspect).sub("Time", "ActiveSupport::TimeWithZone"), e.backtrace
     end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -628,6 +628,12 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "bar", @twz.foo
   end
 
+  def test_method_missing_works_with_kwargs
+    time = @twz.time
+    def time.method_with_kwarg(foo:); foo; end
+    assert_equal "bar", @twz.method_with_kwarg(foo: "bar")
+  end
+
   def test_date_part_value_methods
     twz = ActiveSupport::TimeWithZone.new(Time.utc(1999, 12, 31, 19, 18, 17, 500), @time_zone)
     assert_not_called(twz, :method_missing) do


### PR DESCRIPTION
Use triple dots in method_missing to forward parameters. This fixes #47572