### PR TITLE
In development, raise an error if a `<form>` is nested inside a `<form>`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   In development, raise an error if a `<form>` is nested inside a `<form>`
+
+    Doing so is prohibited, per the HTML spec.
+
+    You can control the behaviour with `Rails.application.config.action_view.nested_form_behaviour`.
+    In Rails 7.1 it will `:raise` in development and test. You can also `:log` or set to `nil` to disable checks.
+
+    *Alex Ghiculescu*
+
 *   Remove deprecated support to passing instance variables as locals to partials.
 
     *Rafael Mendonça França*

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -75,9 +75,18 @@ module ActionView
       #   # form with custom authenticity token
       #
       def form_tag(url_for_options = {}, options = {}, &block)
+        check_for_nested_form!("Forms should not be nested inside forms.")
+
         html_options = html_options_for_form(url_for_options, options)
         if block_given?
-          form_tag_with_body(html_options, capture(&block))
+          output = begin
+            @_inside_form = true
+            capture(&block)
+          ensure
+            @_inside_form = nil
+          end
+
+          form_tag_with_body(html_options, output)
         else
           form_tag_html(html_options)
         end

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -331,6 +331,8 @@ module ActionView
       #   #    </form>"
       #
       def button_to(name = nil, options = nil, html_options = nil, &block)
+        check_for_nested_form!("Forms should not be nested inside forms. button_to uses a form internally, so it cannot be nested inside a form_with.")
+
         html_options, options = options, name if block_given?
         html_options ||= {}
         html_options = html_options.stringify_keys

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -35,6 +35,11 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      nested_form_behaviour = app.config.action_view.delete(:nested_form_behaviour)
+      ActionView::Helpers::FormHelper.nested_form_behaviour = nested_form_behaviour
+    end
+
+    config.after_initialize do |app|
       default_enforce_utf8 = app.config.action_view.delete(:default_enforce_utf8)
       unless default_enforce_utf8.nil?
         ActionView::Helpers::FormTagHelper.default_enforce_utf8 = default_enforce_utf8

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -980,6 +980,26 @@ class FormTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_form_tag_inside_form_is_fine_by_default
+    form_tag do |f|
+      form_tag
+    end
+  end
+
+  def test_form_tag_inside_form_with_raises_if_enabled
+    old_value = ActionView::Helpers::FormHelper.nested_form_behaviour
+    ActionView::Helpers::FormHelper.nested_form_behaviour = :raise
+
+    assert_raises ArgumentError, match: /Forms should not be nested inside forms./ do
+      form_tag do |f|
+        form_tag
+      end
+    end
+
+  ensure
+    ActionView::Helpers::FormHelper.nested_form_behaviour = old_value
+  end
+
   def protect_against_forgery?
     false
   end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -46,6 +46,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::FormHelper
   include routes.url_helpers
 
   include ActionView::Helpers::JavaScriptHelper

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -76,6 +76,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.default_message_verifier_serializer`](#config-active-support-default-message-verifier-serializer): `:json`
 - [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
 - [`config.active_support.use_message_serializer_for_metadata`](#config-active-support-use-message-serializer-for-metadata): `true`
+- [`config.action_view.nested_form_behaviour`](#config-action-view-nested-form-nested_form_behaviour): `:raise if Rails.env.local?`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
 - [`config.precompile_filter_parameters`](#config-precompile-filter-parameters): `true`
@@ -1962,6 +1963,19 @@ The default value depends on the `config.load_defaults` target version:
 #### `config.action_view.prepend_content_exfiltration_prevention`
 
 Determines whether or not the `form_tag` and `button_to` helpers will produce HTML tags prepended with browser-safe (but technically invalid) HTML that guarantees their contents cannot be captured by any preceding unclosed tags. The default value is `false`.
+
+#### `config.action_view.nested_form_behaviour`
+
+Alerts you if a `<form>` is nested inside a `<form>`. This is prohibited in the HTML spec.
+
+Accepts `:raise`, `:log`, or `nil` as options.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is          |
+| --------------------- | ----------------------------- |
+| (original)            | `nil`                         |
+| 7.1                   | `:raise if Rails.env.local?`  |
 
 ### Configuring Action Mailbox
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -309,6 +309,10 @@ module Rails
           if respond_to?(:action_controller)
             action_controller.allow_deprecated_parameters_hash_equality = false
           end
+
+          if respond_to?(:action_view)
+            action_view.nested_form_behaviour = :raise if Rails.env.local?
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -152,3 +152,9 @@
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
 # Rails.application.config.active_record.default_column_serializer = nil
+
+# Raise an error when nesting a <form> inside a <form>.
+# This behaviour is forbidden and will not work as expected.
+# See https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form#the_form_element
+# Set to `:log` to emit a warning instead of raising, or to `nil` to disable checks.
+# Rails.application.config.action_view.nested_form_behaviour = :raise if Rails.env.local?


### PR DESCRIPTION
This is prohibited, per the HTML spec: https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_structure_a_web_form#the_form_element

This PR introduces `Rails.application.config.action_view.nested_form_behaviour`. This tries to alert the developer of nested forms. It works with `form_with`, `form_tag`, and `button_to`.

The config accepts `:raise`, `:log`, or `nil`. In 7.1, the default will be `:raise` in development and test. It will be `nil` in production, so no new errors will be raised.

ref: https://github.com/rails/rails/pull/47505#discussion_r1124655886 for the original idea
