### PR TITLE
Update gems and bundler

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -13,6 +13,10 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development"
 
+# Update gems and bundler
+RUN gem update --system --no-document && \
+    gem install -N bundler
+
 
 # Throw-away build stage to reduce size of final image
 FROM base as build


### PR DESCRIPTION
I see three basic strategies:

* start with whatever version of bundler the developer is actually using
* start with whatever version of bundler was the latest at the time the docker image for the specified Ruby was created
* start with the latest

The first approach seems most likely to produce a successful result, but didn't seem to be popular.

The second approach is the default, but both rubygems and bundler frequently get important fixes, and it is difficult to reason about the behavior of the dockerfile given all of the versions of Ruby that are out there now and will be produced in the future.

The latest at the time of the first deploy means you get recent fixes. Current versions of bundler will automatically downgrade themselves as needed.

THe purpose of this pull requeset is to see if there is any support for automatically upgrading.  This is running in production at fly.io.

](cc: @dhh @zzak @byroot)