### PR TITLE
Make SchemaCache#connection thread-safe

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -33,10 +33,10 @@ module ActiveRecord
       private_class_method :read
 
       attr_reader :version
-      thread_cattr_accessor :connection
+      attr_accessor :connection
 
       def initialize(conn)
-        self.connection = conn
+        @connection = conn
 
         @columns      = {}
         @columns_hash = {}

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -33,10 +33,10 @@ module ActiveRecord
       private_class_method :read
 
       attr_reader :version
-      attr_accessor :connection
+      thread_cattr_accessor :connection
 
       def initialize(conn)
-        @connection = conn
+        self.connection = conn
 
         @columns      = {}
         @columns_hash = {}


### PR DESCRIPTION
### Summary

There is a race condition in SchemaCache when multiple threads attempt to load schema data from the database in parallel. This results in a variety of exceptions and occasional segfaults, typically just after launch when schema info is not yet in memory.

This PR improves the thread safety of ConnectionPool's schema_cache instance by making `schema_cache.connection` a thread-local variable.

<details>
<summary>Example errors</summary>

```
# (1)
NoMethodError: undefined method `map_types!' for nil:NilClass
  conn.async_exec(sql).map_types!(@type_map_for_results).values
                      ^^^^^^^^^^^
in gems/rails-dce7c1cd7c01/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:18:in `block (2 levels) in query'

# (2)
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  zero-length delimited identifier at or near """"
  LINE 1: ...M "good_job_processes" WHERE "good_job_processes"."" IN (SEL...
                                                               ^
in gems/rails-dce7c1cd7c01/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:838:in `exec_params'
# (This one seems to reflect a corrupted internal cache of the field's column name, and requires a manual app restart.)

# (3)
ActiveRecord::StatementInvalid: PG::UnableToSend: message contents do not agree with length in message type "Z"
in gems/rails-d247f491a4e4/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:18:in `exec'

# (4)
NoMethodError: undefined method `clear' for nil:NilClass
  result.clear
        ^^^^^^
in gems/rails-13783f36ad6c/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:825:in `ensure in execute_and_clear'

# (5)
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x6e arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle

# (6)
ruby(35954,0x700002fc8000) malloc: *** error for object 0x600003fa4fc0: pointer being freed was not allocated
ruby(35954,0x700002fc8000) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6

# (7)
gems/rails-dce7c1cd7c01/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:18: [BUG] Segmentation fault at 0x0000000000000488
```

</details>

### Background

Each `ConnectionPool` / `PoolConfig` holds a single, shared `schema_cache` instance (ConnectionPool delegates schema_cache to pool_config). Because pools can be shared across threads, this implicitly shares `pool.schema_cache` across threads as well.

`SchemaCache` maintains an internal copy of the `connection` to use for schema-related queries to the DB. Since SchemaCache is shared across threads, this copy of `connection` also becomes shared.

When `connection.schema_cache` is called, it first assigns `schema_cache.connection = connection`. If two threads attempt to utilize `schema_cache` in parallel, `schema_cache.connection=` is called twice, once for each thread. The second write clobbers the first, giving rise to a lovely race condition: if the first thread makes any further DB queries, it is now suddenly using the second thread's connection, quite possibly in parallel to the second thread.


This appears to have been an issue for a while, possibly since SchemaCache was made global to ConnectionPools (#36371). However, synchronization inside `AbstractAdapter#with_raw_connection` largely compensated for it.

Now that such synchronization has largely been turned into `NullLock` (in #46519), that protection is gone and this race condition is somewhat easier to trigger.


### Context

I experienced the issue with GoodJob (bensheldon/good_job#796) as it fires up multiple threads on start which all make immediate schema related queries to the DB. 

There's also an aging PR (#38577) indicating a similar problem when using Sidekiq.


### Proposed change

This PR changes `SchemaCache#connection` to become thread-local. This avoids having to make farther reaching changes, which was one of the concerns raised in #38577.

### Alternatives

1. Make `PoolConfig#schema_cache` thread-local instead. Unfortunately, this would make SchemaCache itself per-thread, effectively unwinding #36371.

2. Cause `SchemaCache#connection` to checkout its own connection from the associated pool. This avoids thread-local vars, but would require additional DB connections. The checkout/checkin cycle might require API changes as well.

3. #38577 also explored other options.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


cc @byroot @eileencodes @matthewd

Fixes bensheldon/good_job#796
Replaces #38577
Potentially related to #46797
