### PR TITLE
Support prerelease rubies in Gemfile template if possible

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support prerelease rubies in Gemfile template if RubyGems version is 3.3.16 or higher.
+
+    *Yasuo Honda*, *David Rodríguez*
+
 *   Autoloading setup honors root directories manually set by the user.
 
     This is relevant for custom namespaces. For example, if you'd like classes

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "\"#{RUBY_VERSION}\"" -%>
+ruby <%= "\"#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}\"" -%>
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -928,7 +928,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby "#{RUBY_VERSION}"/, content)
+      assert_match(/ruby "#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}"/, content)
     end
     assert_file ".ruby-version" do |content|
       if ENV["RBENV_VERSION"]


### PR DESCRIPTION
### Motivation / Background

This commit brings back #45979 only when RubyGems version is 3.3.13 or higher that includes https://github.com/rubygems/rubygems/pull/5486

Pull request #45979 has been reverted via #47524 because the default versions of RubyGems shipped with Ruby 2.7 and 3.0 are lower than 3.3.13. If users who bumps the RubyGems version or uses Ruby 3.1 or higher, RubyGems version should be satisfied to support prerelease rubies.

Ref #45979 #47524
Fix #47542

### Detail
Here are details of how `Gem.ruby_version` works between RubyGems 3.3.12 and3.3.13. 

- RubyGems 3.3.12` Gem.ruby_version` includes patch level
```ruby
$ gem -v
3.3.12
$ irb
irb(main):001:0> Gem.ruby_version
=> Gem::Version.new("3.1.3.p185")
```

- RubyGems 3.3.13` Gem.ruby_version` does not include patch level
```ruby
$ gem -v
3.3.13
$ irb
irb(main):001:0> Gem.ruby_version
=> Gem::Version.new("3.1.3")
irb(main):002:0>
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
