### PR TITLE
Add nodoc for SourcesController

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rails
-  class Conductor::ActionMailbox::InboundEmails::SourcesController < Rails::Conductor::BaseController
+  class Conductor::ActionMailbox::InboundEmails::SourcesController < Rails::Conductor::BaseController # :nodoc:
     def new
     end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we don't want to document `SourcesController`

This is based on the comment from discord

> **zzak — Today at 11:05 AM**
> Today in things that probably don't need to be documented:
> https://edgeapi.rubyonrails.org/classes/Rails/Rails/Conductor/ActionMailbox/InboundEmails/SourcesController.html
> 
> `Rails::Rails::Conductor::ActionMailbox::InboundEmails::SourcesController`

### Detail

This Pull Request adds `:nodoc:` to `Rails::Rails::Conductor::ActionMailbox::InboundEmails::SourcesController`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
