### PR TITLE
Fix small typo in Object#With rdoc [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/with.rb
+++ b/activesupport/lib/active_support/core_ext/object/with.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Object
-  # Sets and restore the provided attributes around a block.
+  # Set and restore public attributes around a block.
   #
   #   client.timeout # => 5
   #   client.with(timeout: 1) do


### PR DESCRIPTION
It should either be "Sets and restores" or "Set and restore".
I went with last one that is also used in the description from the CHANGELOG entry.
I also copied the "public attributes" part for extra clarity.

cc @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
