### PR TITLE
Improve custom Rake task documentation [ci-skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Rakefile.tt
@@ -1,5 +1,6 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+# Add your own Rake tasks in files placed in lib/tasks ending in .rake.
+# For example: lib/tasks/admin.rake
+# These tasks are automatically available to the `bin/rails` and `rake` commands.
 
 require_relative "config/application"
 


### PR DESCRIPTION
It's currently unclear that custom Rake tasks can be called through the `bin/rails` command. By documenting its usage in the Rakefile we can make things more clear.
This also replaces the less used `capistrano` example with a more generic example.

### Motivation / Background

This was inspired by the following blog post, where the author was confused by the difference between `rake` and `rails`.
https://dev.to/youngbloodcyb/rake-junior-rails-review-13cc

cc @youngbloodcyb

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
