### PR TITLE
Look for created.rid in api_dir (output dir)

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -150,8 +150,8 @@ module Rails
 
         # Only generate documentation for files that have been
         # changed since the API was generated.
-        if Dir.exist?("doc/rdoc") && !ENV["ALL"]
-          last_generation = DateTime.rfc2822(File.open("doc/rdoc/created.rid", &:readline))
+        if Dir.exist?(api_dir) && !ENV["ALL"]
+          last_generation = DateTime.rfc2822(File.open("#{api_dir}/created.rid", &:readline))
 
           rdoc_files.keep_if do |file|
             File.mtime(file).to_datetime > last_generation


### PR DESCRIPTION
This changes to use a single source of truth for the output dir in the rdoc task. Which lets us override this value when building from a different directory.

Mainly this change is a no-op, but we are using Rails::API:Task to test and build SDoc version 3.