### PR TITLE
Add missing `openssl` require to `activerecord/encryption/config.rb` file

### DIFF
--- a/activerecord/lib/active_record/encryption/config.rb
+++ b/activerecord/lib/active_record/encryption/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "openssl"
+
 module ActiveRecord
   module Encryption
     # Container of configuration options


### PR DESCRIPTION
After the change https://github.com/rails/rails/commit/5d7b6d823f50d9cc10f22c4380218e697f6e03bb#diff-be4704f10be1ac4cee2a88fda4fec863e60e7f7204e94624c5137dc8e5d151b4R42, I got a missing constant error - https://github.com/fatkodima/online_migrations/actions/runs/4355294837/jobs/7611732032

That was not detected by activerecord tests, because activerecord uses fixtures and openssl is currently transitively required via https://github.com/rails/rails/blob/308f1de709566e2b231df46c71c1039b16941712/activerecord/lib/active_record/fixtures.rb#L8 and https://github.com/rails/rails/blob/308f1de709566e2b231df46c71c1039b16941712/activesupport/lib/active_support/core_ext/digest/uuid.rb#L4 but my gem does not use fixtures.