### PR TITLE
Fixes 47535 - flag multiple cookies as secure

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -113,7 +113,9 @@ module ActionDispatch
 
       def flag_cookies_as_secure!(headers)
         if cookies = headers["Set-Cookie"]
-          cookies = cookies.split("\n")
+          if cookies.is_a?(String)
+            cookies = cookies.split("\n")
+          end
 
           headers["Set-Cookie"] = cookies.map { |cookie|
             if !/;\s*secure\s*(;|$)/i.match?(cookie)

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -196,6 +196,16 @@ class SecureCookiesTest < SSLTest
     assert_cookies "id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly"
   end
 
+  def test_flag_cookies_as_secure_with_single_cookie_in_array
+    get headers: { "Set-Cookie" => ["id=1"] }
+    assert_cookies "id=1; secure"
+  end
+
+  def test_flag_cookies_as_secure_with_multiple_cookies_in_array
+    get headers: { "Set-Cookie" => ["id=1", "problem=def"] }
+    assert_cookies "id=1; secure", "problem=def; secure"
+  end
+
   def test_flag_cookies_as_secure_at_end_of_line
     get headers: { "Set-Cookie" => "problem=def; path=/; HttpOnly; secure" }
     assert_cookies "problem=def; path=/; HttpOnly; secure"


### PR DESCRIPTION
### Motivation / Background

This PR fixes https://github.com/rails/rails/issues/47535, adding support for multiple cookies in the cookie jar.

### Detail

Currently the `flag_cookies_as_secure!` assumes `cookies` parsed from the "Set-Cookie" header to be a string, but it can indeed be an array. This PR adds a check to confirm `cookies` is a string before splitting it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
