### PR TITLE
Ignore joins on #and calls

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -123,6 +123,11 @@ module ActiveRecord
 
     FROZEN_EMPTY_ARRAY = [].freeze
     FROZEN_EMPTY_HASH = {}.freeze
+    STRUCTURAL_VALUE_METHODS_FOR_OR = (
+      Relation::VALUE_METHODS -
+      [:extending, :where, :having, :unscope, :references, :annotate, :optimizer_hints]
+    ).freeze # :nodoc:
+    STRUCTURAL_VALUE_METHODS_FOR_AND = STRUCTURAL_VALUE_METHODS_FOR_OR - %i(joins left_outer_joins includes eager_load preload) # :nodoc:
 
     Relation::VALUE_METHODS.each do |name|
       method_name, default =
@@ -994,7 +999,7 @@ module ActiveRecord
     #    # => false
     #
     def structurally_compatible?(other)
-      structurally_incompatible_values_for(other).empty?
+      structurally_incompatible_values_for(other, STRUCTURAL_VALUE_METHODS_FOR_OR).empty?
     end
 
     # Returns a new relation, which is the logical intersection of this relation and the one passed
@@ -1016,7 +1021,7 @@ module ActiveRecord
     end
 
     def and!(other) # :nodoc:
-      incompatible_values = structurally_incompatible_values_for(other)
+      incompatible_values = structurally_incompatible_values_for(other, STRUCTURAL_VALUE_METHODS_FOR_AND)
 
       unless incompatible_values.empty?
         raise ArgumentError, "Relation passed to #and must be structurally compatible. Incompatible values: #{incompatible_values}"
@@ -1048,7 +1053,7 @@ module ActiveRecord
     end
 
     def or!(other) # :nodoc:
-      incompatible_values = structurally_incompatible_values_for(other)
+      incompatible_values = structurally_incompatible_values_for(other, STRUCTURAL_VALUE_METHODS_FOR_OR)
 
       unless incompatible_values.empty?
         raise ArgumentError, "Relation passed to #or must be structurally compatible. Incompatible values: #{incompatible_values}"
@@ -1958,14 +1963,9 @@ module ActiveRecord
         end
       end
 
-      STRUCTURAL_VALUE_METHODS = (
-        Relation::VALUE_METHODS -
-        [:extending, :where, :having, :unscope, :references, :annotate, :optimizer_hints]
-      ).freeze # :nodoc:
-
-      def structurally_incompatible_values_for(other)
+      def structurally_incompatible_values_for(other, incompatible_values)
         values = other.values
-        STRUCTURAL_VALUE_METHODS.reject do |method|
+        incompatible_values.reject do |method|
           v1, v2 = @values[method], values[method]
           if v1.is_a?(Array)
             next true unless v2.is_a?(Array)

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -163,7 +163,7 @@ module ActiveRecord
       assert_match %r{#{quoted_posts} /\* foo \*/ /\* bar \*/\z}, Post.annotate("foo", "bar").or(Post.annotate("foo")).to_sql
     end
 
-    def test_structurally_incompatible_values
+    def test_structurally_compatible_values
       assert_nothing_raised do
         Post.includes(:author).includes(:author).or(Post.includes(:author))
         Post.eager_load(:author).eager_load(:author).or(Post.eager_load(:author))


### PR DESCRIPTION
### Motivation / Background

`#and` and `#or` should support different behaviours when joining, this PR fixes that. 

Also, I would like to get some suggestion about what to do with, is that okay how is now?

```ruby
def structurally_compatible?(other)
  structurally_incompatible_values_for(other, STRUCTURAL_VALUE_METHODS_FOR_OR).empty?
end
```

### Detail

This PR closes #47571 

This PR changes the constant that checks the structural pattern to allow or not the and/or to be completed and now each one have their one check.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
