### PR TITLE
Add Canary Is. time zone

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Canary Is.` time zone.
+
+    *Javier Aranda*
+
 *   Add `Object#with` to set and restore public attributes around a block
 
     ```ruby

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -7,7 +7,7 @@ module ActiveSupport
   # The TimeZone class serves as a wrapper around <tt>TZInfo::Timezone</tt> instances.
   # It allows us to do the following:
   #
-  # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
+  # * Limit the set of zones provided by TZInfo to a meaningful subset of 152
   #   zones.
   # * Retrieve and display zones with a friendlier name
   #   (e.g., "Eastern Time (US & Canada)" instead of "America/New_York").
@@ -179,7 +179,8 @@ module ActiveSupport
       "Nuku'alofa"                   => "Pacific/Tongatapu",
       "Tokelau Is."                  => "Pacific/Fakaofo",
       "Chatham Is."                  => "Pacific/Chatham",
-      "Samoa"                        => "Pacific/Apia"
+      "Samoa"                        => "Pacific/Apia",
+      "Canary Is."                   => "Atlantic/Canary"
     }
 
     UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:


### PR DESCRIPTION
### Motivation / Background

The time zone of the Canary Islands (Atlantic/Canary) is one of the two active time zones in Spain.

### Detail

This Pull Request adds the time zone to the `ActiveSupport::TimeZone` class.

### Additional information

https://www.zeitverschiebung.net/es/timezone/atlantic--canary

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
