### PR TITLE
Dockerfile: chown only directories that actually exist

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -78,7 +78,7 @@ COPY --from=build /rails /rails
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --home /rails --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails <%= Dir[*%w(db log storage tmp)].join(" ") %>
 USER rails:rails
 
 # Entrypoint prepares the database.


### PR DESCRIPTION
"storage", for example, won't exist if you specify --minimal.

attn: @dhh