### PR TITLE
Fix schema cache file test

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -41,10 +41,14 @@ module ActiveRecord
 
       def test_cache_path_can_be_in_directory
         cache = SchemaCache.new @connection
-        filename = "some_dir/schema.json"
+        tmp_dir = Dir.mktmpdir
+        filename = File.join(tmp_dir, "schema.json")
+
+        assert_not File.exist?(filename)
         assert cache.dump_to(filename)
+        assert File.exist?(filename)
       ensure
-        File.delete(filename)
+        FileUtils.rm_r(tmp_dir)
       end
 
       def test_yaml_dump_and_load_with_gzip


### PR DESCRIPTION
This test was leaving behind the directory and was never verifying the file existed after dump was called. We can't use a tempfile because it will be created automatically and this is testing that `SchemaCache#open` will create the file if it doesn't exist.