### PR TITLE
Factor out the `valid_column_definition_options` method to AbstractAdapter class

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -586,7 +586,7 @@ module ActiveRecord
 
       private
         def valid_column_definition_options
-          ColumnDefinition::OPTION_NAMES
+          @conn.valid_column_definition_options
         end
 
         def create_column_definition(name, type, options)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1497,6 +1497,18 @@ module ActiveRecord
         non_combinable_operations.each(&:call)
       end
 
+      def valid_table_definition_options
+        [:temporary, :if_not_exists, :options, :as, :comment, :charset, :collation]
+      end
+
+      def valid_column_definition_options
+        ColumnDefinition::OPTION_NAMES
+      end
+
+      def valid_primary_key_options
+        [:limit, :default, :precision]
+      end
+
       private
         def validate_change_column_null_argument!(value)
           unless value == true || value == false
@@ -1593,14 +1605,6 @@ module ActiveRecord
 
         def create_alter_table(name)
           AlterTable.new create_table_definition(name)
-        end
-
-        def valid_table_definition_options
-          [:temporary, :if_not_exists, :options, :as, :comment, :charset, :collation]
-        end
-
-        def valid_primary_key_options
-          [:limit, :default, :precision]
         end
 
         def validate_create_table_options!(options)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because our team at Shopify is implementing a custom ActiveRecord adapter to integrate with [Vitess](https://vitess.io/), and we would like to overload the `valid_{column,table}_definition_options` methods and add additional valid options for schema migrations. For example:

```ruby
module ActiveRecord
  module ConnectionAdapters
    class VitessMysql2Adapter < Mysql2Adapter
      ...

      def valid_table_definition_options
        super + [:skip_vschema_migrations, :sharding_keys, :auto_increment]
      end

      def valid_column_definition_options
        super + [:skip_vschema_migrations, :sharding_keys, :auto_increment]
      end
    end
  end
end
```


### Detail

This Pull Request, as the simplest possible change, factors out the various `valid_{table,column,primary_key}_definition_options` to be a **public** method on an adapter instance.

This allows subclassing adapters to cleanly override their ancestor class' valid options.

### Additional information

I don't see any harm in this, maybe except the awkwardness of the roundabout reference of 

`TableDefinition#valid_column_definition_options` -> `SchemaStatements#valid_column_definition_options` -> `ColumnDefinition::OPTION_NAMES`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
