### PR TITLE
Mention "rake" less in guides

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -402,8 +402,7 @@ Migrations
 
 Rails provides a convenient way to manage changes to a database schema via
 migrations. Migrations are written in a domain-specific language and stored
-in files which are executed against any database that Active Record supports
-using `rake`.
+in files which are executed against any database that Active Record supports.
 
 Here's a migration that creates a new table called `publications`:
 
@@ -424,13 +423,13 @@ end
 ```
 
 Note that the above code is database-agnostic: it will run in MySQL,
-PostgreSQL, Oracle, and others.
+PostgreSQL, SQLite, and others.
 
 Rails keeps track of which migrations have been committed to the database and stores them
 in a neighboring table in that same database called `schema_migrations`.
 
-To actually create the table, you'd run `bin/rails db:migrate`,
-and to roll it back, `bin/rails db:rollback`.
+To run the migration and create the table, you'd run `bin/rails db:migrate`,
+and to roll it back and delete the table, `bin/rails db:rollback`.
 
 You can learn more about migrations in the [Active Record Migrations
 guide](active_record_migrations.html).

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -702,4 +702,10 @@ $ bin/rails "task_name[value 1,value2,value3]" # separate multiple args with a c
 $ bin/rails db:nothing
 ```
 
-NOTE: If you need to interact with your application models, perform database queries, and so on, your task should depend on the `environment` task, which will load your application code.
+If you need to interact with your application models, perform database queries, and so on, your task should depend on the `environment` task, which will load your application code.
+
+```ruby
+task task_that_requires_app_code: [:environment] do
+  User.create!
+end
+```

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -580,7 +580,7 @@ Contains the paths which are used to look for assets. Appending paths to this co
 
 #### `config.assets.precompile`
 
-Allows you to specify additional assets (other than `application.css` and `application.js`) which are to be precompiled when `rake assets:precompile` is run.
+Allows you to specify additional assets (other than `application.css` and `application.js`) which are to be precompiled when `bin/rails assets:precompile` is run.
 
 #### `config.assets.unknown_asset_fallback`
 

--- a/guides/source/webpacker.md
+++ b/guides/source/webpacker.md
@@ -195,7 +195,7 @@ The [Webpacker Documentation](https://github.com/rails/webpacker) gives informat
 
 ### Deploying Webpacker
 
-Webpacker adds a `webpacker:compile` task to the `assets:precompile` rake task, so any existing deploy pipeline that was using `assets:precompile` should work. The compile task will compile the packs and place them in `public/packs`.
+Webpacker adds a `webpacker:compile` task to the `bin/rails assets:precompile` task, so any existing deploy pipeline that was using `assets:precompile` should work. The compile task will compile the packs and place them in `public/packs`.
 
 Additional Documentation
 ------------------------


### PR DESCRIPTION
[This blog post](https://dev.to/youngbloodcyb/rake-junior-rails-review-13cc) is about the confusion between `bin/rake` and `bin/rails` commands. The two have mostly [been aliases since Rails 5](https://github.com/rails/rails/commit/3d252a02ae7f17f94401fe206f4ffc1922610d6f#diff-f5ff9aa07f44111a79d56c09ec37d774b462d97aff68f32490c2e56e74c95783R162), but this means there's all sorts of advice floating around the internet about which command to use. Is `rake db:migrate` the same as `bin/rails db:migrate`? I know that it is, but I can see why it's confusing for a first timer.

The blog post's suggestion was to have a section in the guides that introduces rake and talks about this distinction. I'm not sure about this. I think if we take up too much space too early in the guide discussing this, it risks confusing people even earlier. But if the advice is hidden away too much, nobody will find it.

Something I think we should do, though, is mention `rake` as little as possible in the guides. Mentions in upgrade guides and release notes are fine, but elsewhere we should avoid using it in places where `bin/rails` does an equivalent job. This PR removes a few `rake` mentions from the guides. Before doing this, I was expecting there to be a lot more, so this PR turned out to be a bit smaller than expected. Still, every little bit helps I think.

cc @youngbloodcyb
