### PR TITLE
Add explicit dependency on bigdecimal

### DIFF
--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
+  s.add_dependency "bigdecimal"
   s.add_dependency "globalid", ">= 0.3.6"
 end

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
+  s.add_dependency "bigdecimal"
 end

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 2.0"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
+  s.add_dependency "bigdecimal"
   s.add_dependency "minitest",        ">= 5.1"
 end


### PR DESCRIPTION
### Motivation / Background

Related to https://github.com/rails/rails/issues/44399, but the merged solution doesn't go far enough IMHO. On Fedora and EL8+ you can install Ruby without bigdecimal when you disable weak dependencies (set `install_weak_deps=False` in `/etc/dnf/dnf.conf`).

### Detail

This PR adds a dependency on `bigdecimal` in `$library.gemspec if `$library/lib` has a `require 'bigdecimal'` statement.

### Additional information

It's usually best to set a version range for dependencies, but I don't know what it should be. I'm looking for feedback here since I don't know what the Rails maintainers prefer.

I'm also unsure if this is something that should go into the CHANGELOG. It could be considered a minor bug fix, but it may also be something users will want to know. Please advise :)

Note Fedora's activerecord package already manually adds the dependency (https://src.fedoraproject.org/rpms/rubygem-activesupport/blob/rawhide/f/rubygem-activesupport.spec#_33) but including it here would allow the automatic dependency generator to do its job. It also lists json, so is that something that should also be added (in a separate PR)?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.