### PR TITLE
Fix 47614 issue with inverting create_table/drop_table migration

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -184,7 +184,17 @@ module ActiveRecord
           [:transaction, args, invertions_proc]
         end
 
+        def invert_create_table(args, &block)
+          if args.last.is_a?(Hash)
+            args.last.delete(:if_not_exists)
+          end
+          super
+        end
+
         def invert_drop_table(args, &block)
+          if args.last.is_a?(Hash)
+            args.last.delete(:if_exists)
+          end
           if args.size == 1 && block == nil
             raise ActiveRecord::IrreversibleMigration, "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty)."
           end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -152,6 +152,14 @@ module ActiveRecord
         assert_equal [:drop_table, [:system_settings], nil], drop_table
       end
 
+      def test_invert_create_table_with_if_not_exists
+        @recorder.revert do
+          @recorder.record :create_table, [:system_settings, if_not_exists: true]
+        end
+        drop_table = @recorder.commands.first
+        assert_equal [:drop_table, [:system_settings, {}], nil], drop_table
+      end
+
       def test_invert_create_table_with_options_and_block
         block = Proc.new { }
         drop_table = @recorder.inverse_of :create_table, [:people_reminders, id: false], &block
@@ -161,6 +169,12 @@ module ActiveRecord
       def test_invert_drop_table
         block = Proc.new { }
         create_table = @recorder.inverse_of :drop_table, [:people_reminders, id: false], &block
+        assert_equal [:create_table, [:people_reminders, id: false], block], create_table
+      end
+
+      def test_invert_drop_table_with_if_exists
+        block = Proc.new { }
+        create_table = @recorder.inverse_of :drop_table, [:people_reminders, id: false, if_exists: true], &block
         assert_equal [:create_table, [:people_reminders, id: false], block], create_table
       end
 


### PR DESCRIPTION
### Motivation / Background

This PR fixes issue #47614

### Detail

Decided to go with `Delete the if_exists: true option when running a reverse. (and drop if_not_exists: true when reversing a create_table.`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
