### PR TITLE
Introduce `bin/rails clear` command for clearing logs

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Introduce `bin/rails clear` command for clearing logs and more.
+
+    Currently logs and the tmp directory can be cleared with a single invocation:
+
+    ```bash
+    bin/rails log:clear tmp:clear
+    ```
+
+    With Thor we can't run multiple commands with a single invocation, as
+    additional commands will be seen as arguments to the first command.
+
+    This introduces a single `clear` command that will combine the existing
+    `log:clear` and `tmp:clear` commands. For now it's limited to clearing logs:
+
+    ```bash
+    bin/rails clear --logs
+    ```
+
+    The `--logs` option also supports passing `all` or a list of environments:
+
+    ```bash
+    # similar to `bin/rails log:clear LOGS=all`
+    bin/rails log:clear --logs all
+    # similar to `bin/rails log:clear LOGS=development,test`
+    bin/rails log:clear --logs development test
+    ```
+
+    *Petrik de Heus*
+
 *   Allow calling `bin/rails restart` outside of app directory.
 
     The following would previously fail with a "No Rakefile found" error.

--- a/railties/lib/rails/commands/clear/clear_command.rb
+++ b/railties/lib/rails/commands/clear/clear_command.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Rails
+  module Command
+    class ClearCommand < Base # :nodoc:
+      desc "clear", "Truncate log/*.log files"
+      option :logs, type: :array, lazy_default: [],
+        desc: "Truncate log/*.log files for specified environments to zero bytes. If no environments are specified, truncate logs for all environments."
+      def clear
+        if options[:logs].empty?
+          environments = all_environments
+        else
+          environments = options[:logs]
+        end
+        log_files_for(environments).each { |file| file.truncate(0) }
+      end
+
+      private
+        def log_files_for(environments)
+          pattern = environments == ["all"] ? "*" : "{#{environments.join(",")}}"
+          Rails::Command.application_root.glob("log/#{pattern}.log").select(&:file?)
+        end
+
+        def all_environments
+          Rails::Command.application_root.glob("config/environments/*.rb")
+            .map { |fname| File.basename(fname, ".*") }
+        end
+    end
+  end
+end

--- a/railties/lib/rails/tasks/log.rake
+++ b/railties/lib/rails/tasks/log.rake
@@ -9,6 +9,10 @@ namespace :log do
   #   - ENV['LOGS']='test,development' truncates only specified files
   desc "Truncate all/specified *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)"
   task :clear do
+    Rails.deprecator.warn(<<~MSG.squish)
+      `bin/rails log:clear` is deprecated and will be removed in Rails 7.2.
+      Please use `bin/rails clear --logs` instead.
+    MSG
     log_files.each do |file|
       clear_log_file(file)
     end

--- a/railties/test/commands/clear_test.rb
+++ b/railties/test/commands/clear_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::ClearTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  setup :build_app
+  teardown :teardown_app
+
+  test "`rails clear --logs` clears all environments log files by default" do
+    app_file "config/environments/staging.rb", "# staging"
+
+    app_file "log/staging.log", "staging"
+    app_file "log/test.log", "test"
+    app_file "log/dummy.log", "dummy"
+
+    rails "clear", "--logs"
+
+    assert_file_empty     "log/staging.log"
+    assert_file_empty     "log/test.log"
+    assert_file_not_empty "log/dummy.log"
+  end
+
+  test "`rails clear --logs all` clears all log files" do
+    app_file "log/test.log", "test"
+    app_file "log/dummy.log", "dummy"
+    app_file "log/not_a_log", "not_a_log"
+
+    rails "clear", "--logs", "all"
+
+    assert_file_empty     "log/test.log"
+    assert_file_empty     "log/dummy.log"
+    assert_file_not_empty "log/not_a_log"
+  end
+
+  test "`rails clear --logs env1 env2` clears only logs for the specified environments" do
+    app_file "config/environments/staging.rb", "# staging"
+
+    app_file "log/production.log", "production"
+    app_file "log/staging.log", "staging"
+    app_file "log/test.log", "test"
+    app_file "log/dummy.log", "dummy"
+
+    rails "clear", "--logs", "test", "staging"
+
+    assert_file_not_empty "log/production.log"
+    assert_file_empty     "log/test.log"
+    assert_file_empty     "log/staging.log"
+    assert_file_not_empty "log/dummy.log"
+  end
+
+  private
+    def assert_file_empty(path)
+      assert File.empty? app_path(path)
+    end
+
+    def assert_file_not_empty(path)
+      assert File.size? app_path(path)
+    end
+end


### PR DESCRIPTION
Currently we use both Thor and Rake for `bin/rails` commands.
We eventually want to get all the built-in tasks promoted to Thor Commands:
https://github.com/rails/rails/pull/47610#issuecomment-1461520271
This migrates the `log:clear` task to Thor.

Currently logs and the tmp directory can be cleared with a single invocation:

```bash
bin/rails log:clear tmp:clear
```

With Thor we can't run multiple commands with a single invocation, as
additional commands will be seen as arguments to the first command.

This introduces a single `clear` command that will combine the existing
`log:clear` and `tmp:clear` commands. For now it's limited to clearing logs:

```bash
bin/rails clear --logs
```

The `--logs` option also supports passing `all` or a list of environments:

```bash
bin/rails log:clear --logs all # similar to `bin/rails log:clear LOGS=all`
bin/rails log:clear --logs development test # similar to `bin/rails log:clear LOGS=development,test`
```

Thor doesn't support Rake's FileList, so for truncating all log files we
use a glob pattern and filter out directories.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
