### PR TITLE
Define `ActiveRecord::Base#id` API for composite primary key models

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name
 
-        name = @primary_key if name == "id" && @primary_key
+        name = @primary_key if name == "id" && @primary_key && !@primary_key.is_a?(Array)
         @attributes.fetch_value(name, &block)
       end
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -769,7 +769,8 @@ module ActiveRecord
     def find
       raise FixtureClassNotFound, "No class attached to find." unless model_class
       object = model_class.unscoped do
-        model_class.find(fixture[model_class.primary_key])
+        pk_clauses = fixture.slice(*Array(model_class.primary_key))
+        model_class.find_by!(pk_clauses)
       end
       # Fixtures can't be eagerly loaded
       object.instance_variable_set(:@strict_loading, false)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -10,6 +10,7 @@ require "models/keyboard"
 require "models/mixed_case_monkey"
 require "models/dashboard"
 require "models/non_primary_key"
+require "models/cpk"
 
 class PrimaryKeysTest < ActiveRecord::TestCase
   fixtures :topics, :subscribers, :movies, :mixed_case_monkeys
@@ -331,6 +332,8 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
   self.use_transactional_tests = false
 
+  fixtures :cpk_books, :cpk_orders
+
   def setup
     @connection = ActiveRecord::Base.connection
     @connection.schema_cache.clear!
@@ -386,6 +389,19 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   def test_dumping_composite_primary_key_out_of_order
     schema = dump_table_schema "barcodes_reverse"
     assert_match %r{create_table "barcodes_reverse", primary_key: \["code", "region"\]}, schema
+  end
+
+  def test_model_with_a_composite_primary_key
+    assert_equal(["author_id", "number"], Cpk::Book.primary_key)
+    assert_equal(["shop_id", "id"], Cpk::Order.primary_key)
+  end
+
+  def test_id_is_not_defined_on_a_model_with_composite_primary_key
+    book = cpk_books(:cpk_great_author_first_book)
+    order = cpk_orders(:cpk_groceries_order_1)
+
+    assert_equal([book.author_id, book.number], book.id)
+    assert_equal([order.shop_id, order.read_attribute(:id)], order.id)
   end
 end
 

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -1,0 +1,20 @@
+_fixture:
+  model_class: Cpk::Book
+
+cpk_great_author_first_book:
+  author_id: 1
+  number: 1
+  title: "The first book"
+  revision: 1
+
+cpk_great_author_second_book:
+  author_id: 1
+  number: 2
+  title: "The second book"
+  revision: 1
+
+cpk_famous_author_first_book:
+  author_id: 2
+  number: 1
+  title: "Ruby on Rails"
+  revision: 1

--- a/activerecord/test/fixtures/cpk_orders.yml
+++ b/activerecord/test/fixtures/cpk_orders.yml
@@ -1,0 +1,17 @@
+_fixture:
+  model_class: Cpk::Order
+
+cpk_groceries_order_1:
+  id: 1
+  shop_id: 1
+  status: "paid"
+
+cpk_groceries_order_2:
+  id: 2
+  shop_id: 1
+  status: "paid"
+
+cpk_coffee_order_1:
+  id: 3
+  shop_id: 2
+  status: "cancelled"

--- a/activerecord/test/models/cpk.rb
+++ b/activerecord/test/models/cpk.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "cpk/book"
+require_relative "cpk/order"

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Cpk
+  class Book < ActiveRecord::Base
+    self.table_name = :cpk_books
+    self.primary_key = [:author_id, :number]
+  end
+end

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Cpk
+  class Order < ActiveRecord::Base
+    self.table_name = :cpk_orders
+    self.primary_key = [:shop_id, :id]
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -239,6 +239,19 @@ ActiveRecord::Schema.define do
     t.references :citation
   end
 
+  create_table :cpk_books, primary_key: [:author_id, :number], force: true do |t|
+    t.integer :author_id
+    t.integer :number
+    t.string :title
+    t.integer :revision
+  end
+
+  create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|
+    t.integer :shop_id
+    t.integer :id
+    t.string :status
+  end
+
   create_table :clothing_items, force: true do |t|
     t.string :clothing_type
     t.string :color


### PR DESCRIPTION
This PR defines the public API of how `ActiveRecord::Base#id` should behave given a model with the `primary_key` being an array (a composite primary key).

Given a model with a composite primary key:
```ruby
class Order < ActiveRecord::Base
  self.primary_key = [:shop_id, :id]
end
```

`ActiveRecord::Base#id` method will return an array of values for every column of the primary key.

```ruby
order = Order.create!(shop_id: 1, id: 2)
order.id # => [1, 2]
```

The `id` column is accessible through the `read_attribute` method:

```ruby
order.read_attribute(:id) # => 2
```

### Alternative

We have considered only one alternative and it was based on the `Cpk::Order` model example from the tests. 
In the current approach a model with `id` column being part of the composite primary key raises a fundamental question - how to fetch the `id` column value if `#id` method is taken and returns an array.
To answer this question we have explored an API where `ActiveRecord::Base#id` for a model with CPK returns a single value of the `"id"` column if such exists. This sounds like a very suitable solution for a model like `Cpk::Order`, however we consider this to be harmful from the long term perspective. 
Bringing the dual nature of the `#id` return value is hurting code that heavily relies on the "ID" term to mean "an identifier"  

 For example given a situation like:
```ruby
column_names = Array(record.class.primary_key)
primary_key_values = Array(record.id)
```
It is much more helpful to know that the return values are always consistent regardless of what kind of primary key `record` is using. However the alternative assumes that the `primary_key_values` may suddenly become an array of a single value while `column_names` containing all parts of the primary key complicating handling of such abstract code. 

It should still be possible to be abstract using
```ruby
column_names = Array(record.class.primary_key)
primary_key_values = Array(record.class.primary_key).map { |pk| pk.read_attribute(pk) }
```
But it results in a much less friendly code to be maintained and almost makes the `#id` abstraction redundant as we can't be reliably using it.

Other possible examples of an abstract code that benefits from `#id` being "an identifier" and not a single value of the `id` column:
- If we end up having a row-constructor-like querying syntax in `.where` - `.where(record.class.primary_key => record.id)` can be abstract regardless of the underlying model being used.
- record.class.find(record.id) can also stay abstract once we add support for `.find()` to support composite primary key sets 

With the chosen approach we are preserving the special meaning of the `#id` method as it always has been and assuming newly created tables preferably avoid having a non-primary key column named `id`, similarly to https://github.com/rails/rails/issues/34402#issuecomment-440416107.  While also leaving this up to the application to decide how to fetch the `id` column value. Whether it's through `record.read_attribute(:id)` or `record.attributes["id"]` or `record.id.second` (implies the knowledge of the composite key structure).

### `read_attribute`

Unlike `ids`, `read_attribute` implies a single value being returned for a given attribute so we decided to preserve it as a way to fetch the `id` value for models with a composite primary key 


#### Fixtures

Currently parts of the composite primary key are not being auto-populated based on the fixture name so we need to address it. But for now manually populated values of the composite key are sufficient to cover other aspects of the `primary_key` being nil with tests.

### Next steps

- Setting the `primary_key` to an array should implicitly set `query_constraints` to the same value to enable "virtual primary key" capabilities.
- We should stop issuing a warning when fetching a composite primary key from schema and just allow setting it instead.
