### PR TITLE
fix verbose logging guide info

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -217,7 +217,7 @@ irb(main):001:0> Article.pamplemousse
 => #<Comment id: 2, author: "1", body: "Well, actually...", article_id: 1, created_at: "2018-10-19 00:56:10", updated_at: "2018-10-19 00:56:10">
 ```
 
-After running `ActiveRecord::Base.verbose_query_logs = true` in the `bin/rails console` session to enable verbose query logs and running the method again, it becomes obvious what single line of code is generating all these discrete database calls:
+After running `ActiveRecord.verbose_query_logs = true` in the `bin/rails console` session to enable verbose query logs and running the method again, it becomes obvious what single line of code is generating all these discrete database calls:
 
 ```
 irb(main):003:0> Article.pamplemousse


### PR DESCRIPTION
This is a tiny PR to update the 7.0 branch of the Rails guides about the how to turn on enriched logging for ActiveRecord. The Edge guides are up-to-date, but the 7.0 are not, and using the code currently in the guide results in the following warning:

``> ActiveRecord::Base.verbose_query_logs = true
DEPRECATION WARNING: ActiveRecord::Base.verbose_query_logs= is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.verbose_query_logs=` instead.``

This corrects the guides.