### PR TITLE
Add `*_deliver` callbacks for Action Mailer

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Added `*_deliver` callbacks to `ActionMailer::Base` that wrap mail message delivery.
+
+    Example:
+
+    ```ruby
+    class EventsMailer < ApplicationMailer
+      after_deliver do
+        User.find_by(email: message.to.first).update(email_provider_id: message.message_id, emailed_at: Time.current)
+      end
+    end
+    ```
+
+    *Ben Sheldon*
+
 *   Added `deliver_enqueued_emails` to `ActionMailer::TestHelper`. This method
     delivers all enqueued email jobs.
 

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -43,6 +43,7 @@ module ActionMailer
   end
 
   autoload :Base
+  autoload :Callbacks
   autoload :DeliveryMethods
   autoload :InlinePreviewInterceptor
   autoload :MailHelper

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -316,12 +316,14 @@ module ActionMailer
   #
   # = Callbacks
   #
-  # You can specify callbacks using <tt>before_action</tt> and <tt>after_action</tt> for configuring your messages.
-  # This may be useful, for example, when you want to add default inline attachments for all
-  # messages sent out by a certain mailer class:
+  # You can specify callbacks using <tt>before_action</tt> and <tt>after_action</tt> for configuring your messages,
+  # and using <tt>before_deliver</tt> and <tt>after_deliver</tt> for wrapping the delivery process.
+  # For example, when you want to add default inline attachments and log delivery for all messages
+  # sent out by a certain mailer class:
   #
   #   class NotifierMailer < ApplicationMailer
   #     before_action :add_inline_attachment!
+  #     after_deliver :log_delivery
   #
   #     def welcome
   #       mail
@@ -331,9 +333,13 @@ module ActionMailer
   #       def add_inline_attachment!
   #         attachments.inline["footer.jpg"] = File.read('/path/to/filename.jpg')
   #       end
+  #
+  #       def log_delivery
+  #         Rails.logger.info "Sent email with message id '#{message.message_id}' at #{Time.current}."
+  #       end
   #   end
   #
-  # Callbacks in Action Mailer are implemented using
+  # Action callbacks in Action Mailer are implemented using
   # AbstractController::Callbacks, so you can define and configure
   # callbacks in the same manner that you would use callbacks in classes that
   # inherit from ActionController::Base.
@@ -466,6 +472,7 @@ module ActionMailer
   # * <tt>deliver_later_queue_name</tt> - The queue name used by <tt>deliver_later</tt> with the default
   #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue name.
   class Base < AbstractController::Base
+    include Callbacks
     include DeliveryMethods
     include QueuedDelivery
     include Rescuable

--- a/actionmailer/lib/action_mailer/callbacks.rb
+++ b/actionmailer/lib/action_mailer/callbacks.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ActionMailer
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    included do
+      include ActiveSupport::Callbacks
+      define_callbacks :deliver, skip_after_callbacks_if_terminated: true
+    end
+
+    module ClassMethods
+      # Defines a callback that will get called right before the
+      # message is sent to the delivery method.
+      def before_deliver(*filters, &blk)
+        set_callback(:deliver, :before, *filters, &blk)
+      end
+
+      # Defines a callback that will get called right after the
+      # message's delivery method is finished.
+      def after_deliver(*filters, &blk)
+        set_callback(:deliver, :after, *filters, &blk)
+      end
+
+      # Defines a callback that will get called around the message's deliver method.
+      def around_deliver(*filters, &blk)
+        set_callback(:deliver, :around, *filters, &blk)
+      end
+    end
+  end
+end

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -108,7 +108,9 @@ module ActionMailer
     #
     def deliver_now!
       processed_mailer.handle_exceptions do
-        message.deliver!
+        processed_mailer.run_callbacks(:deliver) do
+          message.deliver!
+        end
       end
     end
 
@@ -118,13 +120,15 @@ module ActionMailer
     #
     def deliver_now
       processed_mailer.handle_exceptions do
-        message.deliver
+        processed_mailer.run_callbacks(:deliver) do
+          message.deliver
+        end
       end
     end
 
     private
       # Returns the processed Mailer instance. We keep this instance
-      # on hand so we can delegate exception handling to it.
+      # on hand so we can run callbacks and delegate exception handling to it.
       def processed_mailer
         @processed_mailer ||= @mailer_class.new.tap do |mailer|
           mailer.process @action, *@args

--- a/actionmailer/test/callbacks_test.rb
+++ b/actionmailer/test/callbacks_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "mailers/callback_mailer"
+
+class ActionMailerCallbacksTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @previous_delivery_method = ActionMailer::Base.delivery_method
+    ActionMailer::Base.delivery_method = :test
+    CallbackMailer.rescue_from_error = nil
+    CallbackMailer.after_deliver_instance = nil
+    CallbackMailer.around_deliver_instance = nil
+    CallbackMailer.abort_before_deliver = nil
+    CallbackMailer.around_handles_error = nil
+  end
+
+  teardown do
+    ActionMailer::Base.deliveries.clear
+    ActionMailer::Base.delivery_method = @previous_delivery_method
+    CallbackMailer.rescue_from_error = nil
+    CallbackMailer.after_deliver_instance = nil
+    CallbackMailer.around_deliver_instance = nil
+    CallbackMailer.abort_before_deliver = nil
+    CallbackMailer.around_handles_error = nil
+  end
+
+  test "deliver_now should call after_deliver callback and can access sent message" do
+    mail_delivery = CallbackMailer.test_message
+    mail_delivery.deliver_now
+
+    assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
+    assert_not_empty CallbackMailer.after_deliver_instance.message.message_id
+    assert_equal mail_delivery.message_id, CallbackMailer.after_deliver_instance.message.message_id
+    assert_equal "test-receiver@test.com", CallbackMailer.after_deliver_instance.message.to.first
+  end
+
+  test "deliver_now! should call after_deliver callback" do
+    CallbackMailer.test_message.deliver_now
+
+    assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
+  end
+
+  test "before_deliver can abort the delivery and not run after_deliver callbacks" do
+    CallbackMailer.abort_before_deliver = true
+
+    mail_delivery = CallbackMailer.test_message
+    mail_delivery.deliver_now
+
+    assert_nil mail_delivery.message_id
+    assert_nil CallbackMailer.after_deliver_instance
+  end
+
+  test "deliver_later should call after_deliver callback and can access sent message" do
+    perform_enqueued_jobs { CallbackMailer.test_message.deliver_later }
+    assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
+    assert_not_empty CallbackMailer.after_deliver_instance.message.message_id
+  end
+
+  test "around_deliver is called after rescue_from on action processing exceptions" do
+    CallbackMailer.around_handles_error = true
+
+    CallbackMailer.test_raise_action.deliver_now
+    assert CallbackMailer.rescue_from_error
+  end
+
+  test "around_deliver is called before rescue_from on deliver! exceptions" do
+    CallbackMailer.around_handles_error = true
+
+    stub_any_instance(Mail::TestMailer, instance: Mail::TestMailer.new({})) do |instance|
+      instance.stub(:deliver!, proc { raise "boom deliver exception" }) do
+        CallbackMailer.test_message.deliver_now
+      end
+    end
+
+    assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
+    assert_nil CallbackMailer.rescue_from_error
+  end
+end

--- a/actionmailer/test/mailers/callback_mailer.rb
+++ b/actionmailer/test/mailers/callback_mailer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+CallbackMailerError = Class.new(StandardError)
+class CallbackMailer < ActionMailer::Base
+  cattr_accessor :rescue_from_error
+  cattr_accessor :after_deliver_instance
+  cattr_accessor :around_deliver_instance
+  cattr_accessor :abort_before_deliver
+  cattr_accessor :around_handles_error
+
+  rescue_from CallbackMailerError do |error|
+    @@rescue_from_error = error
+  end
+
+  before_deliver do
+    throw :abort if @@abort_before_deliver
+  end
+
+  after_deliver do
+    @@after_deliver_instance = self
+  end
+
+  around_deliver do |mailer, block|
+    @@around_deliver_instance = self
+    block.call
+  rescue StandardError
+    raise unless @@around_handles_error
+  end
+
+  def test_message(*)
+    mail(from: "test-sender@test.com", to: "test-receiver@test.com", subject: "Test Subject", body: "Test Body")
+  end
+
+  def test_raise_action
+    raise CallbackMailerError, "boom action processing"
+  end
+end

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -697,9 +697,10 @@ Action Mailer Callbacks
 -----------------------
 
 Action Mailer allows for you to specify a [`before_action`][], [`after_action`][] and
-[`around_action`][].
+[`around_action`][] to configure the message, and [`before_deliver`][], [`after_deliver`][] and
+[`around_deliver`][] to control the delivery.
 
-* Filters can be specified with a block or a symbol to a method in the mailer
+* Callbacks can be specified with a block or a symbol to a method in the mailer
   class similar to controllers.
 
 * You could use a `before_action` to set instance variables, populate the mail
@@ -776,11 +777,16 @@ class UserMailer < ApplicationMailer
 end
 ```
 
-* Mailer Filters abort further processing if body is set to a non-nil value.
+* You could use an `after_delivery` to record the delivery of the message.
+
+* Mailer callbacks abort further processing if body is set to a non-nil value. `before_deliver` can abort with `throw :abort`.
 
 [`after_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-after_action
+[`after_deliver`]: https://api.rubyonrails.org/classes/ActionMailer/Callbacks/ClassMethods.html#method-i-after_deliver
 [`around_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
+[`around_deliver`]: https://api.rubyonrails.org/classes/ActionMailer/Callbacks/ClassMethods.html#method-i-around_deliver
 [`before_action`]: https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action
+[`before_deliver`]: https://api.rubyonrails.org/classes/ActionMailer/Callbacks/ClassMethods.html#method-i-before_deliver
 
 Using Action Mailer Helpers
 ---------------------------

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1290,6 +1290,7 @@ class Uploader {
 
 To implement customized authentication, a new controller must be created on
 the Rails application, similar to the following:
+
 ```ruby
 class DirectUploadsController < ActiveStorage::DirectUploadsController
   skip_before_action :verify_authenticity_token


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to add deliver callbacks (e.g. `before_deliver`, `after_deliver`, `around_deliver`) to Action Mailer. The benefit is that it allows delivery observer/interceptor-like behaviors within the context of the instance of `ActionMailer::Base` rather than operating only on the `Mail` object.

Use cases for this:

- Accurately updating an AR model's `delivered_at` value, especially when using `deliver_later`.
- Doing something with the delivery provider's `message_id` (e.g. storing it with a reference to the user or message so that provider webhooks for opened/clicked/spammed can be associated)
- Handling the weird delivery errors like invalid email addresses that are not visible until the mailer is attempted to be delivered... while having the full context of the Mailer (e.g. adding a note onto the User record that the email was undeliverable).

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I also found https://github.com/rails/rails/pull/42139, which is similar but doesn't go all the way of providing the context of the Mailer.

Something to note: Action Mailer's `rescue_from` wraps both the mailer's action processing/rendering step, and the deliver step (effectively twice). I only wanted the deliver callback to wrap deliver, because the existing other `*_action` callback wraps the action processing/rendering step. In pseudocode:

```ruby
processed_mailer = rescue_from do
  around_action do
    render_mail
  end
end

rescue_from do
  around_deliver do
    deliver(processed_mailer)
  end 
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
