### PR TITLE
Use composite `primary_key` value as a fallback for `query_constraints_list

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -493,7 +493,7 @@ module ActiveRecord
 
       def query_constraints_list # :nodoc:
         @query_constraints_list ||= if base_class? || primary_key != base_class.primary_key
-          @_query_constraints_list
+          primary_key.is_a?(Array) ? primary_key : @_query_constraints_list
         else
           base_class.query_constraints_list
         end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -5,4 +5,7 @@ module Cpk
     self.table_name = :cpk_books
     self.primary_key = [:author_id, :number]
   end
+
+  class BestSeller < Book
+  end
 end


### PR DESCRIPTION
Given a model with a composite primary key, the `query_constraints_list` should equal the `primary_key` value to enable capabilities managed by `query_constraints_list` such as `destroy`, `update`, `delete` and others.

The change is similar to https://github.com/rails/rails/pull/46439/files which was reverted by https://github.com/rails/rails/pull/47378 with one main difference - we will only use `primary_key` value in `query_constraints_list` if the `primary_key` is an array which semantically means that the model is using a composite primary key. This makes the change backwards compatible by keeping `query_constraints_list` `nil` for all existing and non-cpk models. 


### Testing
I decided to test it in the most unit-test way possible. Directly assert for the `query_constraints_list` to be equal to the `primary_key` and rely on the fact that the `query_constraints` works as expected as it's validated by it's own set of tests.

I could have introduced a new set of integration tests for the cpk models but at this point I find this excessive. Though as a sanity check I manually made sure that basic operations like `update` `delete` `reload` work and include all parts of the composite primary keys in SQL.