### PR TITLE
Fix fixtures id generation for composite primary keys

### DIFF
--- a/activerecord/lib/active_record/fixture_set/model_metadata.rb
+++ b/activerecord/lib/active_record/fixture_set/model_metadata.rb
@@ -12,12 +12,22 @@ module ActiveRecord
       end
 
       def primary_key_type
-        @primary_key_type ||= @model_class && @model_class.type_for_attribute(@model_class.primary_key).type
+        @primary_key_type ||= @model_class && column_type(@model_class.primary_key)
       end
 
-      def has_primary_key_column?
-        @has_primary_key_column ||= primary_key_name &&
-          @model_class.columns.any? { |col| col.name == primary_key_name }
+      def column_type(column_name)
+        @column_type ||= {}
+        return @column_type[column_name] if @column_type.key?(column_name)
+
+        @column_type[column_name] = @model_class && @model_class.type_for_attribute(column_name).type
+      end
+
+      def has_column?(column_name)
+        column_names.include?(column_name)
+      end
+
+      def column_names
+        @column_names ||= @model_class ? @model_class.columns.map(&:name).to_set : Set.new
       end
 
       def timestamp_column_names

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -118,10 +118,10 @@ module ActiveRecord
 
         def generate_primary_key
           # generate a primary key if necessary
-          if model_metadata.has_primary_key_column? && !@row.include?(model_metadata.primary_key_name)
-            @row[model_metadata.primary_key_name] = ActiveRecord::FixtureSet.identify(
-              @label, model_metadata.primary_key_type
-            )
+          Array(model_metadata.primary_key_name).each do |pk|
+            next if !model_metadata.has_column?(pk) || @row.include?(pk)
+
+            @row[pk] = ActiveRecord::FixtureSet.identify(@label, model_metadata.column_type(pk))
           end
         end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -33,6 +33,7 @@ require "models/task"
 require "models/topic"
 require "models/traffic_light"
 require "models/treasure"
+require "models/cpk"
 
 class FixturesTest < ActiveRecord::TestCase
   include ConnectionHelper
@@ -1626,5 +1627,16 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
       def readonly_config
         default_config.merge("replica" => true)
       end
+  end
+
+  class CompositePkFixturesTest < ActiveRecord::TestCase
+    fixtures :cpk_orders, :cpk_books
+
+    def test_generates_composite_primary_key_ids
+      assert_not_empty(cpk_orders(:cpk_groceries_order_1).id.compact)
+
+      assert_not_nil(cpk_books(:cpk_great_author_first_book).author_id)
+      assert_not_nil(cpk_books(:cpk_great_author_first_book).number)
+    end
   end
 end

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -2,19 +2,13 @@ _fixture:
   model_class: Cpk::Book
 
 cpk_great_author_first_book:
-  author_id: 1
-  number: 1
   title: "The first book"
   revision: 1
 
 cpk_great_author_second_book:
-  author_id: 1
-  number: 2
   title: "The second book"
   revision: 1
 
 cpk_famous_author_first_book:
-  author_id: 2
-  number: 1
   title: "Ruby on Rails"
   revision: 1

--- a/activerecord/test/fixtures/cpk_orders.yml
+++ b/activerecord/test/fixtures/cpk_orders.yml
@@ -2,16 +2,10 @@ _fixture:
   model_class: Cpk::Order
 
 cpk_groceries_order_1:
-  id: 1
-  shop_id: 1
   status: "paid"
 
 cpk_groceries_order_2:
-  id: 2
-  shop_id: 1
   status: "paid"
 
 cpk_coffee_order_1:
-  id: 3
-  shop_id: 2
   status: "cancelled"


### PR DESCRIPTION
This PR fixes primary key autogeneration in fixtures, this removes the need for explicitly specified primary key columns and allows us to point to models from associated models using `ActiveRecord::FixtureSet.identify(:cpk_fixture_label)`

`ModelMetadata` is private to Rails so I made some refactoring by changing `primary_key_type` to a bit more abstract `column_type` and `has_primary_key_column?` to `has_column?(column_name)`

https://github.com/rails/rails/blob/9539973d2191ddb12b584474c4c7fae8c22b4a15/activerecord/lib/active_record/fixture_set/table_row.rb#L175

Will need to be fixed separately as `primary_key_name` now can be an array.
