### PR TITLE
Remove obsolete `AC::Rendering#_normalize_args`

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -195,13 +195,6 @@ module ActionController
         end
       end
 
-      # Normalize arguments by catching blocks and setting them on :update.
-      def _normalize_args(action = nil, options = {}, &blk)
-        options = super
-        options[:update] = blk if block_given?
-        options
-      end
-
       # Normalize both text and status options.
       def _normalize_options(options)
         _normalize_text(options)


### PR DESCRIPTION
The sole purpose of `ActionController::Rendering#_normalize_args` is to store the given block in `options[:update]`.  This behavior was added long ago in 6923b392b740f2346326634532b40cf24a0f26ef (as [part of `ActionController::Base#_normalize_options`][part-of]) to support RJS. Rails no longer supports RJS, so this override is no longer necessary.

[part-of]: https://github.com/rails/rails/commit/6923b392b740f2346326634532b40cf24a0f26ef#diff-febf2f89e7c197d6a9a7077c96031c68b2b7ac4d8ce7ec634de92b164e5f69adR100
