### PR TITLE
Support composite foreign keys via migration helpers

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Support composite foreign keys via migration helpers.
+
+    ```ruby
+    # Assuming "carts" table has "(shop_id, user_id)" as a primary key.
+
+    add_foreign_key(:orders, :carts, primary_key: [:shop_id, :user_id])
+
+    remove_foreign_key(:orders, :carts, primary_key: [:shop_id, :user_id])
+    foreign_key_exists?(:orders, :carts, primary_key: [:shop_id, :user_id])
+    ```
+
+    *fatkodima*
+
 *   Adds support for `if_not_exists` when adding a check constraint.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -80,10 +80,12 @@ module ActiveRecord
         end
 
         def visit_ForeignKeyDefinition(o)
+          quoted_columns = Array(o.column).map { |c| quote_column_name(c) }
+          quoted_primary_keys = Array(o.primary_key).map { |c| quote_column_name(c) }
           sql = +<<~SQL
             CONSTRAINT #{quote_column_name(o.name)}
-            FOREIGN KEY (#{quote_column_name(o.column)})
-              REFERENCES #{quote_table_name(o.to_table)} (#{quote_column_name(o.primary_key)})
+            FOREIGN KEY (#{quoted_columns.join(", ")})
+              REFERENCES #{quote_table_name(o.to_table)} (#{quoted_primary_keys.join(", ")})
           SQL
           sql << " #{action_sql('DELETE', o.on_delete)}" if o.on_delete
           sql << " #{action_sql('UPDATE', o.on_update)}" if o.on_update

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -162,7 +162,7 @@ module ActiveRecord
       def defined_for?(to_table: nil, validate: nil, **options)
         (to_table.nil? || to_table.to_s == self.to_table) &&
           (validate.nil? || validate == self.options.fetch(:validate, validate)) &&
-          options.all? { |k, v| self.options[k].to_s == v.to_s }
+          options.all? { |k, v| Array(self.options[k]).map(&:to_s) == Array(v).map(&:to_s) }
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1207,7 +1207,7 @@ module ActiveRecord
         foreign_key_for(from_table, to_table: to_table, **options).present?
       end
 
-      def foreign_key_column_for(table_name, column_name = "id") # :nodoc:
+      def foreign_key_column_for(table_name, column_name) # :nodoc:
         name = strip_table_name_prefix_and_suffix(table_name)
         "#{name.singularize}_#{column_name}"
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1219,9 +1219,10 @@ module ActiveRecord
           options[:column] ||= options[:primary_key].map do |pk_column|
             foreign_key_column_for(to_table, pk_column)
           end
+        else
+          options[:column] ||= foreign_key_column_for(to_table, "id")
         end
 
-        options[:column] ||= foreign_key_column_for(to_table)
         options[:name]   ||= foreign_key_name(from_table, options)
 
         if options[:column].is_a?(Array) || options[:primary_key].is_a?(Array)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -877,7 +877,7 @@ module ActiveRecord
           validate_constraint table_name, chk_name_to_validate
         end
 
-        def foreign_key_column_for(table_name, column_name = "id") # :nodoc:
+        def foreign_key_column_for(table_name, column_name) # :nodoc:
           _schema, table_name = extract_schema_qualified_name(table_name)
           super
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -117,12 +117,7 @@ module ActiveRecord
             if indkey.include?(0)
               columns = expressions
             else
-              columns = Hash[query(<<~SQL, "SCHEMA")].values_at(*indkey).compact
-                SELECT a.attnum, a.attname
-                FROM pg_attribute a
-                WHERE a.attrelid = #{oid}
-                AND a.attnum IN (#{indkey.join(",")})
-              SQL
+              columns = column_names_from_column_numbers(oid, indkey)
 
               # prevent INCLUDE columns from being matched
               columns.reject! { |c| include_columns.include?(c) }
@@ -536,7 +531,7 @@ module ActiveRecord
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
           fk_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
-            SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred
+            SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conkey, c.confkey, c.conrelid, c.confrelid
             FROM pg_constraint c
             JOIN pg_class t1 ON c.conrelid = t1.oid
             JOIN pg_class t2 ON c.confrelid = t2.oid
@@ -550,10 +545,22 @@ module ActiveRecord
           SQL
 
           fk_info.map do |row|
+            to_table = Utils.unquote_identifier(row["to_table"])
+            conkey = row["conkey"].scan(/\d+/).map(&:to_i)
+            confkey = row["confkey"].scan(/\d+/).map(&:to_i)
+
+            if conkey.size > 1
+              column = column_names_from_column_numbers(row["conrelid"], conkey)
+              primary_key = column_names_from_column_numbers(row["confrelid"], confkey)
+            else
+              column = Utils.unquote_identifier(row["column"])
+              primary_key = row["primary_key"]
+            end
+
             options = {
-              column: Utils.unquote_identifier(row["column"]),
+              column: column,
               name: row["name"],
-              primary_key: row["primary_key"]
+              primary_key: primary_key
             }
 
             options[:on_delete] = extract_foreign_key_action(row["on_delete"])
@@ -561,7 +568,6 @@ module ActiveRecord
             options[:deferrable] = extract_constraint_deferrable(row["deferrable"], row["deferred"])
 
             options[:validate] = row["valid"]
-            to_table = Utils.unquote_identifier(row["to_table"])
 
             ForeignKeyDefinition.new(table_name, to_table, options)
           end
@@ -871,7 +877,7 @@ module ActiveRecord
           validate_constraint table_name, chk_name_to_validate
         end
 
-        def foreign_key_column_for(table_name) # :nodoc:
+        def foreign_key_column_for(table_name, column_name = "id") # :nodoc:
           _schema, table_name = extract_schema_qualified_name(table_name)
           super
         end
@@ -1088,6 +1094,15 @@ module ActiveRecord
           def extract_schema_qualified_name(string)
             name = Utils.extract_schema_qualified_name(string.to_s)
             [name.schema, name.identifier]
+          end
+
+          def column_names_from_column_numbers(table_oid, column_numbers)
+            Hash[query(<<~SQL, "SCHEMA")].values_at(*column_numbers).compact
+              SELECT a.attnum, a.attname
+              FROM pg_attribute a
+              WHERE a.attrelid = #{table_oid}
+              AND a.attnum IN (#{column_numbers.join(", ")})
+            SQL
           end
       end
     end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -283,7 +283,7 @@ module ActiveRecord
               remove_prefix_and_suffix(foreign_key.to_table).inspect,
             ]
 
-            if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table)
+            if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table, "id")
               parts << "column: #{foreign_key.column.inspect}"
             end
 


### PR DESCRIPTION
Closes #47593.

```ruby
# Assuming "carts" table has "(shop_id, id)" as a primary key.

add_foreign_key(:orders, :carts, primary_key: [:shop_id, :id])
# or
add_foreign_key(:orders, :carts, column: [:cart_shop_id, :cart_id])

remove_foreign_key(:orders, :carts, primary_key: [:shop_id, :id])
foreign_key_exists?(:orders, :carts, primary_key: [:shop_id, :id])
```

We [discussed](https://github.com/rails/rails/issues/47593#issuecomment-1458359213) 3 possible ways of using `add_foreign_key`.

The first one (`add_foreign_key :brochures, :cars`) (no `:column` and `:primary_key` options) turned out to be complex to implement, as it introduced a lot of kinda ugly changes in many places because we needed to properly generate these column names (consider configured table name prefixes and suffixes, pass a connection around to be able to query a primary key for the `to_table`. Some classes, like `ForeignKeyDefinition` does not have access to the connection, and so we needed to calculate these columns at several places differently and pass there). 

And the biggest problem is when we need to add a foreign key for a self referencing tables, like https://github.com/rails/rails/blob/1df6ad0ecc8bdefa233eb388c38d1ff845862428/activerecord/test/cases/migration/references_foreign_key_test.rb#L221-L225 That would produce very not elegant code.

So I made that it is required to pass at least one of `:column` or `:primary_key` options, as it is easy to infer one from the other.

cc @eileencodes @nvasilevski 