### PR TITLE
Remove unused require of "active_support/deprecation" in DBconsole

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/string/filters"
-require "active_support/deprecation"
 require "rails/command/environment_argument"
 
 module Rails


### PR DESCRIPTION
In 7a26f2625533a0d45c0a1efbd264d3eb7462ee7b the usage of `ActiveSupport::Deprecation.warn` in `DBconsoleCommand` was replaced with `Rails.deprecator.warn`, which is already required by Rails::Command.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
