### PR TITLE
Update GitHub organization of Minitest [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -296,7 +296,7 @@ This test should now pass.
 By now you've caught a glimpse of some of the assertions that are available. Assertions are the worker bees of testing. They are the ones that actually perform the checks to ensure that things are going as planned.
 
 Here's an extract of the assertions you can use with
-[`Minitest`](https://github.com/seattlerb/minitest), the default testing library
+[`Minitest`](https://github.com/minitest/minitest), the default testing library
 used by Rails. The `[msg]` parameter is an optional string message you can
 specify to make your test failure messages clearer.
 


### PR DESCRIPTION
### Motivation / Background

https://github.com/seattlerb/minitest repo URL is changed to https://github.com/minitest/minitest.

### Detail

This update avoids unnecessary redirects from the old URL to the new URL.

### Additional information

There doesn't seem to be an alternative URL to http://docs.seattlerb.org/minitest used in guides/source/testing.md, so it's left as is.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
