### PR TITLE
Notify discord when workflows fail on main

### DIFF
--- a/.github/workflows/build-and-test-dev-image.yml
+++ b/.github/workflows/build-and-test-dev-image.yml
@@ -32,3 +32,12 @@ jobs:
         -p 3000:3000 $APP_NAME &
     - name: Test container
       run: ruby -r ./.github/workflows/scripts/test-container.rb
+
+  notify:
+    runs-on: ubuntu-latest
+    if: always() && github.ref_name == 'main'
+    needs: build-and-test-dev-image
+    steps:
+      - uses: zzak/action-discord@v4
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,12 @@ jobs:
           pip install codespell==2.1.0
       - name: Check spelling with codespell
         run: codespell --ignore-words=codespell.txt --skip="./actionview/test/ujs/public/vendor/qunit.js" || exit 1
+
+  notify:
+    runs-on: ubuntu-latest
+    if: always() && github.ref_name == 'main'
+    needs: [rails-bin, codespell]
+    steps:
+      - uses: zzak/action-discord@v4
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,3 +22,12 @@ jobs:
 
     - name: Run RuboCop
       run: bundle exec rubocop --parallel
+
+  notify:
+    runs-on: ubuntu-latest
+    if: always() && github.ref_name == 'main'
+    needs: build
+    steps:
+      - uses: zzak/action-discord@v4
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
[action-discord](https://github.com/zzak/action-discord) is designed to be similar to the existing Buildkite notifications in `#rails-builds` for all workflows on GHA. Especially, we want to know when `main` is failing so it can be fixed accordingly.

## How to setup

We need to pass the `DISCORD_WEBHOOK` url into this action.

### 1. Go to channel settings for the notifications channel in discord

<img width="296" alt="Screenshot 2023-03-12 at 8 09 35" src="https://user-images.githubusercontent.com/277819/224515462-1d234c60-cb24-437c-9456-1fd2939e0dce.png">

### 2. Go to `Integrations > Webhooks`, and click "New Webhook"

<img width="571" alt="Screenshot 2023-03-12 at 8 10 52" src="https://user-images.githubusercontent.com/277819/224515614-690ab375-aead-4927-9df6-c6bea4500bf2.png">

### 3. Open the new webhook and click "Copy Webhook URL"

<img width="669" alt="Screenshot 2023-03-12 at 8 12 20 (2)" src="https://user-images.githubusercontent.com/277819/224515633-3e83b57f-33af-48dc-b035-614cfe76f83e.png">

### 4. Add the secret to github actions:

![Screenshot 2023-03-12 at 8 17 59](https://user-images.githubusercontent.com/277819/224515693-d28e6697-38ef-4f97-9872-080709acdfe3.png)

****If added as an Organization Secret, then we only need to do this once and share across all repos in the org****

****https://github.com/organizations/rails/settings/secrets/actions/new****
---

## Examples

****Still failing****

<img width="519" alt="Screenshot 2023-03-12 at 8 07 06" src="https://user-images.githubusercontent.com/277819/224515772-8adcde46-3769-4585-a911-8fb68ac3b2dd.png">

****Fixed****

<img width="430" alt="Screenshot 2023-03-12 at 8 07 27" src="https://user-images.githubusercontent.com/277819/224515788-a3803878-50ce-4eb5-877e-e8ccd62a0a19.png">

 **(Using v1 output, compressed repo/branch into title like BK notifs in v4)**
