### PR TITLE
Do not log internal options when running migrations

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -969,9 +969,7 @@ module ActiveRecord
     end
 
     def method_missing(method, *arguments, &block)
-      arg_list = arguments.map(&:inspect) * ", "
-
-      say_with_time "#{method}(#{arg_list})" do
+      say_with_time "#{method}(#{format_arguments(arguments)})" do
         unless connection.respond_to? :revert
           unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
             arguments[0] = proper_table_name(arguments.first, table_name_options)
@@ -1078,6 +1076,22 @@ module ActiveRecord
         else
           yield
         end
+      end
+
+      def format_arguments(arguments)
+        arg_list = arguments[0...-1].map(&:inspect)
+        last_arg = arguments.last
+        if last_arg.is_a?(Hash)
+          last_arg = last_arg.reject { |k, _v| internal_option?(k) }
+          arg_list << last_arg.inspect unless last_arg.empty?
+        else
+          arg_list << last_arg.inspect
+        end
+        arg_list.join(", ")
+      end
+
+      def internal_option?(option_name)
+        option_name.start_with?("_")
       end
 
       def command_recorder


### PR DESCRIPTION
A few "internal" options were added recently to enhance new migrations in some way or another and to preserve compatibility with older migrations (see https://github.com/rails/rails/pull/45136, https://github.com/rails/rails/pull/46178 and https://github.com/rails/rails/pull/42350). These options are passed from the compatibility-related code (`compatibility.rb` file) to the migration helpers, and when running migrations, they are logged to the console.

Before: 
```
-- create_table(users, {:_uses_legacy_table_name=>true, :_skip_validate_options=>true})
   -> 0.0065s
```

These are just noise and can confuse the user, so better to hide them from logging.

Now:
```
-- create_table(users)
   -> 0.0065s
```