### PR TITLE
Allow SQL Warnings to be ignored using error codes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow warning codes to be ignore when reporting SQL warnings.
+
+    Active Record config that can ignore warning codes
+
+    ```ruby
+    # Configure allowlist of warnings that should always be ignored
+    config.active_record.db_warnings_ignore = [
+      "1062", # MySQL Error 1062: Duplicate entry
+    ]
+    ```
+
+    This is supported for the MySQL and PostgreSQL adapters.
+
+    *Nick Borromeo*
+
 *   Introduce `:active_record_fixtures` lazy load hook.
 
     Hooks defined with this name will be run whenever `TestFixtures` is included

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1197,7 +1197,9 @@ module ActiveRecord
         end
 
         def warning_ignored?(warning)
-          ActiveRecord.db_warnings_ignore.any? { |warning_matcher| warning.message.match?(warning_matcher) }
+          ActiveRecord.db_warnings_ignore.any? do |warning_matcher|
+            warning.message.match?(warning_matcher) || warning.code.to_s.match?(warning_matcher)
+          end
         end
     end
   end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -115,6 +115,21 @@ module ActiveRecord
       end
     end
 
+    def with_db_warnings_action(action, warnings_to_ignore = [])
+      original_db_warnings_ignore = ActiveRecord.db_warnings_ignore
+
+      ActiveRecord.db_warnings_action = action
+      ActiveRecord.db_warnings_ignore = warnings_to_ignore
+
+      ActiveRecord::Base.connection.disconnect! # Disconnect from the db so that we reconfigure the connection
+
+      yield
+    ensure
+      ActiveRecord.db_warnings_action = @original_db_warnings_action
+      ActiveRecord.db_warnings_ignore = original_db_warnings_ignore
+      ActiveRecord::Base.connection.disconnect!
+    end
+
     def reset_callbacks(klass, kind)
       old_callbacks = {}
       old_callbacks[klass] = klass.send("_#{kind}_callbacks").dup

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1023,7 +1023,7 @@ Controls the action to be taken when a SQL query produces a warning. The followi
 
 #### `config.active_record.db_warnings_ignore`
 
-Specifies an allowlist of warnings that will be ignored, regardless of the configured `db_warnings_action`.
+Specifies an allowlist of warning codes and messages that will be ignored, regardless of the configured `db_warnings_action`.
 The default behavior is to report all warnings. Warnings to ignore can be specified as Strings or Regexps. For example:
 
   ```ruby
@@ -1032,6 +1032,7 @@ The default behavior is to report all warnings. Warnings to ignore can be specif
   config.active_record.db_warnings_ignore = [
     /Invalid utf8mb4 character string/,
     "An exact warning message",
+    "1062", # MySQL Error 1062: Duplicate entry
   ]
   ```
 


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/46690 the `db_warnings_action` and `db_warnings_ignore` config where added. The `db_warnings_ignore` config can take a list of warning messages to match against.

At GitHub we have a subscriber that that does something like this but also filters out error codes. There might also be other applications that filter via error codes and this could be something they can use instead of just the explicit messages.

### Detail

This adds additional logic to the `warning_ignored?` method for the `AbstractAdapter` to match warning codes as well as warning messages.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
