### PR TITLE
Use `Rack::QueryParser` with `nil` missing value.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -391,6 +391,20 @@ module ActionDispatch
       Session::Options.set self, options
     end
 
+    if Rack.release >= "3"
+      class QueryParser < ::Rack::QueryParser
+        def missing_value
+          nil
+        end
+      end
+
+      QUERY_PARSER = QueryParser.make_default(32)
+
+      def query_parser
+        QUERY_PARSER
+      end
+    end
+
     # Override Rack's GET method to support indifferent access.
     def GET
       fetch_header("action_dispatch.request.query_parameters") do |k|

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -403,6 +403,14 @@ module ActionDispatch
       def query_parser
         QUERY_PARSER
       end
+
+      def query_hash_key
+        "action_dispatch.request.query_hash"
+      end
+
+      def form_hash_key
+        "action_dispatch.request.form_hash"
+      end
     end
 
     # Override Rack's GET method to support indifferent access.

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -403,14 +403,6 @@ module ActionDispatch
       def query_parser
         QUERY_PARSER
       end
-
-      def query_hash_key
-        "action_dispatch.request.query_hash"
-      end
-
-      def form_hash_key
-        "action_dispatch.request.form_hash"
-      end
     end
 
     # Override Rack's GET method to support indifferent access.

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -261,7 +261,7 @@ class TestCaseTest < ActionController::TestCase
   def test_body_stream
     params = Hash[:page, { name: "page name" }, "some key", 123]
 
-    post :render_body, params: params.dup
+    post :render_body, body: params.to_query
 
     assert_equal params.to_query, @response.body
   end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -168,7 +168,7 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
           middleware.use(EarlyParse)
         end
 
-        get "/parse", params: actual
+        get "/parse?#{actual}"
         assert_response :ok
         assert_equal(expected, ::QueryStringParsingTest::TestController.last_query_parameters)
       end


### PR DESCRIPTION
Rack 3 follows the WhatWG standard for the query parser. This deviates from
Rack 2 as `?a` as a query string is was previously interpreted as
`{"a" => nil}` but is now interpreted as `{"a" => ""}`. Rails depends on
the previous behaviour for compatibility, so we introduced hooks into Rack
to restore compatibility.

This depends on https://github.com/rack/rack/pull/2052 being merged and released as part of Rack 3.0.

cc @matthewd @tenderlove 