### PR TITLE
Add `rake guides:lint` task that raises error for broken anchors

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -24,6 +24,12 @@ namespace :guides do
     end
   end
 
+  desc "Lint guides, check for broken links"
+  task :lint do
+    ENV["GUIDES_LINT"] = "1"
+    ruby "-Eutf-8:utf-8", "rails_guides.rb"
+  end
+
   # Validate guides -------------------------------------------------------------------------
   desc 'Validate guides, use ONLY=foo to process just "foo.html"'
   task :validate do

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -26,5 +26,6 @@ RailsGuides::Generator.new(
   only:      env_value["ONLY"],
   epub:      env_flag["EPUB"],
   language:  env_value["GUIDES_LANGUAGE"],
-  direction: env_value["DIRECTION"]
+  direction: env_value["DIRECTION"],
+  lint:      env_flag["GUIDES_LINT"]
 ).generate


### PR DESCRIPTION
The guides generator would previous print an warning when it finds a broken anchor link during page generation.

This task uses that ability and raises an exception when that occurs.

For example:

```
Generating configuring.md as configuring.html
*** BROKEN LINK: #config-active-record-default-column-serialize, perhaps you meant #config-active-record-default-column-serializer.
*** BROKEN LINK: #config-active-record-encryption-hash-digest-class, perhaps you meant #config-active-record-automatic-scope-inversing.
Generating form_helpers.md as form_helpers.html
Generating command_line.md as command_line.html
*** BROKEN LINK: #fixme, perhaps you meant #.
Generating 5_2_release_notes.md as 5_2_release_notes.html
Generating 7_1_release_notes.md as 7_1_release_notes.html
[WARN] BROKEN LINK(s): association_basics.md: #bi-drectional-associations
[WARN] BROKEN LINK(s): configuring.md: #config-active-record-default-column-serialize, #config-active-record-encryption-hash-digest-class
[WARN] BROKEN LINK(s): command_line.md: #fixme
rake aborted!
Command failed with status (1): [/Users/zzak/.rubies/ruby-3.3.0/bin/ruby -E...]
```

