### PR TITLE
Adds support for deferrable exclude constraints in PostgreSQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Adds support for deferrable exclude constraints in PostgreSQL.
+
+    By default, exclude constraints in PostgreSQL are checked after each statement.
+    This works for most use cases, but becomes a major limitation when replacing
+    records with overlapping ranges by using multiple statements.
+
+    ```ruby
+    exclusion_constraint :users, "daterange(valid_from, valid_to) WITH &&", deferrable: :immediate
+    ```
+
+    Passing `deferrable: :immediate` checks constraint after each statement,
+    but allows manually deferring the check using `SET CONSTRAINTS ALL DEFERRED`
+    within a transaction. This will cause the excludes to be checked after the transaction.
+
+    It's also possible to change the default behavior from an immediate check
+    (after the statement), to a deferred check (after the transaction):
+
+    ```ruby
+    exclusion_constraint :users, "daterange(valid_from, valid_to) WITH &&", deferrable: :deferred
+    ```
+
+    *Hiroyuki Ishii*
+
 *   Respect `foreign_type` option to `delegated_type` for `{role}_class` method.
 
     Usage of `delegated_type` with non-conventional `{role}_type` column names can now be specified with `foreign_type` option.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -37,11 +37,12 @@ module ActiveRecord
 
           def visit_ExclusionConstraintDefinition(o)
             sql = ["CONSTRAINT"]
-            sql << o.name
+            sql << quote_column_name(o.name)
             sql << "EXCLUDE"
             sql << "USING #{o.using}" if o.using
             sql << "(#{o.expression})"
             sql << "WHERE (#{o.where})" if o.where
+            sql << "DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
 
             sql.join(" ")
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -202,6 +202,10 @@ module ActiveRecord
           options[:where]
         end
 
+        def deferrable
+          options[:deferrable]
+        end
+
         def export_name_on_schema_dump?
           !ActiveRecord::SchemaDumper.excl_ignore_pattern.match?(name) if name
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -37,6 +37,7 @@ module ActiveRecord
 
                 parts << "where: #{exclusion_constraint.where.inspect}" if exclusion_constraint.where
                 parts << "using: #{exclusion_constraint.using.inspect}" if exclusion_constraint.using
+                parts << "deferrable: #{exclusion_constraint.deferrable.inspect}" if exclusion_constraint.deferrable
 
                 if exclusion_constraint.export_name_on_schema_dump?
                   parts << "name: #{exclusion_constraint.name.inspect}"

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -25,15 +25,43 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
         end
 
         def test_exclusion_constraints
-          exclusion_constraints = @connection.exclusion_constraints("test_exclusion_constraints")
-          assert_equal 1, exclusion_constraints.size
+          expected_exclusion_constraints = [
+            {
+              table_name: "test_exclusion_constraints",
+              name: "test_exclusion_constraints_date_overlap",
+              expression: "daterange(start_date, end_date) WITH &&",
+              where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)",
+              using: :gist,
+              deferrable: false
+            }, {
+              table_name: "test_exclusion_constraints",
+              name: "test_exclusion_constraints_valid_overlap",
+              expression: "daterange(valid_from, valid_to) WITH &&",
+              where: "(valid_from IS NOT NULL) AND (valid_to IS NOT NULL)",
+              using: :gist,
+              deferrable: :immediate
+            }, {
+              table_name: "test_exclusion_constraints",
+              name: "test_exclusion_constraints_transaction_overlap",
+              expression: "daterange(transaction_from, transaction_to) WITH &&",
+              where: "(transaction_from IS NOT NULL) AND (transaction_to IS NOT NULL)",
+              using: :gist,
+              deferrable: :deferred
+            }
+          ]
 
-          constraint = exclusion_constraints.first
-          assert_equal "test_exclusion_constraints", constraint.table_name
-          assert_equal "test_exclusion_constraints_date_overlap", constraint.name
-          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
-          assert_equal :gist, constraint.using
-          assert_equal "(start_date IS NOT NULL) AND (end_date IS NOT NULL)", constraint.where
+          exclusion_constraints = @connection.exclusion_constraints("test_exclusion_constraints")
+          assert_equal expected_exclusion_constraints.size, exclusion_constraints.size
+
+          expected_exclusion_constraints.each do |expected_constraint|
+            constraint = exclusion_constraints.find { |constraint| constraint.name == expected_constraint[:name] }
+            assert_equal expected_constraint[:table_name], constraint.table_name
+            assert_equal expected_constraint[:name], constraint.name
+            assert_equal expected_constraint[:expression], constraint.expression
+            assert_equal expected_constraint[:using], constraint.using
+            assert_equal expected_constraint[:where], constraint.where
+            assert_equal expected_constraint[:deferrable], constraint.deferrable
+          end
         end
 
         def test_exclusion_constraints_scoped_to_schemas
@@ -60,8 +88,55 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
           constraint = exclusion_constraints.first
           assert_equal "invoices", constraint.table_name
           assert_equal "excl_rails_74c9160f55", constraint.name
-
+          assert_equal false, constraint.deferrable
           assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_add_exclusion_constraint_deferrable_false
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: false
+
+          exclusion_constraints = @connection.exclusion_constraints("invoices")
+          assert_equal 1, exclusion_constraints.size
+
+          constraint = exclusion_constraints.first
+          assert_equal "invoices", constraint.table_name
+          assert_equal "excl_rails_74c9160f55", constraint.name
+          assert_equal false, constraint.deferrable
+          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_add_exclusion_constraint_deferrable_initially_immediate
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: :immediate
+
+          exclusion_constraints = @connection.exclusion_constraints("invoices")
+          assert_equal 1, exclusion_constraints.size
+
+          constraint = exclusion_constraints.first
+          assert_equal "invoices", constraint.table_name
+          assert_equal "excl_rails_74c9160f55", constraint.name
+          assert_equal :immediate, constraint.deferrable
+          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_add_exclusion_constraint_deferrable_initially_deferred
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: :deferred
+
+          exclusion_constraints = @connection.exclusion_constraints("invoices")
+          assert_equal 1, exclusion_constraints.size
+
+          constraint = exclusion_constraints.first
+          assert_equal "invoices", constraint.table_name
+          assert_equal "excl_rails_74c9160f55", constraint.name
+          assert_equal :deferred, constraint.deferrable
+          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_add_exclusion_constraint_deferrable_invalid
+          error = assert_raises(ArgumentError) do
+            @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: true
+          end
+
+          assert_equal "deferrable must be `:immediate` or `:deferred`, got: `true`", error.message
         end
 
         def test_added_exclusion_constraint_ensures_valid_values
@@ -71,6 +146,29 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
 
           assert_raises(ActiveRecord::StatementInvalid) do
             Invoice.create(start_date: "2020-12-31", end_date: "2021-01-01")
+          end
+        end
+
+        def test_added_deferrable_initially_immediate_exclusion_constraint
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: :immediate, name: "invoices_date_overlap"
+
+          invoice = Invoice.create(start_date: "2020-01-01", end_date: "2021-01-01")
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            Invoice.transaction(requires_new: true) do
+              Invoice.create!(start_date: "2020-12-31", end_date: "2021-01-01")
+            end
+          end
+
+          assert_nothing_raised do
+            Invoice.transaction(requires_new: true) do
+              Invoice.connection.exec_query("SET CONSTRAINTS invoices_date_overlap DEFERRED")
+              Invoice.create!(start_date: "2020-12-31", end_date: "2021-01-01")
+              invoice.update!(end_date: "2020-12-31")
+
+              # NOTE: Clear `SET CONSTRAINTS` statement at the end of transaction.
+              raise ActiveRecord::Rollback
+            end
           end
         end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -222,10 +222,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   if ActiveRecord::Base.connection.supports_exclusion_constraints?
     def test_schema_dumps_exclusion_constraints
-      constraint_definitions = dump_table_schema("test_exclusion_constraints").split(/\n/).grep(/test_exclusion_constraints_date_overlap/)
+      output = dump_table_schema("test_exclusion_constraints")
+      constraint_definitions = output.split(/\n/).grep(/test_exclusion_constraints_.*_overlap/)
 
-      assert_equal 1, constraint_definitions.size
-      assert_equal 't.exclusion_constraint "daterange(start_date, end_date) WITH &&", where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)", using: :gist, name: "test_exclusion_constraints_date_overlap"', constraint_definitions.first.strip
+      assert_equal 3, constraint_definitions.size
+      assert_match 't.exclusion_constraint "daterange(start_date, end_date) WITH &&", where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)", using: :gist, name: "test_exclusion_constraints_date_overlap"', output
+      assert_match 't.exclusion_constraint "daterange(valid_from, valid_to) WITH &&", where: "(valid_from IS NOT NULL) AND (valid_to IS NOT NULL)", using: :gist, deferrable: :immediate, name: "test_exclusion_constraints_valid_overlap"', output
+      assert_match 't.exclusion_constraint "daterange(transaction_from, transaction_to) WITH &&", where: "(transaction_from IS NOT NULL) AND (transaction_to IS NOT NULL)", using: :gist, deferrable: :deferred, name: "test_exclusion_constraints_transaction_overlap"', output
     end
   end
 

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -131,8 +131,14 @@ _SQL
   create_table :test_exclusion_constraints, force: true do |t|
     t.date :start_date
     t.date :end_date
+    t.date :valid_from
+    t.date :valid_to
+    t.date :transaction_from
+    t.date :transaction_to
 
     t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "test_exclusion_constraints_date_overlap"
+    t.exclusion_constraint "daterange(valid_from, valid_to) WITH &&", using: :gist, where: "valid_from IS NOT NULL AND valid_to IS NOT NULL", name: "test_exclusion_constraints_valid_overlap", deferrable: :immediate
+    t.exclusion_constraint "daterange(transaction_from, transaction_to) WITH &&", using: :gist, where: "transaction_from IS NOT NULL AND transaction_to IS NOT NULL", name: "test_exclusion_constraints_transaction_overlap", deferrable: :deferred
   end
 
   create_table :test_unique_keys, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

By default, exclude constraints in PostgreSQL are checked after each row. This works for most use cases, but becomes a major limitation when replacing records with overlapping ranges by using multiple statements.

```ruby
exclusion_constraint :users, "daterange(valid_from, valid_to) WITH &&", deferrable: :immediate
```

Passing `deferrable: :immediate` checks constraint after each statement, but allows manually deferring the check using `SET CONSTRAINTS ALL DEFERRED` within a transaction. This will cause the excludes to be checked after the transaction.

It's also possible to change the default behavior from an immediate check (after the statement), to a deferred check (after the transaction):

```ruby
exclusion_constraint :users, "daterange(valid_from, valid_to) WITH &&", deferrable: :deferred
```

### Detail

This is follow up to #40224

### Additional information

It is with reference to [this comment](https://github.com/rails/rails/pull/46192#issuecomment-1438368442) that the `deferrable` option accepts only `:immediate` and `:deferred`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
