### PR TITLE
Fix non-existant test fixtures from main branch

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -34,9 +34,6 @@ require "models/shipping_line"
 require "models/essay"
 require "models/member"
 require "models/membership"
-require "models/sharded/blog"
-require "models/sharded/blog_post"
-require "models/sharded/comment"
 require "models/member_detail"
 require "models/organization"
 
@@ -438,7 +435,7 @@ end
 
 class PreloaderTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses,
-           :sharded_blog_posts, :sharded_comments, :members, :member_details, :organizations
+           :members, :member_details, :organizations
 
   def test_preload_with_scope
     post = posts(:welcome)


### PR DESCRIPTION
These were added in a commit on [main][1] but mistakenly included in a backport for a [bugfix][2].

[1]: https://github.com/rails/rails/commit/734f424247645abd11835c01d0222de9c7798398
[2]: https://github.com/rails/rails/commit/99ee8bd7d7ad957a8208a6174c177cc518cd0919
