### PR TITLE
Extend `ActiveRecord::FinderMethods#find` with support for composite pk values

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -77,6 +77,10 @@ module ActiveRecord
             @primary_key
           end
 
+          def composite_primary_key? # :nodoc:
+            primary_key.is_a?(Array)
+          end
+
           # Returns a quoted version of the primary key name, used to construct
           # SQL statements.
           def quoted_primary_key

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -442,10 +442,17 @@ module ActiveRecord
       def find_with_ids(*ids)
         raise UnknownPrimaryKey.new(@klass) if primary_key.nil?
 
-        expects_array = ids.first.kind_of?(Array)
+        expects_array = if primary_key.is_a?(Array)
+          ids.first.first.is_a?(Array)
+        else
+          ids.first.is_a?(Array)
+        end
+
         return [] if expects_array && ids.first.empty?
 
-        ids = ids.flatten.compact.uniq
+        ids = ids.first if expects_array
+
+        ids = ids.compact.uniq
 
         model_name = @klass.name
 
@@ -469,7 +476,12 @@ module ActiveRecord
           MSG
         end
 
-        relation = where(primary_key => id)
+        relation = if primary_key.is_a?(Array)
+          where(primary_key.zip(id).to_h)
+        else
+          where(primary_key => id)
+        end
+
         record = relation.take
 
         raise_record_not_found_exception!(id, 0, 1) unless record
@@ -480,7 +492,12 @@ module ActiveRecord
       def find_some(ids)
         return find_some_ordered(ids) unless order_values.present?
 
-        relation = where(primary_key => ids)
+        relation = if primary_key.is_a?(Array)
+          ids.map { |values_set| where(primary_key.zip(values_set).to_h) }.inject(&:or)
+        else
+          where(primary_key => ids)
+        end
+
         relation = relation.select(table[primary_key]) unless select_values.empty?
         result = relation.to_a
 
@@ -506,7 +523,12 @@ module ActiveRecord
       def find_some_ordered(ids)
         ids = ids.slice(offset_value || 0, limit_value || ids.size) || []
 
-        relation = except(:limit, :offset).where(primary_key => ids)
+        relation = except(:limit, :offset)
+        relation = if primary_key.is_a?(Array)
+          ids.map { |values_set| relation.where(primary_key.zip(values_set).to_h) }.inject(&:or)
+        else
+          relation.where(primary_key => ids)
+        end
         relation = relation.select(table[primary_key]) unless select_values.empty?
         result = relation.records
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -442,7 +442,7 @@ module ActiveRecord
       def find_with_ids(*ids)
         raise UnknownPrimaryKey.new(@klass) if primary_key.nil?
 
-        expects_array = if primary_key.is_a?(Array)
+        expects_array = if klass.composite_primary_key?
           ids.first.first.is_a?(Array)
         else
           ids.first.is_a?(Array)
@@ -476,7 +476,7 @@ module ActiveRecord
           MSG
         end
 
-        relation = if primary_key.is_a?(Array)
+        relation = if klass.composite_primary_key?
           where(primary_key.zip(id).to_h)
         else
           where(primary_key => id)
@@ -492,7 +492,7 @@ module ActiveRecord
       def find_some(ids)
         return find_some_ordered(ids) unless order_values.present?
 
-        relation = if primary_key.is_a?(Array)
+        relation = if klass.composite_primary_key?
           ids.map { |values_set| where(primary_key.zip(values_set).to_h) }.inject(&:or)
         else
           where(primary_key => ids)
@@ -524,7 +524,7 @@ module ActiveRecord
         ids = ids.slice(offset_value || 0, limit_value || ids.size) || []
 
         relation = except(:limit, :offset)
-        relation = if primary_key.is_a?(Array)
+        relation = if klass.composite_primary_key?
           ids.map { |values_set| relation.where(primary_key.zip(values_set).to_h) }.inject(&:or)
         else
           relation.where(primary_key => ids)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -213,6 +213,10 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_raises(ActiveModel::MissingAttributeError) { dashboard.id = "1" }
   end
 
+  def composite_primary_key_is_false_for_a_non_cpk_model
+    assert_not_predicate Dashboard, :composite_primary_key?
+  end
+
   if current_adapter?(:PostgreSQLAdapter)
     def test_serial_with_quoted_sequence_name
       column = MixedCaseMonkey.columns_hash[MixedCaseMonkey.primary_key]
@@ -402,6 +406,10 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
     assert_equal([book.author_id, book.number], book.id)
     assert_equal([order.shop_id, order.read_attribute(:id)], order.id)
+  end
+
+  def composite_primary_key_is_true_for_a_cpk_model
+    assert_predicate Cpk::Book, :composite_primary_key?
   end
 end
 


### PR DESCRIPTION
`ActiveRecord::FinderMethods#find` now supports passing sets of composite primary key values like:

```ruby
Cpk::Book.find([1, 1])
Cpk::Book.find([[1, 1]])
Cpk::Book.find([1, 1], [1, 2])
Cpk::Book.find([[1, 1], [1, 2]])
```

and treats values as values of the composite primary key columns but only for models with the `primary_key` being an `Array`.

The `find` method has always had a signature that accepts an "identifier" like:
```ruby
Model.find(ID)
Model.find([ID])
Model.find(ID, ID)
Model.find([ID, ID])
```
where `ID` is what identifies a model. It wasn't particularly clear as long as Rails only supported single-column identifies. Though with introduction of the composite primary keys support the meaning of ID as an identifier has extended - now a model can be identified by a set of values and we need to extend `find`'s signature to support that.


### Implementation details

The behavior changes only for models with `primary_key` being an `Array` which led to having several `is_a?(Array)` branches  and a few duplications like `primary_key.zip(values_set)` being a repetitive pattern or the way how we build batch-query relation using `.inject(&:or)` is also repetitive. However at this point I would prefer to introduce duplication to gather as many use-cases as possible and make a refactoring by abstracting these examples into a single concept and having verbose use-cases will only help with finding a proper name and place for the concept.


