### PR TITLE
Fix "keyword 'const' is reserved" lint error

### DIFF
--- a/actionview/test/ujs/public/test/.eslintrc.yml
+++ b/actionview/test/ujs/public/test/.eslintrc.yml
@@ -19,3 +19,5 @@ rules:
   comma-spacing: 'error'
   comma-dangle: 'off'
   eol-last: 'error'
+parserOptions:
+  ecmaVersion: 6

--- a/actionview/test/ujs/public/test/data-method.js
+++ b/actionview/test/ujs/public/test/data-method.js
@@ -97,7 +97,7 @@ asyncTest('do not interact with contenteditable elements', 6, function() {
 
   collection = document.getElementsByTagName('form')
   for (const item of collection) {
-    notEqual(item.action, "http://www.shouldnevershowindocument.com/")
+    notEqual(item.action, 'http://www.shouldnevershowindocument.com/')
   }
 })
 


### PR DESCRIPTION
```
/rails/actionview/test/ujs/public/test/data-method.js
  99:8  error  Parsing error: The keyword 'const' is reserved
```

This does not show up on main because the [conversion][1] of rails-ujs
to es6 accidentally stopped linting tests. The `parserOptions`
configuration aligns this branch's eslint configuration with
actionview/.eslintrc on main.

[1]: https://github.com/rails/rails/commit/7d116c93cf6cf2470600860c4c17417df7768c34

Co-authored-by: Jonathan Hefner <jonathan@hefner.pro>

Failing on `7-0-stable`:
https://buildkite.com/rails/rails/builds/94681#0186dcb7-e1bd-4787-9b42-79d4696a647c

This should also be backported to `6-1-stable`:
https://buildkite.com/rails/rails/builds/94679#0186dc87-f3ee-4234-9d75-b168d2ac1467