### PR TITLE
Fix NoMethodError in SafeBuffer#bytesplice

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -217,7 +217,7 @@ module ActiveSupport #:nodoc:
     alias << concat
 
     def bytesplice(*args, value)
-      super(*args, implicit_html_escape_interpolated_argument(value))
+      super(*args, html_escape_interpolated_argument(value))
     end
 
     def insert(index, value)


### PR DESCRIPTION
`html_escape_interpolated_argument` was [renamed][1] to `implicit_html_escape_interpolated_argument` during Rails 7.0 development, so the security fix [backport][2] ended up with the wrong method name.

https://buildkite.com/rails/rails/builds/94679#0186dc87-f488-4520-9eb6-eba741748330

Fixes #47677

[1]: https://github.com/rails/rails/commit/147f207a57a03fc7a52040aa1f6878cf70ee0db7
[2]: https://github.com/rails/rails/commit/3cf23c3f891e2e81c977ea4ab83b62bc2a444b70
