### PR TITLE
Extract gem_ruby_version from app generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -399,6 +399,10 @@ module Rails
         end
       end
 
+      def gem_ruby_version
+        Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION
+      end
+
       def rails_prerelease?
         options.dev? || options.edge? || options.main?
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "\"#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}\"" -%>
+ruby <%= "\"#{gem_ruby_version}\"" -%>
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -86,6 +86,7 @@ module GeneratorsTestHelper
   private
     def gemfile_locals
       {
+        gem_ruby_version: RUBY_VERSION,
         rails_prerelease: false,
         skip_active_storage: true,
         depend_on_bootsnap: false,


### PR DESCRIPTION
This _should_ work, I think the method was just in the wrong place from bc185f041d5f97c9ebf3a167c81b191729afda01.

🟢 Tests passed locally, let's see if it passes CI. :pray:

Pulled from #47584