### PR TITLE
deferrable foreign key can be passed to references

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The deferrable foreign key can be passed to `t.references`.
+
+    *Hiroyuki Ishii*
+
 *   Deprecate `deferrable: true` option of `add_foreign_key`.
 
     `deferrable: true` is deprecated in favor of `deferrable: :immediate`, and

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -23,6 +23,12 @@ module ActiveRecord
             end
           end
 
+          def visit_ForeignKeyDefinition(o)
+            super.dup.tap do |sql|
+              sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+            end
+          end
+
           def visit_CheckConstraintDefinition(o)
             super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
           end

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -62,6 +62,48 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           assert_equal([["testings", "testing_parents", "parent_id"]],
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
         end
+
+        if current_adapter?(:PostgreSQLAdapter)
+          test "deferrable: false option can be passed" do
+            @connection.create_table :testings do |t|
+              t.references :testing_parent, foreign_key: { deferrable: false }
+            end
+
+            fks = @connection.foreign_keys("testings")
+            assert_equal([["testings", "testing_parents", "testing_parent_id", false]],
+                         fks.map { |fk| [fk.from_table, fk.to_table, fk.column, fk.deferrable] })
+          end
+
+          test "deferrable: :immediate option can be passed" do
+            @connection.create_table :testings do |t|
+              t.references :testing_parent, foreign_key: { deferrable: :immediate }
+            end
+
+            fks = @connection.foreign_keys("testings")
+            assert_equal([["testings", "testing_parents", "testing_parent_id", :immediate]],
+                         fks.map { |fk| [fk.from_table, fk.to_table, fk.column, fk.deferrable] })
+          end
+
+          test "deferrable: :deferred option can be passed" do
+            @connection.create_table :testings do |t|
+              t.references :testing_parent, foreign_key: { deferrable: :deferred }
+            end
+
+            fks = @connection.foreign_keys("testings")
+            assert_equal([["testings", "testing_parents", "testing_parent_id", :deferred]],
+                         fks.map { |fk| [fk.from_table, fk.to_table, fk.column, fk.deferrable] })
+          end
+
+          test "deferrable and on_(delete|update) option can be passed" do
+            @connection.create_table :testings do |t|
+              t.references :testing_parent, foreign_key: { on_update: :cascade, on_delete: :cascade, deferrable: :immediate }
+            end
+
+            fks = @connection.foreign_keys("testings")
+            assert_equal([["testings", "testing_parents", "testing_parent_id", :cascade, :cascade, :immediate]],
+                         fks.map { |fk| [fk.from_table, fk.to_table, fk.column, fk.on_delete, fk.on_update, fk.deferrable] })
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Fixed a bug in where deferrable foreign_key was ignored when passed to `t.references`

### Detail

This PR is a follow-up to https://github.com/rails/rails/pull/41487 .
#41487 supports the `deferrable` option for `add_foreign_key` but `t.references` does not yet support the `deferrable` option yet.

I think this is just an omission in the implementation.

```
create_table(:testings) do |t|
  t.references(:parent, foreign_key: { deferrable: :immediate }) #=> deferrable must not be ignored!
end
```

### Additional information

This PR needs to be merged after https://github.com/rails/rails/pull/47659 because the return value of `ForeignKeyDefinition#deferrable` will be changed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
