### PR TITLE
Converted StringInquirer into a PORO with better performance.

### DIFF
--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -16,18 +16,20 @@ module ActiveSupport
   #   vehicle = ActiveSupport::StringInquirer.new('car')
   #   vehicle.car?   # => true
   #   vehicle.bike?  # => false
-  class StringInquirer < String
+  class StringInquirer
+    def initialize(method_name)
+      @method_name = method_name
+
+      self.class.send(:define_method, "#{method_name}?") { true }
+    end
+
     private
       def respond_to_missing?(method_name, include_private = false)
         method_name.end_with?("?") || super
       end
 
       def method_missing(method_name, *arguments)
-        if method_name.end_with?("?")
-          self == method_name[0..-2]
-        else
-          super
-        end
+        method_name.end_with?("?") ? false : super
       end
   end
 end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require 'benchmark'
 
 class StringInquirerTest < ActiveSupport::TestCase
   def setup
@@ -23,23 +24,42 @@ class StringInquirerTest < ActiveSupport::TestCase
     assert_respond_to @string_inquirer, :development?
   end
 
-  def test_respond_to_fallback_to_string_respond_to
-    String.class_eval do
+  def test_respond_to_fallback
+    str = ActiveSupport::StringInquirer.new("hello")
+
+    class << str
       def respond_to_missing?(name, include_private = false)
         (name == :bar) || super
       end
     end
-    str = ActiveSupport::StringInquirer.new("hello")
 
     assert_respond_to str, :are_you_ready?
     assert_respond_to str, :bar
     assert_not_respond_to str, :nope
+  end
 
-  ensure
-    String.class_eval do
-      undef_method :respond_to_missing?
-      def respond_to_missing?(name, include_private = false) # rubocop:disable Lint/DuplicateMethods
-        super
+  def test_benchmark
+    str   = ActiveSupport::StringInquirer.new("hello")
+    count = 100_000
+
+    Benchmark.bm do |bm|
+      bm.report 'all true' do
+        count.times do
+          str.hello?
+        end
+      end
+      bm.report 'all false' do
+        count.times do
+          str.hi?
+        end
+      end
+      bm.report 'half' do
+        (count / 2).times do
+          str.hello?
+        end
+        (count / 2).times do
+          str.hi?
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, `ActiveSupport::StringInquirer` inherit from `String`, and use `method_missing` on all of its calls, so we can have a performance problem.

Converting it to a `PORO` and creating a method on the instance with the name of the positive result and leaving just a test to return false to predicate methods can speed up operations.

The current benchmark result returned for the new benchmark test is:

```
all true  0.046796   0.000000   0.046796 (  0.047182)
all false 0.045121   0.000017   0.045138 (  0.045299)
half      0.042590   0.000000   0.042590 (  0.042956)
```

with this change it results in:

```
all true  0.013614   0.000000   0.013614 (  0.013640)
all false 0.029838   0.000008   0.029846 (  0.030124)
half      0.017558   0.000000   0.017558 (  0.017680)
```