### PR TITLE
Add `nodoc` to `valid_*_options` methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1497,15 +1497,15 @@ module ActiveRecord
         non_combinable_operations.each(&:call)
       end
 
-      def valid_table_definition_options
+      def valid_table_definition_options # :nodoc:
         [:temporary, :if_not_exists, :options, :as, :comment, :charset, :collation]
       end
 
-      def valid_column_definition_options
+      def valid_column_definition_options # :nodoc:
         ColumnDefinition::OPTION_NAMES
       end
 
-      def valid_primary_key_options
+      def valid_primary_key_options # :nodoc:
         [:limit, :default, :precision]
       end
 


### PR DESCRIPTION
The quicker fix of @matthewd's comment in https://github.com/rails/rails/pull/47609#issuecomment-1462439956

cc @eileencodes