### PR TITLE
Introduce TestFixtures#fixture_paths

### DIFF
--- a/actionmailbox/test/test_helper.rb
+++ b/actionmailbox/test/test_helper.rb
@@ -14,10 +14,10 @@ require "webmock/minitest"
 require "rails/test_unit/reporter"
 Rails::TestUnitReporter.executable = "bin/test"
 
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
-  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+  ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -6,7 +6,10 @@ require "active_support/json/decoding"
 require "rails/engine"
 
 class TestCaseTest < ActionController::TestCase
-  def self.fixture_path; end
+  def self.fixture_paths
+    []
+  end
+
   self.file_fixture_path = File.expand_path("../fixtures/multipart", __dir__)
 
   class TestController < ActionController::Base
@@ -931,14 +934,14 @@ class TestCaseTest < ActionController::TestCase
     assert_equal "45142", @response.body
   end
 
-  def test_fixture_file_upload_ignores_fixture_path_given_full_path
-    TestCaseTest.stub :fixture_path, __dir__ do
+  def test_fixture_file_upload_ignores_fixture_paths_given_full_path
+    TestCaseTest.stub :fixture_paths, __dir__ do
       uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpeg")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end
   end
 
-  def test_fixture_file_upload_ignores_nil_fixture_path
+  def test_fixture_file_upload_ignores_empty_fixture_paths
     uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpeg")
     assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
   end

--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -16,10 +16,10 @@ Rails::TestUnitReporter.executable = "bin/test"
 I18n.enforce_available_locales = false
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
-  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+  ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
 

--- a/actionview/test/active_record_unit.rb
+++ b/actionview/test/active_record_unit.rb
@@ -94,7 +94,7 @@ class ActiveRecordTestCase < ActionController::TestCase
 
   # Set our fixture path
   if ActiveRecordTestConnector.able_to_connect
-    self.fixture_path = [FIXTURE_LOAD_PATH]
+    self.fixture_paths = [FIXTURE_LOAD_PATH]
     self.use_transactional_tests = false
   end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Introduce `TestFixtures#fixture_paths`.
+
+    Multiple fixture paths can now be specified using the `#fixture_paths` accessor.
+    Apps will continue to have `test/fixtures` as their one fixture path by default,
+    but additional fixture paths can be specified.
+
+    ```ruby
+    ActiveSupport::TestCase.fixture_paths << "component1/test/fixtures"
+    ActiveSupport::TestCase.fixture_paths << "component2/test/fixtures"
+    ```
+
+    `TestFixtures#fixture_path` is now deprecated.
+
+    *Andrew Novoselac*
+
 *   Respect `foreign_type` option to `delegated_type` for `{role}_class` method.
 
     Usage of `delegated_type` with non-conventional `{role}_type` column names can now be specified with `foreign_type` option.

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -27,12 +27,12 @@ module ActiveRecord
     include LoadSchemaHelper
     extend LoadSchemaHelper
 
-    self.fixture_path = FIXTURES_ROOT
+    self.fixture_paths = [FIXTURES_ROOT]
     self.use_instantiated_fixtures = false
     self.use_transactional_tests = true
 
     def create_fixtures(*fixture_set_names, &block)
-      ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_path, fixture_set_names, fixture_class_names, &block)
+      ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_paths, fixture_set_names, fixture_class_names, &block)
     end
 
     def teardown

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -32,7 +32,7 @@ class TestFixturesTest < ActiveRecord::TestCase
       klass = Class.new(Minitest::Test) do
         include ActiveRecord::TestFixtures
 
-        self.fixture_path = tmp_dir
+        self.fixture_paths = [tmp_dir]
         self.use_transactional_tests = true
 
         fixtures :all

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -25,7 +25,7 @@ class ActiveSupport::TestCase
 
   include ActiveRecord::TestFixtures
 
-  self.fixture_path = File.expand_path("fixtures", __dir__)
+  self.fixture_paths = [File.expand_path("fixtures", __dir__)]
 
   setup do
     ActiveStorage::Current.url_options = { protocol: "https://", host: "example.com", port: nil }

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
@@ -12,10 +12,10 @@ require "rails/test_help"
 
 <% unless options[:skip_active_record] -%>
 # Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
-  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+  ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all
 end
 <% end -%>

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -24,12 +24,12 @@ if defined?(ActiveRecord::Base)
     include ActiveRecord::TestDatabases
     include ActiveRecord::TestFixtures
 
-    self.fixture_path = "#{Rails.root}/test/fixtures/"
-    self.file_fixture_path = fixture_path + "files"
+    self.fixture_paths << "#{Rails.root}/test/fixtures/"
+    self.file_fixture_path = "#{Rails.root}/test/fixtures/files"
   end
 
   ActiveSupport.on_load(:action_dispatch_integration_test) do
-    self.fixture_path = ActiveSupport::TestCase.fixture_path
+    self.fixture_paths += ActiveSupport::TestCase.fixture_paths
   end
 else
   ActiveSupport.on_load(:active_support_test_case) do

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -373,7 +373,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/test_helper.rb" do |content|
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+\.\.\/test\/dummy\/db\/migrate/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+<<.+\.\.\/db\/migrate/, content)
-      assert_match(/ActionDispatch::IntegrationTest\.fixture_path = ActiveSupport::TestCase\.fixture_pat/, content)
+      assert_match(/ActionDispatch::IntegrationTest\.fixture_paths = ActiveSupport::TestCase\.fixture_pat/, content)
       assert_no_match(/Rails::TestUnitReporter\.executable = "bin\/test"/, content)
     end
     assert_no_file "bin/test"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we would like to configure the `fixture_path` at the engine level, which will make it easier to break the app down into multiple deployable units.

### Detail

This Pull Request introduces `TestFixtures#fixture_paths`. This a class attr which is an empty array by default. This allows additional fixture paths to be configured by the application in addition to the rails default. For example, for an application with multiple engines, each with their own tests and fixtures, the engines can add the path for their own fixtures onto the fixture path.

```ruby
module UserManagement
  class Engine < Rails::Engine

    initializer("user_management.fixture_path) do
      ActiveSupport.on_load(:active_support_test_case) do
        self.fixture_path << "#{Rails.root}/user_management/test/fixtures}"
      end
    end
  end
end
```

### Additional information

I have deprecated `fixture_path`. I rewrote the `fixture_path` readers and writers to remain backwards compatible with the old behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
