### PR TITLE
Fix Rake-style task arguments for `bin/rails`

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -18,7 +18,7 @@ module Rails
           Rake.with_application do |rake|
             rake.init("rails", [task, *args])
             rake.load_rakefile
-            if unrecognized_task = rake.top_level_tasks.find { |task| !rake.lookup(task) }
+            if unrecognized_task = rake.top_level_tasks.find { |task| !rake.lookup(task[/[^\[]+/]) }
               raise UnrecognizedCommandError.new(unrecognized_task)
             end
 

--- a/railties/test/commands/rake_test.rb
+++ b/railties/test/commands/rake_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+
+class Rails::Command::RakeTest < ActiveSupport::TestCase
+  setup :build_app
+  teardown :teardown_app
+
+  test "runs multiple tasks" do
+    app_file "lib/tasks/foo.rake", 'task(:foo) { puts "FOO!" }'
+    app_file "lib/tasks/bar.rake", 'task(:bar) { puts "BAR!" }'
+
+    output = run_rake_command "foo", "bar"
+    assert_match "FOO!", output
+    assert_match "BAR!", output
+  end
+
+  test "runs task with arguments" do
+    app_file "lib/tasks/hello.rake", <<~RUBY
+      namespace :greetings do
+        task :hello, [:name] do |task, args|
+          puts "Hello, \#{args.name}!"
+        end
+      end
+    RUBY
+
+    assert_match "Hello, World!", run_rake_command("greetings:hello[World]")
+  end
+
+  private
+    def run_rake_command(*args, **options)
+      rails args, **options
+    end
+end


### PR DESCRIPTION
Follow-up to #47208.

When using Rake-style CLI arguments, `Rake::Application#top_level_tasks` will return the full task invocation rather than the parsed task name. For example, when running `rake foo[bar] baz[qux]`, `top_level_tasks` will return `["foo[bar]", "baz[qux]"]` rather than `["foo", "baz"]`. Therefore, we must extract the task name before checking existence.
