### PR TITLE
Fix rubygems version mentioned in CHANGELOG

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Support prerelease rubies in Gemfile template if RubyGems version is 3.3.16 or higher.
+*   Support prerelease rubies in Gemfile template if RubyGems version is 3.3.13 or higher.
 
     *Yasuo Honda*, *David Rodríguez*
 


### PR DESCRIPTION
The version check [added][1] is for 3.3.13, but the CHANGELOG specifies 3.3.16

[1]: https://github.com/rails/rails/commit/7da3353b60749426aac27c6b43d589448f3a3cd0
