### PR TITLE
Revert "Quote binary strings in Arel"

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -46,7 +46,6 @@ module ActiveModel
       def serialize(value)
         case value
         when ::Numeric, ::Symbol, ActiveSupport::Duration then value.to_s
-        when ::String then serialize_cast_value(value)
         when true then @true
         when false then @false
         else super
@@ -54,12 +53,6 @@ module ActiveModel
       end
 
       def serialize_cast_value(value) # :nodoc:
-        if value&.encoding == Encoding::BINARY
-          # If we can treat the bytes as UTF-8 without changing them, then use UTF-8 as encoding
-          new_value = value.dup.force_encoding(Encoding::UTF_8)
-          return new_value if new_value.valid_encoding?
-        end
-
         value
       end
 

--- a/activemodel/test/cases/type/immutable_string_test.rb
+++ b/activemodel/test/cases/type/immutable_string_test.rb
@@ -17,26 +17,6 @@ module ActiveModel
         assert_same s, type.cast(s)
         assert_same s, type.deserialize(s)
       end
-
-      test "leaves validly encoded strings untouched" do
-        s = "string with àccénts".encode(Encoding::ISO_8859_1)
-        type = Type::ImmutableString.new
-        assert_same s, type.serialize(s)
-      end
-
-      test "serializes valid, binary-encoded strings to UTF-8" do
-        s = "string with àccénts".b
-        type = Type::ImmutableString.new
-        serialized = type.serialize(s)
-        assert_equal Encoding::UTF_8, serialized.encoding
-        assert_equal s.bytes, serialized.bytes
-      end
-
-      test "leaves true binary data untouched" do
-        binary_data = "\xEE\x49\xC7".b
-        type = Type::ImmutableString.new
-        assert_same binary_data, type.serialize(binary_data)
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -16,10 +16,7 @@ module ActiveRecord
         when false      then quoted_false
         when nil        then "NULL"
         # BigDecimals need to be put in a non-normalized form and quoted.
-        # Additionally, for Ruby 2.7, the string returned by `to_s` is ASCII-8BIT.
-        # We want to avoid that, as that will cause the string to be quoted as
-        # binary. It is safe to force the encoding to US-ASCII.
-        when BigDecimal then value.to_s("F").force_encoding(Encoding::US_ASCII)
+        when BigDecimal then value.to_s("F")
         when Numeric then value.to_s
         when Type::Binary::Data then quoted_binary(value)
         when Type::Time::Value then "'#{quoted_time(value)}'"

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -6,30 +6,14 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
-        def quote(value)
-          case value
-          when String
-            if value.encoding == Encoding::BINARY
-              quoted_binary(value)
-            else
-              "'#{quote_string(value.to_s)}'"
-            end
-          else
-            super
-          end
-        end
-
         def cast_bound_value(value)
           case value
           when Rational
             value.to_f.to_s
-          when BigDecimal
-            # For Ruby 2.7, the string returned by `to_s` is ASCII-8BIT.
-            # We want to avoid that, as that will cause the string to be quoted as
-            # binary. It is safe to force the encoding to US-ASCII.
-            value.to_s("F").force_encoding(Encoding::US_ASCII)
           when Numeric
             value.to_s
+          when BigDecimal
+            value.to_s("F")
           when true
             "1"
           when false
@@ -67,11 +51,7 @@ module ActiveRecord
         end
 
         def quoted_binary(value)
-          if value.is_a? String
-            "x'#{value.unpack1("H*")}'"
-          else
-            "x'#{value.hex}'"
-          end
+          "x'#{value.hex}'"
         end
 
         def unquote_identifier(identifier)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -4,19 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module Quoting # :nodoc:
-        def quote(value)
-          case value
-          when String
-            if value.encoding == Encoding::BINARY
-              quoted_binary(value)
-            else
-              "'#{quote_string(value.to_s)}'"
-            end
-          else
-            super
-          end
-        end
-
         def quote_string(s)
           ::SQLite3::Database.quote(s)
         end
@@ -39,11 +26,7 @@ module ActiveRecord
         end
 
         def quoted_binary(value)
-          if value.is_a? String
-            "x'#{value.unpack1("H*")}'"
-          else
-            "x'#{value.hex}'"
-          end
+          "x'#{value.hex}'"
         end
 
         def quoted_true
@@ -79,6 +62,12 @@ module ActiveRecord
           case value
           when BigDecimal
             value.to_f
+          when String
+            if value.encoding == Encoding::ASCII_8BIT
+              super(value.encode(Encoding::UTF_8))
+            else
+              super
+            end
           else
             super
           end

--- a/activerecord/test/cases/binary_test.rb
+++ b/activerecord/test/cases/binary_test.rb
@@ -37,19 +37,4 @@ class BinaryTest < ActiveRecord::TestCase
       assert_equal data, bin.reload.data, "Reloaded data differs from original"
     end
   end
-
-  unless current_adapter?(:PostgreSQLAdapter)
-    def test_does_not_cause_database_warnings
-      original_db_warnings_action = ActiveRecord.db_warnings_action
-      ActiveRecord.db_warnings_action = :raise
-
-      Binary.delete_all
-      binary_data = "\xEE\x49\xC7".b
-      Binary.connection.insert(Arel.sql("INSERT INTO binaries(data) VALUES(?)", binary_data))
-      binary = Binary.first
-      assert_equal binary_data, binary.data
-    ensure
-      ActiveRecord.db_warnings_action = original_db_warnings_action || :ignore
-    end
-  end
 end


### PR DESCRIPTION
Reverts rails/rails#47493

It turns out my core assumption in this PR's reasonableness was wrong: MySQL does _not_ see `x'41'` and `'A'` as different spellings of the same string literal.

It mostly seems like they are interchangeable, but when converting to an integer (as for `where("id = ?", "1".encode(Encoding::BINARY))`), `x'31'` gets interpreted as a raw integer value (`49`), while `'1'` gets interpreted as a string representation of an integer (`1`).

I think it could possibly still be interesting to work around this by wrapping with `CAST(? AS CHAR)` -- I don't love the piling on of complexity, but I think it would complete the string-ness of the supplied literal. For now, though, I'm just going to revert... this puts us back where we were, potentially interpolating raw binary bytes into the query text (and breaking its encoding), but restores the previous behaviour for simple cases where the nominally-binary string actually only contains 7-bit characters (like numerals).