### PR TITLE
Rely on `AM::ForbiddenAttributesProtection` autoload

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -3,7 +3,6 @@
 require "active_record/relation/from_clause"
 require "active_record/relation/query_attribute"
 require "active_record/relation/where_clause"
-require "active_model/forbidden_attributes_protection"
 require "active_support/core_ext/array/wrap"
 
 module ActiveRecord


### PR DESCRIPTION
[`ActiveModel::ForbiddenAttributesProtection` is autoloaded](https://github.com/rails/rails/blob/8986050c41345b36b14ae9fe2755b1be1d8871cd/activemodel/lib/active_model.rb#L46), so this `require` is not necessary.
