### PR TITLE
Add `ActiveRecord::Base.extend_relations`

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -39,6 +39,12 @@ module ActiveRecord
         generated_relation_methods.generate_method(method)
       end
 
+      def extend_relations(*modules)
+        @relation_delegate_cache.each_value do |klass|
+          klass.include(*modules)
+        end
+      end
+
       protected
         def include_relation_methods(delegate)
           superclass.include_relation_methods(delegate) unless base_class?


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47314 (fixes what I believe to be the most common use case).

Based on what I could see, a very common use case for extending (in our code base at least) is akin to:

```ruby
class MyModel < AR::Base
  default_scope { extending(MutationGuard::Relation) }
end
```

This use case would be much better served by directly including that module in all the relation delegators.

@rafaelfranca @jhawthorn @matthewd any opinion?