### PR TITLE
Undefine `with` on NilClass and other common immediate types

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/with.rb
+++ b/activesupport/lib/active_support/core_ext/object/with.rb
@@ -36,3 +36,9 @@ class Object
     end
   end
 end
+
+# #with isn't usable on immediates, so we might as well undefine the
+# method in common immediate classes to avoid potential confusion.
+[NilClass, TrueClass, FalseClass, Integer, Float].each do |klass|
+  klass.undef_method(:with)
+end

--- a/activesupport/test/core_ext/object/with_test.rb
+++ b/activesupport/test/core_ext/object/with_test.rb
@@ -87,4 +87,12 @@ class BlankTest < ActiveSupport::TestCase
     end
     assert_equal :mixed, @object.mixed_attr
   end
+
+  test "basic immediates don't respond to #with" do
+    assert_not_respond_to nil, :with
+    assert_not_respond_to true, :with
+    assert_not_respond_to false, :with
+    assert_not_respond_to 1, :with
+    assert_not_respond_to 1.0, :with
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/46681#issuecomment-1471625657

`with` isn't usable on immediates, so we might as well undefine the method in common immediate classes to avoid potential confusion.
