### PR TITLE
Improve js and css options of app generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -15,7 +15,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
-<% if ["webpack", "esbuild", "rollup"].include?(options.javascript) -%>
+<% if using_node? -%>
 
   # Install JavaScript dependencies
   system("yarn check --check-files") || system!("yarn install")


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the Rails app generator currently has two issues:

### First issue

If I choose `importmap` as the javascript option and `bootstrap`, `bulma` or `postcss` as the css option, rails forces me to use `esbuild` as the javascript option, ignoring my choice of `importmap`.

There should be no problem using `importmap` as a javascript option and using `bootstrap`, `bulma` or `postcss` with Node.js

### Second issue

If I choose `importmap` as the javascript option, the `.node-version` file is not created and the `Dockerfile` does not include the Node.js installation steps, even when Rails forces it to use `esbuild` (first issue) or if we are using a css option that requires Node.js

### Detail

This Pull Request changes the requirements for the `.node-version` file to be created and the `Dockerfile` to include the Node.js installation.
It also changes the old behavior and if I choose `importmap` it uses it regardless of the css option selected.

#### Actual behavior

| options[:javascript]     | options[:css]             | gems                                    | install commands                               | require node | install node | status  |
|--------------------------|---------------------------|-----------------------------------------|------------------------------------------------|--------------|--------------|---------|
| importmap                | bootstrap, bulma, postcss | jsbundling-rails<br />cssbundling-rails | javascript:install:esbuild<br />css:install:\* | YES          | NO           | bug[^1] |
| importmap                | tailwind                  | importmap-rails<br />tailwindcss-rails  | importmap:install<br />tailwindcss:install     | NO           | NO           | ok      |
| importmap                | sass                      | importmap-rails<br />dartsass-rails     | importmap:install<br />dartsass:install        | NO           | NO           | ok      |
| webpack, esbuild, rollup | \*                        | jsbundling-rails<br />cssbundling-rails | javascript:install:\*<br />css:install:\*      | YES          | YES          | ok      |

[^1]: no install node (required by jsbundling-rails) and change importmap to esbuild

#### Proposed behavior

| options[:javascript]     | options[:css]             | gems                                    | install commands                           | install  node |
|--------------------------|---------------------------|-----------------------------------------|--------------------------------------------|---------------|
| importmap                | bootstrap, bulma, postcss | importmap-rails<br />cssbundling-rails  | importmap:install<br />css:install:\*      | YES           |
| importmap                | tailwind                  | importmap-rails<br />tailwindcss-rails  | importmap:install<br />tailwindcss:install | NO            |
| importmap                | sass                      | importmap-rails<br />dartsass-rails     | importmap:install<br />dartsass:install    | NO            |
| webpack, esbuild, rollup | \*                        | jsbundling-rails<br />cssbundling-rails | javascript:install:\*<br />css:install:\*  | YES           |

Still, there is a combination that is not possible: if I want to use `importmap` and `cssbundling-rails` to compile the css using `tailwind` or `sass` instead of use `tailwindcss-rails` or `dartsass-rails`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.