### PR TITLE
Run a load hook when TestFixtures is included

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Introduce `:active_record_fixtures` lazy load hook.
+
+    Hooks defined with this name will be run whenever `TestFixtures` is included
+    in a class.
+
+    ```ruby
+    ActiveSupport.on_load(:active_record_fixtures) do
+      self.fixture_paths << "test/fixtures"
+    end
+
+    klass = Class.new
+    klass.include(ActiveRecord::TestFixtures)
+
+    klass.fixture_paths # => ["test/fixtures"]
+    ```
+
+    *Andrew Novoselac*
+
 *   Introduce `TestFixtures#fixture_paths`.
 
     Multiple fixture paths can now be specified using the `#fixture_paths` accessor.

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -25,6 +25,8 @@ module ActiveRecord
       class_attribute :pre_loaded_fixtures, default: false
       class_attribute :lock_threads, default: true
       class_attribute :fixture_sets, default: {}
+
+      ActiveSupport.run_load_hooks(:active_record_fixtures, self)
     end
 
     module ClassMethods

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -21,6 +21,17 @@ class TestFixturesTest < ActiveRecord::TestCase
     assert_equal "foobar", @klass.use_transactional_tests
   end
 
+  def test_inclusion_runs_active_record_fixtures_load_hook
+    ActiveSupport.on_load(:active_record_fixtures) do
+      self.fixture_paths << "test/fixtures"
+    end
+    klass = Class.new
+
+    klass.include(ActiveRecord::TestFixtures)
+
+    assert_includes klass.fixture_paths, "test/fixtures"
+  end
+
   unless in_memory_db?
     def test_doesnt_rely_on_active_support_test_case_specific_methods
       tmp_dir = Dir.mktmpdir

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1493,6 +1493,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveJob::Base`                    | `active_job`                         |
 | `ActiveJob::TestCase`                | `active_job_test_case`               |
 | `ActiveRecord::Base`                 | `active_record`                      |
+| `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveStorage::Attachment`          | `active_storage_attachment`          |
 | `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |
 | `ActiveStorage::Blob`                | `active_storage_blob`                |


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created as a follow up to #47675. In the example I gave in that PR, I showed that you can define an `active_model_test_case` load hook and shovel onto the `fixture_paths`. However, I now realize this won't actually work, because `TestFixtures` itself is included in `ActiveSupport::TestCase` from a load hook. Since there is no way to control the order the hooks are run in, the `fixture_paths` method may be undefined at that the time the hook is run.

### Detail

This Pull Request adds an `:active_record_fixtures` load hook. This load hook is run every time `TestFixtures` is included. So the fixture paths can be added to from this hook. Eg:

```ruby
module UserManagement
  class Engine < Rails::Engine

    initializer("user_management.fixture_path") do
      ActiveSupport.on_load(:active_record_fixtures) do
        self.fixture_paths << "#{Rails.root}/user_management/test/fixtures}"
      end
    end
  end
end
```

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
