### PR TITLE
Allow querying by whole record for composite query constraints associations

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,11 @@ module ActiveRecord
       end
 
       def queries
-        [ associated_table.join_foreign_key => ids ]
+        if associated_table.join_foreign_key.is_a?(Array)
+          ids.map { |ids_set| associated_table.join_foreign_key.zip(ids_set).to_h }
+        else
+          [ associated_table.join_foreign_key => ids ]
+        end
       end
 
       private
@@ -31,6 +35,8 @@ module ActiveRecord
         end
 
         def convert_to_id(value)
+          return primary_key.map { |pk| value.public_send(pk) } if primary_key.is_a?(Array)
+
           if value.respond_to?(primary_key)
             value.public_send(primary_key)
           else

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -147,6 +147,15 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_match(/#{Regexp.escape(Sharded::BlogPost.connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
   end
 
+  def test_querying_by_whole_associated_records_using_query_constraints
+    comments = [sharded_comments(:great_comment_blog_post_one), sharded_comments(:great_comment_blog_post_two)]
+
+    blog_posts = Sharded::BlogPost.where(comments: comments).to_a
+
+    expected_posts = [sharded_blog_posts(:great_post_blog_one), sharded_blog_posts(:great_post_blog_two)]
+    assert_equal(expected_posts.map(&:id).sort, blog_posts.map(&:id).sort)
+  end
+
   def test_has_many_association_with_composite_foreign_key_loads_records
     blog_post = sharded_blog_posts(:great_post_blog_one)
 

--- a/activerecord/test/fixtures/sharded_comments.yml
+++ b/activerecord/test/fixtures/sharded_comments.yml
@@ -18,5 +18,5 @@ unique_comment_blog_post_one:
 
 great_comment_blog_post_two:
   body: "I really enjoyed the post!"
-  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_blog_post_two) %>
+  blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>


### PR DESCRIPTION
Given an association defined with composite query constraints like:
```ruby
BlogPost.has_many :comments, query_constraints: [:blog_id, :blog_post_id]
```

it is possible to query blog posts by whole `comments` objects like:

```ruby
comments = Comment.first(2)
BlogPost.where(comments: comments).to_a
```

### What's left

This capability of being able to build constraints using association name and reach objects and quite powerful so we'll need to at least cover more types of associations (`belongs_to`, `has_one`, `has_many through`, polymorphic associations) along with a subquery use-case like
```ruby
BlogPost.where(comments: Comment.where(id: 1, blog_id: 1))` 
```
So we will be adding additional coverage and fixes, if needed. However we would like to ship fix for the most common use-case to unblock other work to be completed in parallel. It unblocks us to work on features that rely on abstract usages like:
```.where(association_name => association_records)` where for our specific example `association_name` could be `comments:` and `association_records` is an array of `Comment` objects. 
