### PR TITLE
Fix rails-ujs tests not being linted

### DIFF
--- a/actionview/package.json
+++ b/actionview/package.json
@@ -14,7 +14,7 @@
     "build": "rollup --config rollup.config.js",
     "pretest": "rollup --config rollup.config.test.js",
     "test": "karma start",
-    "lint": "eslint app/javascript"
+    "lint": "eslint app/javascript && eslint test/ujs/public/test"
   },
   "repository": {
     "type": "git",

--- a/actionview/test/ujs/public/test/call-ajax.js
+++ b/actionview/test/ujs/public/test/call-ajax.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import Rails from "../../../../app/javascript/rails-ujs/index"
+import Rails from '../../../../app/javascript/rails-ujs/index'
 
 QUnit.module('call-ajax', {
   beforeEach: function() {

--- a/actionview/test/ujs/public/test/data-method.js
+++ b/actionview/test/ujs/public/test/data-method.js
@@ -103,6 +103,6 @@ QUnit.test('do not interact with contenteditable elements', function(assert) {
 
   var collection = document.getElementsByTagName('form')
   for (const item of collection) {
-    assert.notEqual(item.action, "http://www.shouldnevershowindocument.com/")
+    assert.notEqual(item.action, 'http://www.shouldnevershowindocument.com/')
   }
 })

--- a/actionview/test/ujs/public/test/settings.js
+++ b/actionview/test/ujs/public/test/settings.js
@@ -1,4 +1,4 @@
-import $ from 'jquery';
+import $ from 'jquery'
 import Rails from '../../../../app/javascript/rails-ujs/index'
 
 $.rails = Rails


### PR DESCRIPTION
### Motivation / Background

Before rails-ujs was [updated][1] from coffeescript to es6, the lint task ran eslint on both the coffee files and the ujs test files. When it was updated to lint the new es6 files, the test files were erroneously left out.

### Detail

This commit fixes the task to lint the rails-ujs test files and fixes the lint errors that have been introduced since.

[1]: https://github.com/rails/rails/commit/7d116c93cf6cf2470600860c4c17417df7768c34

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
