### PR TITLE
Add methods to ActiveRecord::Store's dirty API

### DIFF
--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -90,6 +90,9 @@ class StoreTest < ActiveRecord::TestCase
   test "updating the store will mark accessor as changed" do
     @john.color = "red"
     assert_predicate @john, :color_changed?
+    assert @john.color_changed?(from: "black", to: "red")
+    assert @john.color_changed?(from: "black")
+    assert @john.color_changed?(to: "red")
   end
 
   test "new record and no accessors changes" do
@@ -161,6 +164,10 @@ class StoreTest < ActiveRecord::TestCase
     assert_predicate @john, :saved_change_to_partner_name?
     assert_equal ["Dallas", "Lena"], @john.saved_change_to_partner_name
     assert_equal "Dallas", @john.partner_name_before_last_save
+    assert @john.saved_change_to_partner_name?(from: "Dallas")
+    assert @john.saved_change_to_partner_name?(to: "Lena")
+    assert @john.saved_change_to_partner_name?(from: "Dallas", to: "Lena")
+    assert_not @john.saved_change_to_partner_name?(to: "Euler")
   end
 
   test "saved changes tracking for accessors with json column" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

ActiveRecord provides corresponding methods for `attribute_changed?` and `attribute_change`, namely `will_save_change_to_attribute?` and `attribute_to_be_saved`, respectively. These methods are named in a way that makes them easy to use in callbacks.

These are not defined in ActiveRecord::Store. To promote consistency, I propose adding alias methods to ActiveRecord::Store that would allow the use of these naming conventions.


### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
