### PR TITLE
Replace deprecated use of Event.initevent has been deprecated with Event constructor in activestorage.js

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -485,8 +485,10 @@ function findElement(root, selector) {
 function dispatchEvent(element, type, eventInit = {}) {
   const {disabled: disabled} = element;
   const {bubbles: bubbles, cancelable: cancelable, detail: detail} = eventInit;
-  const event = document.createEvent("Event");
-  event.initEvent(type, bubbles || true, cancelable || true);
+  const event = new Event(type, {
+    bubbles: bubbles || true,
+    cancelable: cancelable || true
+  });
   event.detail = detail || {};
   try {
     element.disabled = false;

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -482,8 +482,10 @@
   function dispatchEvent(element, type, eventInit = {}) {
     const {disabled: disabled} = element;
     const {bubbles: bubbles, cancelable: cancelable, detail: detail} = eventInit;
-    const event = document.createEvent("Event");
-    event.initEvent(type, bubbles || true, cancelable || true);
+    const event = new Event(type, {
+      bubbles: bubbles || true,
+      cancelable: cancelable || true
+    });
     event.detail = detail || {};
     try {
       element.disabled = false;

--- a/activestorage/app/javascript/activestorage/helpers.js
+++ b/activestorage/app/javascript/activestorage/helpers.js
@@ -25,9 +25,8 @@ export function findElement(root, selector) {
 export function dispatchEvent(element, type, eventInit = {}) {
   const { disabled } = element
   const { bubbles, cancelable, detail } = eventInit
-  const event = document.createEvent("Event")
+  const event = new Event(type, {bubbles: bubbles || true, cancelable: cancelable || true})
 
-  event.initEvent(type, bubbles || true, cancelable || true)
   event.detail = detail || {}
 
   try {


### PR DESCRIPTION

### Motivation / Background

Usage of `Event.initevent` has been deprecated - https://developer.mozilla.org/en-US/docs/web/api/event/initevent

Replace and make use of `Event` constructor instead- https://developer.mozilla.org/en-US/docs/Web/API/Event/Event

### Detail

- Replace usage of `Event.initevent` and ` document.createEvent("Event")`  with simplified `Event` constructor instead
- Pass down same options to constructor as before
- Also runs yarn build to update current builds of AS.js and esm modules

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
