### PR TITLE
Correct typos [ci-skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -174,7 +174,7 @@
     end
     ```
 
-    Then register the config in an inializer:
+    Then register the config in an initializer:
 
     ```ruby
     ActiveRecord::DatabaseConfigurations.register_db_config_handler do |env_name, name, url, config|

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -136,7 +136,7 @@ module ActiveRecord
         def escape_sql_comment(content)
           # Sanitize a string to appear within a SQL comment
           # For compatibility, this also surrounding "/*+", "/*", and "*/"
-          # charcacters, possibly with single surrounding space.
+          # characters, possibly with single surrounding space.
           # Then follows that by replacing any internal "*/" or "/ *" with
           # "* /" or "/ *"
           comment = content.to_s.dup


### PR DESCRIPTION
Correct typos in activerecord changelog and querylogs docs