### PR TITLE
add method Object#not_in?

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -23,6 +23,21 @@ class Object
     raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end
 
+  # Returns true if this object is not included in the argument.
+  #
+  # When argument is a +Range+, +#cover?+ is used to properly handle inclusion
+  # check within open ranges. Otherwise, argument must be any object which responds
+  # to +#include?+. Usage:
+  #
+  #   characters = ["Konata", "Kagami"]
+  #   "Tsukasa".not_in?(characters) # => true
+  #
+  # For non +Range+ arguments, this will throw an +ArgumentError+ if the argument
+  # doesn't respond to +#include?+.
+  def not_in?(another_object)
+    !in?(another_object)
+  end
+
   # Returns the receiver if it's included in the argument otherwise returns +nil+.
   # Argument must be any object which responds to +#include?+. Usage:
   #

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -9,6 +9,10 @@ class InTest < ActiveSupport::TestCase
     assert_not 3.in?([1, 2])
   end
 
+  def test_not_in_array
+    assert 3.not_in?([1, 2])
+  end
+
   def test_in_hash
     h = { "a" => 100, "b" => 200 }
     assert "a".in?(h)


### PR DESCRIPTION
### Motivation / Background

I think it would be beneficial to create a method called ```Object#not_in?``` as the opposite of the current method ```Object#in?```. This approach could improve code readability in certain situations by simplifying conditional statements. For instance, instead of checking whether an object is included in a collection using the 'in' method, we could use 'not_in?' to check if the object is absent. Overall, this approach has the potential to make code more concise and understandable.

