### PR TITLE
Fixing config generator in generators.md

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -215,10 +215,11 @@ config.generators do |g|
   g.orm             :active_record
   g.template_engine :erb
   g.test_framework  :test_unit, fixture: false
+  g.stylesheets     false
 end
 ```
 
-If we generate another resource with the scaffold generator, we can see that stylesheet, JavaScript, and fixture files are not created anymore. If you want to customize it further, for example to use DataMapper and RSpec instead of Active Record and TestUnit, it's just a matter of adding their gems to your application and configuring your generators.
+If we generate another resource with the scaffold generator, we can see that stylesheet and fixture files are not created anymore. If you want to customize it further, for example to use DataMapper and RSpec instead of Active Record and TestUnit, it's just a matter of adding their gems to your application and configuring your generators.
 
 To demonstrate this, we are going to create a new helper generator that simply adds some instance variable readers. First, we create a generator within the rails namespace, as this is where rails searches for generators used as hooks:
 


### PR DESCRIPTION
This change fixes an issue where a `config.generators` block that shows how to create a new helper generator without stylesheets was missing `g.stylesheets  false`.