### PR TITLE
PostgreSQL adapter uses :host instead of :hostname for connection params

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -72,8 +72,8 @@ module ActiveRecord
             raise ActiveRecord::NoDatabaseError.db_error(conn_params[:dbname])
           elsif conn_params && conn_params[:user] && error.message.include?(conn_params[:user])
             raise ActiveRecord::DatabaseConnectionError.username_error(conn_params[:user])
-          elsif conn_params && conn_params[:hostname] && error.message.include?(conn_params[:hostname])
-            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:hostname])
+          elsif conn_params && conn_params[:host] && error.message.include?(conn_params[:host])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:host])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end


### PR DESCRIPTION
### Motivation / Background

I noticed that the error translation code for the PG adapter looks for a `:hostname` arg in the `conn_params` in order to translate to a hostname error. However, [the PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS) specify that either `host` or `hostaddr` should be used, so I'm inclined to think this is an error.

```
irb(main):001:0> require "pg"
=> true
irb(main):002:0> PG.connect(hostname: "localhost")
/Users/adriannachang/.gem/ruby/3.1.1/gems/pg-1.4.5/lib/pg/connection.rb:714:in `conninfo_parse': invalid connection option "hostname" (PG::Error)
        from /Users/adriannachang/.gem/ruby/3.1.1/gems/pg-1.4.5/lib/pg/connection.rb:714:in `connect_to_hosts'   
        from /Users/adriannachang/.gem/ruby/3.1.1/gems/pg-1.4.5/lib/pg/connection.rb:695:in `new'                
        from /Users/adriannachang/.gem/ruby/3.1.1/gems/pg-1.4.5/lib/pg.rb:69:in `connect'                        
        from (irb):2:in `<main>'                                                                                 
        from /Users/adriannachang/.gem/ruby/3.1.1/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'                
        from /Users/adriannachang/.gem/ruby/3.1.1/bin/irb:25:in `load'                                           
        from /Users/adriannachang/.gem/ruby/3.1.1/bin/irb:25:in `<main>'
```

### Detail

Use `:host` from connection params instead of `:hostname` for translating hostname errors in PostgreSQL adapter.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. (If this warrants a test, I'm happy to add one)
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
