### PR TITLE
fix: correct variable name in JS example

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -44,7 +44,7 @@ fetch("/test")
   .then((data) => data.text())
   .then((html) => {
     const results = document.querySelector("#results");
-    results.insertAdjacentHTML("beforeend", data);
+    results.insertAdjacentHTML("beforeend", html);
   });
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because an example of [Working with JavaScript in Rails](https://guides.rubyonrails.org/v6.1.0/working_with_javascript_in_rails.html#an-introduction-to-ajax) uses a variable name that, in my opinion, is not the one available in the scope where it is being used.

### Detail

This Pull Request changes the name of the variable in line `47` of the file `rails/guides/source/working_with_javascript_in_rails.md`
### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
