### PR TITLE
Include READMEs in main framework pages of the API documentation

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -43,6 +43,8 @@ Zeitwerk::Loader.for_gem.tap do |loader|
   loader.inflector.inflect("postgresql" => "PostgreSQL")
 end.setup
 
+# :markup: markdown
+# :include: actioncable/README.md
 module ActionCable
   require_relative "action_cable/version"
   require_relative "action_cable/deprecator"

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -8,6 +8,8 @@ require "action_mailbox/version"
 require "action_mailbox/deprecator"
 require "action_mailbox/mail_ext"
 
+# :markup: markdown
+# :include: actionmailbox/README.md
 module ActionMailbox
   extend ActiveSupport::Autoload
 

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -35,6 +35,7 @@ require "active_support/core_ext/module/attr_internal"
 require "active_support/core_ext/string/inflections"
 require "active_support/lazy_load_hooks"
 
+# :include: actionmailer/README.rdoc
 module ActionMailer
   extend ::ActiveSupport::Autoload
 

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -8,6 +8,8 @@ require "action_text/deprecator"
 
 require "nokogiri"
 
+# :markup: markdown
+# :include: actiontext/README.md
 module ActionText
   extend ActiveSupport::Autoload
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -28,6 +28,7 @@ require "active_support/rails"
 require "action_view/version"
 require "action_view/deprecator"
 
+# :include: actionview/README.rdoc
 module ActionView
   extend ActiveSupport::Autoload
 

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -29,6 +29,8 @@ require "active_job/version"
 require "active_job/deprecator"
 require "global_id"
 
+# :markup: markdown
+# :include: activejob/README.md
 module ActiveJob
   extend ActiveSupport::Autoload
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -28,6 +28,7 @@ require "active_support/rails"
 require "active_model/version"
 require "active_model/deprecator"
 
+# :include: activemodel/README.rdoc
 module ActiveModel
   extend ActiveSupport::Autoload
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -34,6 +34,7 @@ require "active_record/deprecator"
 require "active_model/attribute_set"
 require "active_record/errors"
 
+# :include: activerecord/README.rdoc
 module ActiveRecord
   extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -34,6 +34,8 @@ require "active_storage/errors"
 
 require "marcel"
 
+# :markup: markdown
+# :include: activestorage/README.md
 module ActiveStorage
   extend ActiveSupport::Autoload
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -31,6 +31,7 @@ require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
 
+# :include: activesupport/README.rdoc
 module ActiveSupport
   extend ActiveSupport::Autoload
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -24,6 +24,7 @@ silence_warnings do
   Encoding.default_internal = Encoding::UTF_8
 end
 
+# :include: railties/README.rdoc
 module Rails
   extend ActiveSupport::Autoload
   extend ActiveSupport::Benchmarkable

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -10,6 +10,7 @@ module Rails
         "activesupport" => {
           include: %w(
             README.rdoc
+            lib/active_support.rb
             lib/active_support/**/*.rb
           )
         },
@@ -17,6 +18,7 @@ module Rails
         "activerecord" => {
           include: %w(
             README.rdoc
+            lib/active_record.rb
             lib/active_record/**/*.rb
             lib/arel.rb
           )
@@ -25,6 +27,7 @@ module Rails
         "activemodel" => {
           include: %w(
             README.rdoc
+            lib/active_model.rb
             lib/active_model/**/*.rb
           )
         },
@@ -41,6 +44,7 @@ module Rails
         "actionview" => {
           include: %w(
             README.rdoc
+            lib/action_view.rb
             lib/action_view/**/*.rb
           ),
           exclude: "lib/action_view/vendor/*"
@@ -49,6 +53,7 @@ module Rails
         "actionmailer" => {
           include: %w(
             README.rdoc
+            lib/action_mailer.rb
             lib/action_mailer/**/*.rb
           )
         },
@@ -56,6 +61,7 @@ module Rails
         "activejob" => {
           include: %w(
             README.md
+            lib/active_job.rb
             lib/active_job/**/*.rb
           )
         },
@@ -63,6 +69,7 @@ module Rails
         "actioncable" => {
           include: %w(
             README.md
+            lib/action_cable.rb
             lib/action_cable/**/*.rb
           )
         },
@@ -71,6 +78,7 @@ module Rails
           include: %w(
             README.md
             app/**/active_storage/**/*.rb
+            lib/active_storage.rb
             lib/active_storage/**/*.rb
           )
         },
@@ -79,6 +87,7 @@ module Rails
           include: %w(
             README.md
             app/**/action_mailbox/**/*.rb
+            lib/action_mailbox.rb
             lib/action_mailbox/**/*.rb
           )
         },
@@ -87,6 +96,7 @@ module Rails
           include: %w(
             README.md
             app/**/action_text/**/*.rb
+            lib/action_text.rb
             lib/action_text/**/*.rb
           )
         },


### PR DESCRIPTION
Currently when opening the main framework API pages there is no introduction to the framework. Instead we only see a whole lot of modules and the `gem_version` and `version` methods.

By including the READMEs using the `:include:` directive each frameworks has a nice introduction.
For markdown READMEs we need to add the :markup: directive.

[ci-skip]

Thanks to @zzak for the tip of the `:include:` directive.

## Before
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/28561/226462457-c0a9149e-cd8b-4db4-a007-4922e3646d96.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/28561/226462744-72164ea5-6968-48ad-b652-163021e25e65.png">

## After

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/28561/226462384-f0fdfbb0-cdc3-4cce-a502-ed829b2ece1c.png">

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/28561/226462619-9c90db7a-ef54-4f91-8e87-cbc4c75ae926.png">


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
