### PR TITLE
Add `test:prepare` to `bin/setup` template for new apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -31,6 +31,9 @@ FileUtils.chdir APP_ROOT do
   system! "bin/rails db:prepare"
 <% end -%>
 
+  puts "\n== Setup test environment =="
+  system! "bin/rails test:prepare"
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -56,6 +56,8 @@ module ApplicationTests
           Created database 'app_development'
           Created database 'app_test'
 
+          == Setup test environment ==
+
           == Removing old logs and tempfiles ==
 
           == Restarting application server ==


### PR DESCRIPTION
Suggested by @etiennebarrie [here](https://github.com/rails/rails/pull/47210#issuecomment-1476420481), I think this is a good idea. This way if you clone a repo and want to run a single test, you will be able to successfully do so if you ran `bin/setup` first (which is a good idea as it also tries to set up everything else you need).

Note that this does *not* also call `db:test:prepare`, as that is called automatically when you run your tests (see [here](https://github.com/rails/rails/pull/46664#issuecomment-1379522169)).