### PR TITLE
Accept composite primary key in `id=`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -23,7 +23,11 @@ module ActiveRecord
 
       # Sets the primary key column's value.
       def id=(value)
-        _write_attribute(@primary_key, value)
+        if self.class.composite_primary_key?
+          @primary_key.zip(value) { |attr, value| _write_attribute(attr, value) }
+        else
+          _write_attribute(@primary_key, value)
+        end
       end
 
       # Queries the primary key column's value.

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -373,6 +373,22 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     assert_equal ["code", "region"], @connection.primary_keys("barcodes_reverse")
   end
 
+  def test_assigning_a_composite_primary_key
+    book = Cpk::Book.new
+    book.id = [1, 2]
+    book.save!
+
+    assert_equal [1, 2], book.id
+  end
+
+  def test_assigning_a_non_array_value_to_model_with_composite_primary_key_raises
+    book = Cpk::Book.new
+
+    assert_raises(TypeError) do
+      book.id = 1
+    end
+  end
+
   def test_primary_key_issues_warning
     model = Class.new(ActiveRecord::Base) do
       def self.table_name


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This is part of the ongoing effort to support composite primary keys.

A high-volume code path (often in tests) is setting a model's primary key using the accessor method. This PR modifies the API of `id=` to accept an array in composite primary key contexts.

### Implementation

Use branching to either write the value to the single attribute, or values to the list of attributes corresponding to the primary key.

Combining these branches using `Array` removes some handling on when the `@primary_key` is nil because `Array(nil)` resolves to `[]`. A test fails in that scenario, so I've opted to use branching.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
