### PR TITLE
Fix nullification of has_many :through association with `query_constraints

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
           association_primary_key = source_reflection.association_primary_key(reflection.klass)
 
-          if association_primary_key == reflection.klass.primary_key && !options[:source_type]
+          if Array(association_primary_key) == reflection.klass.composite_query_constraints_list && !options[:source_type]
             join_attributes = { source_reflection.name => records }
           else
             join_attributes = {

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -499,6 +499,13 @@ module ActiveRecord
         end
       end
 
+      # Returns an array of column names to be used in queries. The source of column
+      # names is derived from +query_constraints_list+ or +primary_key+. This method
+      # is for internal use when the primary key is to be treated as an array.
+      def composite_query_constraints_list # :nodoc:
+        @composite_query_constraints_list ||= query_constraints_list || Array(primary_key)
+      end
+
       # Destroy an object (or multiple objects) that has the given id. The object is instantiated first,
       # therefore all callbacks and filters are fired off before the object is deleted. This method is
       # less efficient than #delete but allows cleanup methods and other actions to be run.

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -42,7 +42,7 @@ require "models/organization"
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
            :computers, :people, :readers, :authors, :author_addresses, :author_favorites,
-           :comments, :posts, :sharded_blogs, :sharded_blog_posts, :sharded_comments
+           :comments, :posts, :sharded_blogs, :sharded_blog_posts, :sharded_comments, :sharded_tags, :sharded_blog_posts_tags
 
   def test_eager_loading_should_not_change_count_of_children
     liquid = Liquid.create(name: "salty")
@@ -300,6 +300,17 @@ class AssociationsTest < ActiveRecord::TestCase
 
     assert_includes(blog_post.reload.tags, tag)
     assert_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id, tag_id: tag.id), :exists?
+  end
+
+  def test_nullify_composite_has_many_through_association
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    assert_not_empty(blog_post.tags)
+
+    blog_post.tags = []
+
+    assert_empty(blog_post.tags)
+    assert_empty(blog_post.reload.tags)
+    assert_not_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id), :exists?
   end
 end
 


### PR DESCRIPTION
Given a `has_many :through` association with `query_constraints`:

```ruby
BlogPost.has_many :posts_tags
BlogPost.has_many :tags,
  through: :posts_tags,
  query_constraints: [:blog_id, :post_id]
```

It is possible to nullify the association like `blog_post.tags = []`
which results in deletion of records from the `posts_tags` joining table.


### Implementation details

The test we added fails on main with `NoMethodError: undefined method to_sym for ["blog_id", "id"]:Array` on the line 
https://github.com/rails/rails/blob/d53dc868869f973c7ee0bbcdaacfc0239f261773/activerecord/lib/active_record/associations/through_association.rb#L66

However this failure is misleading as we shouldn't be reaching this line at all, at least for the test we built.
In our case the issue lies a few lines above, at:
https://github.com/rails/rails/blob/d53dc868869f973c7ee0bbcdaacfc0239f261773/activerecord/lib/active_record/associations/through_association.rb#L62

Since the introduction of `query_constraints` in associations `association_primary_key` can be an array while `primary_key` may not necessarily be an array in case if the model uses virtual `query_constraints` definition. So essentially we need to compare `association_primary_key` with `query_constraints_list` if it is not empty and only then compare it with a primary key. To avoid branching I've introduced a new internal concept - `composite_query_constraints_list` this is an always non-empty array of query constraints that either equals  to manually configured `query_constraints` or to the `primary_key` wrapped in an array. This concept will be useful in the future in internal codeplaces that are ready to work with an array of columns to avoid unnecessary branching. 

After comparing primary keys as Arrays the logic follows into the branch and queries the records by the association name which has already been fixed in https://github.com/rails/rails/pull/47692


We still need to address the `else` branch but for this we will need to extend our `Sharded` fixtures to have an association with a custom `source_type` or `query_constraints:` configuration different from the parent's `query_constraints` 

