### PR TITLE
Using Rack::Test::UploadedFile.new with  `StringIO` causes an exception

### DIFF
--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -56,6 +56,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal "racecar.jpg", @user.avatar.filename.to_s
   end
 
+  test "attaching StringIO attachable to an existing record" do
+    upload = Rack::Test::UploadedFile.new StringIO.new(""), original_filename: "test.txt"
+
+    @user.avatar.attach upload
+
+    assert_not_nil @user.avatar_attachment
+    assert_not_nil @user.avatar_blob
+  end
+
   test "attaching a new blob from an uploaded file to an existing record passes record" do
     upload = fixture_file_upload("racecar.jpg")
     def upload.open


### PR DESCRIPTION
### Motivation / Background


This Pull Request has been created because I believe we're using the `Rack::Test::UplaodedFile` wrong. This object can be instantiated with an actual File object (this part is extensively tested throughout the suite), but it can also be instantiated with StringIO. Unfortunately, the latter does not have the `#open` method, and using it results in an exception.  

We need to branch out (with duck-typing, as proposed in this PR, but other suggestions are welcome) and use the `Rack::Test::UploadedFile` depending on what it has "under the hood." 

### Detail

This Pull Request changes `ActiveStorage::Attached::Changes::CreateOne#upload` (and private `#find_or_build_blob`) so it does not call `#open` on a `Rack::Test::UploadedFile` if it does not respond to this method. It uses the object itself (which can be read from just like opened File)

### Additional information

Confirmed with `rack-test`'s maintainer this gem's behavior is expected: https://github.com/rack/rack-test/issues/336

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* N/A CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
