### PR TITLE
Rename "Mail" to "Mail extensions" in API sidebar

### DIFF
--- a/railties/lib/rails/api/generator.rb
+++ b/railties/lib/rails/api/generator.rb
@@ -13,8 +13,12 @@ class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
     if visited.empty?
       classes = classes.reject { |klass| active_storage?(klass) }
       core_exts = classes.extract! { |klass| core_extension?(klass) }
+      mail_exts = classes.extract! { |klass| mail_extension?(klass) }
 
-      super.unshift([ "Core extensions", "", "", build_core_ext_subtree(core_exts, visited) ])
+      super + [
+        ["Core extensions", "", "", build_core_ext_subtree(core_exts, visited)],
+        ["Mail extensions", "", "", build_core_ext_subtree(mail_exts, visited)]
+      ]
     else
       super
     end
@@ -30,6 +34,10 @@ class RDoc::Generator::API < RDoc::Generator::SDoc # :nodoc:
 
     def core_extension?(klass)
       klass.name != "ActiveSupport" && klass.in_files.any? { |file| file.absolute_name.include?("core_ext") }
+    end
+
+    def mail_extension?(klass)
+      klass.name != "ActionMailbox" && klass.in_files.any? { |file| file.absolute_name.include?("mail_ext") }
     end
 
     def active_storage?(klass)


### PR DESCRIPTION
Similar to the "Core extensions" we should move the documentation of the extensions to `Mail` to "Mail extensions".
This also move both "Core extensions" and "Mail extensions" to the bottom of the list, as these are both less important than the main frameworks like ActiveSupport and ActiveRecord.

### Before
<img width="299" alt="image" src="https://user-images.githubusercontent.com/28561/226742634-0a253650-9d06-4c6f-8ae0-54b54c0fcb9b.png">

### After
<img width="300" alt="image" src="https://user-images.githubusercontent.com/28561/226742487-552660e8-6499-4b41-a8a5-b5fbf9e50574.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
