### PR TITLE
Introduce query-by-tuple syntax 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Allow specifying where clauses with column-tuple syntax.
+
+    Querying through `#where` now accepts a new tuple-syntax which accepts, as
+    a key, an array of columns and, as a value, an array of corresponding tuples.
+    The key specifies a list of columns, while the value is an array of
+    ordered-tuples that conform to the column list.
+
+    For instance:
+
+    ```ruby
+    # Cpk::Book => Cpk::Book(author_id: integer, number: integer, title: string, revision: integer)
+    # Cpk::Book.primary_key => ["author_id", "number"]
+
+    book = Cpk::Book.create!(author_id: 1, number: 1)
+    Cpk::Book.where(Cpk::Book.primary_key => [[1, 2]]) # => [book]
+
+    # Topic => Topic(id: integer, title: string, author_name: string...)
+
+    Topic.where([:title, :author_name] => [["The Alchemist", "Paul Coelho"], ["Harry Potter", "J.K Rowling"]])
+    ```
+
+    *Paarth Madan*
+
 *   Allow warning codes to be ignore when reporting SQL warnings.
 
     Active Record config that can ignore warning codes

--- a/activerecord/lib/active_record/destroy_association_async_job.rb
+++ b/activerecord/lib/active_record/destroy_association_async_job.rb
@@ -23,15 +23,8 @@ module ActiveRecord
         raise DestroyAssociationAsyncError, "owner record not destroyed"
       end
 
-      if association_model.query_constraints_list
-        association_ids
-          .map { |assoc_ids| association_model.where(association_primary_key_column.zip(assoc_ids).to_h) }
-          .inject(&:or)
-          .find_each { |r| r.destroy }
-      else
-        association_model.where(association_primary_key_column => association_ids).find_each do |r|
-          r.destroy
-        end
+      association_model.where(association_primary_key_column => association_ids).find_each do |r|
+        r.destroy
       end
     end
 

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -44,7 +44,13 @@ module ActiveRecord
             return args if owner.deterministic_encrypted_attributes&.empty?
 
             if args.is_a?(Array) && (options = args.first).is_a?(Hash)
-              options = options.stringify_keys
+              options = options.transform_keys do |key|
+                if key.is_a?(Array)
+                  key.map(&:to_s)
+                else
+                  key.to_s
+                end
+              end
               args[0] = options
 
               owner.deterministic_encrypted_attributes&.each do |attribute_name|

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -78,7 +78,13 @@ module ActiveRecord
         return ["1=0"] if attributes.empty?
 
         attributes.flat_map do |key, value|
-          if value.is_a?(Hash) && !table.has_column?(key)
+          if key.is_a?(Array)
+            queries = Array(value).map do |ids_set|
+              raise ArgumentError, "Expected corresponding value for #{key} to be an Array" unless ids_set.is_a?(Array)
+              expand_from_hash(key.zip(ids_set).to_h)
+            end
+            grouping_queries(queries)
+          elsif value.is_a?(Hash) && !table.has_column?(key)
             table.associated_table(key, &block)
               .predicate_builder.expand_from_hash(value.stringify_keys)
           elsif table.associated_with?(key)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1476,8 +1476,12 @@ module ActiveRecord
           parts = [klass.sanitize_sql(rest.empty? ? opts : [opts, *rest])]
         when Hash
           opts = opts.transform_keys do |key|
-            key = key.to_s
-            klass.attribute_aliases[key] || key
+            if key.is_a?(Array)
+              key.map { |k| klass.attribute_aliases[k.to_s] || k.to_s }
+            else
+              key = key.to_s
+              klass.attribute_aliases[key] || key
+            end
           end
           references = PredicateBuilder.references(opts)
           self.references_values |= references unless references.empty?

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -386,6 +386,10 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     book.save!
 
     assert_equal [1, 2], book.id
+    assert_equal 1, book.author_id
+    assert_equal 2, book.number
+  ensure
+    Cpk::Book.delete_all
   end
 
   def test_assigning_a_non_array_value_to_model_with_composite_primary_key_raises

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -118,8 +118,6 @@ module ActiveRecord
       assert_equal [book_one], Cpk::Book.where([:author_id, :number] => [[1, 2]])
       assert_equal [book_one, book_two].sort, Cpk::Book.where(Cpk::Book.primary_key => [[1, 2], [3, 4]]).sort
       assert_empty Cpk::Book.where([:author_id, :number] => [[1, 4], [3, 2]])
-    ensure
-      Cpk::Book.delete_all
     end
 
     def test_where_with_tuple_syntax_with_incorrect_arity
@@ -143,8 +141,6 @@ module ActiveRecord
       assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist").sort
       assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[1, 2], [3, 4]]).sort
       assert_equal [book_two], Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[3, 4]])
-    ensure
-      Cpk::Book.delete_all
     end
 
     def test_belongs_to_shallow_where

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -16,6 +16,7 @@ require "models/price_estimate"
 require "models/topic"
 require "models/treasure"
 require "models/vertex"
+require "models/cpk"
 require "support/stubs/strong_parameters"
 
 module ActiveRecord
@@ -93,6 +94,57 @@ module ActiveRecord
 
     def test_rewhere_on_root
       assert_equal posts(:welcome), Post.rewhere(title: "Welcome to the weblog").first
+    end
+
+    def test_where_with_tuple_syntax
+      first_topic = topics(:first)
+      third_topic = topics(:third)
+
+      key = [:title, :author_name]
+
+      conditions = [
+        [first_topic.title, first_topic.author_name],
+        [third_topic.title, third_topic.author_name],
+      ]
+
+      assert_equal [first_topic], Topic.where([:id] => [[first_topic.id]])
+      assert_equal [first_topic, third_topic].sort, Topic.where(key => conditions).sort
+    end
+
+    def test_where_with_tuple_syntax_on_composite_models
+      book_one = Cpk::Book.create!(author_id: 1, number: 2)
+      book_two = Cpk::Book.create!(author_id: 3, number: 4)
+
+      assert_equal [book_one], Cpk::Book.where([:author_id, :number] => [[1, 2]])
+      assert_equal [book_one, book_two].sort, Cpk::Book.where(Cpk::Book.primary_key => [[1, 2], [3, 4]]).sort
+      assert_empty Cpk::Book.where([:author_id, :number] => [[1, 4], [3, 2]])
+    ensure
+      Cpk::Book.delete_all
+    end
+
+    def test_where_with_tuple_syntax_with_incorrect_arity
+      error = assert_raise ArgumentError do
+        Cpk::Book.where([:one, :two, :three] => [1, 2, 3])
+      end
+
+      assert_match(/Expected corresponding value for.*to be an Array/, error.message)
+
+      error = assert_raise ArgumentError do
+        Cpk::Book.where([:one] => 1)
+      end
+
+      assert_match(/Expected corresponding value for.*to be an Array/, error.message)
+    end
+
+    def test_where_with_tuple_syntax_and_regular_syntax_combined
+      book_one = Cpk::Book.create!(author_id: 1, number: 2, title: "The Alchemist")
+      book_two = Cpk::Book.create!(author_id: 3, number: 4, title: "The Alchemist")
+
+      assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist").sort
+      assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[1, 2], [3, 4]]).sort
+      assert_equal [book_two], Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[3, 4]])
+    ensure
+      Cpk::Book.delete_all
     end
 
     def test_belongs_to_shallow_where


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR is related to the ongoing effort of introducing composite primary keys.

A very common Rails abstraction pattern is performing a search given a primary key. Across Rails we see numerous instances of code like this:

- [Example 1](https://github.com/rails/rails/blob/3dd5d4900d01c0b25f44c2fbf6ce261d367a490a/activerecord/lib/active_record/destroy_association_async_job.rb#L26)
- [Example 2](https://github.com/rails/rails/blob/fdceee8d78711dff3af24394dda978efe279c084/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L1368)
- [Example 3](https://github.com/rails/rails/blob/d53dc868869f973c7ee0bbcdaacfc0239f261773/activerecord/lib/active_record/relation/finder_methods.rb#L404)

Now that a model can have a primary key that's composed of more than 1 column, a common querying pattern is to look for a set of records given their composite keys.

This PR brings support for querying using tuple-syntax (happy to hear suggestions on other names):

```ruby
book_one = Cpk::Book.create!(author_id: 1, number: 2)
book_two = Cpk::Book.create!(author_id: 3, number: 4)

# Provide a mapping between a list of columns and an array of corresponding tuples
Cpk::Book.where([:author_id, :number] => [[1, 2]]) # Relation(book_one)
Cpk::Book.where(Cpk::Book.primary_key => [[1, 2], [3, 4]]) # Relation(book_one, book_two)
```

### Detail

This PR changes the predicate builder to consider the case when a key in the `Hash` supplied to `#where` is an array. In that case, it iterates across the set of tuples and computes what the query would look like individually. Previously, it was assumed keys and values were singular. Now, the method accepts an array. When encountering one, we iterate through each tuple, and compute a query by deferring each sub-task to the original implementation (i.e recursively), and then finally regrouping (collecting) the queries.

The implementation of `grouping_queries` injects an `OR` in between sub-queries.

Note: This PR doesn't concern itself too heavily with the performance or format of the generated SQL. We've started to consider future iterations where a user-defined config (think: `active_record.config.bulk_query_strategy`) can be used to configure how and what SQL Active Record generates to perform this query. This would allow us to consider building row constructor SQL, appending hints in sharded contexts, or simply falling back to the current "OR-separated" clauses.

In any case, this PR only concerns itself with designing the API for querying by tuple and is less focused on how the query executes.

This PR will help avoid branching and commits like 26994cb06e6214bf387cc34adbb7fb29834b715e will soon be common as we replace many instances of branching with this new syntax.

This new syntax also helps de-risk the composite primary key rollout because many callsites will "automatically" work now that the abstraction works in both the singular and composite case.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
