### PR TITLE
Allow route constraints to be arrays converted to Regexes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Allow route constraints to be arrays of elements that will be converted to
+    Regexes
+
+    ```ruby
+    get(
+      '/download/:platform' => 'download#platform',
+      constraints: { patform: %w[windows linux macos] },
+      as: :download_platform
+    )
+    ```
+
+    The route will be matched if any element matches.
+
+    Fixes #47726
+
+    *Dorian Marié*
+
 *   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**
 
     *Jason Kotchoff*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,4 @@
-*   Allow route constraints to be arrays of elements that will be converted to
-    Regexes
+*   Allow route constraints to be arrays converted to Regexes.
 
     ```ruby
     get(
@@ -15,7 +14,7 @@
 
     *Dorian Marié*
 
-*   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**
+*   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**.
 
     *Jason Kotchoff*
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -175,6 +175,11 @@ module ActionDispatch
                 missing_keys ||= []
                 missing_keys << key
               end
+            when Array
+              unless tests[key].any? { |value| value.match?(parts[key]) }
+                missing_keys ||= []
+                missing_keys << key
+              end
             else
               unless tests[key].match?(parts[key])
                 missing_keys ||= []

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -172,8 +172,14 @@ module ActionDispatch
         end
 
         def requirements_for_missing_keys_check
-          @requirements_for_missing_keys_check ||= requirements.transform_values do |regex|
-            /\A#{regex}\Z/
+          @requirements_for_missing_keys_check ||= requirements.transform_values do |object|
+            if object.is_a?(Array)
+              object.map do |element|
+                /\A#{element}\Z/
+              end
+            else
+              /\A#{object}\Z/
+            end
           end
         end
 

--- a/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
+++ b/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
@@ -85,6 +85,11 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
     get "/profile", to: "users#profile", as: :profile
     get "/media/:id", to: "media#show", as: :media
     get "/pages/:id", to: "pages#show", as: :page
+    get(
+      "/download/:platform" => "download#platform",
+      constraints: { platform: %w[windows linux macos] },
+      as: :download
+    )
 
     resources :categories, :collections, :products, :manufacturers
 
@@ -143,6 +148,10 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
 
   def params
     ActionController::Parameters.new(page: 2, size: 25)
+  end
+
+  def test_constraints_path
+    assert_equal "/download/macos", download_path(platform: "macos")
   end
 
   def test_direct_paths


### PR DESCRIPTION
```ruby
get(
  '/download/:platform' => 'download#platform',
  constraints: { patform: %w[windows linux macos] },
  as: :download_platform
)
```

The route will be matched if any element matches.

Fixes #47726

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
