### PR TITLE
Fix `#hash` and `#==` for composite pk models

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -21,6 +21,12 @@ module ActiveRecord
         @primary_key.map { |pk| _read_attribute(pk) }
       end
 
+      def primary_key_values_present? # :nodoc:
+        return id.all? if self.class.composite_primary_key?
+
+        !!id
+      end
+
       # Sets the primary key column's value.
       def id=(value)
         _write_attribute(@primary_key, value)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -549,7 +549,7 @@ module ActiveRecord
     def ==(comparison_object)
       super ||
         comparison_object.instance_of?(self.class) &&
-        !id.nil? &&
+        primary_key_values_present? &&
         comparison_object.id == id
     end
     alias :eql? :==
@@ -559,7 +559,7 @@ module ActiveRecord
     def hash
       id = self.id
 
-      if id
+      if primary_key_values_present?
         self.class.hash ^ id.hash
       else
         super

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -217,6 +217,13 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_not_predicate Dashboard, :composite_primary_key?
   end
 
+  def test_primary_key_values_present
+    assert_predicate Topic.new(id: 1), :primary_key_values_present?
+
+    assert_not_predicate Topic.new, :primary_key_values_present?
+    assert_not_predicate Topic.new(title: "Topic A"), :primary_key_values_present?
+  end
+
   if current_adapter?(:PostgreSQLAdapter)
     def test_serial_with_quoted_sequence_name
       column = MixedCaseMonkey.columns_hash[MixedCaseMonkey.primary_key]
@@ -410,6 +417,16 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
   def composite_primary_key_is_true_for_a_cpk_model
     assert_predicate Cpk::Book, :composite_primary_key?
+  end
+
+  def test_primary_key_values_present_for_a_composite_pk_model
+    assert_predicate Cpk::Book.new(author_id: 1, number: 1), :primary_key_values_present?
+
+    assert_not_predicate Cpk::Book.new, :primary_key_values_present?
+    assert_not_predicate Cpk::Book.new(author_id: 1), :primary_key_values_present?
+    assert_not_predicate Cpk::Book.new(number: 1), :primary_key_values_present?
+    assert_not_predicate Cpk::Book.new(title: "Book A"), :primary_key_values_present?
+    assert_not_predicate Cpk::Book.new(author_id: 1, title: "Book A"), :primary_key_values_present?
   end
 end
 


### PR DESCRIPTION
Given a model with a composite primary key, for example: `TravelRoute.primary_key = [:from, :to]`

and two objects of the given model, objects `a` and `b`, should be equal to each other and have the same `hash` value if they have the same values for the composite primary key, like:

```ruby
a = TravelRoute.new(from: "NYC", to: "LAX")
b = TravelRoute.new(from: "NYC", to: "LAX")
a == b # => true

a.hash == b.hash # => true
```

At the same time, two objects of the given model should not be equal to each other and should have different `hash` values if they have different primary key values or no primary key being set, like:

```ruby
a = TravelRoute.new(from: "NYC", to: "LAX")
b = TravelRoute.new(from: "NYC", to: "SFO")
a == b # => false
a.hash == b.hash # => false

TravelRoute.new == TravelRoute.new # => false
TravelRoute.new.hash == TravelRoute.new.hash # => false
```

### Motivation

Currently two objects of a model with a composite primary key will be considered equal and have the same `hash` value even if the values of the composite primary key are not present.
For example if we use models from the test suite:
```ruby
book_1 = Cpk::Book.new(title: "book 1")
book_2 = Cpk::Book.new(title: "book 2")
```
Comparing these like `book_1 == book_2` will return `true` along with `book_1.hash == book_2.hash` 
This happens because the current implementation relies on the presence of the `id` value:
https://github.com/rails/rails/blob/ba19dbc49956a73f417abd68c7a5f33e302eacd3/activerecord/lib/active_record/core.rb#L552
The same applies to the `hash` method:
https://github.com/rails/rails/blob/ba19dbc49956a73f417abd68c7a5f33e302eacd3/activerecord/lib/active_record/core.rb#L562

However for models with a composite primary key the presence of `id` is a bit more complex concept than just truthiness of the `id` attribute. For a composite primary key objects the `id` value is always truthy as it's always an array - `[]`. In our case `id` value ends up returning `[nil, nil]` which is a truthy value and we end up comparing `[nil, nil] == [nil, nil]` resulting in two different objects treated as the same and having the same `hash.`

Since the "presence of the primary key values" became a more complex concept that just a presence of a single value we are introducing a new method - `primary_key_values_present?` to encapsulate the logic on the object itself which makes the change to both `==` and `hash` methods fairly straightforward. We could even split this PR into two - the first one would only introduce the `primary_key_values_present?` abstraction and the second one that extends it for the composite primary keys support. This way we wouldn't even need to touch the `core.rb` file.

For non-composite pk models implementation of `primary_key_values_present?` stays the same - presence of `id` using `!!id` 
And for a model with a composite primary key we need to make sure that the primary key values is a non-empty array and every part of the value is present. We are doing that through checking the `size` of the `id` value being greater than 0, making sure we do have at least some parts of the primary key and then we check that all parts of the primary key are non-nil values using `id.all?` 


### Biggest concern with `primary_key_values_present?` 

We are confident that having `primary_key_values_present?` as a separate abstraction is reasonable. However the biggest concern here is that the newly added abstraction is very similar to the existing `id?` method:
https://github.com/rails/rails/blob/ba19dbc49956a73f417abd68c7a5f33e302eacd3/activerecord/lib/active_record/attribute_methods/primary_key.rb#L34-L36

It feels like the `id?` method would have been the best fit to represent the "presence of the primary key values" abstraction however the way it works right now may not fit our expectations for a composite primary key model.
Let's have an example for a regular model:
```ruby
topic = Topic.new(id: 0)
topic.id? # => false
```
Currently `id?` returns true for a `0` value because it uses `query_attribute` which treats objects that respond to `zero?` as a falsey value - 
https://github.com/rails/rails/blob/ba19dbc49956a73f417abd68c7a5f33e302eacd3/activerecord/lib/active_record/attribute_methods/query.rb#L26-L27

It may be reasonable for `0` to represent an absence of the `id` attribute however this is not consistent with how equality currently treats it, since equality considers `0` to be a thuthy value and compares two objects by it, for example:
```ruby
# ignores the `title` attribute and compares entities by id which is `0 == 0`
Topic.new(id: 0, title: "Topic A") == Topic.new(id: 0, title: "Topic A") # => true
# same for hash
Topic.new(id: 0, title: "Topic A").hash == Topic.new(id: 0, title: "Topic A").hash # => true
```
This inconsistency may deserve a separate discussion but for our goal of supporting composite primary key the way how `query_attribute` treats `0` leads to even more complexities as in a composite primary key setup it should be fairly valid to have one part of the composite primary key values as `0` making it impossible to use `id?` for the composite primary key use-case unless we want to change the meaning of `0` for the `id` attribute.

So in the long-term the `primary_key_values_present?` may become redundant and be substituted with `id?` check but not until we have a clear expectations on that



