### PR TITLE
implement `provider_job_id` for Backburner jobs

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Set `provider_job_id` for Backburner jobs
+
+    *Cameron Matheson*
+
 *   Add `perform_all_later` to enqueue multiple jobs at once
 
     This adds the ability to bulk enqueue jobs, without running callbacks, by

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -16,12 +16,16 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :backburner
     class BackburnerAdapter
       def enqueue(job) # :nodoc:
-        Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority)
+        response = Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority)
+        job.provider_job_id = response[:id] if response.is_a?(Hash)
+        response
       end
 
       def enqueue_at(job, timestamp) # :nodoc:
         delay = timestamp - Time.current.to_f
-        Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority, delay: delay)
+        response = Backburner::Worker.enqueue(JobWrapper, [job.serialize], queue: job.queue_name, pri: job.priority, delay: delay)
+        job.provider_job_id = response[:id] if response.is_a?(Hash)
+        response
       end
 
       class JobWrapper # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This PR implements `provider_job_id` for the Beanstalk ActiveJob QueueAdapter.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
