### PR TITLE
Do not allocate the first character when checking for relative paths

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -68,7 +68,7 @@ module ActionDispatch
 
       private
         def relative_path?(path)
-          path && !path.empty? && path[0] != "/"
+          path && !path.empty? && !path.start_with?("/")
         end
 
         def escape(params)


### PR DESCRIPTION
This is the same optimization applied in https://github.com/rails/rails/commit/a63ae913dfbb3813256144e52ae1063ac59edba4 which I proposed in https://github.com/rails/rails/pull/47714

```rb
require "bundler/inline"

ROOT_STRING = '/'
TEST_PATH = "/some/path"

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

Benchmark.ips do |x|
  x.report("path[0]") do
   TEST_PATH[0] != ROOT_STRING
  end

  x.report("path.start_with?") do
   TEST_PATH.start_with?(ROOT_STRING)
  end

  x.compare!
end
```

```
Warming up --------------------------------------
             path[0]   942.044k i/100ms
    path.start_with?     1.556M i/100ms
Calculating -------------------------------------
             path[0]      9.463M (± 0.9%) i/s -     48.044M in   5.077358s
    path.start_with?     15.611M (± 0.2%) i/s -     79.352M in   5.083056s

Comparison:
    path.start_with?: 15611192.8 i/s
             path[0]:  9463245.0 i/s - 1.65x  slower
```

### Motivation / Background

More optimizations in the code, less CO2 in our planet.

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
