### PR TITLE
Fix Fanout thread safety

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -48,7 +48,7 @@ module ActiveSupport
       include Mutex_m
 
       def initialize
-        @string_subscribers = Hash.new { |h, k| h[k] = [] }
+        @string_subscribers = Concurrent::Map.new { |h, k| h[k] = [] }
         @other_subscribers = []
         @all_listeners_for = Concurrent::Map.new
         @groups_for = Concurrent::Map.new


### PR DESCRIPTION
Fanout is a singleton shared among threads, so all of its hash maps should be concurrent hash maps otherwise we'll see errors like this:

```
RuntimeError: can't add a new key into hash during iteration
```

cc @zenspider 