### PR TITLE
Add `ActiveSupport` load hook for `ActionText::EncryptedRichText`

### DIFF
--- a/actiontext/app/models/action_text/encrypted_rich_text.rb
+++ b/actiontext/app/models/action_text/encrypted_rich_text.rb
@@ -7,3 +7,5 @@ module ActionText
     encrypts :body
   end
 end
+
+ActiveSupport.run_load_hooks :action_text_encrypted_rich_text, ActionText::EncryptedRichText

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1488,6 +1488,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActionText::Content`                | `action_text_content`                |
 | `ActionText::Record`                 | `action_text_record`                 |
 | `ActionText::RichText`               | `action_text_rich_text`              |
+| `ActionText::EncryptedRichText`      | `action_text_encrypted_rich_text`    |
 | `ActionView::Base`                   | `action_view`                        |
 | `ActionView::TestCase`               | `action_view_test_case`              |
 | `ActiveJob::Base`                    | `active_job`                         |


### PR DESCRIPTION
### Motivation / Background

Both `ActionText::Record` and `ActionText::RichText` have dedicated `ActiveSupport` load hooks. This adds an additional hook for `ActionText::EncryptedRichText`, so that external libraries have a similarly simple way to run code after the subclass is loaded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (I didn't see tests for the other two ActionText record load hooks, so I didn't add one)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (this doesn't feel changelog-able to me, but i don't mind adding an entry if that seems appropriate)
