### PR TITLE
Support composite primary keys during transaction rollback

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -416,8 +416,16 @@ module ActiveRecord
             end
             @mutations_from_database = nil
             @mutations_before_last_save = nil
-            if @attributes.fetch_value(@primary_key) != restore_state[:id]
-              @attributes.write_from_user(@primary_key, restore_state[:id])
+            if self.class.composite_primary_key?
+              if restore_state[:id] != @primary_key.map { |col| @attributes.fetch_value(col) }
+                @primary_key.zip(restore_state[:id]).each do |col, val|
+                  @attributes.write_from_user(col, val)
+                end
+              end
+            else
+              if @attributes.fetch_value(@primary_key) != restore_state[:id]
+                @attributes.write_from_user(@primary_key, restore_state[:id])
+              end
             end
             freeze if restore_state[:frozen?]
           end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Part of the ongoing effort to support composite primary keys.

After working on #47729, a testing failure exposed that rollbacks are currently broken in a composite key context.

In a transaction that needs to be rolledback we started to see the following error instead of the underlying exception that caused the rollback.

```sh
ActiveModel::MissingAttributeError: can't write unknown attribute `["author_id", "number"]`
/src/github.com/Shopify/rails/activemodel/lib/active_model/attribute.rb:223:in `with_value_from_database'
/src/github.com/Shopify/rails/activemodel/lib/active_model/attribute_set.rb:60:in `write_from_user'
/src/github.com/Shopify/rails/activerecord/lib/active_record/transactions.rb:420:in `restore_transaction_record_state'
/src/github.com/Shopify/rails/activerecord/lib/active_record/transactions.rb:337:in `rolledback!'
```

This was due in part to the fact that currently restoring a record during a transaction rollback doesn't consider that `@primary_key` can be an array.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
