### PR TITLE
Fix precedence of `primary_key:` in associations with `query_constraints`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -511,13 +511,18 @@ module ActiveRecord
       end
 
       def active_record_primary_key
-        @active_record_primary_key ||= if options[:query_constraints]
+        custom_primary_key = options[:primary_key]
+        @active_record_primary_key ||= if custom_primary_key
+          if custom_primary_key.is_a?(Array)
+            custom_primary_key.map { |pk| pk.to_s.freeze }.freeze
+          else
+            custom_primary_key.to_s.freeze
+          end
+        elsif options[:query_constraints]
           active_record.query_constraints_list
         else
-          -(options[:primary_key]&.to_s || primary_key(active_record))
+          primary_key(active_record).freeze
         end
-
-        @active_record_primary_key
       end
 
       def join_primary_key(klass = nil)

--- a/activerecord/test/models/sharded.rb
+++ b/activerecord/test/models/sharded.rb
@@ -2,6 +2,7 @@
 
 require_relative "sharded/blog"
 require_relative "sharded/blog_post"
+require_relative "sharded/blog_post_with_revision"
 require_relative "sharded/comment"
 require_relative "sharded/tag"
 require_relative "sharded/blog_post_tag"

--- a/activerecord/test/models/sharded/blog_post_with_revision.rb
+++ b/activerecord/test/models/sharded/blog_post_with_revision.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sharded
+  # copy of the original `BlogPost` class, but with a different `query_constraints`
+  class BlogPostWithRevision < ActiveRecord::Base
+    self.table_name = :sharded_blog_posts
+    query_constraints :blog_id, :revision, :id
+
+    has_many :comments, primary_key: [:blog_id, :id], query_constraints: [:blog_id, :blog_post_id]
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -272,6 +272,7 @@ ActiveRecord::Schema.define do
   create_table :sharded_blog_posts, force: true do |t|
     t.string :title
     t.integer :blog_id
+    t.integer :revision
   end
 
   create_table :sharded_comments, force: true do |t|


### PR DESCRIPTION
Currently `primary_key:` option is being ignored in associations where `query_constraints` argument is present and association automatically uses `active_record.query_constraints_list`

We should bring back the priority of a manually specified `primary_key:` attribute and only fallback to the `query_constraints_list` if `primary_key` option is empty.

As the test example shows this is useful in cases where association should use a different setup of the `query_constraints` compared with the parent model. But it can also be useful if the parent model doesn't have any `query_constraints` while we still want the association to use multiple columns in queries 