### PR TITLE
Introduces ActiveRecord::Base#alert

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Introduces ActiveRecord::Base#alert
+
+    ```ruby
+    def alert
+      errors.full_messages.to_sentence
+    end
+    ```
+
+    Example:
+
+    ```ruby
+    if @post.update(post_params)
+      redirect_to @post
+    else
+      flash.now.alert = @post.alert
+      render :edit
+    end
+    ```
+
+    *Dorian Marié*
+
 *   Allow warning codes to be ignore when reporting SQL warnings.
 
     Active Record config that can ignore warning codes

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -37,6 +37,7 @@ require "active_record/errors"
 module ActiveRecord
   extend ActiveSupport::Autoload
 
+  autoload :Alert
   autoload :Base
   autoload :Callbacks
   autoload :ConnectionHandling

--- a/activerecord/lib/active_record/alert.rb
+++ b/activerecord/lib/active_record/alert.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Alert
+    def alert
+      errors.full_messages.to_sentence
+    end
+  end
+end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -330,6 +330,7 @@ module ActiveRecord # :nodoc:
     include SignedId
     include Suppressor
     include Normalization
+    include Alert
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/test/cases/alert_test.rb
+++ b/activerecord/test/cases/alert_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/author"
+require "models/translation"
+
+class AssociationsTest < ActiveRecord::TestCase
+  fixtures :authors
+
+  def test_without_error_messages
+    assert_equal "", authors(:david).alert
+  end
+
+  def test_with_one_error
+    author = authors(:david)
+    author.name = nil
+    assert_not author.valid?
+    assert_equal "Name can’t be blank", author.alert
+  end
+
+  def test_with_two_errors
+    translation = Translation.new
+    assert_not translation.valid?
+    assert_equal(
+      "Locale can’t be blank, Key can’t be blank, and Value can’t be blank",
+      translation.alert
+    )
+  end
+end


### PR DESCRIPTION
```ruby
def alert
  errors.full_messages.to_sentence
end
```

Example:

```ruby
if @post.update(post_params)
  redirect_to @post
else
  flash.now.alert = @post.alert
  render :edit
end
```

### Motivation / Background

In all my personal Ruby on Rails projects I add this alias so I thought it would be helpful for more people.

This Pull Request has been created to make dealing with validation errors easier.

### Detail

This Pull Request changes ActiveRecord::Base to include the method `alert`.

### Additional information

I'm thinking it would be a nice default for the generators to use flash for alerts instead of iterating over errors in the forms.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
