### PR TITLE
TimeWithZone#today? should respect non UTC timezones

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -28,7 +28,7 @@ module DateAndTime
 
     # Returns true if the date/time is today.
     def today?
-      to_date == ::Date.current
+      to_date == self.class.current
     end
 
     # Returns true if the date/time is tomorrow.

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -272,7 +272,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_today
-    Date.stub(:current, Date.new(2000, 1, 1)) do
+    Time.stub(:current, Time.utc(2000, 1, 1)) do
       assert_equal false, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(1999, 12, 31, 23, 59, 59)).today?
       assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 0)).today?
       assert_equal true, ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(2000, 1, 1, 23, 59, 59)).today?


### PR DESCRIPTION
This attempts to fix the bug identified in #46361

---

It seems like the test should also change, since it was failing on my machine (+09:00).