### PR TITLE
Fix test_can_be_garbage_collected

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -106,8 +106,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       [WeakRef.new(checker), Thread.list - threads_before_checker]
     end.value
 
-    # Calling `GC.start` 4 times should trigger a full GC run.
-    4.times do
+    # Calling `GC.start` 30 times should trigger a full GC run.
+    30.times do
       GC.start
     end
 


### PR DESCRIPTION
This number of GC.start calls was enough to trigger a full GC on my machine, any less and it was very flakey. Lower number resulted in consistent failures.

```
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
```

cc #44220 and #42845

---

Actually this number is arbitrary, and hilarious, but it worked for me. Hoping to get some more 👀 on it. :pray:

---

Should also note that without this change, `test_notifies_forked_processes ` results in the same error as mentioned in #44220:
https://buildkite.com/rails/rails/builds/84109#4a72a57f-20d3-44e1-b0a1-61c6a0baf3b3/1191-1201
