### PR TITLE
Fix a race condition in EventedFileUpdateCheckerTest

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -106,10 +106,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       [WeakRef.new(checker), Thread.list - threads_before_checker]
     end.value
 
-    # Calling `GC.start` 4 times should trigger a full GC run.
-    4.times do
-      GC.start
-    end
+    GC.start
+    listener_threads.each { |t| t.join(1) }
 
     assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
     assert_empty Thread.list & listener_threads


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/47746

We need to wait for the listener threads to exit.

@zzak I believe this is the real root cause.