### PR TITLE
Extract sample rate in audio analyzer

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `sample_rate` to `ActiveStorage::Analyzer::AudioAnalyzer` output
+
+    *Matija Čupić*
+
 *   Remove deprecated `purge` and `purge_later` methods from the attachments association.
 
     *Rafael Mendonça França*

--- a/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module ActiveStorage
-  # Extracts duration (seconds) and bit_rate (bits/s) from an audio blob.
+  # Extracts duration (seconds), bit_rate (bits/s) and sample_rate (hertz) from an audio blob.
   #
   # Example:
   #
   #   ActiveStorage::Analyzer::AudioAnalyzer.new(blob).metadata
-  #   # => { duration: 5.0, bit_rate: 320340 }
+  #   # => { duration: 5.0, bit_rate: 320340, sample_rate: 44100 }
   #
   # This analyzer requires the {FFmpeg}[https://www.ffmpeg.org] system library, which is not provided by Rails.
   class Analyzer::AudioAnalyzer < Analyzer
@@ -15,7 +15,7 @@ module ActiveStorage
     end
 
     def metadata
-      { duration: duration, bit_rate: bit_rate }.compact
+      { duration: duration, bit_rate: bit_rate, sample_rate: sample_rate }.compact
     end
 
     private
@@ -27,6 +27,11 @@ module ActiveStorage
       def bit_rate
         bit_rate = audio_stream["bit_rate"]
         Integer(bit_rate) if bit_rate
+      end
+
+      def sample_rate
+        sample_rate = audio_stream["sample_rate"]
+        Integer(sample_rate) if sample_rate
       end
 
       def audio_stream

--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -12,6 +12,7 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
 
     assert_equal 0.914286, metadata[:duration]
     assert_equal 128000, metadata[:bit_rate]
+    assert_equal 44100, metadata[:sample_rate]
   end
 
   test "instrumenting analysis" do


### PR DESCRIPTION
### Motivation / Background

In our application, we use ActiveStorage to store audio blobs to a cloud storage provider. At certain points in the code we need to check the sample rate of the audio file. To do this, we need  to download the file from cloud storage, then run `ffprobe` on it to get the sample rate.

This PR makes it easy and efficient to check the sample rate by adding sample rate to the audio analysis that's done when the file is uploaded.

### Detail

This PR adds a `sample_rate` key in the metadata hash output by the audio analyzer with the blob sample rate.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
