### PR TITLE
ActiveRecord::Relation#async_pending? for introspecting async relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Introduce `ActiveRecord::Relation#async_pending?`
+
+    You can now check if an asynchronous `ActiveRecord::Relation` query is *pending* by using
+    the `async_pending?` predicate. This will return `true` if the relation is still pending on the
+    background thread pool; otherwise, it will return `false`.
+
+    For instance:
+
+    Given an asynchronous query
+
+    ```ruby
+    @posts = Post.all.load_async
+    ```
+
+    If you wanted to define a function that would flush a buffer if it was waiting on an asynchronous
+    query, you could check the status of the query like this:
+
+    ```ruby
+    def await(query)
+      flush if query.async_pending?
+      query
+    end
+    ```
+
+    Then you could use it like this:
+
+    ```ruby
+    await(@posts).each { ... }
+    ```
+
+    *Joel Drapper*
+
 *   Allow specifying where clauses with column-tuple syntax.
 
     Querying through `#where` now accepts a new tuple-syntax which accepts, as

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -693,6 +693,12 @@ module ActiveRecord
       !!@future_result
     end
 
+    # Returns <tt>true</tt> if the relation is pending on the background
+    # thread pool.
+    def async_pending?
+      !!@future_result&.pending?
+    end
+
     # Causes the records to be loaded from the database if they have not
     # been loaded already. You can use this if for some reason you need
     # to explicitly load some records before actually using them. The

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -41,6 +41,28 @@ module ActiveRecord
       assert_not_predicate deferred_posts, :scheduled?
     end
 
+    def test_async_pending_predicate_with_async_query
+      unless in_memory_db?
+        deferred_posts = Post.where(author_id: 1).load_async
+        future_results = deferred_posts.instance_variable_get(:@future_result)
+
+        future_results.stub(:pending?, true) do
+          assert_predicate deferred_posts, :async_pending?
+        end
+
+        future_results.stub(:pending?, false) do
+          assert_not_predicate deferred_posts, :async_pending?
+        end
+      end
+    end
+
+    def test_async_pending_predicate_with_synchronous_query
+      unless in_memory_db?
+        posts = Post.where(author_id: 1)
+        assert_not_predicate posts, :async_pending?
+      end
+    end
+
     def test_reset
       deferred_posts = Post.where(author_id: 1).load_async
       if in_memory_db?


### PR DESCRIPTION
Add `pending?` predicate to `ActiveRecord::Relation` that returns `true` if the relation is pending on the background thread pool; otherwise, returns `false`.

### Motivation / Background

This Pull Request has been created because there is currently no way to tell if an asynchronous `ActiveRecord::Relation` has actually loaded, since `loaded?` returns `true` even if the future is still pending.

An alternative approach might be to update the `loading?` predicate to return `false` when a future result is still pending. That would be a breaking change, and I don't know what else it might impact.

### Detail

This Pull Request adds a `pending?` predicate that returns `true` if the future result is pending; otherwise, returns `false`.

### Additional information

This change is based on [this discussion](https://discuss.rubyonrails.org/t/is-there-a-way-to-check-of-an-async-database-query-has-actually-loaded/82538).

I tried to write a test but wasn’t able to work out how to artificially slow an SQLite query to the point where it would still be pending by the time we check the predicate. There doesn’t seem to be a way to make an SQLite query sleep so let me know if you have any suggestions on how to do this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
