### PR TITLE
Raise error when generating attribute with dangerous name

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Raise error when generating attribute with dangerous name.
+
+    The following will now raise an error as `save` and `hash` are already
+    defined by Active Record.
+
+    ```bash
+    bin/rails generate model Post save
+    bin/rails generate model Post hash
+    ```
+
+    *Petrik de Heus*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Add ability to show slow tests to the test runner

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -43,6 +43,10 @@ module Rails
           type, attr_options = *parse_type_and_options(type)
           type = type.to_sym if type
 
+          if dangerous_name?(name)
+            raise Error, "Could not generate field '#{name}', as it is already defined by Active Record."
+          end
+
           if type && !valid_type?(type)
             raise Error, "Could not generate field '#{name}' with unknown type '#{type}'."
           end
@@ -58,6 +62,10 @@ module Rails
           end
 
           new(name, type, index_type, attr_options)
+        end
+
+        def dangerous_name?(name)
+          ActiveRecord::Base.dangerous_attribute_method?(name)
         end
 
         def valid_type?(type)

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -17,6 +17,14 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     Rails.application.config.active_record.belongs_to_required_by_default = @old_belongs_to_required_by_default
   end
 
+  def test_field_name_with_dangerous_attribute_raises_error
+    e = assert_raise Rails::Generators::Error do
+      create_generated_attribute :string, :save
+    end
+    message = "Could not generate field 'save', as it is already defined by Active Record."
+    assert_match message, e.message
+  end
+
   def test_field_type_returns_number_field
     assert_field_type :integer, :number_field
   end


### PR DESCRIPTION
Generating a model with attributes named `hash` or `save` should raise an error, instead of generating a migration with an invalid attribute.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
