### PR TITLE
Fix Rails generated index name being too long

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Limit max length of auto generated index names
+
+    Auto generated index names are now limited to 62 bytes, which fits within
+    the default index name length limits for MySQL, Postgres and SQLite.
+
+    Any index name over the limit will fallback to the new short format.
+
+    Before (too long):
+    ```
+    index_testings_on_foo_and_bar_and_first_name_and_last_name_and_administrator
+    ```
+
+    After (short format):
+    ```
+    ix_on_foo_bar_first_name_last_name_administrator_5939248142
+    ```
+
+    The short format includes a hash to ensure the name is unique database-wide.
+
+    *Mike Coutermarsh*
+
 *   Introduce a more stable and optimized Marshal serializer for Active Record models.
 
     Can be enabled with `config.active_record.marshalling_format_version = 7.1`.

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -54,6 +54,10 @@ module ActiveRecord
           super
         end
 
+        def add_index(table_name, column_name, **options)
+          options[:name] = legacy_index_name(table_name, column_name) if options[:name].nil?
+          super
+        end
 
         def create_table(table_name, **options)
           options[:_uses_legacy_table_name] = true
@@ -104,6 +108,32 @@ module ActiveRecord
               prepend TableDefinition
             end
             super
+          end
+
+          def legacy_index_name(table_name, options)
+            if Hash === options
+              if options[:column]
+                "index_#{table_name}_on_#{Array(options[:column]) * '_and_'}"
+              elsif options[:name]
+                options[:name]
+              else
+                raise ArgumentError, "You must specify the index name"
+              end
+            else
+              legacy_index_name(table_name, index_name_options(options))
+            end
+          end
+
+          def index_name_options(column_names)
+            if expression_column_name?(column_names)
+              column_names = column_names.scan(/\w+/).join("_")
+            end
+
+            { column: column_names }
+          end
+
+          def expression_column_name?(column_name)
+            column_name.is_a?(String) && /\W/.match?(column_name)
           end
       end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -550,6 +550,22 @@ module ActiveRecord
         connection.drop_table :more_testings rescue nil
       end
 
+      def test_add_index_errors_on_too_long_name_7_0
+        migration = Class.new(ActiveRecord::Migration[7.0]) {
+          def migrate(x)
+            add_column :testings, :very_long_column_name_to_test_with, :string
+            add_index :testings, [:foo, :bar, :very_long_column_name_to_test_with]
+          end
+        }.new
+
+        error = assert_raises(StandardError) do
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        end
+
+        assert_match(/index_testings_on_foo_and_bar_and_very_long_column_name_to_test_with/i, error.message)
+        assert_match(/is too long/i, error.message)
+      end
+
       def test_add_reference_on_6_0
         create_migration = Class.new(ActiveRecord::Migration[6.0]) {
           def version; 100 end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -103,6 +103,11 @@ module ActiveRecord
         assert connection.index_name_exists?(table_name, "index_testings_on_foo_and_bar")
       end
 
+      def test_add_index_fallback_to_short_name
+        connection.add_index(table_name, [:foo, :bar, :first_name, :last_name, :administrator])
+        assert connection.index_name_exists?(table_name, "ix_on_foo_bar_first_name_last_name_administrator_5939248142")
+      end
+
       def test_remove_index_which_does_not_exist_doesnt_raise_with_option
         connection.add_index(table_name, "foo")
 


### PR DESCRIPTION
### Motivation / Background

Frequently I find myself hitting my database's "is too long" error when adding a compound index.

When this happens, I need to manually set a shorter name to run the migration.

### Detail

This updates the index name generation to always create a valid index name if one is not passed by the user.

I set the limit to 62 to ensure it works for the default configurations of sqlite, mysql & postgres.

MySQL: 64
Postgres: 63
Sqlite: 62

I considered using `index_name_length`. But that value could change, resulting in inconsistent index names when migrations are run.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
