### PR TITLE
Update prevents_write docs

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -215,9 +215,6 @@ module ActiveRecord
     #
     # This method does not provide the same protection as a readonly
     # user and is meant to be a safeguard against accidental writes.
-    #
-    # See +READ_QUERY+ for the queries that are blocked by this
-    # method.
     def while_preventing_writes(enabled = true, &block)
       connected_to(role: current_role, prevent_writes: enabled, &block)
     end

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -54,8 +54,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
   test "previewing on the writer DB" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 
-    # prevent_writes option is required because there is no automatic write protection anymore
-    ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, prevent_writes: true) do
+    ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role) do
       blob.preview(resize_to_limit: [640, 280]).processed
     end
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -379,10 +379,11 @@ like `connected_to(role: :nonexistent)` you will get an error that says
 
 If you want Rails to ensure any queries performed are read only, pass `prevent_writes: true`.
 This just prevents queries that look like writes from being sent to the database.
+This is always enabled for `role: :reading`, but can be set to prevent write queries against any role.
 You should also configure your replica database to run in readonly mode.
 
 ```ruby
-ActiveRecord::Base.connected_to(role: :reading, prevent_writes: true) do
+ActiveRecord::Base.connected_to(role: :primary, prevent_writes: true) do
   # Rails will check each query to ensure it's a read query
 end
 ```


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I noticed that the comment about the `READ_QUERY` was backwards (it's a list of allowed queries, not blocked queries) and that `role: :reading` always sets `prevents_writes: true`.  I've removed the reference to `READ_QUERY` because it's a private constant.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
Let me know if you folks would prefer these commits to be squished or split to different PRs.

Demo for `prevents_writes` always being set for `:reading`:
```ruby
> ActiveRecord::Base.connected_to(role: :primary) { ActiveRecord::Base.current_preventing_writes }
false
> ActiveRecord::Base.connected_to(role: :primary, prevent_writes: true) { ActiveRecord::Base.current_preventing_writes }
true
> ActiveRecord::Base.connected_to(role: :reading) { ActiveRecord::Base.current_preventing_writes }
true
> ActiveRecord::Base.connected_to(role: :reading, prevent_writes: false) { ActiveRecord::Base.current_preventing_writes }
true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and~~ documentation changes should not be included.