### PR TITLE
Generalize check for foreign keys when checking for the inverse of a record

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -377,10 +377,16 @@ module ActiveRecord
 
         def matches_foreign_key?(record)
           if foreign_key_for?(record)
-            record.read_attribute(reflection.foreign_key) == owner.id ||
-              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
+            record.read_attribute(reflection.foreign_key) == owner.read_attribute(reflection.association_primary_key) ||
+              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.read_attribute(reflection.association_primary_key))
           else
-            owner.read_attribute(reflection.foreign_key) == record.id
+            record_primary_key = if reflection.polymorphic?
+              record.id
+            else
+              record.read_attribute(reflection.association_primary_key)
+            end
+
+            owner.read_attribute(reflection.foreign_key) == record_primary_key
           end
         end
     end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -670,6 +670,21 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_equal comment.body, comment.children.first.parent.body
   end
 
+  def test_inverse_works_when_the_association_self_references_the_same_object_and_uses_non_id_foreign_key
+    post = Post.create!(token: "A-123", title: "My Post", body: "Post Body")
+    parent = UnconventionalComment.create!(uuid: "d6d98b88", post: post, label: :default, body: "New Parent Comment")
+    UnconventionalComment.create!(comment_uuid: parent.uuid, post: post, label: :child, body: "New Child Comment")
+
+    assert_equal parent.object_id, parent.children.first.parent.object_id
+  end
+
+  def test_inverse_works_with_scoped_association_and_non_id_foreign_key
+    post = Post.create!(token: "A-123", title: "My Post", body: "Post Body")
+    Comment.create!(post: post, label: :default, body: "New Comment")
+
+    assert_equal post.object_id, post.comments.first.post.object_id
+  end
+
   def test_changing_the_association_id_makes_the_inversed_association_target_stale
     post1 = Post.first
     post2 = Post.second

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -29,8 +29,8 @@ module ActiveRecord
         cache.connection = connection
 
         assert_no_queries do
-          assert_equal 12, cache.columns("posts").size
-          assert_equal 12, cache.columns_hash("posts").size
+          assert_equal 13, cache.columns("posts").size
+          assert_equal 13, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
           assert_equal 1, cache.indexes("posts").size

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -140,7 +140,7 @@ module ActiveRecord
     def test_star_select_with_joins_and_includes
       posts = Post.select("posts.*").joins(:comments).includes(:comments)
       assert_equal %w(
-        id author_id title body type legacy_comments_count taggings_with_delete_all_count taggings_with_destroy_count
+        id author_id title body type token legacy_comments_count taggings_with_delete_all_count taggings_with_destroy_count
         tags_count indestructible_tags_count tags_with_destroy_count tags_with_nullify_count
       ), posts.first.attributes.keys
     end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -99,3 +99,18 @@ class CommentWithAfterCreateUpdate < Comment
     update(body: "bar")
   end
 end
+
+class UnconventionalComment < Comment
+  has_many :children,
+    -> { where(label: :child) },
+    class_name: "UnconventionalComment",
+    primary_key: :uuid,
+    foreign_key: :comment_uuid,
+    inverse_of: :parent
+
+  belongs_to :parent,
+    class_name: "UnconventionalComment",
+    primary_key: :uuid,
+    foreign_key: :comment_uuid,
+    inverse_of: :children
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -334,13 +334,16 @@ ActiveRecord::Schema.define do
     t.datetime :deleted_at
     t.integer :comments
     t.integer :company
+    t.string :post_token
+    t.string :uuid
+    t.string :comment_uuid
   end
 
   create_table :companies, force: true do |t|
-    t.string  :type
+    t.string :type
     t.references :firm, index: false
-    t.string  :firm_name
-    t.string  :name
+    t.string :firm_name
+    t.string :name
     t.bigint :client_of
     t.bigint :rating, default: 1
     t.integer :account_id
@@ -926,6 +929,7 @@ ActiveRecord::Schema.define do
       t.text    :body, null: false
     end
     t.string  :type
+    t.string  :token
     t.integer :legacy_comments_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0
     t.integer :taggings_with_destroy_count, default: 0


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/47574

It was reported that when you have an association that uses a scope, querying for inverses do not correctly return the same object.

@andrewberls provided the reproduction steps in the issue that was filed.

### Detail
It turns out, when rails needs to check if the foreign key matches the record in `matches_foreign_key?` it uses the `id` of the record. This works majority of the time but unfortunately does not work when the foreign key is not an `id` but something else like a `token` or a `uuid`.

This change updates the check to call `association_primary_key` from the reflection to properly match the record.


### Additional information

A check for `polymorphic?` needed to be added because when the change was ran against the whole ActiveRecord suite, there were tests that failed with the following trace 

```
ArgumentError: Polymorphic associations do not support computing the class.
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/reflection.rb:447:in `compute_class'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/reflection.rb:406:in `klass'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/reflection.rb:787:in `association_primary_key'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/associations/association.rb:387:in `matches_foreign_key?'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/associations/association.rb:375:in `inversable?'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/associations/association.rb:143:in `inversed_from_queries'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/associations/association.rb:126:in `set_inverse_instance_from_queries'
    /Users/nickborromeo/nickborromeo/rails/activerecord/lib/active_record/association_relation.rb:45:in `block in exec_queries'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
