### PR TITLE
Set charset in content type response headers (OWASP)

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -233,7 +233,7 @@ module ActionCable
 
           logger.error invalid_request_message
           logger.info finished_request_message
-          [ 404, { "Content-Type" => "text/plain" }, [ "Page not found" ] ]
+          [ 404, { "Content-Type" => "text/plain; charset=utf-8" }, [ "Page not found" ] ]
         end
 
         # Tags are declared in the server but computed in the connection. This allows us per-connection tailored tags.

--- a/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
@@ -32,7 +32,7 @@ module ActionDispatch
         if uri.relative? || uri.scheme == "http" || uri.scheme == "https"
           body = ""
         else
-          return [400, { "Content-Type" => "text/plain" }, ["Invalid redirection URI"]]
+          return [400, { "Content-Type" => "text/plain; charset=utf-8" }, ["Invalid redirection URI"]]
         end
 
         [302, {

--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -97,7 +97,8 @@ module ActionDispatch
           msg << "\n#{info[:backtrace].join("\n")}\n" if info[:backtrace]
         end.join("\n\n---\n\n\n")
 
-        [200, { "Content-Type" => "text/plain", "Content-Length" => str.size }, [str]]
+        [200, { "Content-Type" => "text/plain; charset=#{ActionDispatch::Response.default_charset}",
+          "Content-Length" => str.size }, [str]]
       end
 
       def blocked_by?(victim, blocker, all_threads)

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -48,7 +48,7 @@ module ActionDispatch
       rescue Exception => failsafe_error
         $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
 
-        [500, { "Content-Type" => "text/plain" },
+        [500, { "Content-Type" => "text/plain; charset=utf-8" },
           ["500 Internal Server Error\n" \
           "If you are the administrator of this website, then please read this web " \
           "application's log file and/or the web server's log file to find out what " \

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -129,7 +129,7 @@ module ActionDispatch
 
       def redirect_to_https(request)
         [ @redirect.fetch(:status, redirection_status(request)),
-          { "Content-Type" => "text/html",
+          { "Content-Type" => "text/html; charset=utf-8",
             "Location" => https_location_for(request) },
           (@redirect[:body] || []) ]
       end

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -51,7 +51,7 @@ module ActionDispatch
 
         headers = {
           "Location" => uri.to_s,
-          "Content-Type" => "text/html",
+          "Content-Type" => "text/html; charset=#{ActionDispatch::Response.default_charset}",
           "Content-Length" => body.length.to_s
         }
 


### PR DESCRIPTION
### Motivation / Background

An issue was raised during a pentest that the Content-Type header is missing the charset in some responses. OWASP recommends that every HTTP Response contains a Content-Type header with safe character set

> **14.4.1**
> Verify that every HTTP response contains a Content-Type header. Also
> specify a safe character set (e.g., UTF-8, ISO-8859-1) if the content types are
> text/*, /+xml and application/xml. Content must match with the provided
> Content-Type header.

Source: https://github.com/OWASP/ASVS/blob/v4.0.3/4.0/en/0x22-V14-Config.md#v144-http-security-headers

### Detail

I skimmed through the codebase and set an appropriate charset, it's possible I missed some. 