### PR TITLE
Improve reliability of EventedFileUpdateCheckerTest fork test

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -45,6 +45,10 @@ module ActiveSupport
       ObjectSpace.define_finalizer(self, @core.finalizer)
     end
 
+    def inspect
+      "#<ActiveSupport::EventedFileUpdateChecker:#{object_id} @files=#{@core.files.to_a.inspect}"
+    end
+
     def updated?
       if @core.restart?
         @core.thread_safely(&:restart)
@@ -68,7 +72,7 @@ module ActiveSupport
     end
 
     class Core
-      attr_reader :updated
+      attr_reader :updated, :files
 
       def initialize(files, dirs)
         @files = files.map { |file| Pathname(file).expand_path }.to_set
@@ -86,7 +90,11 @@ module ActiveSupport
         @mutex = Mutex.new
 
         start
-        @after_fork = ActiveSupport::ForkTracker.after_fork { start }
+        # inotify / FSEvents file descriptors are inherited on fork, so
+        # we need to reopen them otherwise only the parent or the child
+        # will be notified.
+        # FIXME: this callback is keeping a reference on the instance
+        @after_fork = ActiveSupport::ForkTracker.after_fork { restart }
       end
 
       def finalizer
@@ -107,6 +115,11 @@ module ActiveSupport
         @dtw, @missing = [*@dtw, *@missing].partition(&:exist?)
         @listener = @dtw.any? ? Listen.to(*@dtw, &method(:changed)) : nil
         @listener&.start
+
+        # Wait for the listener to be ready to avoid race conditions
+        # Unfortunately this isn't quite enough on macOS because the Darwin backend
+        # has an extra private thread we can't wait on.
+        @listener&.wait_for_state(:processing_events)
       end
 
       def stop


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/47748

`Listen.to` starts a bunch of background threads that need to perform some work before they are able to receive events, but it doesn't block until they are ready, which expose us to a race condition.

With `wait_for_state(:processing_events)` we can ensure that it's ready on Linux (I couldn't test this), however on macOS, the Darwin backend has a second background thread we can't wait on.

As a workaround we wait a bit after the fork to allow that thread to reach it's listning state.

It may be worth to report that upstream, see if we can get a method to wait until the listener is fully ready.

cc @zzak 
