### PR TITLE
Fix `ActiveRecord::Calculations#ids` for a composite primary key model

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -310,7 +310,7 @@ module ActiveRecord
     #   Person.joins(:companies).ids # SELECT people.id FROM people INNER JOIN companies ON companies.person_id = people.id
     def ids
       if loaded?
-        result = records.pluck(primary_key)
+        result = records.pluck(*Array(primary_key))
         return @async ? Promise::Complete.new(result) : result
       end
 
@@ -319,7 +319,7 @@ module ActiveRecord
         return relation.ids
       end
 
-      columns = arel_columns([primary_key])
+      columns = arel_columns(Array(primary_key))
       relation = spawn
       relation.select_values = columns
       result = if relation.where_clause.contradiction?

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -24,11 +24,12 @@ require "models/rating"
 require "models/too_long_table_name"
 require "support/stubs/strong_parameters"
 require "support/async_helper"
+require "models/cpk/book"
 
 class CalculationsTest < ActiveRecord::TestCase
   include AsyncHelper
 
-  fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments
+  fixtures :companies, :accounts, :authors, :author_addresses, :topics, :speedometers, :minivans, :books, :posts, :comments, :cpk_books
 
   def test_should_sum_field
     assert_equal 318, Account.sum(:credit_limit)
@@ -938,6 +939,25 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_ids
     assert_equal Company.all.map(&:id).sort, Company.all.ids.sort
+  end
+
+  def ids_for_a_composite_primary_key
+    assert_equal Cpk::Book.all.map(&:id).sort, Cpk::Book.all.ids.sort
+  end
+
+  def test_ids_for_a_composite_primary_key_with_scope
+    book = cpk_books(:cpk_great_author_first_book)
+
+    assert_equal [[book.author_id, book.number]], Cpk::Book.all.where(title: book.title).ids
+  end
+
+  def test_ids_for_a_composite_primary_key_on_loaded_relation
+    book = cpk_books(:cpk_great_author_first_book)
+    relation = Cpk::Book.where(title: book.title)
+    relation.to_a
+
+    assert_predicate relation, :loaded?
+    assert_equal [[book.author_id, book.number]], relation.ids
   end
 
   def test_ids_with_scope


### PR DESCRIPTION
Given a model with a composite primary key like:
`TravelRoute.primary_key = [:from, :to]`

Calling `TravelRoute.ids` would return an array of identifiers which is represented by an array of arrays:

```ruby
TravelRoute.all.ids # => [["Ottawa", "New York"], ["London", "Paris"]]
```


### Implementation details

The basic case for a non-loaded relation has already been working so I only added a test to cover that.

So I only fixed the case for a loaded relation to make sure we `Array#pluck` all columns of the composite primary key

