### PR TITLE
`TestFixtures#fixture_path` should return a single path

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -43,8 +43,12 @@ module ActiveRecord
       end
 
       def fixture_path
-        ActiveRecord.deprecator.warn("TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.")
-        fixture_paths
+        ActiveRecord.deprecator.warn(<<~WARNING)
+          TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.
+          If multiple fixture paths have been configured with #fixture_paths, then #fixture_path will just return
+          the first path.
+        WARNING
+        fixture_paths.first
       end
 
       def fixture_path=(path)
@@ -96,8 +100,12 @@ module ActiveRecord
     end
 
     def fixture_path
-      ActiveRecord.deprecator.warn("TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.")
-      fixture_paths
+      ActiveRecord.deprecator.warn(<<~WARNING)
+        TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.
+        If multiple fixture paths have been configured with #fixture_paths, then #fixture_path will just return
+        the first path.
+      WARNING
+      fixture_paths.first
     end
 
     def run_in_transaction?


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/47675 we introduced `TestFixtures#fixture_paths` and deprecated `#fixture_path`. However, the implementation of `#fixture_path` was also changed to have it return an array of paths instead of a single path. This is breaking behaviour.

### Detail

Just return a single path. If an app is using `#fixture_path` we can assume they have no configured `#fixture_paths` yet, so we can just do `fixture_paths.first`. I also updated the deprecation warning to explain this behaviour.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
