### PR TITLE
Fix actionpack CHANGELOG lint error

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**
+*   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**.
 
     *Jason Kotchoff*
 


### PR DESCRIPTION
Due to skipkayhil/rails-bin#3 entries that starts with and ends with `*`, like the author line are assumed to be indented.

We can get around that bug until it's fixed by placing a `.` at the end of the line, ensuring it doesn't get parsed as an author statement.

See also:

* https://github.com/rails/rails/pull/41994#issuecomment-1478544614
* https://github.com/rails/rails/pull/42520#issuecomment-1483187791