### PR TITLE
Fix #45389 | `updated_at` not updating in `before_update` callback

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -460,7 +460,7 @@ module ActiveRecord
     end
 
     def _update_record
-      _run_update_callbacks { super }
+      _run_update_callbacks { record_update_timestamps { super } }
     end
   end
 end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -115,6 +115,17 @@ module ActiveRecord
     end
 
     def _update_record
+      record_update_timestamps
+
+      super
+    end
+
+    def create_or_update(touch: true, **)
+      @_touch_record = touch
+      super
+    end
+
+    def record_update_timestamps
       if @_touch_record && should_record_timestamps?
         current_time = current_time_from_proper_timezone
 
@@ -124,12 +135,7 @@ module ActiveRecord
         end
       end
 
-      super
-    end
-
-    def create_or_update(touch: true, **)
-      @_touch_record = touch
-      super
+      yield if block_given?
     end
 
     def should_record_timestamps?

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -253,6 +253,60 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal @previously_updated_at, @developer.updated_at
   end
 
+  def test_saving_an_unchanged_record_with_a_mutating_before_update_callback_updates_its_timestamp
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers"
+
+      include Developer::TimestampAliases
+
+      before_update :change_name
+
+      private
+        def change_name
+          return if new_record?
+
+          self.name = "Jack Bauer"
+        end
+    end
+
+    @developer = klass.create!
+    @previously_updated_at = @developer.updated_at
+    @previous_name = @developer.name
+
+    travel(1.second) do
+      @developer.save!
+    end
+
+    @developer.reload
+
+    assert_not_equal @previous_name, @developer.name
+    assert_not_equal @previously_updated_at, @developer.updated_at
+  end
+
+  def test_saving_an_unchanged_record_with_a_non_mutating_before_update_callback_does_not_update_its_timestamp
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "developers"
+
+      include Developer::TimestampAliases
+
+      before_update :change_name
+
+      private
+        def change_name; end
+    end
+
+    @developer = klass.create!
+    @previously_updated_at = @developer.updated_at
+
+    travel(1.second) do
+      @developer.save!
+    end
+
+    @developer.reload
+
+    assert_equal @previously_updated_at, @developer.updated_at
+  end
+
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_the_parent_should_update_the_parent_updated_at
     pet   = Pet.first
     owner = pet.owner
@@ -469,7 +523,7 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal time, pet.updated_at
   end
 
-  def test_timestamp_column_values_are_present_in_the_callbacks
+  def test_timestamp_column_values_are_present_in_create_callbacks
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "people"
 
@@ -479,7 +533,34 @@ class TimestampTest < ActiveRecord::TestCase
     end
 
     person = klass.create first_name: "David"
-    assert_not_equal person.born_at, nil
+    assert_not_nil person.born_at
+  end
+
+  def test_timestamp_column_values_are_present_in_update_callbacks
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+
+      before_update do
+        self.born_at = created_at
+      end
+    end
+
+    person = klass.create first_name: "David"
+    person.update first_name: "John"
+    assert_not_nil person.born_at
+  end
+
+  def test_timestamp_column_values_are_present_in_save_callbacks
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+
+      before_create do
+        self.born_at = created_at
+      end
+    end
+
+    person = klass.create first_name: "David"
+    assert_not_nil person.born_at
   end
 
   def test_timestamp_attributes_for_create_in_model


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #45389.

As documented in the issue linked above, it would be expected that mutations made within `update` callbacks also update the `updated_at` timestamp, especially since this behaviour already occurs with `save` callbacks.

### Detail

This Pull Request ensures that timestamps are **rewritten** once all `update` callbacks have run so that mutations made within them (if any) are recognised as updates, updating the `updated_at` timestamp as a result.

I initially considered just changing the ordering of when timestamps are set to be after all callbacks have been completed, but that would introduce a regression with the changes made [in this commit](https://github.com/rails/rails/commit/dddbccb25a709e1897326e2a25d37da83bbfd717) seeing as timestamps always need to be available inside callbacks.

I've also improved coverage for some related tests where timestamps are expected to exist within callbacks. These now test create, update and save callbacks (one type each) and not just a single create callback. I did this because I failed the only test that existed when working on my solution and thought it'd be valuable to cover all 3 of these callback types to ensure no regressions are intorduced.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Shoutout to @markhallen for their debugging efforts and producing a failing test which (which I've stolen for this PR).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
