### PR TITLE
Add zettabyte to `number_to_human_size`

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/bytes.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/bytes.rb
@@ -7,6 +7,7 @@ class Numeric
   TERABYTE = GIGABYTE * 1024
   PETABYTE = TERABYTE * 1024
   EXABYTE  = PETABYTE * 1024
+  ZETTABYTE = EXABYTE * 1024
 
   # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
   #
@@ -63,4 +64,12 @@ class Numeric
     self * EXABYTE
   end
   alias :exabyte :exabytes
+
+  # Returns the number of bytes equivalent to the zettabytes provided.
+  #
+  #   2.zettabytes # => 2_361_183_241_434_822_606_848
+  def zettabytes
+    self * ZETTABYTE
+  end
+  alias :zettabyte :zettabytes
 end

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -113,6 +113,7 @@ en:
           tb: "TB"
           pb: "PB"
           eb: "EB"
+          zb: "ZB"
       # Used in NumberHelper.number_to_human()
       decimal_units:
         format: "%n %u"

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -5,7 +5,7 @@ require "active_support/number_helper/number_converter"
 module ActiveSupport
   module NumberHelper
     class NumberToHumanSizeConverter < NumberConverter # :nodoc:
-      STORAGE_UNITS = [:byte, :kb, :mb, :gb, :tb, :pb, :eb]
+      STORAGE_UNITS = [:byte, :kb, :mb, :gb, :tb, :pb, :eb, :zb]
 
       self.namespace      = :human
       self.validate_float = true

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -114,6 +114,7 @@ class NumericExtSizeTest < ActiveSupport::TestCase
     assert_equal 256.megabytes * 20 + 5.gigabytes, 10.gigabytes
     assert_equal 1.kilobyte**5, 1.petabyte
     assert_equal 1.kilobyte**6, 1.exabyte
+    assert_equal 1.kilobyte**7, 1.zettabyte
   end
 
   def test_units_as_bytes_independently
@@ -129,6 +130,8 @@ class NumericExtSizeTest < ActiveSupport::TestCase
     assert_equal 3377699720527872, 3.petabyte
     assert_equal 3458764513820540928, 3.exabytes
     assert_equal 3458764513820540928, 3.exabyte
+    assert_equal 3541774862152233910272, 3.zettabytes
+    assert_equal 3541774862152233910272, 3.zettabyte
   end
 end
 
@@ -155,6 +158,10 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
 
   def exabytes(number)
     petabytes(number) * 1024
+  end
+
+  def zettabytes(number)
+    exabytes(number) * 1024
   end
 
   def test_to_fs__phone
@@ -289,7 +296,8 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal "1.12 TB",   1234567890123.to_fs(:human_size)
     assert_equal "1.1 PB",    1234567890123456.to_fs(:human_size)
     assert_equal "1.07 EB",   1234567890123456789.to_fs(:human_size)
-    assert_equal "1030 EB",   exabytes(1026).to_fs(:human_size)
+    assert_equal "1020 EB",   exabytes(1023).to_fs(:human_size)
+    assert_equal "16 ZB",     zettabytes(16).to_fs(:human_size)
     assert_equal "444 KB",    kilobytes(444).to_fs(:human_size)
     assert_equal "1020 MB",   megabytes(1023).to_fs(:human_size)
     assert_equal "3 TB",      terabytes(3).to_fs(:human_size)

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -43,6 +43,10 @@ module ActiveSupport
         petabytes(number) * 1024
       end
 
+      def zettabytes(number)
+        exabytes(number) * 1024
+      end
+
       def test_number_to_phone
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal("555-1234", number_helper.number_to_phone(5551234))
@@ -249,7 +253,7 @@ module ActiveSupport
           assert_equal "1.12 TB",    number_helper.number_to_human_size(1234567890123)
           assert_equal "1.1 PB",   number_helper.number_to_human_size(1234567890123456)
           assert_equal "1.07 EB",   number_helper.number_to_human_size(1234567890123456789)
-          assert_equal "1030 EB",   number_helper.number_to_human_size(exabytes(1026))
+          assert_equal "1020 EB",   number_helper.number_to_human_size(exabytes(1023))
           assert_equal "444 KB",    number_helper.number_to_human_size(kilobytes(444))
           assert_equal "1020 MB",   number_helper.number_to_human_size(megabytes(1023))
           assert_equal "3 TB",      number_helper.number_to_human_size(terabytes(3))
@@ -262,6 +266,7 @@ module ActiveSupport
           assert_equal "10 KB",   number_helper.number_to_human_size(kilobytes(10.000), precision: 4)
           assert_equal "1 Byte",   number_helper.number_to_human_size(1.1)
           assert_equal "10 Bytes", number_helper.number_to_human_size(10)
+          assert_equal "16 ZB", number_helper.number_to_human_size(zettabytes(16))
         end
       end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This pull request aims to extend Rails' number_to_human_size method with Zettabyte (ZB) support, addressing the growing data volumes in industries like IoT, AI, and Big Data, and so on.
https://en.wikipedia.org/wiki/Zettabyte_Era

### Detail

```
ActiveSupport::NumberHelper.number_to_human_size(1.kilobyte**7)
#=> "1 ZB"
```

### Additional information

I did not add Yottabyte and larger units because they are not currently needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
