### PR TITLE
Safe for Direct Uploads in js Libraries or Frameworks 

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -145,7 +145,7 @@
 
     *Luke Lau*
 
-*   Safe for direct upload on Libraries or Frameworks 
+*   Safe for direct upload on Libraries or Frameworks
 
     Enable the use of custom headers during direct uploads, which allows for
     the inclusion of Authorization bearer tokens or other forms of authorization

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -145,4 +145,12 @@
 
     *Luke Lau*
 
+*   Safe for direct upload on Libraries or Frameworks 
+
+    Enable the use of custom headers during direct uploads, which allows for
+    the inclusion of Authorization bearer tokens or other forms of authorization
+    tokens through headers.
+
+    *Radamés Roriz*
+
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -503,7 +503,7 @@
     }
   }
   class BlobRecord {
-    constructor(file, checksum, url) {
+    constructor(file, checksum, url, customHeaders = {}) {
       this.file = file;
       this.attributes = {
         filename: file.name,
@@ -517,6 +517,9 @@
       this.xhr.setRequestHeader("Content-Type", "application/json");
       this.xhr.setRequestHeader("Accept", "application/json");
       this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+      Object.keys(customHeaders).forEach((headerKey => {
+        this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
+      }));
       const csrfToken = getMetaValue("csrf-token");
       if (csrfToken != undefined) {
         this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
@@ -596,11 +599,12 @@
   }
   let id = 0;
   class DirectUpload {
-    constructor(file, url, delegate) {
+    constructor(file, url, delegate, customHeaders = {}) {
       this.id = ++id;
       this.file = file;
       this.url = url;
       this.delegate = delegate;
+      this.customHeaders = customHeaders;
     }
     create(callback) {
       FileChecksum.create(this.file, ((error, checksum) => {
@@ -608,7 +612,7 @@
           callback(error);
           return;
         }
-        const blob = new BlobRecord(this.file, checksum, this.url);
+        const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders);
         notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
         blob.create((error => {
           if (error) {

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -17,7 +17,7 @@ export class BlobRecord {
     this.xhr.setRequestHeader("Content-Type", "application/json")
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
-    Object.keys(customHeaders).foreach((headerKey) => {
+    Object.keys(customHeaders).forEach((headerKey) => {
       this.xhr.setRequestHeader(headerKey, customHeaders[headerKey])
     })
 

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -1,7 +1,7 @@
 import { getMetaValue } from "./helpers"
 
 export class BlobRecord {
-  constructor(file, checksum, url) {
+  constructor(file, checksum, url, customHeaders = {}) {
     this.file = file
 
     this.attributes = {
@@ -17,6 +17,9 @@ export class BlobRecord {
     this.xhr.setRequestHeader("Content-Type", "application/json")
     this.xhr.setRequestHeader("Accept", "application/json")
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest")
+    Object.keys(customHeaders).foreach((headerKey) => {
+      this.xhr.setRequestHeader(headerKey, customHeaders[headerKey])
+    })
 
     const csrfToken = getMetaValue("csrf-token")
     if (csrfToken != undefined) {

--- a/activestorage/app/javascript/activestorage/direct_upload.js
+++ b/activestorage/app/javascript/activestorage/direct_upload.js
@@ -5,11 +5,12 @@ import { BlobUpload } from "./blob_upload"
 let id = 0
 
 export class DirectUpload {
-  constructor(file, url, delegate) {
+  constructor(file, url, delegate, customHeaders = {}) {
     this.id = ++id
     this.file = file
     this.url = url
     this.delegate = delegate
+    this.customHeaders = customHeaders
   }
 
   create(callback) {
@@ -19,7 +20,7 @@ export class DirectUpload {
         return
       }
 
-      const blob = new BlobRecord(this.file, checksum, this.url)
+      const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders)
       notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr)
 
       blob.create(error => {

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1290,10 +1290,10 @@ the backend server, similar to the following:
 class DirectUploadsController < ActiveStorage::DirectUploadsController
   skip_before_action :verify_authenticity_token
   before_action :authenticate!
-  
+
   def authenticate!
     @token = request.headers['Authorization']&.split&.last
-    
+
     return head :unauthorized unless valid_token?(@token)
   end
 end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1162,11 +1162,8 @@ input[type=file][data-direct-upload-url][disabled] {
 }
 ```
 
-### Integrating with Libraries or Frameworks
-
-If you want to use the Direct Upload feature from a JavaScript framework, or
-you want to integrate custom drag and drop solutions, you can use the
-`DirectUpload` class for this purpose. Upon receiving a file from your library
+### Custom drag and drop solutions
+you can use the `DirectUpload` class for this purpose. Upon receiving a file from your library
 of choice, instantiate a DirectUpload and call its create method. Create takes
 a callback to invoke when the upload completes.
 
@@ -1213,10 +1210,11 @@ const uploadFile = (file) => {
 }
 ```
 
-If you need to track the progress of the file upload, you can pass a third
-parameter to the `DirectUpload` constructor. During the upload, DirectUpload
-will call the object's `directUploadWillStoreFileWithXHR` method. You can then
-bind your own progress handler on the XHR.
+### Track the progress of the file upload
+When using the `DirectUpload` constructor, it is possible to include a third parameter.
+This will allow the `DirectUpload` object to invoke the `directUploadWillStoreFileWithXHR` 
+method during the upload process. 
+You can then attach your own progress handler to the XHR to suit your needs.
 
 ```js
 import { DirectUpload } from "@rails/activestorage"
@@ -1246,6 +1244,59 @@ class Uploader {
     // Use event.loaded and event.total to update the progress bar
   }
 }
+```
+
+### Integrating with Libraries or Frameworks
+Once you receive a file from the library you have selected, you need to create
+a `DirectUpload` instance and use its "create" method to initiate the upload process, 
+adding any required additional headers as necessary. The "create" method also requires 
+a callback function to be provided that will be triggered once the upload has finished.
+
+```js
+import { DirectUpload } from "@rails/activestorage"
+
+class Uploader {
+  constructor(file, url, token) {
+    const headers = { 'Authentication': `Bearer ${token}` }
+    // INFO: Sending headers is an optional parameter. If you choose not to send headers,
+    //       authentication will be performed using cookies or session data.
+    this.upload = new DirectUpload(this.file, this.url, this, headers)
+  }
+
+  upload(file) {
+    this.upload.create((error, blob) => {
+      if (error) {
+        // Handle the error
+      } else {
+        // Use the with blob.signed_id as a file reference in next request
+      }
+    })
+  }
+
+  directUploadWillStoreFileWithXHR(request) {
+    request.upload.addEventListener("progress",
+      event => this.directUploadDidProgress(event))
+  }
+
+  directUploadDidProgress(event) {
+    // Use event.loaded and event.total to update the progress bar
+  }
+}
+```
+
+To implement customized authentication, a new controller must be created on
+the backend server, similar to the following:
+```ruby
+class DirectUploadsController < ActiveStorage::DirectUploadsController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate!
+  
+  def authenticate!
+    @token = request.headers['Authorization']&.split&.last
+    
+    return head :unauthorized unless valid_token?(@token)
+  end
+end
 ```
 
 NOTE: Using [Direct Uploads](#direct-uploads) can sometimes result in a file that uploads, but never attaches to a record. Consider [purging unattached uploads](#purging-unattached-uploads).


### PR DESCRIPTION
### Motivation / Background
The current implementation of direct upload only supports cookie or session authentication, which may not be sufficient for many modern Rails API and frontend framework setups. To enable support for various types of authentication, such as Bearer tokens, API keys, Basic auth, OAuth 1.0, Digest auth, etc., we propose allowing additional headers to be passed in requests to the Backend.
see more about authentication behavior in nice documentation of postman: https://learning.postman.com/docs/sending-requests/authorization/#contents

I have created this Pull Request to support my company's expected behavior, based on the discussion thread at https://discuss.rubyonrails.org/t/activestorage-direct-uploads-safe-by-default-how-to-make-it-safe/74863.

### Detail
This PR changes the JS code, permitting receive aditional headers. The focus on this PR is change the file activestorage/app/javascript/activestorage/direct_upload.js to receive one more param specificly for new headers.

### New behavior
Specifically, we suggest enabling the passing of an additional header for backend authentication, which would be used for the first request for blob and upload (if the storage is configured to be local). This can be achieved using the following code:
```js
import { DirectUpload } from "@rails/activestorage"

const authenticationHeader = {
  Authentication: `Bearer ${token}`
}

const upload = new DirectUpload(file, backendUrl, undefined, authenticationHeader)
upload.create((error, blob) => {
  if (error) {
    // Handle the error
  } else {
    // use blob.signed_id for something
  }
})
```

### Actual Workaround for similar behavior
For now the only form to pass some customized params is via querystring on url.
```js
import { DirectUpload } from "@rails/activestorage"

const authenticatedUrl = `${backendUrl}?token=${token}`

const upload = new DirectUpload(file, authenticatedUrl)
upload.create((error, blob) => {
  if (error) {
    // Handle the error
  } else {
    // use blob.signed_id for something
  }
})
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. I did not found any spec for js ⚠️ 
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
