### PR TITLE
Don't swallow referential_integrity errors in postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -67,8 +67,8 @@ Rails needs superuser privileges to disable referential integrity.
             end
 
             true
-          rescue ActiveRecord::StatementInvalid
-            false
+          rescue ActiveRecord::StatementInvalid => e
+            raise "Foreign key violations found in your fixture data: #{e.message}"
           end
         end
       end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

My take on this problem https://github.com/rails/rails/pull/44943 

That PR is good and solves the problem in a broader scope, but it seem to be abandoned so I tried to go with a simpler change.

The issue is that when you add a lot of fixtures or migrations at once, there is a chance something would not pass referential integrity and it won't be evident what exactly happened.

What happened to me: I was adding https://github.com/djezzzl/database_consistency this gem to a project I work on. It generated a hundred new migrations, and referential integrity checks stoped passing because our fixtures were inconsistent.

I solved this with putting a debugger in where `all_foreign_keys_valid?` rescues and swallows the error, but that wasn't an ideal experience.

### Detail

This Pull Request changes error handling in postgres referential integrity check. Instead of swallowing the error it raises it with an extra message. This is not the cleanest approach, as it breaks a "ends with `?` means it returns a bool" convention, but it ticks few other boxes:

* improvement: shows the actual error to user which improves user experience
* compatibility: doesn't break anything. This repo uses `all_foreign_keys_valid?` in [this](https://github.com/s-mage/rails/blob/21401c6486c8b873610a07d0a70fcac719dfbee8/activerecord/lib/active_record/fixtures.rb#L633-L635) single place and raises if it returns false, so my change just raises an error one step earlier.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

https://github.com/rails/rails/pull/44943 here is an alternative solution, but it seems to be stuck

Another solution could be logging the error and still returning false. Since it's developer who reads error messages generated here, I thought a proper error would do better.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

no new tests or changelog updates, the change is very minor