### PR TITLE
Output generator usage on two lines

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -210,7 +210,8 @@ INFO: You can also use the alias "g" to invoke the generator command: `bin/rails
 
 ```bash
 $ bin/rails generate
-Usage: rails generate GENERATOR [args] [options]
+Usage:
+  bin/rails generate GENERATOR [args] [options]
 
 ...
 ...
@@ -236,7 +237,8 @@ INFO: All Rails console utilities have help text. As with most *nix utilities, y
 
 ```bash
 $ bin/rails generate controller
-Usage: bin/rails generate controller NAME [action action] [options]
+Usage:
+  bin/rails generate controller NAME [action action] [options]
 
 ...
 ...

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -163,7 +163,8 @@ module Rails
 
       # Show help message with available generators.
       def help(command = "generate")
-        puts "Usage: rails #{command} GENERATOR [args] [options]"
+        puts "Usage:"
+        puts "  bin/rails #{command} GENERATOR [args] [options]"
         puts
         puts "General options:"
         puts "  -h, [--help]     # Print generator's options and usage"


### PR DESCRIPTION
All other command usage uses two lines for "Usage: rails command".
This updates the usage of generators to do the same.
It also changes the command to `bin/rails`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
