### PR TITLE
Fix (Action Cable): rescue BaseConnectionError in redis <5

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -207,7 +207,7 @@ module ActionCable
             end
 
             if ::Redis::VERSION < "5"
-              ConnectionError = ::Redis::ConnectionError
+              ConnectionError = ::Redis::BaseConnectionError
 
               class SubscribedClient
                 def initialize(raw_client)


### PR DESCRIPTION
### Motivation / Background

Follow-up for #46562.

See bug report https://github.com/rails/rails/pull/46562#issuecomment-1484882673

### Detail

`redis-rb` <5 [uses BaseConnectionError class](https://github.com/redis/redis-rb/blob/0afcf1cad6f4fc74213f2b4c7a20819581c36897/lib/redis/errors.rb#L24-L41) for all connection-related exceptions; `redis-rb` 5+ uses `redis-client` under the hood, which [has ConnectionError](https://github.com/redis-rb/redis-client/blob/e252a5872393283400969598eaf42f7870f0abf9/lib/redis_client.rb#L84-L93) as base class.

### Additional information

Backported in [action-cable-redis-backport](https://github.com/anycable/action-cable-redis-backport) 1.0.1.

