### PR TITLE
Only de-dup/cache FileSystemResolvers in ViewPaths

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -12,10 +12,7 @@ module ActionView
 
         rebuild_watcher
 
-        _self = self
-        ActionView::PathRegistry.singleton_class.set_callback(:build_file_system_resolver, :after) do
-          _self.send(:rebuild_watcher)
-        end
+        ActionView::PathRegistry.file_system_resolver_hooks << method(:rebuild_watcher)
       end
 
       def updated?

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -83,9 +83,9 @@ module ActionView
         @digest_cache.values
       end
 
-      def self.view_context_class(klass)
+      def self.view_context_class
         @view_context_mutex.synchronize do
-          @view_context_class ||= klass.with_empty_template_cache
+          @view_context_class ||= ActionView::Base.with_empty_template_cache
         end
       end
     end

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -32,7 +32,8 @@ module ActionView # :nodoc:
       PathSet.new paths.compact
     end
 
-    def +(array)
+    def +(other)
+      array = Array === other ? other : other.paths
       PathSet.new(paths + array)
     end
 
@@ -67,7 +68,11 @@ module ActionView # :nodoc:
         paths.map do |path|
           case path
           when Pathname, String
-            ActionView::PathRegistry.file_system_resolver(path.to_s)
+            # This path should only be reached by "direct" users of
+            # ActionView::Base (not using the ViewPaths or Renderer modules).
+            # We can't cache/de-dup the file system resolver in this case as we
+            # don't know which compiled_method_container we'll be rendering to.
+            FileSystemResolver.new(path)
           when Resolver
             path
           else

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -80,7 +80,7 @@ module ActionView
       end
 
       def view_context_class
-        klass = ActionView::LookupContext::DetailsKey.view_context_class(ActionView::Base)
+        klass = ActionView::LookupContext::DetailsKey.view_context_class
 
         @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
 

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -28,6 +28,13 @@ module ActionView
         end
       end
 
+      def _build_view_paths(paths) # :nodoc:
+        return paths if ActionView::PathSet === paths
+
+        paths = ActionView::PathRegistry.cast_file_system_resolvers(paths)
+        ActionView::PathSet.new(paths)
+      end
+
       # Append a path to the list of view paths for this controller.
       #
       # ==== Parameters
@@ -35,7 +42,7 @@ module ActionView
       #   the default view path. You may also provide a custom view path
       #   (see ActionView::PathSet for more information)
       def append_view_path(path)
-        self._view_paths = ActionView::PathSet.new(view_paths.to_a + Array(path))
+        self._view_paths = view_paths + _build_view_paths(path)
       end
 
       # Prepend a path to the list of view paths for this controller.
@@ -45,7 +52,7 @@ module ActionView
       #   the default view path. You may also provide a custom view path
       #   (see ActionView::PathSet for more information)
       def prepend_view_path(path)
-        self._view_paths = ActionView::PathSet.new(Array(path) + view_paths.to_a)
+        self._view_paths = _build_view_paths(path) + view_paths
       end
 
       # A list of all of the default view paths for this controller.
@@ -59,7 +66,7 @@ module ActionView
       # * <tt>paths</tt> - If a PathSet is provided, use that;
       #   otherwise, process the parameter into a PathSet.
       def view_paths=(paths)
-        self._view_paths = ActionView::PathSet.new(Array(paths))
+        self._view_paths = _build_view_paths(paths)
       end
 
       private
@@ -94,7 +101,7 @@ module ActionView
     #   the default view path. You may also provide a custom view path
     #   (see ActionView::PathSet for more information)
     def append_view_path(path)
-      lookup_context.append_view_paths(Array(path))
+      lookup_context.append_view_paths(self.class._build_view_paths(path))
     end
 
     # Prepend a path to the list of view paths for the current LookupContext.
@@ -104,7 +111,7 @@ module ActionView
     #   the default view path. You may also provide a custom view path
     #   (see ActionView::PathSet for more information)
     def prepend_view_path(path)
-      lookup_context.prepend_view_paths(Array(path))
+      lookup_context.prepend_view_paths(self.class._build_view_paths(path))
     end
   end
 end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -26,7 +26,6 @@ module RailsGuides
       @epub      = epub
       @language  = language
       @direction = direction || "ltr"
-      @view = ActionView::Base.with_empty_template_cache
 
       if @epub
         register_special_mime_types
@@ -133,7 +132,7 @@ module RailsGuides
         puts "Generating #{guide} as #{output_file}"
         layout = @epub ? "epub/layout" : "layout"
 
-        view = @view.with_view_paths(
+        view = ActionView::Base.with_empty_template_cache.with_view_paths(
           [@source_dir],
           edge:     @edge,
           version:  @version,


### PR DESCRIPTION
Fixes #47449

Previously I attempted to de-dup and cache any FileSystemResolver under the same path. This created issues because each Resolver caches its templates. Those cached templates only get compiled once into whatever compiled_method_container is passed on its first render. So separate compiled_method_containers must have different copies of a Template, and therefore separate copies of each Resolvers.

I tried a few approaches where I would have a separate cache of resolvers per-compiled-method-container, but I wasn't really successful as in most of the places we performed the casting we did not know or have access to the view context class and therefore compiled method container (it isn't stored in the LookupContext or ViewPath) and trying to add that relating created incompatibilities in some not-quite-public-but-still-widely used APIs for using ActionView directly.

This approach instead limits where we perform the de-dup and cache, to only descendants of ActionView::ViewPaths. These can be assumed to also inherit from ActionView::Rendering (I think ActionController::API is an exception here, which should be addressed in a future refactor) which means that they should all share the same compiled_method_container and therefore can all be cached safely together.

This should continue to ensure we don't leak memory from {append,prepend}_view_path at runtime, while maintaining compatibility with some of the more specialized uses of ActionView::Base as a standalone API. However this leaves open the possibility (which has always existed) of using that standalone API in a "leaky" way.