### PR TITLE
Accept list of composite primary keys in #destroy

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -526,7 +526,13 @@ module ActiveRecord
       #   todos = [1,2,3]
       #   Todo.destroy(todos)
       def destroy(id)
-        if id.is_a?(Array)
+        multiple_ids = if composite_primary_key?
+          id.is_a?(Array) && id.first.is_a?(Array)
+        else
+          id.is_a?(Array)
+        end
+
+        if multiple_ids
           find(id).each(&:destroy)
         else
           find(id).destroy


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This is part of the on-going effort to support composite primary keys.

The `#destroy` method currently accepts either a single ID or a list of IDs. Historically, IDs have taken on the form of a single integer.

Now, with composite primary keys, we should support the same signature, that is ID and [ID], where ID can now be a composite list of values.

### Detail

This is a fairly straightforward change except for one technicality which is that there's overlap in the integer ID list signature, and the composite ID single signature. That is, they can both be a list of integers.

To reconcile this, we use the model's `composite_primary_key?` status to infer whether we should expect a tuple of values or a single integer. The test cases should make this relatively clear.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
