### PR TITLE
Ensure `Inflector` methods return un-frozen strings

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -71,7 +71,7 @@ module ActiveSupport
       if !uppercase_first_letter || uppercase_first_letter == :lower
         string = string.sub(inflections.acronyms_camelize_regex) { |match| match.downcase! || match }
       elsif string.match?(/\A[a-z\d]*\z/)
-        return inflections.acronyms[string] || string.capitalize
+        return inflections.acronyms[string]&.dup || string.capitalize
       else
         string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
       end
@@ -95,7 +95,7 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
-      return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
+      return camel_cased_word.to_s.dup unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::", "/")
       word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
       word.gsub!(/([A-Z])(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -220,11 +220,21 @@ class InflectorTest < ActiveSupport::TestCase
     ].each do |camel, under, human, title|
       assert_equal(camel, ActiveSupport::Inflector.camelize(under))
       assert_equal(camel, ActiveSupport::Inflector.camelize(camel))
+      assert_not_predicate(ActiveSupport::Inflector.camelize(under), :frozen?)
+      assert_not_predicate(ActiveSupport::Inflector.camelize(camel), :frozen?)
+
       assert_equal(under, ActiveSupport::Inflector.underscore(under))
       assert_equal(under, ActiveSupport::Inflector.underscore(camel))
+      assert_not_predicate(ActiveSupport::Inflector.underscore(under), :frozen?)
+      assert_not_predicate(ActiveSupport::Inflector.underscore(camel), :frozen?)
+
       assert_equal(title, ActiveSupport::Inflector.titleize(under))
       assert_equal(title, ActiveSupport::Inflector.titleize(camel))
+      assert_not_predicate(ActiveSupport::Inflector.titleize(under), :frozen?)
+      assert_not_predicate(ActiveSupport::Inflector.titleize(camel), :frozen?)
+
       assert_equal(human, ActiveSupport::Inflector.humanize(under))
+      assert_not_predicate(ActiveSupport::Inflector.humanize(camel), :frozen?)
     end
   end
 
@@ -638,5 +648,11 @@ class InflectorTest < ActiveSupport::TestCase
       inflect.clear(:acronyms)
       assert_equal({}, inflect.acronyms)
     end
+  end
+
+  def test_output_is_not_frozen_even_if_input_is_frozen
+    input = "plurals"
+    assert_predicate input, :frozen?
+    assert_not_predicate ActiveSupport::Inflector.pluralize(input), :frozen?
   end
 end


### PR DESCRIPTION
https://github.com/rails/rails/commit/3d00c8b97f3b18d89cdeaebe3d07661300ab14e4 introduced a regression. Given this setup:

```ruby
# frozen_string_literal: true
ActiveSupport::Inflector.inflections(:en) do |inflect|
  inflect.acronym("API") # or "API".freeze
end
```

If you have a controller called `APIController`, you may get a crash backtrace that looks like this:

```
FrozenError: can't modify frozen String: "API"
    rails (b8a399cd6ffe) actionpack/lib/action_dispatch/http/request.rb:89:in `controller_class_for'
    rails (b8a399cd6ffe) actionpack/lib/action_dispatch/request/utils.rb:100:in `action_encoding_template'
    rails (b8a399cd6ffe) actionpack/lib/action_dispatch/request/utils.rb:85:in `encode'
    rails (b8a399cd6ffe) actionpack/lib/action_dispatch/request/utils.rb:45:in `set_binary_encoding'
    rails (b8a399cd6ffe) actionpack/lib/action_dispatch/http/parameters.rb:68:in `path_parameters='
```

Here is the root cause:

```ruby
Tanda @ Rails 7.1.0.alpha (test) :004 > "API".freeze.underscore.frozen?
false # this is expected
Tanda @ Rails 7.1.0.alpha (test) :004 > "API".freeze.underscore.camelize.frozen?
true # this is *not* expected, and is what causes the above code to crash
```

I think the correct behaviour is for the inflector to always return non-frozen strings, even if it's using a cached frozen string as is the case in https://github.com/rails/rails/commit/3d00c8b97f3b18d89cdeaebe3d07661300ab14e4. This PR implements that. If that's not accepted, happy to make an alternative PR to have Action Pack work with a frozen string.

Other semi-related PRs: https://github.com/rails/rails/pull/41174, https://github.com/rails/rails/pull/41881
cc @amatsuda (could you share your benchmark code?) @byroot
