### PR TITLE
`assert_broadcasts`: return the messages that were broadcast

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   `assert_broadcasts` now returns the messages that were broadcast.
+
+    This makes it easier to do further analysis on those messages:
+
+    ```ruby
+    message = assert_broadcasts("test", 1) do
+      ActionCable.server.broadcast "test", "message"
+    end
+    assert_equal "message", message
+
+    messages = assert_broadcasts("test", 2) do
+      ActionCable.server.broadcast "test", { message: "one" }
+      ActionCable.server.broadcast "test", { message: "two" }
+    end
+    assert_equal 2, messages.length
+    assert_equal({ "message" => "one" }, messages.first)
+    assert_equal({ "message" => "two" }, messages.last)
+    ```
+
+    *Alex Ghiculescu*
+
 *   Display broadcasted messages on error message when using `assert_broadcast_on`
 
     *Stéphane Robino*

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -44,15 +44,20 @@ module ActionCable
     #
     def assert_broadcasts(stream, number, &block)
       if block_given?
-        original_count = broadcasts_size(stream)
-        _assert_nothing_raised_or_warn("assert_broadcasts", &block)
-        new_count = broadcasts_size(stream)
-        actual_count = new_count - original_count
-      else
-        actual_count = broadcasts_size(stream)
-      end
+        new_messages = new_broadcasts_from(broadcasts(stream), stream, "assert_broadcasts", &block)
 
-      assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
+        actual_count = new_messages.size
+        assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
+
+        if new_messages.size == 1
+          ActiveSupport::JSON.decode(new_messages.first)
+        else
+          new_messages.map { |m| ActiveSupport::JSON.decode(m) }
+        end
+      else
+        actual_count = broadcasts(stream).size
+        assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
+      end
     end
 
     # Asserts that no messages have been sent to the stream.
@@ -103,15 +108,7 @@ module ActionCable
 
       new_messages = broadcasts(stream)
       if block_given?
-        old_messages = new_messages
-        clear_messages(stream)
-
-        _assert_nothing_raised_or_warn("assert_broadcast_on", &block)
-        new_messages = broadcasts(stream)
-        clear_messages(stream)
-
-        # Restore all sent messages
-        (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(stream, m) }
+        new_messages = new_broadcasts_from(new_messages, stream, "assert_broadcast_on", &block)
       end
 
       message = new_messages.find { |msg| ActiveSupport::JSON.decode(msg) == serialized_msg }
@@ -136,8 +133,18 @@ module ActionCable
     delegate :broadcasts, :clear_messages, to: :pubsub_adapter
 
     private
-      def broadcasts_size(channel)
-        broadcasts(channel).size
+      def new_broadcasts_from(current_messages, stream, assertion, &block)
+        old_messages = current_messages
+        clear_messages(stream)
+
+        _assert_nothing_raised_or_warn(assertion, &block)
+        new_messages = broadcasts(stream)
+        clear_messages(stream)
+
+        # Restore all sent messages
+        (old_messages + new_messages).each { |m| pubsub_adapter.broadcast(stream, m) }
+
+        new_messages
       end
   end
 end

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -14,6 +14,21 @@ class TransmissionsTest < ActionCable::TestCase
     end
   end
 
+  def test_assert_broadcasts_returns_broadcast_messages_if_block_given
+    message = assert_broadcasts("test", 1) do
+      ActionCable.server.broadcast "test", "message"
+    end
+    assert_equal "message", message
+
+    messages = assert_broadcasts("test", 2) do
+      ActionCable.server.broadcast "test", { message: "one" }
+      ActionCable.server.broadcast "test", { message: "two" }
+    end
+    assert_equal 2, messages.length
+    assert_equal({ "message" => "one" }, messages.first)
+    assert_equal({ "message" => "two" }, messages.last)
+  end
+
   def test_assert_broadcasts_with_no_block
     assert_nothing_raised do
       ActionCable.server.broadcast "test", "message"


### PR DESCRIPTION
This PR is similar to https://github.com/rails/rails/pull/47025, it makes Action Cable's `assert_broadcasts` return the messages that were broadast. This way you can do more analysis on them:

```ruby
    messages = assert_broadcasts("test", 2) do
      ActionCable.server.broadcast "test", { message: "one" }
      ActionCable.server.broadcast "test", { message: "two" }
    end
    assert_equal 2, messages.length
    assert_equal({ "message" => "one" }, messages.first)
    assert_equal({ "message" => "two" }, messages.last)
```

This is helpful if you expect lots of messages to be broadcast or if you want to only match on some element of the data; `assert_broadcast_on` doesn't work well in either of those scenarios.
