### PR TITLE
Use `bin/rails` for Rake commands help

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -16,7 +16,7 @@ module Rails
           require_rake
 
           Rake.with_application do |rake|
-            rake.init("rails", [task, *args])
+            rake.init("bin/rails", [task, *args])
             rake.load_rakefile
             if unrecognized_task = rake.top_level_tasks.find { |task| !rake.lookup(task[/[^\[]+/]) }
               raise UnrecognizedCommandError.new(unrecognized_task)


### PR DESCRIPTION
Commands should be called with `bin/rails`. Most command help also displays `bin/rails` in the usage section.
This updates the Rake tasks to also use `bin/rails` instead of `rails`.

__Before__

```console
$ bin/rails assets:precompile -h
rails assets:precompile
    Compile all the assets named in config.assets.precompile

```

__After__

```console
$ bin/rails assets:precompile -h
bin/rails assets:precompile
    Compile all the assets named in config.assets.precompile

```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
