### PR TITLE
`#read_attribute(:id)` should always return the primary key

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -29,8 +29,13 @@ module ActiveRecord
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name
 
-        name = @primary_key if name == "id" && @primary_key && !@primary_key.is_a?(Array)
-        @attributes.fetch_value(name, &block)
+        return @attributes.fetch_value(name, &block) unless name == "id" && @primary_key
+
+        if self.class.composite_primary_key?
+          @primary_key.map { |col| @attributes.fetch_value(col, &block) }
+        else
+          @attributes.fetch_value(@primary_key, &block)
+        end
       end
 
       # This method exists to avoid the expensive primary_key check internally, without

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -34,6 +34,19 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal keyboard.key_number, keyboard.read_attribute(:id)
   end
 
+  def test_read_attribute_with_composite_primary_key
+    book = Cpk::Book.new(author_id: 1, number: 2)
+    assert_equal [1, 2], book.read_attribute(:id)
+  end
+
+  def test_read_attribute_with_composite_primary_key_and_column_named_id
+    order = Cpk::Order.new
+    order.id = [1, 2]
+
+    assert_equal [1, 2], order.read_attribute(:id)
+    assert_equal 2, order.attributes["id"]
+  end
+
   def test_to_key_with_primary_key_after_destroy
     topic = Topic.find(1)
     topic.destroy
@@ -425,14 +438,6 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   def test_model_with_a_composite_primary_key
     assert_equal(["author_id", "number"], Cpk::Book.primary_key)
     assert_equal(["shop_id", "id"], Cpk::Order.primary_key)
-  end
-
-  def test_id_is_not_defined_on_a_model_with_composite_primary_key
-    book = cpk_books(:cpk_great_author_first_book)
-    order = cpk_orders(:cpk_groceries_order_1)
-
-    assert_equal([book.author_id, book.number], book.id)
-    assert_equal([order.shop_id, order.read_attribute(:id)], order.id)
   end
 
   def composite_primary_key_is_true_for_a_cpk_model


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Part of the on-going effort to bring support for composite primary keys.

In a standard primary key setup (single value), calling `read_attribute(:id)` will resolve to a call to fetch the **value of the primary key.** 

In commit fb127c0d42adefb8bdafaad460e67a0fdac75d9b, we introduced behaviour for CPK's `#id` and decided to return the value of the column `id` instead of the array of primary key values.

This PR revisits that decision and instead follows suit with the initial behaviour of Rails in both CPK and non-CPK contexts.

In other words, now, any time `read_attribute(:id)` is called, we return the primary key—whether an array or single value. If a user wants to query the value of `id` in CPK contexts, they can directly access the `attributes` hash. We don't anticipate this to be a common scenario, however, because most composite keys wouldn't include an `id`.

### Detail

`read_attribute(:id)` returns a primary key, in both CPK and non-CPK cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
