### PR TITLE
Use bin/rails in generator Base banner

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -327,7 +327,7 @@ module Rails
 
         # Use Rails default banner.
         def self.banner # :doc:
-          "rails generate #{namespace.delete_prefix("rails:")} #{arguments.map(&:usage).join(' ')} [options]".gsub(/\s+/, " ")
+          "bin/rails generate #{namespace.delete_prefix("rails:")} #{arguments.map(&:usage).join(' ')} [options]".gsub(/\s+/, " ")
         end
 
         # Sets the base_name taking into account the current class namespace.

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -152,12 +152,12 @@ class GeneratorsTest < Rails::Generators::TestCase
 
   def test_default_banner_should_show_generator_namespace
     klass = Rails::Generators.find_by_namespace(:foobar)
-    assert_match(/^rails generate foobar:foobar/, klass.banner)
+    assert_match(/^bin\/rails generate foobar:foobar/, klass.banner)
   end
 
   def test_default_banner_should_not_show_rails_generator_namespace
     klass = Rails::Generators.find_by_namespace(:model)
-    assert_match(/^rails generate model/, klass.banner)
+    assert_match(/^bin\/rails generate model/, klass.banner)
   end
 
   def test_no_color_sets_proper_shell


### PR DESCRIPTION
### Motivation / Background

The banner for `bin/rails generate` and some related documentation were updated [recently][1], however `bin/rails generate controller` did not actually include `bin/rails` in its usage.

[1]: https://github.com/rails/rails/commit/f7204d8d357fe86bb2105a9fc5cc9bd6a33b4317