### PR TITLE
Remove deprecated `secrets:setup` and deprecate `secrets:edit/show`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Deprecate `secrets:edit/show` and remove `secrets:setup`
+
+    `bin/rails secrets:setup` has been deprecated since Rails 5.2 in favor of
+    credentials. This command has been removed.
+
+    `bin/rails secrets:show` and `bin/rails secrets:edit` have been deprecated
+    in favor of credentials.
+    Run `bin/rails credentials:help` for more information
+
+    *Petrik de Heus*
+
 *   `bin/rails --help` will now list only framework and plugin commands. Rake
     tasks defined in `lib/tasks/*.rake` files will no longer be included. For a
     list of those tasks, use `rake -T`.

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -9,13 +9,13 @@ module Rails
     class SecretsCommand < Rails::Command::Base # :nodoc:
       include Helpers::Editor
 
-      desc "setup", "Deprecated in favor of credentials -- run `bin/rails credentials:help`"
-      def setup
-        deprecate_in_favor_of_credentials_and_exit
-      end
-
-      desc "edit", "Open the secrets in `$EDITOR` for editing"
+      desc "edit", "**deprecated** Open the secrets in `$EDITOR` for editing"
       def edit
+        Rails.deprecator.warn(<<~MSG.squish)
+          `bin/rails secrets:edit` is deprecated in favor of credentials and will be removed in Rails 7.2.
+          Run `bin/rails credentials:help` for more information.
+        MSG
+
         boot_application!
 
         using_system_editor do
@@ -26,24 +26,21 @@ module Rails
         say error.message
       rescue Errno::ENOENT => error
         if error.message.include?("secrets.yml.enc")
-          deprecate_in_favor_of_credentials_and_exit
+          exit 1
         else
           raise
         end
       end
 
-      desc "show", "Show the decrypted secrets"
+      desc "show", "**deprecated** Show the decrypted secrets"
       def show
+        Rails.deprecator.warn(<<~MSG.squish)
+          `bin/rails secrets:show` is deprecated in favor of credentials and will be removed in Rails 7.2.
+          Run `bin/rails credentials:help` for more information.
+        MSG
+
         say Rails::Secrets.read
       end
-
-      private
-        def deprecate_in_favor_of_credentials_and_exit
-          say "Encrypted secrets is deprecated in favor of credentials. Run:"
-          say "bin/rails credentials:help"
-
-          exit 1
-        end
     end
   end
 end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -4,7 +4,7 @@ require "abstract_unit"
 require "rails/command"
 require "rails/commands/generate/generate_command"
 require "rails/commands/notes/notes_command"
-require "rails/commands/secrets/secrets_command"
+require "rails/commands/credentials/credentials_command"
 require "rails/commands/db/system/change/change_command"
 
 class Rails::Command::BaseTest < ActiveSupport::TestCase
@@ -14,7 +14,7 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
   end
 
   test "printing commands returns namespaced commands" do
-    assert_equal %w(secrets:setup secrets:edit secrets:show), Rails::Command::SecretsCommand.printing_commands.map(&:first)
+    assert_equal %w(credentials:edit credentials:show credentials:diff), Rails::Command::CredentialsCommand.printing_commands.map(&:first)
     assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands.map(&:first)
   end
 

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -14,29 +14,6 @@ class Rails::Command::SecretsTest < ActiveSupport::TestCase
     assert_match "No $EDITOR to open file in", run_edit_command(editor: "")
   end
 
-  test "encrypted secrets are deprecated when using credentials" do
-    assert_match "Encrypted secrets is deprecated", run_setup_command
-    assert_equal 1, $?.exitstatus
-    assert_not File.exist?("config/secrets.yml.enc")
-  end
-
-  test "encrypted secrets are deprecated when running edit without setup" do
-    assert_match "Encrypted secrets is deprecated", run_setup_command
-    assert_equal 1, $?.exitstatus
-    assert_not File.exist?("config/secrets.yml.enc")
-  end
-
-  test "encrypted secrets are deprecated for 5.1 config/secrets.yml apps" do
-    Dir.chdir(app_path) do
-      FileUtils.rm("config/credentials.yml.enc")
-      FileUtils.touch("config/secrets.yml")
-
-      assert_match "Encrypted secrets is deprecated", run_setup_command
-      assert_equal 1, $?.exitstatus
-      assert_not File.exist?("config/secrets.yml.enc")
-    end
-  end
-
   test "edit secrets" do
     # Use expected default MessageEncryptor serializer for Rails < 7.1 to be compatible with hardcoded secrets.yml.enc
     add_to_config <<-RUBY


### PR DESCRIPTION
`bin/rails secrets:setup` has been deprecated since Rails 5.2. Running it would show a deprecation warning and exit without running the command. It's probably save to delete it altogether.

As the `secrets:setup` command has been deprecated for this long, it's probably save to deprecate the `secrets:show` and `secrets:edit` commands as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
