### PR TITLE
Fix Gemfile resolution on parser gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     parallel (1.22.1)
-    parser (3.2.0.0)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
     path_expander (1.1.1)
     pg (1.4.5)


### PR DESCRIPTION
### Motivation / Background

Currently bundle install on `main` branch throws this warning:

```ruby
Your lockfile doesn't include a valid resolution.
You can fix this by regenerating your lockfile or trying to manually editing the bad locked gems to a version that satisfies all dependencies.
The unmet dependencies are:
* parser (>= 3.2.1.0), depended upon rubocop-ast-1.27.0, unsatisfied by parser-3.2.0.0
```


### Detail

- Ran and `bundle update parser` to fix the resolution.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
