### PR TITLE
Unify shapes of ActiveModel::Attributes

### DIFF
--- a/activerecord/lib/active_record/marshalling.rb
+++ b/activerecord/lib/active_record/marshalling.rb
@@ -2,17 +2,15 @@
 
 module ActiveRecord
   module Marshalling
-    @format_version = 6.1
+    @format_version = 7.1
 
     class << self
       attr_reader :format_version
 
       def format_version=(version)
         case version
-        when 6.1
-          Methods.remove_method(:marshal_dump) if Methods.method_defined?(:marshal_dump)
         when 7.1
-          Methods.alias_method(:marshal_dump, :_marshal_dump_7_1)
+          # do nothing
         else
           raise ArgumentError, "Unknown marshalling format: #{version.inspect}"
         end
@@ -21,7 +19,7 @@ module ActiveRecord
     end
 
     module Methods
-      def _marshal_dump_7_1
+      def marshal_dump
         payload = [attributes_for_database, new_record?]
 
         cached_associations = self.class.reflect_on_all_associations.select do |reflection|

--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       end
 
       def value_for_database
-        @value_for_database = _value_for_database unless defined?(@value_for_database)
+        @value_for_database = _value_for_database if UNDEF.equal?(@value_for_database)
         @value_for_database
       end
 

--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -24,7 +24,10 @@ module ActiveRecord
       end
 
       def value_for_database
-        @value_for_database = _value_for_database if UNDEF.equal?(@value_for_database)
+        unless @value_for_database_set
+          @value_for_database = _value_for_database
+          @value_for_database_set = true
+        end
         @value_for_database
       end
 


### PR DESCRIPTION
`if defined?(@ivar)` a performance anti-pattern in Ruby 3.2+ even more so with YJIT.

This pattern cause the object shape to be inconsistent which slow downs instance variable access.

```
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [arm64-darwin22]
       #value (orig):  1811240.2 i/s
        #value (opt):  2045238.9 i/s - 1.13x  faster
```

```
ruby 3.2.1 (2023-02-08 revision 31819e82c8) +YJIT [arm64-darwin22]
       #value (orig):  4379180.3 i/s
        #value (opt):  6347280.7 i/s - 1.45x  faster
```

Benchmark: https://gist.github.com/casperisfine/872f0a486b5ccdf90d9feb830c76d9ad

### Backward compatibility

There is a big backward compatibility concern here, and I'm not sure we can actually make this change safety.

Until https://github.com/rails/rails/pull/47747, when you serialized an `ActiveRecord::Base` instance, lots of `ActiveModel::Attribute` instances would be serialized with it. Which means this optimization would break any instance serialized with an older Rails.

Currently the PR is only enabling the optimization if you switched to the new AR Marshal format, but:

  - You can switch to that format and still deserialize old payloads, this PR would break that.
  - Active Record may not be the only way these are serialized. We may break more stuff.

I can't think of any decent way to do this optimization while still retaining perfect backward/forward compatibility...

cc @tenderlove, I wonder if you have opinions here.