### PR TITLE
Fix `Enumerable#in_order_of` to preserve duplicates

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -194,7 +194,7 @@ module Enumerable
   # If the +series+ include keys that have no corresponding element in the Enumerable, these are ignored.
   # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
-    index_by(&key).values_at(*series).compact
+    group_by(&key).values_at(*series).flatten.compact
   end
 
   # Returns the sole item in the enumerable. If there are no items, or more

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -375,6 +375,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [ Payment.new(1), Payment.new(5) ], values.in_order_of(:price, [ 1, 5 ])
   end
 
+  def test_in_order_of_preserves_duplicates
+    values = [ Payment.new(5), Payment.new(1), Payment.new(5) ]
+    assert_equal [ Payment.new(1), Payment.new(5), Payment.new(5) ], values.in_order_of(:price, [ 1, 5 ])
+  end
+
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 


### PR DESCRIPTION
Fixes #47803.