### PR TITLE
Handle discarded connection pools when disabling query cache

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Handle discarded connection pools when disabling query cache
+
+    If an application forks in the middle of a request of fork, it could cause the following error:
+
+    ```
+    NoMethodError: undefined method `[]' for nil:NilClass
+    active_record/connection_adapters/abstract/connection_pool.rb:190:in `active_connection?'
+    ```
+
+    *Jean Boussier*
+
 *   Limit max length of auto generated index names
 
     Auto generated index names are now limited to 62 bytes, which fits within

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -308,7 +308,8 @@ module ActiveRecord
           @connections.each do |conn|
             conn.discard!
           end
-          @connections = @available = @thread_cached_conns = nil
+          @connections = @available = nil
+          @thread_cached_conns = {}
         end
       end
 

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -30,6 +30,7 @@ module ActiveRecord
     end
 
     def self.complete(pools)
+      pools.reject!(&:discarded?)
       pools.each { |pool| pool.disable_query_cache! }
 
       ActiveRecord::Base.connection_handler.each_connection_pool do |pool|

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -820,4 +820,15 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
 
     assert_equal @connection_1, @connection_2
   end
+
+  test ".complete handle flushed pools" do
+    pools = ActiveRecord::QueryCache.run
+    assert_not_empty pools
+    Task.first
+
+    # This may happen if someone forks from a request or job
+    ActiveRecord::ConnectionAdapters::PoolConfig.discard_pools!
+
+    ActiveRecord::QueryCache.complete(pools)
+  end
 end


### PR DESCRIPTION
Initially reported at https://github.com/mperham/connection_pool/issues/173

If an application forks in the middle of a request of fork, it could cause the following error:

```
NoMethodError: undefined method `[]' for nil:NilClass
active_record/connection_adapters/abstract/connection_pool.rb:190:in `active_connection?'
```
