### PR TITLE
Generate unique members of a composite key in fixtures

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1643,13 +1643,26 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
   end
 
   class CompositePkFixturesTest < ActiveRecord::TestCase
-    fixtures :cpk_orders, :cpk_books
+    fixtures :cpk_orders, :cpk_books, :authors
+
+    def test_generates_composite_primary_key_for_partially_filled_fixtures
+      david = authors(:david)
+      david_cpk_book = cpk_books(:cpk_known_author_david_book)
+
+      assert_not_empty(david_cpk_book.id.compact)
+      assert_equal david.id, david_cpk_book.author_id
+      assert_not_nil david_cpk_book.number
+    end
 
     def test_generates_composite_primary_key_ids
       assert_not_empty(cpk_orders(:cpk_groceries_order_1).id.compact)
 
       assert_not_nil(cpk_books(:cpk_great_author_first_book).author_id)
       assert_not_nil(cpk_books(:cpk_great_author_first_book).number)
+    end
+
+    def test_generates_composite_primary_key_with_unique_components
+      assert_equal 2, cpk_orders(:cpk_groceries_order_1).id.uniq.size
     end
   end
 end

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -12,3 +12,8 @@ cpk_great_author_second_book:
 cpk_famous_author_first_book:
   title: "Ruby on Rails"
   revision: 1
+
+cpk_known_author_david_book:
+  author_id: 1
+  title: "David's CPK Book"
+  revision: 1


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This PR reworks how fixtures automatically generate primary keys in composite models. This PR https://github.com/rails/rails/pull/47635 introduced a foundation for handling composite keys, but simplified the generation process by assigning all elements of the composite key the same hashed label.

While in theory this works, one downside in practice is that on inspection all columns take on the same value. This can appear jarring, or incorrect, and can lead to confusion.

This PR changes the generation process to account for the index of the column in the composite key. It uses this index to shift the label by a particular (deterministic) amount. This has the effect of making the columns appear different and uncorrelated.

### Detail

I use a bit-shift in conjunction with a modulo for the max as a means of "deterministically-shifting" the label, but in a way that is hard to tell immediately. Shifting by a fixed amount (ie. multiplication, addition) could probably still be easily-observed, and lead to confusion. Bit shifts eliminate that worry.

**Note: The desired behaviour is uniqueness amongst the composite key, so this is what is tested.** The implementation should be flexible enough to change.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
