### PR TITLE
Fix markdown lint re: #47773

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1290,6 +1290,7 @@ class Uploader {
 
 To implement customized authentication, a new controller must be created on
 the Rails application, similar to the following:
+
 ```ruby
 class DirectUploadsController < ActiveStorage::DirectUploadsController
   skip_before_action :verify_authenticity_token


### PR DESCRIPTION
* guides/source/active_storage_overview.md:1293: MD031 Fenced code blocks should be surrounded by blank lines
* guides/source/active_storage_overview.md:1301: MD046 Code block style