### PR TITLE
Use rail_inspector gem instead of rails-bin repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,23 +6,19 @@ permissions:
   contents: read
 
 jobs:
-  rails-bin:
-    name: Check rails-bin lints
+  rail_inspector:
+    name: Rail Inspector Checks
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: rail_inspector
     steps:
     - uses: actions/checkout@v3
-      with:
-        repository: skipkayhil/rails-bin
-        ref: 748f4673a5fe5686b5859e89f814166280e51781
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
         bundler-cache: true
-    - uses: actions/checkout@v3
-      with:
-        path: rails
-    - run: bin/check-changelogs ./rails
-    - run: bin/check-config-docs ./rails
+    - run: bundle exec railspect changelogs .
+    - run: bundle exec railspect configuration .
   codespell:
     name: Check spelling all files with codespell
     runs-on: ubuntu-latest
@@ -46,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.ref_name == 'main'
     continue-on-error: true
-    needs: [rails-bin, codespell]
+    needs: [rail_inspector, codespell]
     steps:
       - uses: zzak/action-discord@v4
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ group :mdl do
   gem "mdl", require: false
 end
 
+group :rail_inspector do
+  gem "rail_inspector", require: false
+end
+
 group :doc do
   gem "sdoc", ">= 2.6.0"
   gem "rdoc", "~> 6.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,7 @@ GEM
       ast (~> 2.4.1)
     path_expander (1.1.1)
     pg (1.4.5)
+    prettier_print (1.2.1)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -373,6 +374,9 @@ GEM
     rackup (1.0.0)
       rack (< 3)
       webrick
+    rail_inspector (0.0.2)
+      syntax_tree (= 6.1.1)
+      thor (~> 1.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -494,6 +498,8 @@ GEM
     stringio (3.0.4)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
+    syntax_tree (6.1.1)
+      prettier_print (>= 1.2.0)
     tailwindcss-rails (2.0.21)
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.21-x86_64-darwin)
@@ -589,6 +595,7 @@ DEPENDENCIES
   racc (>= 1.4.6)
   rack (~> 2.0)
   rack-cache (~> 1.2)
+  rail_inspector
   rails!
   rake (>= 13)
   rdoc (~> 6.5)


### PR DESCRIPTION
### Detail

This commit replaces the workflows that cloned skipkayhil/rails-bin with the same checks but packaged as a gem. In addition to no longer requiring clones of multiple repos, the larger benefit is that developers can run the commands locally much easier.