### PR TITLE
Prefer bin/rails over rails

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -163,33 +163,33 @@ You can run `bin/rails -T` to see all the commands you're able to run. You shoul
 
 ```bash
 $ bin/rails -T
-rails db:create                          # Create the database from DATABASE_URL or config/database.yml for the ...
-rails db:create:animals                  # Create animals database for current environment
-rails db:create:primary                  # Create primary database for current environment
-rails db:drop                            # Drop the database from DATABASE_URL or config/database.yml for the cu...
-rails db:drop:animals                    # Drop animals database for current environment
-rails db:drop:primary                    # Drop primary database for current environment
-rails db:migrate                         # Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)
-rails db:migrate:animals                 # Migrate animals database for current environment
-rails db:migrate:primary                 # Migrate primary database for current environment
-rails db:migrate:status                  # Display status of migrations
-rails db:migrate:status:animals          # Display status of migrations for animals database
-rails db:migrate:status:primary          # Display status of migrations for primary database
-rails db:reset                           # Drop and recreates all databases from their schema for the current environment and loads the seeds
-rails db:reset:animals                   # Drop and recreates the animals database from its schema for the current environment and loads the seeds
-rails db:reset:primary                   # Drop and recreates the primary database from its schema for the current environment and loads the seeds
-rails db:rollback                        # Roll the schema back to the previous version (specify steps w/ STEP=n)
-rails db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
-rails db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
-rails db:schema:dump                     # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-rails db:schema:dump:animals             # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-rails db:schema:dump:primary             # Create a db/schema.rb file that is portable against any DB supported  ...
-rails db:schema:load                     # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-rails db:schema:load:animals             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-rails db:schema:load:primary             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-rails db:setup                           # Create all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
-rails db:setup:animals                   # Create the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
-rails db:setup:primary                   # Create the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
+bin/rails db:create                          # Create the database from DATABASE_URL or config/database.yml for the ...
+bin/rails db:create:animals                  # Create animals database for current environment
+bin/rails db:create:primary                  # Create primary database for current environment
+bin/rails db:drop                            # Drop the database from DATABASE_URL or config/database.yml for the cu...
+bin/rails db:drop:animals                    # Drop animals database for current environment
+bin/rails db:drop:primary                    # Drop primary database for current environment
+bin/rails db:migrate                         # Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)
+bin/rails db:migrate:animals                 # Migrate animals database for current environment
+bin/rails db:migrate:primary                 # Migrate primary database for current environment
+bin/rails db:migrate:status                  # Display status of migrations
+bin/rails db:migrate:status:animals          # Display status of migrations for animals database
+bin/rails db:migrate:status:primary          # Display status of migrations for primary database
+bin/rails db:reset                           # Drop and recreates all databases from their schema for the current environment and loads the seeds
+bin/rails db:reset:animals                   # Drop and recreates the animals database from its schema for the current environment and loads the seeds
+bin/rails db:reset:primary                   # Drop and recreates the primary database from its schema for the current environment and loads the seeds
+bin/rails db:rollback                        # Roll the schema back to the previous version (specify steps w/ STEP=n)
+bin/rails db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
+bin/rails db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
+bin/rails db:schema:dump                     # Create a database schema file (either db/schema.rb or db/structure.sql  ...
+bin/rails db:schema:dump:animals             # Create a database schema file (either db/schema.rb or db/structure.sql  ...
+bin/rails db:schema:dump:primary             # Create a db/schema.rb file that is portable against any DB supported  ...
+bin/rails db:schema:load                     # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+bin/rails db:schema:load:animals             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+bin/rails db:schema:load:primary             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+bin/rails db:setup                           # Create all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
+bin/rails db:setup:animals                   # Create the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
+bin/rails db:setup:primary                   # Create the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
 ```
 
 Running a command like `bin/rails db:create` will create both the primary and animals databases.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -167,7 +167,7 @@ ArticleTest#test_should_not_save_article_without_title [/path/to/blog/test/model
 Expected true to be nil or false
 
 
-rails test test/models/article_test.rb:6
+bin/rails test test/models/article_test.rb:6
 
 
 
@@ -250,7 +250,7 @@ NameError: undefined local variable or method 'some_undefined_variable' for #<Ar
     test/models/article_test.rb:11:in 'block in <class:ArticleTest>'
 
 
-rails test test/models/article_test.rb:9
+bin/rails test test/models/article_test.rb:9
 
 
 


### PR DESCRIPTION
This updates the remaining documentation that references `rails` without the `bin/` prefix, if you run those commands today they will retain the prefix in the output.

### `bin/rails test`

```
% bin/rails test test/models/post_test.rb:5
Running 1 tests in a single process (parallelization threshold is 50)
Run options: --seed 28566

# Running:

F

Failure:
PostTest#test_the_truth [/Users/zzak/code/railsdev/test/models/post_test.rb:5]:
Expected false to be truthy.


bin/rails test test/models/post_test.rb:4



Finished in 0.011007s, 90.8513 runs/s, 90.8513 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

### `bin/rails -T`

```
% bin/rails -T
bin/rails action_mailbox:ingress:exim        # Relay an inbound email from Exim to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:ingress:postfix     # Relay an inbound email from Postfix to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:ingress:qmail       # Relay an inbound email from Qmail to Action Mailbox (URL and INGRESS_PASSWORD required)
bin/rails action_mailbox:install             # Install Action Mailbox and its dependencies
bin/rails action_mailbox:install:migrations  # Copy migrations from action_mailbox to application
bin/rails action_text:install                # Copy over the migration, stylesheet, and JavaScript files
bin/rails action_text:install:migrations     # Copy migrations from action_text to application
bin/rails active_storage:install             # Copy over the migration needed to the application
bin/rails app:template                       # Apply the template supplied by LOCATION=(/path/to/template) or URL
bin/rails app:update                         # Update configs and some other initially generated files (or use just update:configs or update:bin)
bin/rails assets:clean[keep]                 # Remove old compiled assets

...
```