### PR TITLE
ActiveRecord::Delegation prevent overriding existing methods

### DIFF
--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -3,6 +3,8 @@
 require "cases/helper"
 require "models/post"
 require "models/comment"
+require "models/project"
+require "models/developer"
 
 module ActiveRecord
   module DelegationTests
@@ -70,6 +72,22 @@ module ActiveRecord
         assert_respond_to klass.all, method
         assert_respond_to klass, method
       end
+    end
+  end
+
+  class DelegationCachingTest < ActiveRecord::TestCase
+    fixtures :projects, :developers
+
+    test "delegation doesn't override methods defined in other relation subclasses" do
+      # precondition, some methods are available on ActiveRecord::Relation subclasses
+      # but not ActiveRecord::Relation itself. Here `delete` is just an example.
+      assert_equal false, ActiveRecord::Relation.method_defined?(:delete)
+      assert_equal true, ActiveRecord::Associations::CollectionProxy.method_defined?(:delete)
+
+      project = projects(:active_record)
+      original_owner = project.developers_with_callbacks.method(:delete).owner
+      Developer.all.delete(12345)
+      assert_equal original_owner, project.developers_with_callbacks.method(:delete).owner
     end
   end
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "ostruct"
+require "models/computer"
 
 class Developer < ActiveRecord::Base
   module TimestampAliases


### PR DESCRIPTION
I discovered this while working on https://github.com/rails/rails/pull/47800

The bug is quite subtle.

If you call `Model.all.delete(id)`, `all` is an `ActiveRecord::Relation` which does not respond to `delete`, so it delegates to `Model.delete` and generate that method in the `GeneratedRelationMethods` module.

The problem however, is that `CollectionProxy` does define `delete`, so after that initial call, the `Model::ActiveRecord_CollectionProxy` subclass now has its `delete` method overridden, and now delegate to the model.

Here I chose to keep that method generation caching, but I'm honestly not convinced it's really needed. I question how much of a hotspot these methods are, and we're busting method caches and generating a lot of code to save on a minor `method_missing` call.

I think we should just remove that caching.

cc @matthewd @rafaelfranca (I may merge soon to unblock myself, but I'd like your opinion on this one).