### PR TITLE
Enable IRB autocomplete only in Rails.env.local? environment.

### DIFF
--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -37,7 +37,7 @@ module Rails
 
         IRB::WorkSpace.prepend(BacktraceCleaner)
 
-        if Rails.env.production?
+        if !Rails.env.local?
           ENV["IRB_USE_AUTOCOMPLETE"] ||= "false"
         end
 

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -58,12 +58,13 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_equal "IRB", Rails::Console.new(app).console.name
   end
 
-  def test_console_disables_IRB_auto_completion_in_production
+  def test_console_disables_IRB_auto_completion_in_non_local
     original_use_autocomplete = ENV["IRB_USE_AUTOCOMPLETE"]
     ENV["IRB_USE_AUTOCOMPLETE"] = nil
 
     with_rack_env "production" do
       app = build_app(nil)
+      assert_not_predicate Rails.env, :local?
       assert_equal "IRB", Rails::Console.new(app).console.name
       assert_equal "false", ENV["IRB_USE_AUTOCOMPLETE"]
     end
@@ -84,12 +85,13 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     ENV["IRB_USE_AUTOCOMPLETE"] = original_use_autocomplete
   end
 
-  def test_console_doesnt_disable_IRB_auto_completion_in_non_production
+  def test_console_doesnt_disable_IRB_auto_completion_in_local
     original_use_autocomplete = ENV["IRB_USE_AUTOCOMPLETE"]
     ENV["IRB_USE_AUTOCOMPLETE"] = nil
 
     with_rails_env nil do
       app = build_app(nil)
+      assert_predicate Rails.env, :local?
       assert_equal "IRB", Rails::Console.new(app).console.name
       assert_nil ENV["IRB_USE_AUTOCOMPLETE"]
     end


### PR DESCRIPTION
- based on original PR comment https://github.com/rails/rails/pull/46656#discussion_r1117987055

Meanwhile https://github.com/rails/rails/pull/46786 was introduced and it was suggested to use this at Discord by @rafaelfranca.

> I do think we should be leveraging the local? check here instead of production?. The problem is that IRB on remote servers is slow to autocomplete, if we are disabling in production, we should be disabling in anything that isn't local