### PR TITLE
Respect explicitly configured `query_constraints`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -488,12 +488,12 @@ module ActiveRecord
       def query_constraints(*columns_list)
         raise ArgumentError, "You must specify at least one column to be used in querying" if columns_list.empty?
 
-        @_query_constraints_list = columns_list.map(&:to_s)
+        @query_constraints_list = columns_list.map(&:to_s)
       end
 
       def query_constraints_list # :nodoc:
         @query_constraints_list ||= if base_class? || primary_key != base_class.primary_key
-          primary_key.is_a?(Array) ? primary_key : @_query_constraints_list
+          primary_key if primary_key.is_a?(Array)
         else
           base_class.query_constraints_list
         end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1488,4 +1488,8 @@ class QueryConstraintsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  def test_child_class_with_query_constraints_overrides_parents
+    assert_equal(["clothing_type", "color", "size"], ClothingItem::Sized.query_constraints_list)
+  end
 end

--- a/activerecord/test/models/clothing_item.rb
+++ b/activerecord/test/models/clothing_item.rb
@@ -6,3 +6,7 @@ end
 
 class ClothingItem::Used < ClothingItem
 end
+
+class ClothingItem::Sized < ClothingItem
+  query_constraints :clothing_type, :color, :size
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -260,6 +260,7 @@ ActiveRecord::Schema.define do
     t.string :clothing_type
     t.string :color
     t.string :type
+    t.string :size
     t.text :description
 
     t.index [:clothing_type, :color], unique: true


### PR DESCRIPTION
This PR simplifies query constraints handling by removing unnecessary `@_query_constraints_list` instance variable
`query_constraints_list` getter shouldn't perform any kind of logic if a model explicitly configured query constraints using `query_constraints` setter. So the setter should directly set `@query_constraints_list` to take precedence


By implication it also fixes query constraints handling in inherited models in cases when child `query_constraints` configuration had no effect and parent's one was used instead