### PR TITLE
Add test coverage for .new_client error handling for various adapters

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -14,6 +14,38 @@ module ActiveRecord
       @connection.materialize_transactions
     end
 
+    test ".new_client on db error" do
+      db_config = {}
+      case @connection.class::ADAPTER_NAME
+      when "PostgreSQL"
+        db_config[:dbname] = "unknown"
+      when "Mysql2"
+        db_config[:database] = "unknown"
+      end
+      assert_raises ActiveRecord::NoDatabaseError do
+        @connection.class.new_client(db_config)
+      end
+    end
+
+    test ".new_client on access denied error" do
+      db_config = {}
+      case @connection.class::ADAPTER_NAME
+      when "PostgreSQL"
+        db_config[:user] = "unknown"
+      when "Mysql2"
+        db_config[:username] = "unknown"
+      end
+      assert_raises ActiveRecord::DatabaseConnectionError do
+        @connection.class.new_client(db_config)
+      end
+    end
+
+    test ".new_client on host error" do
+      assert_raises ActiveRecord::DatabaseConnectionError do
+        @connection.class.new_client(host: "unknown")
+      end
+    end
+
     ##
     # PostgreSQL does not support null bytes in strings
     unless current_adapter?(:PostgreSQLAdapter) ||


### PR DESCRIPTION
### Motivation / Background

The Trilogy Adapter currently has test coverage for the various types of errors that might be encountered when connecting to the db through `.new_client`. As we prepare to upstream Trilogy to Rails, we might as well ensure this test coverage is available across all of the adapters.

### Detail

Adds tests for errors when connecting to the db via `.new_client`.

EDIT: Hm, these pass locally, but the config appears to be slightly different for CI so the connection error is different. Will investigate.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
