### PR TITLE
Add test coverage for AbstractMysqlAdapter

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -61,9 +61,12 @@ end
     Rake::TestTask.new(adapter => "#{adapter}:env") do |t|
       adapter_short = adapter[/^[a-z0-9]+/]
       t.libs << "test"
-      t.test_files = (FileList["test/cases/**/*_test.rb"].reject {
+      files = (FileList["test/cases/**/*_test.rb"].reject {
         |x| x.include?("/adapters/") || x.include?("/encryption/performance")
       } + FileList["test/cases/adapters/#{adapter_short}/**/*_test.rb"])
+      files = files + FileList["test/cases/adapters/abstract_mysql_adapter/**/*_test.rb"] if adapter == "mysql2"
+
+      t.test_files = files
 
       t.warning = true
       t.verbose = true

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/connection_helper"
 
-class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
+class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   include ConnectionHelper
 
   def setup

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/ddl_helper"
 
-class Mysql2AdapterPreventWritesTest < ActiveRecord::Mysql2TestCase
+class AdapterPreventWritesTest < ActiveRecord::AbstractMysqlTestCase
   include DdlHelper
 
   def setup

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2AutoIncrementTest < ActiveRecord::Mysql2TestCase
+class AutoIncrementTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
 
   def setup

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/bind_parameter_test.rb
@@ -6,8 +6,8 @@ require "models/post"
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2Adapter
-      class BindParameterTest < ActiveRecord::Mysql2TestCase
+    class AbstractMysqlAdapter
+      class BindParameterTest < ActiveRecord::AbstractMysqlTestCase
         fixtures :topics, :posts
 
         def test_update_question_marks

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/case_sensitivity_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/case_sensitivity_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class Mysql2CaseSensitivityTest < ActiveRecord::Mysql2TestCase
+class CaseSensitivityTest < ActiveRecord::AbstractMysqlTestCase
   class CollationTest < ActiveRecord::Base
   end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2CharsetCollationTest < ActiveRecord::Mysql2TestCase
+class CharsetCollationTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/connection_helper"
 
-class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
+class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   include ConnectionHelper
 
   fixtures :comments
@@ -79,7 +79,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_wait_timeout_as_url
     run_without_connection do |orig_connection|
-      ActiveRecord::Base.establish_connection(orig_connection.merge("url" => "mysql2:///?wait_timeout=60"))
+      ActiveRecord::Base.establish_connection(orig_connection.merge("url" => "#{orig_connection[:adapter]}:///?wait_timeout=60"))
       result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.wait_timeout")
       assert_equal 60, result
     end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
@@ -7,7 +7,7 @@ require "models/bulb"
 require "models/car"
 
 module ActiveRecord
-  class CountDeletedRowsWithLockTest < ActiveRecord::Mysql2TestCase
+  class CountDeletedRowsWithLockTest < ActiveRecord::AbstractMysqlTestCase
     test "delete and create in different threads synchronize correctly" do
       Bulb.unscoped.delete_all
       Bulb.create!(name: "Jimmy", color: "blue")

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class Mysql2DatetimePrecisionQuotingTest < ActiveRecord::Mysql2TestCase
+class DatetimePrecisionQuotingTest < ActiveRecord::AbstractMysqlTestCase
   setup do
     @connection = ActiveRecord::Base.connection
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/json_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/json_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "cases/json_shared_test_cases"
 
 if ActiveRecord::Base.connection.supports_json?
-  class Mysql2JSONTest < ActiveRecord::Mysql2TestCase
+  class JSONTest < ActiveRecord::AbstractMysqlTestCase
     include JSONSharedTestCases
     self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_boolean_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_boolean_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
+class MySQLBooleanTest < ActiveRecord::AbstractMysqlTestCase
   self.use_transactional_tests = false
 
   class BooleanType < ActiveRecord::Base
@@ -18,7 +18,7 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
     end
     BooleanType.reset_column_information
 
-    @emulate_booleans = ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans
+    @emulate_booleans = @connection.class.emulate_booleans
   end
 
   teardown do
@@ -96,7 +96,7 @@ class Mysql2BooleanTest < ActiveRecord::Mysql2TestCase
   end
 
   def emulate_booleans(value)
-    ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = value
+    @connection.class.emulate_booleans = value
     BooleanType.reset_column_information
   end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2EnumTest < ActiveRecord::Mysql2TestCase
+class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
   self.use_transactional_tests = false
 
   include SchemaDumpingHelper

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "models/author"
 require "models/post"
 
-class Mysql2ExplainTest < ActiveRecord::Mysql2TestCase
+class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   fixtures :authors, :author_addresses
 
   def test_explain_for_one_query

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "support/connection_helper"
 
 module ActiveRecord
-  class Mysql2NestedDeadlockTest < ActiveRecord::Mysql2TestCase
+  class NestedDeadlockTest < ActiveRecord::AbstractMysqlTestCase
     self.use_transactional_tests = false
 
     class Sample < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "models/post"
 
-class Mysql2OptimizerHintsTest < ActiveRecord::Mysql2TestCase
+class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
   if supports_optimizer_hints?
     fixtures :posts
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
+class QuotingTest < ActiveRecord::AbstractMysqlTestCase
   def setup
     super
     @conn = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class SchemaMigrationsTest < ActiveRecord::Mysql2TestCase
+class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
   self.use_transactional_tests = false
 
   def setup

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -6,7 +6,7 @@ require "models/comment"
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2SchemaTest < ActiveRecord::Mysql2TestCase
+    class SchemaTest < ActiveRecord::AbstractMysqlTestCase
       fixtures :posts
 
       def setup

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/set_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/set_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2SetTest < ActiveRecord::Mysql2TestCase
+class SetTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
 
   class SetTest < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "models/topic"
 require "models/reply"
 
-class Mysql2StoredProcedureTest < ActiveRecord::Mysql2TestCase
+class StoredProcedureTest < ActiveRecord::AbstractMysqlTestCase
   fixtures :topics
 
   def setup
@@ -21,18 +21,19 @@ class Mysql2StoredProcedureTest < ActiveRecord::Mysql2TestCase
   def test_multi_results
     rows = @connection.select_rows("CALL ten();")
     assert_equal 10, rows[0][0].to_i, "ten() did not return 10 as expected: #{rows.inspect}"
-    assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select_rows'"
+
+    assert @connection.active?, "Bad connection use by '#{@connection.class}.select_rows'"
   end
 
   def test_multi_results_from_select_one
     row = @connection.select_one("CALL topics(1);")
     assert_equal "David", row["author_name"]
-    assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select_one'"
+    assert @connection.active?, "Bad connection use by '#{@connection.class}.select_one'"
   end
 
   def test_multi_results_from_find_by_sql
     topics = Topic.find_by_sql "CALL topics(3);"
     assert_equal 3, topics.size
-    assert @connection.active?, "Bad connection use by 'Mysql2Adapter.select'"
+    assert @connection.active?, "Bad connection use by '#{@connection.class}.select'"
   end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/sql_types_test.rb
@@ -2,7 +2,7 @@
 
 require "cases/helper"
 
-class Mysql2SqlTypesTest < ActiveRecord::Mysql2TestCase
+class SqlTypesTest < ActiveRecord::AbstractMysqlTestCase
   def test_binary_types
     assert_equal "varbinary(64)", type_to_sql(:binary, 64)
     assert_equal "varbinary(4095)", type_to_sql(:binary, 4095)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
+class TableOptionsTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 
@@ -78,7 +78,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   end
 end
 
-class Mysql2DefaultEngineOptionTest < ActiveRecord::Mysql2TestCase
+class DefaultEngineOptionTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "support/connection_helper"
 
 module ActiveRecord
-  class Mysql2TransactionTest < ActiveRecord::Mysql2TestCase
+  class TransactionTest < ActiveRecord::AbstractMysqlTestCase
     self.use_transactional_tests = false
 
     class Sample < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-class Mysql2UnsignedTypeTest < ActiveRecord::Mysql2TestCase
+class UnsignedTypeTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
   self.use_transactional_tests = false
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "support/schema_dumping_helper"
 
 if ActiveRecord::Base.connection.supports_virtual_columns?
-  class Mysql2VirtualColumnTest < ActiveRecord::Mysql2TestCase
+  class VirtualColumnTest < ActiveRecord::AbstractMysqlTestCase
     include SchemaDumpingHelper
 
     self.use_transactional_tests = false

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -253,6 +253,12 @@ module ActiveRecord
     end
   end
 
+  class AbstractMysqlTestCase < TestCase
+    def self.run(*args)
+      super if current_adapter?(:Mysql2Adapter)
+    end
+  end
+
   class Mysql2TestCase < TestCase
     def self.run(*args)
       super if current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
### Motivation / Background

Currently, a lot of the mysql2 test cases are testing behaviour that is defined in the `AbstractMysqlAdapter`. This commit introduces an `AbstractMysqlTestCase` that will run tests against any MySQL-compatible adapter, and changes relevant Mysql2 tests to use `AbstractMysqlTestCase` instead.

### Detail

- Adds a new `AbstractMysqlTestCase`
- Changes relevant Mysql2 tests to be `AbstractMysqlTestCase` tests instead, moves them to an `abstract_mysql_adapter` test dir
- Tweaks the test task in the Rakefile so that `bundle exec rake test:mysql2` will run the abstract tests

### Additional information

This change will facilitate upstreaming the Trilogy adapter to Rails -- it's a SQL-compatible adapter, so we'll want to ensure full test coverage for any behaviour coming from `AbstractMysqlAdapter`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
