### PR TITLE
Move Template class docs to the correct namespace [ci-skip]

### DIFF
--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActionView # :nodoc:
-  # = Action View Template Handlers
   class Template # :nodoc:
+    # = Action View Template Handlers
     module Handlers # :nodoc:
       autoload :Raw, "action_view/template/handlers/raw"
       autoload :ERB, "action_view/template/handlers/erb"

--- a/actionview/lib/action_view/template/html.rb
+++ b/actionview/lib/action_view/template/html.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActionView # :nodoc:
-  # = Action View HTML Template
   class Template # :nodoc:
+    # = Action View HTML Template
     class HTML # :nodoc:
       attr_reader :type
 

--- a/actionview/lib/action_view/template/raw_file.rb
+++ b/actionview/lib/action_view/template/raw_file.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActionView # :nodoc:
-  # = Action View RawFile Template
   class Template # :nodoc:
+    # = Action View RawFile Template
     class RawFile # :nodoc:
       attr_accessor :type, :format
 

--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActionView
-  # = Action View Renderable Template for objects that respond to #render_in
   class Template
+    # = Action View Renderable Template for objects that respond to #render_in
     class Renderable # :nodoc:
       def initialize(renderable)
         @renderable = renderable

--- a/actionview/lib/action_view/template/text.rb
+++ b/actionview/lib/action_view/template/text.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ActionView # :nodoc:
-  # = Action View Text Template
   class Template # :nodoc:
+    # = Action View Text Template
     class Text # :nodoc:
       attr_accessor :type
 


### PR DESCRIPTION
Documentation of a class should be defined above the class definition, not on the parent namespace.
This fixes the documentation of ActionView::Template::Renderable showing up in ActionView::Template.
Most of the others are marked with `:nodoc:` anyway, so it shouldn't affect their documentation.

## Before
<img width="1387" alt="image" src="https://user-images.githubusercontent.com/28561/228894171-ddcc265a-e90a-416d-83c2-45a104cb881c.png">

## After
<img width="726" alt="image" src="https://user-images.githubusercontent.com/28561/228895907-8ed59979-b459-430f-ad73-e359a362040c.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
