### PR TITLE
Add debug gem back to the Gemfile template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -32,6 +32,13 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 <%- end -%>
+<% if RUBY_ENGINE == "ruby" -%>
+
+group :development, :test do
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
+end
+<% end -%>
 
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -600,6 +600,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "jbuilder"
   end
 
+  def test_inclusion_of_a_debugger
+    run_generator
+    if defined?(JRUBY_VERSION)
+      assert_no_gem "debug"
+    else
+      assert_gem "debug"
+    end
+  end
+
   def test_template_from_dir_pwd
     FileUtils.cd(Rails.root)
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))


### PR DESCRIPTION
As discussed in the removal PR https://github.com/rails/rails/pull/47515, we should add it back once [the fix in Ruby](https://github.com/ruby/ruby/pull/7321) is released with v3.2.2, which [happened today](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/). So this PR adds the gem back to the Gemfile template.

Just to reiterate why I think we need it in the Gemfile: despite working well most of the time, the debugger still receives fixes and enhancements roughly 3~4 times a year (e.g. [`v1.7.2`](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/) was released recently). So to make sure Rails developers get the best debugging experience, we should have it in the Gemfile to help keep it up-to-date.

cc @casperisfine 