### PR TITLE
Fix autoincrement on primary key for mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -94,7 +94,10 @@ module ActiveRecord
           end
 
           def integer_like_primary_key_type(type, options)
-            options[:auto_increment] = true
+            unless options[:auto_increment] == false
+              options[:auto_increment] = true
+            end
+
             type
           end
       end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
@@ -31,4 +31,12 @@ class AutoIncrementTest < ActiveRecord::AbstractMysqlTestCase
     output = dump_table_schema("auto_increments")
     assert_match(/t\.integer\s+"id",\s+null: false,\s+auto_increment: true$/, output)
   end
+
+  def test_auto_increment_false_with_custom_primary_key
+    @connection.create_table :auto_increments, id: false, force: :cascade do |t|
+      t.primary_key :id, auto_increment: false
+    end
+
+    assert_not_predicate @connection.columns(:auto_increments).first, :auto_increment?
+  end
 end


### PR DESCRIPTION
MySQL adapters take an auto_increment option but when using a primary key type that option is silently ignored and doesn't change behavior. This fixes the issue by only applying `options[:auto_increment] = true` if it wasn't set to false already.

I didn't make changes to the other adapters because they don't accept `auto_increment` as an option. If we want this for postgres we'll need to implement the option first.