### PR TITLE
Update 4_0_release_notes.md

### DIFF
--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -204,7 +204,7 @@ Please refer to the [Changelog](https://github.com/rails/rails/blob/4-0-stable/a
 
 * Deprecates the compatibility method `Module#local_constant_names`, use `Module#local_constants` instead (which returns symbols).
 
-* `BufferedLogger` is deprecated. Use `ActiveSupport::Logger`, or the logger from Ruby standard library.
+* `ActiveSupport::BufferedLogger` is deprecated. Use `ActiveSupport::Logger`, or the logger from Ruby standard library.
 
 * Deprecate `assert_present` and `assert_blank` in favor of `assert object.blank?` and `assert object.present?`
 


### PR DESCRIPTION
### Motivation / Background

Use full name ActiveSupport::BufferedLogger in release notes for rails 4.0 for easier finding
