### PR TITLE
Use h1 for Active Model documentation titles [ci-skip]

### DIFF
--- a/activemodel/lib/active_model/api.rb
+++ b/activemodel/lib/active_model/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveModel
-  # == Active \Model \API
+  # = Active \Model \API
   #
   # Includes the required interface for an object to interact with
   # Action Pack and Action View, using different Active Model modules.

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -15,7 +15,7 @@ module ActiveModel
   class MissingAttributeError < NoMethodError
   end
 
-  # == Active \Model \Attribute \Methods
+  # = Active \Model \Attribute \Methods
   #
   # Provides a way to add prefixes and suffixes to your methods as
   # well as handling the creation of <tt>ActiveRecord::Base</tt>-like

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveModel
+  # = Active \Model \Attributes
+  #
   # The Attributes module allows models to define attributes beyond simple Ruby
   # readers and writers. Similar to Active Record attributes, which are
   # typically inferred from the database schema, Active Model Attributes are

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/hash/keys"
 
 module ActiveModel
-  # == Active \Model \Callbacks
+  # = Active \Model \Callbacks
   #
   # Provides an interface for any class to have Active Record like callbacks.
   #

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveModel
-  # == Active \Model \Conversion
+  # = Active \Model \Conversion
   #
   # Handles default conversions: to_model, to_key, to_param, and to_partial_path.
   #

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -3,7 +3,7 @@
 require "active_model/attribute_mutation_tracker"
 
 module ActiveModel
-  # == Active \Model \Dirty
+  # = Active \Model \Dirty
   #
   # Provides a way to track changes in your object in the same way as
   # Active Record does.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -9,7 +9,7 @@ require "active_model/nested_error"
 require "forwardable"
 
 module ActiveModel
-  # == Active \Model \Errors
+  # = Active \Model \Errors
   #
   # Provides error related functionalities you can include in your object
   # for handling error messages and interacting with Action View helpers.

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveModel
-  # == Active \Model \Basic \Model
+  # = Active \Model \Basic \Model
   #
   # Allows implementing models similar to ActiveRecord::Base.
   # Includes ActiveModel::API for the required interface for an

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/enumerable"
 
 module ActiveModel
-  # == Active \Model \Serialization
+  # = Active \Model \Serialization
   #
   # Provides a basic serialization to a serializable_hash for your objects.
   #

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -4,7 +4,7 @@ require "active_support/json"
 
 module ActiveModel
   module Serializers
-    # == Active \Model \JSON \Serializer
+    # = Active \Model \JSON \Serializer
     module JSON
       extend ActiveSupport::Concern
       include ActiveModel::Serialization

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveModel
-  # == Active \Model \Translation
+  # = Active \Model \Translation
   #
   # Provides integration between your object and the Rails internationalization
   # (i18n) framework.

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/array/extract_options"
 
 module ActiveModel
-  # == Active \Model \Validations
+  # = Active \Model \Validations
   #
   # Provides a full validation framework to your objects.
   #
@@ -447,7 +447,7 @@ module ActiveModel
     end
   end
 
-  # = Active Model ValidationError
+  # = Active \Model \ValidationError
   #
   # Raised by <tt>validate!</tt> when the model is invalid. Use the
   # +model+ method to retrieve the record which did not validate.

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -2,7 +2,7 @@
 
 module ActiveModel
   module Validations
-    # == Active \Model \Validation \Callbacks
+    # = Active \Model \Validation \Callbacks
     #
     # Provides an interface for any class to have ClassMethods#before_validation and
     # ClassMethods#after_validation callbacks.

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/module/anonymous"
 
 module ActiveModel
-  # == Active \Model \Validator
+  # = Active \Model \Validator
   #
   # A simple base class that can be used along with
   # ActiveModel::Validations::ClassMethods.validates_with


### PR DESCRIPTION
### Motivation / Background

Most of the other frameworks use a h1(`=`) instead of h2(`==`) for class/module documentation. Having a h1 will improve SEO and makes things look more consistent.

This also adds a missing title and escapes a namespace so it won't be linked.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
