### PR TITLE
Use h1 for Active Job documentation titles [ci-skip]

### DIFF
--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -15,7 +15,7 @@ require "active_job/timezones"
 require "active_job/translation"
 
 module ActiveJob # :nodoc:
-  # = Active Job
+  # = Active Job \Base
   #
   # Active Job objects can be configured to work with different backend
   # queuing frameworks. To specify a queue adapter to use:

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -4,7 +4,7 @@ require "active_support/callbacks"
 require "active_support/core_ext/module/attribute_accessors"
 
 module ActiveJob
-  # = Active Job Callbacks
+  # = Active Job \Callbacks
   #
   # Active Job provides hooks during the life cycle of a job. Callbacks allow you
   # to trigger logic during this cycle. Available callbacks are:

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ActiveJob
+  # = Active Job \Core
+  #
   # Provides general behavior that will be included into every Active Job
   # object that inherits from ActiveJob::Base.
   module Core

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -3,6 +3,8 @@
 require "active_support/core_ext/string/inflections"
 
 module ActiveJob
+  # = Active Job Queue adapter
+  #
   # The <tt>ActiveJob::QueueAdapter</tt> module is used to load the
   # correct adapter. The default queue adapter is the +:async+ queue.
   module QueueAdapter # :nodoc:

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveJob
-  # == Active Job adapters
+  # = Active Job adapters
   #
   # Active Job has adapters for the following queuing backends:
   #

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -7,7 +7,7 @@ require "concurrent/utility/processor_counter"
 
 module ActiveJob
   module QueueAdapters
-    # == Active Job Async adapter
+    # = Active Job Async adapter
     #
     # The Async adapter runs jobs with an in-process thread pool.
     #

--- a/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/backburner_adapter.rb
@@ -4,7 +4,7 @@ require "backburner"
 
 module ActiveJob
   module QueueAdapters
-    # == Backburner adapter for Active Job
+    # = Backburner adapter for Active Job
     #
     # Backburner is a beanstalkd-powered job queue that can handle a very
     # high volume of jobs. You create background jobs and place them on

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/string/inflections"
 
 module ActiveJob
   module QueueAdapters
-    # == Delayed Job adapter for Active Job
+    # = Delayed Job adapter for Active Job
     #
     # Delayed::Job (or DJ) encapsulates the common pattern of asynchronously
     # executing longer tasks in the background. Although DJ can have many

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -2,7 +2,7 @@
 
 module ActiveJob
   module QueueAdapters
-    # == Active Job Inline adapter
+    # = Active Job Inline adapter
     #
     # When enqueuing jobs with the Inline adapter the job will be executed
     # immediately.

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -4,7 +4,7 @@ require "queue_classic"
 
 module ActiveJob
   module QueueAdapters
-    # == queue_classic adapter for Active Job
+    # = queue_classic adapter for Active Job
     #
     # queue_classic provides a simple interface to a PostgreSQL-backed message
     # queue. queue_classic specializes in concurrent locking and minimizing

--- a/activejob/lib/active_job/queue_adapters/resque_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/resque_adapter.rb
@@ -16,7 +16,7 @@ end
 
 module ActiveJob
   module QueueAdapters
-    # == Resque adapter for Active Job
+    # = Resque adapter for Active Job
     #
     # Resque (pronounced like "rescue") is a Redis-backed library for creating
     # background jobs, placing those jobs on multiple queues, and processing

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -5,7 +5,7 @@ require "sidekiq"
 
 module ActiveJob
   module QueueAdapters
-    # == Sidekiq adapter for Active Job
+    # = Sidekiq adapter for Active Job
     #
     # Simple, efficient background processing for Ruby. Sidekiq uses threads to
     # handle many jobs at the same time in the same process. It does not

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -5,7 +5,7 @@ require "monitor"
 
 module ActiveJob
   module QueueAdapters
-    # == Sneakers adapter for Active Job
+    # = Sneakers adapter for Active Job
     #
     # A high-performance RabbitMQ background processing framework for Ruby.
     # Sneakers is being used in production for both I/O and CPU intensive

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -4,7 +4,7 @@ require "sucker_punch"
 
 module ActiveJob
   module QueueAdapters
-    # == Sucker Punch adapter for Active Job
+    # = Sucker Punch adapter for Active Job
     #
     # Sucker Punch is a single-process Ruby asynchronous processing library.
     # This reduces the cost of hosting on a service like Heroku along

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -2,7 +2,7 @@
 
 module ActiveJob
   module QueueAdapters
-    # == Test adapter for Active Job
+    # = Test adapter for Active Job
     #
     # The test adapter should be used only in testing. Along with
     # ActiveJob::TestCase and ActiveJob::TestHelper

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -3,6 +3,8 @@
 require "set"
 
 module ActiveJob
+  # = Active Job \Serializers
+  #
   # The <tt>ActiveJob::Serializers</tt> module is used to store a list of known serializers
   # and to add new ones. It also has helpers to serialize/deserialize objects.
   module Serializers # :nodoc:


### PR DESCRIPTION
### Motivation / Background

Most of the other frameworks use a h1(`=`) instead of h2(`==`) for class/module documentation. Having a h1 will improve SEO and makes things look more consistent.

This also adds a missing title and escapes namespaces so it won't be linked.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
