### PR TITLE
Only default to select primary key when non-composite

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -9,7 +9,11 @@ module ActiveRecord
         end
 
         if value.select_values.empty?
-          value = value.select(value.table[value.klass.primary_key])
+          if value.klass.composite_primary_key?
+            raise ArgumentError, "Cannot map composite primary key #{value.klass.primary_key} to #{attribute.name}"
+          else
+            value = value.select(value.table[value.klass.primary_key])
+          end
         end
 
         attribute.in(value.arel)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Part of the ongoing effort to support composite primary keys.

Historically, when a relation being handled in the predicate builder has no selected values, it falls back to selecting the model's primary key. This tends to work well in single-column PK cases.

In composite key cases, this can lead to attempting to compare a single attribute to a list of attributes, which builds malformed SQL. 

For instance, 

```ruby
order = cpk_orders(:cpk_groceries_order_1)
subquery = Cpk::Order.where(Cpk::Order.primary_key => [order.id])

# => raises ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: cpk_orders.["shop_id", "id"]
Cpk::Order.where(id: subquery).to_a 
```

This check prevents any code from attempting to do so, by raising in CPK cases when defaulting to primary key. For now, users can build these queries themselves.


### Detail

This PR doesn't change behaviour much. With or without this change, Rails will eventually raise. We move the error from a SQL syntax one, to a preventative (more informative) one. This branch will let us eventually build support for defaulting in composite cases, if that's a desired feature. For now, this should do—there's plenty of ways to build the desired query.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
