### PR TITLE
Add support for logging background job enqueue callers

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Log background job enqueue callers
+
+    Add `verbose_enqueue_logs` configuration option to display the caller
+    of background job enqueue in the log to help with debugging.
+
+    Example log line:
+
+    ```
+    Enqueued AvatarThumbnailsJob (Job ID: ab528951-41fb-4c48-9129-3171791c27d6) to Sidekiq(default) with arguments: 1092412064
+    ↳ app/models/user.rb:421:in `generate_avatar_thumbnails'
+    ```
+
+    Enabled in development only for new and upgraded applications. Not recommended for use
+    in the production environment since it relies on Ruby's `Kernel#caller` which is fairly slow.
+
+    *fatkodima*
+
 *   Set `provider_job_id` for Backburner jobs
 
     *Cameron Matheson*

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -52,4 +52,12 @@ module ActiveJob
   # Legacy serialization will be removed in Rails 7.2, along with this config.
   singleton_class.attr_accessor :use_big_decimal_serializer
   self.use_big_decimal_serializer = false
+
+  ##
+  # :singleton-method:
+  #
+  # Specifies if the methods calling background job enqueue should be logged below
+  # their relevant enqueue log lines. Defaults to false.
+  singleton_class.attr_accessor :verbose_enqueue_logs
+  self.verbose_enqueue_logs = false
 end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -83,5 +83,11 @@ module ActiveJob
         end
       end
     end
+
+    initializer "active_job.backtrace_cleaner" do
+      ActiveSupport.on_load(:active_job) do
+        LogSubscriber.backtrace_cleaner = ::Rails.backtrace_cleaner
+      end
+    end
   end
 end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -297,4 +297,18 @@ class LoggingTest < ActiveSupport::TestCase
       assert_match(/Discarded RetryJob \(Job ID: .*?\) due to a DiscardableError.*\./, @logger.messages)
     end
   end
+
+  def test_verbose_enqueue_logs
+    ActiveJob.verbose_enqueue_logs = true
+
+    LoggingJob.perform_later "Dummy"
+    assert_match("↳", @logger.messages)
+  ensure
+    ActiveJob.verbose_enqueue_logs = false
+  end
+
+  def test_verbose_enqueue_logs_disabled_by_default
+    LoggingJob.perform_later "Dummy"
+    assert_no_match("↳", @logger.messages)
+  end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2459,6 +2459,10 @@ Allows to set custom argument serializers. Defaults to `[]`.
 
 Controls if the arguments of a job are logged. Defaults to `true`.
 
+#### `config.active_job.verbose_enqueue_logs`
+
+Specifies if source locations of methods that enqueue background jobs should be logged below relevant enqueue log lines. By default, the flag is `true` in development and `false` in all other environments.
+
 #### `config.active_job.retry_jitter`
 
 Controls the amount of "jitter" (random variation) applied to the delay time calculated when retrying failed jobs.

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -238,6 +238,18 @@ Verbose query logs are enabled by default in the development environment logs af
 
 WARNING: We recommend against using this setting in production environments. It relies on Ruby's `Kernel#caller` method which tends to allocate a lot of memory in order to generate stacktraces of method calls. Use query log tags (see below) instead.
 
+### Verbose Enqueue Logs
+
+Similar to the "Verbose Query Logs" above, allows to print source locations of methods that enqueue background jobs.
+
+It is enabled by default in development. To enable in other environments, add in `application.rb` or any environment initializer:
+
+```rb
+config.active_job.verbose_enqueue_logs = true
+```
+
+As verbose query logs, it is not recommended for use in production environments.
+
 SQL Query Comments
 ------------------
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -63,6 +63,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
   <%- end -%>
   <%- unless skip_sprockets? -%>
   # Suppress logger output for asset requests.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2830,6 +2830,20 @@ module ApplicationTests
       assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled if set in config"
     end
 
+    test "config.active_job.verbose_enqueue_logs defaults to true in development" do
+      build_app
+      app "development"
+
+      assert ActiveJob.verbose_enqueue_logs
+    end
+
+    test "config.active_job.verbose_enqueue_logs defaults to false in production" do
+      build_app
+      app "production"
+
+      assert_not ActiveJob.verbose_enqueue_logs
+    end
+
     test "active record job queue is set" do
       app "development"
 


### PR DESCRIPTION
I recently released a gem (https://github.com/fatkodima/job_enqueue_logger) for logging when background jobs are enqueued (additionally with backtraces). Idea is similar to a familiar [SQL query tracing](https://github.com/rails/rails/pull/26815), but for background jobs. Getting such info is useful for debugging and generally understanding whats going on in a large app. There was a warm welcome of such a feature [on reddit](https://www.reddit.com/r/ruby/comments/126j4cn/announcing_job_enqueue_logger_a_gem_that_logs/).

That gem works only with raw background processors, which are not logging any info when the job is enqueued. Fortunately, ActiveJob already logs such an info, but is missing backtraces. I was suggested to implement that upstream, so this PR adds backtraces on top of that.

It looks like this:
```
Enqueued AvatarThumbnailsJob (Job ID: ab528951-41fb-4c48-9129-3171791c27d6) to Sidekiq(default) with arguments: 1092412064
↳ app/models/user.rb:421:in `generate_avatar_thumbnails'
```

cc @byroot (as we discussed this)