### PR TITLE
Add documentation intros for Action Controller and Action Dispatch

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -6,6 +6,13 @@ require "action_controller/deprecator"
 require "action_controller/metal/strong_parameters"
 require "action_controller/metal/exceptions"
 
+# = Action Controller
+#
+# Action Controller is a module of Action Pack.
+#
+# Action Controller provides a base controller class that can be subclassed to
+# implement filters and actions to handle requests. The result of an action is
+# typically content generated from views.
 module ActionController
   extend ActiveSupport::Autoload
 

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -35,6 +35,14 @@ module Rack
   autoload :Test, "rack/test"
 end
 
+# = Action Dispatch
+#
+# Action Dispatch is a module of Action Pack.
+#
+# Action Dispatch parses information about the web request, handles
+# routing as defined by the user, and does advanced processing related to HTTP
+# such as MIME-type negotiation, decoding parameters in POST, PATCH, or PUT
+# bodies, handling HTTP caching logic, cookies and sessions.
 module ActionDispatch
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor
   extend ActiveSupport::Autoload

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -36,7 +36,9 @@ module Rails
           include: %w(
             README.rdoc
             lib/abstract_controller/**/*.rb
+            lib/action_controller.rb
             lib/action_controller/**/*.rb
+            lib/action_dispatch.rb
             lib/action_dispatch/**/*.rb
           )
         },


### PR DESCRIPTION
In 7c94708d24a4185075f656626ce4b14c9604ffd3 the READMEs were included for the main framework pages of the API documentation, except for Action Pack. As Action Pack doesn't define any code in the ActionPack namespace, only it's included modules (Action Dispatch, Action Controller and Abstract Controller) are documented.

This adds documentation intro's to the main page for Action Controller and Action Dispatch. The content was copied from the Action Pack README. As Abstract Controller isn't mentioned there, it is skipped for now. [ci-skip]

## Before

<img width="938" alt="image" src="https://user-images.githubusercontent.com/28561/229363593-3654ad3a-3870-43a5-9212-a11979acfd64.png">
<img width="929" alt="image" src="https://user-images.githubusercontent.com/28561/229363607-99931bea-9677-464d-be3c-d78457bf6a2a.png">

## After

<img width="981" alt="image" src="https://user-images.githubusercontent.com/28561/229363576-2a9abd57-8054-47ae-9ded-776a91f48256.png">
<img width="958" alt="image" src="https://user-images.githubusercontent.com/28561/229363628-4ec58f59-6622-43cb-a02d-dd31e083010f.png">
