### PR TITLE
Create an `app/lib` directory when generating a new Rails project

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -35,7 +35,7 @@ class PostsController < ApplicationController
 end
 ```
 
-This is not the case in Rails applications, where application classes and modules are just available everywhere without `require` calls:
+This is not the case in Rails applications, where application classes and modules within `app` are just available everywhere without `require` calls:
 
 ```ruby
 class PostsController < ApplicationController
@@ -47,7 +47,7 @@ end
 
 Rails _autoloads_ them on your behalf if needed. This is possible thanks to a couple of [Zeitwerk](https://github.com/fxn/zeitwerk) loaders Rails sets up on your behalf, which provide autoloading, reloading, and eager loading.
 
-On the other hand, those loaders do not manage anything else. In particular, they do not manage the Ruby standard library, gem dependencies, Rails components themselves, or even (by default) the application `lib` directory. That code has to be loaded as usual.
+On the other hand, those loaders do not manage anything else. In particular, they do not manage the Ruby standard library, gem dependencies, Rails components themselves, or even (by default) the project `lib` directory. That code has to be loaded as usual.
 
 
 Project Structure

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Create an `app/lib` directory when generating a new Rails project.
+
+    *Ben Sheldon*
+
 *   `bin/rails --help` will now list only framework and plugin commands. Rake
     tasks defined in `lib/tasks/*.rake` files will no longer be included. For a
     list of those tasks, use `rake -T`.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -92,6 +92,7 @@ module Rails
       directory "app"
 
       empty_directory_with_keep_file "app/assets/images"
+      empty_directory_with_keep_file "app/lib"
 
       keep_file  "app/controllers/concerns"
       keep_file  "app/models/concerns"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -991,6 +991,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     folders_with_keep = %w(
       app/assets/images
       app/controllers/concerns
+      app/lib
       app/models/concerns
       lib/tasks
       lib/assets


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR changes the Rails App Generator to create an `app/lib` directory with a `.keep` file.

#### Why `app/lib`?

One of the most common problems I encounter consulting on Rails projects is that developers have previously added `lib` to autoload paths and then twisted themselves into knots with error-prone conventions for subsequently un-autoloading a subset of files also in `lib`. 

All of this could have been avoided if there was an existing place under `app` where developers felt comfortable placing constants that didn’t quite fit anywhere else but would be autoloaded. `app/lib` can be that place.

> The best practice to accomplish that nowadays is to move that code to `app/lib`. Only the Ruby code you want to reload, tasks or other auxiliary files are OK in `lib`. — [@fxn  comment](https://github.com/rails/rails/issues/37835#issuecomment-757367812)

> A `lib/` directory will only cause pain. Move the code to `app/lib/` and make sure the code inside follows the class/filename conventions. — [Sidekiq: Problems and Troubleshooting](https://github.com/sidekiq/sidekiq/wiki/Problems-and-Troubleshooting#autoloading)

#### Why not?

The following are common arguments I've seen _against_ `app/lib`, and my response:

**It is confusing that `app/lib` is named similarly to `lib` .** I agree, but it is not uncommon to have directories with the same name and similar function nested under different contexts.  I believe developers can handle this complexity. Most similarly, Linux has `lib` and `usr/lib` . Within a new Rails app, there are many such directories that are manageable: 

- `app/assets`  and `lib/assets` (sometimes even `vendor/assets` too)
- `app/javascript` and `vendor/javascript`
- `storage` and `tmp/storage`
- `config` and `app/assets/config`
- `app/controllers` and `app/javascript/controllers`

**Everything has a place so do better and find it.** There is a certain belief that everything within `app` should be organized into functionally-named directories and any files placed in `app/lib` actually belongs in `app/services` or `app/interactors` or `app/models` or someplace if the developers just tried harder. The implication is that developers are bad developers if they don’t yet know what kind of constant they have and where its forever home should be.

I reject this. Over the lifespan of an application, there will be constants that have not yet found their functional kin, if those kin ever come to exist at all; sometimes you simply need some code and a place to put it. `app/lib` can be the convention for where those constants can live temporarily or as long as necessary. Autoloading is really nice, let’s treat them to it.

**Really, "lib" is a bad name.** I’m open to alternative suggestions, and I think conventionalizing it in Rails avoids pushing an otherwise value-less naming choice onto developers (e.g. `app/misc` or `app/extras`).  The need here is that there should be a default, don’t make me think place for autoloaded constants. I think the differences are easy to explain as:

- `lib` is where the project library files live, which is in the LOAD_PATH but not autoloaded. The code defined here is used in scripts and utilities that are not part of the application or  when code will be used within the application but should be loaded, or loaded conditionally, using an explicit `require`
- `app/lib` is where application library files live with the benefit of automatic autoloading. The constants defined in these files are part of the application, but have not (or not yet) been organized into functional groups within their own directory within `app`

#### In conclusion

I think the symmetry of the naming between `lib` and `app/lib` will lead a fresh Rails developer to seek out the answer to “Why are there two `lib` directories?", and they will become illuminated. And it will prevent them from seeking the answer to “How do I autoload `lib`?” which will start them on a rough path that leads to me advising them to undo it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
