### PR TITLE
[ActiveJob] Add logging for `enqueue_all`

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -31,6 +31,7 @@ module ActiveJob
             rescue EnqueueError => e
               job.enqueue_error = e
             end
+            adapter_jobs.count(&:successfully_enqueued?)
           end
         end
       end

--- a/activejob/test/jobs/enqueue_error_job.rb
+++ b/activejob/test/jobs/enqueue_error_job.rb
@@ -3,17 +3,25 @@
 class EnqueueErrorJob < ActiveJob::Base
   class EnqueueErrorAdapter
     class << self
-      def enqueue(*)
-        raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
-      end
-
-      def enqueue_at(*)
-        raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
-      end
+      attr_accessor :should_raise_sequence
     end
+    self.should_raise_sequence = []
+
+    def enqueue(*)
+      raise ActiveJob::EnqueueError, "There was an error enqueuing the job" if should_raise?
+    end
+
+    def enqueue_at(*)
+      raise ActiveJob::EnqueueError, "There was an error enqueuing the job" if should_raise?
+    end
+
+    private
+      def should_raise?
+        self.class.should_raise_sequence.empty? || self.class.should_raise_sequence.shift
+      end
   end
 
-  self.queue_adapter = EnqueueErrorAdapter
+  self.queue_adapter = EnqueueErrorAdapter.new
 
   def perform
     raise "This should never be called"


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/46603.

When working on https://github.com/rails/rails/pull/47839, I noticed that ActiveJob does not print any logs when `perform_all_later` is called, compared to other methods, like `perform_later`.

The log lines look like this:
```
# When all jobs were enqueued successfully
Enqueued 3 jobs to Sidekiq (2 TestJob, 1 AnotherJob)

# When there are enqueued and not enqueued jobs
Enqueued 3 jobs to Sidekiq (2 TestJob, 1 AnotherJob). Failed enqueuing 1 job

# When all jobs failed enqueuing
Failed enqueuing 2 jobs to Sidekiq 
```

I am thinking if there is a need for more detailed log lines, like stating what jobs failed enqueuing, for example. 