### PR TITLE
Notify job should not affect workflow result

### DIFF
--- a/.github/workflows/build-and-test-dev-image.yml
+++ b/.github/workflows/build-and-test-dev-image.yml
@@ -36,6 +36,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     if: always() && github.ref_name == 'main'
+    continue-on-error: true
     needs: build-and-test-dev-image
     steps:
       - uses: zzak/action-discord@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     if: always() && github.ref_name == 'main'
+    continue-on-error: true
     needs: [rails-bin, codespell]
     steps:
       - uses: zzak/action-discord@v4

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -26,6 +26,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     if: always() && github.ref_name == 'main'
+    continue-on-error: true
     needs: build
     steps:
       - uses: zzak/action-discord@v4


### PR DESCRIPTION
Occasionally the notify job will fail, most recently due to rate limits (ref: zzak/action-discord#5).

This will make sure that whatever happens, the total workflow result is not impacted by whether the notification was delivered successfully or not.