### PR TITLE
Add docs for Active Record validation with multiple contexts

### DIFF
--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -62,6 +62,8 @@ module ActiveRecord
     #
     # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
     # {new_record?}[rdoc-ref:Persistence#new_record?] is +true+, and to <tt>:update</tt> if it is not.
+    # If the argument is an array of contexts, <tt>post.valid?([:create, :update])</tt>, the validations are
+    # run within multiple contexts.
     #
     # \Validations with no <tt>:on</tt> option will run no matter the context. \Validations with
     # some <tt>:on</tt> option will only run in the specified context.


### PR DESCRIPTION
### Detail

[The PR documents this change](https://github.com/rails/rails/pull/21535)

Allowing multiple contexts to be validated:
person.valid?([:create, :update])    # => true

The change isn't visible in the API documentation which this PR
fixes.
### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
