### PR TITLE
Correctly dump check constraints for MySQL 8.0.16+

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -526,7 +526,8 @@ module ActiveRecord
               name: row["name"]
             }
             expression = row["expression"]
-            expression = expression[1..-2] unless mariadb? # remove parentheses added by mysql
+            expression = expression[1..-2] if expression.start_with?("(") && expression.end_with?(")")
+            expression = strip_whitespace_characters(expression)
             CheckConstraintDefinition.new(table_name, expression, options)
           end
         else
@@ -714,6 +715,12 @@ module ActiveRecord
       EMULATE_BOOLEANS_TRUE = { emulate_booleans: true }.freeze
 
       private
+        def strip_whitespace_characters(expression)
+          expression = expression.gsub(/\\n|\\\\/, "")
+          expression = expression.gsub(/\s{2,}/, " ")
+          expression
+        end
+
         def text_type?(type)
           TYPE_MAP.lookup(type).is_a?(Type::String) || TYPE_MAP.lookup(type).is_a?(Type::Text)
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because Rails doesn't currently handle check constraints correctly in newer versions of MySQL 8.0.

Fixes #47849.

### Detail

If you're using MySQL 8.0.16+ and your database contains a table with a check constraint, the first and last characters of the constraint will be stripped when dumping the schema; this makes it impossible to use check constraints in a MySQL 8.0 database with the `:ruby` schema format; once dumped, they cannot be re-imported.

This is because, up until MySQL 8.0.16, all check constraints were surrounded by an extra set of parentheses; this behaviour differed from that presented by MariaDB, which handled them correctly thanks to an engine check within the AbstractMySqlAdapter.

With this change, we continue to handle MariaDB correctly, but also add an extra database version check so that MySQL 8.0.16+ behaves in the same way.

It is also possible that the exported check constraint will contain invalid and unexpected whitespace characters; we handle that here too, stripping out sequences of `\\` and `\n`, as well as any other whitespace.

### Additional information

I've tested this as thoroughly as possible against local versions of MySQL 8.0 running in Docker. I wasn't able to figure out how to write a test for the new behaviour; there's only a single test that deals with check constraints in the schema dumper and it doesn't have any MySQL-specific behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
