### PR TITLE
Enable force_ssl=true in production by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enable force_ssl=true in production by default: Force all access to the app over SSL,
+    use Strict-Transport-Security, and use secure cookies
+
+    *Justin Searls*, *Aaron Patterson*, *Guillermo Iguaran*, *Vinícius Bispo*
+
 *   Add engine's draw paths to application route set, so that the application
     can draw route files defined in engine paths.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -49,7 +49,7 @@ module ApplicationTests
       class ::PostsController < ActionController::Base ; end
 
       # the debug_assets params isn't used if compile is off
-      get "/posts?debug_assets=true"
+      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
       assert_match(/<script src="\/assets\/application-([0-z]+)\.js"><\/script>/, last_response.body)
       assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
     end
@@ -62,7 +62,7 @@ module ApplicationTests
 
       class ::PostsController < ActionController::Base ; end
 
-      get "/posts?debug_assets=true"
+      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
       assert_match(/<script src="\/assets\/application(\.debug|\.self)?-([0-z]+)\.js(\?body=1)?"><\/script>/, last_response.body)
     end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -263,7 +263,7 @@ module ApplicationTests
 
       # Checking if Uglifier is defined we can know if Sprockets was reached or not
       assert_not defined?(Uglifier)
-      get "/assets/#{asset_path}"
+      get("/assets/#{asset_path}", {}, "HTTPS" => "on")
       assert_match "alert()", last_response.body
       assert_not defined?(Uglifier)
     end
@@ -348,7 +348,7 @@ module ApplicationTests
       # Load app env
       app "production"
 
-      get "/assets/demo.js"
+      get("/assets/demo.js", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
     end
 
@@ -410,7 +410,7 @@ module ApplicationTests
       class ::PostsController < ActionController::Base ; end
 
       # the debug_assets params isn't used if compile is off
-      get "/posts?debug_assets=true"
+      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
       assert_match(/<script src="\/assets\/application-([0-z]+)\.js"><\/script>/, last_response.body)
       assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
     end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -446,7 +446,7 @@ class LoadingTest < ActiveSupport::TestCase
     require "rack/test"
     extend Rack::Test::Methods
 
-    get "/omg/show"
+    get("/omg/show", {}, "HTTPS" => "on")
     assert_equal "Query cache is enabled.", last_response.body
   end
 

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -26,14 +26,14 @@ module ApplicationTests
 
     test "/rails/mailers is not accessible in production" do
       app("production")
-      get "/rails/mailers"
+      get("/rails/mailers", {}, { "HTTPS" => "on" })
       assert_equal 404, last_response.status
     end
 
     test "/rails/mailers is accessible with correct configuration" do
       add_to_config "config.action_mailer.show_previews = true"
       app("production")
-      get "/rails/mailers", {}, { "REMOTE_ADDR" => "4.2.42.42" }
+      get "/rails/mailers", {}, { "REMOTE_ADDR" => "4.2.42.42", "HTTPS" => "on" }
       assert_equal 200, last_response.status
     end
 

--- a/railties/test/application/middleware/cache_test.rb
+++ b/railties/test/application/middleware/cache_test.rb
@@ -10,6 +10,9 @@ module ApplicationTests
       build_app
       require "rack/test"
       extend Rack::Test::Methods
+
+      add_to_env_config "production", "config.cache_store = :memory_store"
+      add_to_env_config "production", "config.action_dispatch.rack_cache = true"
     end
 
     def teardown
@@ -56,7 +59,7 @@ module ApplicationTests
       simple_controller
       expected = "Wed, 30 May 1984 19:43:31 GMT"
 
-      get "/expires/keeps_if_modified_since", {}, { "HTTP_IF_MODIFIED_SINCE" => expected }
+      get "/expires/keeps_if_modified_since", {}, { "HTTP_IF_MODIFIED_SINCE" => expected, "HTTPS" => "on" }
 
       assert_equal 200, last_response.status
       assert_equal expected, last_response.body, "cache should have kept If-Modified-Since"
@@ -79,15 +82,13 @@ module ApplicationTests
     def test_cache_works_with_expires
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_header"
+      get "/expires/expires_header", {}, { "HTTPS" => "on" }
       assert_equal "miss, store", last_response.headers["X-Rack-Cache"]
       assert_equal "max-age=10, public", last_response.headers["Cache-Control"]
 
       body = last_response.body
 
-      get "/expires/expires_header"
+      get "/expires/expires_header", {}, { "HTTPS" => "on" }
 
       assert_equal "fresh", last_response.headers["X-Rack-Cache"]
 
@@ -97,15 +98,13 @@ module ApplicationTests
     def test_cache_works_with_expires_private
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_header", private: true
+      get "/expires/expires_header", { private: true }, { "HTTPS" => "on" }
       assert_equal "miss",                last_response.headers["X-Rack-Cache"]
       assert_equal "private, max-age=10", last_response.headers["Cache-Control"]
 
       body = last_response.body
 
-      get "/expires/expires_header", private: true
+      get "/expires/expires_header", { private: true }, { "HTTPS" => "on" }
       assert_equal "miss",           last_response.headers["X-Rack-Cache"]
       assert_not_equal body,         last_response.body
     end
@@ -113,15 +112,13 @@ module ApplicationTests
     def test_cache_works_with_etags
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_etag"
-      assert_equal "miss, store", last_response.headers["X-Rack-Cache"]
+      get "/expires/expires_etag", {}, { "HTTPS" => "on" }
       assert_equal "public", last_response.headers["Cache-Control"]
+      assert_equal "miss, store", last_response.headers["X-Rack-Cache"]
 
       etag = last_response.headers["ETag"]
 
-      get "/expires/expires_etag", {}, { "HTTP_IF_NONE_MATCH" => etag }
+      get "/expires/expires_etag", {}, { "HTTP_IF_NONE_MATCH" => etag, "HTTPS" => "on" }
       assert_equal "stale, valid, store", last_response.headers["X-Rack-Cache"]
       assert_equal 304, last_response.status
       assert_equal "", last_response.body
@@ -130,16 +127,14 @@ module ApplicationTests
     def test_cache_works_with_etags_private
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_etag", private: true
+      get "/expires/expires_etag", { private: true }, { "HTTPS" => "on" }
       assert_equal "miss",                                last_response.headers["X-Rack-Cache"]
       assert_equal "must-revalidate, private, max-age=0", last_response.headers["Cache-Control"]
 
       body = last_response.body
       etag = last_response.headers["ETag"]
 
-      get "/expires/expires_etag", { private: true }, { "HTTP_IF_NONE_MATCH" => etag }
+      get "/expires/expires_etag", { private: true }, { "HTTP_IF_NONE_MATCH" => etag, "HTTPS" => "on" }
       assert_equal "miss", last_response.headers["X-Rack-Cache"]
       assert_not_equal body,   last_response.body
     end
@@ -147,15 +142,13 @@ module ApplicationTests
     def test_cache_works_with_last_modified
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_last_modified"
-      assert_equal "miss, store", last_response.headers["X-Rack-Cache"]
+      get "/expires/expires_last_modified", {}, { "HTTPS" => "on" }
       assert_equal "public", last_response.headers["Cache-Control"]
+      assert_equal "miss, store", last_response.headers["X-Rack-Cache"]
 
       last = last_response.headers["Last-Modified"]
 
-      get "/expires/expires_last_modified", {}, { "HTTP_IF_MODIFIED_SINCE" => last }
+      get "/expires/expires_last_modified", {}, { "HTTP_IF_MODIFIED_SINCE" => last, "HTTPS" => "on" }
       assert_equal "stale, valid, store", last_response.headers["X-Rack-Cache"]
       assert_equal 304, last_response.status
       assert_equal "", last_response.body
@@ -164,16 +157,14 @@ module ApplicationTests
     def test_cache_works_with_last_modified_private
       simple_controller
 
-      add_to_config "config.action_dispatch.rack_cache = true"
-
-      get "/expires/expires_last_modified", private: true
+      get "/expires/expires_last_modified", { private: true }, { "HTTPS" => "on" }
       assert_equal "miss",                                last_response.headers["X-Rack-Cache"]
       assert_equal "must-revalidate, private, max-age=0", last_response.headers["Cache-Control"]
 
       body = last_response.body
       last = last_response.headers["Last-Modified"]
 
-      get "/expires/expires_last_modified", { private: true }, { "HTTP_IF_MODIFIED_SINCE" => last }
+      get "/expires/expires_last_modified", { private: true }, { "HTTP_IF_MODIFIED_SINCE" => last, "HTTPS" => "on" }
       assert_equal "miss", last_response.headers["X-Rack-Cache"]
       assert_not_equal body,   last_response.body
     end

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -26,7 +26,7 @@ module ApplicationTests
       RUBY
 
       log = capture(:stdout) do
-        get "/foo"
+        get("/foo", {}, "HTTPS" => "on")
         assert_equal 500, last_response.status
       end
 
@@ -43,12 +43,12 @@ module ApplicationTests
         end
       RUBY
 
-      get "/foo"
+      get "/foo", {}, { "HTTPS" => "on" }
       assert_equal 404, last_response.status
     end
 
     test "renders unknown http methods as 405" do
-      request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD" }
+      request("/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" })
       assert_equal 405, last_response.status
     end
 
@@ -62,7 +62,7 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD" }
+      request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD", "HTTPS" => "on" }
       assert_equal 405, last_response.status
     end
 
@@ -90,7 +90,7 @@ module ApplicationTests
       add_to_config "config.action_dispatch.show_exceptions = :all"
       add_to_config "config.consider_all_requests_local = false"
 
-      get "/foo", {}, { "HTTP_ACCEPT" => "invalid" }
+      get "/foo", {}, { "HTTP_ACCEPT" => "invalid", "HTTPS" => "on" }
       assert_equal 406, last_response.status
       assert_not_equal "rendering index!", last_response.body
     end
@@ -104,7 +104,7 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      get "/foo"
+      get("/foo", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
       assert_equal "YOU FAILED", last_response.body
     end
@@ -120,7 +120,7 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :all
 
-      get "/foo"
+      get("/foo", {}, "HTTPS" => "on")
       assert_equal 500, last_response.status
     end
 
@@ -128,7 +128,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :none
 
       assert_raise(ActionController::RoutingError) do
-        get "/foo"
+        get("/foo", {}, "HTTPS" => "on")
       end
     end
 
@@ -136,7 +136,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
 
       assert_nothing_raised do
-        get "/foo"
+        get("/foo", {}, "HTTPS" => "on")
         assert_match "The page you were looking for doesn't exist.", last_response.body
       end
     end
@@ -146,7 +146,7 @@ module ApplicationTests
       app.config.consider_all_requests_local = true
 
       assert_nothing_raised do
-        get "/foo"
+        get("/foo", {}, "HTTPS" => "on")
         assert_match "No route matches", last_response.body
       end
     end
@@ -161,7 +161,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      get "/articles"
+      get("/articles", {}, "HTTPS" => "on")
       assert_match "<title>Action Controller: Exception caught</title>", last_response.body
     end
 
@@ -181,7 +181,7 @@ module ApplicationTests
         ✓測試テスト시험
       ERB
 
-      get "/foo", utf8: "✓"
+      get("/foo", { utf8: "✓" }, { "HTTPS" => "on" })
       assert_match(/boooom/, last_response.body)
       assert_match(/測試テスト시험/, last_response.body)
     end
@@ -197,7 +197,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      get "/foo?x[y]=1&x[y][][w]=2"
+      get "/foo?x[y]=1&x[y][][w]=2", {}, "HTTPS" => "on"
       assert_equal 400, last_response.status
       assert_match "Invalid query parameters", last_response.body
     end
@@ -216,7 +216,7 @@ module ApplicationTests
       limit = Rack::Utils.param_depth_limit + 1
       malicious_url = "/foo?#{'[test]' * limit}=test"
 
-      get malicious_url
+      get(malicious_url, {}, "HTTPS" => "on")
       assert_equal 400, last_response.status
       assert_match "Invalid query parameters", last_response.body
     end
@@ -233,12 +233,12 @@ module ApplicationTests
       app.config.consider_all_requests_local = true
       app.config.action_dispatch.ignore_accept_header = false
 
-      get "/foo"
+      get("/foo", {}, "HTTPS" => "on")
       assert_equal 500, last_response.status
       assert_match "<title>Action Controller: Exception caught</title>", last_response.body
       assert_match "ActiveRecord::StatementInvalid", last_response.body
 
-      get "/foo", {}, { "HTTP_ACCEPT" => "text/plain", "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest" }
+      get "/foo", {}, { "HTTP_ACCEPT" => "text/plain", "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest", "HTTPS" => "on" }
       assert_equal 500, last_response.status
       assert_equal "text/plain", last_response.media_type
       assert_match "ActiveRecord::StatementInvalid", last_response.body
@@ -255,7 +255,7 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :rescuable
 
-      get "/foo"
+      get "/foo", {}, { "HTTPS" => "on" }
       assert_equal 404, last_response.status
     end
 
@@ -270,7 +270,7 @@ module ApplicationTests
 
       app.config.action_dispatch.show_exceptions = :rescuable
 
-      error = assert_raises(RuntimeError) { get "/foo" }
+      error = assert_raises(RuntimeError) { get("/foo", {}, { "HTTPS" => "on" }) }
       assert_equal "oops", error.message
     end
   end

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -92,7 +92,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_includes comment, "controller:users"
@@ -106,7 +106,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_match(/pid='\d+'/, comment)
@@ -119,7 +119,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_not_includes comment, "controller:users"
@@ -131,7 +131,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_equal("/*action='index',controller='users',database='storage%2Fproduction_animals.sqlite3'*/", comment)
@@ -143,7 +143,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_match(/\/\*action='index',controller='users',pid='\d+'\*\//, comment)
@@ -155,7 +155,7 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
       assert_match(/\/\*action='index',namespaced_controller='users',pid='\d+'\*\//, comment)
@@ -200,11 +200,11 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
 
       first_tags = last_response.body
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
 
       second_tags = last_response.body
 
@@ -230,11 +230,11 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
       assert_equal %(/*action='index',controller='users',namespaced_controller='users'*/), comment
 
-      get "/namespaced/users"
+      get "/namespaced/users", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
       assert_equal %(/*action='index',controller='users',namespaced_controller='name_spaced%2Fusers'*/), comment
     end
@@ -246,11 +246,11 @@ module ApplicationTests
 
       boot_app
 
-      get "/"
+      get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
       assert_equal %(/*action:index,namespaced_controller:users,controller:users*/), comment
 
-      get "/namespaced/users"
+      get "/namespaced/users", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
       assert_equal %(/*action:index,namespaced_controller:name_spaced/users,controller:users*/), comment
     end

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -36,10 +36,10 @@ module ApplicationTests
         <%= params[:id] %>
       RUBY
 
-      get "/pages/foo"
+      get("/pages/foo", {}, "HTTPS" => "on")
       assert_equal 200, last_response.status
 
-      get "/pages/foo.bar"
+      get("/pages/foo.bar", {}, "HTTPS" => "on")
       assert_equal 200, last_response.status
     end
 
@@ -82,7 +82,7 @@ module ApplicationTests
         end
       RUBY
 
-      get "/"
+      get("/", {}, "HTTPS" => "on")
       assert_equal 200, last_response.status
       assert_equal "{:format=>:awesome, :handler=>RubbyHandler}", last_response.body
     end

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -108,25 +108,25 @@ module ApplicationTests
 
     test "rails/welcome in production" do
       app("production")
-      get "/"
+      get("/", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
     end
 
     test "rails/info in production" do
       app("production")
-      get "/rails/info"
+      get("/rails/info", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
     end
 
     test "rails/info/routes in production" do
       app("production")
-      get "/rails/info/routes"
+      get("/rails/info/routes", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
     end
 
     test "rails/info/properties in production" do
       app("production")
-      get "/rails/info/properties"
+      get("/rails/info/properties", {}, "HTTPS" => "on")
       assert_equal 404, last_response.status
     end
 
@@ -139,12 +139,14 @@ module ApplicationTests
         end
       RUBY
 
-      get "/up"
+      get("/up", {}, "HTTPS" => "on")
       assert_equal 200, last_response.status
     end
 
     test "simple controller" do
       simple_controller
+
+      app "development"
 
       get "/foo"
       assert_equal "foo", last_response.body
@@ -173,6 +175,8 @@ module ApplicationTests
         end
       RUBY
 
+      app "development"
+
       get "/foo"
       assert_equal "bar", last_response.body
     end
@@ -186,6 +190,8 @@ module ApplicationTests
           resource :user
         end
       RUBY
+
+      app "development"
 
       get "/blog/archives"
       assert_equal "/archives", last_response.body
@@ -206,6 +212,8 @@ module ApplicationTests
           get '/foo' => 'foo#index'
         end
       RUBY
+
+      app "development"
 
       get "/foo"
       assert_equal "/blog", last_response.body
@@ -233,6 +241,8 @@ module ApplicationTests
           get ':controller(/:action)'
         end
       RUBY
+
+      app "development"
 
       get "/foo"
       assert_equal "foo", last_response.body
@@ -266,6 +276,8 @@ module ApplicationTests
           get 'foo', to: 'foo#index'
         end
       RUBY
+
+      app "development"
 
       get "/foo"
       assert_equal "foo", last_response.body
@@ -383,13 +395,15 @@ module ApplicationTests
 
         app(mode)
 
-        get "/foo"
+        https = (mode == "production" ? "on" : "off")
+
+        get("/foo", {}, "HTTPS" => https)
         assert_equal "bar", last_response.body
 
-        get "/custom"
+        get("/custom", {}, "HTTPS" => https)
         assert_equal "http://www.microsoft.com", last_response.body
 
-        get "/mapping"
+        get("/mapping", {}, "HTTPS" => https)
         assert_equal "/profile", last_response.body
 
         app_file "config/routes.rb", <<-RUBY
@@ -409,13 +423,13 @@ module ApplicationTests
 
         sleep 0.1
 
-        get "/foo"
+        get("/foo", {}, "HTTPS" => https)
         assert_equal expected_action, last_response.body
 
-        get "/custom"
+        get("/custom", {}, "HTTPS" => https)
         assert_equal expected_url, last_response.body
 
-        get "/mapping"
+        get("/mapping", {}, "HTTPS" => https)
         assert_equal expected_mapping, last_response.body
       end
     end
@@ -663,6 +677,8 @@ module ApplicationTests
     end
 
     test "resource routing with irregular inflection" do
+      app("development")
+
       app_file "config/initializers/inflection.rb", <<-RUBY
         ActiveSupport::Inflector.inflections do |inflect|
           inflect.irregular 'yazi', 'yazilar'
@@ -691,6 +707,8 @@ module ApplicationTests
     end
 
     test "reloading routes removes methods and doesn't undefine them" do
+      app("development")
+
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get '/url', to: 'url#index'


### PR DESCRIPTION
I will admit to deploying an app into production and leaving it there for weeks before realizing that authenticated traffic was being transported un-secured HTTP. I'd been operating under the false assumption that `config.force_ssl` would be `true` in production by default for new apps.

Suggesting this change to gauge interest and start a conversation. Since this option was introduced, the state of the web has really changed with Let's Encrypt certificates, and HTTPS has become table stakes for most hosting services. It feels like the time is right to enable Strict-Transport-Security by default for new apps.