### PR TITLE
Enforce no consecutive blank lines with rubocop (Layout/EmptyLines)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -206,6 +206,10 @@ Layout/IndentationStyle:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+# Checks for two or more consecutive blank lines.
+Layout/EmptyLines:
+  Enabled: true
+
 # No trailing whitespace.
 Layout/TrailingWhitespace:
   Enabled: true

--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -82,7 +82,6 @@ pin_all_from "app/javascript/channels", under: "channels"
           RUBY
         end
 
-
         def file_name
           @_file_name ||= super.sub(/_channel\z/i, "")
         end

--- a/actionmailbox/app/controllers/action_mailbox/base_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/base_controller.rb
@@ -18,7 +18,6 @@ module ActionMailbox
         self.class.name.remove(/\AActionMailbox::Ingresses::/, /::InboundEmailsController\z/).underscore.to_sym
       end
 
-
       def authenticate_by_password
         if password.present?
           http_basic_authenticate_or_request_with name: "actionmailbox", password: password, realm: "Action Mailbox"

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -38,7 +38,6 @@ module ActionMailbox
         JSON.parse params.require(:mandrill_events)
       end
 
-
       def authenticate
         head :unauthorized unless authenticated?
       end

--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -100,7 +100,6 @@ module ActionMailbox
       inbound_email.delivered? || inbound_email.bounced?
     end
 
-
     # Enqueues the given +message+ for delivery and changes the inbound email's status to +:bounced+.
     def bounce_with(message)
       inbound_email.bounced!

--- a/actionmailbox/lib/action_mailbox/test_helper.rb
+++ b/actionmailbox/lib/action_mailbox/test_helper.rb
@@ -73,7 +73,6 @@ module ActionMailbox
       ActionMailbox::InboundEmail.create_and_extract_message_id! source, status: status
     end
 
-
     # Create an InboundEmail from fixture using the same arguments as create_inbound_email_from_fixture
     # and immediately route it to processing.
     def receive_inbound_email_from_fixture(*args)

--- a/actionmailbox/test/unit/mailbox/state_test.rb
+++ b/actionmailbox/test/unit/mailbox/state_test.rb
@@ -23,7 +23,6 @@ class BouncingMailbox < ActionMailbox::Base
   end
 end
 
-
 class ActionMailbox::Base::StateTest < ActiveSupport::TestCase
   setup do
     $processed = false

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -557,7 +557,6 @@ module RequestForgeryProtectionTests
     ActionController::Base.logger = old_logger
   end
 
-
   def test_should_warn_on_missing_csrf_token
     old_logger = ActionController::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     # Abstract representation of an index definition on a table. Instances of

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1268,7 +1268,6 @@ module ActiveRecord
         execute schema_creation.accept(at)
       end
 
-
       # Checks to see if a check constraint exists on a table for a given check constraint definition.
       #
       #   check_constraint_exists?(:products, name: "price_check")

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -684,7 +684,6 @@ module ActiveRecord
         end
       end
 
-
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -57,7 +57,6 @@ module ActiveRecord
       Array(connection.schema_cache.primary_keys(model.table_name))
     end
 
-
     def skip_duplicates?
       on_duplicate == :skip
     end
@@ -165,7 +164,6 @@ module ActiveRecord
         connection.schema_cache.indexes(model.table_name).select(&:unique)
       end
 
-
       def ensure_valid_options_for_connection!
         if returning && !connection.supports_insert_returning?
           raise ArgumentError, "#{connection.class} does not support :returning"
@@ -184,11 +182,9 @@ module ActiveRecord
         end
       end
 
-
       def to_sql
         connection.build_insert_sql(ActiveRecord::InsertAll::Builder.new(self))
       end
-
 
       def readonly_columns
         primary_keys + model.readonly_attributes.to_a
@@ -197,7 +193,6 @@ module ActiveRecord
       def unique_by_columns
         Array(unique_by&.columns)
       end
-
 
       def verify_attributes(attributes)
         if keys_including_timestamps != attributes.keys.to_set

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -94,7 +94,6 @@ module ActiveRecord
       end
     end
 
-
     # Returns a signed id that's generated using a preconfigured +ActiveSupport::MessageVerifier+ instance.
     # This signed id is tamper proof, so it's safe to send in an email or otherwise share with the outside world.
     # It can furthermore be set to expire (the default is not to expire), and scoped down with a specific purpose.

--- a/activerecord/test/activejob/destroy_association_async_job_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_job_test.rb
@@ -23,7 +23,6 @@ class UnusedHasManyAsync < ActiveRecord::Base
   self.destroy_association_async_job = nil
 end
 
-
 class DestroyAssociationAsyncJobTest < ActiveRecord::TestCase
   test "destroy_association_async_job requires valid job class" do
     error = assert_raises NameError do

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -224,7 +224,6 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     BookDestroyAsync.delete_all
   end
 
-
   test "enqueues has_one to be deleted with custom primary key" do
     child = DlKeyedHasOne.create!
     parent = DestroyAsyncParent.create!
@@ -239,7 +238,6 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     DlKeyedHasOne.delete_all
     DestroyAsyncParent.delete_all
   end
-
 
   test "has_many" do
     essay = EssayDestroyAsync.create!(name: "Der be treasure")

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -68,7 +68,6 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_schema "other_schema", if_exists: true
   end
 
-
   def test_disable_extension_migration_ignores_prefix_and_suffix
     @connection.enable_extension("hstore")
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -38,7 +38,6 @@ require "models/sharded"
 require "models/member_detail"
 require "models/organization"
 
-
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
            :computers, :people, :readers, :authors, :author_addresses, :author_favorites,

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -109,7 +109,6 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]))
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
 
-
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
     assert_equal [mary], david_and_mary.and(mary_and_bob)

--- a/activerecord/test/models/traffic_light_encrypted.rb
+++ b/activerecord/test/models/traffic_light_encrypted.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 require "models/traffic_light"
 
 class EncryptedTrafficLight < TrafficLight

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -228,7 +228,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
     end
   end
 
-
   # Uploads the +io+ to the service on the +key+ for this blob. Blobs are intended to be immutable, so you shouldn't be
   # using this method after a file has already been uploaded to fit with a blob. If you want to create a derivative blob,
   # you should instead simply create a new blob based on the old one.

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -45,7 +45,6 @@ module ActiveStorage::Blob::Representable
     ActiveStorage.variable_content_types.include?(content_type)
   end
 
-
   # Returns an ActiveStorage::Preview instance with the set of +transformations+ provided. A preview is an image generated
   # from a non-image blob. Active Storage comes with built-in previewers for videos and PDF documents. The video previewer
   # extracts the first frame from a video and the PDF previewer extracts the first page from a PDF document.
@@ -72,7 +71,6 @@ module ActiveStorage::Blob::Representable
   def previewable?
     ActiveStorage.previewers.any? { |klass| klass.accept?(self) }
   end
-
 
   # Returns an ActiveStorage::Preview for a previewable blob or an ActiveStorage::Variant for a variable image blob.
   #

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -107,7 +107,6 @@ class ActiveStorage::Preview
       image.variant(variation).processed
     end
 
-
     def previewer
       previewer_class.new(blob)
     end

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -143,7 +143,6 @@ module ActiveStorage
         uri_for(key).to_s
       end
 
-
       def uri_for(key)
         client.generate_uri("#{container}/#{key}")
       end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -141,7 +141,6 @@ module ActiveStorage
         url_helpers.rails_disk_service_url(verified_key_with_expiration, filename: filename, **url_options)
       end
 
-
       def stream(key)
         File.open(path_for(key), "rb") do |file|
           while data = file.read(5.megabytes)

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -166,7 +166,6 @@ module ActiveStorage
         file_for(key).public_url
       end
 
-
       attr_reader :config
 
       def file_for(key, skip_lookup: true)

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -51,7 +51,6 @@ module ActiveStorage
       perform_across_services :delete_prefixed, prefix
     end
 
-
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.
     def mirror(key, checksum:)
       instrument :mirror, key: key, checksum: checksum do

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -126,7 +126,6 @@ module ActiveStorage
         object_for(key).public_url(**client_opts)
       end
 
-
       MAXIMUM_UPLOAD_PARTS_COUNT = 10000
       MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes
 
@@ -143,7 +142,6 @@ module ActiveStorage
           IO.copy_stream(io, out)
         end
       end
-
 
       def object_for(key)
         bucket.object(key)

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -68,7 +68,6 @@ module ActiveStorage::Service::SharedServiceTests
       end
     end
 
-
     test "downloading in chunks" do
       key = SecureRandom.base58(24)
       expected_chunks = [ "a" * 5.megabytes, "b" ]
@@ -93,7 +92,6 @@ module ActiveStorage::Service::SharedServiceTests
       end
     end
 
-
     test "downloading partially" do
       assert_equal "\x10\x00\x00", @service.download_chunk(@key, 19..21)
       assert_equal "\x10\x00\x00", @service.download_chunk(@key, 19...22)
@@ -104,7 +102,6 @@ module ActiveStorage::Service::SharedServiceTests
         @service.download_chunk(SecureRandom.base58(24), 19..21)
       end
     end
-
 
     test "existing" do
       assert @service.exist?(@key)

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -45,7 +45,6 @@ class DateTime
     deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
   end
 
-
   # Returns a formatted string of the offset from UTC, or an alternative
   # string if the time zone is already UTC.
   #

--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -36,7 +36,6 @@ module ActiveSupport
       @expected_key_length ||= generate_key.length
     end
 
-
     attr_reader :content_path, :key_path, :env_key, :raise_if_missing_key
 
     def initialize(content_path:, key_path:, env_key:, raise_if_missing_key:)
@@ -84,7 +83,6 @@ module ActiveSupport
       writing read, &block
     end
 
-
     private
       def writing(contents)
         tmp_file = "#{Process.pid}.#{content_path.basename.to_s.chomp('.enc')}"
@@ -100,7 +98,6 @@ module ActiveSupport
         FileUtils.rm(tmp_path) if tmp_path&.exist?
       end
 
-
       def encrypt(contents)
         check_key_length
         encryptor.encrypt_and_sign contents
@@ -113,7 +110,6 @@ module ActiveSupport
       def encryptor
         @encryptor ||= ActiveSupport::MessageEncryptor.new([ key ].pack("H*"), cipher: CIPHER, serializer: Marshal)
       end
-
 
       def read_env_key
         ENV[env_key].presence

--- a/activesupport/lib/active_support/html_safe_translation.rb
+++ b/activesupport/lib/active_support/html_safe_translation.rb
@@ -31,7 +31,6 @@ module ActiveSupport
         (@i18n_option_names ||= I18n::RESERVED_KEYS.to_set).include?(name)
       end
 
-
       def html_safe_translation(translation)
         if translation.respond_to?(:map)
           translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -75,7 +75,6 @@ module FailureSafetyBehavior
       other_key => SecureRandom.alphanumeric
     )
 
-
     emulating_unavailability do |cache|
       fetched = cache.fetch_multi(key, other_key) { |k| "unavailable" }
       assert_equal Hash[key => "unavailable", other_key => "unavailable"], fetched

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -149,7 +149,6 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_equal "Ruby on Rails", encryptor.decrypt_and_verify(encrypted_message)
   end
 
-
   private
     def assert_aead_not_decrypted(encryptor, value)
       assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -552,7 +552,6 @@ class TestOrderTest < ActiveSupport::TestCase
   end
 end
 
-
 class ConstStubbable
   CONSTANT = 1
 end

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -362,7 +362,6 @@ module Rails
         options[:skip_asset_pipeline] || options[:asset_pipeline] != "propshaft"
       end
 
-
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
         def initialize(name, version, comment, options = {}, commented_out = false)
           super

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1879,7 +1879,6 @@ module ApplicationTests
       assert_not ActiveRecord.raise_int_wider_than_64bit
     end
 
-
     test "config.active_record.yaml_column_permitted_classes is [Symbol] by default" do
       app "production"
       assert_equal([Symbol], ActiveRecord.yaml_column_permitted_classes)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -555,7 +555,6 @@ module ApplicationTests
           end
         MIGRATION
 
-
         Dir.chdir(app_path) do
           rails "db:migrate:up:primary", "VERSION=01_one_migration.rb"
           rails "db:migrate:up:primary", "VERSION=03_three_migration.rb"

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -158,7 +158,6 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match %r/foo: bar: bad/, run_edit_command
   end
 
-
   test "show credentials" do
     assert_match DEFAULT_CREDENTIALS_PATTERN, run_show_command
   end
@@ -188,7 +187,6 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
 
     assert_match %r/foo: bar/, run_show_command(environment: "prod")
   end
-
 
   test "diff enroll diffing" do
     FileUtils.rm(app_path(".gitattributes"))
@@ -282,7 +280,6 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
 
     assert_match(encrypted_content, run_diff_command(content_path))
   end
-
 
   test "respects config.credentials.content_path when set in config/application.rb" do
     content_path = "my_secrets/credentials.yml.enc"

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -98,7 +98,6 @@ class Rails::Command::EncryptedTest < ActiveSupport::TestCase
     assert_match %r/foo: bar: bad/, run_edit_command
   end
 
-
   test "show encrypted file with custom key" do
     run_edit_command(key: "config/tokens.key")
 

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -68,7 +68,6 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-
   test "appends @import 'actiontext.css'; to base css file" do
     FileUtils.touch("#{destination_root}/app/assets/stylesheets/application.postcss.css")
 


### PR DESCRIPTION
This applies the rules for #47848 programmatically.

Autocorrect all rubocop offenses for [Layout/EmptyLines](https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylines)

```
3156 files inspected, 53 offenses detected, 53 offenses corrected
```

See the diff for the full changes.
