### PR TITLE
Fix duplicate Gemfile entry warning

### DIFF
--- a/.github/workflows/mdl.yml
+++ b/.github/workflows/mdl.yml
@@ -8,8 +8,6 @@ permissions:
 jobs:
   mdl:
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ONLY: mdl
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ end
 
 group :mdl do
   gem "mdl", require: false
-  gem "rake", ">= 13", require: false
 end
 
 group :doc do


### PR DESCRIPTION
```
Your Gemfile lists the gem rake (>= 13) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```