### PR TITLE
Implement `ActiveRecord.disconnect_all!` to close all connections

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord.disconnect_all!` method to immediately close all connections from all pools.
+
+    *Jean Boussier*
+
 *   Discard connections which may have been left in a transaction.
 
     There are cases where, due to an error, `within_new_transaction` may unexpectedly leave a connection in an open transaction. In these cases the connection may be reused, and the following may occur:

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -457,6 +457,11 @@ module ActiveRecord
     ActiveRecord::ConnectionAdapters.eager_load!
     ActiveRecord::Encryption.eager_load!
   end
+
+  # Explicitly closes all database connections in all pools.
+  def self.disconnect_all!
+    ConnectionAdapters::PoolConfig.disconnect_all!
+  end
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -15,6 +15,10 @@ module ActiveRecord
         def discard_pools!
           INSTANCES.each_key(&:discard_pool!)
         end
+
+        def disconnect_all!
+          INSTANCES.each_key(&:disconnect!)
+        end
       end
 
       def initialize(connection_class, db_config, role, shard)


### PR DESCRIPTION
This is basically a multi-db aware version of `ActiveRecord::Base.connection.disconnect!`. It also avoid connecting to the database if we weren't already.

This can be useful to reset state after `establish_connection` has been used.
