### PR TITLE
Allows the default env key of `RAILS_MASTER_KEY` to be configurable by using `config.credentials.env_key` and `--env-key`.

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -278,6 +278,15 @@ Defaults to `config/credentials/#{Rails.env}.key` if it exists, or
 NOTE: In order for the `bin/rails credentials` commands to recognize this value,
 it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
 
+#### `config.credentials.env_key`
+
+The environment key name where the encrypted credential key exists.
+
+Defaults to `RAILS_MASTER_KEY`.
+
+NOTE: In order for the `bin/rails credentials` commands to recognize this value,
+it must be set in `config/application.rb` or `config/environments/#{Rails.env}.rb`.
+
 #### `config.debug_exception_response_format`
 
 Sets the format used in responses when errors occur in the development environment. Defaults to `:api` for API only apps and `:default` for normal apps.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The default environment variable key name for credentials and encrypted key (`RAILS_MASTER_KEY`)
+    is now configurable by using `config.credentials.env_key`, or by passing in `--env-key` to
+    `rails encrypted` command. For usage, see `rails credentials:help` and `rails encrypted:help`.
+
+    *Arian Faurtosh*
+
 *   Deprecate `secrets:edit/show` and remove `secrets:setup`
 
     `bin/rails secrets:setup` has been deprecated since Rails 5.2 in favor of

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -485,13 +485,14 @@ module Rails
     # +production+ environment), or +config/credentials.yml.enc+ if that file
     # does not exist.
     #
-    # The encryption key is taken from either <tt>ENV["RAILS_MASTER_KEY"]</tt>,
+    # The encryption key is taken from either the env variable +config.credentials.env_key+,
     # or from the file specified by +config.credentials.key_path+. By default,
+    # +config.credentials.env_key+ will pull from <tt>ENV["RAILS_MASTER_KEY"]</tt> and
     # +config.credentials.key_path+ will point to either
     # <tt>config/credentials/#{environment}.key</tt> for the current
     # environment, or +config/master.key+ if that file does not exist.
     def credentials
-      @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path)
+      @credentials ||= encrypted(config.credentials.content_path, key_path: config.credentials.key_path, env_key: config.credentials.env_key)
     end
 
     # Returns an ActiveSupport::EncryptedConfiguration instance for an encrypted

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -549,7 +549,7 @@ module Rails
           key_path = root.join("config/credentials/#{Rails.env}.key")
           key_path = root.join("config/master.key") if !key_path.exist?
 
-          { content_path: content_path, key_path: key_path }
+          { content_path: content_path, key_path: key_path, env_key: "RAILS_MASTER_KEY" }
         end
     end
   end

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -31,6 +31,8 @@ Setup:
     If `ENV["RAILS_MASTER_KEY"]` is present, it takes precedence over
     `config/master.key`.
 
+    The default environment lookup key can be overridden using `config.credentials.env_key`.
+
 Set up Git to Diff Credentials:
     Rails provides `<%= executable(:diff) %> --enroll` to instruct Git to call
     `<%= executable(:diff) %>` when `git diff` is run on a credentials file.

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -70,8 +70,12 @@ module Rails
           @key_path ||= relative_path(config.key_path)
         end
 
+        def env_key
+          @env_key ||= config.env_key
+        end
+
         def credentials
-          @credentials ||= Rails.application.encrypted(content_path, key_path: key_path)
+          @credentials ||= Rails.application.encrypted(content_path, key_path: key_path, env_key: env_key)
         end
 
         def ensure_encryption_key_has_been_added

--- a/railties/lib/rails/commands/encrypted/USAGE
+++ b/railties/lib/rails/commands/encrypted/USAGE
@@ -8,6 +8,10 @@ Encryption Keys:
 
         <%= executable(:edit) %> config/encrypted_file.yml.enc --key config/encrypted_file.key
 
+    The environment variable key can also be overridden using `--env-key`:
+
+        <%= executable(:edit) %> config/encrypted_file.yml.enc --env-key RAILS_MAIN_KEY
+
     Don't commit the key! Add it to your source control's ignore file. If you use
     Git, Rails handles this for you.
 

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -12,6 +12,9 @@ module Rails
       class_option :key, aliases: "-k", type: :string,
         default: "config/master.key", desc: "The Rails.root relative path to the encryption key"
 
+      class_option :'env-key', type: :string,
+        default: "RAILS_MASTER_KEY", desc: "The environment variable name to the encryption key"
+
       desc "edit", "Open the decrypted file in `$EDITOR` for editing"
       def edit(*)
         load_environment_config!
@@ -38,8 +41,12 @@ module Rails
           options[:key]
         end
 
+        def env_key
+          options[:'env-key']
+        end
+
         def encrypted_configuration
-          @encrypted_configuration ||= Rails.application.encrypted(content_path, key_path: key_path)
+          @encrypted_configuration ||= Rails.application.encrypted(content_path, key_path: key_path, env_key: env_key)
         end
 
         def ensure_encryption_key_has_been_added
@@ -49,7 +56,7 @@ module Rails
         end
 
         def ensure_encrypted_configuration_has_been_added
-          encrypted_file_generator.add_encrypted_file_silently(content_path, key_path)
+          encrypted_file_generator.add_encrypted_file_silently(content_path, key_path, env_key)
         end
 
         def change_encrypted_configuration_in_system_editor

--- a/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb
@@ -6,12 +6,12 @@ require "active_support/encrypted_file"
 module Rails
   module Generators
     class EncryptedFileGenerator < Base # :nodoc:
-      def add_encrypted_file_silently(file_path, key_path, template = encrypted_file_template)
+      def add_encrypted_file_silently(file_path, key_path, env_key = "RAILS_MASTER_KEY", template = encrypted_file_template)
         unless File.exist?(file_path)
           ActiveSupport::EncryptedFile.new(
             content_path: file_path,
             key_path: key_path,
-            env_key: "RAILS_MASTER_KEY",
+            env_key: env_key,
             raise_if_missing_key: true
           ).write(template)
         end

--- a/railties/test/application/credentials_test.rb
+++ b/railties/test/application/credentials_test.rb
@@ -37,6 +37,17 @@ class Rails::CredentialsTest < ActiveSupport::TestCase
     end
   end
 
+  test "reads credentials using customized environment variable key" do
+    write_credentials_override(:production, with_key: false)
+    add_to_env_config("production", "config.credentials.env_key = 'RAILS_MAIN_KEY'")
+
+    switch_env("RAILS_MAIN_KEY", credentials_key) do
+      app("production")
+
+      assert_equal "revealed", Rails.application.credentials.mystery
+    end
+  end
+
   private
     def write_credentials_override(name, with_key: true)
       Dir.chdir(app_path) do


### PR DESCRIPTION
Allows the default env key of `RAILS_MASTER_KEY` to be configurable by using `config.credentials.env_key` and `--env-key`.

### Motivation / Background

Rails uses a default key name: `RAILS_MASTER_KEY`, which is currently not configurable.

At Apple, we’re [working](https://developer.apple.com/news/?id=1o9zxsxl) to remove and replace non-inclusive language across our applications.

https://support.apple.com/guide/applestyleguide/m-apsg72b28652/1.0/web/1.0#apdef6d37bb5

> The term master can have oppressive associations, even when used in a technological context. For this reason, avoid using master when referring to the following:

This is an important objective for our team which uses Rails.

### Detail

Solved this by allowing the default key of `RAILS_MASTER_KEY` to be configurable by using `config.credentials.env_key`.

The Rails Credentials Command now respects this option as well:

```ruby
# ./config/application.rb
config.credentials.env_key = 'RAILS_MAIN_KEY'
# RAILS_MAIN_KEY="*******" rails credentials:edit
# RAILS_MAIN_KEY="*******" rails credentials:show

# ./config/environments/production.rb
config.credentials.env_key = 'RAILS_PROD_KEY'
# RAILS_PROD_KEY="*******" rails credentials:edit --environment production
# RAILS_PROD_KEY="*******" rails credentials:show --environment production

# ./config/environments/development.rb
config.credentials.env_key = 'RAILS_DEV_KEY'
# RAILS_DEV_KEY="*******" rails credentials:edit --environment development
# RAILS_DEV_KEY="*******" rails credentials:show --environment development
```

In addition, when using the `rails encrypted:edit`, you can also pass in an option for `--env-key` to override the name of default env key.

```bash
RAILS_MAIN_KEY="*******" rails encrypted:edit config/encrypted_file.yml.enc --env-key="RAILS_MAIN_KEY"
RAILS_MAIN_KEY="*******" rails encrypted:show config/encrypted_file.yml.enc --env-key="RAILS_MAIN_KEY"
```

### Additional information

Other approaches:

Modifying `RAILS_MASTER_KEY` to something like `RAILS_PRIMARY_KEY`, or `RAILS_MAIN_KEY`.

Opted not to take this approach, in an effort to not create a breaking change and minimize amount of impact for existing applications.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
