### PR TITLE
Support `.distinct.count` queries on models with a composite PK

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -360,7 +360,11 @@ module ActiveRecord
             if !distinct
               distinct = distinct_select?(select_for_count) if group_values.empty?
             elsif group_values.any? || select_values.empty? && order_values.empty?
-              column_name = primary_key
+              column_name = if klass.composite_primary_key?
+                primary_key.join(", ")
+              else
+                primary_key
+              end
             end
           elsif distinct_select?(column_name)
             distinct = nil


### PR DESCRIPTION
This PR adds coverage for `ActiveRecord::Calculations#count` usages on models with a composite primary key.

Also fixes distinct count queries generation like the one below:
```sql
SELECT COUNT(DISTINCT "travels"."from", "travels"."to") FROM "travels"
```

### Approach

We are turning the composite primary key into a comma-separated string which is the same what is being done for a case where the columns list explicitly specified like `Post.select(:id, :topic).distinct.count` by the `select_for_count` method
https://github.com/rails/rails/blob/c029f97246c5802a8dd5eb96ffeb2137a7bc2c6e/activerecord/lib/active_record/relation/calculations.rb#L564


### Tests
`SELECT COUNT(DISTINCT <list,of,columns>)` syntax is supported only (not 100% confident but definitely breaks on sqlite and postgresql) by mysql so tests are wrapped in an adapter check

