### PR TITLE
Fix AR#== and AR#hash when new_record?

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -555,7 +555,8 @@ module ActiveRecord
       super ||
         comparison_object.instance_of?(self.class) &&
         primary_key_values_present? &&
-        comparison_object.id == id
+        comparison_object.id == id &&
+        !comparison_object.new_record?
     end
     alias :eql? :==
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -551,6 +551,7 @@ module ActiveRecord
     # Note also that destroying a record preserves its ID in the model instance, so deleted
     # models are still comparable.
     def ==(comparison_object)
+      return super if new_record?
       super ||
         comparison_object.instance_of?(self.class) &&
         primary_key_values_present? &&
@@ -563,8 +564,8 @@ module ActiveRecord
     def hash
       id = self.id
 
-      if primary_key_values_present?
-        self.class.hash ^ id.hash
+      if primary_key_values_present? && !new_record?
+        [self.class, id].hash
       else
         super
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -811,8 +811,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "YAML dumping a record with time zone-aware attribute" do
     in_time_zone "Pacific Time (US & Canada)" do
+      Topic.where(id: 1).delete_all
       record = Topic.new(id: 1)
       record.written_on = "Jan 01 00:00:00 2014"
+      record.save!
       payload = YAML.dump(record)
       assert_equal record, YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -624,12 +624,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal topic_2, topic_1
   end
 
-  def test_equality_with_blank_ids
-    one = Subscriber.new(id: "")
-    two = Subscriber.new(id: "")
-    assert_equal one, two
-  end
-
   def test_equality_of_relation_and_collection_proxy
     car = Car.create!
     car.bulbs.build

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -7,9 +7,28 @@ require "pp"
 require "models/cpk"
 
 class NonExistentTable < ActiveRecord::Base; end
+class PkWithDefault < ActiveRecord::Base; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics
+
+  def test_eql_on_default_pk
+    saved_record = PkWithDefault.new
+    saved_record.save!
+    assert_equal 123, saved_record.id
+
+    record = PkWithDefault.new
+    assert_equal 123, record.id
+
+    record2 = PkWithDefault.new
+    assert_equal 123, record2.id
+
+    assert     record.eql?(record),       "record should eql? itself"
+    assert_not record.eql?(saved_record), "new record should not eql? saved"
+    assert_not saved_record.eql?(record), "saved record should not eql? new"
+    assert_not record.eql?(record2),      "new record should not eql? new record"
+    assert_not record2.eql?(record),      "new record should not eql? new record"
+  end
 
   def test_inspect_class
     assert_equal "ActiveRecord::Base", ActiveRecord::Base.inspect

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -68,6 +68,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
     ActiveRecord::Base.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
     account = Admin::Account.new(id: 123, name: "37signals")
     account.inspect
+    account.save!
     assert_equal account, Marshal.load(Marshal.dump(account))
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1392,6 +1392,10 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
+
+  create_table :pk_with_defaults, id: false, force: true do |t|
+    t.bigint :id, default: 123
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
* Don't compute AR#== if new_record?
* Don't compute AR#hash if new_record?
* Use [array].hash for computing hash

### Motivation / Background

`AR#==` and `#hash` both check against `id` and then compute their values... but an instance that is a `new_record?` can have an `id` even if not saved if the schema has a default value associated with `id`.

cc @tenderlove to help backfill tests

### Detail

This fixes both methods to punt to `super` if `new_record?`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [?] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
