### PR TITLE
Fix Active Job log message to correctly report a job failed to enqueue when the adapter raises an `ActiveJob::EnqueueError`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix Active Job log message to correctly report a job failed to enqueue
+    when the adapter raises an `ActiveJob::EnqueueError`.
+
+    *Ben Sheldon*
+
 *   Add `after_discard` method.
 
     This method lets job authors define a block which will be run when a job is about to be discarded. For example:

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -8,7 +8,7 @@ module ActiveJob
 
     def enqueue(event)
       job = event.payload[:job]
-      ex = event.payload[:exception_object]
+      ex = event.payload[:exception_object] || job.enqueue_error
 
       if ex
         error do
@@ -28,7 +28,7 @@ module ActiveJob
 
     def enqueue_at(event)
       job = event.payload[:job]
-      ex = event.payload[:exception_object]
+      ex = event.payload[:exception_object] || job.enqueue_error
 
       if ex
         error do

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -245,6 +245,20 @@ class LoggingTest < ActiveSupport::TestCase
     skip
   end
 
+  def test_enqueue_log_when_enqueue_error_is_set
+    EnqueueErrorJob.disable_test_adapter
+
+    EnqueueErrorJob.perform_later
+    assert_match(/Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
+  end
+
+  def test_enqueue_at_log_when_enqueue_error_is_set
+    EnqueueErrorJob.disable_test_adapter
+
+    EnqueueErrorJob.set(wait: 1.hour).perform_later
+    assert_match(/Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
+  end
+
   def test_for_tagged_logger_support_is_consistent
     set_logger ::Logger.new(nil)
     OverriddenLoggingJob.perform_later "Dummy"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When an Active Job adapter uses the `ActiveJob::EnqueueError` feature introduced in #41191, the log message incorrectly reports that the job was successfully enqueued. This fixes that by using the pre-existing failed-to-enqueue message when `job.enqueue_error` is present. 

It would be really nice if this was backported as a bugfix to Rails 7.0, but I understand if the log message being incorrect is pretty minor. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
