### PR TITLE
Allow a `value` formatted as `HH:MM` for `time_field`

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -6,24 +6,28 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = normalize_datetime(options["value"] || value)
-          options["min"] = normalize_datetime(options["min"])
-          options["max"] = normalize_datetime(options["max"])
+          options["value"] = datetime_value(options["value"] || value)
+          options["min"] = format_datetime(parse_datetime(options["min"]))
+          options["max"] = format_datetime(parse_datetime(options["max"]))
           @options = options
           super
         end
 
         private
+          def datetime_value(value)
+            if value.is_a?(String)
+              value
+            else
+              format_datetime(value)
+            end
+          end
+
           def format_datetime(value)
             raise NotImplementedError
           end
 
-          def normalize_datetime(value)
-            format_datetime(parse_datetime(value))
-          end
-
           def parse_datetime(value)
-            if value.is_a? String
+            if value.is_a?(String)
               DateTime.parse(value) rescue nil
             else
               value

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1165,6 +1165,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, time_field("post", "written_on", value: value))
   end
 
+  def test_time_field_with_value_attr_that_excludes_seconds
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:45" />}
+    assert_dom_equal(expected, time_field("post", "written_on", value: "01:45"))
+  end
+
   def test_time_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
     expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
@@ -1269,6 +1274,11 @@ class FormHelperTest < ActionView::TestCase
   def test_datetime_local_field_without_seconds
     expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00" />}
     assert_dom_equal(expected, datetime_local_field("post", "written_on", include_seconds: false))
+  end
+
+  def test_datetime_local_field_with_value_attr_that_excludes_seconds
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00" />}
+    assert_dom_equal(expected, datetime_local_field("post", "written_on", value: "2004-06-15T00:00"))
   end
 
   def test_month_field


### PR DESCRIPTION
https://github.com/rails/rails/pull/46678 introduced a regression, if you do the following:

```ruby
= time_field(model, attr, value: "01:45")
```

Previously it would render an input with `value="01:45"`, since https://github.com/rails/rails/pull/46678 it renders a value with seconds (`value="01:45:00.000"`). This is a regression from Rails 7, and this PR fixes it.

See https://github.com/rails/rails/pull/41728 for why you might want the value to be rendered without seconds.
