### PR TITLE
Enable Netlify previews for API and Guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /dist/
 /doc/
 /guides/output/
+/preview/
+/.netlify
 Brewfile.lock.json
 debug.log*
 node_modules/

--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,19 @@ else
   Rails::API::StableTask.new("rdoc")
 end
 
+task :preview_docs do
+  load "guides/Rakefile"
+  Rake::Task[:rdoc].invoke
+
+  Dir.chdir("guides") do
+    Rake::Task[:"guides:generate"].invoke
+  end
+
+  FileUtils.mkdir_p("preview")
+  FileUtils.cp_r("doc/rdoc", "preview/api")
+  FileUtils.cp_r("guides/output", "preview/guides")
+end
+
 desc "Bump all versions to match RAILS_VERSION"
 task update_versions: "all:update_versions"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  environment = { BUNDLE_WITHOUT = "db job cable storage ujs test" }
+  command = "bundle exec rake preview_docs"
+  publish = "preview"


### PR DESCRIPTION
We often get PRs to update documentation, adding new features, or simply modify existing docs like changing the visibility, etc. Until now, a reviewer of those changes has to manually pull down that PR branch and build the docs locally.

This PR allows us to preview changes to the documentation per branch, and ensures they build properly for every PR.

You can see a preview here:

* [zzak/rails: api](https://netlify--zzak-rails.netlify.app/api/)
* [zzak/rails: guides](https://netlify--zzak-rails.netlify.app/guides/)

Benefits:

* Quickly review documentation changes to the API and Guides
* GitHub status checks on every PR if the documentation generator fails
  * This can happen if a developer pushes broken RDoc syntax, for example
* Fast feedback, builds and deploys around 2 minutes