### PR TITLE
Doc: Add `:order` option for find_each docs to Query Guides [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -475,6 +475,16 @@ appropriate `:start` and `:finish` options on each worker.
 Overrides the application config to specify if an error should be raised when an
 order is present in the relation.
 
+**`:order`**
+
+Specifies the primary key order (can be `:asc` or `:desc`). Defaults to `:asc`.
+
+```ruby
+Customer.find_each(order: :desc) do |customer|
+  NewsMailer.weekly(customer).deliver_now
+end
+```
+
 #### `find_in_batches`
 
 The [`find_in_batches`][] method is similar to `find_each`, since both retrieve batches of records. The difference is that `find_in_batches` yields _batches_ to the block as an array of models, instead of individually. The following example will yield to the supplied block an array of up to 1000 customers at a time, with the final block containing any remaining customers:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the the description for `:order` option is missing in current Query Guides.

### Detail

This Pull Request just adds the description for `:order` option in `find_each`, `find_in_batches` and `in_batches`.

### Additional information

The change https://github.com/rails/rails/pull/30590 was in Rails 6.1.0, so I think the update should also be merged into `6-1-stable` and `7-0-stable` branches. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
