### PR TITLE
Fixed active-storage version in action text

### DIFF
--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails/activestorage": ">= 7.0.0-alpha1",
+    "@rails/activestorage": ">= 7.1.0-alpha",
     "webpack": "^4.17.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Motivation: 
Few days back I tried installing action text in a new rails app and it install with older active storage version. 
This PR fixes that issue. 
 
from a reference of this pull request https://github.com/rails/rails/pull/42091
