### PR TITLE
Reset composite primary key in `#dup`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -507,7 +507,11 @@ module ActiveRecord
     ##
     def initialize_dup(other) # :nodoc:
       @attributes = @attributes.deep_dup
-      @attributes.reset(@primary_key)
+      if self.class.composite_primary_key?
+        @primary_key.each { |key| @attributes.reset(key) }
+      else
+        @attributes.reset(@primary_key)
+      end
 
       _run_initialize_callbacks
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -28,6 +28,7 @@ require "models/car"
 require "models/bulb"
 require "models/pet"
 require "models/owner"
+require "models/cpk/book"
 require "concurrent/atomic/count_down_latch"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/kernel/reporting"
@@ -101,7 +102,9 @@ class LintTest < ActiveRecord::TestCase
 end
 
 class BasicsTest < ActiveRecord::TestCase
-  fixtures :topics, :companies, :developers, :projects, :computers, :accounts, :minimalistics, "warehouse-things", :authors, :author_addresses, :categorizations, :categories, :posts
+  fixtures :topics, :companies, :developers, :projects, :computers, :accounts,
+    :minimalistics, "warehouse-things", :authors, :author_addresses, :categorizations, :categories,
+    :posts, :cpk_books
 
   def test_generated_association_methods_module_name
     mod = Post.send(:generated_association_methods)
@@ -1000,6 +1003,15 @@ class BasicsTest < ActiveRecord::TestCase
 
     duped_topic.reload
     assert_equal("c", duped_topic.title)
+  end
+
+  def test_dup_for_a_composite_primary_key_model
+    book = cpk_books(:cpk_great_author_first_book)
+    new_book = book.dup
+
+    assert_equal "The first book", new_book.title
+    assert_nil new_book.author_id
+    assert_nil new_book.number
   end
 
   DeveloperSalary = Struct.new(:amount)


### PR DESCRIPTION
This commit ensures that the composite primary key is reset when `#dup` is called on an instance of an `ActiveRecord::Base` subclass.

For example:

```ruby
class TravelRoute < ActiveRecord::Base
  self.primary_key = [:origin, :destination]
end

route = TravelRoute.new(origin: "NYC", destination: "LAX")
route.dup # => #<TravelRoute origin: nil, destination: nil>
```

### Implementation details

As usual we have two options: 1) Unify the logic by wrapping the `@primary_key` value into an array and perform the reset  for every element of the array and 2) Branch based on `composite_primary_key?` to avoid unnecessary allocation

Generally we are choosing to branch to avoid the allocation. However, it made me think that long-term we may want to introduce an internal concept of a `primary_key` value which will always be an array and will be memoized on the class itself. This way array allocation won't be a concern and we will be able to keep the code unified as design-wise I like the unified `pk_as_an_array.each` approach better.


### Tests

I've defined a new test model called `TravelRoute` with `:origin, :destination` composite primary key as I find it more readable in tests compared with existing ones when it comes to directly setting or asserting the primary key values in tests