### PR TITLE
✨ Add `trim_empty_fractional` to `ActiveSupport::NumberHelper.number_to_currency`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `trim_empty_fractional` to `ActiveSupport::NumberHelper.number_to_currency`.
+
+    ```ruby
+    ActiveSupport::NumberHelper.number_to_currency(30.05, trim_empty_fractional: true) # => $30.05
+    ActiveSupport::NumberHelper.number_to_currency(30.50, trim_empty_fractional: true) # => $30.50
+    ActiveSupport::NumberHelper.number_to_currency(30.00, trim_empty_fractional: true) # => $30
+    ```
+
+    *Daniel Vu Dao*
+
 *   A new `7.1` cache format is available which includes an optimization for
     bare string values such as view fragments. The `:message_pack` cache format
     has also been modified to include this optimization.

--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -46,10 +46,17 @@ module ActiveSupport
           options[:strip_insignificant_zeros]
         end
 
+        def trim_empty_fractional
+          options[:trim_empty_fractional]
+        end
+
         def format_number(number)
+          escaped_separator = Regexp.escape(options[:separator])
+
           if strip_insignificant_zeros
-            escaped_separator = Regexp.escape(options[:separator])
             number.sub(/(#{escaped_separator})(\d*[1-9])?0+\z/, '\1\2').sub(/#{escaped_separator}\z/, "")
+          elsif trim_empty_fractional && number.match?(/(#{escaped_separator})(0+\z)/)
+            number.split(options[:separator])[0]
           else
             number
           end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -94,6 +94,16 @@ module ActiveSupport
           assert_equal("-$,11", number_helper.number_to_currency("-,11"))
           assert_equal("$0.00", number_helper.number_to_currency(-0.0))
           assert_equal("$0.00", number_helper.number_to_currency("-0.0"))
+          assert_equal("$1,234,567,892.50", number_helper.number_to_currency(1234567892.50, trim_empty_fractional: true))
+          assert_equal("$1,234,567,891", number_helper.number_to_currency(1234567891.00, trim_empty_fractional: true))
+          assert_equal("$1,234,567,892.05", number_helper.number_to_currency(1234567892.05, trim_empty_fractional: true))
+          assert_equal("&pound;1234567890,50", number_helper.number_to_currency(1234567890.50, unit: "&pound;", separator: ",", delimiter: "", trim_empty_fractional: true))
+          assert_equal("&pound;1234567890", number_helper.number_to_currency(1234567890.00, unit: "&pound;", separator: ",", delimiter: "", trim_empty_fractional: true))
+          assert_equal("$1,234,567,892.05", number_helper.number_to_currency(1234567892.050, trim_empty_fractional: true, strip_insignificant_zeros: true))
+          assert_equal("$1,234,567,892", number_helper.number_to_currency(1234567892.00, trim_empty_fractional: true, strip_insignificant_zeros: true))
+          assert_equal("$1,234,567,892.05", number_helper.number_to_currency(1234567892.050000, trim_empty_fractional: true, strip_insignificant_zeros: true))
+          assert_equal("&pound;1234567890,5", number_helper.number_to_currency(1234567890.50, unit: "&pound;", separator: ",", delimiter: "", trim_empty_fractional: true, strip_insignificant_zeros: true))
+          assert_equal("&pound;1234567890", number_helper.number_to_currency(1234567890.00, unit: "&pound;", separator: ",", delimiter: "", trim_empty_fractional: true, strip_insignificant_zeros: true))
         end
       end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

If I am wrong or this should be closed, please correct or let me know.

One issue that I've found when working with `ActiveSupport::NumberHelper.number_to_currency` was that it lacks support for truncating whole numbers.

Here's an example of what I think could be useful:

```
$30.05 => $30.05
$30.10 => $30.10
$30.00 => $30 # Doesn't exist today
```

I looked on Stackoverflow [here](https://stackoverflow.com/questions/11661592/rails-number-to-currency-delete-trailing-zeros) and the best answer came from supporting precision based on `round`. I'm not a big fan of that because under the hood, rounding is already done for `number_to_currency`, if anything, we should allow for whole number truncation.

**Note** I can also add a `CHANGELOG` if we think this is a viable path forward 🙇🏽‍♂️ 

### Detail

This Pull Request changes how `number_to_currency` works and adds a new parameter `strip_final_zeros`. I'd gladly accept feedback, parameter rename, and more tests if needed.

### Additional information

An alternative solution can be found in StackOverflow link above, but essentially: [here](https://stackoverflow.com/a/11661630/3788419).

```ruby
num = 30.00
number_to_currency(num, :precision => (num.round == num) ? 0 : 2)
  => $30

num = 30.05
number_to_currency(num, :precision => (num.round == num) ? 0 : 2)
  => $30.05
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
