### PR TITLE
Hide the rest of Rails::Conductor from API docs

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 module Rails
   class Conductor::ActionMailbox::InboundEmails::SourcesController < Rails::Conductor::BaseController # :nodoc:
     def new

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 module Rails
   class Conductor::ActionMailbox::InboundEmailsController < Rails::Conductor::BaseController
     def index

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 module Rails
   # Incinerating will destroy an email that is due and has already been processed.
   class Conductor::ActionMailbox::IncineratesController < Rails::Conductor::BaseController

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/reroutes_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/reroutes_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 module Rails
   # Rerouting will run routing and processing on an email that has already been, or attempted to be, processed.
   class Conductor::ActionMailbox::ReroutesController < Rails::Conductor::BaseController


### PR DESCRIPTION
After #47875, I realized `:enddoc:` will work here to remove the rest of `Rails::Conductor` from the docs. My previous attempts was only using `:nodoc:` and `:stopdoc:` and moving the module declarations around, this is much easier!

Previous version on the right:

![Screenshot 2023-04-06 at 16 49 52](https://user-images.githubusercontent.com/277819/230313838-6a05dcfe-0c4c-43ea-a5b3-534a4e4115a1.png)
