### PR TITLE
Backport: Doc: Add :order option for find_each docs to Query Guides [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -470,6 +470,16 @@ appropriate `:start` and `:finish` options on each worker.
 Overrides the application config to specify if an error should be raised when an
 order is present in the relation.
 
+**`:order`**
+
+Specifies the primary key order (can be `:asc` or `:desc`). Defaults to `:asc`.
+
+```ruby
+Customer.find_each(order: :desc) do |customer|
+  NewsMailer.weekly(customer).deliver_now
+end
+```
+
 #### `find_in_batches`
 
 The [`find_in_batches`][] method is similar to `find_each`, since both retrieve batches of records. The difference is that `find_in_batches` yields _batches_ to the block as an array of models, instead of individually. The following example will yield to the supplied block an array of up to 1000 customers at a time, with the final block containing any remaining customers:


### PR DESCRIPTION
Backport of the merged document update https://github.com/rails/rails/pull/47869 to 6-1-stable branch.