### PR TITLE
Fix Rack::Deprecation warning which causes this test to fail

### DIFF
--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -6,10 +6,10 @@ require "rails"
 require "active_support/core_ext/string/filters"
 require "rails/dev_caching"
 require "rails/command/environment_argument"
-require "rack/server"
+require "rails/rackup/server"
 
 module Rails
-  class Server < ::Rack::Server
+  class Server < Rackup::Server
     class Options
       def parse!(args)
         Rails::Command::ServerCommand.new([], args).server_options

--- a/railties/lib/rails/rackup/server.rb
+++ b/railties/lib/rails/rackup/server.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# :enddoc:
+
+module Rails
+  module Rackup
+    begin
+      require "rackup/server"
+      Server = ::Rackup::Server
+    rescue LoadError
+      require "rack/server"
+      Server = ::Rack::Server
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a new (private) constant under Rails:

* `Rails::Rackup::Server` which is used by the `bin/rails server` command.

In order to fix this test:


```
Failure:
Rails::Command::HelpIntegrationTest#test_prints_help_via_`X:help`_command_when_running_`X`_and_`X:X`_command_is_not_defined [/Users/zzak/code/rails/railties/t
est/command/help_integration_test.rb:33]:
--- expected
+++ actual
@@ -1,4 +1,5 @@
-"Commands:
+"Rack::Server is deprecated and replaced by Rackup::Server
+Commands:
   bin/rails dev:cache           # Toggle development mode caching on/off
   bin/rails dev:help [COMMAND]  # Describe available commands or one specific...
```

From @ioquatix:

> Yeah you need to load `rackup/server` and if you get `LoadError` fall back to `Rack::Server`.

This PR implements that paraphrasing, and resolves this deprecation:

```
Rack::Server is deprecated and replaced by Rackup::Server
```

Example build:
https://buildkite.com/rails/rails/builds/95468#0187559d-3190-4e6f-8ac5-65042b2a5412/1334-1342
