### PR TITLE
fix infinite recursion with foreign_key

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -493,12 +493,12 @@ module ActiveRecord
         @join_table ||= -(options[:join_table]&.to_s || derive_join_table)
       end
 
-      def foreign_key
+      def foreign_key(infer_from_inverse_of: true)
         @foreign_key ||= if options[:query_constraints]
           # composite foreign keys support
           options[:query_constraints].map { |fk| fk.to_s.freeze }.freeze
         else
-          -(options[:foreign_key]&.to_s || derive_foreign_key)
+          -(options[:foreign_key]&.to_s || derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of))
         end
       end
 
@@ -726,13 +726,13 @@ module ActiveRecord
           class_name.camelize
         end
 
-        def derive_foreign_key
+        def derive_foreign_key(infer_from_inverse_of: true)
           if belongs_to?
             "#{name}_id"
           elsif options[:as]
             "#{options[:as]}_id"
-          elsif options[:inverse_of]
-            inverse_of.foreign_key
+          elsif options[:inverse_of] && infer_from_inverse_of
+            inverse_of.foreign_key(infer_from_inverse_of: false)
           else
             active_record.model_name.to_s.foreign_key
           end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/topic"
 require "models/customer"
+require "models/comment"
 require "models/company"
 require "models/company_in_module"
 require "models/ship"
@@ -461,6 +462,7 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_foreign_key
     assert_equal "author_id", Author.reflect_on_association(:posts).foreign_key.to_s
     assert_equal "category_id", Post.reflect_on_association(:categorizations).foreign_key.to_s
+    assert_equal "comment_id", FirstPost.reflect_on_association(:comment_with_inverse).foreign_key.to_s
   end
 
   def test_foreign_key_is_inferred_from_model_name

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -23,6 +23,8 @@ class Comment < ActiveRecord::Base
   belongs_to :first_post, foreign_key: :post_id
   belongs_to :special_post_with_default_scope, foreign_key: :post_id
 
+  has_one :post_with_inverse, ->(comment) { where(id: comment.post_id) }, class_name: "FirstPost", inverse_of: :comment_with_inverse
+
   has_many :children, class_name: "Comment", inverse_of: :parent
   belongs_to :parent, class_name: "Comment", counter_cache: :children_count, inverse_of: :children
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -234,6 +234,7 @@ class FirstPost < ActiveRecord::Base
 
   has_many :comments, foreign_key: :post_id
   has_one  :comment,  foreign_key: :post_id
+  has_one  :comment_with_inverse, class_name: "Comment", inverse_of: :post_with_inverse
 end
 
 class PostWithDefaultSelect < ActiveRecord::Base


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This addresses an infinite recursion that occurs as a result of trying to infer foreign key from an association's `inverse_of` when two associations are inverses of one another.

### Detail

In [15369fd](https://github.com/rails/rails/commit/15369fd912af282c51d9e748a2f2152872b1ac92) we introduced the ability to infer the foreign_key for a model using `inverse_of`.

In some association configurations, such as when there is a `has_one` that is the inverse of another `has_one` association, this inference causes infinite recursion when calling `#foreign_key` on the reflection.

This PR addresses that by adding a param to `Reflection#foreign_key` to indicate whether to infer from `inverse_of`, and in `#derive_foreign_key` we explicitly disable this behavior when calling `#foreign_key` on the inverse association.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

There didn't appear to be an existing pair of `has_one` associations that were inverses of one another so I added some to existing models. A pair of `has_one`s is admittedly a bit odd, but we did encounter such associations in testing.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
