### PR TITLE
Fix error in `ActiveRecord::Migration.check_pending!`

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -644,9 +644,7 @@ module ActiveRecord
 
       # Raises <tt>ActiveRecord::PendingMigrationError</tt> error if any migrations are pending.
       def check_pending!(connection = ActiveRecord::Tasks::DatabaseTasks.migration_connection)
-        if pending_migrations = connection.migration_context.pending_migrations
-          raise ActiveRecord::PendingMigrationError.new(pending_migrations: pending_migrations)
-        end
+        raise ActiveRecord::PendingMigrationError if connection.migration_context.needs_migration?
       end
 
       def load_schema_if_pending!

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -89,6 +89,10 @@ module ActiveRecord
         private
           def assert_pending_migrations(*expected_migrations)
             2.times do
+              assert_raises ActiveRecord::PendingMigrationError do
+                ActiveRecord::Migration.check_pending!
+              end
+
               error = assert_raises ActiveRecord::PendingMigrationError do
                 CheckPending.new(proc { flunk }).call({})
               end
@@ -105,6 +109,10 @@ module ActiveRecord
             check_pending = CheckPending.new(app)
 
             2.times do
+              assert_nothing_raised do
+                ActiveRecord::Migration.check_pending!
+              end
+
               app.expect :call, nil, [{}]
               check_pending.call({})
               app.verify


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/e9d835f05a90d6da03f69e1ecb59bc3f38edb979 this method has not worked, it has failed with this error:

```
NoMethodError: undefined method `pending_migrations' for #<ActiveRecord::MigrationContext:0x00005598468f8e58>
Did you mean?  pending_migration_versions
```

I agree with Eileen that eventually we could deprecate it, but to get it working I just reversed the changes in https://github.com/rails/rails/commit/e9d835f05a90d6da03f69e1ecb59bc3f38edb979 and added a regression test.

cc @eileencodes 