### PR TITLE
Fix WARNING block in security guide

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -115,14 +115,7 @@ In test and development applications get a `secret_key_base` derived from the ap
 secret_key_base: 492f...
 ```
 
-WARNING: If your application's secrets may have been exposed, strongly consider
-changing them. Note that changing `secret_key_base` will expire currently active
-sessions and require all users to log in again. In addition to session data, the
-following things may also be affected:
-
-* Encrypted cookies
-* Signed cookies
-* Active Storage Files
+WARNING: If your application's secrets may have been exposed, strongly consider changing them. Note that changing `secret_key_base` will expire currently active sessions and require all users to log in again. In addition to session data: encrypted cookies, signed cookies, and Active Storage files may also be affected.
 
 ### Rotating Encrypted and Signed Cookies Configurations
 


### PR DESCRIPTION
Follow up to #47723 

![Screenshot 2023-04-09 at 8 10 29](https://user-images.githubusercontent.com/277819/230746926-3e8cea58-dc7a-40e8-b163-590b3de846d8.png)

`NOTE` or `WARNING` blocks have some quirks in that they are limited by blank new-lines.

You can see that even if we strip the first empty new-line, the result is not great:

![Screenshot 2023-04-09 at 8 38 37](https://user-images.githubusercontent.com/277819/230746977-97d206db-796e-461b-b58c-07bf42d8ec6f.png)

While there might be something we could change in the CSS, it's much easier to adjust the content within those limitations.

This PR updates the `WARNING` block for `secret_key_base` to use a comma-separated list of possibly affected session data.