### PR TITLE
Extend `ActiveRecord::Core#strict_loading!` to accept a block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Extend `ActiveRecord::Core#strict_loading!` to accept a block
+
+    For parity, introduce `ActiveRecord::Core.strict_loading!` to configure
+    `strict_loading_by_default` with the same support for a self-contained
+    block:
+
+    ```ruby
+    # instance-level
+
+    user = User.first
+    user.strict_loading! do
+      user.comments # => raises ActiveRecord::StrictLoadingViolationError
+    end
+    user.comments   # => #<ActiveRecord::Associations::CollectionProxy>
+
+    # class-level
+
+    User.strict_loading!(true) do
+      user = User.first
+      user.comments # => raises ActiveRecord::StrictLoadingViolationError
+    end
+    user = User.first
+    user.comments   # => #<ActiveRecord::Associations::CollectionProxy>
+    ```
+
+    *Sean Doyle*
+
 *   `after_commit` callbacks defined on models now execute in the correct order.
 
     ```ruby

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1658,7 +1658,13 @@ user = User.strict_loading.first
 user.comments.to_a # raises an ActiveRecord::StrictLoadingViolationError
 ```
 
+To configure strict loading for an Active Record model class, invoke
+[`.strict_loading!`][]. To configure strict loading for a particular instance,
+invoke [`#strict_loading!`][].
+
 [`strict_loading`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-strict_loading
+[`.strict_loading!`]: https://api.rubyonrails.org/classes/ActiveRecord/Core/ClassMethods.html#method-i-strict_loading-21
+[`#strict_loading!`]: https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-strict_loading-21
 
 Scopes
 ------


### PR DESCRIPTION
### Motivation / Background

Once a record enables or disables strict loading, that change is permanent. By extending the `#strict_loading!` method to support a block, that change can be temporarily applied **only within the block**, then reverted.

### Detail

For parity, this commit also introduces a class-level `ActiveRecord::Core.strict_loading!` that configure `strict_loading_by_default` with the same support for a self-contained blocks:

Instance method:

```ruby
user = User.first
user.strict_loading! do
  user.comments # => raises ActiveRecord::StrictLoadingViolationError
end
user.comments   # => #<ActiveRecord::Associations::CollectionProxy>
```

Class method:

```ruby
User.strict_loading!(true) do
  user = User.first
  user.comments # => raises ActiveRecord::StrictLoadingViolationError
end
user = User.first
user.comments   # => #<ActiveRecord::Associations::CollectionProxy>
```

### Additional information

The newly introduced [Object#with](https://edgeapi.rubyonrails.org/classes/Object.html#method-i-with) would be perfect candidate for the self-contained configurations. Unfortunately:

1. Active Record classes define [ActiveRecord::QueryMethods#with](https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-with) for querying
2. Active Record instances store strict loading internally as instance variables

Without the `Object#with` abstraction, the implementation's setup and teardown is messy.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
