### PR TITLE
Add `COPY .. TO` to read queries for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -21,8 +21,9 @@ module ActiveRecord
           end
         end
 
+        copy_to = /copy\s+.*\(?.*\)?\s+to\s+(stdout|program.*|('|").*('|"))/i
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :close, :declare, :fetch, :move, :set, :show
+          :close, copy_to, :declare, :fetch, :move, :set, :show
         ) # :nodoc:
         private_constant :READ_QUERY
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -49,6 +49,16 @@ module ActiveRecord
         end
       end
 
+      def test_errors_when_copy_from_is_used_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("COPY ex (to) FROM STDIN")
+            end
+          end
+        end
+      end
+
       def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
         with_example_table do
           @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
@@ -90,6 +100,36 @@ module ActiveRecord
               assert_equal [], @connection.execute("MOVE cur_ex").entries
               assert_equal [], @connection.execute("CLOSE cur_ex").entries
             end
+          end
+        end
+      end
+
+      def test_doesnt_error_when_copy_to_using_a_query_is_used_while_preventing_writes
+        with_example_table do
+          @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          ActiveRecord::Base.while_preventing_writes do
+            assert_equal [], @connection.execute("COPY (SELECT id FROM ex WHERE data = '138853948594') TO STDOUT").entries
+          end
+        end
+      end
+
+      def test_doesnt_error_when_copy_to_using_a_tablename_and_columns_is_used_while_preventing_writes
+        with_example_table do
+          @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          ActiveRecord::Base.while_preventing_writes do
+            assert_equal [], @connection.execute("COPY ex (id, data) TO STDOUT").entries
+          end
+        end
+      end
+
+      def test_doesnt_error_when_copy_to_using_only_a_tablename_is_used_while_preventing_writes
+        with_example_table do
+          @connection.execute("INSERT INTO ex (data) VALUES ('138853948594')")
+
+          ActiveRecord::Base.while_preventing_writes do
+            assert_equal [], @connection.execute("COPY ex TO STDOUT").entries
           end
         end
       end


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/47870

It was pointed out in the report that

> COPY moves data between PostgreSQL tables and standard file-system files. COPY TO copies the contents of a table to a file, while COPY FROM copies data from a file to a table (appending the data to whatever is in the table already). COPY TO can also copy the results of a SELECT query.

### Detail

Using COPY .. TO with a read only connection should not be a problem because we do not write to the database but only read the records that will be written somewhere else.

This change adds the regex `/copy.*to/i` to the list of read only markers for postgres. I decided to use a regex here so that we can also make sure that `COPY .. FROM` cannot be used with a read only connection.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
