### PR TITLE
Add link to security guide for CSRF from JS token part

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -304,6 +304,8 @@ added to the form that the `button_to` helper renders internally:
 When making non-GET requests from JavaScript the `X-CSRF-Token` header is required.
 Without this header requests won't be accepted by Rails.
 
+NOTE: This token is required by Rails to prevent Cross-Site Request Forgery (CSRF) attacks. Read more in the [security guide](security.html#cross-site-request-forgery-csrf).
+
 [Rails Request.JS](https://github.com/rails/request.js) encapsulates the logic
 of adding the request headers that are required by Rails. Just
 import the `FetchRequest` class from the package and instantiate it


### PR DESCRIPTION
Follow up from https://github.com/rails/rails/pull/47365/files#r1105388459

![Screenshot 2023-04-10 at 7 19 21](https://user-images.githubusercontent.com/277819/230799238-fcf33b07-548a-4481-b9a1-c5e829e13d64.png)
