### PR TITLE
Use triple-dot delegation in AppGenerator

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -21,8 +21,8 @@ module Rails
         RUBY
       end
 
-      def method_missing(meth, *args, &block)
-        @generator.send(meth, *args, &block)
+      def method_missing(...)
+        @generator.send(...)
       end
   end
 


### PR DESCRIPTION
Use triple dots in method_missing to forward parameters. Fixes #47907