### PR TITLE
Fix issue with empty values within delimited authorization header

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -513,6 +513,7 @@ module ActionController
       # delimiters defined in +AUTHN_PAIR_DELIMITERS+.
       def raw_params(auth)
         _raw_params = auth.sub(TOKEN_REGEX, "").split(WHITESPACED_AUTHN_PAIR_DELIMITERS)
+        _raw_params.reject!(&:empty?)
 
         if !_raw_params.first&.start_with?(TOKEN_KEY)
           _raw_params[0] = "#{TOKEN_KEY}#{_raw_params.first}"

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -180,6 +180,16 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_nil actual
   end
 
+  test "token_and_options ignores empty elements in header value" do
+    token = "foo,,bar,  ,   , baz=qux"
+    expected_token = "foo"
+    expected_options = { "bar" => nil, "baz" => "qux" }
+
+    actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token, {}))
+    assert_equal expected_token, actual.first
+    assert_equal expected_options, actual.last
+  end
+
   test "raw_params returns a tuple of two key value pair strings" do
     auth = sample_request("rcHu+HzSFw89Ypyhn/896A=").authorization.to_s
     actual = ActionController::HttpAuthentication::Token.raw_params(auth)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because certain delimited `Authorization` header values can be used to produce an `ArgumentError`, typically resulting in a 500 error response.

### Detail

This Pull Request changes the [`token_and_options`](https://github.com/rails/rails/blob/c2a25803ddce92c43342690d7b6198b14c2a15b4/actionpack/lib/action_controller/metal/http_authentication.rb#L486) method to remove blank values, which cause the argument error. Typically, [`raw_params`](https://github.com/rails/rails/blob/c2a25803ddce92c43342690d7b6198b14c2a15b4/actionpack/lib/action_controller/metal/http_authentication.rb#L514) returns an array of tuples, but when an authorization header contains blank values, such as with `Bearer foo,,bar` (note the blank value, between the 2 `,` delimiters), the `raw_params` method will include non-tuple values. These values are then passed to [`Hash[]`](https://github.com/rails/rails/blob/c2a25803ddce92c43342690d7b6198b14c2a15b4/actionpack/lib/action_controller/metal/http_authentication.rb#L490), but that method only accepts sets of 1 or 2 arguments, not 0. Unfortunately, this ends up raising an `ArgumentError: invalid number of elements (0 for 1..2)`.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
