### PR TITLE
Fix delegation to a method with implicit block.

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -221,7 +221,7 @@ class Module
               "..."
             else
               defn = parameters.filter_map { |type, arg| arg if type == :req }
-              defn << "&block" if parameters.last&.first == :block
+              defn << "&block"
               defn.join(", ")
             end
           else


### PR DESCRIPTION
### Motivation / Background

When https://github.com/rails/rails/commit/8b2f57dc6fc4400a1554a11b24dfb6c854310d81 was introduced it broke delegation of a method with implicit block like this:

```ruby
class Foo
  def self.bar
    yield
  end
end

class Bar
  delegate :bar, to: Foo
end

Bar.new.bar { } # raises LocalJumpError: no block given (yield)
```

It happens because it's impossible to detect a method with implicit block and we rely on method's parameters when we generate delegated methods.

I've found only one solution to this issue: we always generate a method that explicitly accepts block. It kind of makes sense since every Ruby method accepts block implicitly anyway.

Fixes https://github.com/rails/rails/issues/47624
