### PR TITLE
Rename `:rails` deprecator as `:railties`

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -225,13 +225,9 @@ module Rails
     # The collection's configuration methods affect all deprecators in the
     # collection. Additionally, the collection's +silence+ method silences all
     # deprecators in the collection for the duration of a given block.
-    #
-    # The collection is prepopulated with a default deprecator, which can be
-    # accessed via <tt>deprecators[:rails]</tt>. More deprecators can be added
-    # via <tt>deprecators[name] = deprecator</tt>.
     def deprecators
       @deprecators ||= ActiveSupport::Deprecation::Deprecators.new.tap do |deprecators|
-        deprecators[:rails] = Rails.deprecator
+        deprecators[:railties] = Rails.deprecator
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4022,7 +4022,7 @@ module ApplicationTests
       assert_equal ActiveRecord.deprecator, Rails.application.deprecators[:active_record]
       assert_equal ActiveStorage.deprecator, Rails.application.deprecators[:active_storage]
       assert_equal ActiveSupport.deprecator, Rails.application.deprecators[:active_support]
-      assert_equal Rails.deprecator, Rails.application.deprecators[:rails]
+      assert_equal Rails.deprecator, Rails.application.deprecators[:railties]
     end
 
     test "can entirely opt out of deprecation warnings" do


### PR DESCRIPTION
Follow-up to #46049 and #47354.

Since `Rails.deprecator` is now a new `ActiveSupport::Deprecation` instance instead of `ActiveSupport::Deprecation.instance`, it makes sense to register it as `Rails.application.deprecators[:railties]` instead of `Rails.application.deprecators[:rails]`.
