### PR TITLE
Ensure `none` constraint scopes don’t trigger a query

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -69,6 +69,8 @@ module ActiveRecord
           end
         end
 
+        relation.none! if other.null_relation?
+
         merge_select_values
         merge_multi_values
         merge_single_values

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -59,6 +59,16 @@ class NullRelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_null_relation_used_with_constraints
+    post = Post.first
+    assert_no_queries do
+      scope = post.comments
+      none = Post.none
+      scope = scope.merge(none)
+      assert_equal 0, scope.size
+    end
+  end
+
   def test_null_relation_metadata_methods
     assert_includes Developer.none.to_sql, " WHERE (1=0)"
     assert_equal({}, Developer.none.where_values_hash)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

#47800 refactored how `Relation#none` worked, and one side effect of this change was that if you had an association like this:

`has_many :comments_none, ->(post) { none }, class_name: "Comment”`

reading the association caused a query to happen, despite the `none` in the passed in scope.



### Detail

As it turns out, this is because the association performs a merge of the two scopes, and the `@none` instance variable wasn’t getting copied over to the merged scope, so the upfront guard clause checking `@none` in `#exec_main_query`.

Updating the `Merger` object to add a check for null relations and call `none!` ensures the query doesn’t run in this particular scenario.

I suspect there exist other scenarios that rely on `merge` that would also have otherwise failed if you tried to merge a null relation into a non-null relation, and if anyone is familiar of such situations, let me know and I'd be happy to add more test cases so we can avoid regressions.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
