### PR TITLE
Ensure that ids_writer and ids_reader is working for CPK

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -269,7 +269,7 @@ module ActiveRecord
         relation = apply_join_dependency
         relation.pluck(*column_names)
       else
-        klass.disallow_raw_sql!(column_names)
+        klass.disallow_raw_sql!(column_names.flatten)
         columns = arel_columns(column_names)
         relation = spawn
         relation.select_values = columns

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -39,6 +39,7 @@ require "models/translation"
 require "models/chef"
 require "models/cake_designer"
 require "models/drink_designer"
+require "models/cpk"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -596,7 +597,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
 end
 
 class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
-  fixtures :companies, :developers
+  fixtures :companies, :developers, :cpk_order_agreements, :cpk_orders, :cpk_books
 
   def test_invalid_adding
     firm = Firm.find(1)
@@ -728,6 +729,37 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     firm.reload
     assert_equal 2, firm.clients.length
     assert_includes firm.clients, companies(:second_client)
+  end
+
+  def test_assign_ids_with_belongs_to_cpk_model
+    order_agreements = [cpk_order_agreements(:order_agreement_one).id, cpk_order_agreements(:order_agreement_two).id]
+    order = cpk_orders(:cpk_groceries_order_1)
+
+    assert_empty order.order_agreements
+
+    order.order_agreement_ids = order_agreements
+    order.save
+    order.reload
+
+    assert_equal order_agreements, order.order_agreement_ids
+    assert_equal 2, order.order_agreements.length
+    assert_includes order.order_agreements, cpk_order_agreements(:order_agreement_two)
+  end
+
+  def test_assign_ids_with_cpk_for_two_models
+    books = [cpk_books(:cpk_great_author_first_book).id, cpk_books(:cpk_great_author_second_book).id]
+    order = cpk_orders(:cpk_groceries_order_1)
+
+    assert_empty order.books
+
+    order.book_ids = books
+    order.save
+    order.reload
+
+    assert_equal books, order.book_ids
+    assert_equal 2, order.books.length
+    assert_includes order.books, cpk_books(:cpk_great_author_first_book)
+    assert_includes order.books, cpk_books(:cpk_great_author_second_book)
   end
 
   def test_assign_ids_for_through_a_belongs_to

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -941,8 +941,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal Company.all.map(&:id).sort, Company.all.ids.sort
   end
 
-  def ids_for_a_composite_primary_key
+  def test_ids_for_a_composite_primary_key
     assert_equal Cpk::Book.all.map(&:id).sort, Cpk::Book.all.ids.sort
+  end
+
+  def test_pluck_for_a_composite_primary_key
+    assert_equal Cpk::Book.all.pluck([:author_id, :number]).sort, Cpk::Book.all.ids.sort
   end
 
   def test_ids_for_a_composite_primary_key_with_scope

--- a/activerecord/test/fixtures/cpk_order_agreements.yml
+++ b/activerecord/test/fixtures/cpk_order_agreements.yml
@@ -1,0 +1,8 @@
+_fixture:
+  model_class: Cpk::OrderAgreement
+
+order_agreement_one:
+  signature: "abc123"
+
+order_agreement_two:
+  signature: "xyz789"

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -4,6 +4,8 @@ module Cpk
   class Book < ActiveRecord::Base
     self.table_name = :cpk_books
     self.primary_key = [:author_id, :number]
+
+    belongs_to :order
   end
 
   class BestSeller < Book

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -6,5 +6,6 @@ module Cpk
     self.primary_key = [:shop_id, :id]
 
     has_many :order_agreements, primary_key: :id
+    has_many :books
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -244,6 +244,7 @@ ActiveRecord::Schema.define do
     t.integer :number
     t.string :title
     t.integer :revision
+    t.integer :order_id
   end
 
   create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|


### PR DESCRIPTION
This fixes `ids_writer` so that it can handle a composite primary key. Using a CPK model associated with a non-CPK model was working correctly (which I added a test for). Using a CPK model associated with another CPK model was not working correctly. It now takes it into account to write the correct ids.

While working on `ids_reader` I found that `pluck` is not working for CPK because it's passing an array of attributes and that's not supported by `disallow_raw_sql!`. I chose to call `flatten` in `pluck` but not conditionally because this seems like it could be a problem elsewhere as well. This fixes pluck by CPK overall and fixes a test in the calculations test file.

cc/ @nvasilevski @paarthmadan 