### PR TITLE
ignore (mrsk) deployment configuration

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -10,6 +10,9 @@
 /config/master.key
 /config/credentials/*.key
 
+# Ignore (mrsk) deployment configuration
+/config/deploy.yml
+
 # Ignore all environment files.
 /.env*
 !/.env.example


### PR DESCRIPTION
### Summary

This pull request adds `/config/deploy.yml` to dockerignore template file.

### Motivation / Background

This aforementioned file is used by [mrsk](https://github.com/mrsked/mrsk).

It is sensible to ignore this file by default for several reasons:

- The file may contain sensitive information about the infrastructure setup.
- Changing this configuration file triggers an unnecessary container rebuild.

