### PR TITLE
Support deleting records from associations for CPK

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -128,7 +128,9 @@ module ActiveRecord
             records.each(&:destroy!)
             update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
           else
-            scope = self.scope.where(reflection.klass.primary_key => records)
+            query_constraints = reflection.klass.composite_query_constraints_list
+            values = records.map { |r| query_constraints.map { |col| r._read_attribute(col) } }
+            scope = self.scope.where(query_constraints => values)
             update_counter(-delete_count(method, scope))
           end
         end

--- a/activerecord/test/fixtures/cpk_authors.yml
+++ b/activerecord/test/fixtures/cpk_authors.yml
@@ -1,0 +1,8 @@
+_fixture:
+  model_class: Cpk::Author
+
+cpk_great_author:
+  name: "Alice"
+
+cpk_famous_author_first_book:
+  name: "Bob"

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -2,14 +2,17 @@ _fixture:
   model_class: Cpk::Book
 
 cpk_great_author_first_book:
+  author: cpk_great_author
   title: "The first book"
   revision: 1
 
 cpk_great_author_second_book:
+  author: cpk_great_author
   title: "The second book"
   revision: 1
 
 cpk_famous_author_first_book:
+  author: cpk_famous_author
   title: "Ruby on Rails"
   revision: 1
 

--- a/activerecord/test/models/cpk.rb
+++ b/activerecord/test/models/cpk.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "cpk/author"
 require_relative "cpk/book"
 require_relative "cpk/order"
 require_relative "cpk/order_agreement"

--- a/activerecord/test/models/cpk/author.rb
+++ b/activerecord/test/models/cpk/author.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cpk
+  class Author < ActiveRecord::Base
+    self.table_name = :cpk_authors
+
+    has_many :books, class_name: "Cpk::Book", dependent: :delete_all
+  end
+end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -6,6 +6,7 @@ module Cpk
     self.primary_key = [:author_id, :number]
 
     belongs_to :order
+    belongs_to :author, class_name: "Cpk::Author"
   end
 
   class BestSeller < Book

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -7,6 +7,7 @@ module Sharded
 
     belongs_to :blog
     has_many :comments, query_constraints: [:blog_id, :blog_post_id]
+    has_many :delete_comments, class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id], dependent: :delete_all
 
     has_many :blog_post_tags, query_constraints: [:blog_id, :blog_post_id]
     has_many :tags, through: :blog_post_tags

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -247,6 +247,10 @@ ActiveRecord::Schema.define do
     t.integer :order_id
   end
 
+  create_table :cpk_authors, force: true do |t|
+    t.string :name
+  end
+
   create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|
     t.integer :shop_id
     t.integer :id


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Part of the on-going effort to support composite primary keys.

This change properly implements deleting records from associations in composite contexts.

### Detail

Without this change:

```ruby
    great_author = cpk_authors(:cpk_great_author)
    books = great_author.books

    # ArgumentError (Expected corresponding value for [:author_id, :number] to be an Array)
    great_author.books.delete(books.first)
```


It uses the `composite_query_constraints_list` to acquire either the query constraints (or primary key) in an array, and then selects the corresponding columns from the supplied records.

Previously, the common case would resolve to

`where(id => [records])` which would end up using the [`ArrayHandler` logic to default to an `id`.](https://github.com/rails/rails/blob/385903754e1e51e55d87169b48edb6704d97f586/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb#L15)

This is still the case, only the resolution to an ID happens earlier to support composite scenarios.

Note: It's important to use the `query_constraints_list` from the class as opposed to the primary key because there are scenarios in multi tenant setups that would require deleting the record using query constraints instead of simply the primary key.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
