### PR TITLE
[Fix: 47938] self is undefined for actioncable

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -4,8 +4,8 @@
 })(this, (function(exports) {
   "use strict";
   var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
+    logger: typeof console !== "undefined" ? console : undefined,
+    WebSocket: typeof WebSocket !== "undefined" ? WebSocket : undefined
   };
   var logger = {
     log(...messages) {

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -1,6 +1,6 @@
 var adapters = {
-  logger: self.console,
-  WebSocket: self.WebSocket
+  logger: typeof console !== "undefined" ? console : undefined,
+  WebSocket: typeof WebSocket !== "undefined" ? WebSocket : undefined
 };
 
 var logger = {

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -4,8 +4,8 @@
 })(this, (function(exports) {
   "use strict";
   var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
+    logger: typeof console !== "undefined" ? console : undefined,
+    WebSocket: typeof WebSocket !== "undefined" ? WebSocket : undefined
   };
   var logger = {
     log(...messages) {

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,4 @@
 export default {
-  logger: self.console,
-  WebSocket: self.WebSocket
+  logger: typeof console !== "undefined" ? console : undefined,
+  WebSocket: typeof WebSocket !== "undefined" ? WebSocket : undefined,
 }

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -6,13 +6,13 @@ const {module, test} = QUnit
 module("ActionCable", () => {
   module("Adapters", () => {
     module("WebSocket", () => {
-      test("default is self.WebSocket", assert => {
+      test("default is WebSocket", assert => {
         assert.equal(ActionCable.adapters.WebSocket, self.WebSocket)
       })
     })
 
     module("logger", () => {
-      test("default is self.console", assert => {
+      test("default is console", assert => {
         assert.equal(ActionCable.adapters.logger, self.console)
       })
     })


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because ActionCable is unable to build with SSR systems due to `self is undefined` errors, see #47938

### Detail
- replace `self` with `globalThis` and allow `logger` and `WebSocket` to be undefined rather than erroring

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
