### PR TITLE
Remove table alias added when using `where.missing` or `where.associated`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -76,7 +76,11 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.joins!(association)
-          self.not(association => { reflection.association_primary_key => nil })
+          if @scope.table_name == reflection.table_name
+            self.not(association => { reflection.association_primary_key => nil })
+          else
+            self.not(reflection.table_name => { reflection.association_primary_key => nil })
+          end
         end
 
         @scope
@@ -104,7 +108,11 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
-          @scope.where!(association => { reflection.association_primary_key => nil })
+          if @scope.table_name == reflection.table_name
+            @scope.where!(association => { reflection.association_primary_key => nil })
+          else
+            @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
+          end
         end
 
         @scope

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -43,6 +43,10 @@ module ActiveRecord
       assert_match(/An association named `:cars` does not exist on the model `Post`\./, e.message)
     end
 
+    def test_associated_merged_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
@@ -66,6 +70,12 @@ module ActiveRecord
     def test_missing_with_multiple_association
       assert posts(:authorless).comments.empty?
       assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a
+    end
+
+    def test_missing_merged_with_scope_on_association
+      # This query does not make much logical sense, but it is testing
+      # that the generated SQL query is valid.
+      assert_equal Author.find(1).posts.count, Post.where.missing(:author).merge(Author.where(id: 1)).count
     end
 
     def test_not_inverts_where_clause


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/47909.

The bug was introduced in https://github.com/rails/rails/pull/45015 when trying to solve an issue for parent-child associations in `where.associated`/`where.missing`.

We now create a table alias only when we have parent-child associations, and using the direct table name otherwise.

I am not sure this is the correct (or the best) fix, so would appreciate a review from someone with a better familiarity with the internals.