### PR TITLE
Fix regression in test name filters with specs

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -104,9 +104,14 @@ module Rails
           end
 
           def escape_declarative_test_filter(filter)
-            if filter.is_a?(String) && !filter.start_with?("test_")
-              filter = "test_#{filter}" unless regexp_filter?(filter)
-              filter = filter.gsub(/\s+/, "_")
+            # NOTE: This method may be applied multiple times, so any
+            # transformations MUST BE idempotent.
+            if filter.is_a?(String)
+              if regexp_filter?(filter)
+                filter = filter.gsub(/\s+/, '[\s_]+')
+              elsif !filter.start_with?("test_")
+                filter = "test_#{filter.gsub(/\s+/, "_")}"
+              end
             end
             filter
           end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -595,7 +595,7 @@ module ApplicationTests
             assert true
           end
 
-          test "foo again" do
+          test "foo +  + again" do
             puts "hello again"
             assert true
           end
@@ -611,7 +611,7 @@ module ApplicationTests
         assert_match "1 runs, 1 assertions, 0 failures", output
       end
 
-      run_test_command("test/models/post_test.rb -n 'foo again'").tap do |output|
+      run_test_command("test/models/post_test.rb -n 'foo +  + again'").tap do |output|
         assert_match "hello again", output
         assert_match "1 runs, 1 assertions, 0 failures", output
       end
@@ -632,7 +632,7 @@ module ApplicationTests
             assert true
           end
 
-          test "greets bar" do
+          test "greets +  + bar" do
             puts "hello bar"
             assert true
           end
@@ -643,7 +643,41 @@ module ApplicationTests
         end
       RUBY
 
-      run_test_command("test/models/post_test.rb -n '/greets foo|greets bar/'").tap do |output|
+      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  . bar/'").tap do |output|
+        assert_match "hello foo", output
+        assert_match "hello again foo", output
+        assert_match "hello bar", output
+        assert_match "3 runs, 3 assertions, 0 failures", output
+      end
+    end
+
+    def test_declarative_style_regexp_filter_with_minitest_spec
+      app_file "test/models/post_test.rb", <<~RUBY
+        require "minitest/spec"
+
+        class PostTest < Minitest::Spec
+          it "greets foo" do
+            puts "hello foo"
+            assert true
+          end
+
+          it "greets foo again" do
+            puts "hello again foo"
+            assert true
+          end
+
+          it "greets +  + bar" do
+            puts "hello bar"
+            assert true
+          end
+
+          it "greets no one" do
+            assert false
+          end
+        end
+      RUBY
+
+      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  . bar/'").tap do |output|
         assert_match "hello foo", output
         assert_match "hello again foo", output
         assert_match "hello bar", output


### PR DESCRIPTION
This issue is hurting my brain a little, but I'll try and explain it as best I can. It's a regression introduced by https://github.com/rails/rails/pull/44290, in the following scenario:

- You use `minitest/spec` (either direction or via a wrapper like [`minitest-spec-rails`](https://github.com/metaskills/minitest-spec-rails))
- You run tests using a regex filter to identify which tests to run (either directly or via a wrapper like [`m`](https://github.com/qrush/m))
- Your test names have spaces in them

Since https://github.com/rails/rails/pull/44290 you could not execute a test that has a space in its name using the regex filter method. This is because:

- The `test` method in `ActiveSupport::TestCase` [is not defined if `Spec` is defined](https://github.com/rails/rails/blob/444df0eee1b537ecaa11509e819b071d4e87b519/activesupport/lib/active_support/testing/declarative.rb#L6). Recall that the `test` method does 2 things: it defines the test, but it also replaces spaces with underscores in the test method name.
- In minitest specs, you use `it` to define tests. `it` [generates a test method name](https://github.com/minitest/minitest/blob/a9fa045044b4210cfd21a512b06d1a4527d709ba/lib/minitest/spec.rb#L223..L229) by taking user input and prepending `test_` and a number. It does *not* replace spaces with underscores. So the test method is defined as `"test_002_foo bar"`.
- Since https://github.com/rails/rails/pull/44290 when you provide the test runner a filter it replaces spaces with underscores before passing the filter onto minitest. For example, the filter might become `"/test_002_foo_bar/"`.
- Minitest thus can't find the test method, because `/test_002_foo_bar/` does not match `"test_002_foo bar"`.

I think this should be supported because `minitest/spec` is part of minitest, even if it's not the Rails default.

The issue is in `escape_declarative_test_filter`. Rather than converting spaces to underscores, it should match both spaces *and* underscores. This covers all use cases.

cc @jonathanhefner 