### PR TITLE
Implement #inspect for file & null cache store

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -85,6 +85,10 @@ module ActiveSupport
         end
       end
 
+      def inspect # :nodoc:
+        "#<#{self.class.name} cache_path=#{@cache_path}, options=#{@options.inspect}>"
+      end
+
       private
         def read_entry(key, **options)
           if payload = read_serialized_entry(key, **options)

--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -32,6 +32,10 @@ module ActiveSupport
       def delete_matched(matcher, options = nil)
       end
 
+      def inspect # :nodoc:
+        "#<#{self.class.name} options=#{@options.inspect}>"
+      end
+
       private
         def read_entry(key, **s)
           deserialize_entry(read_serialized_entry(key))


### PR DESCRIPTION
### Motivation / Background

Currently, inspect prints out huge output for the `FileStore` & `NullStore` cache stores. 
This PR implements `#inspect` methods for both stores, to make output more reasonable.

### Detail

Before

```ruby
#<ActiveSupport::Cache::NullStore:0x0000000146d682f0 @options={}, @coder=Marshal, @local_cache_key=:active_support_cache_null_store_local_cache_10740, @middleware=#<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x0000000146d51078 @name="ActiveSupport::Cache::Strategy::LocalCache", @local_cache_key=:active_support_cache_null_store_local_cache_10740, @app=#<Rack::Runtime:0x0000000147a9c048 @app=#<Rack::MethodOverride:0x0000000147a9c160 @app=#<ActionDispatch::RequestId:0x0000000147a9c390 @app=#<ActionDispatch::RemoteIp:0x0000000147a9ca98 @app=#<Rails::Rack::Logger:0x0000000147a9cb60 @app=#<ActionDispatch::ShowExceptions:0x0000000147a9cc28 @app=#<Datadog::Contrib::Rails::ExceptionMiddleware:0x0000000147a9ccc8 @app=#<Sentry::Rails::CaptureExceptions:0x0000000147a9d290 @app=#<ActionDispatch::DebugExceptions:0x0000000147a9d3d0 @app=#<Sentry::Rails::RescuedExceptionInterceptor:0x0000000147a9d470 @app=#<ActionDispatch::ActionableExceptions:0x0000000147a9d678 @app=#<ActionDispatch::Reloader:0x0000000147a9d740 @app=#<ActionDispatch::Callbacks:0x0000000147a9d808 @app=#<ActionDispatch::Cookies:0x0000000147a9d8f8 @app=#<ActionDispatch::Session::CookieStore:0x0000000147a9dbc8 @app=#<ActionDispatch::ContentSecurityPolicy::Middleware:0x0000000147a9dd30 @app=#<ActionDispatch::PermissionsPolicy::Middleware:0x0000000147a9ddf8 @app=#<Rack::Head:0x0000000147a9dec0 @app=#<Rack::ConditionalGet:0x0000000147a9dfb0 @app=#<Rack::ETag:0x0000000147a9e0f0 @app=#<Rack::TempfileReaper:0x0000000147a9e208 @app=#<Warden::Manager:0x0000000147a9e640 @config={:default_scope=>:rails, :scope_defaults=>{}, :default_strategies=>{:rails=>[]}, :intercept_401=>false, :failure_app=>#<Devise::Delegator:0x000000014782c088>}, @app=#<OmniAuth::Strategies::GoogleOauth2>>>, @cache_control="max-age=0, private, must-revalidate", @no_cache_control="no-cache">>>>>, @default_options={:path=>"/", :domain=>nil, :expire_after=>nil, :secure=>false, :httponly=>true, :defer=>false, :renew=>false}, @key="_rails_session", @cookie_only=true, @same_site=nil>>>, @executor=#<Class:0x0000000145f56ab8>>>>, @routes_app=#...
```

After:
```ruby
#<ActiveSupport::Cache::FileStore cache_path=/tmp/cache, options={}>
#<ActiveSupport::Cache::NullStore options={}>
```


### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
