### PR TITLE
Support building fixtures with associations that use CPK

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -585,6 +585,18 @@ module ActiveRecord
         end
       end
 
+      # Returns a consistent, platform-independent hash representing a mapping
+      # between the label and the subcomponents of the provided composite key.
+      #
+      # Example:
+      # composite_identify("label", [:a, :b, :c]) => { a: hash_1, b: hash_2, c: hash_3 }
+      def composite_identify(label, key)
+        key
+          .index_with
+          .with_index { |sub_key, index| (identify(label) << index) % MAX_ID }
+          .with_indifferent_access
+      end
+
       # Superclass for the evaluation contexts used by ERB fixtures.
       def context_class
         @context_class ||= Class.new

--- a/activerecord/test/fixtures/cpk_books.yml
+++ b/activerecord/test/fixtures/cpk_books.yml
@@ -16,7 +16,6 @@ cpk_famous_author_first_book:
   title: "Ruby on Rails"
   revision: 1
 
-cpk_known_author_david_book:
-  author_id: 1
-  title: "David's CPK Book"
+cpk_book_with_generated_pk:
+  title: "Generated author's book"
   revision: 1

--- a/activerecord/test/fixtures/cpk_order_agreements.yml
+++ b/activerecord/test/fixtures/cpk_order_agreements.yml
@@ -6,3 +6,8 @@ order_agreement_one:
 
 order_agreement_two:
   signature: "xyz789"
+
+order_agreement_three:
+  order_id: <%= ActiveRecord::FixtureSet.composite_identify(:cpk_groceries_order_2, Cpk::Order.primary_key)[:id] %>
+  signature: "def321"
+

--- a/activerecord/test/fixtures/cpk_reviews.yml
+++ b/activerecord/test/fixtures/cpk_reviews.yml
@@ -1,0 +1,13 @@
+_fixture:
+  model_class: Cpk::Review
+
+first_book_review:
+  book: cpk_book_with_generated_pk
+  rating: 5
+  comment: "The first book was alright."
+
+second_book_review_for_book_with_partial_pk_defined:
+  book: cpk_great_author_first_book
+  author_id: <%= ActiveRecord::FixtureSet.identify(:cpk_great_author) %>
+  rating: 5
+  comment: "The first book was alright."

--- a/activerecord/test/models/cpk.rb
+++ b/activerecord/test/models/cpk.rb
@@ -3,4 +3,5 @@
 require_relative "cpk/author"
 require_relative "cpk/book"
 require_relative "cpk/order"
+require_relative "cpk/review"
 require_relative "cpk/order_agreement"

--- a/activerecord/test/models/cpk/review.rb
+++ b/activerecord/test/models/cpk/review.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Cpk
+  class Review < ActiveRecord::Base
+    self.table_name = :cpk_reviews
+
+    belongs_to :book, class_name: "Cpk::Book", query_constraints: [:author_id, :number]
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -251,6 +251,13 @@ ActiveRecord::Schema.define do
     t.string :name
   end
 
+  create_table :cpk_reviews, force: true do |t|
+    t.integer :author_id
+    t.integer :number
+    t.integer :rating
+    t.string :comment
+  end
+
   create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|
     t.integer :shop_id
     t.integer :id


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Part of the on-going effort to support composite primary keys.

This PR does a few separate things, which is why there are 3 isolated commits
1. Support the usecase when a foreign key of a model is possibly an array, and therefore requires defining values for more than 1 column on the fixture
2. Introduce a new API that enables callsites to resolve a label to a list of hashes
3. Refactor existing code to make use of that API, instead

### Detail

Before, we could safely rely on the fixture label to identify a record. This assumption still holds, but the implementation breaks because now we have the concept of composite identity.

We'd still like to use 1 label, but we need this to resolve to multiple components. We have a new identity method called `composite_identify` which takes a label, an arbitrary list of columns, and performs a mapping of the label to the subcomponents using the same algorithm plus some index shifting to make sure each column is represented differently.

#### Why's `composite_identify` (or something similar) needed?

For cases that reference a composite model using a different key, there's no way to generate the correct sub-component of the key without leaking implementation details at the fixture level.

For instance, take the models:

```ruby
class Order < ActiveRecord::Base
  self.primary_key = [:shop_id, :id]

  has_many :order_agreements, primary_key: :id
end

class OrderAgreement < ActiveRecord::Base
  belongs_to :order, primary_key: :id # foreign key is derived as `order_id`
end
```

To specify a fixture for order_agreement that is associated with an order, we should, at the very least be able to do something like:

```yml
order_agreement_three:
  order_id: <%= How can we appropriately generate a sub-key from the composite key? %>
  signature: "def321"
```

In comes, composite identify:

```yml
order_agreement_three:
  order_id: <%= ActiveRecord::FixtureSet.composite_identify(:cpk_groceries_order_2, Cpk::Order.primary_key)[:id] %>
  signature: "def321"
```

The signature looks like:
```ruby
id = ActiveRecord::FixtureSet.composite_identify("order", [:shop_id, :id])
p id => {"shop_id"=>891917211, "id"=>710092599}
```

The hash representation is helpful because it can be used to generate the whole composite key, but provides access to single columns should they be needed. This is particularly helpful when a model has a composite key, but a different model associated to it references it by a single, often different, unique column.

### Additional information

Naming is open for comment.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
