### PR TITLE
Restore ability to redefine column in `create_table` for Rails 5.2

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -485,14 +485,7 @@ module ActiveRecord
         name = name.to_s
         type = type.to_sym if type
 
-        if @columns_hash[name]
-          if @columns_hash[name].primary_key?
-            raise ArgumentError, "you can't redefine the primary key column '#{name}' on '#{@name}'. To define a custom primary key, pass { id: false } to create_table."
-          else
-            raise ArgumentError, "you can't define an already defined column '#{name}' on '#{@name}'."
-          end
-        end
-
+        raise_on_duplicate_column(name)
         @columns_hash[name] = new_column_definition(name, type, **options)
 
         if index
@@ -607,6 +600,16 @@ module ActiveRecord
 
         def integer_like_primary_key_type(type, options)
           type
+        end
+
+        def raise_on_duplicate_column(name)
+          if @columns_hash[name]
+            if @columns_hash[name].primary_key?
+              raise ArgumentError, "you can't redefine the primary key column '#{name}' on '#{@name}'. To define a custom primary key, pass { id: false } to create_table."
+            else
+              raise ArgumentError, "you can't define an already defined column '#{name}' on '#{@name}'."
+            end
+          end
         end
     end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -294,6 +294,9 @@ module ActiveRecord
           private
             def raise_on_if_exist_options(options)
             end
+
+            def raise_on_duplicate_column(name)
+            end
         end
 
         module CommandRecorder

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -282,6 +282,24 @@ module ActiveRecord
         connection.drop_table :tests, if_exists: true
       end
 
+      def test_create_table_allows_duplicate_column_names
+        migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def migrate(x)
+            create_table :tests do |t|
+              t.integer :some_id
+              t.string :some_id
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+
+        column = connection.columns(:tests).find { |column| column.name == "some_id" }
+        assert_equal :string, column.type
+      ensure
+        connection.drop_table :tests, if_exists: true
+      end
+
       if current_adapter?(:PostgreSQLAdapter)
         class Testing < ActiveRecord::Base
         end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/47936.

https://github.com/rails/rails/pull/33029 introduced some code changes to raise when duplicate column is specified during `create_table`, but was missing proper compatibility changes. This PR fixes that. 