### PR TITLE
Fix NoMethodError in dev.rb when skip-active-job

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -63,6 +63,8 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  <%- end -%>
+  <%- unless options[:skip_active_job] -%>
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -726,6 +726,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_skip_active_job_option
+    run_generator [destination_root, "--skip-active-job"]
+
+    ["production", "development", "test"].each do |env|
+      assert_file "config/environments/#{env}.rb" do |content|
+        assert_no_match(/active_job/, content)
+      end
+    end
+  end
+
   def test_skip_javascript_option
     generator([destination_root], skip_javascript: true)
 


### PR DESCRIPTION
### Motivation / Background

`config.active_jobs.verbose_enqueue_logs` was [added][1] to the development.rb template, but it was put inside the skip-active-record block. This means that it will be included in generated development.rb even when Active Job is skipped.

### Detail

This commit fixes this issue by moving it outside of the skip-active-record check and into its own skip-active-job check.

[1]: https://github.com/rails/rails/commit/f6d56fed27cfd11aa7161129e2c59a972f90b76b

### Additional information

Ref #47839 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ Fix for unreleased change
