### PR TITLE
Add support in Arel for materialized subqueries in CTEs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Introduce `Arel::Nodes::Materialized` to support materialized CTEs in
+    PostgreSQL and SQLite.
+
+    ```ruby
+    posts = Arel::Table.new(:posts)
+    comments = Arel::Table.new(:comments)
+    good_comments = Arel::Table.new(:good_comments)
+    subquery = comments.project(Arel.star).where(comments[:rating].gt(7))
+    materialized_subquery = Arel::Nodes::Materialized.new(subquery)
+
+    posts.
+      project(Arel.star).
+      with(Arel::Nodes::As.new(good_comments, materialized_subquery)).
+      where(posts[:id].in(good_comments.project(:post_id))).
+      to_sql
+
+    # "WITH \"good_comments\" AS MATERIALIZED (SELECT * FROM \"comments\" WHERE \"comments\".\"rating\" > 7) SELECT * FROM \"posts\" WHERE \"posts\".\"id\" IN (SELECT post_id FROM \"good_comments\")"
+    ```
+
+    *Jon Zeppieri*
+
 *   Introduce adapter for Trilogy database client
 
     Trilogy is a MySQL-compatible database client. Rails applications can use Trilogy

--- a/activerecord/lib/arel/nodes/unary.rb
+++ b/activerecord/lib/arel/nodes/unary.rb
@@ -32,6 +32,7 @@ module Arel # :nodoc: all
       Lateral
       Limit
       Lock
+      Materialized
       Not
       Offset
       On

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -64,6 +64,11 @@ module Arel # :nodoc: all
           visit o.expr, collector
         end
 
+        # no-op
+        def visit_Arel_Nodes_Materialized(o, collector)
+          visit o.expr, collector
+        end
+
         # In the simple case, MySQL allows us to place JOINs directly into the UPDATE
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -321,6 +321,11 @@ module Arel # :nodoc: all
           visit o.expr, collector
         end
 
+        def visit_Arel_Nodes_Materialized(o, collector)
+          collector << "MATERIALIZED "
+          visit o.expr, collector
+        end
+
         def visit_Arel_Nodes_Grouping(o, collector)
           if o.expr.is_a? Nodes::Grouping
             visit(o.expr, collector)

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -161,6 +161,19 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::Materialized" do
+        it "omits the MATERIALIZED keyword" do
+          manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr"))
+          materialized_subquery = Nodes::Materialized.new(Table.new(:bar).project(Arel.star))
+          aliased_subquery = Nodes::As.new(Table.new(:expr), materialized_subquery)
+          manager.with(aliased_subquery)
+
+          _(compile(manager.ast)).must_be_like %{
+            WITH "expr" AS (SELECT * FROM "bar") SELECT * FROM expr
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Postgres and SQLite both support a non-standard extension to the CTE syntax to indicate that a CTE subquery should be materialized, i.e., not folded into the main query but evaluated separately. This can be useful in cases where the query planner would otherwise make poor decisions.

The syntax, in both databases, is:
  `WITH foo AS MATERIALIZED (...) ...`

### Detail

This PR adds support by introducing a new unary `Materialized` node that can wrap a subquery like so:

   ```ruby
   posts = Arel::Table.new(:posts)
   comments = Arel::Table.new(:comments)
   good_comments = Arel::Table.new(:good_comments)
   subquery = comments.project(Arel.star).where(comments[:rating].gt(7))
   materialized_subquery = Arel::Nodes::Materialized.new(subquery)

   posts.
     project(Arel.star).
     with(Arel::Nodes::As.new(good_comments, materialized_subquery)).
     where(posts[:id].in(good_comments.project(:post_id))).
     to_sql

   # "WITH \"good_comments\" AS MATERIALIZED (SELECT * FROM \"comments\" WHERE \"comments\".\"rating\" > 7) SELECT * FROM \"posts\" WHERE \"posts\".\"id\" IN (SELECT post_id FROM \"good_comments\")"
   ```

MySQL doesn't support this SQL extension. I've taken the approach of simply omitting the `MATERIALIZED` keyword when generating SQL for MySQL.

### Checklist

Before submitting the PR make sure the following are checked:

* [ x ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ x ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ x ] Tests are added or updated if you fix a bug or add a feature.
* [ x ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
