### PR TITLE
make new objects with explicit ids equal to each other

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -27,6 +27,10 @@ module ActiveRecord
         !!id
       end
 
+      def id_changed?
+        @attributes[@primary_key].changed?
+      end
+
       # Sets the primary key column's value.
       def id=(value)
         if self.class.composite_primary_key?
@@ -66,7 +70,7 @@ module ActiveRecord
         end
 
         module ClassMethods
-          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database id_for_database).to_set
+          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database id_for_database id_changed?).to_set
           PRIMARY_KEY_NOT_SET = BasicObject.new
 
           def instance_method_already_implemented?(method_name)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -551,12 +551,13 @@ module ActiveRecord
     # Note also that destroying a record preserves its ID in the model instance, so deleted
     # models are still comparable.
     def ==(comparison_object)
-      return super if new_record?
+      return super if new_record? && !id_changed?
       super ||
         comparison_object.instance_of?(self.class) &&
         primary_key_values_present? &&
         comparison_object.id == id &&
-        !comparison_object.new_record?
+        !(comparison_object.new_record? &&
+          !comparison_object.id_changed?)
     end
     alias :eql? :==
 
@@ -565,7 +566,7 @@ module ActiveRecord
     def hash
       id = self.id
 
-      if primary_key_values_present? && !new_record?
+      if primary_key_values_present? && !(new_record? && !id_changed?)
         [self.class, id].hash
       else
         super

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -29,6 +29,7 @@ require "models/bulb"
 require "models/pet"
 require "models/owner"
 require "models/cpk"
+require "models/pk_with_default"
 require "concurrent/atomic/count_down_latch"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/kernel/reporting"
@@ -622,6 +623,32 @@ class BasicsTest < ActiveRecord::TestCase
     topic_1.destroy
     assert_equal topic_1, topic_2
     assert_equal topic_2, topic_1
+  end
+
+  def test_equality_with_set_ids
+    one = Subscriber.new(id: 1)
+    two = Subscriber.new(id: 1)
+    assert_equal one, two
+  end
+
+  def test_equality_with_unset_ids
+    one = Subscriber.new
+    two = Subscriber.new
+    assert_not_equal one, two
+  end
+
+  def test_equality_with_unset_ids_and_default_values
+    one = PkWithDefault.new
+    two = PkWithDefault.new
+
+    assert_not_equal one, two
+  end
+
+  def test_equality_with_set_ids_and_default_values
+    one = PkWithDefault.new(id: 123)
+    two = PkWithDefault.new(id: 123)
+
+    assert_not_equal one, two
   end
 
   def test_equality_of_relation_and_collection_proxy

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -3,11 +3,11 @@
 require "cases/helper"
 require "models/person"
 require "models/topic"
+require "models/pk_with_default"
 require "pp"
 require "models/cpk"
 
 class NonExistentTable < ActiveRecord::Base; end
-class PkWithDefault < ActiveRecord::Base; end
 
 class CoreTest < ActiveRecord::TestCase
   fixtures :topics, :cpk_books
@@ -28,6 +28,28 @@ class CoreTest < ActiveRecord::TestCase
     assert_not saved_record.eql?(record), "saved record should not eql? new"
     assert_not record.eql?(record2),      "new record should not eql? new record"
     assert_not record2.eql?(record),      "new record should not eql? new record"
+  end
+
+  def test_hash_on_default_pk
+    record = PkWithDefault.new
+    assert_equal 123, record.id
+
+    record2 = PkWithDefault.new
+    assert_equal 123, record2.id
+
+    assert_equal record.hash, record.hash
+    assert_not_equal record2.hash, record.hash
+  end
+
+  def test_hash_on_changed_default_pk
+    record = PkWithDefault.new(id: 456)
+    assert_equal 456, record.id
+
+    record2 = PkWithDefault.new(id: 456)
+    assert_equal 456, record2.id
+
+    assert_equal record.hash, record.hash
+    assert_equal record2.hash, record.hash
   end
 
   def test_inspect_class

--- a/activerecord/test/models/pk_with_default.rb
+++ b/activerecord/test/models/pk_with_default.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PkWithDefault < ActiveRecord::Base
+end


### PR DESCRIPTION
After https://github.com/rails/rails/pull/47864 was merged we realised that GitHub, Shopify and likely other applications rely on the old behaviour where new objects with explicitly set IDs are equal. 

This PR brings the old behaviour back for records with set ids while keeping the new inequality behaviour for records using default primary key value.

cc @matthewd