### PR TITLE
Backport of #46087

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,13 +23,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install codespell==2.1.0
       - name: Check spelling with codespell
-        run: codespell --ignore-words=codespell.txt || exit 1
-  misspell:
-    name: Check spelling all files in commit with misspell
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install
-        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
-      - name: Misspell
-        run: git ls-files --empty-directory | xargs ./misspell -i 'aircrafts,devels,invertions' -error
+        run: codespell --ignore-words=codespell.txt --skip="./actionview/test/ujs/public/vendor/qunit.js" || exit 1


### PR DESCRIPTION
Backport of #46087 with merge conflict resolved.

misspell has started failing on `7-0-stable` (see #47957). We could try to fix it, but since its been removed on main it makes sense to remove it here as well.