### PR TITLE
Fix backport of 47948 including other change [6-1-stable]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -498,9 +498,9 @@ module ActiveRecord
         def raise_on_duplicate_column(name)
           if @columns_hash[name]
             if @columns_hash[name].primary_key?
-              raise ArgumentError, "you can't redefine the primary key column '#{name}' on '#{@name}'. To define a custom primary key, pass { id: false } to create_table."
+              raise ArgumentError, "you can't redefine the primary key column '#{name}'. To define a custom primary key, pass { id: false } to create_table."
             else
-              raise ArgumentError, "you can't define an already defined column '#{name}' on '#{@name}'."
+              raise ArgumentError, "you can't define an already defined column '#{name}'."
             end
           end
         end


### PR DESCRIPTION
### Motivation / Background

The backports of a [bugfix][1] for migrations to [7-0-stable][2] and [6-1-stable][3] ended up including another [change][4] from main, which is now causing CI to fail for those stable branches.

### Detail

This commit fixes the CI issues by un-including the additional change from main.

### Additional information

An alternative to this fix would be to backport the test changes from the additional commit, but since it changes error messages it seems better to leave that on the main branch.

Ref #47966 for the 7-0-stable PR

[1]: https://github.com/rails/rails/11aaa3db6ca350fe7bd0be93ce2a9e8a9c17ab61
[2]: https://github.com/rails/rails/e2a99b56e57a0517d88fc0ff9bc111704e44d7df
[3]: https://github.com/rails/rails/33a9277546644bd2fac328f1c764a3323bad3eea
[4]: https://github.com/rails/rails/39a20095bf006de816eec32b4d431226b80f10cf
