### PR TITLE
Fix uniqueness validation, #id_in_database can be composite

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -53,7 +53,11 @@ module ActiveRecord
 
       # Returns the primary key column's value from the database.
       def id_in_database
-        attribute_in_database(@primary_key)
+        if self.class.composite_primary_key?
+          @primary_key.map { |col| attribute_in_database(col) }
+        else
+          attribute_in_database(@primary_key)
+        end
       end
 
       def id_for_database # :nodoc:

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         relation = build_relation(finder_class, attribute, value)
         if record.persisted?
           if finder_class.primary_key
-            relation = relation.where.not(finder_class.primary_key => record.id_in_database)
+            relation = relation.where.not(finder_class.primary_key => [record.id_in_database])
           else
             raise UnknownPrimaryKey.new(finder_class, "Cannot validate uniqueness for persisted record without primary key.")
           end


### PR DESCRIPTION
Part of the ongoing work to support composite keys.

Until now, specifying uniqueness validations for records that have a composite key fail. This is because uniqueness validation relies on `#id_in_database`, which didn't yet consider the case when primary key is an array.

I'm preparing a follow up PR to audit the `primary_key.rb` file, there's a few more usages of primary key that should be fitted to composite scenarios.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
