### PR TITLE
Permit frozen models to be validated

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -483,10 +483,6 @@ module ActiveModel
 
   class ValidationContext # :nodoc:
     attr_accessor :context
-
-    def initialize(context = nil)
-      @context = context
-    end
   end
 end
 

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -45,27 +45,6 @@ module ActiveModel
       extend  HelperMethods
       include HelperMethods
 
-      ##
-      # :method: validation_context
-      # Returns the context when running validations.
-      #
-      # This is useful when running validations except a certain context (opposite to the +on+ option).
-      #
-      #   class Person
-      #     include ActiveModel::Validations
-      #
-      #     attr_accessor :name
-      #     validates :name, presence: true, if: -> { validation_context != :custom }
-      #   end
-      #
-      #   person = Person.new
-      #   person.valid?          #=> false
-      #   person.valid?(:new)    #=> false
-      #   person.valid?(:custom) #=> true
-
-      ##
-      attr_accessor :validation_context
-      private :validation_context=
       define_callbacks :validate, scope: :name
 
       class_attribute :_validators, instance_writer: false, default: Hash.new { |h, k| h[k] = [] }
@@ -361,14 +340,22 @@ module ActiveModel
     #   person.valid?       # => true
     #   person.valid?(:new) # => false
     def valid?(context = nil)
-      current_context, self.validation_context = validation_context, context
+      current_context = validation_context
+      context_for_validation.context = context
       errors.clear
       run_validations!
     ensure
-      self.validation_context = current_context
+      context_for_validation.context = current_context
     end
 
     alias_method :validate, :valid?
+
+    def freeze
+      errors
+      context_for_validation
+
+      super
+    end
 
     # Performs the opposite of <tt>valid?</tt>. Returns +true+ if errors were
     # added, +false+ otherwise.
@@ -430,7 +417,34 @@ module ActiveModel
     #   end
     alias :read_attribute_for_validation :send
 
+    # Returns the context when running validations.
+    #
+    # This is useful when running validations except a certain context (opposite to the +on+ option).
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates :name, presence: true, if: -> { validation_context != :custom }
+    #   end
+    #
+    #   person = Person.new
+    #   person.valid?          #=> false
+    #   person.valid?(:new)    #=> false
+    #   person.valid?(:custom) #=> true
+    def validation_context
+      context_for_validation.context
+    end
+
   private
+    def validation_context=(context)
+      context_for_validation.context = context
+    end
+
+    def context_for_validation
+      @context_for_validation ||= ValidationContext.new
+    end
+
     def init_internals
       super
       @errors = nil
@@ -464,6 +478,14 @@ module ActiveModel
       @model = model
       errors = @model.errors.full_messages.join(", ")
       super(I18n.t(:"#{@model.class.i18n_scope}.errors.messages.model_invalid", errors: errors, default: :"errors.messages.model_invalid"))
+    end
+  end
+
+  class ValidationContext # :nodoc:
+    attr_accessor :context
+
+    def initialize(context = nil)
+      @context = context
     end
   end
 end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 
 require "models/topic"
+require "models/person"
 require "models/reply"
 require "models/custom_reader"
 
@@ -14,6 +15,7 @@ class ValidationsTest < ActiveModel::TestCase
 
   def teardown
     Topic.clear_validators!
+    Person.clear_validators!
   end
 
   def test_single_field_validation
@@ -452,5 +454,12 @@ class ValidationsTest < ActiveModel::TestCase
     t = Topic.new(author_name: "Admiral")
     assert_predicate t, :invalid?
     assert_equal ["Title is missing. You have failed me for the last time, Admiral."], t.errors[:title]
+  end
+
+  def test_frozen_models_can_be_validated
+    Person.validates :title, presence: true
+    person = Person.new.freeze
+    assert_predicate person, :frozen?
+    assert_not person.valid?
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Recently stumbled upon `composed_of` and started to use it to model a concept. One nice thing about it I noticed was i could isolate all logic related to that value object outside of a model, like for example validations. Take for example:

```ruby
class HourlyRate
  include ActiveModel::Validations

  attr_reader :rate

  validates :rate, numericality: { greater_than_or_equal_to: 0 }

  def initialize(rate)
    @rate = rate
  end
end

class Person < ApplicationRecord
  composed_of :hourly_rate, mapping: [%w[hourly_rate rate]]

  validates_associated :hourly_rate
end
```

With this setup you can validate existing people no problem, but if you change the hourly_rate you run into issues.

### Detail

When you set a value using `composed_of` the value is frozen (see: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/aggregations.rb#L279). But when you try to validate the object is raises a `FrozenError: can't modify frozen Person`. This is due to it trying to set the `errors` instance variable and keeping track of `validation_context`. My $0.02 is that validating shouldn't be seen as altering an object so these changes retain existing public API while making validation possible on frozen object.

This is done by memoizing errors prior to freezing, and moving the validation context into a separate object that can be altered during validation and memoizing that object prior to freezing.

### Additional information

I did find a related issue that was a blast from the past https://github.com/rails/rails/issues/1513. It looks to have been closed on the belief that `composed_of` was on its way out which turned out to not be the case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
