### PR TITLE
Fix Active Storage compiled code in sync with src

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -327,7 +327,7 @@
         return {
           buff: this._buff,
           length: this._length,
-          hash: this._hash
+          hash: this._hash.slice()
         };
       };
       SparkMD5.prototype.setState = function(state) {


### PR DESCRIPTION
### Motivation / Background

The locked SparkMD5 was updated in a recent [security release][1]. Since then, test_compiled_code_is_in_sync_with_source_code has been failing on 6-1-stable because SparkMD5 gets compiled into the activestorage.js bundle.

### Detail

This commit fixes the issue by recompiling activestorage.js.

### Additional information

Another possible solution would be to lock SparkMD5 to 3.0.0. However, since the version constraint on SparkMD5 is ^3.0.0, this change would already be possible if someone was compiling the package themselves.

[1]: https://github.com/rails/rails/commit/c443466a99f8ed951605fb4993a01de5e41349a4