### PR TITLE
Adds support `USING INDEX` for unique constraints in PostgreSQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -228,11 +228,12 @@
     add_unique_key :items, [:position], deferrable: :deferred
     ```
 
-    PostgreSQL allows users to create a unique constraints on top of the unique
-    index that cannot be deferred. In this case, even if users creates deferrable
-    unique constraint, the existing unique index does not allow users to violate uniqueness
-    within the transaction. If you want to change existing unique index to deferrable,
-    you need execute `remove_index` before creating deferrable unique constraints.
+    If you want to change an existing unique index to deferrable, you can use :using_index
+    to create deferrable unique constraints.
+
+    ```ruby
+    add_unique_key :items, deferrable: :deferred, using_index: "index_items_on_position"
+    ```
 
     *Hiroyuki Ishii*
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -53,7 +53,12 @@ module ActiveRecord
             sql = ["CONSTRAINT"]
             sql << quote_column_name(o.name)
             sql << "UNIQUE"
-            sql << "(#{column_name})"
+
+            if o.using_index
+              sql << "USING INDEX #{quote_column_name(o.using_index)}"
+            else
+              sql << "(#{column_name})"
+            end
 
             if o.deferrable
               sql << "DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -220,6 +220,10 @@ module ActiveRecord
           options[:deferrable]
         end
 
+        def using_index
+          options[:using_index]
+        end
+
         def export_name_on_schema_dump?
           !ActiveRecord::SchemaDumper.unique_ignore_pattern.match?(name) if name
         end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -318,6 +318,13 @@ module ActiveRecord
           super
         end
 
+        def invert_add_unique_key(args)
+          options = args.dup.extract_options!
+
+          raise ActiveRecord::IrreversibleMigration, "add_unique_key is not reversible if given an using_index." if options[:using_index]
+          super
+        end
+
         def invert_remove_unique_key(args)
           _table, columns = args.dup.tap(&:extract_options!)
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -471,6 +471,12 @@ module ActiveRecord
         end
       end
 
+      def test_invert_add_unique_key_constraint_with_using_index
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :add_unique_key, [:dogs, using_index: "unique_index"]
+        end
+      end
+
       def test_invert_remove_unique_key_constraint
         enable = @recorder.inverse_of :remove_unique_key, [:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed"]
         assert_equal [:add_unique_key, [:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed"], nil], enable

--- a/activerecord/test/cases/migration/unique_key_test.rb
+++ b/activerecord/test/cases/migration/unique_key_test.rb
@@ -147,6 +147,42 @@ if ActiveRecord::Base.connection.supports_unique_keys?
           end
         end
 
+        def test_add_unique_key_with_name_and_using_index
+          @connection.add_index :sections, [:position], name: "unique_index", unique: true
+          @connection.add_unique_key :sections, name: "unique_constraint", deferrable: :immediate, using_index: "unique_index"
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "unique_constraint", constraint.name
+          assert_equal ["position"], constraint.columns
+          assert_equal :immediate, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_only_using_index
+          @connection.add_index :sections, [:position], name: "unique_index", unique: true
+          @connection.add_unique_key :sections, using_index: "unique_index"
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal "uniq_rails_79b901ffb4", constraint.name
+          assert_equal ["position"], constraint.columns
+          assert_equal false, constraint.deferrable
+        end
+
+        def test_add_unique_key_with_columns_and_using_index
+          @connection.add_index :sections, [:position], name: "unique_index", unique: true
+
+          assert_raises(ArgumentError) do
+            @connection.add_unique_key :sections, [:position], using_index: "unique_index"
+          end
+        end
+
         def test_remove_unique_key
           assert_equal 0, @connection.unique_keys("sections").size
 


### PR DESCRIPTION
### Motivation / Background

follow-up #46192

### Detail

Adds `:using_index` option to use an existing index when defining a unique constraint. When the `:using_index` option is used, the specified unique index is changed to a unique constraint.

```ruby
add_unique_key :users, deferrable: :immediate, using_index: 'unique_index_name'
```

A unique constraint internally constructs a unique index.
If an existing unique index has already been created, the unique constraint
can be created much faster, since there is no need to create the unique index
when generating the constraint.

You can change a non-deferrable unique index to a deferrable unique constraint.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
