### PR TITLE
Active Record: assign connection pool before checking version

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -684,9 +684,10 @@ module ActiveRecord
         alias_method :release, :remove_connection_from_thread_cache
 
         def new_connection
-          Base.public_send(db_config.adapter_method, db_config.configuration_hash).tap do |conn|
-            conn.check_version
-          end
+          connection = Base.public_send(db_config.adapter_method, db_config.configuration_hash)
+          connection.pool = self
+          connection.check_version
+          connection
         end
 
         # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -83,6 +83,18 @@ module ActiveRecord
         assert_equal 0, active_connections(pool).size
       end
 
+      def test_new_connection_no_query
+        skip("Can't test with in-memory dbs") if in_memory_db?
+        assert_equal 0, pool.connections.size
+        pool.with_connection { |_conn| } # warm the schema cache
+        pool.flush(0)
+        assert_equal 0, pool.connections.size
+
+        assert_no_queries do
+          pool.with_connection { |_conn| }
+        end
+      end
+
       def test_active_connection_in_use
         assert_not_predicate pool, :active_connection?
         main_thread = pool.connection

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -180,6 +180,7 @@ module ActiveRecord
 
           child = Thread.new do
             conn = pool.checkout
+            conn.query("SELECT 1") # ensure connected
             event.set
             Thread.stop
           end


### PR DESCRIPTION
`connection.check_version` will emit a query if it doesn't have a connection pool on which to grab a SchemaCache.
