### PR TITLE
Use Trilogy#discard! when discard! called on TrilogyAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -207,7 +207,11 @@ module ActiveRecord
       end
 
       def discard!
-        self.connection = nil
+        super
+        unless connection.nil?
+          connection.discard!
+          self.connection = nil
+        end
       end
 
       def each_hash(result)


### PR DESCRIPTION
### Motivation / Background

Go through the `Trilogy#discard!` method added in https://github.com/github/trilogy/pull/65 to ensure that forked connections can be discarded cleanly when calling `TrilogyAdapter#discard!`. We should also call `super` in `discard!`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
