### PR TITLE
Populate auto-incremented `id` column on CPK record creation

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1239,7 +1239,11 @@ module ActiveRecord
         attributes_with_values(attribute_names)
       )
 
-      self.id ||= new_id if @primary_key
+      if self.class.composite_primary_key?
+        _write_attribute("id", new_id) if has_attribute?("id") && !_read_attribute("id")
+      else
+        self.id ||= new_id if @primary_key
+      end
 
       @new_record = false
       @previously_new_record = true

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -462,6 +462,20 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal("New Topic", topic_reloaded.title)
   end
 
+  def test_create_composite_primary_key
+    book = Cpk::Book.create(author_id: 111_222, number: 333, title: "created book")
+
+    assert_equal("created book", Cpk::Book.find(book.id).title)
+  end
+
+  def test_create_with_id_as_part_of_a_composite_primary_key
+    order = Cpk::Order.create(shop_id: 111_222, name: "created order")
+
+    _shop_id, order_id = order.id
+    assert_not_nil(order_id)
+    assert_equal("created order", Cpk::Order.find(order.id).name)
+  end
+
   def test_build
     topic = Topic.build(title: "New Topic")
     assert_equal "New Topic", topic.title

--- a/activerecord/test/fixtures/cpk_orders.yml
+++ b/activerecord/test/fixtures/cpk_orders.yml
@@ -3,9 +3,12 @@ _fixture:
 
 cpk_groceries_order_1:
   status: "paid"
+  name: "Order 1"
 
 cpk_groceries_order_2:
   status: "paid"
+  name: "Order 2"
 
 cpk_coffee_order_1:
   status: "cancelled"
+  name: "Coffee order 1"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -258,10 +258,11 @@ ActiveRecord::Schema.define do
     t.string :comment
   end
 
-  create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|
+  # not a db-level composite primary key to have the `id` column being autoincremented
+  create_table :cpk_orders, force: true do |t|
     t.integer :shop_id
-    t.integer :id
     t.string :status
+    t.string :name
   end
 
   create_table :cpk_order_agreements, force: true do |t|


### PR DESCRIPTION
Given an Active Record model with a composite primary key like:
```ruby
Order.primary_key = [:shop_id, :id]
```

and `id` column being autoincremented by the database, Rails should populate the `id` attribute with the value returned by the db, for example:
```ruby
order = Order.create(shop_id: 500)
puts order.inspect # => Order id: 1, shop_id: 500
```

### Limitations 

Current implementation doesn't require `id` column to be a part of the composite primary key.
However, that means that we are not handling an auto incremented column that has any name different from `id`. A complete algorithm will require to "Populate an auto incremented column regardless of its position or name" but fulfilling such requirement leads to an overcomplicated code which either based on a guess of which column needs to be populated or based on us fetching the auto incremented column name from the schema. We don't have a reasonable use-case to justify complexity being added so we are starting with the simplest approach.
