### PR TITLE
Use h1 for guide titles

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -530,16 +530,22 @@ a, a:link, a:visited {
 --------------------------------------- */
 
 h1 {
-  font-size: 2.5em;
-  line-height: 1;
-  margin: 0.6em 0 .2em;
-  font-weight: bold;
-}
-
-h2 {
   font-size: 2.1428em;
   line-height: 1;
   margin: 0.7em 0 .2333em;
+  font-weight: bold;
+}
+
+@media screen and (max-width: 480px) {
+  h1 {
+    font-size: 1.45em;
+  }
+}
+
+h2 {
+  font-size: 1.7142em;
+  line-height: 1.286;
+  margin: 0.875em 0 0.2916em;
   font-weight: bold;
 }
 
@@ -550,33 +556,20 @@ h2 {
 }
 
 h3 {
-  font-size: 1.7142em;
-  line-height: 1.286;
-  margin: 0.875em 0 0.2916em;
-  font-weight: bold;
-}
-
-@media screen and (max-width: 480px) {
-  h3 {
-    font-size: 1.45em;
-  }
-}
-
-h4 {
   font-size: 1.2857em;
   line-height: 1.2;
   margin: 1.6667em 0 .3887em;
   font-weight: bold;
 }
 
-h5 {
+h4 {
   font-size: 1em;
   line-height: 1.5;
   margin: 1em 0 .5em;
   font-weight: bold;
 }
 
-h6 {
+h5 {
   font-size: 1em;
   line-height: 1.5;
   margin: 1em 0 .5em;
@@ -600,15 +593,15 @@ h6 {
 :where(body[dir="rtl"]) #topNav strong { margin-left: 0.5em; }
 #topNav strong a {color: #FFF;}
 
-#header h1 {
+#header .header-logo {
   background: url(../images/rails_guides_logo_1x.png) no-repeat;
   width: 297px;
   text-indent: -9999em;
   margin: 0;
   padding: 0;
 }
-:where(body[dir="ltr"]) #header h1 { float: left; }
-:where(body[dir="rtl"]) #header h1 { float: right; }
+:where(body[dir="ltr"]) #header .header-logo { float: left; }
+:where(body[dir="rtl"]) #header .header-logo { float: right; }
 
 @media
 only screen and (-webkit-min-device-pixel-ratio: 2),
@@ -617,19 +610,19 @@ only screen and (     -o-min-device-pixel-ratio: 2/1),
 only screen and (        min-device-pixel-ratio: 2),
 only screen and (                min-resolution: 192dpi),
 only screen and (                min-resolution: 2dppx) {
-  #header h1 {
+  #header .header-logo {
     background: url(../images/rails_guides_logo_2x.png) no-repeat;
     background-size: 160%;
   }
 }
 
 @media screen and (max-width: 480px) {
-  #header h1 {
+  #header .header-logo {
     float: none;
   }
 }
 
-#header h1 a {
+#header .header-logo a {
   text-decoration: none;
   display: block;
   height: 77px;

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -98,17 +98,17 @@ module RailsGuides
             hierarchy = []
 
             doc.children.each do |node|
-              if /^h[3-6]$/.match?(node.name)
+              if /^h[2-5]$/.match?(node.name)
                 case node.name
-                when "h3"
+                when "h2"
                   hierarchy = [node]
                   @headings_for_index << [1, node, node.inner_html]
-                when "h4"
+                when "h3"
                   hierarchy = hierarchy[0, 1] + [node]
                   @headings_for_index << [2, node, node.inner_html]
-                when "h5"
+                when "h4"
                   hierarchy = hierarchy[0, 2] + [node]
-                when "h6"
+                when "h5"
                   hierarchy = hierarchy[0, 3] + [node]
                 end
 
@@ -117,7 +117,7 @@ module RailsGuides
               end
             end
 
-            doc.css("h3, h4, h5, h6").each do |node|
+            doc.css("h2, h3, h4, h5").each do |node|
               node.inner_html = "<a class='anchorlink' href='##{node[:id]}'>#{node.inner_html}</a>"
             end
           end

--- a/guides/rails_guides/markdown/epub_renderer.rb
+++ b/guides/rails_guides/markdown/epub_renderer.rb
@@ -25,9 +25,6 @@ module RailsGuides
       end
 
       def header(text, header_level)
-        # Always increase the heading level by 1, so we can use h1, h2 heading in the document
-        header_level += 1
-
         header_with_id = text.scan(/(.*){#(.*)}/)
         unless header_with_id.empty?
           %(<h#{header_level} id="#{header_with_id[0][1].strip}">#{header_with_id[0][0].strip}</h#{header_level}>)

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -33,9 +33,6 @@ module RailsGuides
       end
 
       def header(text, header_level)
-        # Always increase the heading level by 1, so we can use h1, h2 heading in the document
-        header_level += 1
-
         header_with_id = text.scan(/(.*){#(.*)}/)
         unless header_with_id.empty?
           %(<h#{header_level} id="#{header_with_id[0][1].strip}">#{header_with_id[0][0].strip}</h#{header_level}>)

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -42,7 +42,7 @@
   </div>
   <div id="header">
     <div class="wrapper clearfix">
-      <h1><a href="index.html" title="Return to home page">Guides.rubyonrails.org</a></h1>
+      <div class="header-logo"><a href="index.html" title="Return to home page">Guides.rubyonrails.org</a></div>
       <ul class="nav">
         <li><a class="nav-item" href="index.html">Home</a></li>
         <li class="guides-index guides-index-large">


### PR DESCRIPTION
### Motivation / Background

Currently the guides use the h1 tag for the guides logo instead of the guides title (which is a h2). As the guides title is more important in describing the content of a guide, the title should use the h1 instead. This also move every other heading to a more important heading (h3 becomes h2, etc.).

This change should improve SEO for the guides.

It doesn't seem to affect the epub version output.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
