### PR TITLE
Better deprecation warning for `ActiveSupport::Deprecation.warn`

### DIFF
--- a/activesupport/lib/active_support/deprecation/instance_delegator.rb
+++ b/activesupport/lib/active_support/deprecation/instance_delegator.rb
@@ -22,8 +22,10 @@ module ActiveSupport
             when :silence, :behavior=, :disallowed_behavior=, :disallowed_warnings=, :silenced=, :debug=
               target = "(defined?(Rails.application.deprecators) ? Rails.application.deprecators : ActiveSupport::Deprecation._instance)"
               "Rails.application.deprecators.#{method_name}"
-            when :warn, :deprecate_methods, :gem_name, :gem_name=, :deprecation_horizon, :deprecation_horizon=
+            when :deprecate_methods, :gem_name, :gem_name=, :deprecation_horizon, :deprecation_horizon=
               "your own Deprecation object"
+            when :warn
+              "`ActiveSupport.deprecator.warn`"
             else
               "Rails.application.deprecators[framework].#{method_name} where framework is for example :active_record"
             end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -765,7 +765,7 @@ class DeprecationTest < ActiveSupport::TestCase
     end
     assert_equal 2, deprecations.size
     assert_match("foo", deprecations.first)
-    assert_match("use your own Deprecation object instead", deprecations.last)
+    assert_match("Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use `ActiveSupport.deprecator.warn` instead)", deprecations.last)
   end
 
   test "deprecate_methods delegator is deprecated" do


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/47354#discussion_r1170553124

It is common to see this code in apps (not in gems/engines, but in user code):

```ruby
ActiveSupport::Deprecation.warn "foo"
```

Currently that code will emit this warning:

> DEPRECATION WARNING: Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use your own Deprecation object instead)

This PR changes the warning so that it gives you more direct advice on how to fix it:

> DEPRECATION WARNING: Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use `ActiveSupport.deprecator.warn` instead)

My understanding is that this is fine for user code, and we are not expecting users to define their own deprecators for in-app use. Given that, we should just tell the user what to do in the error message.
