### PR TITLE
Extend primary key methods to support composite keys

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -38,17 +38,29 @@ module ActiveRecord
 
       # Queries the primary key column's value.
       def id?
-        query_attribute(@primary_key)
+        if self.class.composite_primary_key?
+          @primary_key.all? { |col| query_attribute(col) }
+        else
+          query_attribute(@primary_key)
+        end
       end
 
       # Returns the primary key column's value before type cast.
       def id_before_type_cast
-        attribute_before_type_cast(@primary_key)
+        if self.class.composite_primary_key?
+          @primary_key.map { |col| attribute_before_type_cast(col) }
+        else
+          attribute_before_type_cast(@primary_key)
+        end
       end
 
       # Returns the primary key column's previous value.
       def id_was
-        attribute_was(@primary_key)
+        if self.class.composite_primary_key?
+          @primary_key.map { |col| attribute_was(col) }
+        else
+          attribute_was(@primary_key)
+        end
       end
 
       # Returns the primary key column's value from the database.
@@ -61,7 +73,11 @@ module ActiveRecord
       end
 
       def id_for_database # :nodoc:
-        @attributes[@primary_key].value_for_database
+        if self.class.composite_primary_key?
+          @primary_key.map { |col| @attributes[col].value_for_database }
+        else
+          @attributes[@primary_key].value_for_database
+        end
       end
 
       private

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -53,6 +53,24 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal [1], topic.to_key
   end
 
+  def test_id_was
+    topic = Topic.find(1)
+    assert_equal 1, topic.id
+
+    topic.id = 3
+
+    assert_equal 1, topic.id_was
+    assert_equal 3, topic.id
+  end
+
+  def test_id?
+    topic = Topic.find(1)
+
+    assert_changes("topic.id?", from: true, to: false) do
+      topic.id = nil
+    end
+  end
+
   def test_integer_key
     topic = Topic.find(1)
     assert_equal(topics(:first).author_name, topic.author_name)
@@ -410,6 +428,38 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
     assert_raises(TypeError) do
       book.id = 1
+    end
+  end
+
+  def test_id_was_composite
+    book = cpk_books(:cpk_great_author_first_book)
+    book_id = book.id
+
+    assert_not_equal [42, 42], book_id
+
+    book.id = [42, 42]
+
+    assert_equal book_id, book.id_was
+    assert_equal [42, 42], book.id
+  end
+
+  def test_id_predicate_composite
+    book = cpk_books(:cpk_great_author_first_book)
+
+    valid_id = [42, 42]
+
+    invalid_ids = [
+      [42, nil],
+      [nil, 42],
+      [nil, nil],
+    ]
+
+    invalid_ids.each do |invalid_id|
+      book.id = valid_id
+
+      assert_changes("book.id?", from: true, to: false) do
+        book.id = invalid_id
+      end
     end
   end
 


### PR DESCRIPTION
`primary_key.rb` has many methods in it's public interface that work with the primary key. Since this is now possibly an array, let's unify the behaviour and ensure all of them are compatible with the composite design.

Note: Many of the high-volume methods have already been changed in other PRs, this PR touches the smaller ones that hadn't yet been ported.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
