### PR TITLE
Revert "Merge pull request #47864 from zenspider/zenspider/ar_core_hash"

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -551,12 +551,10 @@ module ActiveRecord
     # Note also that destroying a record preserves its ID in the model instance, so deleted
     # models are still comparable.
     def ==(comparison_object)
-      return super if new_record?
       super ||
         comparison_object.instance_of?(self.class) &&
         primary_key_values_present? &&
-        comparison_object.id == id &&
-        !comparison_object.new_record?
+        comparison_object.id == id
     end
     alias :eql? :==
 
@@ -565,8 +563,8 @@ module ActiveRecord
     def hash
       id = self.id
 
-      if primary_key_values_present? && !new_record?
-        [self.class, id].hash
+      if primary_key_values_present?
+        self.class.hash ^ id.hash
       else
         super
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -811,10 +811,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "YAML dumping a record with time zone-aware attribute" do
     in_time_zone "Pacific Time (US & Canada)" do
-      Topic.where(id: 1).delete_all
       record = Topic.new(id: 1)
       record.written_on = "Jan 01 00:00:00 2014"
-      record.save!
       payload = YAML.dump(record)
       assert_equal record, YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -625,6 +625,12 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal topic_2, topic_1
   end
 
+  def test_equality_with_blank_ids
+    one = Subscriber.new(id: "")
+    two = Subscriber.new(id: "")
+    assert_equal one, two
+  end
+
   def test_equality_of_relation_and_collection_proxy
     car = Car.create!
     car.bulbs.build

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -68,7 +68,6 @@ class FilterAttributesTest < ActiveRecord::TestCase
     ActiveRecord::Base.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
     account = Admin::Account.new(id: 123, name: "37signals")
     account.inspect
-    account.save!
     assert_equal account, Marshal.load(Marshal.dump(account))
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1411,10 +1411,6 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
-
-  create_table :pk_with_defaults, id: false, force: true do |t|
-    t.bigint :id, default: 123
-  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
This reverts commit 2815cb96207172f675a49860666f26167757f93c, reversing
changes made to 11a5e3771570f05cb888326765561d4cacbcac5a.
    
The change broke application code and if we are going to make this
change we will need to deprecate the prior behavior. See #47864 for more
details.
