### PR TITLE
Docs: backport #44706 Modernize contributing docs to 7-0-stable branch [ci-skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -25,15 +25,15 @@ Reporting an Issue
 
 Ruby on Rails uses [GitHub Issue Tracking](https://github.com/rails/rails/issues) to track issues (primarily bugs and contributions of new code). If you've found a bug in Ruby on Rails, this is the place to start. You'll need to create a (free) GitHub account to submit an issue, comment on issues, or create pull requests.
 
-NOTE: Bugs in the most recent released version of Ruby on Rails will likely get the most attention. Additionally, the Rails core team is always interested in feedback from those who can take the time to test _edge Rails_ (the code for the version of Rails that is currently under development). Later in this guide, you'll find out how to get edge Rails for testing.
+NOTE: Bugs in the most recent released version of Ruby on Rails will likely get the most attention. Additionally, the Rails core team is always interested in feedback from those who can take the time to test _edge Rails_ (the code for the version of Rails that is currently under development). Later in this guide, you'll find out how to get edge Rails for testing. See our [maintenance policy](https://guides.rubyonrails.org/maintenance_policy.html) for information on which versions are supported. Never report a security issue on the GitHub issues tracker.
 
 ### Creating a Bug Report
 
 If you've found a problem in Ruby on Rails that is not a security risk, search the [Issues](https://github.com/rails/rails/issues) on GitHub, in case it has already been reported. If you cannot find any open GitHub issues addressing the problem you found, your next step will be to [open a new issue](https://github.com/rails/rails/issues/new). (See the next section for reporting security issues.)
 
-Your issue report should contain a title and a clear description of the issue at the bare minimum. You should include as much relevant information as possible and a code sample that demonstrates the issue. It would be even better to include a failing unit test that tests the expected behavior. Your goal should be to make it easy for yourself - and others - to reproduce the bug and figure out a fix.
+We've provided an issue template for you so that when creating an issue you include all the information needed to determine whether there is a bug in the framework. Each issue needs to include a title and clear description of the problem. Make sure to include as much relevant information as possible including a code sample or failing test that demonstrates the expected behavior, as well as your system configuration. Your goal should be to make it easy for yourself - and others - to reproduce the bug and figure out a fix.
 
-Then, don't get your hopes up! Unless you have a "Code Red, Mission Critical, the World is Coming to an End" kind of bug, do not expect that the issue report will automatically see any activity or that someone will jump to fix it. You're creating this issue report so that other people with the same problem can confirm the bug and collaborate with you in fixing it.
+Once you open an issue it may or may not see activity right away unless it is a "Code Red, Mission Critical, the World is Coming to an End" kind of bug. That doesn't mean we don't care about your bug, just that there are a lot of issues and pull requests to get through. Other people with the same problem can find your issue and confirm the bug and may collaborate with you on fixing it. If you know how to fix the bug, go ahead and open a pull request.
 
 ### Create an Executable Test Case
 
@@ -68,7 +68,7 @@ can expect it to be marked "invalid" as soon as it's reviewed.
 
 Sometimes, the line between 'bug' and 'feature' is a hard one to draw.
 Generally, a feature is anything that adds new behavior, while a bug
-is anything that causes incorrect behavior. Sometimes, the core team will have
+is anything that causes incorrect behavior. Sometimes, the Core team will have
 to make a judgment call. That said, the distinction generally determines which
 patch your change is released with; we love feature submissions! They just
 won't get backported to maintenance branches.
@@ -86,7 +86,7 @@ discussions new features require.
 Helping to Resolve Existing Issues
 ----------------------------------
 
-Beyond reporting issues, you can help the core team resolve existing ones by providing feedback about them. If you are new to Rails core development, that might be a great way to walk your first steps, you'll get familiar with the codebase and the processes.
+Beyond reporting issues, you can help the core team resolve existing ones by providing feedback about them. If you are new to Rails core development providing feedback will help you get familiar with the codebase and the processes.
 
 If you check the [issues list](https://github.com/rails/rails/issues) in GitHub Issues, you'll find lots of issues already requiring attention. What can you do about these? Quite a bit, actually:
 
@@ -115,6 +115,8 @@ $ git remote add JohnSmith https://github.com/JohnSmith/rails.git
 $ git pull JohnSmith orange
 ```
 
+An alternative to adding their remote to your checkout is to use the [GitHub CLI tool](https://cli.github.com/) to checkout their pull request.
+
 After applying their branch, test it out! Here are some things to think about:
 
 * Does the change actually work?
@@ -122,7 +124,7 @@ After applying their branch, test it out! Here are some things to think about:
 * Does it have the proper documentation coverage? Should documentation elsewhere be updated?
 * Do you like the implementation? Can you think of a nicer or faster way to implement a part of their change?
 
-Once you're happy that the pull request contains a good change, comment on the GitHub issue indicating your approval. Your comment should indicate that you like the change and what you like about it. Something like:
+Once you're happy that the pull request contains a good change, comment on the GitHub issue indicating your findings. Your comment should indicate that you like the change and what you like about it. Something like:
 
 >I like the way you've restructured that code in generate_finder_sql - much nicer. The tests look good too.
 
@@ -187,17 +189,19 @@ Contributing to the Rails Code
 
 To move on from submitting bugs to helping resolve existing issues or contributing your own code to Ruby on Rails, you _must_ be able to run its test suite. In this section of the guide, you'll learn how to set up the tests on your computer.
 
-#### The Easiest Way
+#### Using GitHub Codespaces
 
-Start a GitHub Codespace from the repository and start developing right away from the browser IDE or in your local VScode. The Codespace is initialized with all required dependencies and allows you to run all tests.
+If you're a member of an organization that has codespaces enabled, you can fork Rails into that organization and use codespaces on GitHub. The Codespace will be initialized with all required dependencies and allows you to run all tests.
 
-#### The Easy Way
+If you're not a member of an organization that has codespaces enabled you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the `.devcontainer` configuration in the repository and build the Docker container locally.
 
-The easiest and recommended way to get a development environment ready to hack is to use the [rails-dev-box](https://github.com/rails/rails-dev-box).
+#### Using rails-dev-box
 
-#### The Hard Way
+It's also possible to use the [rails-dev-box](https://github.com/rails/rails-dev-box) to get a development environment ready. However, the rails-dev-box uses Vagrant and Virtual Box which will not work with the M1 processors.
 
-In case you can't use the Rails development box, see [this other guide](development_dependencies_install.html).
+#### Local Development
+
+When you can't use GitHub Codespaces, see [this other guide](development_dependencies_install.html) for how to set up local development. This is considered the hard way because installing dependencies may be OS specific.
 
 ### Clone the Rails Repository
 
@@ -247,12 +251,13 @@ $ yarn link "@rails/activestorage"
 
 ### Write Your Code
 
-Now get busy and add/edit code. You're on your branch now, so you can write whatever you want (make sure you're on the right branch with `git branch -a`). But if you're planning to submit your change back for inclusion in Rails, keep a few things in mind:
+Now it's time to write some code! When making changes for Rails here are some things to keep in mind:
 
-* Get the code right.
+* Follow Rails style and conventions.
 * Use Rails idioms and helpers.
 * Include tests that fail without your code, and pass with it.
 * Update the (surrounding) documentation, examples elsewhere, and the guides: whatever is affected by your contribution.
+* If the change adds, removes, or changes a feature, be sure to include a CHANGELOG entry. If your change is a bug fix, a CHANGELOG entry is not necessary.
 
 TIP: Changes that are cosmetic and do not add anything substantial to the stability, functionality, or testability of Rails will generally not be accepted (read more about [our rationales behind this decision](https://github.com/rails/rails/pull/13771#issuecomment-32746700)).
 
@@ -465,7 +470,7 @@ will now run the three of them in turn.
 You can also run any single test separately:
 
 ```bash
-$ ARCONN=sqlite3 bundle exec ruby -Itest test/cases/associations/has_many_associations_test.rb
+$ ARCONN=mysql2 bundle exec ruby -Itest test/cases/associations/has_many_associations_test.rb
 ```
 
 To run a single test against all adapters, use:
@@ -574,7 +579,7 @@ simplifies future cherry picks and keeps the git log clean.
 
 ### Update Your Branch
 
-It's pretty likely that other changes to main have happened while you were working. Go get them:
+It's pretty likely that other changes to main have happened while you were working. To get new changes in main:
 
 ```bash
 $ git checkout main
@@ -588,7 +593,13 @@ $ git checkout my_new_branch
 $ git rebase main
 ```
 
-No conflicts? Tests still pass? Change still seems reasonable to you? Then move on.
+No conflicts? Tests still pass? Change still seems reasonable to you? Then push the rebased changes to GitHub:
+
+```bash
+$ git push --force-with-lease
+```
+
+We disallow force pushing on the rails/rails repository base, but you are able to force push to your fork. When rebasing this is a requirement since the history has changed.
 
 ### Fork
 
@@ -628,7 +639,7 @@ $ git push fork main
 $ git push fork my_new_branch
 ```
 
-### Issue a Pull Request
+### Open a Pull Request
 
 Navigate to the Rails repository you just pushed to (e.g.
 https://github.com/your-user-name/rails) and click on "Pull Requests" in the top bar (just above the code).
@@ -640,7 +651,7 @@ whatever name you gave your branch. Click "create pull request" when you're read
 
 Ensure the changesets you introduced are included. Fill in some details about
 your potential patch, using the pull request template provided. When finished, click "Create
-pull request". The Rails core team will be notified about your submission.
+pull request".
 
 ### Get Some Feedback
 
@@ -663,14 +674,13 @@ While you're waiting for feedback on your pull request, open up a few other
 pull requests and give someone else some! They'll appreciate it in
 the same way that you appreciate feedback on your patches.
 
-Note that your pull request may be marked as "Approved" by somebody who does not
-have access to merge it. Further changes may still be required before members of
-the core or committer teams accept it. To prevent confusion, when giving
-feedback on someone else's pull request, please avoid marking it as "Approved."
+Note that only the Core and Committers teams are permitted to merge code changes.
+If someone gives feedback and "approves" your changes they may not have the ability
+or final say to merge your change.
 
 ### Iterate as Necessary
 
-It's entirely possible that the feedback you get will suggest changes. Don't get discouraged: the whole point of contributing to an active open source project is to tap into the community's knowledge. If people encourage you to tweak your code, then it's worth making the tweaks and resubmitting. If the feedback is that your code doesn't belong in the core, you might still think about releasing it as a gem.
+It's entirely possible that the feedback you get will suggest changes. Don't get discouraged: the whole point of contributing to an active open source project is to tap into the community's knowledge. If people encourage you to tweak your code, then it's worth making the tweaks and resubmitting. If the feedback is that your code won't be merged, you might still think about releasing it as a gem.
 
 #### Squashing Commits
 
@@ -705,6 +715,7 @@ you can force push to your branch on GitHub as described earlier in
 squashing commits section:
 
 ```bash
+$ git commit --amend
 $ git push fork my_new_branch --force-with-lease
 ```
 
@@ -715,47 +726,41 @@ that you don't already have.
 
 ### Older Versions of Ruby on Rails
 
-If you want to add a fix to older versions of Ruby on Rails, you'll need to set up and switch to your own local tracking branch. Here is an example to switch to the 4-0-stable branch:
+If you want to add a fix to versions of Ruby on Rails older than the next release, you'll need to set up and switch to your own local tracking branch. Here is an example to switch to the 7-0-stable branch:
 
 ```bash
-$ git branch --track 4-0-stable rails/4-0-stable
-$ git checkout 4-0-stable
+$ git branch --track 7-0-stable rails/7-0-stable
+$ git checkout 7-0-stable
 ```
 
-TIP: You may want to [put your Git branch name in your shell prompt](http://qugstart.com/blog/git-and-svn/add-colored-git-branch-name-to-your-shell-prompt/) to make it easier to remember which version of the code you're working with.
-
-NOTE: Before working on older versions, please check the [maintenance policy](maintenance_policy.html).
+NOTE: Before working on older versions, please check the [maintenance policy](maintenance_policy.html). Changes will not be accepted to versions that have reached end of life.
 
 #### Backporting
 
-Changes that are merged into main are intended for the next major release of Rails. Sometimes, it might be beneficial to propagate your changes back to older stable branches for inclusion in maintenance releases. Generally, security fixes and bug fixes are good candidates for a backport, while new features and patches that change expected behavior will not be accepted. When in doubt, it is best to consult a Rails team member before backporting your changes to avoid wasted effort.
+Changes that are merged into main are intended for the next major release of Rails. Sometimes, it might be beneficial to propagate your changes back to stable branches for inclusion in maintenance releases. Generally, security fixes and bug fixes are good candidates for a backport, while new features and patches that change expected behavior will not be accepted. When in doubt, it is best to consult a Rails team member before backporting your changes to avoid wasted effort.
 
-For simple fixes, the easiest way to backport your changes is to [extract a diff from your changes in main and apply them to the target branch](https://www.devroom.io/2009/10/26/how-to-create-and-apply-a-patch-with-git/).
-
-First, make sure your changes are the only difference between your current branch and main:
+First, make sure your main branch is up to date.
 
 ```bash
-$ git log main..HEAD
+$ git checkout main
+$ git pull --rebase
 ```
 
-Then extract the diff:
+Check out the branch you're backporting to, for example, `7-0-stable` and make sure it's up to date:
 
 ```bash
-$ git format-patch main --stdout > ~/my_changes.patch
+$ git checkout 7-0-stable
+$ git reset --hard origin/7-0-stable
+$ git checkout -b my-backport-branch
 ```
 
-Switch over to the target branch and apply your changes:
+If you're backporting a merged pull request, find the commit for the merge and cherry-pick it:
 
 ```bash
-$ git checkout -b my_backport_branch 4-2-stable
-$ git apply ~/my_changes.patch
+$ git cherry-pick -m1 MERGE_SHA
 ```
 
-This works well for simple changes. However, if your changes are complicated or if the code in main has deviated significantly from your target branch, it might require more work on your part. The difficulty of a backport varies greatly from case to case, and sometimes it is simply not worth the effort.
-
-Once you have resolved all conflicts and made sure all the tests are passing, push your changes and open a separate pull request for your backport. It is also worth noting that older branches might have a different set of build targets than main. When possible, it is best to first test your backport locally against the oldest Ruby version permitted by the target branch's `rails.gemspec` before submitting your pull request.
-
-And then... think about your next contribution!
+Fix any conflicts that occurred in the cherry-pick, push your changes, then open a PR pointing at the stable branch you're backporting to. If you have a more complex set of changes, the [cherry-pick](https://git-scm.com/docs/git-cherry-pick) documentation can help.
 
 Rails Contributors
 ------------------


### PR DESCRIPTION
### Motivation / Background

I created this Pull Request because I believe that the update made to the contribution guide (https://github.com/rails/rails/pull/44706) deserves to be backported to the current 7-0-stable branch.

### Detail

This Pull Request just cherry-picks the 4b3910a.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
