### PR TITLE
Fix #47956: Update comment to reference values with single quotes

### DIFF
--- a/actionmailbox/test/dummy/config/locales/en.yml
+++ b/actionmailbox/test/dummy/config/locales/en.yml
@@ -24,7 +24,7 @@
 # Instead, surround them with single quotes.
 #
 # en:
-#   "true": "foo"
+#   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/actiontext/test/dummy/config/locales/en.yml
+++ b/actiontext/test/dummy/config/locales/en.yml
@@ -24,7 +24,7 @@
 # Instead, surround them with single quotes.
 #
 # en:
-#   "true": "foo"
+#   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/activestorage/test/dummy/config/locales/en.yml
+++ b/activestorage/test/dummy/config/locales/en.yml
@@ -24,7 +24,7 @@
 # Instead, surround them with single quotes.
 #
 # en:
-#   "true": "foo"
+#   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
@@ -24,7 +24,7 @@
 # Instead, surround them with single quotes.
 #
 # en:
-#   "true": "foo"
+#   'true': 'foo'
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.


### PR DESCRIPTION
Fixes #47956

This Pull Request has been created because autogenerated config/locales/en.yml file template mentions surrounding specific keys with 'single quotes' while the examples were presented with "double quotes"

### Detail

This Pull Request fixes generated documentation that erroneously gives examples of single quote keys with double quotes
