### PR TITLE
Use proper heading for "N + 1 queries" section [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1493,7 +1493,7 @@ Eager Loading Associations
 
 Eager loading is the mechanism for loading the associated records of the objects returned by `Model.find` using as few queries as possible.
 
-**N + 1 queries problem**
+### N + 1 Queries Problem
 
 Consider the following code, which finds 10 books and prints their authors' last_name:
 
@@ -1507,7 +1507,7 @@ end
 
 This code looks fine at the first sight. But the problem lies within the total number of queries executed. The above code executes 1 (to find 10 books) + 10 (one per each book to load the author) = **11** queries in total.
 
-**Solution to N + 1 queries problem**
+#### Solution to N + 1 Queries Problem
 
 Active Record lets you specify in advance all the associations that are going to be loaded.
 


### PR DESCRIPTION
### Motivation / Background
Instead of using a bold pseudo heading, use a real heading.

### Before
<img width="663" alt="image" src="https://user-images.githubusercontent.com/28561/233042728-7eb5d1a3-491e-4711-8c76-ad6a4854dfb2.png">

### After
<img width="670" alt="image" src="https://user-images.githubusercontent.com/28561/233042655-098f0e8b-754a-4165-806d-a46d6fe953ea.png">
