### PR TITLE
Support `.distinct.count` by multiple columns for non-mysql adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -578,6 +578,11 @@ module ActiveRecord
         true
       end
 
+      # Does this adapter support `COUNT (DISTINCT col1, col2)` syntax?
+      def supports_distinct_count_by_multiple_columns?
+        false
+      end
+
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
           !ActiveRecord.async_query_executor.nil? && !pool.async_executor.nil?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -168,6 +168,10 @@ module ActiveRecord
         true
       end
 
+      def supports_distinct_count_by_multiple_columns?
+        true
+      end
+
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end


### PR DESCRIPTION
This commit adds support for `.select(:col1, :col2).distinct.count` for non-mysql adapters. Now distinct count by multiple columns will use a subquery similarly to what is happening when `.select(:col1, :col2).distinct.count(:all)` is being used.

### Motivation

Currently doing `Post.select(:id, :title).distinct.count` fails on non-mysql adapters because of the `COUNT(DISTINCT(id, title)` syntax being unsupported. This is not the best experience even though documentations kind of implies that there are limitations
https://github.com/rails/rails/blob/2c8c1dfc9c8e86dc074ddc3c2d12a43debba5e83/activerecord/lib/active_record/relation/calculations.rb#L81-L82

But we would like to still provide an alternative where possible instead of bubbling up a database exception. 
Supporting distinct count for all adapters allows us to support distinct count across all adapters for composite primary key models as well as in this case `.select(:id, :title)` is implicitly being substituted by `.select(*primary_key_columns)`

### Alternative

As an alternative we could have kept the `supports_distinct_count_by_multiple_columns?` but instead of providing support we could have raised with an "unsupported" message and asked applications to explicitly use the `count(:all)` version to force the subquery. 

### What SQL is being generated

Given a call like `Account.select(:firm_id, :id).distinct.count`

mysql adapter:
```sql
SELECT COUNT(DISTINCT firm_id, id) FROM `accounts`
end

non-mysql adapter:
```sql
SELECT COUNT(count_column) FROM (SELECT DISTINCT firm_id, id AS count_column FROM "accounts") subquery_for_count
```

### New adapter based flag

`supports_distinct_count_by_multiple_columns?` flag was added to specify which adapter is capable of parsing SQL like `COUNT(DISTINCT col1, col2, col3)` and currently only mysql seems to be able to work with it. 

### Implementation details

Unfortunately I don't find the proposed solution as elegant as I wish it was. However, since current `Calculations` implementation seems to be bloated with nested conditions which are not the clearest one to read and handling for `count` operation spread across the flow:
https://github.com/rails/rails/blob/795d52473740866d0f7194ea5cdc5247e51016eb/activerecord/lib/active_record/relation/calculations.rb#L207
https://github.com/rails/rails/blob/795d52473740866d0f7194ea5cdc5247e51016eb/activerecord/lib/active_record/relation/calculations.rb#L372
https://github.com/rails/rails/blob/795d52473740866d0f7194ea5cdc5247e51016eb/activerecord/lib/active_record/relation/calculations.rb#L409

 instead of being consolidated in one place as an abstraction I had no choice other than keep adding a few more conditions. So at least I tried to make sure that the newly added clauses have descriptive names and it's easy to follow them because each part now has a meaningful name and represents a certain concept.