### PR TITLE
Show reason for foreign key error when loading fixtures

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -636,7 +636,17 @@ module ActiveRecord
 
       # Override to check all foreign key constraints in a database.
       def all_foreign_keys_valid?
+        check_all_foreign_keys_valid!
         true
+      rescue ActiveRecord::StatementInvalid
+        false
+      end
+      deprecate :all_foreign_keys_valid?, deprecator: ActiveRecord.deprecator
+
+      # Override to check all foreign key constraints in a database.
+      # The adapter should raise a +ActiveRecord::StatementInvalid+ if foreign key
+      # constraints are not met.
+      def check_all_foreign_keys_valid!
       end
 
       # CONNECTION MANAGEMENT ====================================

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -38,7 +38,7 @@ Rails needs superuser privileges to disable referential integrity.
           end
         end
 
-        def all_foreign_keys_valid? # :nodoc:
+        def check_all_foreign_keys_valid! # :nodoc:
           sql = <<~SQL
             do $$
               declare r record;
@@ -61,14 +61,8 @@ Rails needs superuser privileges to disable referential integrity.
             $$;
           SQL
 
-          begin
-            transaction(requires_new: true) do
-              execute(sql)
-            end
-
-            true
-          rescue ActiveRecord::StatementInvalid
-            false
+          transaction(requires_new: true) do
+            execute(sql)
           end
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -241,8 +241,14 @@ module ActiveRecord
         end
       end
 
-      def all_foreign_keys_valid? # :nodoc:
-        execute("PRAGMA foreign_key_check").blank?
+      def check_all_foreign_keys_valid! # :nodoc:
+        sql = "PRAGMA foreign_key_check"
+        result = execute(sql)
+
+        unless result.blank?
+          tables = result.map { |row| row["table"] }
+          raise ActiveRecord::StatementInvalid.new("Foreign key violations found: #{tables.join(", ")}", sql: sql)
+        end
       end
 
       # SCHEMA STATEMENTS ========================================

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -646,14 +646,22 @@ module ActiveRecord
 
             conn.insert_fixtures_set(table_rows_for_connection, table_rows_for_connection.keys)
 
-            if ActiveRecord.verify_foreign_keys_for_fixtures && !conn.all_foreign_keys_valid?
-              raise "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations."
-            end
+            check_all_foreign_keys_valid!(conn)
 
             # Cap primary key sequences to max(pk).
             if conn.respond_to?(:reset_pk_sequence!)
               set.each { |fs| conn.reset_pk_sequence!(fs.table_name) }
             end
+          end
+        end
+
+        def check_all_foreign_keys_valid!(conn)
+          return unless ActiveRecord.verify_foreign_keys_for_fixtures
+
+          begin
+            conn.check_all_foreign_keys_valid!
+          rescue ActiveRecord::StatementInvalid => e
+            raise "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations. Error from database:\n\n#{e.message}"
           end
         end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -445,6 +445,12 @@ module ActiveRecord
       @connection.disable_query_cache!
     end
 
+    def test_all_foreign_keys_valid_is_deprecated
+      assert_deprecated(ActiveRecord.deprecator) do
+        @connection.all_foreign_keys_valid?
+      end
+    end
+
     # test resetting sequences in odd tables in PostgreSQL
     if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
       require "models/movie"


### PR DESCRIPTION
https://github.com/rails/rails/pull/42674 added the ability to have Rails verify foreign keys when creating fixtures. Feedback from users since then is it would be handy to know *which* foreign keys are being violated. See https://github.com/rails/rails/pull/44943 and https://github.com/rails/rails/pull/47780 for attempts to fix this.

This PR rolls up some of the ideas from those PRs into one that's hopefully mergable.

- [x] `all_foreign_keys_valid?` is deprecated in favour of `check_all_foreign_keys_valid!`.
- [x] Postgres and Sqlite adapters raise an error with detail about the foreign key error.
- [x] Authors of other PRs added as co-authors here to get credit.
- [x] Deprecations updated to work with new deprecation APIs.
- [x] Tests updated.

Here's what the error messages will now look like.

Postgres:

```
Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations. Error from database:

PG::ForeignKeyViolation: ERROR:  insert or update on table "fk_pointing_to_non_existent_objects" violates foreign key constraint "fk_that_will_be_broken"
DETAIL:  Key (fk_object_to_point_to_id)=(980190962) is not present in table "fk_object_to_point_tos".
CONTEXT:  SQL statement "UPDATE pg_constraint SET convalidated=false WHERE conname = 'fk_that_will_be_broken' AND connamespace::regnamespace = 'public'::regnamespace; ALTER TABLE public.fk_pointing_to_non_existent_objects VALIDATE CONSTRAINT fk_that_will_be_broken;"
PL/pgSQL function inline_code_block line 16 at EXECUTE
```

Sqlite:
```
Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations. Error from database:

Foreign key violations found: fk_pointing_to_non_existent_objects
```

Closes https://github.com/rails/rails/pull/47780
Closes https://github.com/rails/rails/pull/44943

cc @s-mage @danini-the-panini