### PR TITLE
Fix trilogy builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ platforms :ruby, :windows do
   group :db do
     gem "pg", "~> 1.3"
     gem "mysql2", "~> 0.5"
-    gem "trilogy", "~> 2.4"
+    gem "trilogy", github: "github/trilogy", branch: "main", glob: "contrib/ruby/*.gemspec"
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/github/trilogy.git
+  revision: 8e4ae98569c12894da9bcbee5edb32b76068dbfd
+  branch: main
+  glob: contrib/ruby/*.gemspec
+  specs:
+    trilogy (2.4.0)
+
+GIT
   remote: https://github.com/matthewd/websocket-client-simple.git
   revision: e161305f1a466b9398d86df3b1731b03362da91b
   branch: close-race
@@ -338,8 +346,12 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
     parallel (1.22.1)
@@ -486,8 +498,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.4)
+    sqlite3 (1.6.2)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.6.2-x86_64-darwin)
+    sqlite3 (1.6.2-x86_64-linux)
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -507,7 +521,6 @@ GEM
     timeout (0.3.2)
     tomlrb (2.0.3)
     trailblazer-option (0.1.2)
-    trilogy (2.4.0)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -619,7 +632,7 @@ DEPENDENCIES
   sucker_punch
   tailwindcss-rails
   terser (>= 1.1.4)
-  trilogy (~> 2.4)
+  trilogy!
   turbo-rails
   tzinfo-data
   w3c_validators (~> 1.3.6)

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -209,10 +209,19 @@ end
 
 namespace :db do
   namespace :mysql do
-    connection_arguments = lambda do |connection_name|
-      config = ARTest.config["connections"]["mysql2"][connection_name]
-      ["--user=#{config["username"]}", ("--password=#{config["password"]}" if config["password"]), ("--host=#{config["host"]}" if config["host"]), ("--socket=#{config["socket"]}" if config["socket"])].join(" ")
+    mysql2_config = ARTest.config["connections"]["mysql2"]
+    mysql2_connection_arguments = lambda do |connection_name|
+      mysql2_connection = mysql2_config[connection_name]
+      ["--user=#{mysql2_connection["username"]}", ("--password=#{mysql2_connection["password"]}" if mysql2_connection["password"]), ("--host=#{mysql2_connection["host"]}" if mysql2_connection["host"]), ("--socket=#{mysql2_connection["socket"]}" if mysql2_connection["socket"])].join(" ")
     end
+
+    trilogy_config = ARTest.config["connections"]["trilogy"]
+    trilogy_connection_arguments = lambda do |connection_name|
+      trilogy_connection = trilogy_config[connection_name]
+      ["--user=#{trilogy_connection["username"]}", ("--password=#{trilogy_connection["password"]}" if trilogy_connection["password"]), ("--host=#{trilogy_connection["host"]}" if trilogy_connection["host"]), ("--socket=#{trilogy_connection["socket"]}" if trilogy_connection["socket"])].join(" ")
+    end
+
+    mysql_configs = [mysql2_config, trilogy_config]
 
     desc "Create the MySQL Rails User"
     task :build_user do
@@ -226,26 +235,30 @@ namespace :db do
         mysql_command = "mysql -uroot -e"
       end
 
-      config = ARTest.config["connections"]["mysql2"]
-      %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit"]["username"]}'@'localhost';" )
-      %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit2"]["username"]}'@'localhost';" )
-      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit"]["database"]}.* to '#{config["arunit"]["username"]}'@'localhost'" )
-      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit2"]["database"]}.* to '#{config["arunit2"]["username"]}'@'localhost'" )
-      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to '#{config["arunit"]["username"]}'@'localhost';" )
+      mysql_configs.each do |config|
+        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit"]["username"]}'@'localhost';" )
+        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit2"]["username"]}'@'localhost';" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit"]["database"]}.* to '#{config["arunit"]["username"]}'@'localhost'" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit2"]["database"]}.* to '#{config["arunit2"]["username"]}'@'localhost'" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to '#{config["arunit"]["username"]}'@'localhost';" )
+      end
     end
 
     desc "Build the MySQL test databases"
     task build: ["db:mysql:build_user"] do
-      config = ARTest.config["connections"]["mysql2"]
-      %x( mysql #{connection_arguments["arunit"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
-      %x( mysql #{connection_arguments["arunit2"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql #{mysql2_connection_arguments["arunit"]} -e "create DATABASE IF NOT EXISTS #{mysql2_config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql #{mysql2_connection_arguments["arunit2"]} -e "create DATABASE IF NOT EXISTS #{mysql2_config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql #{trilogy_connection_arguments["arunit"]} -e "create DATABASE IF NOT EXISTS #{trilogy_config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
+      %x( mysql #{trilogy_connection_arguments["arunit2"]} -e "create DATABASE IF NOT EXISTS #{trilogy_config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
     end
 
     desc "Drop the MySQL test databases"
     task :drop do
-      config = ARTest.config["connections"]["mysql2"]
-      %x( mysqladmin #{connection_arguments["arunit"]} -f drop #{config["arunit"]["database"]} )
-      %x( mysqladmin #{connection_arguments["arunit2"]} -f drop #{config["arunit2"]["database"]} )
+      %x( mysql #{mysql2_connection_arguments["arunit"]} -e "drop database IF EXISTS #{mysql2_config["arunit"]["database"]}" )
+      %x( mysql #{mysql2_connection_arguments["arunit2"]} -e "drop database IF EXISTS #{mysql2_config["arunit2"]["database"]}" )
+
+      %x( mysql #{trilogy_connection_arguments["arunit"]} -e "drop database IF EXISTS #{trilogy_config["arunit"]["database"]}" )
+      %x( mysql #{trilogy_connection_arguments["arunit2"]} -e "drop database IF EXISTS #{trilogy_config["arunit2"]["database"]}" )
     end
 
     desc "Rebuild the MySQL test databases"

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -1,37 +1,5 @@
 default_connection: <%= defined?(JRUBY_VERSION) ? 'jdbcsqlite3' : 'sqlite3' %>
 
-mysql: &mysql
-  arunit:
-    username: rails
-    encoding: utf8mb4
-    collation: utf8mb4_unicode_ci
-  <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
-    prepared_statements: true
-  <% else %>
-    prepared_statements: false
-  <% end %>
-  <% if ENV['MYSQL_HOST'] %>
-    host: <%= ENV['MYSQL_HOST'] %>
-  <% end %>
-  <% if ENV['MYSQL_SOCK'] %>
-    socket: "<%= ENV['MYSQL_SOCK'] %>"
-  <% end %>
-  arunit2:
-    username: rails
-    encoding: utf8mb4
-    collation: utf8mb4_general_ci
-  <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
-    prepared_statements: true
-  <% else %>
-    prepared_statements: false
-  <% end %>
-  <% if ENV['MYSQL_HOST'] %>
-    host: <%= ENV['MYSQL_HOST'] %>
-  <% end %>
-  <% if ENV['MYSQL_SOCK'] %>
-    socket: "<%= ENV['MYSQL_SOCK'] %>"
-  <% end %>
-
 connections:
   jdbcderby:
     arunit:  activerecord_unittest
@@ -68,7 +36,36 @@ connections:
       timeout:  5000
 
   mysql2:
-    <<: *mysql
+    arunit:
+      username: rails
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
+    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
+      prepared_statements: true
+    <% else %>
+      prepared_statements: false
+    <% end %>
+    <% if ENV['MYSQL_HOST'] %>
+      host: <%= ENV['MYSQL_HOST'] %>
+    <% end %>
+    <% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+    <% end %>
+    arunit2:
+      username: rails
+      encoding: utf8mb4
+      collation: utf8mb4_general_ci
+    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
+      prepared_statements: true
+    <% else %>
+      prepared_statements: false
+    <% end %>
+    <% if ENV['MYSQL_HOST'] %>
+      host: <%= ENV['MYSQL_HOST'] %>
+    <% end %>
+    <% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+    <% end %>
 
   oracle:
      arunit:
@@ -112,4 +109,33 @@ connections:
       database: ':memory:'
 
   trilogy:
-    <<: *mysql
+    arunit:
+      username: rails
+      encoding: utf8mb4
+      collation: utf8mb4_unicode_ci
+    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
+      prepared_statements: true
+    <% else %>
+      prepared_statements: false
+    <% end %>
+    <% if ENV['MYSQL_HOST'] %>
+      host: <%= ENV['MYSQL_HOST'] %>
+    <% end %>
+    <% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+    <% end %>
+    arunit2:
+      username: rails
+      encoding: utf8mb4
+      collation: utf8mb4_general_ci
+    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
+      prepared_statements: true
+    <% else %>
+      prepared_statements: false
+    <% end %>
+    <% if ENV['MYSQL_HOST'] %>
+      host: <%= ENV['MYSQL_HOST'] %>
+    <% end %>
+    <% if ENV['MYSQL_SOCK'] %>
+      socket: "<%= ENV['MYSQL_SOCK'] %>"
+    <% end %>

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -113,11 +113,7 @@ connections:
       username: rails
       encoding: utf8mb4
       collation: utf8mb4_unicode_ci
-    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
-      prepared_statements: true
-    <% else %>
       prepared_statements: false
-    <% end %>
     <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>
     <% end %>
@@ -128,11 +124,7 @@ connections:
       username: rails
       encoding: utf8mb4
       collation: utf8mb4_general_ci
-    <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
-      prepared_statements: true
-    <% else %>
       prepared_statements: false
-    <% end %>
     <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>
     <% end %>

--- a/activerecord/test/schema/trilogy_specific_schema.rb
+++ b/activerecord/test/schema/trilogy_specific_schema.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+ActiveRecord::Schema.define do
+  if connection.supports_datetime_with_precision?
+    create_table :datetime_defaults, force: true do |t|
+      t.datetime :modified_datetime, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :precise_datetime, default: -> { "CURRENT_TIMESTAMP(6)" }
+      t.datetime :updated_datetime, default: -> { "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)" }
+    end
+
+    create_table :timestamp_defaults, force: true do |t|
+      t.timestamp :nullable_timestamp
+      t.timestamp :modified_timestamp, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+      t.timestamp :precise_timestamp, precision: 6, default: -> { "CURRENT_TIMESTAMP(6)" }
+      t.timestamp :updated_timestamp, precision: 6, default: -> { "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)" }
+    end
+  end
+
+  create_table :defaults, force: true do |t|
+    t.date :fixed_date, default: "2004-01-01"
+    t.datetime :fixed_time, default: "2004-01-01 00:00:00"
+    t.column :char1, "char(1)", default: "Y"
+    t.string :char2, limit: 50, default: "a varchar field"
+    if ActiveRecord::TestCase.supports_default_expression?
+      t.binary :uuid, limit: 36, default: -> { "(uuid())" }
+    end
+  end
+
+  create_table :binary_fields, force: true do |t|
+    t.binary :var_binary, limit: 255
+    t.binary :var_binary_large, limit: 4095
+
+    t.tinyblob   :tiny_blob
+    t.blob       :normal_blob
+    t.mediumblob :medium_blob
+    t.longblob   :long_blob
+    t.tinytext   :tiny_text
+    t.text       :normal_text
+    t.mediumtext :medium_text
+    t.longtext   :long_text
+
+    t.binary :tiny_blob_2, size: :tiny
+    t.binary :medium_blob_2, size: :medium
+    t.binary :long_blob_2, size: :long
+    t.text :tiny_text_2, size: :tiny
+    t.text :medium_text_2, size: :medium
+    t.text :long_text_2, size: :long
+
+    t.index :var_binary
+  end
+
+  create_table :key_tests, force: true, options: "CHARSET=utf8 ENGINE=MyISAM" do |t|
+    t.string :awesome
+    t.string :pizza
+    t.string :snacks
+    t.index :awesome, type: :fulltext, name: "index_key_tests_on_awesome"
+    t.index :pizza, using: :btree, name: "index_key_tests_on_pizza"
+    t.index :snacks, name: "index_key_tests_on_snack"
+  end
+
+  create_table :collation_tests, id: false, force: true do |t|
+    t.string :string_cs_column, limit: 1, collation: "utf8mb4_bin"
+    t.string :string_ci_column, limit: 1, collation: "utf8mb4_general_ci"
+    t.binary :binary_column,    limit: 1
+  end
+
+  execute "DROP PROCEDURE IF EXISTS ten"
+
+  execute <<~SQL
+    CREATE PROCEDURE ten() SQL SECURITY INVOKER
+    BEGIN
+      SELECT 10;
+    END
+  SQL
+
+  execute "DROP PROCEDURE IF EXISTS topics"
+
+  execute <<~SQL
+    CREATE PROCEDURE topics(IN num INT) SQL SECURITY INVOKER
+    BEGIN
+      SELECT * FROM topics LIMIT num;
+    END
+  SQL
+end

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -25,5 +25,12 @@ module ARTest
     ActiveRecord::Base.configurations = test_configuration_hashes
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2
+
+    arunit_adapter = ActiveRecord::Base.connection.pool.db_config.adapter
+
+    if connection_name != arunit_adapter
+      return if connection_name == "sqlite3_mem" && arunit_adapter == "sqlite3"
+      raise ArgumentError, "The connection name did not match the adapter name. Connection name is '#{connection_name}' and the adapter name is '#{arunit_adapter}'."
+    end
   end
 end


### PR DESCRIPTION
I found out we weren't running trilogy in CI (or locally) because I messed up the config. This PR aims to fix it.

[Fix database configuration and generation](https://github.com/rails/rails/commit/5e5300aca2029e0da64d49ad5a7359833e78eda3) 

I tried using the same config for mysql2 and trilogy but instead it
eneded up breaking the trilogy tests - they were only running in mysql2
mode. I wanted to do this so that the rake tasks for trilogy wouldn't
need to be duplicated but since that didn't work out quite right, I've
decide to duplicate the calls and add if exists / if not exists where
applicable. The configs should be the same but this will make sure that
if they do deviate, the dbs are always created/dropped.

[Raise an error if the connection name doesn't match the adapter](https://github.com/rails/rails/commit/d284d6fd22d49c4632b7390f1c2855c83d8910f6) 

This will prevent us from accidentally running mysql2 tests against
trilogy adapter as we currently are doing.

[Bump trilogy to fix connection error translation](https://github.com/rails/rails/pull/47993/commits/124298bd3f99291df7a21f5c49fb086859004273) 

Until we do a new release we need to run against main on trilogy to get
the latest changes from https://github.com/github/trilogy/pull/69