### PR TITLE
Fix AR#== and AR#hash when id == table's default id (take2)

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -25,7 +25,7 @@ module ActiveRecord
       def primary_key_values_present? # :nodoc:
         return id.all? if self.class.composite_primary_key?
 
-        !!id
+        id != self.class._default_attributes["id"].value
       end
 
       # Sets the primary key column's value.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -565,7 +565,7 @@ module ActiveRecord
       id = self.id
 
       if primary_key_values_present?
-        self.class.hash ^ id.hash
+        [self.class, id].hash
       else
         super
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -811,8 +811,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "YAML dumping a record with time zone-aware attribute" do
     in_time_zone "Pacific Time (US & Canada)" do
+      Topic.where(id: 1).delete_all
       record = Topic.new(id: 1)
       record.written_on = "Jan 01 00:00:00 2014"
+      record.save!
       payload = YAML.dump(record)
       assert_equal record, YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -7,9 +7,28 @@ require "pp"
 require "models/cpk"
 
 class NonExistentTable < ActiveRecord::Base; end
+class PkWithDefault < ActiveRecord::Base; end
 
 class CoreTest < ActiveRecord::TestCase
-  fixtures :topics
+  fixtures :topics, :cpk_books
+
+  def test_eql_on_default_pk
+    saved_record = PkWithDefault.new
+    saved_record.save!
+    assert_equal 123, saved_record.id
+
+    record = PkWithDefault.new
+    assert_equal 123, record.id
+
+    record2 = PkWithDefault.new
+    assert_equal 123, record2.id
+
+    assert     record.eql?(record),       "record should eql? itself"
+    assert_not record.eql?(saved_record), "new record should not eql? saved"
+    assert_not saved_record.eql?(record), "saved record should not eql? new"
+    assert_not record.eql?(record2),      "new record should not eql? new record"
+    assert_not record2.eql?(record),      "new record should not eql? new record"
+  end
 
   def test_inspect_class
     assert_equal "ActiveRecord::Base", ActiveRecord::Base.inspect
@@ -155,12 +174,12 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_composite_pk_models_added_to_a_set
     library = Set.new
-    # with primary key present
+    # new record with primary key present
     library << Cpk::Book.new(author_id: 1, number: 2)
 
     # duplicate
-    library << Cpk::Book.new(author_id: 1, number: 3)
-    library << Cpk::Book.new(author_id: 1, number: 3)
+    library << cpk_books(:cpk_great_author_first_book)
+    library << cpk_books(:cpk_great_author_first_book)
 
     # without primary key being set
     library << Cpk::Book.new(title: "Book A")
@@ -170,22 +189,21 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_composite_pk_models_equality
-    assert Cpk::Book.new(author_id: 1, number: 2) == Cpk::Book.new(author_id: 1, number: 2)
+    book = cpk_books(:cpk_great_author_first_book)
+    book_instance_1 = Cpk::Book.find_by(author_id: book.author_id, number: book.number)
+    book_instance_2 = Cpk::Book.find_by(author_id: book.author_id, number: book.number)
 
-    assert_not Cpk::Book.new(author_id: 1, number: 2) == Cpk::Book.new(author_id: 1, number: 3)
+    assert book_instance_1 == book_instance_1
+    assert book_instance_1 == book_instance_2
+
+    # two new records with the same primary key
+    assert Cpk::Book.new(author_id: 1, number: 2) == Cpk::Book.new(author_id: 1, number: 2)
+    # two new records with an empty primary key values
     assert_not Cpk::Book.new == Cpk::Book.new
     assert_not Cpk::Book.new(title: "Book A") == Cpk::Book.new(title: "Book B")
     assert_not Cpk::Book.new(author_id: 1) == Cpk::Book.new(author_id: 1)
     assert_not Cpk::Book.new(author_id: 1, title: "Same title") == Cpk::Book.new(author_id: 1, title: "Same title")
-  end
-
-  def test_composite_pk_models_hash
-    assert_equal Cpk::Book.new(author_id: 1, number: 2).hash, Cpk::Book.new(author_id: 1, number: 2).hash
-
-    assert_not_equal Cpk::Book.new(author_id: 1, number: 2).hash, Cpk::Book.new(author_id: 1, number: 3).hash
-    assert_not_equal Cpk::Book.new.hash, Cpk::Book.new.hash
-    assert_not_equal Cpk::Book.new(title: "Book A").hash, Cpk::Book.new(title: "Book B").hash
-    assert_not_equal Cpk::Book.new(author_id: 1).hash, Cpk::Book.new(author_id: 1).hash
-    assert_not_equal Cpk::Book.new(author_id: 1, title: "Same title").hash, Cpk::Book.new(author_id: 1, title: "Same title").hash
+    # two persisted records with a different primary key
+    assert_not cpk_books(:cpk_great_author_first_book) == cpk_books(:cpk_great_author_second_book)
   end
 end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -68,6 +68,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
     ActiveRecord::Base.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
     account = Admin::Account.new(id: 123, name: "37signals")
     account.inspect
+    account.save!
     assert_equal account, Marshal.load(Marshal.dump(account))
   end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1411,6 +1411,10 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
+
+  create_table :pk_with_defaults, id: false, force: true do |t|
+    t.bigint :id, default: 123
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
This tries to address probems found via #47864. See discussion on that PR for details.

### Motivation / Background

AR#== and #hash both check against id and then compute their values... but an instance that is a new_record? can have an id even if not saved if the schema has a default value associated with id.

This Pull Request has been created because [REPLACE ME]

### Detail

This PR modifies `primary_key_values_present?` to check against the default value for id rather than plain truthiness. This method is used in both AR#== and AR#hash and should fix problems of having new records w/ non-nil ids

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
