### PR TITLE
Fix name extraction for module queue adapters

### DIFF
--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -43,7 +43,8 @@ module ActiveJob
           assign_adapter(name_or_adapter.to_s, queue_adapter)
         else
           if queue_adapter?(name_or_adapter)
-            adapter_name = "#{name_or_adapter.class.name.demodulize.remove('Adapter').underscore}"
+            adapter_class = name_or_adapter.is_a?(Module) ? name_or_adapter : name_or_adapter.class
+            adapter_name = "#{adapter_class.name.demodulize.remove('Adapter').underscore}"
             assign_adapter(adapter_name, name_or_adapter)
           else
             raise ArgumentError

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -50,4 +50,23 @@ class QueueAdapterTest < ActiveJob::TestCase
 
     assert_not_nil child_job_three.queue_adapter
   end
+
+  test "should extract a reasonable name from a class instance" do
+    child_job = Class.new(ActiveJob::Base)
+    child_job.queue_adapter = ActiveJob::QueueAdapters::StubOneAdapter.new
+    assert_equal "stub_one", child_job.queue_adapter_name
+  end
+
+  module StubThreeAdapter
+    class << self
+      def enqueue(*); end
+      def enqueue_at(*); end
+    end
+  end
+
+  test "should extract a reasonable name from a class or module" do
+    child_job = Class.new(ActiveJob::Base)
+    child_job.queue_adapter = StubThreeAdapter
+    assert_equal "stub_three", child_job.queue_adapter_name
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Currently, setting a module as queue adapter makes `queue_adapter_name` return `"module"`, instead of a name derived from the name of the module.

### Detail

This Pull Request fixes the name extraction logic to also derive a name for module or class queue adapters.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
