### PR TITLE
Extend query-association interface for composite models

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -10,7 +10,10 @@ module ActiveRecord
 
       def queries
         if associated_table.join_foreign_key.is_a?(Array)
-          ids.map { |ids_set| associated_table.join_foreign_key.zip(ids_set).to_h }
+          id_list = ids
+          id_list = id_list.pluck(primary_key) if id_list.is_a?(Relation)
+
+          id_list.map { |ids_set| associated_table.join_foreign_key.zip(ids_set).to_h }
         else
           [ associated_table.join_foreign_key => ids ]
         end

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -26,7 +26,7 @@ module ActiveRecord
           when Array
             value.map { |v| convert_to_id(v) }
           else
-            convert_to_id(value)
+            [convert_to_id(value)]
           end
         end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -166,6 +166,15 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(expected_posts.map(&:id).sort, blog_posts.map(&:id).sort)
   end
 
+  def test_querying_by_single_associated_record_works_using_query_constraints
+    comments = [sharded_comments(:great_comment_blog_post_one), sharded_comments(:great_comment_blog_post_two)]
+
+    blog_posts = Sharded::BlogPost.where(comments: comments.last).to_a
+
+    expected_posts = [sharded_blog_posts(:great_post_blog_two)]
+    assert_equal(expected_posts.map(&:id).sort, blog_posts.map(&:id).sort)
+  end
+
   def test_has_many_association_with_composite_foreign_key_loads_records
     blog_post = sharded_blog_posts(:great_post_blog_one)
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -175,6 +175,14 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(expected_posts.map(&:id).sort, blog_posts.map(&:id).sort)
   end
 
+  def test_querying_by_relation_with_composite_key
+    expected_posts = [sharded_blog_posts(:great_post_blog_one), sharded_blog_posts(:great_post_blog_two)]
+
+    blog_posts = Sharded::BlogPost.where(comments: Sharded::Comment.where(body: "I really enjoyed the post!")).to_a
+
+    assert_equal(expected_posts.map(&:id).sort, blog_posts.map(&:id).sort)
+  end
+
   def test_has_many_association_with_composite_foreign_key_loads_records
     blog_post = sharded_blog_posts(:great_post_blog_one)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
This PR improves the types of ways you can specify associations in where clauses for models that use primary keys.

Before we could do:

```ruby
comments = [Comment.new(body: "I really enjoyed the post", Comment.new(body: "Didn't like it")]

Sharded::BlogPost.where(comments: comments).to_a
```

Now we can do:

```ruby
Sharded::BlogPost.where(comments: comments.last).to_a
Sharded::BlogPost.where(comments: Sharded::Comment.where(body: "I really enjoyed the post!")).to_a
```

### Detail
The commit messages explain rationale for each of the changes. In short, we should try to bring consistency to the structure of the `ids` list. In the single record case, we wrap it in an array so that we easily disambiguate a single composite key from a list of single PKs.

The second commit works to support specifying sub relations in association queries. One limitation so far is that the query by tuple syntax **strictly assumes** that values take on the same shape (ie. `[:column_a, :column_b] => [[1, 2], [3, 4]]`). As such, we need to eager-evaluate the sub-relation and pluck the required values only in the composite case.

When we start accepting more types in the tuple syntax, this may not be required.

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
