### PR TITLE
Use h1 from header for guides title tag [ci-skip]

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -150,7 +150,7 @@ module RailsGuides
       end
 
       def generate_title
-        if heading = Nokogiri::HTML.fragment(@header).at(:h2)
+        if heading = Nokogiri::HTML.fragment(@header).at(:h1)
           @title = "#{heading.text} — Ruby on Rails Guides"
         else
           @title = "Ruby on Rails Guides"


### PR DESCRIPTION
As the main heading is now a h1, the h1 should be used for the title.