### PR TITLE
Allow queue adapters to provide a custom name

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow queue adapters to provide a custom name by implementing `queue_adapter_name`
+
+    *Sander Verdonschot*
+
 *   Log background job enqueue callers
 
     Add `verbose_enqueue_logs` configuration option to display the caller

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -43,8 +43,7 @@ module ActiveJob
           assign_adapter(name_or_adapter.to_s, queue_adapter)
         else
           if queue_adapter?(name_or_adapter)
-            adapter_class = name_or_adapter.is_a?(Module) ? name_or_adapter : name_or_adapter.class
-            adapter_name = "#{adapter_class.name.demodulize.remove('Adapter').underscore}"
+            adapter_name = extract_adapter_name(name_or_adapter)
             assign_adapter(adapter_name, name_or_adapter)
           else
             raise ArgumentError
@@ -62,6 +61,13 @@ module ActiveJob
 
         def queue_adapter?(object)
           QUEUE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
+        end
+
+        def extract_adapter_name(adapter)
+          return adapter.queue_adapter_name if adapter.respond_to?(:queue_adapter_name)
+
+          adapter_class = adapter.is_a?(Module) ? adapter : adapter.class
+          "#{adapter_class.name.demodulize.remove('Adapter').underscore}"
         end
     end
   end

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -69,4 +69,18 @@ class QueueAdapterTest < ActiveJob::TestCase
     child_job.queue_adapter = StubThreeAdapter
     assert_equal "stub_three", child_job.queue_adapter_name
   end
+
+  class StubFourAdapter
+    def enqueue(*); end
+    def enqueue_at(*); end
+    def queue_adapter_name
+      "fancy_name"
+    end
+  end
+
+  test "should use the name provided by the adapter" do
+    child_job = Class.new(ActiveJob::Base)
+    child_job.queue_adapter = StubFourAdapter.new
+    assert_equal "fancy_name", child_job.queue_adapter_name
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This gives queue adapters more freedom to name and organize their code.

For example, if `FancyQueue` wants to have their adapter at `FancyQueue::ActiveJobAdapter`, the inferred name would be `active_job` before this change. After this change, they can implement `queue_adapter_name` to return `fancy_queue`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
