### PR TITLE
Fix some doc headings naming [ci-skip]

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -26,7 +26,7 @@ module AbstractController
     end
   end
 
-  # = AbstractController \Base
+  # = Abstract Controller \Base
   #
   # AbstractController::Base is a low-level API. Nobody should be
   # using it directly, and subclasses (like ActionController::Base) are

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -2,7 +2,7 @@
 
 module AbstractController
   module Caching
-    # = AbstractController Caching \Fragments
+    # = Abstract Controller Caching \Fragments
     #
     # Fragment caching is used for caching various blocks within
     # views without caching the entire action as a whole. This is

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionDispatch
-  # = ActionDispatch \PublicExceptions
+  # = Action Dispatch \PublicExceptions
   #
   # When called, this middleware renders an error page. By default if an HTML
   # response is expected it will render static error pages from the <tt>/public</tt>

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -6,7 +6,7 @@ require "rack/session/cookie"
 
 module ActionDispatch
   module Session
-    # = ActionDispatch Session \CookieStore
+    # = Action Dispatch Session \CookieStore
     #
     # This cookie-based session store is the Rails default. It is
     # dramatically faster than the alternatives.

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -26,7 +26,7 @@ module ActionDispatch
     end
   end
 
-  # = ActionDispatch \FileHandler
+  # = Action Dispatch \FileHandler
   #
   # This endpoint serves static files from disk using +Rack::Files+.
   #


### PR DESCRIPTION
Headings should use the name of library instead of the namespace.