### PR TITLE
Add after_discard method to ActiveJob

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Add `after_discard` method
+
+    This method lets job authors define a block which will be run when a job is about to be discarded. For example:
+
+    ```ruby
+      class AfterDiscardJob < ActiveJob::Base
+        after_discard do |job, exception|
+          Rails.logger.info("#{job.class} raised an exception: #{exception}")
+        end
+
+        def perform
+          raise StandardError
+        end
+      end
+    ```
+
+    The above job will run the block passed to `after_discard` after the job is discarded. The exception will
+    still be raised after the block has been run.
+
+    *Rob Cardy*
+
 *   Allow queue adapters to provide a custom name by implementing `queue_adapter_name`
 
     *Sander Verdonschot*

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -9,6 +9,7 @@ module ActiveJob
 
     included do
       class_attribute :retry_jitter, instance_accessor: false, instance_predicate: false, default: 0.0
+      class_attribute :after_discard_procs, default: []
     end
 
     module ClassMethods
@@ -65,8 +66,10 @@ module ActiveJob
               instrument :retry_stopped, error: error do
                 yield self, error
               end
+              run_after_discard_procs(error)
             else
               instrument :retry_stopped, error: error
+              run_after_discard_procs(error)
               raise error
             end
           end
@@ -95,8 +98,25 @@ module ActiveJob
         rescue_from(*exceptions) do |error|
           instrument :discard, error: error do
             yield self, error if block_given?
+            run_after_discard_procs(error)
           end
         end
+      end
+
+      # A block to run when a job is about to be discarded for any reason.
+      #
+      # ==== Example
+      #
+      #  class WorkJob < ActiveJob::Base
+      #    after_discard do |job, exception|
+      #      ExceptionNotifier.report(exception)
+      #    end
+      #
+      #    ...
+      #
+      #  end
+      def after_discard(&blk)
+        self.after_discard_procs += [blk]
       end
     end
 
@@ -163,6 +183,16 @@ module ActiveJob
           # Guard against jobs that were persisted before we started having individual executions counters per retry_on
           executions
         end
+      end
+
+      def run_after_discard_procs(exception)
+        exceptions = []
+        after_discard_procs.each do |blk|
+          instance_exec(self, exception, &blk)
+        rescue StandardError => e
+          exceptions << e
+        end
+        raise exceptions.last unless exceptions.empty?
       end
   end
 end

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -45,7 +45,11 @@ module ActiveJob
 
       _perform_job
     rescue Exception => exception
-      rescue_with_handler(exception) || raise
+      handled = rescue_with_handler(exception)
+      return handled if handled
+
+      run_after_discard_procs(exception)
+      raise
     end
 
     def perform(*)

--- a/activejob/test/jobs/after_discard_retry_job.rb
+++ b/activejob/test/jobs/after_discard_retry_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../support/job_buffer"
+require "active_support/core_ext/integer/inflections"
+
+class AfterDiscardRetryJob < ActiveJob::Base
+  class UnhandledError < StandardError; end
+  class DefaultsError < StandardError; end
+  class CustomCatchError < StandardError; end
+  class DiscardableError < StandardError; end
+  class CustomDiscardableError < StandardError; end
+  class AfterDiscardError < StandardError; end
+  class ChildAfterDiscardError < AfterDiscardError; end
+
+  retry_on DefaultsError
+  retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
+  retry_on(AfterDiscardError)
+  retry_on(ChildAfterDiscardError)
+
+  discard_on DiscardableError
+  discard_on(CustomDiscardableError) { |_job, error| JobBuffer.add("Dealt with a job that was discarded in a custom way. Message: #{error.message}") }
+
+  after_discard { |_job, error| JobBuffer.add("Ran after_discard for job. Message: #{error.message}") }
+
+  def perform(raising, attempts)
+    if executions < attempts
+      JobBuffer.add("Raised #{raising} for the #{executions.ordinalize} time")
+      raise raising.constantize
+    else
+      JobBuffer.add("Successfully completed job")
+    end
+  end
+end


### PR DESCRIPTION
`after_discard` lets job authors define a block which will be run when a job is about to be discarded.

This has utility for both job authors and for gems/modules included on jobs, which can use this method to run a block when a job fails.

`after_discard` respects the existing retry behaviour of jobs, but will run even if a retried exception is handled in a block passed to `retry_on` or `discard_on`.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`after_discard` has been used in Shopify's monolith for many years. Developers take advantage of it to define cleanup and failure handling code, and features have been built that rely on it for tracking job failures.

While other parts of ActiveJob's current exception handling system get close to this behaviour, I believe that there is value in having a clearly defined way to run a block of code when a job has failed.

### Detail

This Pull Request changes no existing behaviour, but adds `after_discard`.

`after_discard` is called in any situation where the job is about to be discarded due to a failure. Those cases are:

- When an exception is being raised by the job without `retry_on` or `discard_on` used
- When an exception is handled by `discard_on` (with or without a block)
- When an exception is handled by `retry_on` (with or without a block), but only after the job has run out of retries for that exception
- If multiple exceptions are raised when running the `after_discard` blocks, then only the last exception will be raised. This behaviour ensures that all blocks will be run despite exceptions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
