### PR TITLE
Add load hook for `ActiveRecord::ConnectionAdapters::Mysql2Adapter`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add a load hook for `ActiveRecord::ConnectionAdapters::Mysql2Adapter`
+    (named `active_record_mysql2adapter`) to allow for overriding aspects of the
+    `ActiveRecord::ConnectionAdapters::Mysql2Adapter` class. This makes `Mysql2Adapter`
+    consistent with `PostgreSQLAdapter` and `SQLite3Adapter` that already have load hooks.
+
+    *fatkodima*
+
 *   Introduce adapter for Trilogy database client
 
     Trilogy is a MySQL-compatible database client. Rails applications can use Trilogy

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -179,5 +179,6 @@ module ActiveRecord
           false
         end
     end
+    ActiveSupport.run_load_hooks(:active_record_mysql2adapter, Mysql2Adapter)
   end
 end

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1495,6 +1495,9 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveJob::TestCase`                | `active_job_test_case`               |
 | `ActiveRecord::Base`                 | `active_record`                      |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
+| `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |
+| `ActiveRecord::ConnectionAdapters::Mysql2Adapter`        | `active_record_mysql2adapter`        |
+| `ActiveRecord::ConnectionAdapters::SQLite3Adapter`       | `active_record_sqlite3adapter`       |
 | `ActiveStorage::Attachment`          | `active_storage_attachment`          |
 | `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |
 | `ActiveStorage::Blob`                | `active_storage_blob`                |


### PR DESCRIPTION
I wanted to extend postgres and mysql adapters with additional functionality, but only when they are used in the project, so avoiding to manually require it to be able to extend. But noticed, that `Mysql2Adapter` does not have a load hook, compared to `PostgreSQLAdapter` and `SQLite3Adapter`. This PR fixes that.