### PR TITLE
Allow `insert_all`/`upsert_all` to use indexes with columns not in the same order as in `:unique_by`

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -151,8 +151,9 @@ module ActiveRecord
 
         name_or_columns = unique_by || model.primary_key
         match = Array(name_or_columns).map(&:to_s)
+        sorted_match = match.sort
 
-        if index = unique_indexes.find { |i| match.include?(i.name) || i.columns == match }
+        if index = unique_indexes.find { |i| match.include?(i.name) || Array(i.columns).sort == sorted_match }
           index
         elsif match == primary_keys
           unique_by.nil? ? nil : ActiveRecord::ConnectionAdapters::IndexDefinition.new(model.table_name, "#{model.table_name}_primary_key", true, match)

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -219,6 +219,18 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_and_upsert_all_finds_index_with_inverted_unique_by_columns
+    skip unless supports_insert_conflict_target?
+
+    columns = [:author_id, :name]
+    assert ActiveRecord::Base.connection.index_exists?(:books, columns)
+
+    assert_difference "Book.count", +2 do
+      Book.insert_all [{ name: "Remote", author_id: 1 }], unique_by: columns.reverse
+      Book.upsert_all [{ name: "Rework", author_id: 1 }], unique_by: columns.reverse
+    end
+  end
+
   def test_insert_all_and_upsert_all_works_with_composite_primary_keys_when_unique_by_is_provided
     skip unless supports_insert_conflict_target?
 


### PR DESCRIPTION
This is a small UX improvement.

Problem: If a user have a unique index on `(a, b)` columns and uses `Model.insert_all ..., unique_by: [:a, :b]` everything works fine. But then he decides that a unique index on `(b, a)` would be better (because he is able to search on `b` column via index). Now he must update all the uses of this index in all `insert_all`/`upsert_all` call in his code.

The same can be applied to the composite primary keys (see line 157), but is it common to switch columns in primary keys? 