### PR TITLE
Fix header level for ActiveModel::Naming and DelegatedType

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -230,7 +230,7 @@ module ActiveModel
       end
   end
 
-  # == Active \Model \Naming
+  # = Active \Model \Naming
   #
   # Creates a +model_name+ method on your object.
   #

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -3,7 +3,7 @@
 require "active_support/core_ext/string/inquiry"
 
 module ActiveRecord
-  # == Delegated types
+  # = Delegated types
   #
   # Class hierarchies can map to relational database tables in many ways. Active Record, for example, offers
   # purely abstract classes, where the superclass doesn't persist any attributes, and single-table inheritance,


### PR DESCRIPTION
A class should have a h1 instead of a h2.