### PR TITLE
Add a section on unique constraints to the AR PostgreSQL guide

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -10,6 +10,7 @@ After reading this guide, you will know:
 * How to use PostgreSQL's datatypes.
 * How to use UUID primary keys.
 * How to use deferrable foreign keys.
+* How to use unique constraints.
 * How to implement full text search with PostgreSQL.
 * How to back your Active Record models with database views.
 
@@ -599,6 +600,27 @@ end
 ```
 
 By default `:deferrable` is `false` and the constraint is always checked immediately.
+
+Unique Constraint
+-----------------
+
+* [unique constraints](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS)
+
+```ruby
+# db/migrate/20230422225213_create_items.rb
+create_table :items do |t|
+  t.integer :position, null: false
+  t.unique_key [:position], deferrable: :immediate
+end
+```
+
+If you want to change an existing unique index to deferrable, you can use `:using_index` to create deferrable unique constraints.
+
+```ruby
+add_unique_key :items, deferrable: :deferred, using_index: "index_items_on_position"
+```
+
+Like foreign keys, unique constraints can be deferred by setting `:deferrable` to either `:immediate` or `:deferred`. By default, `:deferrable` is `false` and the constraint is always checked immediately.
 
 Full Text Search
 ----------------


### PR DESCRIPTION
I have added documentation for the AR PostgreSQL guide about the recently added `unique constraint`.
As @ghiculescu mentioned in https://github.com/rails/rails/issues/48011, unique constraints are not mentioned in the AR PostgreSQL guide.

Related PR of the feature are the following.
https://github.com/rails/rails/pull/47971
https://github.com/rails/rails/pull/46192