### PR TITLE
Clean up Action Cable documentation headers [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -4,7 +4,7 @@ require "active_support/callbacks"
 
 module ActionCable
   module Channel
-    # = Action Cable Channel Callbacks
+    # = Action Cable \Channel \Callbacks
     #
     # Action Cable Channel provides hooks during the life cycle of a channel subscription.
     # Callbacks allow triggering logic during this cycle. Available callbacks are:

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -15,6 +15,8 @@ module ActionCable
       end
     end
 
+    # = Action Cable \Channel Stub
+    #
     # Stub +stream_from+ to track streams for the channel.
     # Add public aliases for +subscription_confirmation_sent?+ and
     # +subscription_rejected?+.

--- a/actioncable/lib/action_cable/connection/callbacks.rb
+++ b/actioncable/lib/action_cable/connection/callbacks.rb
@@ -4,7 +4,7 @@ require "active_support/callbacks"
 
 module ActionCable
   module Connection
-    # = Action Cable Connection Callbacks
+    # = Action Cable \Connection \Callbacks
     #
     # There are <tt>before_command</tt>, <tt>after_command</tt>, and <tt>around_command</tt> callbacks
     # available to be invoked before, after or around every command received by a client respectively.

--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -3,6 +3,8 @@
 require "active_support/core_ext/module/redefine_method"
 
 module ActionCable
+  # = Action Cable Remote Connections
+  #
   # If you need to disconnect a given connection, you can go through the
   # RemoteConnections. You can find the connections you're looking for by
   # searching for the identifier declared on the connection. For example:
@@ -36,6 +38,8 @@ module ActionCable
     end
 
     private
+      # = Action Cable Remote \Connection
+      #
       # Represents a single remote connection found via <tt>ActionCable.server.remote_connections.where(*)</tt>.
       # Exists solely for the purpose of calling #disconnect on that connection.
       class RemoteConnection

--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -2,7 +2,7 @@
 
 module ActionCable
   module SubscriptionAdapter
-    # == Test adapter for Action Cable
+    # == \Test adapter for Action Cable
     #
     # The test adapter should be used only in testing. Along with
     # ActionCable::TestHelper it makes a great tool to test your Rails application.


### PR DESCRIPTION
Adds missing headers, escapes headers and fixes header levels.