### PR TITLE
Use FileUtils.mkdir_p for ujs log directory

### DIFF
--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -39,7 +39,7 @@ namespace :test do
       listen_host = "localhost"
       listen_port = "4567"
 
-      Dir.mkdir("log")
+      FileUtils.mkdir_p("log")
       pid = File.open("log/test.log", "w") do |f|
         spawn(*%W(rackup test/ujs/config.ru -o #{listen_host} -p #{listen_port} -s puma), out: f, err: f, pgroup: true)
       end


### PR DESCRIPTION
Noticed this when debugging the ujs tests for buildkite locally.

This change ensures that this task can be rerun.

For example:

```
$ mkdir log && ruby -e 'Dir.mkdir("log")'
-e:1:in `mkdir': File exists @ dir_s_mkdir - log (Errno::EEXIST)
        from -e:1:in `<main>'
```

