### PR TITLE
Improve SauceLabs connection handling for CI

### DIFF
--- a/actioncable/karma.conf.js
+++ b/actioncable/karma.conf.js
@@ -22,6 +22,11 @@ const config = {
 }
 
 if (process.env.CI) {
+  if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+    console.log('Make sure the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are set.')
+    process.exit(1)
+  }
+
   config.customLaunchers = {
     sl_chrome: sauce("chrome", 70),
     sl_ff: sauce("firefox", 63),
@@ -36,6 +41,9 @@ if (process.env.CI) {
     testName: "ActionCable JS Client",
     retryLimit: 3,
     build: buildId(),
+    connectOptions: {
+      logfile: 'sauce_connect.log'
+    }
   }
 
   function sauce(browserName, version, platform) {

--- a/actionview/karma.conf.js
+++ b/actionview/karma.conf.js
@@ -28,6 +28,11 @@ const config = {
 }
 
 if (process.env.CI) {
+  if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+    console.log('Make sure the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are set.')
+    process.exit(1)
+  }
+
   config.customLaunchers = {
     sl_chrome: sauce("chrome", "latest", "Windows 10")
   }
@@ -39,6 +44,9 @@ if (process.env.CI) {
     testName: "Rails UJS",
     retryLimit: 3,
     build: buildId(),
+    connectOptions: {
+      logfile: 'sauce_connect.log'
+    }
   }
 
   function sauce(browserName, version, platform) {


### PR DESCRIPTION
When debugging the SauceLabs integration in my local CI environment, I discovered this option for connection logs.

Also, the example from the karma-sauce-launcher recommends adding this check for the environment variables: https://github.com/karma-runner/karma-sauce-launcher/blob/69dcb822a45d29e57297b0eda7af4123ae55aafd/examples/karma.conf-ci.js#L2-L5

Even though we hard code the SauceLabs connection info for CI, that doesn't guarantee it will always be there in the same place, or work.