### PR TITLE
Allow symbols as queue names in activejob test assertions

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -694,6 +694,10 @@ module ActiveJob
 
       def prepare_args_for_assertion(args)
         args.dup.tap do |arguments|
+          if arguments[:queue].is_a?(Symbol)
+            arguments[:queue] = arguments[:queue].to_s
+          end
+
           if arguments[:at].acts_like?(:time)
             at_range = arguments[:at] - 1..arguments[:at] + 1
             arguments[:at] = ->(at) { at_range.cover?(at) }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I noticed inconsistent behavior when using `assert_enqueued_jobs` and `assert_enqueued_with`.
- `assert_enqueued_jobs` and `assert_performed_jobs` allow both `Symbol` and `String` as `queue` names.
- `assert_enqueued_with` and `assert_performed_with` allow `String` as the `queue` name but fails if it's `Symbol`.

### Detail

Example:

```rb
assert_enqueued_with(job: LoggingJob, queue: :default) do
  LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
end
```
Result:
```
Failure:
No enqueued job found with {:job=>LoggingJob, :queue=>:default}

Potential matches: {"job_class"=>"LoggingJob", "job_id"=>"LOGGING-JOB-ID", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>nil, "enqueued_at"=>"2023-04-23T13:53:20.183425000Z", :job=>LoggingJob, :args=>[], :queue=>"default", :priority=>nil, :at=>2023-04-24 12:00:00 +0530}
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
