### PR TITLE
Make Rails cookies RFC6265-compliant with domain: :all

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove leading dot from domains on cookies set with `domain: :all`, to meet RFC6265 requirements
+
+    *Gareth Adams*
+
 *   Include source location in routes extended view.
 
     ```bash

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -470,7 +470,7 @@ module ActionDispatch
             end
 
             options[:domain] = if cookie_domain.present?
-              ".#{cookie_domain}"
+              cookie_domain
             end
           elsif options[:domain].is_a? Array
             # If host matches one of the supplied domains.

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1122,63 +1122,63 @@ class CookiesTest < ActionController::TestCase
   def test_cookie_with_all_domain_option
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_tld
     @request.host = "two.subdomains.nextangle.local"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_australian_style_tld
     @request.host = "nextangle.com.au"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.com.au; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_australian_style_tld_and_two_subdomains
     @request.host = "x.nextangle.com.au"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com.au; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.com.au; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_uk_style_tld
     @request.host = "nextangle.co.uk"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.co.uk; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_two_letter_one_level_tld
     @request.host = "hawth.ca"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.hawth.ca; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=hawth.ca; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_two_letter_one_level_tld_and_subdomain
     @request.host = "x.hawth.ca"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.hawth.ca; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=hawth.ca; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_uk_style_tld_and_two_subdomains
     @request.host = "x.nextangle.co.uk"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.co.uk; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.co.uk; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_host_with_port
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_localhost
@@ -1206,48 +1206,48 @@ class CookiesTest < ActionController::TestCase
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domain
     assert_response :success
-    assert_set_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; domain=nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_and_tld_length
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.com; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_tld_and_tld_length
     @request.host = "two.subdomains.nextangle.local"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_a_non_standard_2_letter_tld
     @request.host = "admin.lvh.me"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.lvh.me; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=lvh.me; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_host_with_port_and_tld_length
     @request.host = "nextangle.local:3000"
     get :set_cookie_with_domain_and_tld
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.nextangle.local; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=nextangle.local; path=/; SameSite=Lax"
   end
 
   def test_cookie_with_all_domain_option_using_longer_tld_length
     @request.host = "x.y.z.t.com"
     get :set_cookie_with_domain_and_longer_tld
     assert_response :success
-    assert_set_cookie_header "user_name=rizwanreza; domain=.y.z.t.com; path=/; SameSite=Lax"
+    assert_set_cookie_header "user_name=rizwanreza; domain=y.z.t.com; path=/; SameSite=Lax"
   end
 
   def test_deleting_cookie_with_all_domain_option_and_tld_length
     request.cookies[:user_name] = "Joe"
     get :delete_cookie_with_domain_and_tld
     assert_response :success
-    assert_set_cookie_header "user_name=; domain=.nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+    assert_set_cookie_header "user_name=; domain=nextangle.com; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_cookie_with_several_preset_domains_using_one_of_these_domains

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -385,7 +385,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   def test_session_store_with_all_domains
     with_test_route_set(domain: :all) do
       get "/set_session_value"
-      assert_match(/domain=\.example\.com/, headers["Set-Cookie"])
+      assert_match(/domain=example\.com/, headers["Set-Cookie"])
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Rails has incorrectly been adding leading dots to cookie domain values in `Set-Cookie` headers when the `domain: :all` option is present.

This leading dot was required in cookies based on [RFC 2965][rfc2965] (October 2000), but [RFC 6265][rfc6265] (April 2011) changed that behaviour, making a leading dot strictly incorrect. Todays browsers aim to conform to RFC6265 with respect to cookies. The `domain: :all` functionality in Rails predates RFC6265.

The new behaviour is that *any* cookie with an explicitly passed domain is sent to all matching subdomains[[ref][mdn]]. For a server to indicate that only the exact origin server should receive the cookie, it should instead pass *no* domain attribute.

Despite the change in behaviour, browser devtools often display a cookie domain with a leading dot to indicate that it is valid for subdomains - this prefixed domain is *not* necessarily the raw value that was passed in the Set-Cookie header. This explains why it's still a common belief among developers that the leading dot is required.

![image](https://user-images.githubusercontent.com/4975/233853934-0b908c49-9868-45e6-ad41-6ef109c7c4b3.png)

RFC6265 standard gives UAs [an algorithm to handle old-style cookie domain parameters][rfc6265-b] (they can drop a leading dot if present), so it's unlikely that this error would ever have had any effect on web browsers.

However, cookies generated this way can't be processed by Ruby's own CGI::Cookie class (<=0.3.5):

```ruby
> CGI::Cookie.new "domain" => ".example.com", "name" => "foo"
ArgumentError: invalid domain: ".example.com"
```

Newer versions of the Ruby CGI library now accommodate the same UA fallback behaviour (dropping the extra dot) but this isn't a justification for it being the right way to set a cookie.

[rfc2965]: https://www.rfc-editor.org/rfc/rfc2965#section-3.2
[rfc6265]: https://www.rfc-editor.org/rfc/rfc6265#section-4.1.1
[rfc6265-b]: https://www.rfc-editor.org/rfc/rfc6265#section-5.2.3
[mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent

### Detail

This Pull Request removes the dot from the cookie's domain property when `:all` is set as the cookie domain.

### Additional information

This issue has been discussed before, in #46578, but was closed because of [a change in `ruby/cgi`](https://github.com/ruby/cgi/pull/29). However as mentioned, the change in `ruby/cgi` doesn't mean that Rails is doing the right thing, only that there's fallback behaviour to handle the wrong thing.

The PR currently only changes the functionality and tests that relate to the `domain: :all` feature, however there are other tests that explicitly pass a domain with a leading dot, and these may need to be changed too. I'm not sure if that should be in the scope of this PR.

Additionally, Rails appears to have separate tests relating to subdomains with and without the leading dot. Since browsers treat these cases identically, they probably don't need separate tests any more - I'm happy to tidy those up here if needed but wanted to focus on one change at a time.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
