### PR TITLE
Return `INCLUDE` columns in PostgreSQL indexes as strings

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -56,7 +56,7 @@ module ActiveRecord
           (name.nil? || self.name == name.to_s) &&
           (unique.nil? || self.unique == unique) &&
           (valid.nil? || self.valid == valid) &&
-          (include.nil? || Array(self.include) == Array(include))
+          (include.nil? || Array(self.include) == Array(include).map(&:to_s))
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -148,7 +148,7 @@ module ActiveRecord
               opclasses: opclasses,
               where: where,
               using: using.to_sym,
-              include: include_columns.map(&:to_sym).presence,
+              include: include_columns.presence,
               comment: comment.presence,
               valid: valid
             )

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -319,7 +319,7 @@ module ActiveRecord
         with_example_table do
           @connection.add_index "ex", %w{ id }, name: "include", include: :number
           index = @connection.indexes("ex").find { |idx| idx.name == "include" }
-          assert_equal [:number], index.include
+          assert_equal ["number"], index.include
         end
       end
 
@@ -327,7 +327,7 @@ module ActiveRecord
         with_example_table do
           @connection.add_index "ex", %w{ id }, name: "include", include: [:number, :data]
           index = @connection.indexes("ex").find { |idx| idx.name == "include" }
-          assert_equal [:number, :data], index.include
+          assert_equal ["number", "data"], index.include
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -775,7 +775,7 @@ class SchemaIndexIncludeColumnsTest < ActiveRecord::PostgreSQLTestCase
   def test_schema_dumps_index_included_columns
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_include_index/).first.strip
     if ActiveRecord::Base.connection.supports_index_include?
-      assert_equal 't.index ["firm_id", "type"], name: "company_include_index", include: [:name, :account_id]', index_definition
+      assert_equal 't.index ["firm_id", "type"], name: "company_include_index", include: ["name", "account_id"]', index_definition
     else
       assert_equal 't.index ["firm_ids", "type"], name: "company_include_index"', index_definition
     end


### PR DESCRIPTION
I was surprised [to find out](https://github.com/gregnavis/active_record_doctor/pull/133/files#diff-e501fa20770a6823a7bddf4e491cb236969113ac77430ec8249cd406ba6eb820R101) an inconsistency between the types of returned values for `columns` and `include` for PostgreSQL `INCLUDE` indexes (introduced in https://github.com/rails/rails/pull/44803). `columns` is always returned as a string or an array of strings, but `include` as an array of symbols.

This PR fixes that.