### PR TITLE
Fix `Marshal.dump` on records that use AR Encryption

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -84,7 +84,7 @@ module ActiveRecord
 
             attribute name do |cast_type|
               ActiveRecord::Encryption::EncryptedAttributeType.new(scheme: attribute_scheme, cast_type: cast_type,
-                                                                    default: -> { columns_hash[name.to_s]&.default })
+                                                                    default: columns_hash[name.to_s]&.default)
             end
 
             preserve_original_encrypted(name) if attribute_scheme.ignore_case?

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -76,9 +76,7 @@ module ActiveRecord
         def decrypt(value)
           with_context do
             unless value.nil?
-              default = @default.call if @default
-
-              if default && default == value
+              if @default && @default == value
                 value
               else
                 encryptor.decrypt(value, **decryption_options)

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -303,6 +303,11 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_equal "<untitled>", book.name
   end
 
+  test "can dump and load records that use encryption" do
+    book = EncryptedBook.create!
+    assert_equal book, Marshal.load(Marshal.dump(book))
+  end
+
   private
     class FailingKeyProvider
       def decryption_key(message) end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/48038

I don't think we need to use a proc here - it doesn't seem like there is any performance benefit in doing so. The default is being read from the `columns_hash`, which will already be loaded in memory. And then the `default` method is just reading a value (or returning nil).

cc @fatkodima @jorgemanrubia 