### PR TITLE
Fix a deprecation in `referential_integrity_test.rb` file

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -126,7 +126,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     SQL
 
     assert_equal 1, result.first["count"], "referential_integrity_test_schema should have 1 foreign key"
-    assert @connection.all_foreign_keys_valid?
+    @connection.check_all_foreign_keys_valid!
   ensure
     @connection.drop_schema "referential_integrity_test_schema", if_exists: true
   end


### PR DESCRIPTION
After merging https://github.com/rails/rails/pull/47990, a deprecation warning appeared in active record tests - https://buildkite.com/rails/rails/builds/95868#0187af98-754c-4452-8393-4a56e29e5ed5/1187-1196

cc @ghiculescu 