### PR TITLE
Consistently raise an `ArgumentError` if the `ActiveSupport::Cache` key is blank

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Consistently raise an `ArgumentError` if the `ActiveSupport::Cache` key is blank.
+
+    *Joshua Young*
+
 *   Deprecate usage of the singleton `ActiveSupport::Deprecation`.
 
     All usage of `ActiveSupport::Deprecation` as a singleton is deprecated, the most common one being

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -783,10 +783,14 @@ module ActiveSupport
           options
         end
 
-        # Expands and namespaces the cache key. May be overridden by
-        # cache stores to do additional normalization.
+        # Expands and namespaces the cache key.
+        # Raises an exception when the key is +nil+ or an empty string.
+        # May be overridden by cache stores to do additional normalization.
         def normalize_key(key, options = nil)
-          namespace_key expanded_key(key), options
+          str_key = expanded_key(key)
+          raise(ArgumentError, "key cannot be blank") if !str_key || str_key.empty?
+
+          namespace_key str_key, options
         end
 
         # Prefix the key with a namespace string:

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -42,18 +42,6 @@ module CacheInstrumentationBehavior
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
-  def test_instrumentation_empty_fetch_multi
-    events = with_instrumentation "read_multi" do
-      @cache.fetch_multi() { |key| key * 2 }
-    end
-
-    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
-    assert_equal :fetch_multi, events[0].payload[:super_operation]
-    assert_equal [], events[0].payload[:key]
-    assert_equal [], events[0].payload[:hits]
-    assert_equal @cache.class.name, events[0].payload[:store]
-  end
-
   def test_read_multi_instrumentation
     key_1 = SecureRandom.uuid
     @cache.write(key_1, SecureRandom.alphanumeric)
@@ -67,17 +55,6 @@ module CacheInstrumentationBehavior
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
     assert_equal [key_2, key_1], events[0].payload[:key]
     assert_equal [key_1], events[0].payload[:hits]
-    assert_equal @cache.class.name, events[0].payload[:store]
-  end
-
-  def test_empty_read_multi_instrumentation
-    events = with_instrumentation "read_multi" do
-      @cache.read_multi()
-    end
-
-    assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
-    assert_equal [], events[0].payload[:key]
-    assert_equal [], events[0].payload[:hits]
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -159,12 +159,6 @@ module CacheStoreBehavior
     end
   end
 
-  def test_read_multi_with_empty_keys_and_a_logger_and_no_namespace
-    cache = lookup_store(namespace: nil)
-    cache.logger = ActiveSupport::Logger.new(nil)
-    assert_equal({}, cache.read_multi)
-  end
-
   def test_fetch_multi
     key = SecureRandom.uuid
     other_key = SecureRandom.uuid
@@ -462,6 +456,22 @@ module CacheStoreBehavior
     key = "case_sensitive_key"
     @cache.write(key, "bar")
     assert_nil @cache.read(key.upcase)
+  end
+
+  def test_blank_key
+    invalid_keys = [nil, "", [], {}]
+    invalid_keys.each do |key|
+      assert_raises(ArgumentError) { @cache.write(key, "bar") }
+      assert_raises(ArgumentError) { @cache.read(key) }
+      assert_raises(ArgumentError) { @cache.delete(key) }
+    end
+
+    valid_keys = ["foo", ["bar"], { foo: "bar" }, 0, 1, InstanceTest.new("foo", 2)]
+    valid_keys.each do |key|
+      assert_nothing_raised { @cache.write(key, "bar") }
+      assert_nothing_raised { @cache.read(key) }
+      assert_nothing_raised { @cache.delete(key) }
+    end
   end
 
   def test_exist

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -164,12 +164,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
-    def test_fetch_multi_without_names
-      assert_not_called(@cache.redis, :mget) do
-        @cache.fetch_multi() { }
-      end
-    end
-
     def test_write_expires_at
       @cache.write "key_with_expires_at", "bar", expires_at: 30.minutes.from_now
       assert @cache.redis.ttl("#{@namespace}:key_with_expires_at") > 0


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, when the expanded cache key is `nil` or `""`:
- An `ArgumentError` is raised in the `mem_cache` store implementation which happens within the client here: https://github.com/petergoldstein/dalli/blob/a2e2951ec8de2ba6fb00bd4e0775f9846f1e99b9/lib/dalli/key_manager.rb#L50-L55.

- A `TypeError` is raised **only for** `nil` in the `redis` store implementation which happens within the client here: https://github.com/redis-rb/redis-client/blob/54f82471ce8b9fb06f03d7b1d4a0710cd58e6524/lib/redis_client/command_builder.rb#L75.

- The `file_store` implementation would error as such:
   <img width="1728" alt="Screenshot 2023-04-24 at 3 32 11 pm" src="https://user-images.githubusercontent.com/54629302/233907970-6b6f9418-65b3-4b19-ae3f-7a22fd9d267e.png">

- The `memory` and `null` stores would succeed with the operation without raising.

This PR ensures that we consistently raise on a blank key for all store implementations.

### Detail

This Pull Request adds a validation step in `ActiveSupport::Cache::Store#normalize_key` to ensure that an `ArgumentError` is consistently raised when the expanded cache key is `nil` or `""` within all methods relying on `#read_entry`, `#write_entry` and `#delete_entry` (`#read`, `#fetch` etc.).

### Additional information

I'm unsure if we should raise on a blank or just a `nil` key. I went with the former seeing as it already happens within one implementation.

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
