### PR TITLE
Escape namespaces in some doc headers [ci-skip]

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AbstractController
-  # = Abstract Controller Callbacks
+  # = Abstract Controller \Callbacks
   #
   # Abstract Controller provides hooks during the life cycle of a controller action.
   # Callbacks allow you to trigger logic during this cycle. Available callbacks are:

--- a/actionview/lib/action_view/helpers/csp_helper.rb
+++ b/actionview/lib/action_view/helpers/csp_helper.rb
@@ -2,9 +2,8 @@
 
 module ActionView
   module Helpers # :nodoc:
+    # = Action View CSP \Helpers
     module CspHelper
-      # = Action View CSP \Helpers
-      #
       # Returns a meta tag "csp-nonce" with the per-session nonce value
       # for allowing inline <script> tags.
       #

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -10,7 +10,7 @@ require "active_support/core_ext/object/with_options"
 
 module ActionView
   module Helpers # :nodoc:
-    # = Action View Date \Helpers
+    # = Action View \Date \Helpers
     #
     # The Date Helper primarily creates select/option tags for different kinds of dates and times or date and time
     # elements. All of the select-type methods share a number of common options that are as follows:

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   module Helpers # :nodoc:
-    # = Action View Rendering \Helpers
+    # = Action View \Rendering \Helpers
     #
     # Implements methods that allow rendering from a view context.
     # In order to use this module, all you need is to implement


### PR DESCRIPTION
Also move the CSP header from a method to the module.