### PR TITLE
Address `DEPRECATION WARNING: all_foreign_keys_valid? is deprecated`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -126,7 +126,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     SQL
 
     assert_equal 1, result.first["count"], "referential_integrity_test_schema should have 1 foreign key"
-    assert @connection.all_foreign_keys_valid?
+    assert @connection.check_all_foreign_keys_valid!
   ensure
     @connection.drop_schema "referential_integrity_test_schema", if_exists: true
   end


### PR DESCRIPTION
### Motivation / Background

This pull request addresses the `DEPRECATION WARNING: all_foreign_keys_valid? is deprecated` warning introduced via #47990 at test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas

### Detail

Here is the deprecation warning addressed by this pull request.

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/referential_integrity_test.rb -n test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas
Using postgresql
Run options: -n test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas --seed 38041

DEPRECATION WARNING: all_foreign_keys_valid? is deprecated and will be removed from Rails 7.2 (called from block (3 levels) in run at /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:102)
/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb:129:in `test_all_foreign_keys_valid_having_foreign_keys_in_multiple_schemas'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:102:in `block (3 levels) in run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:199:in `capture_exceptions'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:97:in `block (2 levels) in run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:296:in `time_it'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:96:in `block in run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:391:in `on_signal'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:247:in `with_info_handler'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest/test.rb:95:in `run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:1051:in `run_one_method'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:365:in `run_one_method'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:352:in `block (2 levels) in run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:351:in `each'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:351:in `block in run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:391:in `on_signal'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:378:in `with_info_handler'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:350:in `run'
  /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in `run'
  /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/test_case.rb:252:in `run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:182:in `block in __run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:182:in `map'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:182:in `__run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:159:in `run'
  /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.17.0/lib/minitest.rb:83:in `block in autorun'
.

Finished in 0.025025s, 39.9607 runs/s, 79.9214 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
