### PR TITLE
Fix `find_or_create_by`/`find_or_create_by!` when used within concurrent transactions

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -215,7 +215,11 @@ module ActiveRecord
     def create_or_find_by(attributes, &block)
       transaction(requires_new: true) { create(attributes, &block) }
     rescue ActiveRecord::RecordNotUnique
-      find_by!(attributes)
+      if connection.transaction_open?
+        where(attributes).lock.find_by!(attributes)
+      else
+        find_by!(attributes)
+      end
     end
 
     # Like #create_or_find_by, but calls
@@ -224,7 +228,11 @@ module ActiveRecord
     def create_or_find_by!(attributes, &block)
       transaction(requires_new: true) { create!(attributes, &block) }
     rescue ActiveRecord::RecordNotUnique
-      find_by!(attributes)
+      if connection.transaction_open?
+        where(attributes).lock.find_by!(attributes)
+      else
+        find_by!(attributes)
+      end
     end
 
     # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/48035 (see there for the problem and investigation)

> Hum, should we only do that if we're inside a transaction?

Yes, this is not needed when outside of the transaction, so updated with that.

There is some nuance with this approach. For PostgreSQL ("read committed" isolation level by default), for example, previously the row read by `find_or_create_by` (when the `find_by` path of the whole method triggers) in the transaction acquired a read lock until the transaction ends, so other transactions can read/update this row. Now, this row is selected with `FOR UPDATE`, so no other transaction can modify it until the end of the transaction holding the lock. Seems like should be a rare problem. 

So, this change is really only needed for MySQL only (when in default isolation mode) or for any transactions with "repeatable read" mode, but it seems dirty to incorporate this knowledge into the `Relation` class.  

cc @byroot