### PR TITLE
Refactor Mysql2Adapter and TrilogyAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Trilogy
+      module DatabaseStatements
+        READ_QUERY = AbstractAdapter.build_read_query_regexp(
+          :desc, :describe, :set, :show, :use
+        ) # :nodoc:
+        private_constant :READ_QUERY
+
+        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
+        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+
+        def select_all(*, **) # :nodoc:
+          result = nil
+          with_raw_connection do |conn|
+            result = super
+            conn.next_result while conn.more_results_exist?
+          end
+          result
+        end
+
+        def write_query?(sql) # :nodoc:
+          !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
+        end
+
+        def explain(arel, binds = [], options = [])
+          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
+          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result  = exec_query(sql, "EXPLAIN", binds)
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
+        end
+
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+
+          result = raw_execute(sql, name, async: async)
+          ActiveRecord::Result.new(result.fields, result.to_a)
+        end
+
+        alias exec_without_stmt exec_query
+
+        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+
+          raw_execute(to_sql(sql, binds), name)
+        end
+
+        def exec_delete(sql, name = nil, binds = [])
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+
+          result = raw_execute(to_sql(sql, binds), name)
+          result.affected_rows
+        end
+
+        alias :exec_update :exec_delete
+
+        def high_precision_current_timestamp
+          HIGH_PRECISION_CURRENT_TIMESTAMP
+        end
+
+        def build_explain_clause(options = [])
+          return "EXPLAIN" if options.empty?
+
+          explain_clause = "EXPLAIN #{options.join(" ").upcase}"
+
+          if analyze_without_explain? && explain_clause.include?("ANALYZE")
+            explain_clause.sub("EXPLAIN ", "")
+          else
+            explain_clause
+          end
+        end
+
+        private
+          def last_inserted_id(result)
+            result.last_insert_id
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -36,7 +36,7 @@ module ActiveRecord
           MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
 
@@ -44,16 +44,14 @@ module ActiveRecord
           ActiveRecord::Result.new(result.fields, result.to_a)
         end
 
-        alias exec_without_stmt exec_query
-
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
+        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
 
           raw_execute(to_sql(sql, binds), name)
         end
 
-        def exec_delete(sql, name = nil, binds = [])
+        def exec_delete(sql, name = nil, binds = []) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
 
@@ -61,7 +59,7 @@ module ActiveRecord
           result.affected_rows
         end
 
-        alias :exec_update :exec_delete
+        alias :exec_update :exec_delete # :nodoc:
 
         def high_precision_current_timestamp
           HIGH_PRECISION_CURRENT_TIMESTAMP

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -5,6 +5,7 @@ require "active_record/connection_adapters/abstract_mysql_adapter"
 gem "trilogy", "~> 2.4"
 require "trilogy"
 
+require "active_record/connection_adapters/trilogy/database_statements"
 require "active_record/connection_adapters/trilogy/lost_connection_exception_translator"
 require "active_record/connection_adapters/trilogy/errors"
 
@@ -37,95 +38,13 @@ module ActiveRecord
   end
   module ConnectionAdapters
     class TrilogyAdapter < AbstractMysqlAdapter
-      module DatabaseStatements
-        READ_QUERY = AbstractAdapter.build_read_query_regexp(
-          :desc, :describe, :set, :show, :use
-        ) # :nodoc:
-        private_constant :READ_QUERY
-
-        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
-        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
-
-        def select_all(*, **) # :nodoc:
-          result = nil
-          with_raw_connection do |conn|
-            result = super
-            conn.next_result while conn.more_results_exist?
-          end
-          result
-        end
-
-        def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
-        rescue ArgumentError # Invalid encoding
-          !READ_QUERY.match?(sql.b)
-        end
-
-        def explain(arel, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
-          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = exec_query(sql, "EXPLAIN", binds)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
-        end
-
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-
-          result = raw_execute(sql, name, async: async)
-          ActiveRecord::Result.new(result.fields, result.to_a)
-        end
-
-        alias exec_without_stmt exec_query
-
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-
-          raw_execute(to_sql(sql, binds), name)
-        end
-
-        def exec_delete(sql, name = nil, binds = [])
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-
-          result = raw_execute(to_sql(sql, binds), name)
-          result.affected_rows
-        end
-
-        alias :exec_update :exec_delete
-
-        def high_precision_current_timestamp
-          HIGH_PRECISION_CURRENT_TIMESTAMP
-        end
-
-        def build_explain_clause(options = [])
-          return "EXPLAIN" if options.empty?
-
-          explain_clause = "EXPLAIN #{options.join(" ").upcase}"
-
-          if analyze_without_explain? && explain_clause.include?("ANALYZE")
-            explain_clause.sub("EXPLAIN ", "")
-          else
-            explain_clause
-          end
-        end
-
-        private
-          def last_inserted_id(result)
-            result.last_insert_id
-          end
-      end
-
       ER_BAD_DB_ERROR = 1049
       ER_DBACCESS_DENIED_ERROR = 1044
       ER_ACCESS_DENIED_ERROR = 1045
 
       ADAPTER_NAME = "Trilogy"
 
-      include DatabaseStatements
+      include Trilogy::DatabaseStatements
 
       SSL_MODES = {
         SSL_MODE_DISABLED: ::Trilogy::SSL_DISABLED,

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -230,28 +230,28 @@ module ActiveRecord
         raw_execute(sql, name, allow_retry: allow_retry)
       end
 
-      def each_hash(result)
-        return to_enum(:each_hash, result) unless block_given?
+      private
+        def each_hash(result)
+          return to_enum(:each_hash, result) unless block_given?
 
-        keys = result.fields.map(&:to_sym)
-        result.rows.each do |row|
-          hash = {}
-          idx = 0
-          row.each do |value|
-            hash[keys[idx]] = value
-            idx += 1
+          keys = result.fields.map(&:to_sym)
+          result.rows.each do |row|
+            hash = {}
+            idx = 0
+            row.each do |value|
+              hash[keys[idx]] = value
+              idx += 1
+            end
+            yield hash
           end
-          yield hash
+
+          nil
         end
 
-        nil
-      end
+        def error_number(exception)
+          exception.error_code if exception.respond_to?(:error_code)
+        end
 
-      def error_number(exception)
-        exception.error_code if exception.respond_to?(:error_code)
-      end
-
-      private
         def connection
           @raw_connection
         end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -319,7 +319,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     exception = Minitest::Mock.new
     exception.expect :error_code, 123
 
-    assert_equal 123, @conn.error_number(exception)
+    assert_equal 123, @conn.send(:error_number, exception)
   end
 
   def assert_raises_with_message(exception, message, &block)


### PR DESCRIPTION
Mostly revolve around stopping to use `#execute` as an internal method as it forces us to expose private parameters that aren't properly documented.

Also do some minor cleanup in the recently merged `TrilogyAdapter` to make it more consistent with other adapters.