### PR TITLE
Fix PostgreSQL timestamp encoder for default timezone on `pg` 1.5.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1096,7 +1096,7 @@ module ActiveRecord
               PG::TextDecoder::TimestampUtc :
               PG::TextDecoder::TimestampWithoutTimeZone
 
-            @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h)
+            @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h.except(:flags))
             @raw_connection.type_map_for_results.add_coder(@timestamp_decoder)
 
             @mapped_default_timezone = default_timezone

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1096,7 +1096,7 @@ module ActiveRecord
               PG::TextDecoder::TimestampUtc :
               PG::TextDecoder::TimestampWithoutTimeZone
 
-            @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h.except(:flags))
+            @timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h.except(:flags))
             @raw_connection.type_map_for_results.add_coder(@timestamp_decoder)
 
             @mapped_default_timezone = default_timezone


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes https://github.com/rails/rails/issues/48049.

### Detail

Thank you to @yahonda for including the `git-bisect` information in the issue, which points to a subtle regression in the `pg` gem around how hash arguments are merged in timestamp encoders:

```ruby
# Before
class TimestampUtc < Timestamp
  def initialize(params={})
    super(params.merge(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC))
  end
end

# After
class TimestampUtc < Timestamp
  def initialize(**kwargs)
    super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **kwargs)
  end
end
```

I believe that the previous value of the `flags` param is overriding the timezone-specific flags when using keyword arguments:

```ruby
@timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h)
```

### Additional information

Would it be better to resolve the regression in `pg` itself?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
