### PR TITLE
tmp:create creates the same dirs that tmp:clear removes

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -651,10 +651,11 @@ The `Rails.root/tmp` directory is, like the *nix /tmp directory, the holding pla
 The `tmp:` namespaced commands will help you clear and create the `Rails.root/tmp` directory:
 
 * `bin/rails tmp:cache:clear` clears `tmp/cache`.
-* `bin/rails tmp:sockets:clear` clears `tmp/sockets`.
 * `bin/rails tmp:screenshots:clear` clears `tmp/screenshots`.
-* `bin/rails tmp:clear` clears all cache, sockets, and screenshot files.
-* `bin/rails tmp:create` creates tmp directories for cache, sockets, and pids.
+* `bin/rails tmp:sockets:clear` clears `tmp/sockets`.
+* `bin/rails tmp:storage:clear` clears `tmp/storage`.
+* `bin/rails tmp:clear` clears all cache, screenshot, sockets, and storage files.
+* `bin/rails tmp:create` creates tmp directories for cache, pids, screenshots, sockets, and storage.
 
 ### Miscellaneous
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `bin/rake tmp:create` now creates tmp/screenshots and tmp/storage directories
+
+    *Jason Karns*
+
 *   Trying to set a config key with the same name of a method now raises:
 
     ```ruby

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -4,10 +4,11 @@ namespace :tmp do
   desc "Clear cache, socket and screenshot files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear, tmp:screenshots:clear)"
   task clear: ["tmp:cache:clear", "tmp:sockets:clear", "tmp:screenshots:clear", "tmp:storage:clear"]
 
-  tmp_dirs = [ "tmp/cache",
-               "tmp/sockets",
+  tmp_dirs = [ "tmp/cache/assets",
                "tmp/pids",
-               "tmp/cache/assets" ]
+               "tmp/screenshots",
+               "tmp/sockets",
+               "tmp/storage" ]
 
   tmp_dirs.each { |d| directory d }
 

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 namespace :tmp do
-  desc "Clear cache, socket and screenshot files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear, tmp:screenshots:clear)"
-  task clear: ["tmp:cache:clear", "tmp:sockets:clear", "tmp:screenshots:clear", "tmp:storage:clear"]
+  desc "Clear cache, screenshot, socket, and storage files from tmp/ (narrow w/ tmp:cache:clear, tmp:screenshots:clear, tmp:sockets:clear, tmp:storage:clear)"
+  task clear: ["tmp:cache:clear", "tmp:screenshots:clear", "tmp:sockets:clear", "tmp:storage:clear"]
 
   tmp_dirs = [ "tmp/cache/assets",
                "tmp/pids",
@@ -12,7 +12,7 @@ namespace :tmp do
 
   tmp_dirs.each { |d| directory d }
 
-  desc "Create tmp directories for cache, sockets, and pids"
+  desc "Create tmp directories for cache, pids, screenshots, sockets, and storage"
   task create: tmp_dirs
 
   namespace :cache do

--- a/railties/test/application/rake/tmp_test.rb
+++ b/railties/test/application/rake/tmp_test.rb
@@ -42,6 +42,20 @@ module ApplicationTests
         FileUtils.remove_dir("#{app_path}/tmp")
         rails "tmp:clear"
       end
+
+      test "tmp:create creates cache, sockets, pids, screenshots, and storage folders" do
+        Dir.chdir(app_path) do
+          FileUtils.remove_dir("#{app_path}/tmp")
+
+          rails "tmp:create"
+
+          assert Dir.exist?("tmp/cache/assets")
+          assert Dir.exist?("tmp/sockets")
+          assert Dir.exist?("tmp/pids")
+          assert Dir.exist?("tmp/screenshots")
+          assert Dir.exist?("tmp/storage")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
After running tmp:clear, tmp:create should ensure the same folders that are cleared are created.

### Motivation / Background

This Pull Request has been created because the current tmp:clear and tmp:create tasks are opposites of each other, but do not currently affect the same directories. `tmp:clear` presently clears cache, sockets, screenshots and storage, but `tmp:create` only creates the directories for cache, sockets, and pids.

Thus there is some incongruency between `tmp:clear` and `tmp:create`. Running `tmp:create`, for instance, does not result in a `tmp/storage/` directory and thus any ActiveStorage tests must create the directory themselves.


### Detail

This Pull Request changes the `tmp:create` rake task to additional ensure screenshots and storage directories are created.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.