### PR TITLE
Active Record: clear query cache automatically when calling `#execute`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     module QueryCache
       class << self
         def included(base) # :nodoc:
-          dirties_query_cache base, :create, :insert, :update, :delete, :truncate, :truncate_tables,
+          dirties_query_cache base, :execute, :create, :insert, :update, :delete, :truncate, :truncate_tables,
             :rollback_to_savepoint, :rollback_db_transaction, :restart_db_transaction, :exec_insert_all
 
           base.set_callback :checkout, :after, :configure_query_cache!
@@ -17,7 +17,7 @@ module ActiveRecord
         def dirties_query_cache(base, *method_names)
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
-              def #{method_name}(*)
+              def #{method_name}(...)
                 ActiveRecord::Base.clear_query_caches_for_current_thread
                 super
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -220,27 +220,6 @@ module ActiveRecord
       # DATABASE STATEMENTS ======================================
       #++
 
-      # Executes the SQL statement in the context of this connection.
-      #
-      # Setting +allow_retry+ to true causes the db to reconnect and retry
-      # executing the SQL statement in case of a connection-related exception.
-      # This option should only be enabled for known idempotent queries.
-      def execute(sql, name = nil, allow_retry: false)
-        sql = transform_query(sql)
-        check_if_write_query(sql)
-
-        mark_transaction_written_if_write(sql)
-
-        log(sql, name) do
-          with_raw_connection(allow_retry: allow_retry) do |conn|
-            sync_timezone_changes(conn)
-            result = conn.query(sql)
-            handle_warnings(sql)
-            result
-          end
-        end
-      end
-
       # Mysql2Adapter doesn't have to free a result after using it, but we use this method
       # to write stuff in an abstract way without concerning ourselves about whether it
       # needs to be explicitly freed or not.
@@ -253,11 +232,11 @@ module ActiveRecord
       end
 
       def begin_db_transaction # :nodoc:
-        internal_execute("BEGIN", "TRANSACTION")
+        internal_execute("BEGIN", "TRANSACTION", allow_retry: true, uses_transaction: false)
       end
 
       def begin_isolated_db_transaction(isolation) # :nodoc:
-        internal_execute "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "TRANSACTION"
+        internal_execute("SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "TRANSACTION", allow_retry: true, uses_transaction: false)
         begin_db_transaction
       end
 
@@ -746,19 +725,6 @@ module ActiveRecord
           end
         end
 
-        def raw_execute(sql, name, async: false, allow_retry: false, uses_transaction: true)
-          mark_transaction_written_if_write(sql)
-
-          log(sql, name, async: async) do
-            with_raw_connection(allow_retry: allow_retry, uses_transaction: uses_transaction) do |conn|
-              sync_timezone_changes(conn)
-              result = conn.query(sql)
-              handle_warnings(sql)
-              result
-            end
-          end
-        end
-
         def handle_warnings(sql)
           return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
@@ -779,12 +745,6 @@ module ActiveRecord
         # Make sure we carry over any changes to ActiveRecord.default_timezone that have been
         # made since we established the connection
         def sync_timezone_changes(raw_connection)
-        end
-
-        def internal_execute(sql, name = "SCHEMA", allow_retry: true, uses_transaction: false)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          raw_execute(sql, name, allow_retry: allow_retry, uses_transaction: uses_transaction)
         end
 
         # See https://dev.mysql.com/doc/mysql-errors/en/server-error-reference.html

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         end
 
         def query(sql, name = nil) # :nodoc:
-          execute(sql, name).to_a
+          raw_execute(sql, name).to_a
         end
 
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
@@ -167,6 +167,17 @@ module ActiveRecord
 
           def max_allowed_packet
             @max_allowed_packet ||= show_variable("max_allowed_packet")
+          end
+
+          def raw_execute(sql, name, async: false, allow_retry: false, uses_transaction: true)
+            log(sql, name, async: async) do
+              with_raw_connection(allow_retry: allow_retry, uses_transaction: uses_transaction) do |conn|
+                sync_timezone_changes(conn)
+                result = conn.query(sql)
+                handle_warnings(sql)
+                result
+              end
+            end
           end
 
           def exec_stmt_and_free(sql, name, binds, cache_stmt: false, async: false)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -18,10 +18,6 @@ module ActiveRecord
           result
         end
 
-        def query(sql, name = nil) # :nodoc:
-          raw_execute(sql, name).to_a
-        end
-
         READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
           :desc, :describe, :set, :show, :use
         ) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -864,8 +864,8 @@ module ActiveRecord
           stmt_key = prepare_statement(sql, binds)
           type_casted_binds = type_casted_binds(binds)
 
-          log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
-            with_raw_connection do |conn|
+          with_raw_connection do |conn|
+            log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
               conn.exec_prepared(stmt_key, type_casted_binds)
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -691,7 +691,7 @@ module ActiveRecord
         def configure_connection
           @raw_connection.busy_timeout(self.class.type_cast_config_to_integer(@config[:timeout])) if @config[:timeout]
 
-          execute("PRAGMA foreign_keys = ON", "SCHEMA")
+          raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
         end
     end
     ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, SQLite3Adapter)

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -142,13 +142,6 @@ module ActiveRecord
         end
       end
 
-      def execute(sql, name = nil, allow_retry: false)
-        sql = transform_query(sql)
-        check_if_write_query(sql)
-
-        raw_execute(sql, name, allow_retry: allow_retry)
-      end
-
       private
         def each_hash(result)
           return to_enum(:each_hash, result) unless block_given?

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -745,7 +745,7 @@ module ActiveRecord
             connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
             sleep 0.05
           when "Mysql2", "Trilogy"
-            connection.send(:internal_execute, "set @@wait_timeout=1")
+            connection.send(:internal_execute, "set @@wait_timeout=1", uses_transaction: false)
             sleep 1.2
           else
             skip("remote_disconnect unsupported")

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -40,6 +40,22 @@ class QueryCacheTest < ActiveRecord::TestCase
     super
   end
 
+  def test_execute_clear_cache
+    assert_cache :off
+
+    mw = middleware { |env|
+      Post.first
+      query_cache = ActiveRecord::Base.connection.query_cache
+      assert_equal 1, query_cache.length, query_cache.keys
+      Post.connection.execute("SELECT 1")
+      query_cache = ActiveRecord::Base.connection.query_cache
+      assert_equal 0, query_cache.length, query_cache.keys
+    }
+    mw.call({})
+
+    assert_cache :off
+  end
+
   def test_writes_should_always_clear_cache
     assert_cache :off
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/44005

Also refactor #execute to be defined in AbstractAdapter.

`#exec_query` would need a similar refactoring, but this one is big enough already, so I'll do that in a followup.