### PR TITLE
Only flatten first level to preserve nested

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -194,7 +194,7 @@ module Enumerable
   # If the +series+ include keys that have no corresponding element in the Enumerable, these are ignored.
   # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
-    group_by(&key).values_at(*series).flatten.compact
+    group_by(&key).values_at(*series).flatten(1).compact
   end
 
   # Returns the sole item in the enumerable. If there are no items, or more

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -380,6 +380,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [ Payment.new(1), Payment.new(5), Payment.new(5) ], values.in_order_of(:price, [ 1, 5 ])
   end
 
+  def test_in_order_of_preserves_nested_elements
+    values = [[:paid, { price: 1, currency: :eur }], [:opened, { price: 2, currency: :usd }]]
+    assert_equal [[:opened, { price: 2, currency: :usd }], [:paid, { price: 1, currency: :eur }]], values.in_order_of(:first, [:opened, :paid])
+  end
+
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 


### PR DESCRIPTION
### Motivation / Background

I just tried edge Rails to see what breaks in my app, and this was the first thing that broke 😅

I have a hash of hashes for which I use in_order_of, and since this change I don't get ordered array of hashes, but I get a longer array of flattened values.

The actual object:
```
{:closed=>{:value=>0, :status=>"Closed"},
 :opened=>{:value=>1, :status=>"Opened"},
 :temporarily_closed=>{:value=>2, :status=>"Temporarily closed"},
 :recommended=>{:value=>3, :status=>"Recommended"},
 :declined=>{:value=>4, :status=>"Declined"},
 :submitted=>{:value=>5, :status=>"Submitted"},
 :invited=>{:value=>6, :status=>"Invited"}}
```

Before:
```
irb(main):001:0> Cafe.symbolized_status_map.in_order_of(:first, [:opened, :submitted, :recommended, :invited, :temporarily_closed, :closed, :decline
d])
[[:opened, {:value=>1, :status=>"Opened"}],
 [:submitted, {:value=>5, :status=>"Submitted"}],
 [:recommended, {:value=>3, :status=>"Recommended"}],
 [:invited, {:value=>6, :status=>"Invited"}],
 [:temporarily_closed, {:value=>2, :status=>"Temporarily closed"}],
 [:closed, {:value=>0, :status=>"Closed"}],
 [:declined, {:value=>4, :status=>"Declined"}]]
```

Currently:
```
irb(main):001:0> Cafe.symbolized_status_map.in_order_of(:first, [:opened, :submitted, :recommended, :invited, :temporarily_closed, :closed, :decline
d])
=>
[:opened,
 {:value=>1, :status=>"Opened"},
 :submitted,
 {:value=>5, :status=>"Submitted"},
 :recommended,
 {:value=>3, :status=>"Recommended"},
 :invited,
 {:value=>6, :status=>"Invited"},
 :temporarily_closed,
 {:value=>2, :status=>"Temporarily closed"},
 :closed,
 {:value=>0, :status=>"Closed"},
 :declined,
 {:value=>4, :status=>"Declined"}]
 ```

And it broke, because I'm using it like so:
```
<% Cafe.symbolized_status_map.in_order_of(:first, [:opened, :submitted, :recommended, :invited, :temporarily_closed, :closed, :declined]).each do |sym, info| %>
```
and now of course the `info` is `nil` 😅 

This PR fixes it so the behavior stays the same.

### Detail

This Pull Request ~changes~ improves the implementation of #47805.

### Additional information

[Asked if this is intended behavior or a broken thing on Discord, and got instructed to open a PR](https://discord.com/channels/849034466856665118/974005005768069211/1100427123136659557) so here we are 😄

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
