### PR TITLE
Disallow assertionless tests in Active Model

### DIFF
--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -145,10 +145,16 @@ module ActiveModel
     end
 
     test "duping does not eagerly type cast if we have not yet type cast" do
-      @type.define_singleton_method(:deserialize) { flunk }
-      attribute = Attribute.from_database(nil, "a value", @type)
+      deserialize_called = false
+      deserialize_called_with = nil
+      @type.define_singleton_method(:deserialize) do |value|
+        deserialize_called_with = value
+        deserialize_called = true
+      end
+      attribute = Attribute.from_database(nil, "my_attribute_value", @type)
 
       attribute.dup
+      assert_not deserialize_called, "deserialize should not have been called, but was called with #{deserialize_called_with}"
     end
 
     class MyType

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -16,6 +16,14 @@ require "active_support/core_ext/integer/time"
 class ActiveModel::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
+  class AssertionlessTest < StandardError; end
+
+  def after_teardown
+    super
+
+    raise AssertionlessTest, "No assertions made." if passed? && assertions.zero?
+  end
+
   private
     # Skips the current run on JRuby using Minitest::Assertions#skip
     def jruby_skip(message = "")


### PR DESCRIPTION
This PR does two things: cosmetically tweaks one of the tests to perform an explicit assertion along with disallowing assertionless tests in the `activemodel` test suite. Let me know if you'd prefer seeing these changes as separate commits/PRs.

### The attributes test

Currently the `"duping does not eagerly type cast if we have not yet type cast"` works perfectly fine from a technical point of view as it fails if the underlying logic violations our expectation. However the way it fails is misleading as instead of failing with a meaningful message it fails with an argument error. 

Let's have an example, if we intentionally make the test fail by explicitly loading the value:

```diff
    test "duping does not eagerly type cast if we have not yet type cast" do
      @type.define_singleton_method(:deserialize) { flunk }
      attribute = Attribute.from_database(nil, "a value", @type)
+    attribute.value # intentionally fails the test
    end
```

It fails with 
```
ArgumentError: wrong number of arguments (given 1, expected 0)
    /workspaces/rails/activemodel/test/cases/attribute_test.rb:148
```

which is good to catch the issue but the message is really confusing and doesn't help with understanding the failure.
The `ArgumentError` happens because we overrode the `deserialize` 
https://github.com/rails/rails/blob/2fa766d9bc9da5087b76b153423ac99d3156aaa9/activemodel/test/cases/attribute_test.rb#L148

while forgetting that the original method takes `value` argument:
https://github.com/rails/rails/blob/2fa766d9bc9da5087b76b153423ac99d3156aaa9/activemodel/lib/active_model/type/value.rb#L43

The smallest improvement we can make here is to make sure the newly defined method accepts `value`:
`@type.define_singleton_method(:deserialize) { |_value| flunk }`

Which moves us forward but still produces a confusing error, this time `flunk` being unavailable in the context of the `Attribute`:

```
NameError: undefined local variable or method `flunk' for #<ActiveModel::AttributeTest::InscribingType:0x00007f5ed0cf1378>
```
which makes sense as the block gets executed in scope of an attribute object and not within the test context.

So we end up extending the test to make sure it 1) performs an actual assertions which by implication means it increments the assertions counter and 2) it produces a meaningful error message in case of a failure

So now in case of a failure the test fails with the following error:
```
Failure:
ActiveModel::AttributeTest#test_duping_does_not_eagerly_type_cast_if_we_have_not_yet_type_cast [/workspaces/rails/activemodel/test/cases/attribute_test.rb:157]:
deserialize should not have been called, but called with my_attribute_value
``` 

which is self descriptive and understandable within the test context. In addition to that I would argue that despite of the test becoming more verbose it only improve readability and makes it easy to realize what the test is asserting for.

### The assertionless tests exception

We are adding an `after_teardown` logic to the `activemodel` test suite which ensures that performed test incremented the `assertions` counter at least once. Otherwise it raises an `AssertionlessTest` error.

We chose `after_teardown` as one of the latest places that gets called after a test run to make sure we allow for all assertions to be accounted including the ones performed in a `teardown {}` block. 

This leads to a requirement for tests to be verbose about assertions even if technically it may not be needed. For example a test like:
```ruby
def test_submitting_a_review_doesnt_raise
  review.submit!
end
```
will now fail with `ActiveModel::TestCase::AssertionlessTest: test_submitting_a_review_doesnt_raise performs no assertions.` (the message could and most likely should be improved to provide some guidance on how to action on it)

and will have to at least become

```ruby
def test_submitting_a_review_doesnt_raise
  assert_nothing_raised { review.submit! }
end
```

or preferably it should perform a semantically meaningful assertion that will imply not exception being raised, for example:

```ruby
def test_submitting_a_review_populates_submitted_at
  review.submit!

  assert_not_nil review.submitted_at
end
```

As an ultimate fallback, in case of a very specific case that doesn't have any suitable way of performing an assertion we can fallback to using [pass](https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-pass) to increment assertions:

```ruby
def test_stuff
  ... # test body
   # we can consider this test passed as long as we reach the line below
   pass
end
```


Overall while the requirement is being defensive it improves readability of the tests along with ensuring we will never end up having tests that test nothing. To support the statement I'll list a few tests that were either improved, fixed or removed from Rails test suite that were doing nothing but were found using the assertionless check:
https://github.com/rails/rails/pull/44442
https://github.com/rails/rails/pull/44365
https://github.com/rails/rails/pull/44347
https://github.com/rails/rails/pull/44345
https://github.com/rails/rails/pull/44342


### Long term plans

Long-term we expect the assertions check to live in `ActiveSupport::TestCase` but we can't immediately put it there as  other Rails frameworks still have at least cosmetically  "assertionless" tests and we will address these on per-framework basis starting from Active Model
