### PR TITLE
Remove noise from actionmailer callbacks test

### DIFF
--- a/actionmailer/test/callbacks_test.rb
+++ b/actionmailer/test/callbacks_test.rb
@@ -2,9 +2,11 @@
 
 require "abstract_unit"
 require "mailers/callback_mailer"
+require "active_support/testing/stream"
 
 class ActionMailerCallbacksTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
+  include ActiveSupport::Testing::Stream
 
   setup do
     @previous_delivery_method = ActionMailer::Base.delivery_method
@@ -53,7 +55,11 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
   end
 
   test "deliver_later should call after_deliver callback and can access sent message" do
-    perform_enqueued_jobs { CallbackMailer.test_message.deliver_later }
+    perform_enqueued_jobs do
+      silence_stream($stdout) do
+        CallbackMailer.test_message.deliver_later
+      end
+    end
     assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
     assert_not_empty CallbackMailer.after_deliver_instance.message.message_id
   end


### PR DESCRIPTION
This PR removes the noise in the tests below

```
bin/test test/callbacks_test.rb

# Running:

.....[ActiveJob] [ActionMailer::MailDeliveryJob] [9388b095-a5f6-4a34-a0d8-9c87d89f1c1e] Performing ActionMailer::MailDeliveryJob (Job ID: 9388b095-a5f6-4a34-a0d8-9c87d89f1c1e) from Test(mailers) enqueued at 2023-04-26T14:46:50.506852000Z with arguments: "CallbackMailer", "test_message", "deliver_now", {:args=>[]}
[ActiveJob] [ActionMailer::MailDeliveryJob] [9388b095-a5f6-4a34-a0d8-9c87d89f1c1e] Performed ActionMailer::MailDeliveryJob (Job ID: 9388b095-a5f6-4a34-a0d8-9c87d89f1c1e) from Test(mailers) in 1.22ms
[ActiveJob] Enqueued ActionMailer::MailDeliveryJob (Job ID: 9388b095-a5f6-4a34-a0d8-9c87d89f1c1e) to Test(mailers) with arguments: "CallbackMailer", "test_message", "deliver_now", {:args=>[]}
.

Finished in 0.110022s, 54.5345 runs/s, 136.3364 assertions/s.
6 runs, 15 assertions, 0 failures, 0 errors, 0 skips
```