### PR TITLE
Add system tests screenshots rotation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActionDispatch::SystemTesting.rotate_screenshots` to automatically delete old failure screenshots.
+
+    *Vladimir Dementyev*
+
 *   Remove leading dot from domains on cookies set with `domain: :all`, to meet RFC6265 requirements
 
     *Gareth Adams*


### PR DESCRIPTION
### Motivation / Background

The `tmp/screenshots` (or `Capybara.save_path`) folder can grow pretty quickly, especially when you try to debug/profile/de-flaky system tests. The life a screenshot (or HTML snapshot) is short: we either check it right after the failure or don't pay attention to it at all. Thus, it makes sense to automatically clean up older screenshots to keep the folder's size under control and don't waste local disk space.

### Detail

This Pull Request introduces a new method, `ActionDispatch::SystemTesting.rotate_screenshots(ttl: Numeric)`, to trigger the rotation.

### Additional information

Current implementation is not automatic. The main reason why we can not invoke this method right on the module load (like we do with the `.start_application`) is that it relies on the `Capybara.save_path` value that may be configured after we loaded the system testing code.

I think, making this feature ON by default makes sense, and I see two ways to proceed:

1) Just add the `ActionDispatch::SystemTesting.rotate_screenshots` line to the generated `test_helper.rb` and encourage developers to update their existing applications to add this line.

2) Consider introducing a _before suite hook_ (as a separate feature, similar to RSpec's `config.before(:suite)`), and use it to handle screenshots rotation. Suggested API: `ActiveSupport::Testing.run_before_suite(&block)`. I think, we can put the execution of these hooks into the `testing/autorun` file (or, maybe, there is a better option?).

I like option 2, but that would require some amount of work/time. Probably, we can start with 1) for 7.1 and think about further improvements for the next release.

/cc @eileencodes 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
