### PR TITLE
Fix flaky test in AR - token_for_test

### DIFF
--- a/activerecord/test/cases/token_for_test.rb
+++ b/activerecord/test/cases/token_for_test.rb
@@ -104,7 +104,7 @@ class TokenForTest < ActiveRecord::TestCase
   test "supports JSON-serializable embedded data" do
     snapshot_token = @user.generate_token_for(:snapshot)
     assert_equal @user, User.find_by_token_for(:snapshot, snapshot_token)
-    @user.touch
+    @user.touch(time: @user.updated_at.advance(seconds: 1))
     assert_nil User.find_by_token_for(:snapshot, snapshot_token)
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

While running tests for active record, I noticed that this test was flaky. https://github.com/rails/rails/blob/f457544f445fc7b0a4d270bcc6428e528bcbd8cf/activerecord/test/cases/token_for_test.rb#L104-L109

The test runs fine if it's run independently but fails sometimes when we run tests for the whole `token_for_test.rb` file.
### Detail

Below is the error log:
```shell
bin/test test/cases/token_for_test.rb
Using sqlite3
Run options: --seed 16870

# Running:

.F

Failure:
TokenForTest#test_supports_JSON-serializable_embedded_data [/Users/shivamchahar/Work/OSS/rails/activerecord/test/cases/token_for_test.rb:109]:
Expected #<TokenForTest::User id: 1, token: "hhf1YhAHBmBRjuKTrrK1mJi4", auth_token: "WoST7xyDYXLP3yzu1xAvCbz7GkaB4uQ9UoCD", password_digest: "$2a$4$xxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyy...", recovery_password_digest: nil, created_at: "2023-04-28 03:13:47.062098000 +0000", updated_at: "2023-04-28 03:13:47.062709000 +0000"> to be nil.


bin/test test/cases/token_for_test.rb:104

...............
```

To confirm this flaky behavior, I wrote a small script and executed it in irb. Make sure you're inside the `activerecord` directory before you execute this:

```ruby
times_failed = 0
20.times do
  times_failed += 1 if `bin/test test/cases/token_for_test.rb`.include?("Failure")
end

p times_failed
```

### Before the fix
`times_failed` will be greater than 0 most of the time.

### After the fix
`times_failed` will always be 0


### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
