### PR TITLE
Document ActiveModel::Dirty dispatch targets [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -175,22 +175,22 @@ module ActiveModel
     end
 
     # Dispatch target for <tt>*_changed?</tt> attribute methods.
-    def attribute_changed?(attr_name, **options) # :nodoc:
+    def attribute_changed?(attr_name, **options)
       mutations_from_database.changed?(attr_name.to_s, **options)
     end
 
     # Dispatch target for <tt>*_was</tt> attribute methods.
-    def attribute_was(attr_name) # :nodoc:
+    def attribute_was(attr_name)
       mutations_from_database.original_value(attr_name.to_s)
     end
 
     # Dispatch target for <tt>*_previously_changed?</tt> attribute methods.
-    def attribute_previously_changed?(attr_name, **options) # :nodoc:
+    def attribute_previously_changed?(attr_name, **options)
       mutations_before_last_save.changed?(attr_name.to_s, **options)
     end
 
     # Dispatch target for <tt>*_previously_was</tt> attribute methods.
-    def attribute_previously_was(attr_name) # :nodoc:
+    def attribute_previously_was(attr_name)
       mutations_before_last_save.original_value(attr_name.to_s)
     end
 


### PR DESCRIPTION
### Motivation / Background

As part of my Railsconf talk I mentioned that attribute_changed? was an undocumented method. Sage was surprised by this, and suggested that we should probably be documenting this, since *_changed? methods are part of the public API of Active Model.

I discussed this further with Rafael at Railsconf and we believe that in addition to attribute_changed?, we should probably be documenting the other dispatch targets in ActiveModel::Dirty as well.

cc @sgrif @rafaelfranca 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
