### PR TITLE
In older migrations, allow column collation to be explicitly specified

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -122,7 +122,7 @@ module ActiveRecord
         def change_column(table_name, column_name, type, **options)
           options[:_skip_validate_options] = true
           if connection.adapter_name == "Mysql2" || connection.adapter_name == "Trilogy"
-            options[:collation] = :no_collation
+            options[:collation] ||= :no_collation
           end
           super
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

#46127 sought to address an issue in which older migrations without an explicit `collation` option specified would break.

However, it addressed the issue by unconditionally setting the `:no_collation` option when changing columns in older migrations.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This change allows older migrations to explicitly specify the collation when changing a column and having that option be respected.

We noticed this behavior at GitHub when Trilogy was added to Rails in 5ed3f60 and the mysql2 adapter's collation compatibility behavior was added for Trilogy as well, and with this change we found collation data was missing from generated schema files. Because the collation option was being set with `=` instead of `||=` we had no way of manually fixing the old migrations to explicitly specify the collation.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
