### PR TITLE
Clean up bundler install directions

### DIFF
--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -108,10 +108,9 @@ HTML Guides
 -----------
 
 Before generating the guides, make sure that you have the latest version of
-Bundler installed on your system. You can find the latest Bundler version
-[here](https://rubygems.org/gems/bundler). As of this writing, it's v1.17.1.
+Bundler installed on your system. To install the latest version of Bundler, run `gem install bundler`.
 
-To install the latest version of Bundler, run `gem install bundler`.
+If you already have Bundler installed, you can update with `gem update bundler`.
 
 ### Generation
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the bundler installation information in the guides seems out of date. It had a link to RubyGems to find the latest version, then called out the latest version as of time of writing with a version from 5 years back or so.

It seems to me that linking to RubyGems and calling out a version number that would continuously need to be updated is extraneous information that is not required and might lead to confusion. 

The line following this paragraph informs the user how to install the latest version of bundler. This PR removes the link to RubyGems, the sentence for the latest version at time of writing, and combines 2 sentences in an attempt to make this section a little clearer. 

### Detail

This Pull Request changes one section of a guides docs file. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
