### PR TITLE
Add support to use where with a relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add support for `.where` to `ActiveRecord::Relation`.
+
+    For example:
+
+    ```ruby
+    authors_relation = Author.where("authors.id = posts.author_id")
+
+    Post.where(authors_relation)
+    #=> SELECT "posts".* FROM "posts" WHERE EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id))
+
+    Post.where.not(authors_relation)
+    #=> SELECT "posts".* FROM "posts" WHERE NOT (EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id)))
+    ```
+
+    *Lázaro Nixon*
+
 *   Add support for `Array#intersect?` to `ActiveRecord::Relation`.
 
     `Array#intersect?` is only available on Ruby 3.1 or later.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -918,6 +918,8 @@ module ActiveRecord
     def where(*args)
       if args.empty?
         WhereChain.new(spawn)
+      elsif args.length == 1 && args.first.is_a?(Relation)
+        spawn.where!(args.first)
       elsif args.length == 1 && args.first.blank?
         self
       else
@@ -1510,6 +1512,8 @@ module ActiveRecord
           parts = predicate_builder.build_from_hash(opts) do |table_name|
             lookup_table_klass_from_join_dependencies(table_name)
           end
+        when Relation
+          parts = [opts.reselect(1).arel.exists]
         when Arel::Nodes::Node
           parts = [opts]
         else

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -453,6 +453,16 @@ module ActiveRecord
       assert_equal author_addresses(:david_address), author_address
     end
 
+    def test_where_with_relation_as_argument
+      authors = Author.where("authors.id = posts.author_id")
+
+      Post.where(authors).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_includes     relation, posts(:sti_habtm)
+        assert_not_includes relation, posts(:authorless)
+      end
+    end
+
     def test_where_on_association_with_select_relation
       essay = Essay.where(author: Author.where(name: "David").select(:name)).take
       assert_equal essays(:david_modest_proposal), essay


### PR DESCRIPTION
### Motivation / Background

This PR adds the ability to use `where` with an `ActiveRecord::Relation`. Some people argue about that string condition in the authors_relation not being "rails way", this is why I'm not documenting this feature, I have plans to add a new method, maybe `Author.correlates(:post)` as a second interaction. That said, I think it's a good feature to add because it's a small change with a positive impact.

For example:

```ruby
authors_relation = Author.where("authors.id = posts.author_id")

Post.where(authors_relation)
#=> SELECT "posts".* FROM "posts" WHERE EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id))
Post.where.not(authors_relation)
#=> SELECT "posts".* FROM "posts" WHERE NOT (EXISTS (SELECT 1 FROM "authors" WHERE (authors.id = posts.author_id)))
```

### Detail

https://stackoverflow.com/a/3964770

https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization-with-exists.html

https://discuss.rubyonrails.org/t/proposal-activerecord-support-for-exists-clause/81618/9

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
