### PR TITLE
Raise retryable exception class on abrupt Postgres connection closure

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -739,6 +739,12 @@ module ActiveRecord
           when nil
             if exception.message.match?(/connection is closed/i)
               ConnectionNotEstablished.new(exception)
+            elsif exception.is_a?(PG::UnableToSend)
+              if exception.message.match?(/server closed the connection/i)
+                ConnectionNotEstablished.new(exception)
+              else
+                super
+              end
             elsif exception.is_a?(PG::ConnectionBad)
               # libpq message style always ends with a newline; the pg gem's internal
               # errors do not. We separate these cases because a pg-internal


### PR DESCRIPTION
### Motivation / Background & Details

👋 Hi team! Fresh off RailsConf here. Enjoyed some of the convos with matthewd and figured I'd check out the new connection and query retry feature on rails@main. We have monkey patched ActiveRecord internally to perform query retry and connection retry to recover from failures automatically with Postgres.

While testing, I came across the following issue:

Postgres can at times throw the following error.
```
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```

This can happen during a database crash or a failover, or when connections are intentionally terminated. When this happens, an already checked out ActiveRecord connection would raise `ActiveRecord::StatementInvalid: PG::UnableToSend: server closed the connection unexpectedly`.

Raising an `ActiveRecord::StatementInvalid` means that the query will not get retried, even when `allow_retry` is set to `true` because only `ConnectionNotEstablished` or `ConnectionFailed` are considered for retries (via `retryable_connection_error?`).

Hence, with this change, we will now also throw a `ConnectionNotEstablished` by extending the already existing error message matching for when Postgres is down.


### Additional information


In this PR, we also use `pg_terminate_backend` to recreate the database failover scenario in the test. Which would prompt `pg` gem to throw `PG::UnableToSend: server closed the connection unexpectedly`. Accordingly we retry and recover from the queries.


**Question**: Should this change be logged in CHANGELOG?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
