### PR TITLE
Fix unscope not working when where by tripe dot range

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Fix unscope is not working in specific case
+
+    Before:
+    ```ruby
+    Post.where(id: 1...3).unscope(where: :id).to_sql # "SELECT `posts`.* FROM `posts` WHERE `posts`.`id` >= 1 AND `posts`.`id` < 3"
+
+    ```
+
+    After:
+    ```ruby
+    Post.where(id: 1...3).unscope(where: :id).to_sql # "SELECT `posts`.* FROM `posts`"
+    ```
+
+    Fixes: #48094
+
+    *Kazuya Hatanaka*
+
 *   Allow composite primary key to be derived from schema
 
     Booting an application with a schema that contains composite primary keys

--- a/activerecord/lib/arel/nodes/and.rb
+++ b/activerecord/lib/arel/nodes/and.rb
@@ -18,6 +18,10 @@ module Arel # :nodoc: all
         children[1]
       end
 
+      def fetch_attribute(&block)
+        children.any? && children.all? { |child| child.fetch_attribute(&block) }
+      end
+
       def hash
         children.hash
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2329,6 +2329,20 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal Post.count, posts.unscope(where: :title).count
   end
 
+  def test_unscope_with_double_dot_where
+    posts = Post.where(id: 1..2)
+
+    assert_equal 2, posts.count
+    assert_equal Post.count, posts.unscope(where: :id).count
+  end
+
+  def test_unscope_with_triple_dot_where
+    posts = Post.where(id: 1...3)
+
+    assert_equal 2, posts.count
+    assert_equal Post.count, posts.unscope(where: :id).count
+  end
+
   def test_locked_should_not_build_arel
     posts = Post.locked
     assert_predicate posts, :locked?


### PR DESCRIPTION
### Motivation / Background

Fixes #48094 
`unscope` not working when where by tripe dot range

### Detail

Define `fetch_attribute` to `activerecord/lib/arel/nodes/and.rb`, because unscope uses fetch_attribute to determine whether to exclude predicate or not.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
