### PR TITLE
Document queue_with_priority block arguments and their use [ci skip]

### DIFF
--- a/activejob/lib/active_job/queue_priority.rb
+++ b/activejob/lib/active_job/queue_priority.rb
@@ -18,7 +18,24 @@ module ActiveJob
       #     end
       #   end
       #
-      # Specify either an argument or a block.
+      # Can be given a block that will evaluate in the context of the job
+      # so that a dynamic priority can be applied:
+      #
+      #   class PublishToFeedJob < ApplicationJob
+      #     queue_with_priority do
+      #       post = self.arguments.first
+      #
+      #       if post.paid?
+      #         10
+      #       else
+      #         50
+      #       end
+      #     end
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
       def queue_with_priority(priority = nil, &block)
         if block_given?
           self.priority = block


### PR DESCRIPTION
Currently, we don't document the use case for ActiveJob's `queue_with_priority` block arguments. It seems necessary to document them in the API docs as well considering how useful this option is.