### PR TITLE
Add a picture_tag helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,51 @@
+*   Add support for the HTML picture tag. It supports passing a String, an Array or a Block.
+    Supports passing properties directly to the img tag via the `:image` key.
+    Since the picture tag requires an img tag, the last element you provide will be used for the img tag.
+    For complete control over the picture tag, a block can be passed, which will populate the contents of the tag accordingly.
+
+    Can be used like this for a single source:
+    ```erb
+    <%= picture_tag("picture.webp") %>
+    ```
+    which will generate the following:
+    ```html
+    <picture>
+        <img src="/images/picture.webp" />
+    </picture>
+    ```
+
+    For multiple sources:
+    ```erb
+    <%= picture_tag("picture.webp", "picture.png", :class => "mt-2", :image => { alt: "Image", class: "responsive-img" }) %>
+    ```
+    will generate:
+    ```html
+    <picture class="mt-2">
+        <source srcset="/images/picture.webp" />
+        <source srcset="/images/picture.png" />
+        <img alt="Image" class="responsive-img" src="/images/picture.png" />
+    </picture>
+    ```
+
+    Full control via a block:
+    ```erb
+    <%= picture_tag(:class => "my-class") do %>
+        <%= tag(:source, :srcset => image_path("picture.webp")) %>
+        <%= tag(:source, :srcset => image_path("picture.png")) %>
+        <%= image_tag("picture.png", :alt => "Image") %>
+    <% end %>
+    ```
+    will generate:
+    ```html
+    <picture class="my-class">
+        <source srcset="/images/picture.webp" />
+        <source srcset="/images/picture.png" />
+        <img alt="Image" src="/images/picture.png" />
+    </picture>
+    ```
+
+    *Juan Pablo Balarini*
+
 *   Remove deprecated support to passing instance variables as locals to partials.
 
     *Rafael Mendonça França*

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -247,6 +247,68 @@ class AssetTagHelperTest < ActionView::TestCase
     %(image_tag("rss.gif", srcset: [["pic_640.jpg", "640w"], ["pic_1024.jpg", "1024w"]])) => %(<img srcset="/images/pic_640.jpg 640w, /images/pic_1024.jpg 1024w" src="/images/rss.gif" />)
   }
 
+  PicturePathToTag = {
+    %(image_path("xml"))           => %(/images/xml),
+    %(image_path("xml.webp"))      => %(/images/xml.webp),
+    %(image_path("dir/xml.webp"))  => %(/images/dir/xml.webp),
+    %(image_path("/dir/xml.webp")) => %(/dir/xml.webp)
+  }
+
+  PathToPictureToTag = {
+    %(path_to_image("xml"))           => %(/images/xml),
+    %(path_to_image("xml.webp"))      => %(/images/xml.webp),
+    %(path_to_image("dir/xml.webp"))  => %(/images/dir/xml.webp),
+    %(path_to_image("/dir/xml.webp")) => %(/dir/xml.webp)
+  }
+
+  PictureUrlToTag = {
+    %(image_url("xml"))           => %(http://www.example.com/images/xml),
+    %(image_url("xml.webp"))      => %(http://www.example.com/images/xml.webp),
+    %(image_url("dir/xml.webp"))  => %(http://www.example.com/images/dir/xml.webp),
+    %(image_url("/dir/xml.webp")) => %(http://www.example.com/dir/xml.webp)
+  }
+
+  UrlToPictureToTag = {
+    %(url_to_image("xml"))           => %(http://www.example.com/images/xml),
+    %(url_to_image("xml.webp"))      => %(http://www.example.com/images/xml.webp),
+    %(url_to_image("dir/xml.webp"))  => %(http://www.example.com/images/dir/xml.webp),
+    %(url_to_image("/dir/xml.webp")) => %(http://www.example.com/dir/xml.webp)
+  }
+
+  PictureLinkToTag = {
+    %(picture_tag("picture.webp")) => %(<picture><img src="/images/picture.webp" /></picture>),
+    %(picture_tag("gold.png", :image => { :size => "20" })) => %(<picture><img height="20" src="/images/gold.png" width="20" /></picture>),
+    %(picture_tag("gold.png", :image => { :size => 20 })) => %(<picture><img height="20" src="/images/gold.png" width="20" /></picture>),
+    %(picture_tag("silver.png", :image => { :size => "90.9" })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9" /></picture>),
+    %(picture_tag("silver.png", :image => { :size => 90.9 })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9" /></picture>),
+    %(picture_tag("gold.png", :image => { :size => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45" /></picture>),
+    %(picture_tag("gold.png", :image => { "size" => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45" /></picture>),
+    %(picture_tag("silver.png", :image => { :size => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12" /></picture>),
+    %(picture_tag("silver.png", :image => { "size" => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12" /></picture>),
+    %(picture_tag("bronze.png", :image => { :size => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10" /></picture>),
+    %(picture_tag("bronze.png", :image => { "size" => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10" /></picture>),
+    %(picture_tag("platinum.png", :image => { :size => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9" /></picture>),
+    %(picture_tag("platinum.png", :image => { "size" => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9" /></picture>),
+    %(picture_tag("error.png", :image => { "size" => "45 x 70" })) => %(<picture><img src="/images/error.png" /></picture>),
+    %(picture_tag("error.png", :image => { "size" => "1,024x768" })) => %(<picture><img src="/images/error.png" /></picture>),
+    %(picture_tag("error.png", :image => { "size" => "768x1,024" })) => %(<picture><img src="/images/error.png" /></picture>),
+    %(picture_tag("error.png", :image => { "size" => "x" })) => %(<picture><img src="/images/error.png" /></picture>),
+    %(picture_tag("google.com.png")) => %(<picture><img src="/images/google.com.png" /></picture>),
+    %(picture_tag("slash..png")) => %(<picture><img src="/images/slash..png" /></picture>),
+    %(picture_tag(".pdf.png")) => %(<picture><img src="/images/.pdf.png" /></picture>),
+    %(picture_tag("http://www.rubyonrails.com/images/rails.png")) => %(<picture><img src="http://www.rubyonrails.com/images/rails.png" /></picture>),
+    %(picture_tag("//www.rubyonrails.com/images/rails.png")) => %(<picture><img src="//www.rubyonrails.com/images/rails.png" /></picture>),
+    %(picture_tag("mouse.png", :image => { :alt => nil })) => %(<picture><img src="/images/mouse.png" /></picture>),
+    %(picture_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :image => { :alt => nil })) => %(<picture><img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /></picture>),
+    %(picture_tag("")) => %(<picture><img src="" /></picture>),
+    %(picture_tag("picture.webp", "picture.png")) => %(<picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp", "picture.png", :class => "my-class")) => %(<picture class="my-class"><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag(:class => "my-class") { tag(:source, :srcset => image_path("picture.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture class="my-class"><source srcset="/images/picture.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)" /><source srcset="/images/picture-big.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
+  }
+
   FaviconLinkToTag = {
     %(favicon_link_tag) => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon" />),
     %(favicon_link_tag 'favicon.ico') => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon" />),
@@ -709,6 +771,26 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_preload_link_tag
     PreloadLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_picture_path
+    PicturePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_path_to_picture_alias_for_picture_path
+    PathToPictureToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_picture_url
+    PictureUrlToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_url_to_picture_alias_for_picture_url
+    UrlToPictureToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+  end
+
+  def test_picture_tag
+    PictureLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
 
   def test_video_path


### PR DESCRIPTION
### Motivation / Background

We wanted to use the HTML `<picture>` tag in our website for responsive images (specifically, for art direction) and found that Rails did not have built-in support for it. By introducing the `picture_tag` helper, we can simplify the usage of the `<picture>` element in Rails applications, enabling developers to incorporate responsive images in their projects easily.

The need for a `picture_tag` in Rails led to the creation of [this gem](https://github.com/eagerworks/next_gen_images) and this [RailsConf talk](https://railsconf2023.sessionize.com/session/452773). After presenting the talk, a lot of people told me I should add this feature to Rails, so I'm porting some of the gem's functionality here.

The `picture` tag is a more "robust" version of the `img` tag, because it supports resolution switching, art direction, and image support fallback, so I think we should have it in Rails (the `img` tag only supports resolution switching). More information here:
- [Picture tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
- [Responsive images & picture element](https://webdesign.tutsplus.com/tutorials/quick-tip-how-to-use-html5-picture-for-responsive-images--cms-21015)
- [Responsive images & Art direction](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)

### Detail

This PR adds support for the HTML picture tag. It supports passing one element (String), multiple (an Array), or a Block if you need full control of what it's being generated. All properties that are passed to the helper will apply to the `picture` tag. If you need to pass properties to the `img` tag, you can do it inside the `:image` key. 

Since the `picture` tag requires an `img` tag (contrary to the `audio_tag` or `video_tag`, which only require `source`s), the last element you provide will be used as the source for the `img` tag. For complete control over the picture tag, a block can be passed, which will populate the contents of the tag accordingly.

It can be used like this for a single source:
```erb
<%= picture_tag("picture.webp") %>
```
which will generate the following:
```html
<picture>
    <img src="/images/picture.webp" />
</picture>
```

For multiple sources:
```erb
<%= picture_tag("picture.webp", "picture.png", :class => "mt-2",  :image => { alt: "Image", class: "responsive-img" }) %>
```
will generate:
```html
<picture class="mt-2">
    <source srcset="/images/picture.webp" />
    <source srcset="/images/picture.png" />
    <img alt="Image" class="responsive-img" src="/images/picture.png" />
</picture>
```

Full control via a block:
```erb
<%= picture_tag(:class => "my-class") do %>
    <%= tag(:source, :srcset => image_path("picture.webp")) %>
    <%= tag(:source, :srcset => image_path("picture.png")) %>
    <%= image_tag("picture.png", :alt => "Image") %>
<% end %>
```
will generate:
```html
<picture class="my-class">
    <source srcset="/images/picture.webp" />
    <source srcset="/images/picture.png" />
    <img alt="Image" src="/images/picture.png" />
</picture>
```

### Additional information

Another option would be to be more explicit on the image and sources that are generated (could be more cumbersome).
Something like this:
```
picture_tag("image.jpg", sources: [{ srcset: "image_small.jpg", media: "(min-width: 400px)" }, { srcset: "image_big.jpg" }], alt: "An example image", class: "responsive-image")
```
The issue with this is that we would need a way to specify which properties belong to the `img` tag and which to the `picture` tag itself. I did not go with this approach since I tried to more or less replicate how the `audio_tag`, `video_tag`, and `image_tag` helpers work.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
