### PR TITLE
[Fix #48080] Use `group` over `distinct` in `ActiveRecord::Calculations#ids` with `includes(...).order(...)`

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1049,6 +1049,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal Company.all.map(&:id).sort, Company.all.includes(:contracts).ids.sort
   end
 
+  def test_ids_with_includes_and_non_primary_key_order
+    rating = 1
+    Company.all.each { |company| company.update!(rating: rating += 1) }
+    assert_equal Company.all.sort_by(&:rating).map(&:id), Company.includes(:comments).order(:rating).ids
+  end
+
   def test_ids_with_includes_and_scope
     scoped_ids = [1, 2]
     company = Company.where(id: scoped_ids).first


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix https://github.com/rails/rails/issues/48080.
As mentioned in the issue, a regression was introduced in https://github.com/rails/rails/pull/46503 where `includes(...).order(...)` would error with `#ids` due to a `DISTINCT` that wouldn't contain the ordering columns as required by `postgres` and `mysql`.

From the `PostgreSQL` docs:

<img width="1543" alt="Screenshot 2023-05-01 at 3 16 49 pm" src="https://user-images.githubusercontent.com/54629302/235410227-17f40e1b-afef-482a-8c87-64050c0fe52f.png">

### Detail

This Pull Request changes `ActiveRecord::Calculations#ids` to use `#group` over `#distinct` to avoid having a `DISTINCT` that would be incompatible with the selected columns.

I went with this approach since:
- `group` will give us the same result using the same execution plan (both use `HashAggregate`).
- Including the ordering columns in the `SELECT` is not an option as we want to `SELECT` only the primary key/s for `#ids`.
- The only other alternative I could think of was constructing a subquery for the above which seems overcomplicated and would probably introduce unnecessary overhead.

### Additional information

Not relevant to the issue but https://github.com/rails/rails/pull/46697 is a related follow up PR to the one that introduced the regression.

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
