### PR TITLE
Support `:message_pack` as cookies serializer

### DIFF
--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -82,7 +82,7 @@ module ActionDispatch
 
     def test_from_session_value_on_json_serializer
       decrypted_data = "{ \"session_id\":\"d98bdf6d129618fc2548c354c161cfb5\", \"flash\":{\"discard\":[\"farewell\"], \"flashes\":{\"greeting\":\"Hello\",\"farewell\":\"Goodbye\"}} }"
-      session = ActionDispatch::Cookies::JsonSerializer.load(decrypted_data)
+      session = ActiveSupport::Messages::SerializerWithFallback[:json].load(decrypted_data)
       hash = Flash::FlashHash.from_session_value(session["flash"])
 
       assert_equal({ "greeting" => "Hello" }, hash.to_hash)

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -629,33 +629,13 @@ Refer to the [API documentation](https://api.rubyonrails.org/classes/ActionDispa
 for more details.
 
 These special cookie jars use a serializer to serialize the assigned values into
-strings and deserializes them into Ruby objects on read.
+strings and deserialize them into Ruby objects on read. You can specify which
+serializer to use via [`config.action_dispatch.cookies_serializer`][].
 
-You can specify what serializer to use:
-
-```ruby
-Rails.application.config.action_dispatch.cookies_serializer = :json
-```
-
-The default serializer for new applications is `:json`. For compatibility with
-old applications with existing cookies, `:marshal` is used when `serializer`
-option is not specified.
-
-You may also set this option to `:hybrid`, in which case Rails would transparently
-deserialize existing (`Marshal`-serialized) cookies on read and re-write them in
-the `JSON` format. This is useful for migrating existing applications to the
-`:json` serializer.
-
-It is also possible to pass a custom serializer that responds to `load` and
-`dump`:
-
-```ruby
-Rails.application.config.action_dispatch.cookies_serializer = MyCustomSerializer
-```
-
-When using the `:json` or `:hybrid` serializer, you should beware that not all
-Ruby objects can be serialized as JSON. For example, `Date` and `Time` objects
-will be serialized as strings, and `Hash`es will have their keys stringified.
+The default serializer for new applications is `:json`. Be aware that JSON has
+limited support for roundtripping Ruby objects. For example, `Date`, `Time`, and
+`Symbol` objects (including `Hash` keys) will be serialized and deserialized
+into `String`s:
 
 ```ruby
 class CookiesController < ApplicationController
@@ -670,13 +650,13 @@ class CookiesController < ApplicationController
 end
 ```
 
-It's advisable that you only store simple data (strings and numbers) in cookies.
-If you have to store complex objects, you would need to handle the conversion
-manually when reading the values on subsequent requests.
+If you need to store these or more complex objects, you may need to manually
+convert their values when reading them in subsequent requests.
 
-If you use the cookie session store, this would apply to the `session` and
+If you use the cookie session store, the above applies to the `session` and
 `flash` hash as well.
 
+[`config.action_dispatch.cookies_serializer`]: configuring.html#config-action-dispatch-cookies-serializer
 [`cookies`]: https://api.rubyonrails.org/classes/ActionController/Cookies.html#method-i-cookies
 
 Rendering

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1652,7 +1652,9 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.action_dispatch.cookies_serializer`
 
-Specifies which serializer to use for cookies. For more information, see [Action Controller Cookies](action_controller_overview.html#cookies).
+Specifies which serializer to use for cookies. Accepts the same values as
+[`config.active_support.message_serializer`](#config-active-support-message-serializer),
+plus `:hybrid` which is an alias for `:json_allow_marshal`.
 
 The default value depends on the `config.load_defaults` target version:
 


### PR DESCRIPTION
This commit adds support for `:message_pack` and `:message_pack_allow_marshal` as serializers for `config.action_dispatch.cookies_serializer`, just like `config.active_support.message_serializer`.

The `:message_pack` serializer can fall back to deserializing with `AS::JSON`, and the `:message_pack_allow_marshal` serializer can fall back to deserializing with `AS::JSON` or `Marshal`.  Additionally, the `:marshal`, `:json`, and `:hybrid` / `:json_allow_marshal` serializers can now fall back to deserializing with `AS::MessagePack`.  These behaviors make it easier to migrate between cookies serializers.