### PR TITLE
`Object#deep_dup` no longer duplicate named classes and modules.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   `Object#deep_dup` no longer duplicate named classes and modules.
+
+    Before:
+
+    ```ruby
+    hash = { class: Object, module: Kernel }
+    hash.deep_dup # => {:class=>#<Class:0x00000001063ffc80>, :module=>#<Module:0x00000001063ffa00>}
+    ```
+
+    After:
+
+    ```ruby
+    hash = { class: Object, module: Kernel }
+    hash.deep_dup # => {:class=>Object, :module=>Kernel}
+    ```
+
+    *Jean Boussier*
+
 *   Consistently raise an `ArgumentError` if the `ActiveSupport::Cache` key is blank.
 
     *Joshua Young*

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -53,3 +53,19 @@ class Hash
     hash
   end
 end
+
+class Module
+  # Returns a copy of module or class if it's anonymous. If it's
+  # named, returns +self+.
+  #
+  #   Object.deep_dup == Object # => true
+  #   klass = Class.new
+  #   klass.deep_dup == klass # => false
+  def deep_dup
+    if name.nil?
+      super
+    else
+      self
+    end
+  end
+end

--- a/activesupport/test/core_ext/object/deep_dup_test.rb
+++ b/activesupport/test/core_ext/object/deep_dup_test.rb
@@ -66,4 +66,16 @@ class DeepDupTest < ActiveSupport::TestCase
 
     assert_not_equal hash.keys, dup.keys
   end
+
+  def test_named_modules_arent_duped
+    hash = { class: Object, module: Kernel }
+    assert_equal hash, hash.deep_dup
+  end
+
+  def test_anonymous_modules_are_duped
+    hash = { class: Class.new, module: Module.new }
+    duped_hash = hash.deep_dup
+    assert_not_equal hash[:class], duped_hash[:class]
+    assert_not_equal hash[:module], duped_hash[:module]
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47352

It makes very little sense to duplicate named classes and modules.

Before:

```ruby
hash = { class: Object, module: Kernel }
hash.deep_dup # => {:class=>#<Class:0x00000001063ffc80>, :module=>#<Module:0x00000001063ffa00>}
```

After:

```ruby
hash = { class: Object, module: Kernel }
hash.deep_dup # => {:class=>Object, :module=>Kernel}
```
