### PR TITLE
Improve queue adapter name extraction for logs

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -67,7 +67,8 @@ module ActiveJob
           end
         else
           failed_enqueue_count = jobs.size - enqueued_count
-          "Failed enqueuing #{failed_enqueue_count} #{'job'.pluralize(failed_enqueue_count)} to #{adapter_name(adapter)}"
+          "Failed enqueuing #{failed_enqueue_count} #{'job'.pluralize(failed_enqueue_count)} "\
+            "to #{ActiveJob.adapter_name(adapter)}"
         end
       end
     end
@@ -137,11 +138,7 @@ module ActiveJob
 
     private
       def queue_name(event)
-        adapter_name(event.payload[:adapter]) + "(#{event.payload[:job].queue_name})"
-      end
-
-      def adapter_name(adapter)
-        adapter.class.name.demodulize.delete_suffix("Adapter")
+        ActiveJob.adapter_name(event.payload[:adapter]) + "(#{event.payload[:job].queue_name})"
       end
 
       def args_info(job)
@@ -205,7 +202,7 @@ module ActiveJob
       def enqueued_jobs_message(adapter, enqueued_jobs)
         enqueued_count = enqueued_jobs.size
         job_classes_counts = enqueued_jobs.map(&:class).tally.sort_by { |_k, v| -v }
-        "Enqueued #{enqueued_count} #{'job'.pluralize(enqueued_count)} to #{adapter_name(adapter)}"\
+        "Enqueued #{enqueued_count} #{'job'.pluralize(enqueued_count)} to #{ActiveJob.adapter_name(adapter)}"\
           " (#{job_classes_counts.map { |klass, count| "#{count} #{klass}" }.join(', ')})"
       end
   end

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -3,6 +3,15 @@
 require "active_support/core_ext/string/inflections"
 
 module ActiveJob
+  class << self
+    def adapter_name(adapter) # :nodoc:
+      return adapter.queue_adapter_name if adapter.respond_to?(:queue_adapter_name)
+
+      adapter_class = adapter.is_a?(Module) ? adapter : adapter.class
+      "#{adapter_class.name.demodulize.delete_suffix('Adapter')}"
+    end
+  end
+
   # = Active Job Queue adapter
   #
   # The <tt>ActiveJob::QueueAdapter</tt> module is used to load the
@@ -43,7 +52,7 @@ module ActiveJob
           assign_adapter(name_or_adapter.to_s, queue_adapter)
         else
           if queue_adapter?(name_or_adapter)
-            adapter_name = extract_adapter_name(name_or_adapter)
+            adapter_name = ActiveJob.adapter_name(name_or_adapter).underscore
             assign_adapter(adapter_name, name_or_adapter)
           else
             raise ArgumentError
@@ -61,13 +70,6 @@ module ActiveJob
 
         def queue_adapter?(object)
           QUEUE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
-        end
-
-        def extract_adapter_name(adapter)
-          return adapter.queue_adapter_name if adapter.respond_to?(:queue_adapter_name)
-
-          adapter_class = adapter.is_a?(Module) ? adapter : adapter.class
-          "#{adapter_class.name.demodulize.remove('Adapter').underscore}"
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

We recently made improvements to the name extraction for `MyJob.queue_adapter_name` (see https://github.com/rails/rails/pull/47995 and https://github.com/rails/rails/pull/48003). I had overlooked that we also extract the queue adapter name in a similar (but not identical) way for log messages, so this change aligns the two.

### Detail

This PR fixes the bug described in the first PR, where queue adapters set as `MyJob.queue_adapter = FancyQueueAdapter` (note the lack of `.new`) get called `Class` because `adapter.class` is Class.

It also checks for `adapter.queue_adapter_name` and uses that preferentially.

### Additional information

We don't seem to test the queue adapter name extraction in the logs, and the quick tests I tried to write failed because it kept using the test adapter even when overridden at the job level. Is it okay to ship this without tests?

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
