### PR TITLE
Make Active Record's query cache an LRU

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Active Record query cache is now evicts least recently used entries
+
+    By default it only keeps the `50` most recently used queries.
+
+    The cache size can be configured via `database.yml`
+
+    ```yaml
+    development:
+      adapter: mysql2
+      query_cache: 100
+    ```
+
+    It can also be entirely disabled:
+
+    ```yaml
+    development:
+      adapter: mysql2
+      query_cache: false
+    ```
+
+    *Jean Boussier*
+
 *   Deprecate `check_pending!` in favor of `check_pending_migrations!`.
 
     `check_pending!` will only check for pending migrations on the current database connection or the one passed in. This has been deprecated in favor of `check_pending_migrations!` which will find all pending migrations for the database configurations in a given environment.

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -5,6 +5,8 @@ require "concurrent/map"
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module QueryCache
+      DEFAULT_SIZE = 100 # :nodoc:
+
       class << self
         def included(base) # :nodoc:
           dirties_query_cache base, :exec_query, :execute, :create, :insert, :update, :delete, :truncate,
@@ -52,8 +54,9 @@ module ActiveRecord
 
       def initialize(*)
         super
-        @query_cache         = Hash.new { |h, sql| h[sql] = {} }
+        @query_cache         = {}
         @query_cache_enabled = false
+        @query_cache_max_size = nil
       end
 
       # Enable the query cache within the block.
@@ -114,31 +117,52 @@ module ActiveRecord
 
       private
         def lookup_sql_cache(sql, name, binds)
+          key = binds.empty? ? sql : [sql, binds]
+          hit = false
+          result = nil
+
           @lock.synchronize do
-            if @query_cache[sql].key?(binds)
-              ActiveSupport::Notifications.instrument(
-                "sql.active_record",
-                cache_notification_info(sql, name, binds)
-              )
-              @query_cache[sql][binds]
+            if (result = @query_cache.delete(key))
+              hit = true
+              @query_cache[key] = result
             end
+          end
+
+          if hit
+            ActiveSupport::Notifications.instrument(
+              "sql.active_record",
+              cache_notification_info(sql, name, binds)
+            )
+
+            result
           end
         end
 
         def cache_sql(sql, name, binds)
+          key = binds.empty? ? sql : [sql, binds]
+          result = nil
+          hit = false
+
           @lock.synchronize do
-            result =
-              if @query_cache[sql].key?(binds)
-                ActiveSupport::Notifications.instrument(
-                  "sql.active_record",
-                  cache_notification_info(sql, name, binds)
-                )
-                @query_cache[sql][binds]
-              else
-                @query_cache[sql][binds] = yield
+            if (result = @query_cache.delete(key))
+              hit = true
+              @query_cache[key] = result
+            else
+              result = @query_cache[key] = yield
+              if @query_cache_max_size && @query_cache.size > @query_cache_max_size
+                @query_cache.shift
               end
-            result.dup
+            end
           end
+
+          if hit
+            ActiveSupport::Notifications.instrument(
+              "sql.active_record",
+              cache_notification_info(sql, name, binds)
+            )
+          end
+
+          result.dup
         end
 
         # Database adapters can override this method to
@@ -155,7 +179,20 @@ module ActiveRecord
         end
 
         def configure_query_cache!
-          enable_query_cache! if pool.query_cache_enabled
+          case query_cache = pool.db_config.query_cache
+          when 0, false
+            return
+          when Integer
+            @query_cache_max_size = query_cache
+          when nil
+            @query_cache_max_size = DEFAULT_SIZE
+          else
+            @query_cache_max_size = nil # no limit
+          end
+
+          if pool.query_cache_enabled
+            enable_query_cache!
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -53,6 +53,10 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def query_cache
+        raise NotImplementedError
+      end
+
       def checkout_timeout
         raise NotImplementedError
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -76,6 +76,10 @@ module ActiveRecord
         (configuration_hash[:max_threads] || pool).to_i
       end
 
+      def query_cache
+        configuration_hash[:query_cache]
+      end
+
       def max_queue
         max_threads * 4
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3062,6 +3062,29 @@ development:
   retry_deadline: 5 # Stop retrying queries after 5 seconds
 ```
 
+#### Configuring Query Cache
+
+By default, Rails automatically caches the result sets returned by queries. If Rails encounters the same query
+again for that request or job, it will use the cached result set as opposed to running the query against
+the database again.
+
+The query cache is stored in memory, and to avoid using too much memory, it automatically evicts the least recently
+used queries when reaching a threshold. By default the threshold is `100`, but can be configured in the `database.yml`.
+
+```yaml
+development:
+  adapter: mysql2
+  query_cache: 200
+```
+
+To entirely disable query caching, it can be set to `false`
+
+```yaml
+development:
+  adapter: mysql2
+  query_cache: false
+```
+
 ### Creating Rails Environments
 
 By default Rails ships with three environments: "development", "test", and "production". While these are sufficient for most use cases, there are circumstances when you want more environments.


### PR DESCRIPTION
I don't know how prevalent this really is, but I heard several time about users having memory exhaustion issues caused by the query cache when dealing with long running jobs.

Overall it seems sensible for this cache not to be entirely unbounded.

Opening this for feedback.

TODO:
  - [x] Changelog
  - [x] Document the flag
  - [x] Decide if 50 is a good default

Ping @tenderlove in (the unlikely) case you'd remember the context on https://github.com/rails/rails/commit/9ce02118061fda778e592be83f7c4c3c7c75bfbf as I'm essentially reverting it.

Public complaints:
  - https://code.jjb.cc/turning-off-activerecord-query-cache-to-improve-memory-consumption-in-background-jobs
  - https://github.com/sidekiq/sidekiq/issues/3752#issuecomment-366001877
  - (I remember a bunch more but these search term return a lot of noise)