### PR TITLE
Use `#include?` with String instead of Regexp for Trilogy conn errors

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -79,7 +79,7 @@ module ActiveRecord
           when ER_ACCESS_DENIED_ERROR
             ActiveRecord::DatabaseConnectionError.username_error(config[:username])
           else
-            if error.message.include?(/TRILOGY_DNS_ERROR/)
+            if error.message.include?("TRILOGY_DNS_ERROR")
               ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
             else
               ActiveRecord::ConnectionNotEstablished.new(error.message)


### PR DESCRIPTION
### Motivation / Background

Using `#include?` with a regular expression produces `TypeError: no implicit conversion of Regexp into String`

Note that the external adapter currently [uses `#match?`](https://github.com/github/activerecord-trilogy-adapter/blob/main/lib/active_record/connection_adapters/trilogy_adapter.rb#L104), but Rubocop prefers `#include?` with a String instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
