### PR TITLE
Clean up shared DB statements code between Mysql2 and Trilogy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -3,6 +3,7 @@
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/mysql/column"
+require "active_record/connection_adapters/mysql/database_statements"
 require "active_record/connection_adapters/mysql/explain_pretty_printer"
 require "active_record/connection_adapters/mysql/quoting"
 require "active_record/connection_adapters/mysql/schema_creation"
@@ -14,6 +15,7 @@ require "active_record/connection_adapters/mysql/type_metadata"
 module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
+      include MySQL::DatabaseStatements
       include MySQL::Quoting
       include MySQL::SchemaStatements
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module DatabaseStatements
+        READ_QUERY = AbstractAdapter.build_read_query_regexp(
+          :desc, :describe, :set, :show, :use
+        ) # :nodoc:
+        private_constant :READ_QUERY
+
+        # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_current-timestamp
+        # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-type-syntax.html
+        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
+        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+
+        def write_query?(sql) # :nodoc:
+          !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
+        end
+
+        def high_precision_current_timestamp
+          HIGH_PRECISION_CURRENT_TIMESTAMP
+        end
+
+        def explain(arel, binds = [], options = [])
+          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
+          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result  = internal_exec_query(sql, "EXPLAIN", binds)
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
+        end
+
+        def build_explain_clause(options = [])
+          return "EXPLAIN" if options.empty?
+
+          explain_clause = "EXPLAIN #{options.join(" ").upcase}"
+
+          if analyze_without_explain? && explain_clause.include?("ANALYZE")
+            explain_clause.sub("EXPLAIN ", "")
+          else
+            explain_clause
+          end
+        end
+
+        private
+          # https://mariadb.com/kb/en/analyze-statement/
+          def analyze_without_explain?
+            mariadb? && database_version >= "10.1.0"
+          end
+
+          def default_insert_value(column)
+            super unless column.auto_increment?
+          end
+
+          def combine_multi_statements(total_sql)
+            total_sql.each_with_object([]) do |sql, total_sql_chunks|
+              previous_packet = total_sql_chunks.last
+              if max_allowed_packet_reached?(sql, previous_packet)
+                total_sql_chunks << +sql
+              else
+                previous_packet << ";\n"
+                previous_packet << sql
+              end
+            end
+          end
+
+          def max_allowed_packet_reached?(current_packet, previous_packet)
+            if current_packet.bytesize > max_allowed_packet
+              raise ActiveRecordError,
+                "Fixtures set is too large #{current_packet.bytesize}. Consider increasing the max_allowed_packet variable."
+            elsif previous_packet.nil?
+              true
+            else
+              (current_packet.bytesize + previous_packet.bytesize + 2) > max_allowed_packet
+            end
+          end
+
+          def max_allowed_packet
+            @max_allowed_packet ||= show_variable("max_allowed_packet")
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -18,26 +18,6 @@ module ActiveRecord
           result
         end
 
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :desc, :describe, :set, :show, :use
-        ) # :nodoc:
-        private_constant :READ_QUERY
-
-        def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
-        rescue ArgumentError # Invalid encoding
-          !READ_QUERY.match?(sql.b)
-        end
-
-        def explain(arel, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
-          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = internal_exec_query(sql, "EXPLAIN", binds)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
-        end
-
         def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
           if without_prepared_statement?(binds)
             execute_and_free(sql, name, async: async) do |result|
@@ -70,27 +50,6 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
-        # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_current-timestamp
-        # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-type-syntax.html
-        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
-        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
-
-        def high_precision_current_timestamp
-          HIGH_PRECISION_CURRENT_TIMESTAMP
-        end
-
-        def build_explain_clause(options = [])
-          return "EXPLAIN" if options.empty?
-
-          explain_clause = "EXPLAIN #{options.join(" ").upcase}"
-
-          if analyze_without_explain? && explain_clause.include?("ANALYZE")
-            explain_clause.sub("EXPLAIN ", "")
-          else
-            explain_clause
-          end
-        end
-
         private
           def sync_timezone_changes(raw_connection)
             raw_connection.query_options[:database_timezone] = default_timezone
@@ -104,10 +63,6 @@ module ActiveRecord
                 conn.abandon_results!
               end
             end
-          end
-
-          def default_insert_value(column)
-            super unless column.auto_increment?
           end
 
           def last_inserted_id(result)
@@ -136,33 +91,6 @@ module ActiveRecord
             ensure
               conn.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
             end
-          end
-
-          def combine_multi_statements(total_sql)
-            total_sql.each_with_object([]) do |sql, total_sql_chunks|
-              previous_packet = total_sql_chunks.last
-              if max_allowed_packet_reached?(sql, previous_packet)
-                total_sql_chunks << +sql
-              else
-                previous_packet << ";\n"
-                previous_packet << sql
-              end
-            end
-          end
-
-          def max_allowed_packet_reached?(current_packet, previous_packet)
-            if current_packet.bytesize > max_allowed_packet
-              raise ActiveRecordError,
-                "Fixtures set is too large #{current_packet.bytesize}. Consider increasing the max_allowed_packet variable."
-            elsif previous_packet.nil?
-              true
-            else
-              (current_packet.bytesize + previous_packet.bytesize + 2) > max_allowed_packet
-            end
-          end
-
-          def max_allowed_packet
-            @max_allowed_packet ||= show_variable("max_allowed_packet")
           end
 
           def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
@@ -213,11 +141,6 @@ module ActiveRecord
                 ret
               end
             end
-          end
-
-          # https://mariadb.com/kb/en/analyze-statement/
-          def analyze_without_explain?
-            mariadb? && database_version >= "10.1.0"
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module ConnectionAdapters
-    module MySQL
+    module Mysql2
       module DatabaseStatements
         # Returns an ActiveRecord::Result instance.
         def select_all(*, **) # :nodoc:
@@ -120,7 +120,7 @@ module ActiveRecord
             if flags.is_a?(Array)
               flags.include?("MULTI_STATEMENTS")
             else
-              flags.anybits?(Mysql2::Client::MULTI_STATEMENTS)
+              flags.anybits?(::Mysql2::Client::MULTI_STATEMENTS)
             end
           end
 
@@ -130,11 +130,11 @@ module ActiveRecord
             end
 
             with_raw_connection do |conn|
-              conn.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+              conn.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
 
               yield
             ensure
-              conn.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
+              conn.set_server_option(::Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record/connection_adapters/abstract_mysql_adapter"
-require "active_record/connection_adapters/mysql/database_statements"
+require "active_record/connection_adapters/mysql2/database_statements"
 
 gem "mysql2", "~> 0.5"
 require "mysql2"
@@ -28,12 +28,12 @@ module ActiveRecord
 
       ADAPTER_NAME = "Mysql2"
 
-      include MySQL::DatabaseStatements
+      include Mysql2::DatabaseStatements
 
       class << self
         def new_client(config)
-          Mysql2::Client.new(config)
-        rescue Mysql2::Error => error
+          ::Mysql2::Client.new(config)
+        rescue ::Mysql2::Error => error
           if error.error_number == ConnectionAdapters::Mysql2Adapter::ER_BAD_DB_ERROR
             raise ActiveRecord::NoDatabaseError.db_error(config[:database])
           elsif error.error_number == ConnectionAdapters::Mysql2Adapter::ER_ACCESS_DENIED_ERROR
@@ -54,7 +54,7 @@ module ActiveRecord
         if @config[:flags].kind_of? Array
           @config[:flags].push "FOUND_ROWS"
         else
-          @config[:flags] |= Mysql2::Client::FOUND_ROWS
+          @config[:flags] |= ::Mysql2::Client::FOUND_ROWS
         end
 
         @connection_parameters ||= @config
@@ -159,9 +159,9 @@ module ActiveRecord
         end
 
         def translate_exception(exception, message:, sql:, binds:)
-          if exception.is_a?(Mysql2::Error::TimeoutError) && !exception.error_number
+          if exception.is_a?(::Mysql2::Error::TimeoutError) && !exception.error_number
             ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
-          elsif exception.is_a?(Mysql2::Error::ConnectionError)
+          elsif exception.is_a?(::Mysql2::Error::ConnectionError)
             if exception.message.match?(/MySQL client is not connected/i)
               ActiveRecord::ConnectionNotEstablished.new(exception)
             else

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -4,14 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module Trilogy
       module DatabaseStatements
-        READ_QUERY = AbstractAdapter.build_read_query_regexp(
-          :desc, :describe, :set, :show, :use
-        ) # :nodoc:
-        private_constant :READ_QUERY
-
-        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
-        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
-
         def select_all(*, **) # :nodoc:
           result = nil
           with_raw_connection do |conn|
@@ -19,21 +11,6 @@ module ActiveRecord
             conn.next_result while conn.more_results_exist?
           end
           result
-        end
-
-        def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
-        rescue ArgumentError # Invalid encoding
-          !READ_QUERY.match?(sql.b)
-        end
-
-        def explain(arel, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
-          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = internal_exec_query(sql, "EXPLAIN", binds)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
         end
 
         def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
@@ -64,22 +41,6 @@ module ActiveRecord
 
         alias :exec_update :exec_delete # :nodoc:
 
-        def high_precision_current_timestamp
-          HIGH_PRECISION_CURRENT_TIMESTAMP
-        end
-
-        def build_explain_clause(options = [])
-          return "EXPLAIN" if options.empty?
-
-          explain_clause = "EXPLAIN #{options.join(" ").upcase}"
-
-          if analyze_without_explain? && explain_clause.include?("ANALYZE")
-            explain_clause.sub("EXPLAIN ", "")
-          else
-            explain_clause
-          end
-        end
-
         private
           def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
             log(sql, name, async: async) do
@@ -94,6 +55,43 @@ module ActiveRecord
 
           def last_inserted_id(result)
             result.last_insert_id
+          end
+
+          def sync_timezone_changes(conn)
+            # Sync any changes since connection last established.
+            if default_timezone == :local
+              conn.query_flags |= ::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
+            else
+              conn.query_flags &= ~::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
+            end
+          end
+
+          def execute_batch(statements, name = nil)
+            statements = statements.map { |sql| transform_query(sql) }
+            combine_multi_statements(statements).each do |statement|
+              with_raw_connection do |conn|
+                raw_execute(statement, name)
+                conn.next_result while conn.more_results_exist?
+              end
+            end
+          end
+
+          def multi_statements_enabled?
+            !!@config[:multi_statement]
+          end
+
+          def with_multi_statements
+            if multi_statements_enabled?
+              return yield
+            end
+
+            with_raw_connection do |conn|
+              conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
+
+              yield
+            ensure
+              conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF)
+            end
           end
       end
     end

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       end
 
       def build_explain_clause(options = [])
-        if connection.respond_to?(:build_explain_clause)
+        if connection.respond_to?(:build_explain_clause, true)
           connection.build_explain_clause(options)
         else
           "EXPLAIN for:"


### PR DESCRIPTION
### Motivation / Background

There is a lot of duplicated code between `ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements` (used by `Mysql2Adapter`) and `ActiveRecord::ConnectionAdapters::Trilogy::DatabaseStatements`. This PR introduces a `DatabaseStatements` module at the `AbstractMysqlAdapter` level, and moves this shared code into it.

### Detail

This PR makes two changes:
1) Renames the existing `MySQL::DatabaseStatements` module to `Mysql2::DatabaseStatements`, since it's Mysql2-specific rather than MySQL specific. I did this because I'd like to use `MySQL::DatabaseStatements` to hold shared database statement logic for all MySQL-compatible adapters.
2) Moves shared logic out of the Trilogy + Mysql2 database statement modules and into a new `ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements` module. This involves removing some code that was in the `TrilogyAdapter` that ought to have lived in the `Trilogy::DatabaseStatements` module (e.g. multi-statement support).

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
