### PR TITLE
Add `:limit` to `validates_numericality_of`

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -27,7 +27,7 @@ module ActiveModel
         end
 
         options.slice(*RANGE_CHECKS.keys).each do |option, value|
-          unless value.is_a?(Range)
+          unless value == :limit || value.is_a?(Range)
             raise ArgumentError, ":#{option} must be a range"
           end
         end
@@ -52,6 +52,7 @@ module ActiveModel
               record.errors.add(attr_name, option, **filtered_options(value))
             end
           elsif RANGE_CHECKS.include?(option)
+            next if option_value == :limit
             unless value.public_send(RANGE_CHECKS[option], option_value)
               record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
             end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add support for `:limit` to `ActiveModel::Validations::NumericalityValidator#validates_numericality_of`.
+
+    `:limit` will verify the column's SQL type metadata limit to create a range with it.
+
+    If the value is a `virtual attribute`, an exception is raised.
+
+    If the column doesn't have a `limit` value set, the validation will be ignored.
+
+    ```ruby
+    validates_numericality_of :some_column, in: :limit
+    ```
+
+    *edaroit*
+
 *   Add support for `Array#intersect?` to `ActiveRecord::Relation`.
 
     `Array#intersect?` is only available on Ruby 3.1 or later.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because Rails doesn't provide by default a way to validate if a number is within the database limit. That's problematic when one is trying to store an ID to another table without foreign key since one would need to manually add the logic for this validation, possibly using `validates_numericality_of` range.

```ruby
MAX_EIGHT_BYTES_SIGNED_NUMBER = 2**63 - 1
private_constant :MAX_EIGHT_BYTES_SIGNED_NUMBER

# It should store a valid database record; thus, it should not be negative and it can go up to the maximum value
# supported by the column, which is using the default bigint type size of 8 bytes.
VALID_ID_RANGE = (..MAX_EIGHT_BYTES_SIGNED_NUMBER)
private_constant :VALID_ID_RANGE

validates :model_id, numericality: { in: VALID_ID_RANGE }
```

### Detail

This Pull Request changes `ActiveRecord::Validations::NumericalityValidator` to support a new value for the `in:` option: `:limit`.

`:limit` will verify the column's SQL type metadata limit to create a range with it. If the value is a `virtual attribute`, an exception is raised. If the column doesn't have a `limit` value set, the validation will be ignored.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
