### PR TITLE
Support upsert in Postgres temp tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1071,7 +1071,7 @@ module ActiveRecord
                 "'f'"
               end
             scope = {}
-            scope[:schema] = schema ? quote(schema) : "ANY (current_schemas(false))"
+            scope[:schema] = schema ? quote(schema) : "ANY (array_prepend((SELECT pg_my_temp_schema()::regnamespace::name),current_schemas(false)))"
             scope[:name] = quote(name) if name
             scope[:type] = type if type
             scope

--- a/activerecord/test/cases/adapters/postgresql/temporary_tables_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/temporary_tables_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgresqlTemporaryTablesTest < ActiveRecord::PostgreSQLTestCase
+  class TempModel < ActiveRecord::Base
+    def self.with_temp_table(as:)
+      transaction do
+        connection.create_table(table_name, temporary: true, force: true, as: as)
+        yield
+      end
+    end
+  end
+
+  def test_upsert_all
+    TempModel.with_temp_table(as: "select 1 as id, 'foo' as some_column") do
+      TempModel.connection.add_index(TempModel.table_name, :id, unique: true)
+
+      assert_equal TempModel.new(id: 1, some_column: "foo"), TempModel.sole
+
+      TempModel.upsert_all([{ id: 1, some_column: "bar" }], unique_by: :id)
+
+      assert_equal TempModel.new(id: 1, some_column: "bar2"), TempModel.sole
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This Pull Request changes the Postgres database adapter. It allows me to create models that are backed by a temporary table and use them just like regular tables. Without this change e.g. `insert_all` and `upsert_all` are not possible.

### Test

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activerecord", path: './activerecord'
  gem "pg"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "postgresql", url: "postgres://localhost/rails-issue") rescue puts 'Please create a DB "rails-issue" yourself first'
ActiveRecord::Base.logger = Logger.new(STDOUT)

class Post < ActiveRecord::Base
  def self.with_temp_table(as:)
    transaction do
      connection.create_table(table_name, temporary: true, force: true, as: as)
      yield
    end
  end
end

class BugTest < Minitest::Test
  def test_upsert_in_temp_table

    # Create a model backed by a temp table. Prefill the table with some data from a query.
    Post.with_temp_table(as: "select 1 as id, 'foo' as some_column") do
      # Upserts require a unique constraint
      Post.connection.add_index(Post.table_name, :id, unique: true)

      assert_equal Post.new(id: 1, some_column: 'foo'), Post.sole

      # The following line fails on master with:
      #
      #   ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  syntax error at or near ")"
      #   LINE 1: ...id","some_column") VALUES (1, 'bar') ON CONFLICT () DO UPDAT...
      #
      # The temp table, including all indices, constraints, etc are not 'seen'
      # by Rails. The PostgreSQL adapter only considers stuff in the schemas
      # returned by current_schemas(false). The temporary namespace
      # 'pg_temp_xyz' is excluded.
      #
      # See https://www.postgresql.org/docs/15/functions-info.html
      #
      #   current_schemas ( include_implicit boolean ) → name[]
      #
      #   Returns an array of the names of all schemas presently in the
      #   effective search path, in their priority order. (Items in the current
      #   search_path setting that do not correspond to existing, searchable
      #   schemas are omitted.) If the Boolean argument is true, then
      #   implicitly-searched system schemas such as pg_catalog are included in
      #   the result.
      #
      # If you include implicit tables, via current_schemas(true), the
      # temporary table is found, but that is also true for the other system
      # schemas that we don't want.
      #
      # Luckily Postgres provides a means to find the temp schema name via:
      #
      #   pg_my_temp_schema () → oid
      #
      #   Returns the OID of the current session's temporary schema, or zero if
      #   it has none (because it has not created any temporary tables).
      #
      # If we add that to the search path, then temp tables work just like
      # regular tables.
      Post.upsert_all([{ id: 1, some_column: 'bar' }], unique_by: :id)

      assert_equal Post.new(id: 1, some_column: 'bar'), Post.sole
    end
  end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
