### PR TITLE
Use `_read_attribute` in associations preloader instead of public reader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -252,9 +252,9 @@ module ActiveRecord
 
           def derive_key(owner, key)
             if key.is_a?(Array)
-              key.map { |k| convert_key(owner[k]) }
+              key.map { |k| convert_key(owner._read_attribute(k)) }
             else
-              convert_key(owner[key])
+              convert_key(owner._read_attribute(key))
             end
           end
 


### PR DESCRIPTION
Using `ActiveModel::AttributeMethods#[]` or `AttributeMethods#read_attribute` is
not suitable when association involves a model with `id` column which is
not a whole primary key but still used as a foreign key. Public reader
treats `id` as an idenfitier and thus returns value for the primary key
column and not the `id` column. By using `_read_attribute` reader we can
ensure we are reading the column value directly.

`[]` reader is almost the same as `_read_attribute` with a few differences, `_read_attribute` skips the following capabilities

1. alias attribute check
2. treat `id` as an identifier and thus return a value behind the primary key column instead of the `id` column value

We intentionally want to avoid doing n2 to fix the issue and skipping the alias attribute check is not a concern as the association can not be defined using an aliased attribute name as foreign or primary key

https://github.com/rails/rails/blob/9e5cb08ab2494b306447977c0e9cef445cd03fe5/activerecord/lib/active_record/attribute_methods.rb#L338-L339
https://github.com/rails/rails/blob/9e5cb08ab2494b306447977c0e9cef445cd03fe5/activerecord/lib/active_record/attribute_methods/read.rb#L43-L44
