### PR TITLE
Silence msgpack warnings when detecting format

### DIFF
--- a/activesupport/lib/active_support/cache/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/cache/serializer_with_fallback.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/kernel/reporting"
+
 module ActiveSupport
   module Cache
     module SerializerWithFallback # :nodoc:
@@ -156,7 +158,7 @@ module ActiveSupport
           private
             def available?
               return @available if defined?(@available)
-              require "active_support/message_pack"
+              silence_warnings { require "active_support/message_pack" }
               @available = true
             rescue LoadError
               @available = false


### PR DESCRIPTION
This silences a ["ActiveSupport::MessagePack requires the msgpack gem" warning](https://github.com/rails/rails/blob/8049d7983f3f8fa9679e5ccfb21814554cd60297/activesupport/lib/active_support/message_pack.rb#L7-L8) that can occur when using a non-`:message_pack` serializer and trying to detect the format of a serialized cache entry.

`silence_warnings` is a blunt instrument, but this `require` is only for decoding legacy cache entries that were encoded using `:message_pack`, if any.  (i.e. If `:message_pack` is currently being used as a serializer, then `SerializerWithFallback::[]` should have already loaded `active_support/message_pack`.)  Therefore, it seems less hazardous to inadvertently silence other warnings that may occur when loading the file.
