### PR TITLE
feat: use configured pk type in Action Mailbox migration

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support configured primary key types in generated migrations.
+
+    *Nishiki Liu*
+
 *   Fixed ingress controllers' ability to accept emails that contain no UTF-8 encoded parts.
 
     Fixes #46297.

--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -1,6 +1,6 @@
 class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
-    create_table :action_mailbox_inbound_emails do |t|
+    create_table :action_mailbox_inbound_emails, id: primary_key_type do |t|
       t.integer :status, default: 0, null: false
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
@@ -10,4 +10,10 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
 end

--- a/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
@@ -1,6 +1,6 @@
 class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
-    create_table :action_mailbox_inbound_emails do |t|
+    create_table :action_mailbox_inbound_emails, id: primary_key_type do |t|
       t.integer :status, default: 0, null: false
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
@@ -10,4 +10,10 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
 end

--- a/actionmailbox/test/migrations_test.rb
+++ b/actionmailbox/test/migrations_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require ActionMailbox::Engine.root.join("db/migrate/20180917164000_create_action_mailbox_tables.rb").to_s
+
+class ActionMailbox::MigrationsTest < ActiveSupport::TestCase
+  setup do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    @connection = ActiveRecord::Base.connection
+    @original_options = Rails.configuration.generators.options.deep_dup
+  end
+
+  teardown do
+    Rails.configuration.generators.options = @original_options
+    rerun_migration
+    ActiveRecord::Migration.verbose = @original_verbose
+  end
+
+  test "migration creates tables with default primary key type" do
+    action_mailbox_tables.each do |table|
+      assert_equal :integer, primary_key(table).type
+    end
+  end
+
+  test "migration creates tables with configured primary key type" do
+    Rails.configuration.generators do |g|
+      g.orm :active_record, primary_key_type: :string
+    end
+
+    rerun_migration
+
+    action_mailbox_tables.each do |table|
+      assert_equal :string, primary_key(table).type
+    end
+  end
+
+  private
+    def rerun_migration
+      CreateActionMailboxTables.migrate(:down)
+      CreateActionMailboxTables.migrate(:up)
+    end
+
+    def action_mailbox_tables
+      [:action_mailbox_inbound_emails]
+    end
+
+    def primary_key(table)
+      @connection.columns(table).find { |c| c.name == "id" }
+    end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I recently ran Action Mailbox's generators on a new Rails 7 project and noticed that it didn't carry over my generator primary key configuration. I had to manually modify the migration in my project. I know that Active Storage is a gem that uses a project's configured primary key, so I thought this would be a great opportunity for Action Mailbox to do the same.

### Detail

This PR adds a `migrations_test.rb` for Action Mailbox that closely mirrors the same file in Active Storage. It then adds a private `primary_key_type` method in the Action Mailbox migration which pulls a project's configured primary key type. This method is also closely modeled after Active Storage's.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
