### PR TITLE
create (and use) /home/rails as home directory in Dockerfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -79,7 +79,7 @@ COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
 # Run and own only the runtime files as a non-root user for security
-RUN useradd rails --home /rails --shell /bin/bash && \
+RUN useradd rails --create-home --shell /bin/bash && \
     chown -R rails:rails <%= dockerfile_chown_directories.join(" ") %>
 USER rails:rails
 


### PR DESCRIPTION
Fixes #48105