### PR TITLE
Make `increment_counter`/`decrement_counter` accept an amount argument

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Make `increment_counter`/`decrement_counter` accept an amount argument
+
+    ```ruby
+    Post.increment_counter(:comments_count, 5, by: 3)
+    ```
+
+    *fatkodima*
+
 *   Add support for `Array#intersect?` to `ActiveRecord::Relation`.
 
     `Array#intersect?` is only available on Ruby 3.1 or later.

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -126,6 +126,7 @@ module ActiveRecord
       #
       # * +counter_name+ - The name of the field that should be incremented.
       # * +id+ - The id of the object that should be incremented or an array of ids.
+      # * <tt>:by</tt> - The amount by which to increment the value. Defaults to +1+.
       # * <tt>:touch</tt> - Touch timestamp columns when updating.
       #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
       #   touch that column or an array of symbols to touch just those ones.
@@ -136,10 +137,14 @@ module ActiveRecord
       #   DiscussionBoard.increment_counter(:posts_count, 5)
       #
       #   # Increment the posts_count column for the record with an id of 5
+      #   # by a specific amount.
+      #   DiscussionBoard.increment_counter(:posts_count, 5, by: 3)
+      #
+      #   # Increment the posts_count column for the record with an id of 5
       #   # and update the updated_at value.
       #   DiscussionBoard.increment_counter(:posts_count, 5, touch: true)
-      def increment_counter(counter_name, id, touch: nil)
-        update_counters(id, counter_name => 1, touch: touch)
+      def increment_counter(counter_name, id, by: 1, touch: nil)
+        update_counters(id, counter_name => by, touch: touch)
       end
 
       # Decrement a numeric field by one, via a direct SQL update.
@@ -151,6 +156,7 @@ module ActiveRecord
       #
       # * +counter_name+ - The name of the field that should be decremented.
       # * +id+ - The id of the object that should be decremented or an array of ids.
+      # * <tt>:by</tt> - The amount by which to increment the value. Defaults to +1+.
       # * <tt>:touch</tt> - Touch timestamp columns when updating.
       #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
       #   touch that column or an array of symbols to touch just those ones.
@@ -161,10 +167,14 @@ module ActiveRecord
       #   DiscussionBoard.decrement_counter(:posts_count, 5)
       #
       #   # Decrement the posts_count column for the record with an id of 5
+      #   by a specific amount.
+      #   DiscussionBoard.decrement_counter(:posts_count, 5, by: 3)
+      #
+      #   # Decrement the posts_count column for the record with an id of 5
       #   # and update the updated_at value.
       #   DiscussionBoard.decrement_counter(:posts_count, 5, touch: true)
-      def decrement_counter(counter_name, id, touch: nil)
-        update_counters(id, counter_name => -1, touch: touch)
+      def decrement_counter(counter_name, id, by: 1, touch: nil)
+        update_counters(id, counter_name => -by, touch: touch)
       end
 
       def counter_cache_column?(name) # :nodoc:

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -40,9 +40,21 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "increment counter by specific amount" do
+    assert_difference "@topic.reload.replies_count", +2 do
+      Topic.increment_counter(:replies_count, @topic.id, by: 2)
+    end
+  end
+
   test "decrement counter" do
     assert_difference "@topic.reload.replies_count", -1 do
       Topic.decrement_counter(:replies_count, @topic.id)
+    end
+  end
+
+  test "decrement counter by specific amount" do
+    assert_difference "@topic.reload.replies_count", -2 do
+      Topic.decrement_counter(:replies_count, @topic.id, by: 2)
     end
   end
 


### PR DESCRIPTION
When the user wants to increment some counter by an amount other that 1 (after some data import, for example), he needs:
1. to call `increment_counter` a few times, which is slow 
2. or to call `where(id: id).update_all("counter = counter + 5")`, which is not as convenient as `increment_counter` (which also takes care of using `COALESCE` and incrementing optimistic locking column, if present)
3. or to call `record.increment(:counter, 5)` which does an update of the counter in memory and then writes that value to the database, which can override just yet updated value due to race conditions

Example usage:
```ruby
Company.increment_counter(:users_count, 5, by: 3)
```

This change will also be on par with the existing increment methods in rails, which already accept an amount: [`ActiveRecord::Persistance#increment`](https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-increment) and [`ActiveSupport::CacheStore#increment`](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-increment).