### PR TITLE
prevent belongs_to association double savings when saved with has_one…

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support configured primary key types in generated migrations.
+
+    *Nishiki Liu*
+
 *   Fixed ingress controllers' ability to accept emails that contain no UTF-8 encoded parts.
 
     Fixes #46297.

--- a/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
+++ b/actionmailbox/db/migrate/20180917164000_create_action_mailbox_tables.rb
@@ -1,6 +1,6 @@
 class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
-    create_table :action_mailbox_inbound_emails do |t|
+    create_table :action_mailbox_inbound_emails, id: primary_key_type do |t|
       t.integer :status, default: 0, null: false
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
@@ -10,4 +10,10 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
 end

--- a/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
+++ b/actionmailbox/test/dummy/db/migrate/20180208205311_create_action_mailbox_tables.rb
@@ -1,6 +1,6 @@
 class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
   def change
-    create_table :action_mailbox_inbound_emails do |t|
+    create_table :action_mailbox_inbound_emails, id: primary_key_type do |t|
       t.integer :status, default: 0, null: false
       t.string  :message_id, null: false
       t.string  :message_checksum, null: false
@@ -10,4 +10,10 @@ class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
       t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
     end
   end
+
+  private
+    def primary_key_type
+      config = Rails.configuration.generators
+      config.options[config.orm][:primary_key_type] || :primary_key
+    end
 end

--- a/actionmailbox/test/migrations_test.rb
+++ b/actionmailbox/test/migrations_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require ActionMailbox::Engine.root.join("db/migrate/20180917164000_create_action_mailbox_tables.rb").to_s
+
+class ActionMailbox::MigrationsTest < ActiveSupport::TestCase
+  setup do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    @connection = ActiveRecord::Base.connection
+    @original_options = Rails.configuration.generators.options.deep_dup
+  end
+
+  teardown do
+    Rails.configuration.generators.options = @original_options
+    rerun_migration
+    ActiveRecord::Migration.verbose = @original_verbose
+  end
+
+  test "migration creates tables with default primary key type" do
+    action_mailbox_tables.each do |table|
+      assert_equal :integer, primary_key(table).type
+    end
+  end
+
+  test "migration creates tables with configured primary key type" do
+    Rails.configuration.generators do |g|
+      g.orm :active_record, primary_key_type: :string
+    end
+
+    rerun_migration
+
+    action_mailbox_tables.each do |table|
+      assert_equal :string, primary_key(table).type
+    end
+  end
+
+  private
+    def rerun_migration
+      CreateActionMailboxTables.migrate(:down)
+      CreateActionMailboxTables.migrate(:up)
+    end
+
+    def action_mailbox_tables
+      [:action_mailbox_inbound_emails]
+    end
+
+    def primary_key(table)
+      @connection.columns(table).find { |c| c.name == "id" }
+    end
+end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/topic"    # For booleans
 require "models/pirate"   # For timestamps
+require "models/ship"     # For has_one saved_changes
 require "models/parrot"
 require "models/person"   # For optimistic locking
 require "models/aircraft"
@@ -889,6 +890,15 @@ class DirtyTest < ActiveRecord::TestCase
     person.save
 
     assert_not_predicate person, :saved_changes?
+  end
+
+  test "saved_changes? returns hash when saved with has_one association" do
+    ship = Ship.new(name: "Nights Dirty Lightning")
+    ship.pirate = Pirate.new(catchphrase: "Yar!")
+
+    ship.save
+
+    assert_equal [nil, "Nights Dirty Lightning"], ship.saved_changes[:name]
   end
 
   test "saved_changes returns a hash of all the changes that occurred" do


### PR DESCRIPTION
### Motivation / Background
"Fixes #[48077](https://github.com/rails/rails/issues/48077)"

copy of [PR](https://github.com/rails/rails/pull/48078) that was closed because of wrong rebase

### Detail

When object is saved with `belongs_to` association, that associated to object with `has_one` relation, object actually saved   twice. For example:
```
class Post < ActiveRecord::Base
  belongs_to :user
  belongs_to :poll

  after_commit :test_after_commit
  # after_save :test_after_commit saved_changes here are exists
  after_save :test_after_save

  attr_reader :after_save_counter

  def test_after_commit
    # saved_changes here are blank
    if saved_change_to_release_stage?(to: 'published')
      user.increment(:published_posts_count)
    end
  end

  def test_after_save
    # invokes twice
    @after_save_counter ||= 0
    @after_save_counter += 1
  end
end

class Poll < ActiveRecord::Base
  has_one :post
end

post = Post.new(
  user: user,
  title: 'yoyo',
  release_stage: 'published'
)

post.poll = Poll.new(multiple: true)

post.save
```

First poll object is saved, then AR try to save post from `save_has_one_association`, after that invokes `save` method second time and this second `save` call clears saved_changes.

I decided to add variable that show that object already saving and prevent second save from `save_has_one_association` callback 

