### PR TITLE
Fix belongs to with has one association multiple savings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Prevent belongs_to association from double saving when created with has_one association.
+
+    *Igor Biryukov*
+
 *   Fix mutation detection for serialized attributes backed by binary columns.
 
     *Jean Boussier*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -150,6 +150,7 @@ module ActiveRecord
 
     included do
       Associations::Builder::Association.extensions << AssociationBuilderExtension
+      around_save :around_save_mark_as_saving_record
     end
 
     module ClassMethods # :nodoc:
@@ -275,6 +276,7 @@ module ActiveRecord
     private
       def init_internals
         super
+        @_marked_as_saving = false
         @_already_called = nil
       end
 
@@ -364,6 +366,18 @@ module ActiveRecord
         else
           "#{reflection.name}.#{attribute}"
         end
+      end
+
+      def already_trying_to_save?
+        @_marked_as_saving
+      end
+
+      def around_save_mark_as_saving_record
+        @_marked_as_saving = true
+        yield
+        @_marked_as_saving = false
+      ensure
+        @_marked_as_saving = false
       end
 
       # Is used as an around_save callback to check while saving a collection
@@ -456,6 +470,8 @@ module ActiveRecord
                 record[reflection.foreign_key] = key
                 association.set_inverse_instance(record)
               end
+
+              return if record.send(:already_trying_to_save?)
 
               saved = record.save(validate: !autosave)
               raise ActiveRecord::Rollback if !saved && autosave

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "models/topic"    # For booleans
 require "models/pirate"   # For timestamps
 require "models/parrot"
+require "models/ship"     # For has_one saved_changes
 require "models/person"   # For optimistic locking
 require "models/aircraft"
 require "models/numeric_data"
@@ -889,6 +890,15 @@ class DirtyTest < ActiveRecord::TestCase
     person.save
 
     assert_not_predicate person, :saved_changes?
+  end
+
+  test "saved_changes? returns hash when saved with has_one association" do
+    ship = Ship.new(name: "Nights Dirty Lightning")
+    ship.pirate = Pirate.new(catchphrase: "Yar!")
+
+    ship.save
+
+    assert_equal [nil, "Nights Dirty Lightning"], ship.saved_changes[:name]
   end
 
   test "saved_changes returns a hash of all the changes that occurred" do


### PR DESCRIPTION
### Motivation / Background
"Fixes #[48077](https://github.com/rails/rails/issues/48077)"

copy of [PR](https://github.com/rails/rails/pull/48078) that was closed because of wrong rebase

### Detail

When object is saved with `belongs_to` association, that associated to object with `has_one` relation, object actually saved   twice. For example:
```
class Post < ActiveRecord::Base
  belongs_to :user
  belongs_to :poll

  after_commit :test_after_commit
  # after_save :test_after_commit saved_changes here are exists
  after_save :test_after_save

  attr_reader :after_save_counter

  def test_after_commit
    # saved_changes here are blank
    if saved_change_to_release_stage?(to: 'published')
      user.increment(:published_posts_count)
    end
  end

  def test_after_save
    # invokes twice
    @after_save_counter ||= 0
    @after_save_counter += 1
  end
end

class Poll < ActiveRecord::Base
  has_one :post
end

post = Post.new(
  user: user,
  title: 'yoyo',
  release_stage: 'published'
)

post.poll = Poll.new(multiple: true)

post.save
```

First poll object is saved, then AR try to save post from `save_has_one_association`, after that invokes `save` method second time and this second `save` call clears saved_changes.

I decided to add variable that show that object already saving and prevent second save from `save_has_one_association` callback 

