### PR TITLE
Postgresql improvements to create_schema and drop_schema 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Improve support for postgresql options in `create_schema` and `drop_schema`.
+
+    `create_schema` now accept `if_not_exists` and `force` options, similar to `create_table`.
+
+    `drop_schema` no longer uses `CASCADE` as default, now accept `force: :cascade` option similar to `drop_table`.
+    `config.active_record.postgresql_drop_schema_cascade` was added to maintain the previous behavior of `drop_schema`.
+
+    `create_schema` and `drop_schema` are now reversible.
+
+    *Adam Stomski*
+
 *   Add support for `Array#intersect?` to `ActiveRecord::Relation`.
 
     `Array#intersect?` is only available on Ruby 3.1 or later.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -440,6 +440,9 @@ module ActiveRecord
   singleton_class.attr_accessor :yaml_column_permitted_classes
   self.yaml_column_permitted_classes = [Symbol]
 
+  singleton_class.attr_accessor :postgresql_drop_schema_cascade
+  self.postgresql_drop_schema_cascade = true
+
   def self.marshalling_format_version
     Marshalling.format_version
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -222,7 +222,7 @@ module ActiveRecord
 
         # Drops the schema for the given schema name.
         def drop_schema(schema_name, **options)
-          execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)}#{' CASCADE' if options[:force] == :cascade}"
+          execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)}#{' CASCADE' if ActiveRecord.postgresql_drop_schema_cascade || options[:force] == :cascade}"
         end
 
         # Sets the schema search path to a string of comma-separated schema names.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -213,7 +213,10 @@ module ActiveRecord
         end
 
         # Creates a schema for the given schema name.
-        def create_schema(schema_name, if_not_exists: false)
+        def create_schema(schema_name, if_not_exists: false, force: false)
+          if force
+            drop_schema(schema_name, if_exists: true, force: force)
+          end
           execute "CREATE SCHEMA#{' IF NOT EXISTS' if if_not_exists} #{quote_schema_name(schema_name)}"
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -219,7 +219,7 @@ module ActiveRecord
 
         # Drops the schema for the given schema name.
         def drop_schema(schema_name, **options)
-          execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)} CASCADE"
+          execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)}#{' CASCADE' if options[:force] == :cascade}"
         end
 
         # Sets the schema search path to a string of comma-separated schema names.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -213,6 +213,13 @@ module ActiveRecord
         end
 
         # Creates a schema for the given schema name.
+        #
+        # [<tt>:force</tt>]
+        #   Set to +:cascade+ to drop dependent objects as well.
+        #   Defaults to false.
+        # [<tt>:if_not_exists</tt>]
+        #   Set to true to avoid raising an error when the schema already exists.
+        #   Defaults to false.
         def create_schema(schema_name, if_not_exists: false, force: false)
           if force
             drop_schema(schema_name, if_exists: true, force: force)
@@ -221,6 +228,13 @@ module ActiveRecord
         end
 
         # Drops the schema for the given schema name.
+        #
+        # [<tt>:force</tt>]
+        #   Set to +:cascade+ to drop dependent objects as well.
+        #   Defaults to false.
+        # [<tt>:if_exists</tt>]
+        #   Set to +true+ to only drop the schema if it exists.
+        #   Defaults to false.
         def drop_schema(schema_name, **options)
           execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)}#{' CASCADE' if ActiveRecord.postgresql_drop_schema_cascade || options[:force] == :cascade}"
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -213,8 +213,8 @@ module ActiveRecord
         end
 
         # Creates a schema for the given schema name.
-        def create_schema(schema_name)
-          execute "CREATE SCHEMA #{quote_schema_name(schema_name)}"
+        def create_schema(schema_name, if_not_exists: false)
+          execute "CREATE SCHEMA#{' IF NOT EXISTS' if if_not_exists} #{quote_schema_name(schema_name)}"
         end
 
         # Drops the schema for the given schema name.

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -342,27 +342,27 @@ module ActiveRecord
           super
         end
 
-      def invert_create_schema(args, &block)
-        if args.last.is_a?(Hash)
-          args.last.delete(:if_not_exists)
+        def invert_create_schema(args, &block)
+          if args.last.is_a?(Hash)
+            args.last.delete(:if_not_exists)
 
-          if args.last[:force]
-            raise ActiveRecord::IrreversibleMigration, "create_schema is not reversible if given a :force option."
+            if args.last[:force]
+              raise ActiveRecord::IrreversibleMigration, "create_schema is not reversible if given a :force option."
+            end
           end
+          super
         end
-        super
-      end
 
-      def invert_drop_schema(args, &block)
-        if args.last.is_a?(Hash)
-          args.last.delete(:if_exists)
+        def invert_drop_schema(args, &block)
+          if args.last.is_a?(Hash)
+            args.last.delete(:if_exists)
 
-          if args.last[:force]
-            raise ActiveRecord::IrreversibleMigration, "drop_schema is not reversible if given a :force option."
+            if args.last[:force]
+              raise ActiveRecord::IrreversibleMigration, "drop_schema is not reversible if given a :force option."
+            end
           end
+          super
         end
-        super
-      end
 
         def respond_to_missing?(method, _)
           super || delegate.respond_to?(method)

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -186,7 +186,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       @connection.drop_enum("test_schema.mood_in_other_schema")
     end
   ensure
-    @connection.drop_schema("test_schema", if_exists: true)
+    @connection.drop_schema("test_schema", force: :cascade)
   end
 
   def test_schema_dump_scoped_to_schemas
@@ -207,7 +207,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       assert_not_includes output, 'create_enum "other_schema.mood_in_other_schema"'
     end
   ensure
-    @connection.drop_schema("other_schema")
+    @connection.drop_schema("other_schema", force: :cascade)
   end
 
   def test_schema_load_scoped_to_schemas
@@ -229,7 +229,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       assert @connection.column_exists?("test_schema.postgresql_enums_in_test_schema", :current_mood, sql_type: "test_schema.mood_in_test_schema")
     end
   ensure
-    @connection.drop_schema("test_schema")
+    @connection.drop_schema("test_schema", force: :casade)
   end
 
   private
@@ -239,7 +239,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       @connection.schema_search_path = "#{name}, public"
       yield
     ensure
-      @connection.drop_schema(name) if drop
+      @connection.drop_schema(name, force: :cascade) if drop
       @connection.schema_search_path = old_search_path
       @connection.schema_cache.clear!
     end

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -65,7 +65,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
 
     assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
   ensure
-    @connection.drop_schema "other_schema", if_exists: true
+    @connection.drop_schema "other_schema", force: :cascade
   end
 
 

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -128,7 +128,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     assert_equal 1, result.first["count"], "referential_integrity_test_schema should have 1 foreign key"
     @connection.check_all_foreign_keys_valid!
   ensure
-    @connection.drop_schema "referential_integrity_test_schema", if_exists: true
+    @connection.drop_schema "referential_integrity_test_schema", force: :cascade
   end
 
   private

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -33,7 +33,7 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
     set_session_auth
     @connection.execute "RESET search_path"
     USERS.each do |u|
-      @connection.drop_schema u
+      @connection.drop_schema u, force: :cascade
       @connection.execute "DROP USER #{u}"
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -130,6 +130,21 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_schema "test_schema3"
   end
 
+  def test_create_schema_if_not_exists
+    @connection.create_schema "test_schema3", if_not_exists: true
+    assert @connection.schema_names.include? "test_schema3"
+  ensure
+    @connection.drop_schema "test_schema3"
+  end
+
+  def test_create_schema_if_not_exists_with_existing_schema
+    @connection.create_schema "test_schema3"
+    @connection.create_schema "test_schema3", if_not_exists: true
+    assert @connection.schema_names.include? "test_schema3"
+  ensure
+    @connection.drop_schema "test_schema3"
+  end
+
   def test_drop_schema
     begin
       @connection.create_schema "test_schema3"

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -80,6 +80,8 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
+    ActiveRecord.postgresql_drop_schema_cascade = false
+
     @connection = ActiveRecord::Base.connection
     @connection.execute "CREATE SCHEMA #{SCHEMA_NAME} CREATE TABLE #{TABLE_NAME} (#{COLUMNS.join(',')})"
     @connection.execute "CREATE TABLE #{SCHEMA_NAME}.\"#{TABLE_NAME}.table\" (#{COLUMNS.join(',')})"
@@ -179,6 +181,17 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   ensure
     @connection.drop_schema "test_schema3", force: :cascade
+  end
+
+  def test_drop_schema_cascade_with_postgresql_drop_schema_cascade
+    ActiveRecord.postgresql_drop_schema_cascade = true
+    @connection.create_schema "test_schema3"
+    @connection.create_table "test_schema3.test_table", force: true do |t|
+      t.integer :foo
+    end
+    @connection.drop_schema "test_schema3"
+  ensure
+    ActiveRecord.postgresql_drop_schema_cascade = false
   end
 
   def test_drop_schema_if_exists

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -145,6 +145,20 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_schema "test_schema3"
   end
 
+  def test_create_schema_with_force
+    @connection.create_schema "test_schema3"
+    @connection.create_table "test_schema3.test_with_force_table", force: true do |t|
+    end
+    assert @connection.table_exists?("test_schema3.test_with_force_table")
+
+    @connection.create_schema "test_schema3", force: :cascade
+
+    assert @connection.schema_names.include? "test_schema3"
+    assert_not @connection.table_exists?("test_schema3.test_with_force_table")
+  ensure
+    @connection.drop_schema "test_schema3", force: :cascade
+  end
+
   def test_drop_schema
     begin
       @connection.create_schema "test_schema3"

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -102,7 +102,7 @@ if ActiveRecord::Base.connection.supports_check_constraints?
               @connection.add_check_constraint "test_schema.trades", "quantity > 0"
             end
           ensure
-            @connection.drop_schema "test_schema"
+            @connection.drop_schema "test_schema", force: :cascade
           end
         end
 

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -512,6 +512,38 @@ module ActiveRecord
           @recorder.inverse_of :drop_enum, [:color, if_exists: true]
         end
       end
+
+      def test_invert_create_schema
+        drop = @recorder.inverse_of :create_schema, [:writers]
+        assert_equal [:drop_schema, [:writers], nil], drop
+      end
+
+      def test_invert_create_schema_with_if_exists
+        drop = @recorder.inverse_of :create_schema, [:writers, if_not_exists: true]
+        assert_equal [:drop_schema, [:writers, {}], nil], drop
+      end
+
+      def test_invert_create_schema_with_force
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :create_schema, [:writers, force: :cascade]
+        end
+      end
+
+      def test_invert_drop_schema
+        create = @recorder.inverse_of :drop_schema, [:writers]
+        assert_equal [:create_schema, [:writers], nil], create
+      end
+
+      def test_invert_drop_schema_with_if_exists
+        create = @recorder.inverse_of :drop_schema, [:writers, if_exists: true]
+        assert_equal [:create_schema, [:writers, {}], nil], create
+      end
+
+      def test_invert_drop_schema_with_force
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_schema, [:writers, force: :cascade]
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -76,7 +76,7 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
             @connection.add_exclusion_constraint "test_schema.invoices", "daterange(start_date, end_date) WITH &&", using: :gist
           end
         ensure
-          @connection.drop_schema "test_schema"
+          @connection.drop_schema "test_schema", force: :cascade
         end
 
         def test_add_exclusion_constraint

--- a/activerecord/test/cases/migration/unique_key_test.rb
+++ b/activerecord/test/cases/migration/unique_key_test.rb
@@ -64,7 +64,7 @@ if ActiveRecord::Base.connection.supports_unique_keys?
             @connection.add_unique_key "test_schema.sections", [:position]
           end
         ensure
-          @connection.drop_schema "test_schema"
+          @connection.drop_schema "test_schema", force: :cascade
         end
 
         def test_add_unique_key_without_deferrable

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1210,7 +1210,7 @@ class IndexForTableWithSchemaMigrationTest < ActiveRecord::TestCase
       connection.remove_index("my_schema.values", :value)
       assert_not connection.index_exists?("my_schema.values", :value)
     ensure
-      connection.drop_schema("my_schema")
+      connection.drop_schema("my_schema", force: :cascade)
     end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -69,6 +69,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.default_column_serializer`](#config-active-record-default-column-serializer): `nil`
 - [`config.active_record.encryption.hash_digest_class`](#config-active-record-encryption-hash-digest-class): `OpenSSL::Digest::SHA256`
 - [`config.active_record.marshalling_format_version`](#config-active-record-marshalling-format-version): `7.1`
+- [`config.active_record.postgresql_drop_schema_cascade`](#config-active-record-postgresql-drop-schema-cascade): `false`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
 - [`config.active_record.run_after_transaction_callbacks_in_order_defined`](#config-active-record-run-after-transaction-callbacks-in-order-defined): `true`
@@ -1145,6 +1146,13 @@ enabled.
 | --------------------- | -------------------- |
 | (original)            | `6.1`                |
 | 7.1                   | `7.1`                |
+
+#### `config.active_record.postgresql_drop_schema_cascade`
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 7.1                   | `false`              |
 
 #### `config.active_record.action_on_strict_loading_violation`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -285,6 +285,7 @@ module Rails
             active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
             active_record.marshalling_format_version = 7.1
             active_record.run_after_transaction_callbacks_in_order_defined = true
+            active_record.postgresql_drop_schema_cascade = false
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -166,3 +166,6 @@
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 # Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
+# Previous versions of active record would run CASCADE on drop_schema migration by default
+# Rails.application.config.active_record.postgresql_drop_schema_cascade = false


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We are working a lot with postgresql and schemas. I noticed that the ActiveRecord does not support many options for them. I want to enable possible options while maintaining similar behavior to `create_table` and `drop_table`

### Detail

- Added support of **IF NOT EXISTS** statement in `create_schema`
- Added support for `force: cascade` option in `create_schema` 
- **BREAKING CHANGE** Changed default behavior of `drop_schema`
  - no longer runs **CASCADE** by default
  - supports `force: :cascade` option, similar to `drop_table`
