### PR TITLE
Deprecate `check_pending!` in favor of `check_all_pending!`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `check_pending!` in favor of `check_pending_migrations!`.
+
+    `check_pending!` will only check for pending migrations on the current database connection or the one passed in. This has been deprecated in favor of `check_pending_migrations!` which will find all pending migrations for the database configurations in a given environment.
+
+    *Eileen M. Uchitelle*
+
 *   Make `increment_counter`/`decrement_counter` accept an amount argument
 
     ```ruby

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -44,6 +44,11 @@ module ActiveRecord
           assert_pending_migrations("01_create_foo.rb")
         end
 
+        def test_errors_if_pending_with_deprecated_method
+          create_migration "01", "create_foo"
+          assert_deprecated_check_pending("01_create_foo.rb")
+        end
+
         def test_checks_if_supported
           run_migrations
           assert_no_pending_migrations
@@ -87,10 +92,29 @@ module ActiveRecord
         end
 
         private
+          def assert_deprecated_check_pending(*expected_migrations)
+            2.times do
+              assert_raises ActiveRecord::PendingMigrationError do
+                assert_deprecated(ActiveRecord.deprecator) do
+                  ActiveRecord::Migration.check_pending!
+                end
+              end
+
+              error = assert_raises ActiveRecord::PendingMigrationError do
+                CheckPending.new(proc { flunk }).call({})
+              end
+
+              assert_includes error.message, "Migrations are pending."
+              expected_migrations.each do |migration|
+                assert_includes error.message, migration
+              end
+            end
+          end
+
           def assert_pending_migrations(*expected_migrations)
             2.times do
               assert_raises ActiveRecord::PendingMigrationError do
-                ActiveRecord::Migration.check_pending!
+                ActiveRecord::Migration.check_all_pending!
               end
 
               error = assert_raises ActiveRecord::PendingMigrationError do
@@ -110,7 +134,7 @@ module ActiveRecord
 
             2.times do
               assert_nothing_raised do
-                ActiveRecord::Migration.check_pending!
+                ActiveRecord::Migration.check_all_pending!
               end
 
               app.expect :call, nil, [{}]


### PR DESCRIPTION
`check_pending!` takes a connection that defaults to `Base.connection` (or migration_connection but right now that's always Base.connection). This means that we aren't able to loop through all the configs for an environment because this is a public API that accepts a single connection. To fix this I've deprecated `check_pending!` in favor of `check_all_pending!` which will loop through the configs and check for pending migrations on all the connections.

Example results:

```
Migrations are pending. To resolve this issue, run:

        bin/rails db:migrate

You have 3 pending migrations:

db/migrate/20221213152217_create_posts.rb
db/migrate/20230503150812_add_active_column_to_posts.rb
db/secondary_migrate/20230503173111_create_dogs.rb
```

Before this change, only migrations in `db/migrate` or `db/secondary_migrate` would be output by `ActiveRecord::Migration.check_pending!`. I chose not to accept a connection or db_config argument for this new method because it's not super useful. It's more useful to know all pending migrations. If it becomes problematic, we can reimplement the connection option on this method (or reintroduce `check_pending!`.