### PR TITLE
Note cache_format_version in framework defaults

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -166,3 +166,14 @@
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 # Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
+# ** Please read carefully, this must be configured in config/application.rb **
+# Change the format of the cache entry.
+# Changing this default means that all new cache entries added to the cache
+# will have a different format that is not supported by Rails 7.0
+# applications.
+# Only change this value after your application is fully deployed to Rails 7.1
+# and you have no plans to rollback.
+# When you're ready to change format, add this to `config/application.rb` (NOT
+# this file):
+#   config.active_support.cache_format_version = 7.1


### PR DESCRIPTION
### Motivation / Background

Since 7.1 was made the [default][1] for applications using `load_defaults 7.1`, this adds a note of how to safely opt into the configuration to new_framework_defaults.

### Detail

The comment is the same as we used when the [same change][2] was made for 7.0

[1]: https://github.com/rails/rails/commit/c94760cc0bb69a1fb52c23085c8f1a70f2de9adc
[2]: https://github.com/rails/rails/commit/270a2ddd6b70a1d188650afe48dddd025c4e605a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
