### PR TITLE
Fix active record insert values of type cast and serialize

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -237,7 +237,7 @@ module ActiveRecord
 
           values_list = insert_all.map_key_with_value do |key, value|
             next value if Arel::Nodes::SqlLiteral === value
-            connection.with_yaml_fallback(types[key].serialize(value))
+            types[key].serialize(types[key].cast(value))
           end
 
           connection.visitor.compile(Arel::Nodes::ValuesList.new(values_list))

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -46,6 +46,17 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_with_type_casting_and_serialize_is_consistent
+    skip unless supports_insert_returning?
+
+    book_name = ["Array"]
+    created_book_id = Book.create!(name: book_name).id
+    inserted_book_id = Book.insert!({ name: book_name }, returning: :id).first["id"]
+    raw_created_book_name = Book.connection.select_value(Book.select(:name).where(id: created_book_id))
+    raw_inserted_book_name = Book.connection.select_value(Book.select(:name).where(id: inserted_book_id))
+    assert_equal raw_created_book_name, raw_inserted_book_name
+  end
+
   def test_insert_all
     assert_difference "Book.count", +10 do
       Book.insert_all! [


### PR DESCRIPTION
### Motivation / Background

This is a problem that has existed since the introduction of [ActiveRecord::InsertAll](https://github.com/rails/rails/pull/35077/files#r260410047).
Initially, `ActiveRecord::InsertAll` used `ActiveRecord::Relation::QueryAttribute#value_for_database` to convert values. As the code evolved, it switched to using `ActiveModel::Type::XXX#serialize` to serialize values. 
This is inconsistent with how attributes are converted in `Model#save`, which uses `ActiveModel::Attribute::FromUser#value_for_database`. 
Therefore, in some cases, data created using `Model#insert` and `Model#create` may be inconsistent. eg:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org/"

  gem "sqlite3", "~> 1.7.0"
  gem "activerecord", "~> 7.1.0"
  gem "minitest"
  gem "minitest-reporters"
end

require "minitest/autorun"
require "minitest/reporters"
require "active_record"

Minitest::Reporters.use!

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name, null: false
  end
end

class User < ActiveRecord::Base; end

class BugTest < Minitest::Test
  def test_array_convertion
    created_id = User.create(name: ['Array']).id
    inserted_id = User.insert!({ name: ['Array'] }).first["id"]

    raw_created_name = User.connection.select_value(User.select(:name).where(id: created_id))
    raw_inserted_name = User.connection.select_value(User.select(:name).where(id: inserted_id))
    assert_equal raw_created_name, raw_inserted_name
  end

  def test_hash_convertion
    created_id = User.create(name: { foo: :bar }).id
    inserted_id = User.insert!({ name: { foo: :bar } }).first["id"]

    raw_created_name = User.connection.select_value(User.select(:name).where(id: created_id))
    raw_inserted_name = User.connection.select_value(User.select(:name).where(id: inserted_id))
    assert_equal raw_created_name, raw_inserted_name
  end
end
```

### Detail

- Fix value conversion of ActiveRecord::InsertAll::Builder#values_list

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @boblail @tenderlove @kamipo 

_PS: English is not my native language; please excuse typing errors._