### PR TITLE
Fix chmod race condition when generating key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ PATH
       irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
+      thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
 
 GEM
@@ -517,7 +517,7 @@ GEM
       railties (>= 6.0.0)
     terser (1.1.13)
       execjs (>= 0.3.0, < 3)
-    thor (1.2.1)
+    thor (1.2.2)
     tilt (2.0.11)
     timeout (0.3.2)
     tomlrb (2.0.3)

--- a/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
@@ -26,8 +26,7 @@ module Rails
       end
 
       def add_key_file_silently(key_path, key = nil)
-        create_file key_path, key || ActiveSupport::EncryptedFile.generate_key
-        key_path.chmod 0600
+        create_file key_path, key || ActiveSupport::EncryptedFile.generate_key, perm: 0600
       end
 
       def ignore_key_file(key_path, ignore: key_ignore(key_path))

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rackup", ">= 1.0.0"
   s.add_dependency "rake", ">= 12.2"
-  s.add_dependency "thor", "~> 1.0"
+  s.add_dependency "thor", "~> 1.0", ">= 1.2.2"
   s.add_dependency "zeitwerk", "~> 2.6"
   s.add_dependency "irb"
 


### PR DESCRIPTION
### Motivation / Background

Fixes #48135 

Encrypted keys were updated [previously][1] to restrict other users from reading the file by default. However, there is a brief period of time between an encrypted key being created and its permissions being set to 0600. This means that it is possible for another user to read that file during that time.

### Detail

This commit fixes that issue by setting the desired permissions when the file is created. The ability to use the `perm` option was added in Thor 1.2.2 so the minimum version was updated in the Railties gemspec.

[1]: https://github.com/rails/rails/commit/4c6c3575c66ce10043c9ea04023788890a228de8

### Additional information

~I've pointed this at my branch of Thor to show that rails/thor#820 would enable fixing this, but that would have to be changed to merge this.~ Done!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
