### PR TITLE
Call proxy attribute methods for reserved aliases 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   `alias_attribute` can be used to alias columns named Active Record reserved terms.
+
+    If database schema end up having column named with one of the reserved terms like
+    `id_before_type_cast`, `id_was`, `id_in_database`, `id_for_database` or `id` where `id` is not being used as a
+    primary key it is possible to alias attribute to a new name to be able to access the column value.
+
+    For example:
+
+    ```ruby
+      class Post < ActiveRecord::Base
+        # table has both `id` and `title` columns
+        self.primary_key = :title
+
+        alias_attribute :id_value, :id
+      end
+
+      # returns the `id` column value and not the `title`
+      Post.create(title: "New post").id_value # => 1
+    ```
+
+    *Nikita Vasilevsky*
+
 *   Fix mutation detection for serialized attributes backed by binary columns.
 
     *Jean Boussier*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -106,6 +106,11 @@ module ActiveRecord
         ::ActiveRecord::AttributeMethods.dangerous_attribute_methods.include?(name.to_s)
       end
 
+      # Same as dangerous_attribute_method? but includes primary key methods.
+      def framework_reserved_method?(method_name) # :nodoc:
+        ::ActiveRecord::AttributeMethods.dangerous_attribute_methods.include?(method_name.to_s)
+      end
+
       def method_defined_within?(name, klass, superklass = klass.superclass) # :nodoc:
         if klass.method_defined?(name) || klass.private_method_defined?(name)
           if superklass.method_defined?(name) || superklass.private_method_defined?(name)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -13,6 +13,7 @@ require "models/reply"
 require "models/contact"
 require "models/keyboard"
 require "models/numeric_data"
+require "models/cpk"
 
 class AttributeMethodsTest < ActiveRecord::TestCase
   include InTimeZone
@@ -28,6 +29,24 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   teardown do
     ActiveRecord::Base.send(:attribute_method_patterns).clear
     ActiveRecord::Base.send(:attribute_method_patterns).concat(@old_matchers)
+  end
+
+  test "aliasing `id` attribute allows reading the column value" do
+    t = Topic.create(id: 123_456, title: "title").becomes(TitlePrimaryKeyTopic)
+
+    assert_not_nil(t.id_value)
+    assert_equal(123_456, t.id_value)
+  ensure
+    t.delete
+  end
+
+  test "aliasing `id` attribute allows reading the column value for a CPK model" do
+    order = Cpk::Order.create(id: [1, 123_456])
+
+    assert_not_nil(order.id_value)
+    assert_equal(123_456, order.id_value)
+  ensure
+    order.delete
   end
 
   test "attribute_for_inspect with a string" do

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -5,6 +5,8 @@ module Cpk
     self.table_name = :cpk_orders
     self.primary_key = [:shop_id, :id]
 
+    alias_attribute :id_value, :id
+
     has_many :order_agreements, primary_key: :id
     has_many :books
   end

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -144,6 +144,9 @@ end
 
 class TitlePrimaryKeyTopic < Topic
   self.primary_key = :title
+
+  alias_attribute :id_value, :id
+  alias_attribute :subject, :title
 end
 
 module Web


### PR DESCRIPTION
This PR allows aliasing columns named with one of the reserved
methods like `id`, `id_before_type_cast`, `id_was`, etc if database
schema happed to have one of these.

Currently there is no convenient way of reading the `id` column value
which is not being used as a primary key as `id` in Rails is a reserved
term which means "an identifier" or the value stored in the primary key
column.

Given a `posts` table with both `id` and `title` columns where `title`
is being used as a primary key it is possible to alias `id` attribute
to a new name so we can fetch the column value.

For example:
```ruby
class Post < ActiveRecord::Base
  self.primary_key = :title
  alias_attribute :post_id, :id
end

post = Post.create(title: "Hello world")
post.post_id # => 1
```

### Technical details

Currently aliasing an attribute like `alias_attribute :subject, :title` will define `<prefix_subject_suffix>` methods that directly delegate to the `*title*` methods. For example the `subject` reader would look like:

```ruby
def subject
  title
end
```
This works fine but doesn't work when aliasing any of the Active Record reserved methods so in current implementation an alias like `alias_attribute :subject, :id` ends up generating

```ruby
def subject
  id
end
```

which will return the value behind the `primary_key` column and not the `id` column value. 

With the change we are proposing aliasing reserved method will generate methods that call into so-called "proxy" methods that read directly from the attributes. So aliasing `id` attribute will generate:

```ruby
def subject
  attribute("id")
end
```
https://github.com/rails/rails/blob/d503e893056650524caaf9ffe0364417224c051a/activemodel/lib/active_model/attributes.rb#L148-L149

along with `attribute_was?` `attribute_changed?`, etc and allow to access the `id` value directly. 

Since now we have versions of the alias attribute method body we had to make sure we are using two different namespaces to avoid one of the bodies being cached. This is to prevent issues when a non Active Record model, like an Active Model model aliases `id` and pollutes the `:alias_attribute` namespace cache with a non-primary key implementation. 

### Long-term plans

Despite of the solution being generic enough to allow for any of the reserved method names to be aliased, Rails currently disallows having schema with columns named as one of the reserved methods. The exception will be raised from:
https://github.com/rails/rails/blob/e7f7a13950abfd980089fc581b56128ea4a04f8e/activerecord/lib/active_record/attribute_methods.rb#L89
However eventually Rails may end up relaxing this restriction assuming that a model could alias the reserved method column. For example if the application ends up in a situation where it needs to work with a schema that contains columns named with reserved terms it could alias these columns like:

```ruby
alias_attribute :delete_value, :delete
alias_attribute :save_value, :save
alias_attribute :update_value, :update
...
```

### Side note

Overall it looks like the `alias_attribute` generation could be simplified and we could at least get rid of one of the regexes 
https://github.com/rails/rails/blob/d503e893056650524caaf9ffe0364417224c051a/activemodel/lib/active_model/attribute_methods.rb#L67-L68

Also `COMPILABLE` term doesn't seem to be the best fit for the logic anymore. As far as I can tell it used to differentiate between methods built inline like a string (compiled) and methods that were defined using `define_method` 
We are not using `define_method` anymore which means both of the branches are "complied" in the legacy terms.
So it looks like we can refactor the logic to only do the `.match` once to determine whether we want a `send` body or `self.method` body. It may not result in any performance gains but overall the logic is complex and it would be nice to simplify it a bit.
