### PR TITLE
Fix empty collection caching raising on blank key during instrumentation

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -946,6 +946,12 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
     end
   end
 
+  test "collection caching with empty collection and logger with level debug" do
+    ActionView::PartialRenderer.collection_cache.logger = Logger.new(nil, level: :debug)
+
+    assert_nil @view.render(partial: "test/cached_customer", collection: [], cached: true)
+  end
+
   test "collection caching with repeated collection" do
     sets = [
         [1, 2, 3, 4, 5],


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix a regression introduced in https://github.com/rails/rails/pull/48043 where an `ArgumentError` would raise during collection caching instrumentation when the collection is empty.

Additional context [in this comment](https://github.com/rails/rails/pull/48043#issuecomment-1535542971).

### Detail

This Pull Request changes:
- `ActiveSupport::Cache#normalize_key` to have an optional param for disabling key validation.
- `ActiveSupport::Cache#instrument`to skip key validation during normalization for logging.

I opted for this approach over simply skipping normalization during instrumentation because the order of instrumentation and normalization can't be guaranteed, so it might be possible for instrumentation to occur before the key is validated, in which case we want to avoid this occuring in similar cases in the future.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

None.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
