### PR TITLE
Add credentials convenience method on Rails

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Convenience method for direct access to Rails credentials
+
+    ```ruby
+    Rails.credentials
+    ```
+
+    *Matt Polito*
+
 *   `bin/rails app:template` now runs `bundle install` and any `after_bundle`
     blocks after the template is executed.
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -51,6 +51,11 @@ module Rails
       application.config
     end
 
+    # Access to decrypted credentials hash
+    def credentials
+      application.credentials
+    end
+
     def backtrace_cleaner
       @backtrace_cleaner ||= Rails::BacktraceCleaner.new
     end

--- a/railties/test/application/credentials_test.rb
+++ b/railties/test/application/credentials_test.rb
@@ -37,6 +37,11 @@ class Rails::CredentialsTest < ActiveSupport::TestCase
     end
   end
 
+  test "application has convenience method for accessing credentials" do
+    app("production")
+    assert_equal(Rails.application.credentials, Rails.credentials)
+  end
+
   private
     def write_credentials_override(name, with_key: true)
       Dir.chdir(app_path) do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because writing `Rails.application.credentials` can be a tad cumbersome.

### Detail

This Pull Request changes `Rails` to have a convenient `credentials` method for one less hop to get to credentials. (Similar to `Rails.configuration`)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
