### PR TITLE
Log key summary for `*_multi` cache operations

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -442,7 +442,7 @@ module ActiveSupport
         options = names.extract_options!
         options = merged_options(options)
 
-        instrument :read_multi, names, options do |payload|
+        instrument_multi :read_multi, names, options do |payload|
           read_multi_entries(names, **options, event: payload).tap do |results|
             payload[:hits] = results.keys
           end
@@ -455,7 +455,7 @@ module ActiveSupport
 
         options = merged_options(options)
 
-        instrument :write_multi, hash, options do |payload|
+        instrument_multi :write_multi, hash, options do |payload|
           entries = hash.each_with_object({}) do |(name, value), memo|
             memo[normalize_key(name, options)] = Entry.new(value, **options.merge(version: normalize_version(name, options)))
           end
@@ -500,7 +500,7 @@ module ActiveSupport
         options = names.extract_options!
         options = merged_options(options)
 
-        instrument :read_multi, names, options do |payload|
+        instrument_multi :read_multi, names, options do |payload|
           if options[:force]
             reads = {}
           else
@@ -582,7 +582,7 @@ module ActiveSupport
         options = merged_options(options)
         names.map! { |key| normalize_key(key, options) }
 
-        instrument :delete_multi, names do
+        instrument_multi :delete_multi, names do
           delete_multi_entries(names, **options)
         end
       end
@@ -868,14 +868,33 @@ module ActiveSupport
           end
         end
 
-        def instrument(operation, key, options = nil)
+        def instrument(operation, key, options = nil, &block)
+          _instrument(operation, key: key, options: options, &block)
+        end
+
+        def instrument_multi(operation, keys, options = nil, &block)
+          _instrument(operation, multi: true, key: keys, options: options, &block)
+        end
+
+        def _instrument(operation, multi: false, options: nil, **payload, &block)
           if logger && logger.debug? && !silence?
-            logger.debug "Cache #{operation}: #{normalize_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}"
+            debug_key =
+              if multi
+                ": #{payload[:key].size} key(s) specified"
+              elsif payload[:key]
+                ": #{normalize_key(payload[:key], options)}"
+              end
+
+            debug_options = " (#{options.inspect})" unless options.blank?
+
+            logger.debug "Cache #{operation}#{debug_key}#{debug_options}"
           end
 
-          payload = { key: key, store: self.class.name }
+          payload[:store] = self.class.name
           payload.merge!(options) if options.is_a?(Hash)
-          ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) { yield(payload) }
+          ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) do
+            block&.call(payload)
+          end
         end
 
         def handle_expired_entry(entry, key, options)
@@ -895,7 +914,7 @@ module ActiveSupport
         end
 
         def get_entry_value(entry, name, options)
-          instrument(:fetch_hit, name, options) { }
+          instrument(:fetch_hit, name, options)
           entry.value
         end
 

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -76,7 +76,7 @@ module ActiveSupport
       # Preemptively iterates through all stored keys and removes the ones which have expired.
       def cleanup(options = nil)
         options = merged_options(options)
-        instrument(:cleanup, size: @data.size) do
+        _instrument(:cleanup, size: @data.size) do
           keys = synchronize { @data.keys }
           keys.each do |key|
             entry = @data[key]

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -178,7 +178,7 @@ module ActiveSupport
         return {} if names.empty?
 
         options = names.extract_options!
-        instrument(:read_multi, names, options) do |payload|
+        instrument_multi(:read_multi, names, options) do |payload|
           read_multi_entries(names, **options).tap do |results|
             payload[:hits] = results.keys
           end

--- a/activesupport/test/cache/behaviors.rb
+++ b/activesupport/test/cache/behaviors.rb
@@ -3,6 +3,7 @@
 require_relative "behaviors/cache_delete_matched_behavior"
 require_relative "behaviors/cache_increment_decrement_behavior"
 require_relative "behaviors/cache_instrumentation_behavior"
+require_relative "behaviors/cache_logging_behavior"
 require_relative "behaviors/cache_store_behavior"
 require_relative "behaviors/cache_store_version_behavior"
 require_relative "behaviors/cache_store_coder_behavior"

--- a/activesupport/test/cache/behaviors/cache_logging_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_logging_behavior.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/with"
+
+module CacheLoggingBehavior
+  def test_read_multi_logging
+    assert_logs("Cache read_multi: 1 key(s)") { @cache.read_multi("foo") }
+    assert_logs("Cache read_multi: 2 key(s)") { @cache.read_multi("foo", "bar") }
+  end
+
+  def test_write_multi_logging
+    key = SecureRandom.uuid
+    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi("#{key}1" => 1) }
+    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi("#{key}1" => 1, "#{key}2" => 2) }
+  end
+
+  def test_delete_multi_logging
+    key = SecureRandom.uuid
+    assert_logs("Cache delete_multi: 1 key(s)") { @cache.delete_multi(["#{key}1"]) }
+    assert_logs("Cache delete_multi: 2 key(s)") { @cache.delete_multi(["#{key}1", "#{key}2"]) }
+  end
+
+  private
+    def assert_logs(pattern, &block)
+      io = StringIO.new
+      ActiveSupport::Cache::Store.with(logger: Logger.new(io, level: :debug), &block)
+      assert_match pattern, io.string
+    end
+end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -36,6 +36,7 @@ class FileStoreTest < ActiveSupport::TestCase
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
+  include CacheLoggingBehavior
 
   def test_clear
     gitkeep = File.join(cache_dir, ".gitkeep")

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -81,6 +81,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   include LocalCacheBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
+  include CacheLoggingBehavior
   include EncodedKeyCacheBehavior
   include ConnectionPoolBehavior
   include FailureSafetyBehavior

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -147,6 +147,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include LocalCacheBehavior
     include CacheIncrementDecrementBehavior
     include CacheInstrumentationBehavior
+    include CacheLoggingBehavior
     include EncodedKeyCacheBehavior
 
     def test_fetch_multi_uses_redis_mget


### PR DESCRIPTION
This commit addresses a few problems:

1.  `read_multi` (and `fetch_multi` and `delete_multi`) logs multiple keys as if they were a single composite key.  For example, `read_multi("posts/1", "posts/2")` will log "Cache read_multi: posts/1/posts/2".  This can make the log confusing or indecipherable when keys contain more slashes, such as with view fragments.

2.  `write_multi` logs its entire argument as a single composite key.  For example, `write_multi("p1" => post1, "p2" => post2)` will log "Cache write_multi: p1=#<Post:0x...>/p2=#<Post:0x...>".

3.  `MemoryStore#cleanup` logs its instrumentation payload instead of setting it on the event.  For example, when 10 entries are in the cache, `cleanup` will log "Cache cleanup: size=10" instead of merging `{ size: 10 }` into the event payload.

Multi-key logging was first added in ca6aba7f30ad9910f17e4c5b39667889d9518794, then reverted in c4a46fa781d39f1b4607cb1613a1c67fa044ce54 due to being unwieldy, and then re-added in 2b96d5822bfe407be7589e293f3265c0c7a6726c (for `write_multi`) and 62023884f76c108127c8966f4d67bb717338dd66 (for `read_multi`) but without any handling or formatting.

This commit changes the way multi-key operations are logged in order to prevent these problems.  For example, `read_multi("posts/1", "posts/2")` will now log "Cache read_multi: 2 key(s) specified", and `write_multi("p1" => post1, "p2" => post2)` will now log "Cache write_multi: 2 key(s) specified".
