### PR TITLE
Document `cache_*_multi` events [ci-skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -451,7 +451,16 @@ INFO. This event is only emitted when `config.active_record.action_on_strict_loa
 | `:key`             | Key used in the store                               |
 | `:store`           | Name of the store class                             |
 | `:hit`             | If this read is a hit                               |
-| `:super_operation` | `:fetch` is added when a read is used with `#fetch` |
+| `:super_operation` | `:fetch` is added when a read is done with `#fetch` |
+
+#### cache_read_multi.active_support
+
+| Key                | Value                                                           |
+| ------------------ | --------------------------------------------------------------- |
+| `:key`             | Keys used in the store                                          |
+| `:store`           | Name of the store class                                         |
+| `:hits`            | Keys of cache hits                                              |
+| `:super_operation` | `:fetch_multi` is added when a read is done with `#fetch_multi` |
 
 #### cache_generate.active_support
 
@@ -505,6 +514,13 @@ INFO. Cache stores may add their own keys
 }
 ```
 
+#### cache_write_multi.active_support
+
+| Key      | Value                                |
+| -------- | ------------------------------------ |
+| `:key`   | Keys and values written to the store |
+| `:store` | Name of the store class              |
+
 #### cache_delete.active_support
 
 | Key      | Value                   |
@@ -518,6 +534,13 @@ INFO. Cache stores may add their own keys
   store: "ActiveSupport::Cache::MemCacheStore"
 }
 ```
+
+#### cache_delete_multi.active_support
+
+| Key      | Value                   |
+| -------- | ----------------------- |
+| `:key`   | Keys used in the store  |
+| `:store` | Name of the store class |
 
 #### cache_exist?.active_support
 


### PR DESCRIPTION
This adds documentation for the `cache_read_multi.active_support`, `cache_write_multi.active_support`, and `cache_delete_multi.active_support` events to the Instrumentation guide.
