### PR TITLE
Fix a Gem::Version Comparison

### DIFF
--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -100,7 +100,7 @@ module ActiveRecord
       end
 
       def test_yaml_column_permitted_classes_are_consumed_by_safe_dump
-        if Gem::Version.new(Psych::VERSION) < "5.1"
+        if Gem::Version.new(Psych::VERSION) < Gem::Version.new("5.1")
           skip "YAML.safe_dump is either missing on unavailable on #{Psych::VERSION}"
         end
 


### PR DESCRIPTION
Gem::Version comparison against strings breaks for older versions of RubyGems.


### Motivation / Background

I am trying to create a [Nix environment](https://github.com/JoeDupuis/rails-contrib-nix) to help with contributing to Rails and this test fails unless running a recent version of RubyGems. 
This change makes spinning up a contributor environment a little bit easier.  

Plus it would match the style in the [rest of the framework](https://github.com/search?q=repo%3Arails%2Frails%20Gem%3A%3AVersion&type=code) (including [the code under test](https://github.com/rails/rails/blob/37d040884969d5e9a819b623e67af26f5d0d9a71/activerecord/lib/active_record/coders/yaml_column.rb#L14)).


### Checklist

* [x] This Pull Request is related to one change. 
* [x] Commit message has a detailed description of what changed and why. 
* [x] Tests are added or updated if you fix a bug or add a feature. (Fixing a test)
* [X] CHANGELOG  (Small fix, N/A)
