### PR TITLE
Fix a code block in the Arel documentation

### DIFF
--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -40,7 +40,7 @@ module Arel
   # for more information.
   #
   # To construct a more complex query fragment, including the possible
-  # use of user-provided values, the +sql_string+ may contain +?+ and
+  # use of user-provided values, the +sql_string+ may contain <tt>?</tt> and
   # +:key+ placeholders, corresponding to the additional arguments. Note
   # that this behavior only applies when bind value parameters are
   # supplied in the call; without them, the placeholder tokens have no


### PR DESCRIPTION
Fix a code block in the Arel documentation 
`+?+` doesn't compile to a code block.

Can be tested with:
`echo "+?+" | rdoc --pipe  #=> <p>+?+</p>`
`echo "<tt>?</tt>" | rdoc --pipe  #=> <p><code>?</code></p>`
