### PR TITLE
Handle empty list of cache keys

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -946,6 +946,12 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
     end
   end
 
+  test "collection caching with empty collection and logger with level debug" do
+    ActionView::PartialRenderer.collection_cache.logger = Logger.new(nil, level: :debug)
+
+    assert_nil @view.render(partial: "test/cached_customer", collection: [], cached: true)
+  end
+
   test "collection caching with repeated collection" do
     sets = [
         [1, 2, 3, 4, 5],

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -437,6 +437,8 @@ module ActiveSupport
       #
       # Returns a hash mapping the names provided to the values found.
       def read_multi(*names)
+        return {} if names.empty?
+
         options = names.extract_options!
         options = merged_options(options)
 
@@ -449,6 +451,8 @@ module ActiveSupport
 
       # Cache Storage API to write multiple values at once.
       def write_multi(hash, options = nil)
+        return hash if hash.empty?
+
         options = merged_options(options)
 
         instrument :write_multi, hash, options do |payload|
@@ -491,6 +495,7 @@ module ActiveSupport
       #   # => nil
       def fetch_multi(*names)
         raise ArgumentError, "Missing block: `Cache#fetch_multi` requires a block." unless block_given?
+        return {} if names.empty?
 
         options = names.extract_options!
         options = merged_options(options)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -175,6 +175,8 @@ module ActiveSupport
       # Read multiple values at once. Returns a hash of requested keys ->
       # fetched values.
       def read_multi(*names)
+        return {} if names.empty?
+
         options = names.extract_options!
         instrument(:read_multi, names, options) do |payload|
           read_multi_entries(names, **options).tap do |results|

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -147,6 +147,10 @@ module CacheStoreBehavior
     assert_equal({ key => "bar", other_key => "baz" }, @cache.read_multi(key, other_key))
   end
 
+  def test_read_multi_empty_list
+    assert_equal({}, @cache.read_multi())
+  end
+
   def test_read_multi_with_expires
     time = Time.now
     key = SecureRandom.uuid
@@ -157,6 +161,10 @@ module CacheStoreBehavior
     Time.stub(:now, time + 11) do
       assert_equal({ other_key => "baz" }, @cache.read_multi(other_key, SecureRandom.alphanumeric))
     end
+  end
+
+  def test_write_multi_empty_hash
+    assert @cache.write_multi({})
   end
 
   def test_fetch_multi
@@ -170,6 +178,10 @@ module CacheStoreBehavior
 
     assert_equal({ key => "bar", other_key => "biz", third_key => (third_key * 2) }, values)
     assert_equal((third_key * 2), @cache.read(third_key))
+  end
+
+  def test_fetch_multi_empty_hash
+    assert_equal({}, @cache.fetch_multi() { raise "Not called" })
   end
 
   def test_fetch_multi_without_expires_in


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/48145

`read_multi`, `write_multi` and `fetch multi` should all bail out early if somehow called with an empty list.

I believe the actual bug to fix is to properly handle empty list of keys.

cc @joshuay03, giving you co-authorship for your Action View test.

also cc @jonathanhefner.