### PR TITLE
Handle empty key list for `delete_multi`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -579,6 +579,8 @@ module ActiveSupport
       #
       # Options are passed to the underlying cache implementation.
       def delete_multi(names, options = nil)
+        return 0 if names.empty?
+
         options = merged_options(options)
         names.map! { |key| normalize_key(key, options) }
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -519,6 +519,10 @@ module CacheStoreBehavior
     assert_not @cache.exist?(other_key)
   end
 
+  def test_delete_multi_empty_list
+    assert_equal(0, @cache.delete_multi([]))
+  end
+
   def test_original_store_objects_should_not_be_immutable
     bar = +"bar"
     key = SecureRandom.alphanumeric


### PR DESCRIPTION
Follow-up to #48154.

This adds short-circuiting behavior to `delete_multi` when an empty key list is specified in order to prevent an `ArgumentError` from being raised, similar to `read_multi`.
