### PR TITLE
Test `String#blank?` with every non-dummy encoding

### DIFF
--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,12 +16,19 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE") ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {} ]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now ]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }
     NOT.each   { |v| assert_equal false, v.blank?, "#{v.inspect} should not be blank" }
+  end
+
+  def test_blank_with_bundled_string_encodings
+    Encoding.list.reject(&:dummy?).each do |encoding|
+      assert_predicate " ".encode(encoding), :blank?
+      assert_not_predicate "a".encode(encoding), :blank?
+    end
   end
 
   def test_present


### PR DESCRIPTION
This adds test coverage for `String#blank?` with every non-dummy encoding that is bundled with Ruby.
