### PR TITLE
Use "library.name" format in initializer examples [ci skip]

### DIFF
--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -22,7 +22,7 @@ module ActiveSupport
   #
   #   module MyLibrary
   #     class Railtie < Rails::Railtie
-  #       initializer "deprecator" do |app|
+  #       initializer "my_library.deprecator" do |app|
   #         app.deprecators[:my_library] = MyLibrary.deprecator
   #       end
   #     end

--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -172,7 +172,7 @@ Error-reporting libraries can register their subscribers in a `Railtie`:
 ```ruby
 module MySdk
   class Railtie < ::Rails::Railtie
-    initializer "error_subscribe.my_sdk" do
+    initializer "my_sdk.error_subscribe" do
       Rails.error.subscribe(MyErrorSubscriber.new)
     end
   end


### PR DESCRIPTION
### Detail 

This updates two instances of custom initializer examples in the docs to use the standard "library.name" format. Previously, one used just "name" which can lead to hard to debug "cyclic dependency" errors, and the other used "name.library" which is not the suggested format.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
