### PR TITLE
Fix a race condition in Action Text's test suite

### DIFF
--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class ActionText::ModelTest < ActiveSupport::TestCase
+  include QueryHelpers
+
   test "html conversion" do
     message = Message.new(subject: "Greetings", content: "<h1>Hello world</h1>")
     assert_equal %Q(<div class="trix-content">\n  <h1>Hello world</h1>\n</div>\n), "#{message.content}"


### PR DESCRIPTION
`assert_queries` in Action Text's test helpers can detect queries from a previous test if background jobs are allowed to run during its execution.

Changing the queue_adapter to the test adapter for all tests that have access to this helper ensure no jobs can run during its execution.

### Motivation / Background
I encountered some flaky tests while working on another PR.

### Detail
#### Repro
The race condition is hard to reproduce, since it depends on your dev environment, but I am able to reproduce it fairly consistently with `SEED=59837 bin/test`.

When I run the test in isolation the test pass. (` SEED=59837 bin/test test/unit/model_test.rb -n test_eager_loading`)

#### Why the new module?
Including `ActiveJob::TestHelper` in all Action Text test files seems overkill and including it only where it is currently used (`model_test.rb`) leave us exposed to race condition in the future if the `assert_queries` helper ends up being used in another file.

Therefore, I made it where you can't use the helper without also including `ActiveJob::TestHelper` by moving the helpers in module.

#### The error

This is the error I get:

```
Failure:
ActionText::ModelTest#test_eager_loading [/home/twistedjoe/Documents/testdouble/growth/save_and_open_page/rails/actiontext/test/unit/model_test.rb:102]:
3 instead of 2 queries were executed. ["SELECT \"messages\".* FROM \"messages\" ORDER BY \"messages\".\"id\" DESC LIMIT ?", "UPDATE \"active_storage_blobs\" SET \"metadata\" = ? WHERE \"active_storage_blobs\".\"id\" = ?", "SELECT \"action_text_rich_texts\".* FROM \"action_text_rich_texts\" WHERE \"action_text_rich_texts\".\"record_type\" = ? AND \"action_text_rich_texts\".\"name\" = ? AND \"action_text_rich_texts\".\"record_id\" = ?"].
Expected: 2
  Actual: 3
```
I cleaned up the queries to help with review:
```
SELECT "messages".* FROM "messages" ORDER BY "messages"."id" DESC LIMIT ?
UPDATE "active_storage_blobs" SET "metadata" = ? WHERE "active_storage_blobs"."id" = ?
SELECT "action_text_rich_texts".* FROM "action_text_rich_texts" WHERE "action_text_rich_texts"."record_type" = ? AND "action_text_rich_texts"."name" = ? AND "action_text_rich_texts"."record_id" = ?
```

The middle one doesn't belong since the [test doesn't do anything with Active Storage](https://github.com/rails/rails/blob/main/actiontext/test/unit/model_test.rb#L97-L104). 

3 tests in the same file (2 of them running before the faulty test with `SEED=59837`) do interact with active storage.

### Additional information
This also adds the positive side effect that libvips won't run during the model *unit* tests. Making the test suite faster! 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. 
* [x] Commit message has a detailed description of what changed and why. 
* [x] Tests are added or updated if you fix a bug or add a feature. N/A
* [x] CHANGELOG N/A
