### PR TITLE
Optimize mime types validation in ActionView::LookupContext

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -73,6 +73,6 @@ autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime::SET.symbols
-  ActionView::Template::Types.delegate_to Mime
+  ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -147,6 +147,6 @@ autoload :Mime, "action_dispatch/http/mime_type"
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime::SET.symbols
-  ActionView::Template::Types.delegate_to Mime
+  ActionView::Template.mime_types_implementation = Mime
   ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -42,6 +42,10 @@ module Mime
       Type.lookup_by_extension(type)
     end
 
+    def symbols
+      SET.symbols
+    end
+
     def fetch(type, &block)
       return type if type.is_a?(Type)
       EXTENSION_LOOKUP.fetch(type.to_s, &block)

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -11,6 +11,7 @@ module Mime
     def initialize
       @mimes = []
       @symbols = []
+      @symbols_set = Set.new
     end
 
     def each(&block)
@@ -19,16 +20,24 @@ module Mime
 
     def <<(type)
       @mimes << type
-      @symbols << type.to_sym
+      sym_type = type.to_sym
+      @symbols << sym_type
+      @symbols_set << sym_type
     end
 
     def delete_if
       @mimes.delete_if do |x|
         if yield x
-          @symbols.delete(x.to_sym)
+          sym_type = x.to_sym
+          @symbols.delete(sym_type)
+          @symbols_set.delete(sym_type)
           true
         end
       end
+    end
+
+    def valid_symbols?(symbols) # :nodoc
+      symbols.all? { |s| @symbols_set.include?(s) }
     end
   end
 
@@ -44,6 +53,10 @@ module Mime
 
     def symbols
       SET.symbols
+    end
+
+    def valid_symbols?(symbols) # :nodoc:
+      SET.valid_symbols?(symbols)
     end
 
     def fetch(type, &block)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -63,9 +63,11 @@ module ActionView
       end
 
       def self.details_cache_key(details)
-        if details[:formats]
-          details = details.dup
-          details[:formats] &= Template::Types.symbols
+        if formats = details[:formats]
+          unless Template::Types.valid_symbols?(formats)
+            details = details.dup
+            details[:formats] &= Template::Types.symbols
+          end
         end
         @details_keys[details] ||= TemplateDetails::Requested.new(**details)
       end
@@ -262,7 +264,7 @@ module ActionView
         values.concat(default_formats) if values.delete "*/*"
         values.uniq!
 
-        unless values.all? { |v| Template::Types.symbols.include?(v) }
+        unless Template::Types.valid_symbols?(values)
           invalid_values = values - Template::Types.symbols
           raise ArgumentError, "Invalid formats: #{invalid_values.map(&:inspect).join(", ")}"
         end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -63,13 +63,15 @@ module ActionView
       end
 
       def self.details_cache_key(details)
-        if formats = details[:formats]
-          unless Template::Types.valid_symbols?(formats)
-            details = details.dup
-            details[:formats] &= Template::Types.symbols
+        @details_keys.fetch(details) do
+          if formats = details[:formats]
+            unless Template::Types.valid_symbols?(formats)
+              details = details.dup
+              details[:formats] &= Template::Types.symbols
+            end
           end
+          @details_keys[details] ||= TemplateDetails::Requested.new(**details)
         end
-        @details_keys[details] ||= TemplateDetails::Requested.new(**details)
       end
 
       def self.clear

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -109,6 +109,7 @@ module ActionView
       autoload :Handlers
       autoload :HTML
       autoload :Inline
+      autoload :Types
       autoload :Sources
       autoload :Text
       autoload :Types
@@ -118,6 +119,17 @@ module ActionView
 
     singleton_class.attr_accessor :frozen_string_literal
     @frozen_string_literal = false
+
+    class << self # :nodoc:
+      def mime_types_implementation=(implementation)
+        # This method isn't thread-safe, but it's not supposed
+        # to be called after initialization
+        if self::Types != implementation
+          remove_const(:Types)
+          const_set(:Types, implementation)
+        end
+      end
+    end
 
     attr_reader :identifier, :handler
     attr_reader :variable, :format, :variant, :virtual_path

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -4,14 +4,23 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
   class Template # :nodoc:
+    # SimpleType is mostly just a stub implementation for when Action View
+    # is used without Action Dispatch.
     class SimpleType # :nodoc:
-      SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
+      @symbols = [ :html, :text, :js, :css, :xml, :json ]
+      class << self
+        attr_reader :symbols
 
-      def self.[](type)
-        if type.is_a?(self)
-          type
-        else
-          new(type)
+        def [](type)
+          if type.is_a?(self)
+            type
+          else
+            new(type)
+          end
+        end
+
+        def valid_symbols?(symbols) # :nodoc
+          symbols.all? { |s| @symbols.include?(s) }
         end
       end
 

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -4,53 +4,38 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
   class Template # :nodoc:
-    module Types
-      class Type
-        SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
+    class SimpleType # :nodoc:
+      SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
 
-        def self.[](type)
-          if type.is_a?(self)
-            type
-          else
-            new(type)
-          end
-        end
-
-        attr_reader :symbol
-
-        def initialize(symbol)
-          @symbol = symbol.to_sym
-        end
-
-        def to_s
-          @symbol.to_s
-        end
-        alias to_str to_s
-
-        def ref
-          @symbol
-        end
-        alias to_sym ref
-
-        def ==(type)
-          @symbol == type.to_sym unless type.blank?
+      def self.[](type)
+        if type.is_a?(self)
+          type
+        else
+          new(type)
         end
       end
 
-      class << self
-        attr_reader :symbols
+      attr_reader :symbol
 
-        def delegate_to(klass)
-          @symbols = klass::SET.symbols
-          @type_klass = klass
-        end
-
-        def [](type)
-          @type_klass[type]
-        end
+      def initialize(symbol)
+        @symbol = symbol.to_sym
       end
 
-      delegate_to Type
+      def to_s
+        @symbol.to_s
+      end
+      alias to_str to_s
+
+      def ref
+        @symbol
+      end
+      alias to_sym ref
+
+      def ==(type)
+        @symbol == type.to_sym unless type.blank?
+      end
     end
+
+    Types = SimpleType # :nodoc:
   end
 end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -4,7 +4,7 @@ require "abstract_unit"
 require "active_support/ordered_options"
 
 require "action_dispatch"
-ActionView::Template::Types.delegate_to Mime
+ActionView::Template.mime_types_implementation = Mime
 
 module AssetTagHelperTestHelpers
   def with_preload_links_header(new_preload_links_header = true)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48156

The assumption here is that in the overwhelming majority of cases, all formats are valid.

So we first check if any of the formats is invalid before duping the details hash and filtering them.

Additionally, by exposing a (non-public) `valid_symbols?` method, we can check symbols are valid without resporting to `Array#%` which would needlessly duplicate the `formats` array.

This optimization is based on a prior refactor of ActionView::Template::Types to avoid delegation.

The `Type` class was introduced in https://github.com/rails/rails/pull/23085 for the sole purpose of breaking the dependency of Action View on Action Dispatch.

Unless you are somehow running Action View standalone, this is actually never used.

So instead of delegating, we can use constant swapping, this saves us a useless layer.

Ultimately we could consider moving `Mime::Types` into Active Support but it requires some more thoughts.

cc @headius @ghiculescu

Also cc @jhawthorn as I see you've optimized the `Template::Types` delegation in the past.

I still need to benchmark to see how much we gain here, and if another approach may be faster, but I'd like to first check CI is green.