### PR TITLE
Discard connection when in an unknown transaction state.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1714,5 +1714,9 @@
 
     *Jonathan Hefner*
 
+*   Fix connections being left in untracked, open transactions.
+
+    *Nick Dower*
+
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -128,6 +128,7 @@ module ActiveRecord
       # method may be manually memory managed. Consider using #exec_query
       # wrapper instead.
       def execute(sql, name = nil, allow_retry: false)
+        transaction_manager.check_transaction_state_known!
         internal_execute(sql, name, allow_retry: allow_retry)
       end
 
@@ -326,6 +327,7 @@ module ActiveRecord
       # isolation level.
       #  :args: (requires_new: nil, isolation: nil, &block)
       def transaction(requires_new: nil, isolation: nil, joinable: true, &block)
+        transaction_manager.check_transaction_state_known!
         if !requires_new && current_transaction.joinable?
           if isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -534,4 +534,8 @@ module ActiveRecord
   # values, such as request parameters or model attributes to query methods.
   class UnknownAttributeReference < ActiveRecordError
   end
+
+  # Raised when, due to an error, it is unknown whether the current connection is in a transaction.
+  class TransactionStateUnknown < ActiveRecordError
+  end
 end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -80,6 +80,215 @@ class TransactionTest < ActiveRecord::TestCase
     ensure
       ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
     end
+
+    def test_connection_removed_from_pool_when_commit_raises_and_rollback_raises
+      connection = Topic.connection
+
+      # Update commit_transaction to raise the first time it is called.
+      Topic.connection.transaction_manager.class_eval do
+        alias :real_commit_transaction :commit_transaction
+        define_method(:commit_transaction) do
+          @ran_once ||= false
+          unless @ran_once
+            @ran_once = true
+            raise "commit failed"
+          end
+          real_commit_transaction
+        end
+      end
+
+      # Update rollback_transaction to raise.
+      Topic.connection.transaction_manager.class_eval do
+        alias :real_rollback_transaction :rollback_transaction
+        define_method(:rollback_transaction) do |*_args|
+          raise "rollback failed"
+        end
+      end
+
+      # Start a transaction and update a record. The commit and rollback will fail.
+      topic = topics(:fifth)
+      assert_raises(RuntimeError, "rollback failed") do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Updated title")
+        end
+      end
+      assert_not connection.active?
+      assert_not Topic.connection_pool.connections.include?(connection)
+      assert_equal "The Fifth Topic of the day", topic.reload.title
+    ensure
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
+
+    def test_connection_removed_from_pool_when_begin_raises_after_successfully_beginning_a_transaction
+      connection = Topic.connection
+      # Disable lazy transactions so that we will begin a transaction before attempting to write.
+      connection.disable_lazy_transactions!
+
+      # Update begin_db_transaction to successfully begin a transaction, then raise.
+      Topic.connection.class_eval do
+        alias :real_begin_db_transaction :begin_db_transaction
+        define_method(:begin_db_transaction) do |*_args|
+          real_begin_db_transaction
+          @ran_once ||= false
+          unless @ran_once
+            @ran_once = true
+            raise "begin failed"
+          end
+        end
+      end
+
+      # Attempt to begin a transaction. This will raise, causing a rollback.
+      assert_raises(RuntimeError, "begin failed") do
+        ActiveRecord::Base.transaction { }
+      end
+      assert_not connection.active?
+      assert_not Topic.connection_pool.connections.include?(connection)
+    ensure
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
+
+    def test_connection_removed_from_pool_when_new_transaction_created_while_previous_transaction_state_unknown
+      connection = Topic.connection
+
+      # Update rollback_transaction to raise.
+      Topic.connection.transaction_manager.class_eval do
+        alias :real_rollback_transaction :rollback_transaction
+        define_method(:rollback_transaction) do
+          raise "rollback failed"
+        end
+      end
+
+      # Update throw_away! to raise the first time it is called.
+      Topic.connection.class_eval do
+        alias :real_throw_away! :throw_away!
+        define_method(:throw_away!) do
+          @ran_once ||= false
+          unless @ran_once
+            @ran_once = true
+            raise "throw away failed"
+          end
+          real_throw_away!
+        end
+      end
+
+      # Start a transaction, update a record, then roll back. The rollback and connection removal will fail.
+      topic = topics(:fifth)
+      assert_raises(RuntimeError, "throw away failed") do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Updated title")
+          raise ActiveRecord::Rollback
+        end
+      end
+      assert connection.active?
+      assert Topic.connection_pool.connections.include?(connection)
+
+      # Attempt to reuse the connection. This will raise since the connection was left in a bad state.
+      assert_raises(ActiveRecord::TransactionStateUnknown) do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "More updated title")
+        end
+      end
+      assert_not connection.active?
+      assert_not Topic.connection_pool.connections.include?(connection)
+      assert_equal "The Fifth Topic of the day", topic.reload.title
+    ensure
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
+
+    def test_connection_removed_from_pool_when_statement_executed_while_previous_transaction_state_unknown
+      connection = Topic.connection
+
+      # Update rollback_transaction to raise.
+      Topic.connection.transaction_manager.class_eval do
+        alias :real_rollback_transaction :rollback_transaction
+        define_method(:rollback_transaction) do
+          raise "rollback failed"
+        end
+      end
+
+      # Update throw_away! to raise the first time it is called.
+      Topic.connection.class_eval do
+        alias :real_throw_away! :throw_away!
+        define_method(:throw_away!) do
+          @ran_once ||= false
+          unless @ran_once
+            @ran_once = true
+            raise "throw away failed"
+          end
+          real_throw_away!
+        end
+      end
+
+      # Start a transaction, update a record, then roll back. The rollback and connection removal will fail.
+      topic = topics(:fifth)
+      assert_raises(RuntimeError, "throw away failed") do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Updated title")
+          raise ActiveRecord::Rollback
+        end
+      end
+      assert connection.active?
+      assert Topic.connection_pool.connections.include?(connection)
+
+      # Attempt to reuse the connection. This will raise since the connection was left in a bad state.
+      assert_raises(ActiveRecord::TransactionStateUnknown) do
+        ActiveRecord::Base.connection.execute("SELECT 1;")
+      end
+      assert_not connection.active?
+      assert_not Topic.connection_pool.connections.include?(connection)
+      assert_equal "The Fifth Topic of the day", topic.reload.title
+    ensure
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
+
+    def test_connection_removed_from_pool_when_nested_transaction_state_unknown
+      connection = Topic.connection
+
+      # Update rollback_transaction to raise.
+      Topic.connection.transaction_manager.class_eval do
+        alias :real_rollback_transaction :rollback_transaction
+        define_method(:rollback_transaction) do
+          raise "rollback failed"
+        end
+      end
+
+      # Update throw_away! to raise the first time it is called.
+      Topic.connection.class_eval do
+        alias :real_throw_away! :throw_away!
+        define_method(:throw_away!) do
+          @ran_once ||= false
+          unless @ran_once
+            @ran_once = true
+            raise "throw away failed"
+          end
+          real_throw_away!
+        end
+      end
+
+      # Start a transaction, update a record, then start a nested transaction which will get into an unknown state.
+      topic = topics(:fifth)
+      assert_raises(ActiveRecord::TransactionStateUnknown) do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Updated title")
+
+          # Start a nested transaction, update a record, then roll back. The rollback and connection removal will fail.
+          assert_raises(RuntimeError, "throw away failed") do
+            ActiveRecord::Base.transaction(requires_new: true) do
+              topic.update(author_name: "Updated author")
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+      end
+      assert_not connection.active?
+      assert_not Topic.connection_pool.connections.include?(connection)
+
+      # Nothing was committed.
+      assert_equal "The Fifth Topic of the day", topic.reload.title
+      assert_equal "Jason", topic.author_name
+    ensure
+      ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+    end
   end
 
   def test_rollback_dirty_changes_multiple_saves


### PR DESCRIPTION
### Motivation / Background

Fixes #48164

### Detail

Introduces the concept of a transaction lock. This is used to detect cases where `within_new_transaction` raises, potentially leaving the connection in an untracked, open transaction.

The idea is to store and acquire a new lock before attempting to materialize a transaction, and to only discard the lock once the transaction state is definitely known. If `within_new_transaction` raises, without the lock being discarded, subsequent attempts to create a transaction will detect this case and discard the connection.

### Additional information

- The `within_new_transaction` diff is mostly whitespace. Please consider reviewing with whitespace hidden: https://github.com/rails/rails/pull/48165/files?diff=unified&w=1
- I have split `begin_transaction` into `create_transaction` and `materialize_transaction_if_required` because creating a transaction cannot leave the connection in a bad state. If it raises, there is no need to discard the connection.
- I have introduced a new method to the TransactionManager API: `check_transaction_state_known!`. If this change turns out to be acceptable, this method should be invoked before allowing access to the raw connection. For demonstration purposes, I have added a call to this method in `execute` and `transaction`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
