### PR TITLE
Document associations and scopes on ActiveStorage::Attachment/Blob [ci-skip]

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -20,7 +20,16 @@ require "active_support/core_ext/module/delegation"
 class ActiveStorage::Attachment < ActiveStorage::Record
   self.table_name = "active_storage_attachments"
 
+  ##
+  # :method: record
+  #
+  # Returns the associated record.
   belongs_to :record, polymorphic: true, touch: true
+
+  ##
+  # :method: blob
+  #
+  # Returns the associated <tt>ActiveStorage::Blob</tt>.
   belongs_to :blob, class_name: "ActiveStorage::Blob", autosave: true
 
   delegate_missing_to :blob
@@ -29,6 +38,12 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   after_create_commit :mirror_blob_later, :analyze_blob_later
   after_destroy_commit :purge_dependent_blob_later
 
+  ##
+  # :singleton-method: with_all_variant_records
+  #
+  # Eager load all variant records on an attachment at once.
+  #
+  #   User.first.avatars.with_all_variant_records
   scope :with_all_variant_records, -> { includes(blob: { variant_records: { image_attachment: :blob } }) }
 
   # Synchronously deletes the attachment and {purges the blob}[rdoc-ref:ActiveStorage::Blob#purge].

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -31,8 +31,16 @@ class ActiveStorage::Blob < ActiveStorage::Record
   class_attribute :services, default: {}
   class_attribute :service, instance_accessor: false
 
+  ##
+  # :method: attachments
+  #
+  # Returns the associated <tt>ActiveStorage::Attachment</tt>s.
   has_many :attachments
 
+  ##
+  # :singleton-method: unattached
+  #
+  # Returns the blobs that aren't attached to any record.
   scope :unattached, -> { where.missing(:attachments) }
 
   after_initialize do


### PR DESCRIPTION
Scopes and associations aren't picked up by RDoc, but we can use
`:method:` and `:singleton-method:` directives to document them.

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/28561/236806612-ccf6dcc6-683a-4ee3-b57a-bc4ee173d013.png">

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/28561/236806768-3d4ddcc6-6725-4f53-a07d-15b8045a6156.png">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
