### PR TITLE
Default message serializer to `:json_allow_marshal`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -756,18 +756,20 @@
 *   Change the default serializer of `ActiveSupport::MessageVerifier` from
     `Marshal` to `ActiveSupport::JSON` when using `config.load_defaults 7.1`.
 
-    Existing apps can use the `:json_allow_marshal` serializer to migrate. See
+    Messages serialized with `Marshal` can still be read, but new messages will
+    be serialized with `ActiveSupport::JSON`. For more information, see
     https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer.
 
-    *Saba Kiaei* and *David Buckley*
+    *Saba Kiaei*, *David Buckley*, and *Jonathan Hefner*
 
 *   Change the default serializer of `ActiveSupport::MessageEncryptor` from
     `Marshal` to `ActiveSupport::JSON` when using `config.load_defaults 7.1`.
 
-    Existing apps can use the `:json_allow_marshal` serializer to migrate. See
+    Messages serialized with `Marshal` can still be read, but new messages will
+    be serialized with `ActiveSupport::JSON`. For more information, see
     https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer.
 
-    *Zack Deveau* and *Martin Gingras*
+    *Zack Deveau*, *Martin Gingras*, and *Jonathan Hefner*
 
 *   Add `ActiveSupport::TestCase#stub_const` to stub a constant for the duration of a yield.
 

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -157,8 +157,8 @@ module ActiveSupport
     #   where a message signing secret has been leaked. <em>If possible, choose
     #   a serializer that does not support +Marshal+.</em>
     #
-    #   When using \Rails with <tt>config.load_defaults 7.1</tt> or later, the
-    #   default is +:json+. Otherwise, the default is +:marshal+.
+    #   When using \Rails, the default depends on +config.active_support.message_serializer+.
+    #   Otherwise, the default is +:marshal+.
     #
     # [+:url_safe+]
     #   By default, MessageEncryptor generates RFC 4648 compliant strings

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -128,8 +128,8 @@ module ActiveSupport
     #   where a message signing secret has been leaked. <em>If possible, choose
     #   a serializer that does not support +Marshal+.</em>
     #
-    #   When using \Rails with <tt>config.load_defaults 7.1</tt> or later, the
-    #   default is +:json+. Otherwise, the default is +:marshal+.
+    #   When using \Rails, the default depends on +config.active_support.message_serializer+.
+    #   Otherwise, the default is +:marshal+.
     #
     # [+:url_safe+]
     #   By default, MessageVerifier generates RFC 4648 compliant strings which are

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -75,7 +75,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`](#config-active-record-run-commit-callbacks-on-first-saved-instances-in-transaction): `false`
 - [`config.active_record.sqlite3_adapter_strict_strings_by_default`](#config-active-record-sqlite3-adapter-strict-strings-by-default): `true`
 - [`config.active_support.cache_format_version`](#config-active-support-cache-format-version): `7.1`
-- [`config.active_support.message_serializer`](#config-active-support-message-serializer): `:json`
+- [`config.active_support.message_serializer`](#config-active-support-message-serializer): `:json_allow_marshal`
 - [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
 - [`config.active_support.use_message_serializer_for_metadata`](#config-active-support-use-message-serializer-for-metadata): `true`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
@@ -2281,7 +2281,7 @@ The default value depends on the `config.load_defaults` target version:
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
 | (original)            | `:marshal`           |
-| 7.1                   | `:json`              |
+| 7.1                   | `:json_allow_marshal` |
 
 [`ActiveSupport::MessageEncryptor`]: https://api.rubyonrails.org/classes/ActiveSupport/MessageEncryptor.html
 [`ActiveSupport::MessageVerifier`]: https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -303,7 +303,7 @@ module Rails
 
           if respond_to?(:active_support)
             active_support.cache_format_version = 7.1
-            active_support.message_serializer = :json
+            active_support.message_serializer = :json_allow_marshal
             active_support.use_message_serializer_for_metadata = true
             active_support.raise_on_invalid_cache_expiration_time = true
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -79,20 +79,27 @@
 # Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
-# instances. The legacy default is `:marshal`, which is a potential vector for
-# deserialization attacks in cases where a message signing secret has been
-# leaked. New apps use `:json`.
+# instances.
 #
-# To make migration easier, an additional `:json_allow_marshal` variant is
-# provided. It will serialize and deserialize JSON, but will also fall back to
-# deserializing with `Marshal` if necessary. For more information, see
+# The legacy default is `:marshal`, which is a potential vector for
+# deserialization attacks in cases where a message signing secret has been
+# leaked.
+#
+# In Rails 7.1, the new default is `:json_allow_marshal` which serializes and
+# deserializes with `ActiveSupport::JSON`, but can fall back to deserializing
+# with `Marshal` so that legacy messages can still be read.
+#
+# In Rails 7.2, the default will become `:json` which serializes and
+# deserializes with `ActiveSupport::JSON` only.
+#
+# For more information, see
 # https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer
 #
 # If you are performing a rolling deploy of a Rails 7.1 upgrade, wherein servers
 # that have not yet been upgraded must be able to read messages from upgraded
 # servers, first deploy without changing the serializer, then set the serializer
-# to `:json_allow_marshal` in a subsequent deploy.
-# Rails.application.config.active_support.message_serializer = :json
+# in a subsequent deploy.
+# Rails.application.config.active_support.message_serializer = :json_allow_marshal
 
 # Enable a performance optimization that serializes message data and metadata
 # together. This changes the message format, so messages serialized this way

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3710,10 +3710,10 @@ module ApplicationTests
       assert_equal true, Rails.application.config.rake_eager_load
     end
 
-    test "ActiveSupport::Messages::Codec.default_serializer is :json by default for new apps" do
+    test "ActiveSupport::Messages::Codec.default_serializer is :json_allow_marshal by default for new apps" do
       app "development"
 
-      assert_equal :json, ActiveSupport::Messages::Codec.default_serializer
+      assert_equal :json_allow_marshal, ActiveSupport::Messages::Codec.default_serializer
     end
 
     test "ActiveSupport::Messages::Codec.default_serializer is :marshal by default for upgraded apps" do


### PR DESCRIPTION
Prior to this commit, `config.load_defaults 7.1` would cause old messages (or messages from older apps) to become unreadable, and developers were encouraged to manually set
`config.active_support.message_serializer = :json_allow_marshal` in order to prevent this.

This commit changes the default message serializer set by `config.load_defaults 7.1` from `:json` to `:json_allow_marshal` so that upgraded apps can continue to read old messages without additional configuration.

The intention is to eventually change the default to `:json` (with no `Marshal` fallback) in Rails 7.2, after some time has passed with apps generating JSON-serialized messages.

Apps can opt in to JSON-only serialization before Rails 7.2 by manually setting `config.active_support.message_serializer = :json`.

Fixes #48118.
