### PR TITLE
Allow PredicateBuilder to recognize schema namespaced table names

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -29,8 +29,8 @@ module ActiveRecord
       attributes.each_with_object([]) do |(key, value), result|
         if value.is_a?(Hash)
           result << Arel.sql(key)
-        elsif key.include?(".")
-          result << Arel.sql(key.split(".").first)
+        elsif (idx = key.rindex("."))
+          result << Arel.sql(key[0, idx])
         end
       end
     end
@@ -149,19 +149,25 @@ module ActiveRecord
       end
 
       def convert_dot_notation_to_hash(attributes)
-        dot_notation = attributes.select do |k, v|
-          k.include?(".") && !v.is_a?(Hash)
+        attributes.each_with_object({}) do |(key, value), converted|
+          if value.is_a?(Hash)
+            if (existing = converted[key])
+              existing.merge!(value)
+            else
+              converted[key] = value.dup
+            end
+          elsif (idx = key.rindex("."))
+            table_name, column_name = key[0, idx], key[idx + 1, key.length]
+
+            if (existing = converted[table_name])
+              existing[column_name] = value
+            else
+              converted[table_name] = { column_name => value }
+            end
+          else
+            converted[key] = value
+          end
         end
-
-        dot_notation.each_key do |key|
-          table_name, column_name = key.split(".")
-          value = attributes.delete(key)
-          attributes[table_name] ||= {}
-
-          attributes[table_name] = attributes[table_name].merge(column_name => value)
-        end
-
-        attributes
       end
 
       def handler_for(object)

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -23,6 +23,20 @@ module ActiveRecord
       assert_match %r{#{Regexp.escape(topic_title)} ~ 'rails'}i, Reply.joins(:topic).where(topics: { title: /rails/ }).to_sql
     end
 
+    def test_references_with_schema
+      assert_equal %w{schema.table}, ActiveRecord::PredicateBuilder.references(%w{schema.table.column})
+    end
+
+    def test_build_from_hash_with_schema
+      assert_match %r{schema.+table.+column}i, Topic.predicate_builder.build_from_hash("schema.table.column" => "value").first.to_sql
+    end
+
+    def test_does_not_mutate
+      defaults = { topics: { title: "rails" }, "topics.approved" => true }
+      Topic.where(defaults).to_sql
+      assert_equal({ topics: { title: "rails" }, "topics.approved" => true }, defaults)
+    end
+
     private
       def topic_title
         Topic.connection.quote_table_name("topics.title")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

`ActiveRecord::PredicateBuilder` currently assumes that a column name will only be specified in dot notation with a single period. If a column is specified in dot notation for a table that is namespaced in a schema, it will use the schema name as the table name. This PR allows columns to specified in the format `schema.table.column` as well as `table.column`.

This fixes #48172

### Detail

This Pull Request changes the behavior of `ActiveRecord::PredicateBuilder.references` and `ActiveRecord::PredicateBuilder#convert_dot_notation_to_hash`

I didn't add this to the CHANGELOG, but if a reviewer thinks it's significant enough I'm happy to do so.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
