### PR TITLE
Fix ordered list rendering in multi-DB guide

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -579,14 +579,14 @@ SELECT "yards".* FROM "yards" WHERE "yards"."home_id" = ? [["home_id", 1]]
 
 There are some important things to be aware of with this option:
 
-1) There may be performance implications since now two or more queries will be performed (depending
-on the association) rather than a join. If the select for `humans` returned a high number of IDs
-the select for `treats` may send too many IDs.
-2) Since we are no longer performing joins, a query with an order or limit is now sorted in-memory since
-order from one table cannot be applied to another table.
-3) This setting must be added to all associations where you want joining to be disabled.
-Rails can't guess this for you because association loading is lazy, to load `treats` in `@dog.treats`
-Rails already needs to know what SQL should be generated.
+1. There may be performance implications since now two or more queries will be performed (depending
+   on the association) rather than a join. If the select for `humans` returned a high number of IDs
+   the select for `treats` may send too many IDs.
+2. Since we are no longer performing joins, a query with an order or limit is now sorted in-memory since
+   order from one table cannot be applied to another table.
+3. This setting must be added to all associations where you want joining to be disabled.
+   Rails can't guess this for you because association loading is lazy, to load `treats` in `@dog.treats`
+   Rails already needs to know what SQL should be generated.
 
 ### Schema Caching
 


### PR DESCRIPTION
### Motivation / Background
In the [AR multi-DB guide](https://edgeguides.rubyonrails.org/active_record_multiple_databases.html#handling-associations-with-joins-across-databases), this ordered list is not rendered correctly.
![image](https://user-images.githubusercontent.com/16783036/237011982-ecceca81-18e9-4e96-b136-5fad10944bda.png)

### Detail
The rendering issue is due to use of Github-flavored Markdown syntax `1)` with parentheses delimiting list items. Not all Markdown implementations support this, and the [Ordered List Best Practices](https://www.markdownguide.org/basic-syntax/#ordered-list-best-practices) on markdownguide.org suggest to use periods only, for compatibility.

This change fixed the issue when generating the guides locally:
<img width="801" alt="image" src="https://user-images.githubusercontent.com/16783036/237014372-28c40ac3-c36e-405d-a73f-40757e506ac0.png">

### Additional information
The [Guides Guidelines](https://edgeguides.rubyonrails.org/ruby_on_rails_guides_guidelines.html#markdown) (heh) open with "Guides are written in GitHub Flavored Markdown", so in theory this shouldn't be an issue. Debugging the markdown renderer is further than I wanted to go right now.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
