### PR TITLE
Clean up docs and code using mysql2 when we mean trilogy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -322,7 +322,7 @@ module ActiveRecord
       # * You are joining an existing open transaction
       # * You are creating a nested (savepoint) transaction
       #
-      # The mysql2 and postgresql adapters support setting the transaction
+      # The mysql2, trilogy, and postgresql adapters support setting the transaction
       # isolation level.
       #  :args: (requires_new: nil, isolation: nil, &block)
       def transaction(requires_new: nil, isolation: nil, joinable: true, &block)

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       # Override to return the quoted table name for assignment. Defaults to
       # table quoting.
       #
-      # This works for mysql2 where table.column can be used to
+      # This works for MySQL where table.column can be used to
       # resolve ambiguity.
       #
       # We override this in the sqlite3 and postgresql adapters to use only

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -656,11 +656,6 @@ module ActiveRecord
           def initialize_type_map(m)
             super
 
-            m.register_type(%r(char)i) do |sql_type|
-              limit = extract_limit(sql_type)
-              Type.lookup(:string, adapter: :mysql2, limit: limit)
-            end
-
             m.register_type %r(tinytext)i,   Type::Text.new(limit: 2**8 - 1)
             m.register_type %r(tinyblob)i,   Type::Binary.new(limit: 2**8 - 1)
             m.register_type %r(text)i,       Type::Text.new(limit: 2**16 - 1)
@@ -680,9 +675,6 @@ module ActiveRecord
 
             m.alias_type %r(year)i, "integer"
             m.alias_type %r(bit)i,  "binary"
-
-            m.register_type %r(^enum)i, Type.lookup(:string, adapter: :mysql2)
-            m.register_type %r(^set)i,  Type.lookup(:string, adapter: :mysql2)
           end
 
           def register_integer_type(mapping, key, **options)
@@ -704,7 +696,6 @@ module ActiveRecord
           end
       end
 
-      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
       EXTENDED_TYPE_MAPS = Concurrent::Map.new
       EMULATE_BOOLEANS_TRUE = { emulate_booleans: true }.freeze
 
@@ -713,10 +704,6 @@ module ActiveRecord
           expression = expression.gsub(/\\n|\\\\/, "")
           expression = expression.gsub(/\s{2,}/, " ")
           expression
-        end
-
-        def text_type?(type)
-          TYPE_MAP.lookup(type).is_a?(Type::String) || TYPE_MAP.lookup(type).is_a?(Type::Text)
         end
 
         def extended_type_map_key
@@ -975,14 +962,6 @@ module ActiveRecord
         def version_string(full_version_string)
           full_version_string.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
         end
-
-        ActiveRecord::Type.register(:immutable_string, adapter: :mysql2) do |_, **args|
-          Type::ImmutableString.new(true: "1", false: "0", **args)
-        end
-        ActiveRecord::Type.register(:string, adapter: :mysql2) do |_, **args|
-          Type::String.new(true: "1", false: "0", **args)
-        end
-        ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -63,7 +63,7 @@ module ActiveRecord
         end
 
         # Override +type_cast+ we pass to mysql2 Date and Time objects instead
-        # of Strings since mysql2 is able to handle those classes more efficiently.
+        # of Strings since MySQL adapters are able to handle those classes more efficiently.
         def type_cast(value) # :nodoc:
           case value
           when ActiveSupport::TimeWithZone

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -453,7 +453,7 @@ module ActiveRecord
   # * You are joining an existing open transaction
   # * You are creating a nested (savepoint) transaction
   #
-  # The mysql2 and postgresql adapters support setting the transaction isolation level.
+  # The mysql2, trilogy, and postgresql adapters support setting the transaction isolation level.
   class TransactionIsolationError < ActiveRecordError
   end
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -280,6 +280,7 @@ module ActiveRecord
       # The following bundled adapters throw the ActiveRecord::RecordNotUnique exception:
       #
       # * ActiveRecord::ConnectionAdapters::Mysql2Adapter.
+      # * ActiveRecord::ConnectionAdapters::TrilogyAdapter.
       # * ActiveRecord::ConnectionAdapters::SQLite3Adapter.
       # * ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.
       def validates_uniqueness_of(*attr_names)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -106,7 +106,7 @@ module ActiveRecord
   end
 end
 
-class Mysql2AnsiQuotesTest < ActiveRecord::Mysql2TestCase
+class MysqlAnsiQuotesTest < ActiveRecord::AbstractMysqlTestCase
   def setup
     @connection = ActiveRecord::Base.connection
     @connection.execute("SET SESSION sql_mode='ANSI_QUOTES'")

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1436,7 +1436,7 @@ Defaults to `true`. Determines whether to raise an exception or not when
 the PostgreSQL adapter is provided an integer that is wider than signed
 64bit representation.
 
-#### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans`
+#### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` and `ActiveRecord::ConnectionAdapters::TrilogyAdapter.emulate_booleans`
 
 Controls whether the Active Record MySQL adapter will consider all `tinyint(1)` columns as booleans. Defaults to `true`.
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -458,6 +458,7 @@ You can now run the tests as you did for `sqlite3`. The tasks are respectively:
 
 ```bash
 $ bundle exec rake test:mysql2
+$ bundle exec rake test:trilogy
 $ bundle exec rake test:postgresql
 ```
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1497,6 +1497,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |
 | `ActiveRecord::ConnectionAdapters::Mysql2Adapter`        | `active_record_mysql2adapter`        |
+| `ActiveRecord::ConnectionAdapters::TrilogyAdapter`       | `active_record_trilogyadapter`       |
 | `ActiveRecord::ConnectionAdapters::SQLite3Adapter`       | `active_record_sqlite3adapter`       |
 | `ActiveStorage::Attachment`          | `active_storage_attachment`          |
 | `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |


### PR DESCRIPTION
This PR does the following:

* Adds `trilogy` to lists of adapters where applicable
* Uses `MySQL` instead of adatper names where applicable
* Splits type information into adapters code so that the adapter is set correctly.
* Fix tests that were using mysql2 when they should be abstract

cc/ @adrianna-chang-shopify 