### PR TITLE
Prevent non-anonymous modules from becoming frozen

### DIFF
--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -5,7 +5,7 @@ module ActiveModel
     module Helpers # :nodoc: all
       module Mutable
         def immutable_value(value)
-          value.deep_dup.freeze
+          value.deep_dup
         end
 
         def cast(value)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -180,6 +180,15 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_not_empty ClassifiedTopic.where(important: Symbol)
   end
 
+  def test_serialized_class_does_not_become_frozen
+    ActiveRecord.yaml_column_permitted_classes += [Class]
+
+    assert_not_predicate Symbol, :frozen?
+    ClassifiedTopic.create(important: Symbol)
+    assert_not_empty ClassifiedTopic.where(important: Symbol)
+    assert_not_predicate Symbol, :frozen?
+  end
+
   def test_nil_serialized_attribute_without_class_constraint
     topic = Topic.new
     assert_nil topic.content


### PR DESCRIPTION
In #48106, `Module#deep_dup` was changed to return the module itself (not a copy) when the module is not anonymous.  However, that causes non-anonymous modules to become frozen via `value.deep_dup.freeze` when passed to `ActiveModel::Type::Helpers::Mutable#immutable_value`.  So, for example, class attributes can no longer be set on the module.

To prevent such issues, this commit removes the `freeze` from `immutable_value`.  `immutable_value` is only called by `ActiveRecord::PredicateBuilder#build_bind_attribute`, which only cares that other code cannot mutate the value, not that the value is actually frozen.

---

This fixes failures in isolated tests such as https://buildkite.com/rails/rails/builds/96281#0187fcf2-e832-4914-a6e5-b55a04c4a04f/1649-1659.