### PR TITLE
Add `Object#isolated_copy`

### DIFF
--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -5,7 +5,7 @@ module ActiveModel
     module Helpers # :nodoc: all
       module Mutable
         def immutable_value(value)
-          value.deep_dup
+          value.isolated_copy
         end
 
         def cast(value)

--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/deep_dup"
+
 # == Attribute Accessors per Thread
 #
 # Extends the module object with class/module and instance accessors for
@@ -52,8 +54,7 @@ class Module
           end
         EOS
       else
-        default = default.dup.freeze unless default.frozen?
-        singleton_class.define_method("#{sym}_default_value") { default }
+        singleton_class.define_method("#{sym}_default_value") { default.isolated_copy }
 
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def self.#{sym}

--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -15,6 +15,10 @@ class Object
   def deep_dup
     duplicable? ? dup : self
   end
+
+  def isolated_copy # :nodoc:
+    frozen? ? self : deep_dup
+  end
 end
 
 class Array


### PR DESCRIPTION
This adds `Object#isolated_copy` (as a private API) which performs a `deep_dup` unless the object is frozen or a non-anonymous module.  In which case, it simply returns `self`.


TODO:
- [ ] tests
- [ ] update `thread_mattr_accessor` docs

---

@byroot `Module#deep_dup` returning `self` may cause unexpected behavior (see #48178).  What do you think of replacing `Module#deep_dup` with `Module#isolated_copy`?  (In other words, restoring the original behavior of `Module#deep_dup`, and defining `Module#isolated_copy` with the specialized behavior instead.)
