### PR TITLE
Precompile `config.filter_parameters` in place

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -675,10 +675,11 @@ module Rails
 
       def filter_parameters
         if config.precompile_filter_parameters
-          ActiveSupport::ParameterFilter.precompile_filters(config.filter_parameters)
-        else
-          config.filter_parameters
+          config.filter_parameters.replace(
+            ActiveSupport::ParameterFilter.precompile_filters(config.filter_parameters)
+          )
         end
+        config.filter_parameters
       end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -557,6 +557,21 @@ module ApplicationTests
       assert_equal filters, Rails.application.env_config["action_dispatch.parameter_filter"]
     end
 
+    test "filter_parameters reflects changes to config.filter_parameters after being precompiled" do
+      add_to_config <<~RUBY
+        config.filter_parameters += [/foo/, :bar]
+        config.precompile_filter_parameters = true
+      RUBY
+
+      app "development"
+
+      assert_not_empty Rails.application.env_config["action_dispatch.parameter_filter"]
+
+      Rails.application.config.filter_parameters << "baz.qux"
+
+      assert_includes Rails.application.env_config["action_dispatch.parameter_filter"], "baz.qux"
+    end
+
     test "config.precompile_filter_parameters is true by default for new apps" do
       app "development"
 


### PR DESCRIPTION
Applications may try to modify `config.filter_parameters` after `Rails::Application#env_config` has already been memoized.  For example, in the `development` environment, models with encrypted attributes will append filters when the model is (re)loaded.  Prior to this commit, if `config.precompile_filter_parameters` was enabled, such changes would not be reflected in `env_config["action_dispatch.parameter_filter"]`.

This commit ensures that `env_config["action_dispatch.parameter_filter"]` is the `config.filter_parameters` array itself, regardless of whether `config.precompile_filter_parameters` is enabled.

---

@fatkodima  This addresses one of the issues you mentioned in https://github.com/rails/rails/issues/47913#issuecomment-1504075540.  Thank you for uncovering it! :raised_hands:
