### PR TITLE
Properly fallback when ERB column can't be computed

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -179,7 +179,7 @@ module ActionView
     # source location inside the template.
     def translate_location(backtrace_location, spot)
       if handler.respond_to?(:translate_location)
-        handler.translate_location(spot, backtrace_location, encode!)
+        handler.translate_location(spot, backtrace_location, encode!) || spot
       else
         spot
       end

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -24,6 +24,8 @@ module ActionView
 
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 
+        LocationParsingError = Class.new(StandardError) # :nodoc:
+
         def self.call(template, source)
           new.call(template, source)
         end
@@ -52,6 +54,8 @@ module ActionView
           spot[:script_lines] = source.lines
 
           spot
+        rescue LocationParsingError
+          nil
         end
 
         def call(template, source)
@@ -110,15 +114,15 @@ module ActionView
             tok_name, str = *tok
             case tok_name
             when :TEXT
-              raise unless compiled.scan(str)
+              raise LocationParsingError unless compiled.scan(str)
             when :CODE
-              raise "We went too far" if compiled.pos > error_column
+              raise LocationParsingError, "We went too far" if compiled.pos > error_column
 
               if compiled.pos + str.bytesize >= error_column
                 offset = error_column - compiled.pos
                 return passed_tokens.map(&:last).join.bytesize + offset
               else
-                raise unless compiled.scan(str)
+                raise LocationParsingError unless compiled.scan(str)
               end
             when :OPEN
               next_tok = source_tokens.first.last
@@ -133,7 +137,7 @@ module ActionView
                 compiled.getch
               end
             else
-              raise NotImplemented, tok.first
+              raise LocationParsingError, "Not implemented: #{tok.first}"
             end
 
             passed_tokens << tok

--- a/actionview/test/fixtures/test/unparseable_runtime_error.html.erb
+++ b/actionview/test/fixtures/test/unparseable_runtime_error.html.erb
@@ -1,0 +1,8 @@
+<h1>Oh no!</h1>
+This template has a runtime error
+<b>
+  <% if true %>
+    <%= method_that_does_not_exist %>
+  <% end %>
+</b>
+Yikes!

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -221,6 +221,19 @@ module RenderTestCases
 
       assert_equal 6, translated_spot[:first_column]
     end
+
+    def test_render_location_map_failure
+      ex = assert_raises(ActionView::Template::Error) {
+        @view.render(template: "test/unparseable_runtime_error")
+      }
+      erb_btl = ex.backtrace_locations.first
+
+      # Get the spot information from ErrorHighlight
+      translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
+      translated_spot = translating_frame.spot(ex.cause)
+
+      assert_not_nil translated_spot[:first_column]
+    end
   end
 
   def test_render_partial


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48173

If for some reason the column identification fails, we should fallback to the old error rendering with only line information.

cc @tenderlove

FYI @jasonkim