### PR TITLE
Support more direct upload services by customize HTTP method and respose type

### DIFF
--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -15,9 +15,20 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
     end
 
     def direct_upload_json(blob)
-      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
+      direct_upload = {
         url: blob.service_url_for_direct_upload,
         headers: blob.service_headers_for_direct_upload
-      })
+      }
+
+      if (http_method = blob.service_http_method_for_direct_upload).present?
+        direct_upload[:method] = http_method
+      end
+      if (response_type = blob.service_http_response_type_for_direct_upload).present?
+        direct_upload[:responseType] = response_type
+      end
+      if (form_data = blob.service_form_data_for_direct_upload).present?
+        direct_upload[:formData] = form_data
+      end
+      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: direct_upload)
     end
 end

--- a/activestorage/app/javascript/activestorage/blob_upload.js
+++ b/activestorage/app/javascript/activestorage/blob_upload.js
@@ -3,11 +3,11 @@ export class BlobUpload {
     this.blob = blob
     this.file = blob.file
 
-    const { url, headers } = blob.directUploadData
+    const { url, headers, method, responseType } = blob.directUploadData
 
     this.xhr = new XMLHttpRequest
-    this.xhr.open("PUT", url, true)
-    this.xhr.responseType = "text"
+    this.xhr.open(method || "PUT", url, true)
+    this.xhr.responseType = responseType || "text"
     for (const key in headers) {
       this.xhr.setRequestHeader(key, headers[key])
     }
@@ -17,7 +17,22 @@ export class BlobUpload {
 
   create(callback) {
     this.callback = callback
-    this.xhr.send(this.file.slice())
+    const { formData } = this.blob.directUploadData
+    if(formData){
+      var data, fileKey
+      data = new FormData()
+      if(formData[':file']){
+        fileKey = formData[':file']
+        delete formData[':file']
+      }
+      for(const key in formData){
+        data.append(key, formData[key])
+      }
+      data.append(fileKey || 'file', this.file)
+      this.xhr.send(data)
+    }else{
+      this.xhr.send(this.file.slice())
+    }
   }
 
   requestDidLoad(event) {

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -57,14 +57,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   validates :service_name, presence: true
   validates :checksum, presence: true, unless: :composed
-
-  validate do
-    if service_name_changed? && service_name.present?
-      services.fetch(service_name) do
-        errors.add(:service_name, :invalid)
-      end
-    end
-  end
+  validate :validate_service_name_in_services, if: -> { service_name_changed? && service_name.present? }
 
   class << self
     # You can use the signed ID of a blob to refer to it on the client side without fear of tampering.
@@ -226,6 +219,27 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.headers_for_direct_upload key, filename: filename, content_type: content_type, content_length: byte_size, checksum: checksum, custom_metadata: custom_metadata
   end
 
+  # Returns HTTP method(PUT/POST) for +service_url_for_direct_upload+ requests.
+  def service_http_method_for_direct_upload
+    service.respond_to?(:http_method_for_direct_upload) ? service.http_method_for_direct_upload : nil
+  end
+
+  # Returns HTTP response type for +service_url_for_direct_upload+ requests.
+  def service_http_response_type_for_direct_upload
+    service.respond_to?(:http_response_type_for_direct_upload) ? service.http_response_type_for_direct_upload : nil
+  end
+
+  # Support sending credential/key from form submission instead of headers
+  def service_form_data_for_direct_upload(expires_in: ActiveStorage.service_urls_expire_in)
+    return {} unless service.respond_to?(:form_data_for_direct_upload)
+
+    service.form_data_for_direct_upload(key,
+                                        expires_in: expires_in,
+                                        content_type: content_type,
+                                        content_length: byte_size,
+                                        checksum: checksum)
+  end
+
   def content_type_for_serving # :nodoc:
     forcibly_serve_as_binary? ? ActiveStorage.binary_content_type : content_type
   end
@@ -384,6 +398,12 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
     def update_service_metadata
       service.update_metadata key, **service_metadata if service_metadata.any?
+    end
+
+    def validate_service_name_in_services
+      services.fetch(service_name) do
+        errors.add(:service_name, :invalid)
+      end
     end
 end
 


### PR DESCRIPTION
### Motivation / Background

When building a new Service for ActiveStorage, we got two requirements:

1. We need to direct upload a file with `POST` method instead of `PUT`, and send credential(token), key(filename) and file(binary to upload) with `Content-Type:   multipart/form-data; boundary=<frontier>`, instead of sending them with headers.
2. We are creating a SaaS that make each Tenant has their own Cloud Service configuration, hence it's not possible to write all service configurations into `config/storage.yml`. For now, `ActiveStorage::Blob` has an anonymous validator to check `service_name` has to be declared in `ActiveStorage::Blob.services`, we can't disable this validator.

### Detail

**I think it's better to make them configurable like this:**

```ruby
# write my own service
module ActiveStorage
  class Service::QiniumService < Service

    # declare direct upload with HTTP POST method
    def http_method_for_direct_upload
      'POST'
    end

   # declare direct upload response type, "text" or "json"
    def http_response_type_for_direct_upload
      'json'
    end

    # declare direct upload file as multipart/form-data, the value of ':file' is the form data key to file
    def form_data_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, **)
      put_policy = Qinium::PutPolicy.new(config, key: key, expires_in: expires_in)
      put_policy.fsize_limit = content_length.to_i + 1000
      put_policy.mime_limit = content_type
      put_policy.detect_mime = 1
      put_policy.insert_only = 1
      {
        key: key,
        token: put_policy.to_token,
        ':file': 'file'
      }
    end
end
```

With above changes, `ActiveStorage::Service` can support all types of HTTP methods, send token to cloud service with HTTP header or form data.

**change `activestorage/app/models/active_storage/blob.rb` anonymous validator to named one:**

```ruby
  validate do
    if service_name_changed? && service_name.present?
      services.fetch(service_name) do
        errors.add(:service_name, :invalid)
      end
    end
  end
```

changes to 

```ruby
validate :validate_service_name_in_services, if: -> { service_name_changed? && service_name.present? }
private
    def validate_service_name_in_services
      services.fetch(service_name) do
        errors.add(:service_name, :invalid)
      end
    end
```

Now, we can write our own Module prepend to ActiveStorage::Blob, to override `validate_service_name_in_services`, such as:

```ruby
module ActiveStorageSaas::BlobModelMixin
  private
    def validate_service_name_in_services
      # dynamically define service name per TenantStorageService#id, later we can resolve tenant storage
      #   configuration by parsing TenantStorageService:1 to tenant_storage = TenantStorageService.find(1)
      #   tenant_storage.service_name => Real Storage Service Name
      #.  tenant_storage.service_options => options to make instance of Service
      /^TenantStorageService:\d+$/.match?(service_name) || super
    end
end

ActiveSupport.on_load(:active_storage_blob) do
  prepend ActiveStorageSaas::BlobModelMixin
end
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

- This is another PR #45442 that has the same requirement to customize HTTP Method
- This is my real project that is working on this PR : https://github.com/xiaohui-zhangxh/activestorage_qinium/blob/main/lib/active_storage/service/qinium_service.rb
- This is my real project that need to make our Tenants have their own storage configurations : https://github.com/xiaohui-zhangxh/activestorage_saas/blob/main/lib/active_storage/service/saas_service.rb
- A duplicate PR #45839 to fix tests errors

