### PR TITLE
Remove redundant `case` condition in ActiveJob::Arguments

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -110,8 +110,6 @@ module ActiveJob
 
       def deserialize_argument(argument)
         case argument
-        when String
-          argument
         when *PERMITTED_TYPES
           argument
         when BigDecimal # BigDecimal may have been legacy serialized; Remove in 7.2


### PR DESCRIPTION
### Motivation / Background

In commit 72300f97 the code for the `String` condition was simplified, and it's now the same as the code for the `*PERMITTED_TYPES` condition.
Since `String` is one of the `PERMITTED_TYPES` we can just eliminate this condition and let the `*PERMITTED_TYPES` condition cover it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
