### PR TITLE
Document generated dirty attribute methods [ci-skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -13,8 +13,7 @@ module ActiveModel
   # * <tt>include ActiveModel::Dirty</tt> in your object.
   # * Call <tt>define_attribute_methods</tt> passing each method you want to
   #   track.
-  # * Call <tt>[attr_name]_will_change!</tt> before each change to the tracked
-  #   attribute.
+  # * Call <tt>*_will_change!</tt> before each change to the tracked attribute.
   # * Call <tt>changes_applied</tt> after the changes are persisted.
   # * Call <tt>clear_changes_information</tt> when you want to reset the changes
   #   information.
@@ -109,10 +108,10 @@ module ActiveModel
   #   person.changes # => {"name" => ["Bill", "Bob"]}
   #
   # If an attribute is modified in-place then make use of
-  # <tt>[attribute_name]_will_change!</tt> to mark that the attribute is changing.
+  # {*_will_change!}[rdoc-label:method-i-2A_will_change-21] to mark that the attribute is changing.
   # Otherwise \Active \Model can't track changes to in-place attributes. Note
   # that Active Record can detect in-place modifications automatically. You do
-  # not need to call <tt>[attribute_name]_will_change!</tt> on Active Record models.
+  # not need to call <tt>*_will_change!</tt> on Active Record models.
   #
   #   person.name_will_change!
   #   person.name_change # => ["Bill", "Bill"]
@@ -123,6 +122,119 @@ module ActiveModel
     include ActiveModel::AttributeMethods
 
     included do
+      ##
+      # :method: *_previously_changed?
+      #
+      # :call-seq: *_previously_changed?(**options)
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns true if the attribute previously had unsaved changes.
+      #
+      #   person = Person.new
+      #   person.name = 'Britanny'
+      #   person.save
+      #   person.name_previously_changed?  # => true
+      #   person.name_previously_changed?(from: nil, to: 'Britanny')  # => true
+
+      ##
+      # :method: *_changed?
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns true if the attribute has unsaved changes.
+      #
+      #   person = Person.new
+      #   person.name = 'Andrew'
+      #   person.name_changed?  # => true
+
+      ##
+      # :method: *_change
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns the old and the new value of the attribute.
+      #
+      #   person = Person.new
+      #   person.name = 'Nick'
+      #   person.name_change  # => [nil, 'Nick']
+
+      ##
+      # :method: *_will_change!
+      #
+      # This method is generated for each attribute.
+      #
+      # If an attribute is modified in-place then make use of
+      # <tt>*_will_change!</tt> to mark that the attribute is changing.
+      # Otherwise Active Model can’t track changes to in-place attributes. Note
+      # that Active Record can detect in-place modifications automatically. You
+      # do not need to call <tt>*_will_change!</tt> on Active Record
+      # models.
+      #
+      #   person = Person.new('Sandy')
+      #   person.name_will_change!
+      #   person.name_change ['Sandy', 'Sandy']
+
+      ##
+      # :method: *_was
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns the old value of the attribute.
+      #
+      #   person = Person.new(name: 'Steph')
+      #   person.name = 'Stephanie'
+      #   person.name_change  # => ['Steph', 'Stephanie']
+
+      ##
+      # :method: *_previous_change
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns the old and the new value of the attribute before the last save.
+      #
+      #   person = Person.new
+      #   person.name = 'Emmanuel'
+      #   person.save
+      #   person.name_previous_change  # => [nil, 'Emmanuel']
+
+      ##
+      # :method: *_previously_was
+      #
+      # This method is generated for each attribute.
+      #
+      # Returns the old value of the attribute before the last save.
+      #
+      #   person = Person.new
+      #   person.name = 'Sage'
+      #   person.save
+      #   person.name_previously_was  # => nil
+
+      ##
+      # :method: restore_*!
+      #
+      # This method is generated for each attribute.
+      #
+      # Restores the attribute to the old value.
+      #
+      #   person = Person.new
+      #   person.name = 'Amanda'
+      #   person.restore_name!
+      #   person.name # => nil
+
+      ##
+      # :method: clear_*_change
+      #
+      # This method is generated for each attribute.
+      #
+      # Clears all dirty data of the attribute: current changes and previous changes.
+      #
+      #   person = Person.new(name: 'Chris')
+      #   person.name = 'Jason'
+      #   person.name_change # => ['Chris', 'Jason']
+      #   person.clear_name_change
+      #   person.name_change # => nil
+
       attribute_method_suffix "_previously_changed?", "_changed?", parameters: "**options"
       attribute_method_suffix "_change", "_will_change!", "_was", parameters: false
       attribute_method_suffix "_previous_change", "_previously_was", parameters: false
@@ -174,22 +286,22 @@ module ActiveModel
       mutations_from_database.changed_attribute_names
     end
 
-    # Dispatch target for <tt>*_changed?</tt> attribute methods.
+    # Dispatch target for {*_changed}[rdoc-label:method-i-2A_changed-3F] attribute methods.
     def attribute_changed?(attr_name, **options)
       mutations_from_database.changed?(attr_name.to_s, **options)
     end
 
-    # Dispatch target for <tt>*_was</tt> attribute methods.
+    # Dispatch target for {*_was}[rdoc-label:method-i-2A_was] attribute methods.
     def attribute_was(attr_name)
       mutations_from_database.original_value(attr_name.to_s)
     end
 
-    # Dispatch target for <tt>*_previously_changed?</tt> attribute methods.
+    # Dispatch target for {*_previously_changed}[rdoc-label:method-i-2A_previously_changed-3F] attribute methods.
     def attribute_previously_changed?(attr_name, **options)
       mutations_before_last_save.changed?(attr_name.to_s, **options)
     end
 
-    # Dispatch target for <tt>*_previously_was</tt> attribute methods.
+    # Dispatch target for {*_previously_was}[rdoc-label:method-i-2A_previously_was] attribute methods.
     def attribute_previously_was(attr_name)
       mutations_before_last_save.original_value(attr_name.to_s)
     end


### PR DESCRIPTION
Active Model generates methods for each attribute to handle dirty changes. As these methods are generated and depend on the attributes in the model, they can't be found when searching for them in the API documentation.

We can use the `:method:` directive to document them in the form of `*_will_change`, `*_previously_was`, etc. This notation is [already used](https://github.com/rails/rails/blob/b180e2c522c372f5d028d6a5113e69ff416128ab/activemodel/lib/active_model/dirty.rb#L177) in the documentation of ActiveModel::Dirty.

<img width="1304" alt="image" src="https://github.com/rails/rails/assets/28561/d83064e3-aab0-4942-8d38-517837566118">

An [alternative](https://github.com/rails/rails/blob/cb1073e664c41c3c4c87dee4788cc2a326247b4f/activemodel/lib/active_model/dirty.rb#L112) could be documenting the methods as: `[attribute_name]_will_change`, `[attribute_name]_previously_was`, etc...

<img width="1339" alt="image" src="https://github.com/rails/rails/assets/28561/af5b48e5-901a-4596-8890-041b78d05611">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
