### PR TITLE
Handle non-ASCII-only in `AS::MessagePack#signature?`

### DIFF
--- a/activesupport/lib/active_support/message_pack/serializer.rb
+++ b/activesupport/lib/active_support/message_pack/serializer.rb
@@ -25,7 +25,7 @@ module ActiveSupport
       end
 
       def signature?(dumped)
-        dumped.start_with?(SIGNATURE)
+        dumped.getbyte(0) == SIGNATURE.getbyte(0) && dumped.getbyte(1) == SIGNATURE.getbyte(1)
       end
 
       def message_pack_factory

--- a/activesupport/test/message_pack/shared_serializer_tests.rb
+++ b/activesupport/test/message_pack/shared_serializer_tests.rb
@@ -41,6 +41,11 @@ module MessagePackSharedSerializerTests
       assert_not serializer.signature?("{}")
     end
 
+    test "#signature? handles non-ASCII-only non-binary-encoded strings" do
+      assert serializer.signature?(dump("ümlaut").force_encoding(Encoding::UTF_8))
+      assert_not serializer.signature?("ümlaut")
+    end
+
     test "roundtrips Symbol" do
       assert_roundtrip :some_symbol
     end


### PR DESCRIPTION
Because `ActiveSupport::MessagePack::Serializer::SIGNATURE` includes a non-ASCII-only byte (`"\xCC"`), it raises `Encoding::CompatibilityError` when compared with another string that is not encoded with `Encoding::BINARY` and also includes a non-ASCII-only byte.

To prevent that, this commit changes `AS::MessagePack#signature?` to directly compare the first two bytes of both strings.

Fixes #48196.
