### PR TITLE
Remove redundant protocol test for url_for

### DIFF
--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -180,13 +180,6 @@ module AbstractController
         )
       end
 
-      def test_protocol
-        add_host!
-        assert_equal("https://www.basecamphq.com/c/a/i",
-          W.new.url_for(controller: "c", action: "a", id: "i", protocol: "https")
-        )
-      end
-
       def test_protocol_with_and_without_separators
         add_host!
         assert_equal("https://www.basecamphq.com/c/a/i",


### PR DESCRIPTION
Going through the tests while working on another PR I noticed that this test is now redundant.

`test_protocol_with_and_without_separators` already has [the same assertion.](https://github.com/rails/rails/compare/main...JoeDupuis:remove-redundant-test?expand=1#diff-70e7b8f0866ad1ef711c751f1d4216fa15907daeb8212293be7cdbf995488682L191-L194)

