### PR TITLE
Discard connections which may be left in a transaction

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Discard connections which may have been left in a transaction.
+
+    There are cases where, due to an error, `within_new_transaction` may unexpectedly leave a connection in an open transaction. In these cases the connection may be reused, and the following may occur:
+    - Writes appear to fail when they actually succeed.
+    - Writes appear to succeed when they actually fail.
+    - Reads return stale or uncommitted data.
+
+    Previously, the following case was detected:
+    - An error is encountered during the transaction, then another error is encountered while attempting to roll it back.
+
+    Now, the following additional cases are detected:
+    - An error is encountered just after successfully beginning a transaction.
+    - An error is encountered while committing a transaction, then another error is encountered while attempting to roll it back.
+    - An error is encountered while rolling back a transaction.
+
+    *Nick Dower*
+
 *   Active Record query cache now evicts least recently used entries
 
     By default it only keeps the `100` most recently used queries.


### PR DESCRIPTION
### Motivation / Background

Partially Fixes #48164

### Detail

Today, connections are discarded in `within_transaction` if rolling back fails after the call to `yield` raises. This is done to prevent a connection from being left in a transaction if the rollback actually failed.

This change causes connections to be discarded in the following additional cases where the connection may be left in a transaction:
- If beginning the transaction fails.
- If rolling back the transaction fails.
- If committing the transaction fails, then rolling back fails.

This is accomplished by rescuing all exceptions raised in `within_transaction` and discarding the connection if the transaction has not been been both initialized and completed.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
