### PR TITLE
Allow url_for to prioritize the current route on ambiguous recall.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -75,6 +75,11 @@
 
     *Jon Dufresne*
 
+*   Prioritize the current route when multiple recall matches are possible with
+    `ActionDispatch::Routing::UrlFor`.
+
+    *Joé Dupuis*
+
 *   `config.action_dispatch.cookies_serializer` now accepts `:message_pack` and
     `:message_pack_allow_marshal` as serializers. These serializers require the
     [`msgpack` gem](https://rubygems.org/gems/msgpack) (>= 1.7.0).

--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -37,7 +37,7 @@ module ActionController
         host: request.host,
         port: request.optional_port,
         protocol: request.protocol,
-        _recall: request.path_parameters
+        _recall: recall,
       }.merge!(super).freeze
 
       if (same_origin = _routes.equal?(request.routes)) ||
@@ -59,5 +59,10 @@ module ActionController
         @_url_options
       end
     end
+
+    private
+      def recall
+        request.path_parameters.merge(_route: request.current_route)
+      end
   end
 end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -327,6 +327,16 @@ module ActionDispatch
       set_header ACTION_DISPATCH_REQUEST_ID, id
     end
 
+    ACTION_DISPATCH_CURRENT_ROUTE = "action_dispatch.current_route" # :nodoc:
+
+    def current_route # :nodoc:
+      get_header ACTION_DISPATCH_CURRENT_ROUTE
+    end
+
+    def current_route=(route) # :nodoc:
+      set_header ACTION_DISPATCH_CURRENT_ROUTE, route
+    end
+
     alias_method :uuid, :request_id
 
     # Returns the lowercase name of the HTTP server software.

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -47,6 +47,7 @@ module ActionDispatch
 
           req.path_parameters = tmp_params
           req.route_uri_pattern = route.path.spec.to_s
+          req.current_route = route
 
           _, headers, _ = response = route.app.serve(req)
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -676,6 +676,18 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
       controller.url_for(only_path: true)
   end
 
+  def test_current_route_precedence_on_multiple_recall_match
+    rs.draw do
+      get "/route_with_higher_precedence" => "pages#index"
+      get "/current_route"                => "pages#index"
+    end
+
+    get URI("http://test.host/current_route")
+    assert_equal "/current_route",   controller.url_for(only_path: true)
+    assert_equal "/current_route",   controller.url_for(controller: "pages", action: "index", only_path: true)
+    assert_equal "/route_with_higher_precedence", url_for(rs, controller: "pages", action: "index", only_path: true)
+  end
+
   def test_backwards
     rs.draw do
       ActionDispatch.deprecator.silence do

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -170,6 +170,7 @@ module ActionPack
       ["/posts?foo%5B%5D=bar&foo%5B%5D=baz", [{ controller: "posts", foo: ["bar", "baz"] }]],
       ["/posts?page=2",  [{ controller: "posts", page: 2 }]],
       ["/posts?q%5Bfoo%5D%5Ba%5D=b", [{ controller: "posts", q: { foo: { a: "b" } } }]],
+      ["/posts?_route=1", [{ controller: "posts", _route: 1 }]],
 
       ["/news.rss", [{ controller: "news", action: "index", format: "rss" }]],
     ].each_with_index do |(url, params), i|

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -740,6 +740,17 @@ class RequestMethod < BaseRequestTest
     assert_predicate request, :get?
   end
 
+
+  test "current_route can be set on the rack env" do
+    current_route = "foo"
+    request = stub_request()
+
+    request.current_route = current_route
+
+    assert_equal current_route, request.current_route
+    assert_equal current_route, request.env["action_dispatch.current_route"]
+  end
+
   test "invalid http method raises exception" do
     assert_raise(ActionController::UnknownHttpMethod) do
       stub_request("REQUEST_METHOD" => "RANDOM_METHOD").request_method

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -118,6 +118,14 @@ module ActionDispatch
         assert_equal 404, resp.first
       end
 
+      def test_route_presence_in_env
+        get "/foo", to: "comments#index"
+
+        request = rails_env("REQUEST_METHOD" => "GET", "PATH_INFO" => "/foo")
+        router.serve(request)
+        assert_equal routes.first, request.current_route
+      end
+
       def test_clear_trailing_slash_from_script_name_on_root_unanchored_routes
         app = lambda { |env| [200, {}, ["success!"]] }
         get "/weblog", to: app


### PR DESCRIPTION


Fix #48013


If two routes end up with the same score when trying to recall the url from url_for, we currently pick the one with highest precedence (order of the route file).

This change bumps the current route (if matched) in front of the others.

The repro for the issue could help understand what this is trying to fix: https://gist.github.com/JoeDupuis/e0f18020c85a05d5188ee35485685387

### Motivation / Background

Fixes #48013

We are already trying to recall the current request with `url_for`, this helps recalling the correct route when there is multiple hit.

Currently, only the router knows which route is served. This adds the current route in the rack env allowing class further in the request to infer things from it.


### Detail

- I don't know if we should merge this. I could see it as confusing if someone is calling url_for in the context of a request vs outside of a request (test or mailer). But then again, [it's also confusing to users if we don't](https://github.com/rails/rails/issues/48013).


### Additional information

A bit of fun trivia. The current (7.0.4.2) guide for `ActionController::UrlFor` mention:


> This module requires the host class to implement env which needs to be Rack-compatible and request which is either an instance of ActionDispatch::Request **or an object that responds to the host, optional_port, protocol, and symbolized_path_parameter methods.**


Which led me to write an initial version of this where I was checking if the request object responds to `current_route` to make sure the code would still work if the request is not an `ActionDispatch::Request`.

Then I noticed while reading the same doc through the code that [this was changed](https://github.com/rails/rails/commit/d69501a3d60f07dc68578278041ed74682084c9a) and I was unnecessarily playing hard mode :man_facepalming: :laughing: 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
