### PR TITLE
Add namelist rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -208,6 +208,10 @@ task :preview_docs do
   system("tar -czf preview.tar.gz -C preview .")
 end
 
+Rails::API::NameListTask.new("namelist") do |name_list_task|
+  name_list_task.rdoc_dir = "doc/names"
+end
+
 # We have a webhook configured in GitHub that gets invoked after pushes.
 # This hook triggers the following tasks:
 #

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -3,6 +3,8 @@
 require "rdoc/task"
 require "rails/api/generator"
 
+require "sdoc"
+
 module Rails
   module API
     class Task < RDoc::Task
@@ -229,6 +231,18 @@ module Rails
 
       def canonical_url
         "https://api.rubyonrails.org/#{badge_version}"
+      end
+    end
+
+    class NameListTask < RepoTask
+      def configure_sdoc
+        options << "-e"  << "UTF-8"
+
+        options << "-f"  << "namelist"
+      end
+
+      def setup_horo_variables
+        nil
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

We want a way to be able to audit the public API of Rails, and find things that are missing `:nodoc:`.

This was implemented in rails/sdoc#222, and we're pulling in the latest branch to use it here.

In the future we might want a way to diff this data in some way, for example to provide PRs with feedback that introduce new classes or methods for reviewers to quickly check.
