### PR TITLE
Revert "Active Record: clear query cache automatically when calling #execute"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -124,7 +124,7 @@ module ActiveRecord
       # method may be manually memory managed. Consider using the exec_query
       # wrapper instead.
       def execute(sql, name = nil, allow_retry: false)
-        internal_execute(sql, name, allow_retry: allow_retry)
+        raise NotImplementedError
       end
 
       # Executes +sql+ statement in the context of this connection using
@@ -491,23 +491,14 @@ module ActiveRecord
       end
 
       private
-        def internal_execute(sql, name = "SCHEMA", allow_retry: false, materialize_transactions: true)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-
-          mark_transaction_written_if_write(sql)
-
-          raw_execute(sql, name, allow_retry: allow_retry, materialize_transactions: materialize_transactions)
+        def internal_execute(sql, name = "SCHEMA")
+          execute(sql, name)
         end
 
         def execute_batch(statements, name = nil)
           statements.each do |statement|
-            internal_execute(statement, name)
+            execute(statement, name)
           end
-        end
-
-        def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
-          raise NotImplementedError
         end
 
         DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       class << self
         def included(base) # :nodoc:
-          dirties_query_cache base, :execute, :create, :insert, :update, :delete, :truncate, :truncate_tables,
+          dirties_query_cache base, :create, :insert, :update, :delete, :truncate, :truncate_tables,
             :rollback_to_savepoint, :rollback_db_transaction, :restart_db_transaction, :exec_insert_all
 
           base.set_callback :checkout, :after, :configure_query_cache!
@@ -19,7 +19,7 @@ module ActiveRecord
         def dirties_query_cache(base, *method_names)
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
-              def #{method_name}(...)
+              def #{method_name}(*)
                 ActiveRecord::Base.clear_query_caches_for_current_thread
                 super
               end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -14,6 +14,10 @@ module ActiveRecord
         HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
         private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
 
+        def query(sql, name = nil) # :nodoc:
+          raw_execute(sql, name).to_a
+        end
+
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
         rescue ArgumentError # Invalid encoding

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
 
         def query(sql, name = nil) # :nodoc:
-          raw_execute(sql, name).to_a
+          execute(sql, name).to_a
         end
 
         def write_query?(sql) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -864,8 +864,8 @@ module ActiveRecord
           stmt_key = prepare_statement(sql, binds)
           type_casted_binds = type_casted_binds(binds)
 
-          with_raw_connection do |conn|
-            log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
+          log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
+            with_raw_connection do |conn|
               conn.exec_prepared(stmt_key, type_casted_binds)
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -21,6 +21,19 @@ module ActiveRecord
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end
 
+        def execute(sql, name = nil, allow_retry: false) # :nodoc:
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+
+          mark_transaction_written_if_write(sql)
+
+          log(sql, name) do
+            with_raw_connection(allow_retry: allow_retry) do |conn|
+              conn.execute(sql)
+            end
+          end
+        end
+
         def exec_query(sql, name = nil, binds = [], prepare: false, async: false) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
@@ -109,14 +122,6 @@ module ActiveRecord
         end
 
         private
-          def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: false)
-            log(sql, name, async: async) do
-              with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-                conn.execute(sql)
-              end
-            end
-          end
-
           def reset_read_uncommitted
             read_uncommitted = ActiveSupport::IsolatedExecutionState[:active_record_read_uncommitted]
             return unless read_uncommitted

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -691,7 +691,7 @@ module ActiveRecord
         def configure_connection
           @raw_connection.busy_timeout(self.class.type_cast_config_to_integer(@config[:timeout])) if @config[:timeout]
 
-          raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
+          execute("PRAGMA foreign_keys = ON", "SCHEMA")
         end
     end
     ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, SQLite3Adapter)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -15,7 +15,6 @@ module ActiveRecord
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
 
           result = raw_execute(sql, name, async: async)
           ActiveRecord::Result.new(result.fields, result.to_a)
@@ -24,7 +23,6 @@ module ActiveRecord
         def exec_insert(sql, name, binds, pk = nil, sequence_name = nil) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
 
           raw_execute(to_sql(sql, binds), name)
         end
@@ -32,7 +30,6 @@ module ActiveRecord
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
 
           result = raw_execute(to_sql(sql, binds), name)
           result.affected_rows
@@ -41,17 +38,6 @@ module ActiveRecord
         alias :exec_update :exec_delete # :nodoc:
 
         private
-          def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
-            log(sql, name, async: async) do
-              with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-                sync_timezone_changes(conn)
-                result = conn.query(sql)
-                handle_warnings(sql)
-                result
-              end
-            end
-          end
-
           def last_inserted_id(result)
             result.last_insert_id
           end

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -156,6 +156,13 @@ module ActiveRecord
         end
       end
 
+      def execute(sql, name = nil, allow_retry: false)
+        sql = transform_query(sql)
+        check_if_write_query(sql)
+
+        raw_execute(sql, name, allow_retry: allow_retry)
+      end
+
       private
         def text_type?(type)
           TYPE_MAP.lookup(type).is_a?(Type::String) || TYPE_MAP.lookup(type).is_a?(Type::Text)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -745,7 +745,7 @@ module ActiveRecord
             connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
             sleep 0.05
           when "Mysql2", "Trilogy"
-            connection.send(:internal_execute, "set @@wait_timeout=1", materialize_transactions: false)
+            connection.send(:internal_execute, "set @@wait_timeout=1")
             sleep 1.2
           else
             skip("remote_disconnect unsupported")

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -40,22 +40,6 @@ class QueryCacheTest < ActiveRecord::TestCase
     super
   end
 
-  def test_execute_clear_cache
-    assert_cache :off
-
-    mw = middleware { |env|
-      Post.first
-      query_cache = ActiveRecord::Base.connection.query_cache
-      assert_equal 1, query_cache.length, query_cache.keys
-      Post.connection.execute("SELECT 1")
-      query_cache = ActiveRecord::Base.connection.query_cache
-      assert_equal 0, query_cache.length, query_cache.keys
-    }
-    mw.call({})
-
-    assert_cache :off
-  end
-
   def test_writes_should_always_clear_cache
     assert_cache :off
 


### PR DESCRIPTION
### Motivation / Background

This reverts commits fe6876415d2467c967aa190d3182f511fd4f2c86 and 63c0d6b31bcd0fc33745ec6fd278b2d1aab9be54 from https://github.com/rails/rails/pull/48061.

As with https://github.com/rails/rails/pull/48188, the changes made in https://github.com/rails/rails/pull/48061 forced `SELECT` queries to go through a different codepath, circumventing the patch on `execute` to retry queries. Since we also patch `execute` from Semian it's not clear the correct path forward and we're going to revert for now.

cc/ @eileencodes 
cc/ @casperisfine @byroot (for visibility)

Note that I handrolled most of this revert because some of the changes conflicted with more recent changes made to Rails (e.g. refactoring shared abstract mysql db statements, renaming `uses_transactions` to `materialize_transactions`) so please take a good look 👀 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
