### PR TITLE
Revert "MySQL2 and TrilogyAdapter: stop using `#execute` as internal API"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -13,28 +13,16 @@ module ActiveRecord
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
-
-          result = raw_execute(sql, name, async: async)
+          result = execute(sql, name, async: async)
           ActiveRecord::Result.new(result.fields, result.to_a)
         end
 
         def exec_insert(sql, name, binds, pk = nil, sequence_name = nil) # :nodoc:
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
-
-          raw_execute(to_sql(sql, binds), name)
+          execute(to_sql(sql, binds), name)
         end
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
-
-          result = raw_execute(to_sql(sql, binds), name)
+          result = execute(to_sql(sql, binds), name)
           result.affected_rows
         end
 


### PR DESCRIPTION
This reverts commit f69bbcbc0752ca5d5af327d55922614a26f5c7e9.

The changes here force our code through a different codepath, circumventing the patch on execute to retry queries. Since we also patch execute from Semian it's not clear the correct path forward and we're going to revert for now.

cc/ @casperisfine @byroot (for visibility)
### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
