### PR TITLE
Enable passing column size to migration generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Enable passing column size to migration generator
+
+    Previously you could pass a limit to the migration generator:
+
+    `rails generate migration CreateAuthor name:text{65535}`
+
+    Now, a size attribute can be passed to the migration generator:
+
+    `rails generate migration CreateAuthor name:text{medium}`
+
+    This generates a migration which includes the size attribute:
+
+    ```ruby
+    class CreateAuthor < ActiveRecord::Migration[7.1]
+      def change
+        create_table :authors do |t|
+          t.text :name, size: :medium
+        end
+      end
+    end
+    ```
+
+    *Josh Broughton*, *Hartley McGuire*
+
 *   Trying to set a config key with the same name of a method now raises:
 
     ```ruby

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -78,6 +78,8 @@ module Rails
           # when declaring options curly brackets should be used
           def parse_type_and_options(type)
             case type
+            when /(text|binary)\{([a-z]+)\}/
+              return $1, size: $2.to_sym
             when /(string|text|binary|integer)\{(\d+)\}/
               return $1, limit: $2.to_i
             when /decimal\{(\d+)[,.-](\d+)\}/

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -135,6 +135,30 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     )
   end
 
+  def test_size_option_can_be_passed_to_string_text_and_binary
+    %w(text binary).each do |attribute_type|
+      generated_attribute = create_generated_attribute("#{attribute_type}{medium}")
+      assert_equal generated_attribute.attr_options[:size], :medium
+    end
+  end
+
+  def test_size_option_raises_exception_when_passed_to_invalid_type
+    %w(integer string).each do |attribute_type|
+      e = assert_raise Rails::Generators::Error do
+        create_generated_attribute("#{attribute_type}{medium}")
+      end
+      message = "Could not generate field 'test' with unknown type '#{attribute_type}{medium}'"
+      assert_match message, e.message
+    end
+  end
+
+  def test_limit_option_can_be_passed_to_string_text_integer_and_binary
+    %w(string text binary integer).each do |attribute_type|
+      generated_attribute = create_generated_attribute("#{attribute_type}{65535}")
+      assert_equal generated_attribute.attr_options[:limit], 65535
+    end
+  end
+
   def test_reference_is_true
     %w(references belongs_to).each do |attribute_type|
       assert_predicate create_generated_attribute(attribute_type), :reference?


### PR DESCRIPTION
### Motivation / Background

Previously you could pass a limit to the migration generator:

`rails generate migration CreateAuthor name:text{65535}`

However, size more accurately reflects how supported databases define column sizes and is also more human-friendly. While size can already be specified within a migration, it cannot currently be passed to the migration generator.

### Detail

This commit enables passing a size attribute to the rails migration generator so that it doesn't need to be manually added to the migration file after it is generated.

`rails generate migration CreateAuthor name:text{medium}`

This generates a migration which includes the size attribute:

```ruby
class CreateAuthor < ActiveRecord::Migration[7.1]
  def change
    create_table :authors do |t|
      t.text :name, size: :medium
    end
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
