### PR TITLE
Content Security Policy: add `:unsafe_hashes` mapping

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -375,4 +375,16 @@
 
     *Drew Bragg*
 
+*   Add `:unsafe_hashes` mapping for `content_security_policy`
+
+    ```ruby
+    # Before
+    policy.script_src  :strict_dynamic, "'unsafe-hashes'", "'sha256-rRMdkshZyJlCmDX27XnL7g3zXaxv7ei6Sg+yt4R3svU='"
+
+    # After
+    policy.script_src  :strict_dynamic, :unsafe_hashes, "'sha256-rRMdkshZyJlCmDX27XnL7g3zXaxv7ei6Sg+yt4R3svU='"
+    ```
+
+    *Igor Morozov*
+
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -126,6 +126,7 @@ module ActionDispatch # :nodoc:
     MAPPINGS = {
       self:             "'self'",
       unsafe_eval:      "'unsafe-eval'",
+      unsafe_hashes:    "'unsafe-hashes'",
       unsafe_inline:    "'unsafe-inline'",
       none:             "'none'",
       http:             "http:",

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -59,6 +59,9 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
 
     @policy.script_src :none, :report_sample
     assert_equal "script-src 'none' 'report-sample'", @policy.build
+
+    @policy.script_src :unsafe_hashes
+    assert_equal "script-src 'unsafe-hashes'", @policy.build
   end
 
   def test_fetch_directives


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

When we're working with [Content Security Policy](https://api.rubyonrails.org/classes/ActionDispatch/ContentSecurityPolicy.html) with `script-src 'strict-dynamic'`, we can not use inline JavaScript unless we explicitly allow it.

However, there's a distinct class of inline JavaScript which requires its own separate CSP modifier. See those examples:

```html
<button id="btn" onclick="doSomething()"></button>
<a href="javascript:void(0)">...</a>
<a href="javascript:false">...</a>
```

Browsers won't execute those scripts even if we calculate their hashes. CSP requires us to add `'unsafe-hashes'`. However, when we try to add `policy.script_src :strict_dynamic, **:unsafe_hashes**`, Rails fails with an error:

```
Unknown content security policy source mapping: :unsafe_hashes
```

This happens because this mapping just wasn't added. There's a simple workaround, as we can just pass plain strings. 

### Detail

This Pull Request request adds the corresponding mapping, which now allows us to use `:unsafe_hashes` instead of `'unsafe-hashes'`

**Before**:

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    # ...
    policy.script_src  :self, :strict_dynamic, "'unsafe-hashes'",
                       "'sha256-lo7ZdP6kFds+wf1WMWvn7MhcFVFJV44kAXODRevzRZ8='" # javascript:false
    # ...
  end
  # ...
end
```

**After**:

```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    # ...
    policy.script_src  :self, :strict_dynamic, :unsafe_hashes, 
                       "'sha256-lo7ZdP6kFds+wf1WMWvn7MhcFVFJV44kAXODRevzRZ8='" # javascript:false
   # ...
  end
  # ...
end
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

* [MDN example](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#examples). See example and the "If you cannot replace inline event handlers, you can use the 'unsafe-hashes' source expression to allow them"

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
