### PR TITLE
Add missing closing bracket to picture_tag example [ci-skip]

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -455,7 +455,7 @@ module ActionView
       #
       #   picture_tag("picture.webp")
       #   # => <picture><img src="/images/picture.webp" /></picture>
-      #   picture_tag("gold.png", :image => { :size => "20" }
+      #   picture_tag("gold.png", :image => { :size => "20" })
       #   # => <picture><img height="20" src="/images/gold.png" width="20" /></picture>
       #   picture_tag("gold.png", :image => { :size => "45x70" })
       #   # => <picture><img height="70" src="/images/gold.png" width="45" /></picture>


### PR DESCRIPTION
Add missing closing bracket to picture_tag example introduced in https://github.com/rails/rails/pull/48100

cc: @jpbalarini 