### PR TITLE
Refactor conditions code in uniq! and order_column definitons

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1735,7 +1735,8 @@
 
     *wahabmangat*
 
-*    Refactored the code in `uniq!` and `order_column` definition in `activerecord/lib/active_record/relation/query_methods.rb`
+*   Refactored the code in `uniq!` and `order_column` definition in
+    `activerecord/lib/active_record/relation/query_methods.rb`
 
     ```ruby
     attr_name == "count" && !group_values.empty?

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1738,7 +1738,6 @@
 *    Refactored the code in uniq! and order_column definition in activerecord/lib/ active_record/relation/query_methods.rb
 
     ```ruby
-
     #PREVIOUSLY uniq! & order_columns
     def order_column(field)
       arel_column(field) do |attr_name|

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1735,14 +1735,10 @@
 
     *wahabmangat*
 
-*    Refactored the code in uniq! and order_column definition in activerecord/lib/ active_record/relation/query_methods.rb
+*    Refactored the code in `uniq!` and `order_column` definition in `activerecord/lib/active_record/relation/query_methods.rb`
 
     ```ruby
-    #PREVIOUSLY uniq! & order_columns
-    def order_column(field)
-      arel_column(field) do |attr_name|
-        if attr_name == "count" && !group_values.empty?
-        ...
+    attr_name == "count" && !group_values.empty?
 
     def uniq!(name)
       if values = @values[name]
@@ -1750,11 +1746,11 @@
       end
       self
     end
+    ```
 
-    #UPDATED
-    def order_column(field)
-      arel_column(field) do |attr_name|
-        if attr_name == "count" && group_values.present?
+    `UPDATED`
+    ```ruby
+    attr_name == "count" && group_values.present?
 
     def uniq!(name)
       values = @values[name]

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1733,36 +1733,36 @@
     User.authenticate_by(email: "...", password: "...")
     ```
 
-  *wahabmangat*
-  Refactored the code in uniq! and order_column definition in activerecord/lib/active_record/relation/query_methods.rb
+    *wahabmangat*
 
-  ```ruby
-  #PREVIOUSLY
-  def uniq!(name)
-    if values = @values[name]
-      values.uniq! if values.is_a?(Array) && !values.empty?
+*    Refactored the code in uniq! and order_column definition in activerecord/lib/ active_record/relation/query_methods.rb
+
+    ```ruby
+
+    #PREVIOUSLY uniq! & order_columns
+    def order_column(field)
+      arel_column(field) do |attr_name|
+        if attr_name == "count" && !group_values.empty?
+        ...
+
+    def uniq!(name)
+      if values = @values[name]
+        values.uniq! if values.is_a?(Array) && !values.empty?
+      end
+      self
     end
-    self
-  end
 
-  #UPDATED
-  def uniq!(name)
-    values = @values[name]
-    values.uniq! if values&.is_a?(Array)
-    self
-  end
+    #UPDATED
+    def order_column(field)
+      arel_column(field) do |attr_name|
+        if attr_name == "count" && group_values.present?
 
-  #PREVIOUSLY
-  def order_column(field)
-    arel_column(field) do |attr_name|
-      if attr_name == "count" && !group_values.empty?
-      ...
-
-  #UPDATED
-  def order_column(field)
-    arel_column(field) do |attr_name|
-      if attr_name == "count" && group_values.present?
-  ```
-  *wahabmangat*
+    def uniq!(name)
+      values = @values[name]
+      values.uniq! if values&.is_a?(Array)
+      self
+    end
+    ```
+    *wahabmangat*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1733,7 +1733,36 @@
     User.authenticate_by(email: "...", password: "...")
     ```
 
-    *Jonathan Hefner*
+  *wahabmangat*
+  Refactored the code in uniq! and order_column definition in activerecord/lib/active_record/relation/query_methods.rb
 
+  ```ruby
+  #PREVIOUSLY
+  def uniq!(name)
+    if values = @values[name]
+      values.uniq! if values.is_a?(Array) && !values.empty?
+    end
+    self
+  end
+
+  #UPDATED
+  def uniq!(name)
+    values = @values[name]
+    values.uniq! if values&.is_a?(Array)
+    self
+  end
+
+  #PREVIOUSLY
+  def order_column(field)
+    arel_column(field) do |attr_name|
+      if attr_name == "count" && !group_values.empty?
+      ...
+
+  #UPDATED
+  def order_column(field)
+    arel_column(field) do |attr_name|
+      if attr_name == "count" && group_values.present?
+  ```
+  *wahabmangat*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1424,9 +1424,8 @@ module ActiveRecord
 
     # Deduplicate multiple values.
     def uniq!(name)
-      if values = @values[name]
-        values.uniq! if values.is_a?(Array) && !values.empty?
-      end
+      values = @values[name]
+      values.uniq! if values&.is_a?(Array)
       self
     end
 
@@ -1911,7 +1910,7 @@ module ActiveRecord
 
       def order_column(field)
         arel_column(field) do |attr_name|
-          if attr_name == "count" && !group_values.empty?
+          if attr_name == "count" && group_values.present?
             table[attr_name]
           else
             Arel.sql(connection.quote_table_name(attr_name))


### PR DESCRIPTION
 Refactored the code in `uniq!` and `order_column` definition in `activerecord/lib/active_record/relation/query_methods.rb`

  ```ruby
  #PREVIOUSLY
  def uniq!(name)
    if values = @values[name]
      values.uniq! if values.is_a?(Array) && !values.empty?
    end
    self
  end

  #UPDATED
  def uniq!(name)
    values = @values[name]
    values.uniq! if values&.is_a?(Array)
    self
  end

  #PREVIOUSLY
  def order_column(field)
    arel_column(field) do |attr_name|
      if attr_name == "count" && !group_values.empty?
      ...

  #UPDATED
  def order_column(field)
    arel_column(field) do |attr_name|
      if attr_name == "count" && group_values.present?
  ```