### PR TITLE
Adds missing key argument for I18n.translate

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -93,7 +93,7 @@ module ActionView
           break translated unless translated == MISSING_TRANSLATION
 
           if alternatives.present? && !alternatives.first.is_a?(Symbol)
-            break alternatives.first && I18n.translate(**options, default: alternatives)
+            break alternatives.first && I18n.translate(nil, **options, default: alternatives)
           end
 
           first_key ||= key


### PR DESCRIPTION
### Motivation / Background

I18n.translate is called with wrong arguments, key is missing.

### Detail

This Pull Request changes argument list of I18n.translate, adds a missing key.

### Additional information

This call is made in the case when translation is missing and there is a default in the options.
Tests are not affected. I18n.translate returns correct results using options hash as key, which also is missing.
It depends on particular I18n backend and may cause inexplicable errors.
