### PR TITLE
Updated ActiveSupport instrumentation guide to include Server Timings…

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -11,6 +11,7 @@ After reading this guide, you will know:
 
 * What instrumentation can provide.
 * How to add a subscriber to a hook.
+* How to view timings from instrumentation in your browser.
 * The hooks inside the Rails framework for instrumentation.
 * How to build a custom instrumentation implementation.
 
@@ -94,6 +95,18 @@ end
 [`ActiveSupport::Notifications::Event`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications/Event.html
 [`ActiveSupport::Notifications.monotonic_subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-monotonic_subscribe
 [`ActiveSupport::Notifications.subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-subscribe
+
+View timings from instrumentation in your browser
+-----------------------
+
+Rails implements the [Server Timing](https://www.w3.org/TR/server-timing/) standard to make timing information available in the web browser. To enable, edit your environment configuration (usually `development.rb` as this is most-used in development) to include the following:
+
+
+```ruby
+  config.server_timing = true
+```
+
+Once configured (including restarting your server), you can go to the Developer Tools pane of your browser, then select Network and reload your page. You can then select any request to your Rails server, and will see server timings in the timings tab. For an example of doing this, see the [Firefox Documentation](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#server-timing).
 
 Rails Framework Hooks
 ---------------------


### PR DESCRIPTION
Updates the ActiveSupport::Instrumentation guide on how to enable the `server_timings` functionality so that this data can be easily viewed in the browser.