### PR TITLE
Add health check on standalone Action Cable

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added `health_check_path` and `health_check_application` config to
+    mount a given health check rack app on a given path.
+    Useful when mounting Action Cable standalone.
+
+    *Joé Dupuis*
+
 *   `assert_broadcasts` now returns the messages that were broadcast.
 
     This makes it easier to do further analysis on those messages:

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -24,6 +24,12 @@ module ActionCable
       ActiveSupport.on_load(:action_cable) { self.logger ||= ::Rails.logger }
     end
 
+    initializer "action_cable.health_check_application" do
+      ActiveSupport.on_load(:action_cable) {
+        self.health_check_application = ->(env) { Rails::HealthController.action(:show).call(env) }
+      }
+    end
+
     initializer "action_cable.asset" do
       config.after_initialize do |app|
         if app.config.respond_to?(:assets) && app.config.action_cable.precompile_assets

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -31,6 +31,7 @@ module ActionCable
 
       # Called by Rack to set up the server.
       def call(env)
+        return config.health_check_application.call(env) if env["PATH_INFO"] == config.health_check_path
         setup_heartbeat_timer
         config.connection_class.call.new(self, env).process
       end

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -12,6 +12,7 @@ module ActionCable
       attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
       attr_accessor :cable, :url, :mount_path
       attr_accessor :precompile_assets
+      attr_accessor :health_check_path, :health_check_application
 
       def initialize
         @log_tags = []
@@ -22,6 +23,10 @@ module ActionCable
         @disable_request_forgery_protection = false
         @allow_same_origin_as_host = true
         @filter_parameters = []
+
+        @health_check_application = ->(env) {
+          [204, { "Content-Type" => "text/html", "date" => Time.now.httpdate }, []]
+        }
       end
 
       # Returns constant of subscription adapter specified in config/cable.yml.

--- a/actioncable/test/server/health_check_test.rb
+++ b/actioncable/test/server/health_check_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_support/core_ext/hash/indifferent_access"
+
+class HealthCheckTest < ActionCable::TestCase
+  def setup
+    @config = ActionCable::Server::Configuration.new
+    @config.logger = Logger.new(nil)
+    @server = ActionCable::Server::Base.new config: @config
+    @server.config.cable = { adapter: "async" }.with_indifferent_access
+    @server.config.health_check_application = health_check_application
+  end
+
+
+  test "no health check app are mounted by default" do
+    get "/up"
+    assert_equal 404, response.first
+  end
+
+  test "setting health_check_path mount the configured health check application" do
+    @server.config.health_check_path = "/up"
+    get "/up"
+
+    assert_equal 200, response.first
+    assert_equal "Hello world!", response.last
+  end
+
+
+  private
+    def get(path)
+      env = Rack::MockRequest.env_for "/up", "HTTP_HOST" => "localhost"
+      @response = @server.call env
+    end
+
+    attr_reader :response
+
+    def health_check_application
+      ->(env) {
+        [
+          200,
+          { "Content-Type" => "text/html" },
+          "Hello world!"
+        ]
+      }
+    end
+end


### PR DESCRIPTION
Fixes #48185

Action Cable can be mounted standalone, but it loses the health check route provided by the railties.
This change adds configuration for a health check rack app and a health check route to "mount" the rack app.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
