### PR TITLE
Use locks to detect connections which are in an unknown transaction state

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -12,6 +12,7 @@
     - An error is encountered just after successfully beginning a transaction.
     - An error is encountered while committing a transaction, then another error is encountered while attempting to roll it back.
     - An error is encountered while rolling back a transaction.
+    - An error is encountered which prevents the connection from being discarded.
 
     *Nick Dower*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -322,6 +322,7 @@ module ActiveRecord
           if isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"
           end
+          transaction_manager.check_transaction_state_known!
           yield
         else
           transaction_manager.within_new_transaction(isolation: isolation, joinable: joinable, &block)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -534,4 +534,8 @@ module ActiveRecord
   # values, such as request parameters or model attributes to query methods.
   class UnknownAttributeReference < ActiveRecordError
   end
+
+  # Raised when, due to an error, it is unknown whether the current connection is in a transaction.
+  class TransactionStateUnknown < ActiveRecordError
+  end
 end


### PR DESCRIPTION
Please consider viewing the diff with whitespace disabled: https://github.com/rails/rails/pull/48224/files?w=1

### Motivation / Background

A proposal for a way to improve the fix for #48164 which was added in #48200. Please see [this discussion](https://github.com/rails/rails/issues/48164#issuecomment-1544018445).

### Detail

Introduces the concept of a transaction lock. This is used to detect cases where `within_new_transaction` raises, potentially leaving the connection in a transaction, and the attempt to discard the connection fails.

The idea is to store and acquire a new lock before attempting to begin a transaction, and to only discard the lock once the transaction state is definitely known. If `within_new_transaction` raises, without the lock being discarded, subsequent attempts to create a transaction will detect this and discard the connection.

Note that no such check is performed in other methods which may use a connection in an unknown transaction state. For instance, it will still be possible to invoke `execute`. In case this change ends up being acceptable, such checks could be added.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
