### PR TITLE
Handle subqueries using EXISTS instead of IN

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Handle subqueries using `EXISTS` instead of `IN`, It can bring some performance improvements.
+
+    ```ruby
+    Post.where(author: Author.all)
+
+    # Before, subqueries were handled using IN:
+    #=> SELECT ... WHERE "posts"."author_id" IN (SELECT "authors"."id" FROM "authors")
+
+    # After, subqueries are handled using EXISTS:
+    #=> SELECT ... WHERE EXISTS (SELECT 1 FROM "authors" WHERE "authors"."id" = "posts"."author_id")
+    ```
+
+    This behavior can be controlled by configuration:
+
+    ```ruby
+    config.active_record.use_exists_for_subqueries = false
+    ```
+
+    and will be enabled by default with `config.load_defaults 7.1`.
+
+    *Lázaro Nixon*
+
 *   Discard connections which may have been left in a transaction.
 
     There are cases where, due to an error, `within_new_transaction` may unexpectedly leave a connection in an open transaction. In these cases the connection may be reused, and the following may occur:

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -316,6 +316,9 @@ module ActiveRecord
   singleton_class.attr_accessor :run_after_transaction_callbacks_in_order_defined
   self.run_after_transaction_callbacks_in_order_defined = false
 
+  singleton_class.attr_accessor :use_exists_for_subqueries
+  self.use_exists_for_subqueries = true
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -38,6 +38,7 @@ module ActiveRecord
     config.active_record.cache_query_log_tags = false
     config.active_record.raise_on_assign_to_attr_readonly = false
     config.active_record.belongs_to_required_validates_foreign_key = true
+    config.active_record.use_exists_for_subqueries = true
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -6,6 +6,8 @@ module ActiveRecord
     require "active_record/relation/predicate_builder/basic_object_handler"
     require "active_record/relation/predicate_builder/range_handler"
     require "active_record/relation/predicate_builder/relation_handler"
+    require "active_record/relation/predicate_builder/relation_in_handler"
+    require "active_record/relation/predicate_builder/relation_exists_handler"
     require "active_record/relation/predicate_builder/association_query_value"
     require "active_record/relation/predicate_builder/polymorphic_array_value"
 
@@ -15,7 +17,7 @@ module ActiveRecord
 
       register_handler(BasicObject, BasicObjectHandler.new(self))
       register_handler(Range, RangeHandler.new(self))
-      register_handler(Relation, RelationHandler.new)
+      register_handler(Relation, PredicateBuilder.relation_handler)
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
     end
@@ -33,6 +35,10 @@ module ActiveRecord
           result << Arel.sql(key[0, idx])
         end
       end
+    end
+
+    def self.relation_handler
+      ActiveRecord.use_exists_for_subqueries ? RelationExistsHandler.new : RelationInHandler.new
     end
 
     # Define how a class is converted to Arel nodes when passed to +where+.

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_exists_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_exists_handler.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class RelationExistsHandler # :nodoc:
+      def call(attribute, value)
+        if value.arel_table == attribute.relation
+          return ActiveRecord::PredicateBuilder::RelationInHandler.new.call(attribute, value)
+        end
+
+        if value.eager_loading?
+          value = value.send(:apply_join_dependency)
+        end
+
+        correlation_clause =
+          if value.select_values.present?
+            value.table[value.select_values.first].eq(attribute)
+          else
+            if value.klass.composite_primary_key?
+              raise ArgumentError, "Cannot map composite primary key #{value.klass.primary_key} to #{attribute.name}"
+            else
+              value.table[value.klass.primary_key].eq(attribute)
+            end
+          end
+
+        value.reselect(1).where(correlation_clause).arel.exists
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_in_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_in_handler.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class RelationInHandler # :nodoc:
+      def call(attribute, value)
+        if value.eager_loading?
+          value = value.send(:apply_join_dependency)
+        end
+
+        if value.select_values.empty?
+          if value.klass.composite_primary_key?
+            raise ArgumentError, "Cannot map composite primary key #{value.klass.primary_key} to #{attribute.name}"
+          else
+            value = value.select(value.table[value.klass.primary_key])
+          end
+        end
+
+        attribute.in(value.arel)
+      end
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -74,6 +74,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.run_after_transaction_callbacks_in_order_defined`](#config-active-record-run-after-transaction-callbacks-in-order-defined): `true`
 - [`config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`](#config-active-record-run-commit-callbacks-on-first-saved-instances-in-transaction): `false`
 - [`config.active_record.sqlite3_adapter_strict_strings_by_default`](#config-active-record-sqlite3-adapter-strict-strings-by-default): `true`
+- [`config.active_record.use_exists_for_subqueries`](#config-active-record-use-exists-for-subqueries): `true`
 - [`config.active_support.cache_format_version`](#config-active-support-cache-format-version): `7.1`
 - [`config.active_support.message_serializer`](#config-active-support-message-serializer): `:json_allow_marshal`
 - [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
@@ -1368,6 +1369,16 @@ For example, it is possible to create an index for a non existing column.
 See [SQLite documentation](https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted) for more details.
 
 The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
+
+#### `config.active_record.use_exists_for_subqueries`
+
+Enable handling subqueries using `EXISTS`, It can bring some performance improvements.
+The previous behavior was handling subqueries using `IN`.
 
 | Starting with version | The default value is |
 | --------------------- | -------------------- |

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -285,6 +285,7 @@ module Rails
             active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
             active_record.marshalling_format_version = 7.1
             active_record.run_after_transaction_callbacks_in_order_defined = true
+            active_record.use_exists_for_subqueries = true
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -54,6 +54,10 @@
 # See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
 # Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
 
+# Enable handling subqueries using `EXISTS`, It can bring some performance improvements.
+# The previous behavior was handling subqueries using `IN`.
+# Rails.application.config.active_record.use_exists_for_subqueries = true
+
 # Disable deprecated singular associations names
 # Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
 


### PR DESCRIPTION
### Motivation / Background

This pull request changes the subqueries to use EXISTS instead of IN as default since EXISTS is generally faster than IN and it can bring performance improvements for free. It would be awesome if we had someone in a big application to measure how much improvement we are talking about.

```ruby
Post.where(author: Author.all)

# Before, subqueries were handled using IN:
#=> SELECT ... WHERE "posts"."author_id" IN (SELECT "authors"."id" FROM "authors")

# After, subqueries are handled using EXISTS:
#=> SELECT ... WHERE EXISTS (SELECT 1 FROM "authors" WHERE "authors"."id" = "posts"."author_id")
```

This behavior can be controlled by configuration:

```ruby
config.active_record.use_exists_for_subqueries = false
```

### Detail

https://stackoverflow.com/a/3964770

https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization-with-exists.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
