### PR TITLE
[Tests only] Populate auto-generated UUID primary key

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -22,6 +22,7 @@ require "models/ship"
 require "models/admin"
 require "models/admin/user"
 require "models/cpk"
+require "models/chat_message"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses,
@@ -461,6 +462,23 @@ class PersistenceTest < ActiveRecord::TestCase
     topic_reloaded = Topic.find(topic.id)
     assert_equal("New Topic", topic_reloaded.title)
   end
+
+  def test_create_model_with_uuid_pk_populates_id
+    message = ChatMessage.create(content: "New Message")
+    assert_not_nil message.id
+
+    message_reloaded = ChatMessage.find(message.id)
+    assert_equal "New Message", message_reloaded.content
+  end if current_adapter?(:PostgreSQLAdapter)
+
+
+  def test_create_model_with_custom_named_uuid_pk_populates_id
+    message = ChatMessageCustomPk.create(content: "New Message")
+    assert_not_nil message.message_id
+
+    message_reloaded = ChatMessageCustomPk.find(message.message_id)
+    assert_equal "New Message", message_reloaded.content
+  end if current_adapter?(:PostgreSQLAdapter)
 
   def test_build
     topic = Topic.build(title: "New Topic")

--- a/activerecord/test/models/chat_message.rb
+++ b/activerecord/test/models/chat_message.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChatMessage < ActiveRecord::Base
+end
+
+class ChatMessageCustomPk < ActiveRecord::Base
+  self.table_name = "chat_messages_custom_pk"
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -6,6 +6,15 @@ ActiveRecord::Schema.define do
 
   uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
 
+  create_table :chat_messages, id: :uuid, force: true, **uuid_default do |t|
+    t.text :content
+  end
+
+  create_table :chat_messages_custom_pk, id: false, force: true do |t|
+    t.uuid :message_id, primary_key: true, default: "uuid_generate_v4()"
+    t.text :content
+  end
+
   create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|
     t.string :name
   end


### PR DESCRIPTION
We are making some changes around the logic that is responsible for populating auto-generated (auto-incremented for most cases) primary key values and we realized that an auto-generated UUID primary key wasn't properly covered with tests
https://github.com/rails/rails/blob/ae92a8a30e01e3328d357769f2d7bfa9db2d9b22/activerecord/lib/active_record/persistence.rb#L1242

The coverage is not essential for the current implementation of `_create_record` but will be important when we start extending it to populate more auto-generated columns than just a primary key.