### PR TITLE
Use double quotes for escaping yaml (re #47983)

### DIFF
--- a/actionmailbox/test/dummy/config/locales/en.yml
+++ b/actionmailbox/test/dummy/config/locales/en.yml
@@ -21,10 +21,10 @@
 #
 # true, false, on, off, yes, no
 #
-# Instead, surround them with single quotes.
+# Instead, surround them with double quotes.
 #
 # en:
-#   'true': 'foo'
+#   "true": "foo"
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/actiontext/test/dummy/config/locales/en.yml
+++ b/actiontext/test/dummy/config/locales/en.yml
@@ -21,10 +21,10 @@
 #
 # true, false, on, off, yes, no
 #
-# Instead, surround them with single quotes.
+# Instead, surround them with double quotes.
 #
 # en:
-#   'true': 'foo'
+#   "true": "foo"
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/activestorage/test/dummy/config/locales/en.yml
+++ b/activestorage/test/dummy/config/locales/en.yml
@@ -21,10 +21,10 @@
 #
 # true, false, on, off, yes, no
 #
-# Instead, surround them with single quotes.
+# Instead, surround them with double quotes.
 #
 # en:
-#   'true': 'foo'
+#   "true": "foo"
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.

--- a/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
+++ b/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml
@@ -21,10 +21,10 @@
 #
 # true, false, on, off, yes, no
 #
-# Instead, surround them with single quotes.
+# Instead, surround them with double quotes.
 #
 # en:
-#   'true': 'foo'
+#   "true": "foo"
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.


### PR DESCRIPTION
This was originally introduced in #47259 (I think), because the framework is set to prefer double quotes.

The effect is essentially the same, so let's just stick with the style guide and move on. (e.g. if the dummy apps are regenerated does this change get re-introduced).

cc @skipkayhil 