### PR TITLE
Assign auto populated columns on Active Record object creation 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Assign auto populated columns on Active Record record creation
+
+    Changes record creation logic to allow for the `auto_increment` column to be assigned
+    right after creation regardless of it's relation to model's primary key.
+    PostgreSQL adapter benefits the most from the change allowing for any number of auto-populated
+    columns to be assigned on the object immediately after row insertion utilizing the `RETURNING` statement.
+
+    *Nikita Vasilevsky*
+
 *   Use the first key in the `shards` hash from `connected_to` for the `default_shard`.
 
     Some applications may not want to use `:default` as a shard name in their connection model. Unfortunately Active Record expects there to be a `:default` shard because it must assume a shard to get the right connection from the pool manager. Rather than force applications to manually set this, `connects_to` can infer the default shard name from the hash of shards and will now assume that the first shard is your default.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -106,8 +106,9 @@ module ActiveRecord
       # Returns an array of +Column+ objects for the table specified by +table_name+.
       def columns(table_name)
         table_name = table_name.to_s
-        column_definitions(table_name).map do |field|
-          new_column_from_field(table_name, field)
+        definitions = column_definitions(table_name)
+        definitions.map do |field|
+          new_column_from_field(table_name, field, definitions)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -580,6 +580,10 @@ module ActiveRecord
         true
       end
 
+      def return_value_after_insert?(column) # :nodoc:
+        column.auto_incremented_by_db?
+      end
+
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
           !ActiveRecord.async_query_executor.nil? && !pool.async_executor.nil?

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -63,6 +63,15 @@ module ActiveRecord
         coder["comment"] = @comment
       end
 
+      # whether the column is auto-populated by the database using a sequence
+      def auto_incremented_by_db?
+        false
+      end
+
+      def auto_populated?
+        auto_incremented_by_db? || default_function
+      end
+
       def ==(other)
         other.is_a?(Column) &&
           name == other.name &&

--- a/activerecord/lib/active_record/connection_adapters/mysql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/column.rb
@@ -17,6 +17,7 @@ module ActiveRecord
         def auto_increment?
           extra == "auto_increment"
         end
+        alias_method :auto_incremented_by_db?, :auto_increment?
 
         def virtual?
           /\b(?:VIRTUAL|STORED|PERSISTENT)\b/.match?(extra)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -175,7 +175,7 @@ module ActiveRecord
             end
           end
 
-          def new_column_from_field(table_name, field)
+          def new_column_from_field(table_name, field, _definitions)
             field_name = field.fetch(:Field)
             type_metadata = fetch_type_metadata(field[:Type], field[:Extra])
             default, default_function = field[:Default], nil

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -15,6 +15,7 @@ module ActiveRecord
         def serial?
           @serial
         end
+        alias_method :auto_incremented_by_db?, :serial?
 
         def virtual?
           # We assume every generated column is virtual, no matter the concrete type

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -75,22 +75,23 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
-        def sql_for_insert(sql, pk, binds) # :nodoc:
+        def sql_for_insert(sql, pk, binds, returning) # :nodoc:
           if pk.nil?
             # Extract the table from the insert sql. Yuck.
             table_ref = extract_table_ref_from_insert_sql(sql)
             pk = primary_key(table_ref) if table_ref
           end
 
-          if pk = suppress_composite_primary_key(pk)
-            sql = "#{sql} RETURNING #{quote_column_name(pk)}"
-          end
+          returning_columns = returning || Array(pk)
+
+          returning_columns_statement = returning_columns.map { |c| quote_column_name(c) }.join(", ")
+          sql = "#{sql} RETURNING #{returning_columns_statement}" if returning_columns.any?
 
           super
         end
         private :sql_for_insert
 
-        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil) # :nodoc:
+        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           if use_insert_returning? || pk == false
             super
           else
@@ -170,6 +171,10 @@ module ActiveRecord
           # Returns the current ID of a table's sequence.
           def last_insert_id_result(sequence_name)
             internal_exec_query("SELECT currval(#{quote(sequence_name)})", "SQL")
+          end
+
+          def returning_column_values(result)
+            result.rows.first
           end
 
           def suppress_composite_primary_key(pk)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -897,7 +897,7 @@ module ActiveRecord
             PostgreSQL::AlterTable.new create_table_definition(name)
           end
 
-          def new_column_from_field(table_name, field)
+          def new_column_from_field(table_name, field, _definitions)
             column_name, type, default, notnull, oid, fmod, collation, comment, attgenerated = field
             type_metadata = fetch_type_metadata(column_name, type, oid.to_i, fmod.to_i)
             default_value = extract_value_from_default(default)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -281,6 +281,10 @@ module ActiveRecord
         { concurrently: "CONCURRENTLY" }
       end
 
+      def return_value_after_insert?(column) # :nodoc:
+        column.auto_populated?
+      end
+
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         def initialize(connection, max)
           super(max)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -4,13 +4,20 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       class Column < ConnectionAdapters::Column # :nodoc:
-        def initialize(*, auto_increment: nil, **)
+        attr_reader :rowid
+
+        def initialize(*, auto_increment: nil, rowid: false, **)
           super
           @auto_increment = auto_increment
+          @rowid = rowid
         end
 
         def auto_increment?
           @auto_increment
+        end
+
+        def auto_incremented_by_db?
+          auto_increment? || rowid
         end
 
         def init_with(coder)
@@ -33,7 +40,8 @@ module ActiveRecord
         def hash
           Column.hash ^
             super.hash ^
-            auto_increment?.hash
+            auto_increment?.hash ^
+            rowid.hash
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           ActiveRecord::Result.new(result.fields, result.to_a)
         end
 
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil) # :nodoc:
+        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           sql = transform_query(sql)
           check_if_write_query(sql)
           mark_transaction_written_if_write(sql)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -422,6 +422,12 @@ module ActiveRecord
         @columns ||= columns_hash.values.freeze
       end
 
+      def _returning_columns_for_insert # :nodoc:
+        @_returning_columns_for_insert ||= columns.filter_map do |c|
+          c.name if connection.return_value_after_insert?(c)
+        end
+      end
+
       def attribute_types # :nodoc:
         load_schema
         @attribute_types ||= Hash.new(Type.default_value)
@@ -546,6 +552,7 @@ module ActiveRecord
         end
 
         def reload_schema_from_cache(recursive = true)
+          @_returning_columns_for_insert = nil
           @arel_table = nil
           @column_names = nil
           @symbol_column_to_string_name_hash = nil

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -561,7 +561,7 @@ module ActiveRecord
         delete_by(primary_key => id_or_array)
       end
 
-      def _insert_record(values) # :nodoc:
+      def _insert_record(values, returning) # :nodoc:
         primary_key = self.primary_key
         primary_key_value = nil
 
@@ -580,7 +580,10 @@ module ActiveRecord
           im.insert(values.transform_keys { |name| arel_table[name] })
         end
 
-        connection.insert(im, "#{self} Create", primary_key || false, primary_key_value)
+        connection.insert(
+          im, "#{self} Create", primary_key || false, primary_key_value,
+          returning: returning
+        )
       end
 
       def _update_record(values, constraints) # :nodoc:
@@ -1235,11 +1238,16 @@ module ActiveRecord
     def _create_record(attribute_names = self.attribute_names)
       attribute_names = attributes_for_create(attribute_names)
 
-      new_id = self.class._insert_record(
-        attributes_with_values(attribute_names)
+      returning_columns = self.class._returning_columns_for_insert
+
+      returning_values = self.class._insert_record(
+        attributes_with_values(attribute_names),
+        returning_columns
       )
 
-      self.id ||= new_id if @primary_key
+      returning_columns.zip(returning_values).each do |column, value|
+        _write_attribute(column, value) if !_read_attribute(column)
+      end if returning_values
 
       @new_record = false
       @previously_new_record = true

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -39,6 +39,7 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
   end
 
   teardown do
+    UUIDType.reset_column_information
     drop_table "uuid_data_type"
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -710,6 +710,42 @@ module ActiveRecord
         end
       end
 
+      def test_rowid_column
+        with_example_table "id_uppercase INTEGER PRIMARY KEY" do
+          assert @conn.columns("ex").index_by(&:name)["id_uppercase"].rowid
+        end
+      end
+
+      def test_lowercase_rowid_column
+        with_example_table "id_lowercase integer PRIMARY KEY" do
+          assert @conn.columns("ex").index_by(&:name)["id_lowercase"].rowid
+        end
+      end
+
+      def test_non_integer_column_returns_false_for_rowid
+        with_example_table "id_int_short int PRIMARY KEY" do
+          assert_not @conn.columns("ex").index_by(&:name)["id_int_short"].rowid
+        end
+      end
+
+      def test_mixed_case_integer_colum_returns_true_for_rowid
+        with_example_table "id_mixed_case InTeGeR PRIMARY KEY" do
+          assert @conn.columns("ex").index_by(&:name)["id_mixed_case"].rowid
+        end
+      end
+
+      def test_rowid_column_with_autoincrement_returns_true_for_rowid
+        with_example_table "id_autoincrement integer PRIMARY KEY AUTOINCREMENT" do
+          assert @conn.columns("ex").index_by(&:name)["id_autoincrement"].rowid
+        end
+      end
+
+      def test_integer_cpk_column_returns_false_for_rowid
+        with_example_table("id integer, shop_id integer, PRIMARY KEY (shop_id, id)", "cpk_table") do
+          assert_not @conn.columns("cpk_table").any?(&:rowid)
+        end
+      end
+
       private
         def assert_logged(logs)
           subscriber = SQLSubscriber.new

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -23,10 +23,37 @@ require "models/admin"
 require "models/admin/user"
 require "models/cpk"
 require "models/chat_message"
+require "models/default"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses,
     :posts, :minivans, :clothing_items, :cpk_books
+
+  def test_populates_non_primary_key_autoincremented_column
+    topic = TitlePrimaryKeyTopic.create!(title: "title pk topic")
+
+    assert_not_nil topic.attributes["id"]
+  end
+
+  def test_populates_non_primary_key_autoincremented_column_for_a_cpk_model
+    order = Cpk::Order.create(shop_id: 111_222)
+
+    _shop_id, order_id = order.id
+
+    assert_not_nil order_id
+  end
+
+  def test_fills_auto_populated_columns_on_creation
+    record_with_defaults = Default.create
+    assert_not_nil record_with_defaults.id
+    assert_equal "Ruby on Rails", record_with_defaults.ruby_on_rails
+    assert_not_nil record_with_defaults.rand_number
+    assert_not_nil record_with_defaults.modified_date
+    assert_not_nil record_with_defaults.modified_date_function
+    assert_not_nil record_with_defaults.modified_time
+    assert_not_nil record_with_defaults.modified_time_without_precision
+    assert_not_nil record_with_defaults.modified_time_function
+  end if current_adapter?(:PostgreSQLAdapter)
 
   def test_update_many
     topic_data = { 1 => { "content" => "1 updated" }, 2 => { "content" => "2 updated" } }

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :defaults, force: true do |t|
+    t.integer :rand_number, default: -> { "random() * 100" }
+    t.string :ruby_on_rails, default: -> { "concat('Ruby ', 'on ', 'Rails')" }
     t.date :modified_date, default: -> { "CURRENT_DATE" }
     t.date :modified_date_function, default: -> { "now()" }
     t.date :fixed_date, default: "2004-01-01"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -259,9 +259,10 @@ ActiveRecord::Schema.define do
     t.string :comment
   end
 
-  create_table :cpk_orders, primary_key: [:shop_id, :id], force: true do |t|
+  # not a composite primary key on the db level to get autoincrement behavior for `id` column
+  # composite primary key is configured on the model level
+  create_table :cpk_orders, force: true do |t|
     t.integer :shop_id
-    t.integer :id
     t.string :status
   end
 


### PR DESCRIPTION
This PR extends Active Record creation logic to allow for a database
auto-populated attributes to be assigned on object creation.

Given a `Post` model represented by the following schema:
```ruby
create_table :posts, id: false do |t|
  t.integer :sequential_number, auto_increment: true
  t.string :title, primary_key: true
  t.string :ruby_on_rails, default: -> { "concat('R', 'o', 'R')" }
end
```
where `title` is being used as a primary key, the table has an
integer `sequential_number` column populated by a sequence and
`ruby_on_rails` column has a default function - creation of
`Post` records should populate the `sequential_number` and
`ruby_on_rails` attributes:

```ruby
new_post = Post.create(title: 'My first post')
new_post.sequential_number # => 1
new_post.ruby_on_rails # => 'RoR'
```

_At this moment MySQL and SQLite adapters are limited to only one
column being populated and the column must be the `auto_increment`
while PostgreSQL adapter supports any number of auto-populated
columns through `RETURNING` statement._

### Implementation details

Overall solution is trying to be generic and extensible to allow for additions while still maintains (for MySQL and SQLite) the fact that currently Rails only populates a single column on creation.

- The most important change I'd like to bring the most attention to is the method signature change for both `exec_insert` and `insert` public methods. We are adding a new `returning` keyword which accepts either a single value or an array of columns to control the return value of the method and define what column values to be returned after row insertion. Currently only supported by Postgresql using `RETURNING` statement. The behavior of the `returning` argument is defined as following: `nil` is the default value and doesn't change the behavior of the methods - they continue to return a single primary key or `LAST_INSERT_ID()` value. If an array of column names is passed - an array is returned back. However non-`nil` value for the argument is only supported by postgresql adapter at the moment. 
- `ConnectionAdapters::Column` gets a new adapter-abstract attribute called `auto_incremented_by_db?` which indicates whether a given column is being auto-incremented by the database regardless of the way it's being incremented. For mysql we alias it to `auto_increment` and for postgresql we alias it to `serial`. 
- `ConnectionAdapters::Column` also gets a new `auto_populated?` method which allows us to identify columns auto-populated by the database regardless of the way how the column is being populated. Currently only checks for `auto_incremented_by_db` or a default function
- `SQLite3::Column` has a new `rowid` property which is an implicit way to have an integer column being autoincremented
- `ModelSchema._returning_columns_for_insert` has been added to gather a list of columns values for which we want to get back after insertion. Adapter defines the selection rule. postgresql will select any auto-populated column while mysql and sqlite will select only `auto_incremented_by_db?` which by implication limits the selection to a single column.


### Long term plans

The feature is flexible enough to be extended to support not just postgresql adapter but any other database that is capable of returning column values after creation. 
The closest candidates are:
- [MariaDB starting with 10.5.0](https://mariadb.com/kb/en/insertreturning/)
- [SQLite since version 3.35.0 (2021-03-12).](https://www.sqlite.org/lang_returning.html)

We'll have to teach adapters how to build a `RETURNING` statement in `sql_for_insert`
https://github.com/rails/rails/blob/aa162cefe19b81daa5d7f8c2b9ee4fe2564e73fc/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L632-L633
and then just extend the `return_value_after_insert?` method to ask for more than just an auto-increment being returned after an insert. 
https://github.com/rails/rails/blob/aa162cefe19b81daa5d7f8c2b9ee4fe2564e73fc/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L284-L285

Databases that don't support `RETURNING` statement or an alternative will require an additional `SELECT` query to be performed to fetch values for every auto-populated columns. An additional query may not be desirable for every application so the behavior should be configurable which brings more complexity and one of the reasons why we are not trying to tackle it all at once.