### PR TITLE
Update and fixup ActionController::Parameters docs

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -104,7 +104,7 @@ module ActionController
   #   * +false+ to take no action.
   #   * <tt>:log</tt> to emit an <tt>ActiveSupport::Notifications.instrument</tt> event on the
   #     <tt>unpermitted_parameters.action_controller</tt> topic and log at the DEBUG level.
-  #   * <tt>:raise</tt> to raise a <tt>ActionController::UnpermittedParameters</tt> exception.
+  #   * <tt>:raise</tt> to raise an ActionController::UnpermittedParameters exception.
   #
   # Examples:
   #
@@ -153,7 +153,7 @@ module ActionController
     # :method: each_key
     #
     # :call-seq:
-    #   each_key()
+    #   each_key(&block)
     #
     # Calls block once for each key in the parameters, passing the key.
     # If no block is given, an enumerator is returned instead.
@@ -175,34 +175,10 @@ module ActionController
     # Returns true if the given key is not present in the parameters.
 
     ##
-    # :method: has_key?
-    #
-    # :call-seq:
-    #   has_key?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
     # :method: include?
     #
     # :call-seq:
     #   include?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
-    # :method: key?
-    #
-    # :call-seq:
-    #   key?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
-    # :method: member?
-    #
-    # :call-seq:
-    #   member?(key)
     #
     # Returns true if the given key is present in the parameters.
 
@@ -222,8 +198,12 @@ module ActionController
     #
     # Returns the content of the parameters as a string.
 
-    delegate :keys, :key?, :has_key?, :member?, :empty?, :exclude?, :include?,
+    delegate :keys, :empty?, :exclude?, :include?,
       :as_json, :to_s, :each_key, to: :@parameters
+
+    alias_method :has_key?, :include?
+    alias_method :key?, :include?
+    alias_method :member?, :include?
 
     # By default, never raise an UnpermittedParameters exception if these
     # params are present. The default includes both 'controller' and 'action'
@@ -242,7 +222,7 @@ module ActionController
       end
     end
 
-    # Returns a new instance of <tt>ActionController::Parameters</tt>.
+    # Returns a new <tt>ActionController::Parameters</tt> instance.
     # Also, sets the +permitted+ attribute to the default value of
     # <tt>ActionController::Parameters.permit_all_parameters</tt>.
     #
@@ -303,7 +283,7 @@ module ActionController
       [self.class, @parameters, @permitted].hash
     end
 
-    # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
+    # Returns a safe ActiveSupport::HashWithIndifferentAccess
     # representation of the parameters with all unpermitted keys removed.
     #
     #   params = ActionController::Parameters.new({
@@ -363,18 +343,15 @@ module ActionController
     #   safe_params.to_query("user")
     #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
     #
-    # The string pairs "key=value" that conform the query string
+    # The string pairs <tt>"key=value"</tt> that conform the query string
     # are sorted lexicographically in ascending order.
-    #
-    # This method is also aliased as +to_param+.
     def to_query(*args)
       to_h.to_query(*args)
     end
     alias_method :to_param, :to_query
 
-    # Returns an unsafe, unfiltered
-    # <tt>ActiveSupport::HashWithIndifferentAccess</tt> representation of the
-    # parameters.
+    # Returns an unsafe, unfiltered ActiveSupport::HashWithIndifferentAccess
+    # representation of the parameters.
     #
     #   params = ActionController::Parameters.new({
     #     name: "Senjougahara Hitagi",
@@ -419,7 +396,7 @@ module ActionController
     # looping in the common use case permit + mass-assignment. Defined in a
     # method to instantiate it only if needed.
     #
-    # Testing membership still loops, but it's going to be faster than our own
+    # \Testing membership still loops, but it's going to be faster than our own
     # loop that converts values. Also, we are not going to build a new array
     # object per fetch.
     def converted_arrays
@@ -467,7 +444,7 @@ module ActionController
     #   ActionController::Parameters.new(person: { name: "Francesco" }).require(:person)
     #   # => #<ActionController::Parameters {"name"=>"Francesco"} permitted: false>
     #
-    # Otherwise raises <tt>ActionController::ParameterMissing</tt>:
+    # Otherwise raises ActionController::ParameterMissing:
     #
     #   ActionController::Parameters.new.require(:person)
     #   # ActionController::ParameterMissing: param is missing or the value is empty: person
@@ -519,7 +496,6 @@ module ActionController
       end
     end
 
-    # Alias of #require.
     alias :required :require
 
     # Returns a new <tt>ActionController::Parameters</tt> instance that
@@ -541,7 +517,7 @@ module ActionController
     # +:name+ passes if it is a key of +params+ whose associated value is of type
     # +String+, +Symbol+, +NilClass+, +Numeric+, +TrueClass+, +FalseClass+,
     # +Date+, +Time+, +DateTime+, +StringIO+, +IO+,
-    # +ActionDispatch::Http::UploadedFile+ or +Rack::Test::UploadedFile+.
+    # ActionDispatch::Http::UploadedFile or +Rack::Test::UploadedFile+.
     # Otherwise, the key +:name+ is filtered out.
     #
     # You may declare that the parameter should be an array of permitted scalars
@@ -663,16 +639,16 @@ module ActionController
     end
 
     # Assigns a value to a given +key+. The given key may still get filtered out
-    # when +permit+ is called.
+    # when #permit is called.
     def []=(key, value)
       @parameters[key] = value
     end
 
     # Returns a parameter for the given +key+. If the +key+
     # can't be found, there are several options: With no other arguments,
-    # it will raise an <tt>ActionController::ParameterMissing</tt> error;
+    # it will raise an ActionController::ParameterMissing error;
     # if a second argument is given, then that is returned (converted to an
-    # instance of ActionController::Parameters if possible); if a block
+    # instance of +ActionController::Parameters+ if possible); if a block
     # is given, then that will be run and its result returned.
     #
     #   params = ActionController::Parameters.new(person: { name: "Francesco" })
@@ -718,7 +694,7 @@ module ActionController
       new_instance_with_inherited_permitted_status(@parameters.slice(*keys))
     end
 
-    # Returns current <tt>ActionController::Parameters</tt> instance which
+    # Returns the current <tt>ActionController::Parameters</tt> instance which
     # contains only the given +keys+.
     def slice!(*keys)
       @parameters.slice!(*keys)
@@ -745,7 +721,7 @@ module ActionController
       new_instance_with_inherited_permitted_status(@parameters.extract!(*keys))
     end
 
-    # Returns a new <tt>ActionController::Parameters</tt> with the results of
+    # Returns a new <tt>ActionController::Parameters</tt> instance with the results of
     # running +block+ once for every value. The keys are unchanged.
     #
     #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
@@ -792,9 +768,9 @@ module ActionController
       )
     end
 
-    # Returns the <tt>ActionController::Parameters</tt> instance changing its keys.
-    # This includes the keys from the root hash and from all nested hashes and arrays.
-    # The values are unchanged.
+    # Returns the same <tt>ActionController::Parameters</tt> instance with
+    # changed keys. This includes the keys from the root hash and from all
+    # nested hashes and arrays. The values are unchanged.
     def deep_transform_keys!(&block)
       @parameters.deep_transform_keys!(&block)
       self
@@ -802,13 +778,13 @@ module ActionController
 
     # Deletes a key-value pair from +Parameters+ and returns the value. If
     # +key+ is not found, returns +nil+ (or, with optional code block, yields
-    # +key+ and returns the result). Cf. #extract!, which returns the
-    # corresponding +ActionController::Parameters+ object.
+    # +key+ and returns the result). This method is similar to #extract!, which
+    # returns the corresponding +ActionController::Parameters+ object.
     def delete(key, &block)
       convert_value_to_parameters(@parameters.delete(key, &block))
     end
 
-    # Returns a new instance of <tt>ActionController::Parameters</tt> with only
+    # Returns a new <tt>ActionController::Parameters</tt> instance with only
     # items that the block evaluates to true.
     def select(&block)
       new_instance_with_inherited_permitted_status(@parameters.select(&block))
@@ -821,7 +797,7 @@ module ActionController
     end
     alias_method :keep_if, :select!
 
-    # Returns a new instance of <tt>ActionController::Parameters</tt> with items
+    # Returns a new <tt>ActionController::Parameters</tt> instance with items
     # that the block evaluates to true removed.
     def reject(&block)
       new_instance_with_inherited_permitted_status(@parameters.reject(&block))
@@ -834,7 +810,7 @@ module ActionController
     end
     alias_method :delete_if, :reject!
 
-    # Returns a new instance of <tt>ActionController::Parameters</tt> with +nil+ values removed.
+    # Returns a new <tt>ActionController::Parameters</tt> instance with +nil+ values removed.
     def compact
       new_instance_with_inherited_permitted_status(@parameters.compact)
     end
@@ -844,7 +820,7 @@ module ActionController
       self if @parameters.compact!
     end
 
-    # Returns a new instance of <tt>ActionController::Parameters</tt> without the blank values.
+    # Returns a new <tt>ActionController::Parameters</tt> instance without the blank values.
     # Uses Object#blank? for determining if a value is blank.
     def compact_blank
       reject { |_k, v| v.blank? }
@@ -869,7 +845,7 @@ module ActionController
       convert_value_to_parameters(@parameters.values_at(*keys))
     end
 
-    # Returns a new <tt>ActionController::Parameters</tt> with all keys from
+    # Returns a new <tt>ActionController::Parameters</tt> instance with all keys from
     # +other_hash+ merged into current hash.
     def merge(other_hash)
       new_instance_with_inherited_permitted_status(
@@ -877,15 +853,15 @@ module ActionController
       )
     end
 
-    # Returns current <tt>ActionController::Parameters</tt> instance with
+    # Returns the current <tt>ActionController::Parameters</tt> instance with
     # +other_hash+ merged into current hash.
     def merge!(other_hash)
       @parameters.merge!(other_hash.to_h)
       self
     end
 
-    # Returns a new <tt>ActionController::Parameters</tt> with all keys from
-    # current hash merged into +other_hash+.
+    # Returns a new <tt>ActionController::Parameters</tt> instance with all keys
+    # from current hash merged into +other_hash+.
     def reverse_merge(other_hash)
       new_instance_with_inherited_permitted_status(
         other_hash.to_h.merge(@parameters)
@@ -893,7 +869,7 @@ module ActionController
     end
     alias_method :with_defaults, :reverse_merge
 
-    # Returns current <tt>ActionController::Parameters</tt> instance with
+    # Returns the current <tt>ActionController::Parameters</tt> instance with
     # current hash merged into +other_hash+.
     def reverse_merge!(other_hash)
       @parameters.merge!(other_hash.to_h) { |key, left, right| left }
@@ -943,7 +919,7 @@ module ActionController
       coder.map = { "parameters" => @parameters, "permitted" => @permitted }
     end
 
-    # Returns duplicate of object including all parameters.
+    # Returns a duplicate +ActionController::Parameters+ instance with the same permitted parameters.
     def deep_dup
       self.class.new(@parameters.deep_dup, @logging_context).tap do |duplicate|
         duplicate.permitted = @permitted
@@ -1051,10 +1027,11 @@ module ActionController
       # This is a list of permitted scalar types that includes the ones
       # supported in XML and JSON requests.
       #
-      # This list is in particular used to filter ordinary requests, String goes
+      # This list is in particular used to filter ordinary requests, \String goes
       # as first element to quickly short-circuit the common case.
       #
-      # If you modify this collection please update the API of +permit+ above.
+      # If you modify this collection please update the one in the #permit doc
+      # as well.
       PERMITTED_SCALAR_TYPES = [
         String,
         Symbol,
@@ -1110,8 +1087,8 @@ module ActionController
         value.is_a?(Array) || value.is_a?(Parameters)
       end
 
-      EMPTY_ARRAY = []
-      EMPTY_HASH  = {}
+      EMPTY_ARRAY = [] # :nodoc:
+      EMPTY_HASH  = {} # :nodoc:
       def hash_filter(params, filter)
         filter = filter.with_indifferent_access
 


### PR DESCRIPTION
### Detail

- Small wording tweaks for grammar or consistency
- Add links to methods/classes when possible, and fix some cases where there were links but shouldn't be (`API`, `Testing`, etc.)
- Fixed `call-seq` for `each_key`
- Change `has_key?`, `key?`, and `member?` to aliases instead of delegates so that they are documented as aliases (This is how the methods are [documented for Hash in Ruby](https://rubyapi.org/3.2/o/hash#method-i-include-3F))
- Remove explicit "also aliased as" docs because rdoc does this already
- Add `:nodoc:` to `EMPTY_ARRAY` and `EMPTY_HASH` constants since these are internal optimizations

### Additional Information

Not skipping CI because of the `delegate` -> `alias_method` change

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
