### PR TITLE
Remove test that requires network access

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -614,12 +614,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
-  def test_template_from_url
-    url = "https://raw.githubusercontent.com/rails/rails/f95c0b7e96/railties/test/fixtures/lib/template.rb"
-    FileUtils.cd(Rails.root)
-    assert_match(/It works from file!/, run_generator([destination_root, "-m", url]))
-  end
-
   def test_template_from_abs_path
     absolute_path = File.expand_path(Rails.root, "fixtures")
     FileUtils.cd(Rails.root)


### PR DESCRIPTION
Follow-up to #43072.

`test_template_from_url` fetches an app template from `raw.githubusercontent.com`, which requires network access and requires `raw.githubusercontent.com` to be available.  (It also requires the app generator to support a specific template that existed at the point of rails/rails@f95c0b7e96.)

The [`test_template_is_executed_when_supplied_an_https_path`](https://github.com/rails/rails/blob/4e1fe73028f4b01c8e5179989511b21925f70b20/railties/test/generators/shared_generator_tests.rb#L104-L116) test in `railties/test/generators/shared_generator_tests.rb` already covers passing a template URL, so this commit simply removes `test_template_from_url`.
