### PR TITLE
Move shared tests into `SharedGeneratorTests`

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -609,24 +609,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_template_from_dir_pwd
-    FileUtils.cd(Rails.root)
-    assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
-  end
-
-  def test_template_from_abs_path
-    absolute_path = File.expand_path(Rails.root, "fixtures")
-    FileUtils.cd(Rails.root)
-    assert_match(/It works from file!/, run_generator([destination_root, "-m", "#{absolute_path}/lib/template.rb"]))
-  end
-
-  def test_template_from_env_var_path
-    ENV["FIXTURES_HOME"] = File.expand_path(Rails.root, "fixtures")
-    FileUtils.cd(Rails.root)
-    assert_match(/It works from file!/, run_generator([destination_root, "-m", "$FIXTURES_HOME/lib/template.rb"]))
-    ENV.delete("FIXTURES_HOME")
-  end
-
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -183,12 +183,12 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_ensure_that_plugin_options_are_not_passed_to_app_generator
-    FileUtils.cd(Rails.root)
+    FileUtils.cd(fixtures_root)
     assert_no_match(/It works from file!.*It works_from_file/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
   def test_ensure_that_test_dummy_can_be_generated_from_a_template
-    FileUtils.cd(Rails.root)
+    FileUtils.cd(fixtures_root)
     run_generator([destination_root, "-m", "lib/create_test_dummy_template.rb", "--skip-test"])
     assert_directory "spec/dummy"
     assert_no_directory "test"
@@ -275,11 +275,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--full", "--skip-action-mailer", "--skip-active-job"]
     assert_no_directory "app/mailers"
     assert_no_directory "app/jobs"
-  end
-
-  def test_template_from_dir_pwd
-    FileUtils.cd(Rails.root)
-    assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
   def test_ensure_that_migration_tasks_work_with_mountable_option

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require "env_helpers"
 
 #
 # Tests, setup, and teardown common to the application and plugin generator suites.
 #
 module SharedGeneratorTests
+  include EnvHelpers
+
   def setup
     Rails.application = TestApp::Application
     super
@@ -90,6 +93,21 @@ module SharedGeneratorTests
   def test_shebang_when_is_the_same_as_default_use_env
     run_generator [destination_root, "--ruby", Thor::Util.ruby_command, "--full"]
     assert_file "bin/rails", /#!\/usr\/bin\/env/
+  end
+
+  def test_template_from_absolute_path
+    assert_match "It works from file!", run_generator([destination_root, "-m", "#{fixtures_root}/lib/template.rb"])
+  end
+
+  def test_template_from_relative_path
+    FileUtils.cd(fixtures_root)
+    assert_match "It works from file!", run_generator([destination_root, "-m", "lib/template.rb"])
+  end
+
+  def test_template_with_env_var_in_path
+    switch_env "FIXTURES_ROOT", fixtures_root do
+      assert_match "It works from file!", run_generator([destination_root, "-m", "$FIXTURES_ROOT/lib/template.rb"])
+    end
   end
 
   def test_template_raises_an_error_with_invalid_path
@@ -334,6 +352,10 @@ module SharedGeneratorTests
   end
 
   private
+    def fixtures_root
+      File.expand_path("../fixtures", __dir__)
+    end
+
     def run_generator_instance
       @bundle_commands = []
       @bundle_command_stub ||= -> (command, *) { @bundle_commands << command }


### PR DESCRIPTION
These tests are relevant to both the app generator and plugin generator.
