### PR TITLE
Fix special characters in app template path

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -247,15 +247,13 @@ module Rails
 
       def set_default_accessors! # :doc:
         self.destination_root = File.expand_path(app_path, destination_root)
-        self.rails_template = \
-          case options[:template]
-          when /^https?:\/\//
-            options[:template]
-          when String
-            File.expand_path(`echo #{options[:template]}`.strip)
-          else
-            options[:template]
-          end
+
+        if options[:template].is_a?(String) && !options[:template].match?(/^https?:\/\//)
+          interpolated = options[:template].gsub(/\$(\w+)|\$\{\g<1>\}|%\g<1>%/) { |m| ENV[$1] || m }
+          self.rails_template = File.expand_path(interpolated)
+        else
+          self.rails_template = options[:template]
+        end
       end
 
       def database_gemfile_entry # :doc:

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -110,6 +110,27 @@ module SharedGeneratorTests
     end
   end
 
+  def test_template_with_curly_brace_env_var_in_path
+    switch_env "FIXTURES_ROOT", fixtures_root do
+      assert_match "It works from file!", run_generator([destination_root, "-m", "${FIXTURES_ROOT}/lib/template.rb"])
+    end
+  end
+
+  def test_template_with_windows_env_var_in_path
+    switch_env "FIXTURES_ROOT", fixtures_root do
+      assert_match "It works from file!", run_generator([destination_root, "-m", "%FIXTURES_ROOT%/lib/template.rb"])
+    end
+  end
+
+  def test_template_with_special_characters_in_path
+    Dir.mktmpdir do |dir|
+      template_path = "#{dir}/company's $99 template  (original).rb"
+      FileUtils.cp "#{fixtures_root}/lib/template.rb", template_path
+
+      assert_match "It works from file!", run_generator([destination_root, "-m", template_path])
+    end
+  end
+
   def test_template_raises_an_error_with_invalid_path
     quietly do
       content = capture(:stderr) { run_generator([destination_root, "-m", "non/existent/path"]) }


### PR DESCRIPTION
Since #43072, the app template path has been passed through `echo` in order to interpolate environment variables, and thus allow `.railsrc` files to include environment variables in the path.  However, passing an unescaped string to `echo` may cause problems when the string contains special characters, e.g. `company's template (original).rb`. Also, `echo` does not preserve multiple consecutive spaces.

This commit replaces the call to `echo` with manual interpolation using `gsub`.  This only supports basic variable interpolation (i.e. `$FOO`, `${FOO}`, and `%FOO%`), but that should cover most use cases.
