### PR TITLE
Adds Arel::Nodes::Cte for use in WITH expressions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Add `Arel::Nodes::Cte` for use in `WITH` expressions
+
+    `Cte` nodes also support explicit `MATERIALIZED` or `NOT MATERIALIZED` hints for the query planner.
+
+    ```ruby
+    posts = Arel::Table.new(:posts)
+    comments = Arel::Table.new(:comments)
+
+    good_comments_query = comments.project(Arel.star).where(comments[:rating].gt(7))
+    cte = Arel::Nodes::Cte.new(:good_comments, good_comments_query, materialized: true)
+
+    query = posts.
+      project(Arel.star).
+      with(cte).
+      where(posts[:id].in(cte.to_table.project(:post_id))).
+
+    puts query.to_sql
+
+    # WITH "good_comments" AS MATERIALIZED (SELECT * FROM "comments" WHERE "comments"."rating" > 7) SELECT * FROM "posts" WHERE "posts"."id" IN (SELECT post_id FROM "good_comments")
+    ```
+
+    *Jon Zeppieri*
+
 *   Fix mutation detection for serialized attributes backed by binary columns.
 
     *Jean Boussier*

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -39,6 +39,7 @@ require "arel/nodes/unary_operation"
 require "arel/nodes/over"
 require "arel/nodes/matches"
 require "arel/nodes/regexp"
+require "arel/nodes/cte"
 
 # nary
 require "arel/nodes/and"

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -39,6 +39,12 @@ module Arel # :nodoc: all
       end
     end
 
+    class As < Binary
+      def to_cte
+        Arel::Nodes::Cte.new(left.name, right)
+      end
+    end
+
     class Between < Binary; include FetchAttribute; end
 
     class GreaterThan < Binary
@@ -112,7 +118,6 @@ module Arel # :nodoc: all
     end
 
     %w{
-      As
       Assignment
       Join
       Union

--- a/activerecord/lib/arel/nodes/cte.rb
+++ b/activerecord/lib/arel/nodes/cte.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class Cte < Arel::Nodes::Binary
+      alias :name :left
+      alias :relation :right
+      attr_reader :materialized
+
+      def initialize(name, relation, materialized: nil)
+        super(name, relation)
+        @materialized = materialized
+      end
+
+      def hash
+        [name, relation, materialized].hash
+      end
+
+      def eql?(other)
+        self.class == other.class &&
+          self.name == other.name &&
+          self.relation == other.relation &&
+          self.materialized == other.materialized
+      end
+      alias :== :eql?
+
+      def to_cte
+        self
+      end
+
+      def to_table
+        Arel::Table.new(name)
+      end
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/table_alias.rb
+++ b/activerecord/lib/arel/nodes/table_alias.rb
@@ -26,6 +26,10 @@ module Arel # :nodoc: all
       def able_to_type_cast?
         relation.respond_to?(:able_to_type_cast?) && relation.able_to_type_cast?
       end
+
+      def to_cte
+        Arel::Nodes::Cte.new(name, relation)
+      end
     end
   end
 end

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -64,6 +64,12 @@ module Arel # :nodoc: all
           visit o.expr, collector
         end
 
+        def visit_Arel_Nodes_Cte(o, collector)
+          collector << quote_table_name(o.name)
+          collector << " AS "
+          visit o.relation, collector
+        end
+
         # In the simple case, MySQL allows us to place JOINs directly into the UPDATE
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.

--- a/activerecord/test/cases/arel/nodes/as_test.rb
+++ b/activerecord/test/cases/arel/nodes/as_test.rb
@@ -31,6 +31,18 @@ module Arel
           assert_equal 2, array.uniq.size
         end
       end
+
+      describe "#to_cte" do
+        it "returns a Cte node using the LHS's name and the RHS as the relation" do
+          table = Table.new(:users)
+          as_node = As.new(table, "foo")
+          cte_node = as_node.to_cte
+
+          assert_kind_of Arel::Nodes::Cte, cte_node
+          assert_equal as_node.left.name, cte_node.name
+          assert_equal as_node.right, cte_node.relation
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/arel/nodes/cte_test.rb
+++ b/activerecord/test/cases/arel/nodes/cte_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+
+module Arel
+  module Nodes
+    describe "Cte" do
+      describe "equality" do
+        it "is equal with equal ivars" do
+          array = [
+            Cte.new("foo", "bar", materialized: true),
+            Cte.new("foo", "bar", materialized: true)
+          ]
+
+          assert_equal 1, array.uniq.size
+        end
+
+        it "is not equal with unequal ivars" do
+          array = [
+            Cte.new("foo", "bar", materialized: true),
+            Cte.new("foo", "bar")
+          ]
+
+          assert_equal 2, array.uniq.size
+        end
+      end
+
+      describe "#to_cte" do
+        it "returns self" do
+          cte = Cte.new("foo", "bar")
+
+          assert_equal cte.to_cte, cte
+        end
+      end
+
+      describe "#to_table" do
+        it "returns an Arel::Table using the Cte's name" do
+          table = Cte.new("foo", "bar").to_table
+
+          assert_kind_of Arel::Table, table
+          assert_equal "foo", table.name
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/arel/nodes/table_alias_test.rb
+++ b/activerecord/test/cases/arel/nodes/table_alias_test.rb
@@ -24,6 +24,18 @@ module Arel
           assert_equal 2, array.uniq.size
         end
       end
+
+      describe "#to_cte" do
+        it "returns a Cte node using the TableAlias's name and relation" do
+          relation = Table.new(:users).project(Arel.star)
+          table_alias = TableAlias.new(relation, :foo)
+          cte = table_alias.to_cte
+
+          assert_kind_of Arel::Nodes::Cte, cte
+          assert_equal :foo, cte.name
+          assert_equal relation, cte.relation
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -161,6 +161,24 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::Cte" do
+        it "ignores MATERIALIZED modifiers" do
+          cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: true)
+
+          _(compile(cte)).must_be_like %{
+            "foo" AS (SELECT * FROM "bar")
+          }
+        end
+
+        it "ignores NOT MATERIALIZED modifiers" do
+          cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: false)
+
+          _(compile(cte)).must_be_like %{
+            "foo" AS (SELECT * FROM "bar")
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background
Postgres and SQLite both support a non-standard extension to the CTE syntax to indicate that a CTE subquery should be materialized, i.e., not folded into the main query but evaluated separately. This can be useful in cases where the query planner would otherwise make poor decisions.

The syntax, in both databases, is:
`WITH foo AS MATERIALIZED (...) ...`

Similarly, they support an explicit hint that a CTE should _not_ be materialized:
`WITH foo AS NOT MATERIALIZED (...) ...`

### Detail

This Pull Request adds `Arel::Nodes::Cte`, which represents a CTE query and contains an alias, a relation, and a materialization flag. The latter is either `true` to request materialization, `false` to request no materialization, or `nil` which omits any materialization hint. The node can be used like so:
```ruby
    posts = Arel::Table.new(:posts)
    comments = Arel::Table.new(:comments)

    good_comments_query = comments.project(Arel.star).where(comments[:rating].gt(7))
    cte = Arel::Nodes::Cte.new(:good_comments, good_comments_query, materialized: true)

    query = posts.
      project(Arel.star).
      with(cte).
      where(posts[:id].in(cte.to_table.project(:post_id))).

    puts query.to_sql

    # WITH "good_comments" AS MATERIALIZED (SELECT * FROM "comments" WHERE "comments"."rating" > 7) SELECT * FROM "posts" WHERE "posts"."id" IN (SELECT post_id FROM "good_comments")
```

`As` and `TableAlias` nodes continue to be supported as arguments to `SelectManager#with`.

### Additional information

This is an alternative to #47951, following @matthewd's suggestion of adding a `Cte` node that contains both an alias and a relation, instead of adding a node just to represent the addition of the `MATERIALIZED` keyword. This keeps the syntax tree shallower and allows us easily to support `NOT MATERIALIZED` hints without needing to resort to yet another keyword-specific node type or deeper nesting of nodes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
