### PR TITLE
Add conditional for serialized to handle the odd Blob serialization case

### DIFF
--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -5,6 +5,7 @@ require "models/person"
 require "models/traffic_light"
 require "models/post"
 require "models/binary_field"
+require "models/blob"
 
 class SerializedAttributeTest < ActiveRecord::TestCase
   def setup
@@ -714,5 +715,13 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     assert_deprecated(/Please pass the class as a keyword argument/, ActiveRecord.deprecator) do
       Topic.serialize(:content, Hash)
     end
+  end
+
+  def test_unicode_is_not_changed_when_stored_in_mysql_blob
+    value = "\u2022"
+    model = Blob.create!(blob: value)
+    # This looks nonsensical, but without special handling, reading a value can cause binary fields to register as changed.
+    model.blob
+    assert_not model.changed?
   end
 end

--- a/activerecord/test/models/blob.rb
+++ b/activerecord/test/models/blob.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Blob < ActiveRecord::Base
+  serialize :blob
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1113,6 +1113,10 @@ ActiveRecord::Schema.define do
     t.references :customer_carrier
   end
 
+  create_table :blobs, force: true do |t|
+    t.blob :blob
+  end
+
   create_table :speedometers, force: true, id: false do |t|
     t.string :speedometer_id
     t.string :name


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because serialization of hashes seems to not handle Dirty tracking correctly in certain circumstances. I added a test that reproduces the exact issue, the column type seems to be important (:blob). The conditional that I'm adding seems _very_ specific, and I'd love to have a more general way to do the check, but it's also made with avoiding any side effects in mind as well. 

Fixes #48255 .

### Detail

This Pull Request changes the [`changed_in_place?`](https://github.com/rails/rails/blob/fc9470aa973a8b6f1a5693bae4edec4c2b4e61aa/activerecord/lib/active_record/type/serialized.rb#LL37C11-L37C27) method found in serialized.rb to support aligning encoding of binary data more appropriately in the specific circumstance that we get a value we are forcing encoding and comparing it to an old value which, today, is unencoded. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
