### PR TITLE
Deprecate `SafeBuffer#clone_empty`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `SafeBuffer#clone_empty`.
+
+    This method has not been used internally since Rails 4.2.0.
+
+    *Mike Dalessio*
+
 *   `MessageEncryptor`, `MessageVerifier`, and `config.active_support.message_serializer`
     now accept `:message_pack` and `:message_pack_allow_marshal` as serializers.
     These serializers require the [`msgpack` gem](https://rubygems.org/gems/msgpack)

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -77,7 +77,10 @@ module ActiveSupport # :nodoc:
       @html_safe = other.html_safe?
     end
 
-    def clone_empty
+    def clone_empty # :nodoc:
+      ActiveSupport.deprecator.warn <<~EOM
+        ActiveSupport::SafeBuffer#clone_empty is deprecated and will be removed in Rails 7.2.
+      EOM
       self[0, 0]
     end
 

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -196,12 +196,18 @@ class SafeBufferTest < ActiveSupport::TestCase
   end
 
   test "clone_empty returns an empty buffer" do
-    assert_equal "", ActiveSupport::SafeBuffer.new("foo").clone_empty
+    assert_deprecated(ActiveSupport.deprecator) do
+      assert_equal "", ActiveSupport::SafeBuffer.new("foo").clone_empty
+    end
   end
 
   test "clone_empty keeps the original dirtiness" do
-    assert_predicate @buffer.clone_empty, :html_safe?
-    assert_not_predicate @buffer.gsub!("", "").clone_empty, :html_safe?
+    assert_deprecated(ActiveSupport.deprecator) do
+      assert_predicate @buffer.clone_empty, :html_safe?
+    end
+    assert_deprecated(ActiveSupport.deprecator) do
+      assert_not_predicate @buffer.gsub!("", "").clone_empty, :html_safe?
+    end
   end
 
   test "Should be safe when sliced if original value was safe" do


### PR DESCRIPTION
### Motivation / Background

`SafeBuffer#clone_empty` is unused within the Rails codebase. The last caller was removed by 479c7cac in 2014 (Rails 4.2.0).

### Additional information

A [search on github](https://github.com/search?q=clone_empty+language%3ARuby&type=code&l=Ruby&p=1) suggests that this method isn't called often by any public code written or updated in the last 11 years.

Is this a method we want to continue to support?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
