### PR TITLE
update `ERB::Util.html_escape_once` to always return an `html_safe` string

### DIFF
--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -103,9 +103,9 @@ class ErbUtilTest < ActiveSupport::TestCase
     assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", html_escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
 
-  def test_html_escape_once_returns_unsafe_strings_when_passed_unsafe_strings
+  def test_html_escape_once_returns_safe_strings_when_passed_unsafe_strings
     value = html_escape_once("1 < 2 &amp; 3")
-    assert_not_predicate value, :html_safe?
+    assert_predicate value, :html_safe?
   end
 
   def test_html_escape_once_returns_safe_strings_when_passed_safe_strings

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   `ERB::Util.html_escape_once` always returns an `html_safe` string.
+
+    This method previously maintained the `html_safe?` property of a string on the return
+    value. Because this string has been escaped, however, not marking it as `html_safe` causes
+    entities to be double-escaped.
+
+    As an example, take this view snippet:
+
+      ```html
+      <p><%= html_escape_once("this & that &amp; the other") %></p>
+      ```
+
+    Before this change, that would be double-escaped and render as:
+
+      ```html
+      <p>this &amp;amp; that &amp;amp; the other</p>
+      ```
+
+    After this change, it renders correctly as:
+
+      ```html
+      <p>this &amp; that &amp; the other</p>
+      ```
+
+    Fixes #48256
+
+    *Mike Dalessio*
+
 *   Deprecate `SafeBuffer#clone_empty`.
 
     This method has not been used internally since Rails 4.2.0.

--- a/activesupport/lib/active_support/core_ext/erb/util.rb
+++ b/activesupport/lib/active_support/core_ext/erb/util.rb
@@ -63,8 +63,7 @@ class ERB
     #   html_escape_once('&lt;&lt; Accept & Checkout')
     #   # => "&lt;&lt; Accept &amp; Checkout"
     def html_escape_once(s)
-      result = ActiveSupport::Multibyte::Unicode.tidy_bytes(s.to_s).gsub(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE)
-      s.html_safe? ? result.html_safe : result
+      ActiveSupport::Multibyte::Unicode.tidy_bytes(s.to_s).gsub(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE).html_safe
     end
 
     module_function :html_escape_once


### PR DESCRIPTION
### Motivation / Background

This PR updates the behavior of `ERB::Util.html_escape_once` to always return an `html_safe` string.

This method previously maintained the `html_safe?` property of a string on the return value. Because this string has been escaped, however, not marking it as `html_safe` causes entities to be double-escaped.

As an example, take this view snippet:

  ```html
  <p><%= html_escape_once("this & that &amp; the other") %></p>
  ```

Before this change, that would be double-escaped and render as:

  ```html
  <p>this &amp;amp; that &amp;amp; the other</p>
  ```

After this change, it renders correctly as:

  ```html
  <p>this &amp; that &amp; the other</p>
  ```

Fixes #48256


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
