### PR TITLE
FIX correctly sort records with the in_batches method

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -280,7 +280,7 @@ module ActiveRecord
           end
         else
           ids = batch_relation.ids
-          yielded_relation = where(primary_key => ids)
+          yielded_relation = where(primary_key => ids).order(batch_orders.to_h)
         end
 
         break if ids.empty?

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -694,6 +694,10 @@ class EachTest < ActiveRecord::TestCase
 
       assert_equal @total, total
     end
+
+    test "in_batches should correctly sorted when load is #{load}" do
+      assert_equal Post.order(id: :desc).pluck(:id), Post.in_batches(order: :desc, use_ranges: false, load: load).first.pluck(:id)
+    end
   end
 
   test ".find_each respects table alias" do


### PR DESCRIPTION
Fixed incorrect sorting using order keyword in in_batches method

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Fix incorrect sorting using order keyword in in_batches method.

example (posts table has id as the primary key)
```
Post.in_batches(order: :desc, use_ranges: false).first.pluck(:id)
:actual => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
:expected  => [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
```

### Additional information
if use_ranges keyword is true, the sorting does not work either because of [this code](https://github.com/rails/rails/blob/55c3066da325703ff7a9524dbdc479b860db3970/activerecord/lib/active_record/relation/batches.rb#LL278), but I am not sure if this is the expected behavior.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
