### PR TITLE
Run `after_bundle` blocks with `app:template` command

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -60,11 +60,7 @@ gem "bj"
 gem "nokogiri"
 ```
 
-Please note that this will NOT install the gems for you and you will have to run `bundle install` to do that.
-
-```bash
-$ bundle install
-```
+Note that this method only adds the gem to the `Gemfile`; it does not install the gem.
 
 ### gem_group(*names, &block)
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `bin/rails app:template` now runs `bundle install` and any `after_bundle`
+    blocks after the template is executed.
+
+    *Jonathan Hefner* and *Gerry Caulfield*
+
 *   Enable passing column size to migration generator
 
     Previously you could pass a limit to the migration generator:

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -309,6 +309,14 @@ module Rails
 
       META_OPTIONS = [:minimal] # :nodoc:
 
+      def self.apply_rails_template(template, destination) # :nodoc:
+        generator = new([destination], { template: template }, { destination_root: destination })
+        generator.set_default_accessors!
+        generator.apply_rails_template
+        generator.run_bundle
+        generator.run_after_bundle_callbacks
+      end
+
       def initialize(*args)
         super
 
@@ -537,7 +545,8 @@ module Rails
         build(:leftovers)
       end
 
-      public_task :apply_rails_template, :run_bundle
+      public_task :apply_rails_template
+      public_task :run_bundle
       public_task :generate_bundler_binstub
       public_task :run_javascript
       public_task :run_hotwire

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -8,11 +8,9 @@ namespace :app do
   task template: :environment do
     template = ENV["LOCATION"]
     raise "No LOCATION value given. Please set LOCATION either as path to a file or a URL" if template.blank?
-    template = File.expand_path(template) unless %r{\A[A-Za-z][A-Za-z0-9+\-.]*://}.match?(template)
     require "rails/generators"
     require "rails/generators/rails/app/app_generator"
-    generator = Rails::Generators::AppGenerator.new [Rails.root], {}, { destination_root: Rails.root }
-    generator.apply template, verbose: false
+    Rails::Generators::AppGenerator.apply_rails_template(template, Rails.root)
   end
 
   namespace :templates do

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1012,6 +1012,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_equal @bundle_commands_before_callback, @bundle_commands
   end
 
+  def test_apply_rails_template_class_method_runs_bundle_and_after_bundle_callbacks
+    run_generator
+
+    FileUtils.cd(destination_root) do
+      template = "lib/template.rb"
+      File.write(template, "after_bundle { create_file 'after_bundle_callback_ran' }")
+
+      generator_class.no_commands do
+        assert_called_on_instance_of(generator_class, :run_bundle) do
+          quietly { generator_class.apply_rails_template(template, destination_root) }
+        end
+      end
+
+      assert_file "after_bundle_callback_ran"
+    end
+  end
+
   def test_gitignore
     run_generator
 


### PR DESCRIPTION
App templates may contain `after_bundle` blocks which should be run after the template is executed, after running `bundle install`.  For example:

  ```ruby
  gem "devise"

  after_bundle do
    generate "devise:install"
  end
  ```

Prior to this commit, `bundle install` and `after_bundle` blocks were run only when applying a template via `rails new`.  This commit makes `bin/rails app:template` run them as well.

---

/cc @gerrywastaken I've added you as a co-author for your work on #40197.
/cc @quintrino Since you expressed interest #40197.
