### PR TITLE
Rescue Exception while the connection pool 'checkout_and_verify'

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -739,7 +739,7 @@ module ActiveRecord
             c.clean!
           end
           c
-        rescue
+        rescue Exception
           remove c
           c.disconnect!
           raise


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We discovered the presence of “zombie” database connections in the ActiveRecord connection pool, which can eventually trigger the `ActiveRecord::ConnectionTimeoutError` due to the inability to "reap" or "re-checkout" these connections.

The problem lies in the `ConnectionPool#release_connection` method, where it attempts to locate and release a connection in the `@thread_cached_conns` variable:

```ruby
if conn = @thread_cached_conns.delete(connection_cache_key(owner_thread))
  checkin conn
end
```

In cases where `#checkout_and_verify` raises an `Exception` (such as ["Rack::Timeout::RequestTimeoutException"](https://github.com/zombocom/rack-timeout/blob/main/doc/exceptions.md#exceptions)), the connection won't be present in `@thread_cached_conns`, but it will remain busy because its owner is still active. So the `#release_connection` won't release any connection in this situation.

### Detail

Rescue `Exception` instead of `StandardError` in the `#checkout_and_verify` method.


