### PR TITLE
TrilogyAdapter: translate `Trilogy::TimeoutError` in `AdapterTimeout`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -211,6 +211,9 @@ module ActiveRecord
         end
 
         def translate_exception(exception, message:, sql:, binds:)
+          if exception.is_a?(::Trilogy::TimeoutError) && !exception.error_code
+            return ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
+          end
           error_code = exception.error_code if exception.respond_to?(:error_code)
 
           Trilogy::LostConnectionExceptionTranslator.new(exception, message, error_code).translate || super


### PR DESCRIPTION
Prior to this patch it would translate it to `InvalidStatement` which is the catch all and is hard to work with.

FYI: @eileencodes @adrianna-chang-shopify @matthewd 