### PR TITLE
Link to ActionView::Helpers top level namespace for all helpers

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -17,7 +17,7 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-NOTE: This guide is not intended to be a complete documentation of available form helpers and their arguments. Please visit [the Rails API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html) for a complete reference.
+NOTE: This guide is not intended to be a complete documentation of available form helpers and their arguments. Please visit [the Rails API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers.html) for a complete reference of all available helpers.
 
 Dealing with Basic Forms
 ------------------------


### PR DESCRIPTION
Follow up to #48087 

After thinking about it, makes sense to link to the top level module so the reader can see all of the helpers available.

/cc @mikepmunroe since this was originally your patch, it could have been taken care of in the previous review; I've added you as a co-author. :bow: