### PR TITLE
Docs: Fix `queue_as` doc wording [ci skip]

### DIFF
--- a/activejob/lib/active_job/queue_name.rb
+++ b/activejob/lib/active_job/queue_name.rb
@@ -19,8 +19,7 @@ module ActiveJob
       #   end
       #
       # Can be given a block that will evaluate in the context of the job
-      # allowing +self.arguments+ to be accessed so that a dynamic queue name
-      # can be applied:
+      # so that a dynamic queue name can be applied:
       #
       #   class PublishToFeedJob < ApplicationJob
       #     queue_as do


### PR DESCRIPTION
Changing the wording of `queue_as` doc as per https://github.com/rails/rails/pull/48099#discussion_r1197516258