### PR TITLE
ActiveRecord: make query timeout errors inherit from the base connection error

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -156,10 +156,7 @@ module ActiveRecord
     end
   end
 
-  # Superclass for all database execution errors.
-  #
-  # Wraps the underlying database error as +cause+.
-  class StatementInvalid < ActiveRecordError
+  module QueryError # :nodoc:
     def initialize(message = nil, sql: nil, binds: nil)
       super(message || $!&.message)
       @sql = sql
@@ -176,6 +173,13 @@ module ActiveRecord
 
       self
     end
+  end
+
+  # Superclass for all database execution errors.
+  #
+  # Wraps the underlying database error as +cause+.
+  class StatementInvalid < ActiveRecordError
+    include QueryError
   end
 
   # Defunct wrapper class kept for compatibility.
@@ -488,7 +492,8 @@ module ActiveRecord
   end
 
   # Superclass for errors that have been aborted (either by client or server).
-  class QueryAborted < StatementInvalid
+  class QueryAborted < ConnectionNotEstablished
+    include QueryError
   end
 
   # LockWaitTimeout will be raised when lock wait timeout exceeded.


### PR DESCRIPTION
In my experience, to enable efficient handling of exceptions, network clients must clearly categorize their exceptions in two categories:

  - Network/Connection errors: whenever we didn't actually get a response from the server and perhaps the issue is transient and retrying now or later will work. e.g. Timeout, authentication error, DNS error, etc.

  - Client errors: when the client did something wrong, and it's likely a bug in the user code and they should fix something. e.g. SQL Syntax error, unkown column, etc.

Such categorization allows for better automated handling of exceptions, like retrying or not, sending the exception to a reporting service or just emitting a health metric, etc.

Historically Active Record was quite bad at translating the underlying adapter errors into clean errors of its own, and lots of network related errors were translated into `SatementInvalid` as a big catch all.

In 2019 we started better tranlating these errors (https://github.com/rails/rails/pull/36692, https://github.com/rails/rails/pull/36694) but for backward compatibility reasons these new errors still inherited from `StatementInvalid`.

I think now would be a good time to consider fixing this historical cruft.

Note: opening as a draft as this PR isn't necessarily exactly what I want to change, I'm more interested in gathering thoughts from interested parties.

cc @matthewd @eileencodes @rafaelfranca any opinions?
