### PR TITLE
Add curl to work with the default healthcheck strategy in MRSK

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -558,6 +558,9 @@ module Rails
         # ActiveRecord databases
         packages << deploy_package_for_database unless skip_active_record?
 
+        # Add curl to work with the default healthcheck strategy in MRSK
+        packages << "curl"
+
         # ActiveStorage preview support
         packages << "libvips" unless skip_active_storage?
 


### PR DESCRIPTION
Rails should work with MRSK out of the box. MRSK uses curl from within the app container to perform its health check, which works with the new default /up. Adding curl as a default package makes the entire flow zero config.