### PR TITLE
Revert "Add curl to work with the default healthcheck strategy in MRSK"

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -558,9 +558,6 @@ module Rails
         # ActiveRecord databases
         packages << deploy_package_for_database unless skip_active_record?
 
-        # Add curl to work with the default healthcheck strategy in MRSK
-        packages << "curl"
-
         # ActiveStorage preview support
         packages << "libvips" unless skip_active_storage?
 


### PR DESCRIPTION
Reverts rails/rails#48282. We already had this on main!