### PR TITLE
Fixing invert_where method to handle empty where conditions

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -83,13 +83,13 @@ module ActiveRecord
       end
 
       def invert
-        if predicates.size == 1
-          inverted_predicates = [ invert_predicate(predicates.first) ]
+        if predicates.empty?
+          WhereClause.empty
+        elsif predicates.size == 1
+          WhereClause.new([ invert_predicate(predicates.first) ])
         else
-          inverted_predicates = [ Arel::Nodes::Not.new(ast) ]
+          WhereClause.new([ Arel::Nodes::Not.new(ast) ])
         end
-
-        WhereClause.new(inverted_predicates)
       end
 
       def self.empty

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -486,6 +486,10 @@ module ActiveRecord
       assert_equal 1, posts.invert_where.first.id
     end
 
+    def test_invert_where_without_where_clause
+      assert_equal Post.count, Post.where(id: 1).unscope(:where).invert_where.count
+    end
+
     def test_nested_conditional_on_enum
       post = Post.first
       Comment.create!(label: :default, post: post, body: "Nice weather today")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Currently, when`invert_where` is called without any existing where conditions, it throws an error with invalid query. 
```
Post.invert_where.to_sql
#=> SELECT "posts".* FROM "posts" WHERE NOT ()
```

modified the `invert_where` to return the receiver as is when there are no `where` conditions to invert. 
```
Post.order(:id).invert_where.to_sql
#=>  "SELECT \"posts\".* FROM \"posts\" ORDER BY \"posts\".\"id\" ASC"
```

### Detail

When the method chain of `ActiveRecord_Relation` includes an unintentional method such as `unscope(:where)` and I use invert_where after that, unexpected errors occur.
```
relation = Post.where(id: 2)
relation = relation.unscope(:where)
relation.invert_where
```

Also, this change has some kind of consistency with how `unscope(:where)` behaves when there are no scopes defined, I think 🙇‍♀️ 
```
Post.order(:id).unscope(:where)
#=> "SELECT \"posts\".* FROM \"posts\" ORDER BY \"posts\".\"id\" ASC"
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
