### PR TITLE
Fix NameError in Mysql2::DatabaseStatements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -126,7 +126,7 @@ module ActiveRecord
                   result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                     stmt.execute(*type_casted_binds)
                   end
-                rescue Mysql2::Error => e
+                rescue ::Mysql2::Error => e
                   if cache_stmt
                     @statements.delete(sql)
                   else


### PR DESCRIPTION
### Motivation / Background

The recent [refactor][1] to the MySQL DatabaseStatements classes renamed Mysql::DatabaseStatements to Mysql2::DatabaseStatements. That commit also updated most of the references to the top level Mysql2 to be explicit since Ruby will now assume they refer to ActiveRecord::ConnectionAdapters::Mysql2. However, Mysql2::Error was not updated, and that rescue will currently raise:

```
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::Mysql2::Error
```

if the execute raises any error.

[1]: https://github.com/rails/rails/commit/93b5fc1f95e04b6a51f3e8dd2c885ba9ddd139a6

### Detail

To fix this, Mysql2 must be changed to explicitly refer to the top level namespace.

### Additional Information

I'm looking into writing a test case but mostly wanted to get the fix submitted because its currently making it harder for my team to debug an error

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
