### PR TITLE
Automatically add `test/fixtures` in engines to `fixture_paths`

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -21,7 +21,8 @@ module ActiveRecord
   #
   # They are stored in YAML files, one file per model, which are placed in the directories
   # appointed by <tt>ActiveSupport::TestCase.fixture_paths=(path)</tt> (this is automatically
-  # configured for Rails, so you can just put your files in <tt><your-rails-app>/test/fixtures/</tt>).
+  # configured for Rails, so you can just put your files in <tt><your-rails-app>/test/fixtures/</tt>,
+  # or in the <tt>test/fixtures</tt> folder under any of your application's engines).
   # The fixture file ends with the +.yml+ file extension, for example:
   # <tt><your-rails-app>/test/fixtures/web_sites.yml</tt>).
   #

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add engine's `test/fixtures` path to `fixture_paths` in `on_load` hook if
+    path exists and is under the Rails application root.
+
+    *Chris Salzberg*
+
 *   `bin/rails app:template` now runs `bundle install` and any `after_bundle`
     blocks after the template is executed.
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -615,6 +615,15 @@ module Rails
       end
     end
 
+    initializer :add_fixture_paths do
+      next if is_a?(Rails::Application)
+
+      fixtures = config.root.join("test", "fixtures")
+      if fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s)
+        ActiveSupport.on_load(:active_record_fixtures) { self.fixture_paths |= ["#{fixtures}/"] }
+      end
+    end
+
     initializer :prepend_helpers_path do |app|
       if !isolated? || (app == self)
         app.config.helpers_paths.unshift(*paths["app/helpers"].existent)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -304,6 +304,19 @@ module RailtiesTest
       assert_equal "Hi bukkits\n", response[2].body
     end
 
+    test "adds its fixtures path to fixture_paths" do
+      @plugin.write "test/fixtures/bukkits.yml", ""
+
+      boot_rails
+
+      test_class = Class.new
+      test_class.singleton_class.attr_accessor :fixture_paths
+      test_class.fixture_paths = []
+      ActiveSupport.run_load_hooks(:active_record_fixtures, test_class)
+
+      assert_equal test_class.fixture_paths, ["#{Bukkits::Engine.root}/test/fixtures/"]
+    end
+
     test "adds its mailer previews to mailer preview paths" do
       @plugin.write "app/mailers/bukkit_mailer.rb", <<-RUBY
         class BukkitMailer < ActionMailer::Base


### PR DESCRIPTION
### Motivation / Background

Make the addition of `test/fixtures` directories to `TestFixtures#fixture_paths` automatic by default via an initializer, to avoid a lot of boilerplate in engine setup.

### Detail

https://github.com/rails/rails/pull/47675 introduced `TestFixtures#fixture_paths` to assign multiple fixture paths, mainly for use in engines. https://github.com/rails/rails/pull/47690 further supplied a hook to add such paths.

As a result, it is now possible for engines to add their own fixture paths like this:

```ruby
ActiveSupport.on_load(:active_record_fixtures) do
  self.fixture_paths << Engine.root.join("test", "fixtures").to_s
end
```

However, it is easy to forget this code, and it is exactly the same for every engine. Given that, it would make sense to just make engines automatically look for `test/fixtures` and if the directory exists, add it to `fixture_paths` like this. That's what this PR does.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.