### PR TITLE
Support nested elements inside <button>

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -771,9 +771,9 @@ function start() {
 }
 
 function didClick(event) {
-  const {target: target} = event;
-  if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
-    submitButtonsByForm.set(target.form, target);
+  const submitButton = event.target.closest(":is(button, input)[type='submit']");
+  if (submitButton && submitButton.form) {
+    submitButtonsByForm.set(submitButton.form, submitButton);
   }
 }
 

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -754,9 +754,9 @@
     }
   }
   function didClick(event) {
-    const {target: target} = event;
-    if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
-      submitButtonsByForm.set(target.form, target);
+    const submitButton = event.target.closest(":is(button, input)[type='submit']");
+    if (submitButton && submitButton.form) {
+      submitButtonsByForm.set(submitButton.form, submitButton);
     }
   }
   function didSubmitForm(event) {

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -15,9 +15,9 @@ export function start() {
 }
 
 function didClick(event) {
-  const { target } = event
-  if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
-    submitButtonsByForm.set(target.form, target)
+  const submitButton = event.target.closest(":is(button, input)[type='submit']")
+  if (submitButton && submitButton.form) {
+    submitButtonsByForm.set(submitButton.form, submitButton)
   }
 }
 


### PR DESCRIPTION
### Motivation / Background

This change is necessary to address a potential issue that could arise when a button or an input of type submit contains child elements, such as spans, icons, or other HTML elements. 

Currently, ActiveStorage's `didClick` event listener checks the target of the click event to determine if a submit button was clicked. The target property of the event refers to the specific HTML element that was clicked.

In cases where a submit button contains child elements, and one of these child elements is the element that actually gets clicked, the target would refer to this child element, not the button itself. 

Since the `didClick` function checks if the target is a button or an input of type submit, this check would fail, and the button wouldn't be stored in `submitButtonsByForm`.

As a result, if the form is then submitted after a direct upload, the first submit button in the form could be incorrectly used to submit the form, even if a different button was originally clicked. This could cause unexpected behavior, as different submit buttons might be intended to trigger different actions on form submission.

### Detail

By using the `Element.closest()` method to find the nearest ancestor of the clicked element that is a button or an input of type submit, we ensure that the correct button is stored in `submitButtonsByForm`, even if the click event was triggered by a child element of the button. This addresses the issue and ensures that the correct button is used to submit the form after a direct upload.