### PR TITLE
Store `connection_pool` in database-related exceptions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Include the `connection_pool` with exceptions raised from an adapter.
+
+    The `connection_pool` provides added context such as the connection used
+    that led to the exception as well as which role and shard.
+
+    *Luan Vieira*
+
 *   Fix where on association with has_one/has_many polymorphic relations.
 
     Before:

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -690,6 +690,8 @@ module ActiveRecord
           connection.pool = self
           connection.check_version
           connection
+        rescue ConnectionNotEstablished => ex
+          raise ex.set_pool(self)
         end
 
         # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1154,7 +1154,7 @@ module ActiveRecord
           when RuntimeError, ActiveRecord::ActiveRecordError
             exception
           else
-            ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds)
+            ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy/lost_connection_exception_translator.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/lost_connection_exception_translator.rb
@@ -6,10 +6,11 @@ module ActiveRecord
       class LostConnectionExceptionTranslator
         attr_reader :exception, :message, :error_number
 
-        def initialize(exception, message, error_number)
+        def initialize(exception, message, error_number, connection_pool)
           @exception = exception
           @message = message
           @error_number = error_number
+          @connection_pool = connection_pool
         end
 
         def translate
@@ -25,23 +26,23 @@ module ActiveRecord
           def translate_database_exception
             case error_number
             when ER_SERVER_SHUTDOWN
-              Errors::ServerShutdown.new(message)
+              Errors::ServerShutdown.new(message, connection_pool: @connection_pool)
             when CR_SERVER_LOST, CR_SERVER_LOST_EXTENDED
-              Errors::ServerLost.new(message)
+              Errors::ServerLost.new(message, connection_pool: @connection_pool)
             when CR_SERVER_GONE_ERROR
-              Errors::ServerGone.new(message)
+              Errors::ServerGone.new(message, connection_pool: @connection_pool)
             end
           end
 
           def translate_ruby_exception
             case exception
             when Errno::EPIPE
-              Errors::BrokenPipe.new(message)
+              Errors::BrokenPipe.new(message, connection_pool: @connection_pool)
             when SocketError, IOError
-              Errors::SocketError.new(message)
+              Errors::SocketError.new(message, connection_pool: @connection_pool)
             when ::Trilogy::ConnectionError
               if message.include?("Connection reset by peer")
-                Errors::ConnectionResetByPeer.new(message)
+                Errors::ConnectionResetByPeer.new(message, connection_pool: @connection_pool)
               end
             end
           end
@@ -51,11 +52,11 @@ module ActiveRecord
 
             case message
             when /TRILOGY_CLOSED_CONNECTION/
-              Errors::ClosedConnection.new(message)
+              Errors::ClosedConnection.new(message, connection_pool: @connection_pool)
             when /TRILOGY_INVALID_SEQUENCE_ID/
-              Errors::InvalidSequenceId.new(message)
+              Errors::InvalidSequenceId.new(message, connection_pool: @connection_pool)
             when /TRILOGY_UNEXPECTED_PACKET/
-              Errors::UnexpectedPacket.new(message)
+              Errors::UnexpectedPacket.new(message, connection_pool: @connection_pool)
             end
           end
       end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -14,9 +14,10 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_connection_error
-    assert_raises ActiveRecord::ConnectionNotEstablished do
+    error = assert_raises ActiveRecord::ConnectionNotEstablished do
       ActiveRecord::Base.mysql2_connection(socket: File::NULL, prepared_statements: false).connect!
     end
+    assert_kind_of ActiveRecord::ConnectionAdapters::NullPool, error.connection_pool
   end
 
   def test_reconnection_error
@@ -37,9 +38,11 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       nil,
       { socket: File::NULL, prepared_statements: false }
     )
-    assert_raises ActiveRecord::ConnectionNotEstablished do
+    error = assert_raises ActiveRecord::ConnectionNotEstablished do
       @conn.reconnect!
     end
+
+    assert_equal @conn.pool, error.connection_pool
   end
 
   def test_mysql2_default_prepared_statements
@@ -144,6 +147,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       error.message
     )
     assert_not_nil error.cause
+    assert_equal @conn.pool, error.connection_pool
   ensure
     @conn.execute("ALTER TABLE engines DROP COLUMN old_car_id") rescue nil
   end
@@ -169,6 +173,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
         error.message
       )
       assert_not_nil error.cause
+      assert_equal @conn.pool, error.connection_pool
     ensure
       @conn.remove_reference(:engines, :person)
       @conn.remove_reference(:engines, :old_car)
@@ -198,6 +203,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       error.message
     )
     assert_not_nil error.cause
+    assert_equal @conn.pool, error.connection_pool
   ensure
     @conn.drop_table :foos, if_exists: true
   end
@@ -225,6 +231,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       error.message
     )
     assert_not_nil error.cause
+    assert_equal @conn.pool, error.connection_pool
   ensure
     @conn.drop_table :foos, if_exists: true
   end
@@ -249,6 +256,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       column on `foos` to be :string. (For example `t.string :subscriber_id`).
     MSG
     assert_not_nil error.cause
+    assert_equal @conn.pool, error.connection_pool
   ensure
     @conn.drop_table :foos, if_exists: true
   end
@@ -259,30 +267,33 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Base.establish_connection(
       db_config.configuration_hash.merge("read_timeout" => 1)
     )
+    connection = ActiveRecord::Base.connection
 
     error = assert_raises(ActiveRecord::AdapterTimeout) do
-      ActiveRecord::Base.connection.execute("SELECT SLEEP(2)")
+      connection.execute("SELECT SLEEP(2)")
     end
     assert_kind_of ActiveRecord::QueryAborted, error
-
     assert_equal Mysql2::Error::TimeoutError, error.cause.class
+    assert_equal connection.pool, error.connection_pool
   ensure
     ActiveRecord::Base.establish_connection :arunit
   end
 
   def test_statement_timeout_error_codes
     raw_conn = @conn.raw_connection
-    assert_raises(ActiveRecord::StatementTimeout) do
+    error = assert_raises(ActiveRecord::StatementTimeout) do
       raw_conn.stub(:query, ->(_sql) { raise Mysql2::Error.new("fail", 50700, ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::ER_FILSORT_ABORT) }) {
         @conn.execute("SELECT 1")
       }
     end
+    assert_equal @conn.pool, error.connection_pool
 
-    assert_raises(ActiveRecord::StatementTimeout) do
+    error = assert_raises(ActiveRecord::StatementTimeout) do
       raw_conn.stub(:query, ->(_sql) { raise Mysql2::Error.new("fail", 50700, ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::ER_QUERY_TIMEOUT) }) {
         @conn.execute("SELECT 1")
       }
     end
+    assert_equal @conn.pool, error.connection_pool
   end
 
   def test_database_timezone_changes_synced_to_connection
@@ -312,9 +323,11 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_raises_warnings_when_behaviour_raise
     with_db_warnings_action(:raise) do
-      assert_raises(ActiveRecord::SQLWarning) do
+      error = assert_raises(ActiveRecord::SQLWarning) do
         @conn.execute('SELECT 1 + "foo"')
       end
+
+      assert_equal @conn.pool, error.connection_pool
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

While investigating database-related errors at GitHub we found ourselves consistently digging through the code to find out more information about the connection, like the cluster or role. 

The goal of this PR is to store the `connection_pool` associated with any exceptions raised from an adapter so the application can easily access it and send it along to an exception tracking system.
We believe that's an appropriate feature given Rails supports multiple databases.

Anytime [^almost] an exception is raised from an adapter we now provide a `connection_pool` along for the application to further debug what went wrong. This is an important feature when running a multi-database Rails application.

We chose to provide the `connection_pool` as it has relevant context like connection, role and shard. We wanted to avoid providing the `connection` directly as it might accidentally be used after it's returned to the pool and been handed to another thread.
The `ConnectionAdapters::PoolConfig` would also have been a reasonable option except it's `:nodoc:`.

[^almost]: There's one exception I caught: sqlite3's adapter raises an `ArgumentError` if no database file is specified. I didn't think it was appropriate to change that exception to include the connection pool https://github.com/rails/rails/blob/02df5fe1e77c38f8086ec45e349ba3d1b25605a0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L106
