### PR TITLE
Ensure binary-destined values have binary encoding during type cast

### DIFF
--- a/activemodel/lib/active_model/type/binary.rb
+++ b/activemodel/lib/active_model/type/binary.rb
@@ -21,7 +21,9 @@ module ActiveModel
         if value.is_a?(Data)
           value.to_s
         else
-          super
+          value = super
+          value = value.b if ::String === value && value.encoding != Encoding::BINARY
+          value
         end
       end
 

--- a/activemodel/test/cases/type/binary_test.rb
+++ b/activemodel/test/cases/type/binary_test.rb
@@ -7,9 +7,15 @@ module ActiveModel
     class BinaryTest < ActiveModel::TestCase
       def test_type_cast_binary
         type = Type::Binary.new
+
         assert_nil type.cast(nil)
-        assert_equal "1", type.cast("1")
         assert_equal 1, type.cast(1)
+
+        assert_equal "1", type.cast("1")
+        assert_equal Encoding::BINARY, type.cast("1").encoding
+
+        assert_equal "ƒée".b, type.cast("ƒée")
+        assert_not_equal "ƒée", type.cast("ƒée")
       end
 
       def test_serialize_binary_strings


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/48274#issuecomment-1562217321

In settling the behaviour in my head, I found there was still a discrepancy between when attributes get type cast (as exemplified by the int -> string conversion in the test here), vs when the encoding changed on strings destined to be stored in a binary column.

I think this completes the idea that the encoding switch is itself a type cast operation, despite both types using the same class.

I note in passing that this comment: https://github.com/rails/rails/blob/38e8bf76f85ac551db10f4b9825801ad823392f9/activemodel/lib/active_model/type/binary.rb#L10

is inconsistent with this test: https://github.com/rails/rails/blob/38e8bf76f85ac551db10f4b9825801ad823392f9/activemodel/test/cases/type/binary_test.rb#L12

I had to make the implementation a bit more explicit on that point (by only applying the encoding swap when it sees a string), but I'm reluctant to poke further there.