### PR TITLE
Refactor error highlight detection

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -123,7 +123,6 @@ module ActionDispatch
           trace_to_show: wrapper.trace_to_show,
           routes_inspector: routes_inspector(wrapper),
           source_extracts: wrapper.source_extracts,
-          error_highlight_available: wrapper.error_highlight_available?
         )
       end
 

--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -13,10 +13,15 @@ module ActionDispatch
       paths = RESCUES_TEMPLATE_PATHS.dup
       lookup_context = ActionView::LookupContext.new(paths)
       super(lookup_context, assigns, nil)
+      @exception_wrapper = assigns[:exception_wrapper]
     end
 
     def compiled_method_container
       self.class
+    end
+
+    def error_highlight_available?
+      @exception_wrapper.error_highlight_available?
     end
 
     def debug_params(params)

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -209,10 +209,7 @@ module ActionDispatch
 
     def error_highlight_available?
       # ErrorHighlight.spot with backtrace_location keyword is available since error_highlight 0.4.0
-      unless defined?(@@error_highlight_available)
-        @@error_highlight_available = defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
-      end
-      @@error_highlight_available
+      defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
     end
 
     def trace_to_show

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -28,7 +28,7 @@
           </tr>
         </table>
       </div>
-      <%- if defined?(ErrorHighlight) && !error_highlight_available -%>
+      <%- unless self.error_highlight_available? -%>
         <p class="error_highlight_tip">Tip: You may want to add <code>gem 'error_highlight', '&gt;= 0.4.0'</code> into your Gemfile, which will display the fine-grained error location.</p>
       <%- end -%>
     </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -11,7 +11,7 @@
   <%= render "rescues/message_and_suggestions", exception: @exception, exception_wrapper: @exception_wrapper %>
   <%= render "rescues/actions", exception: @exception, request: @request, exception_wrapper: @exception_wrapper %>
 
-  <%= render "rescues/source", source_extracts: @source_extracts, error_highlight_available: @error_highlight_available, show_source_idx: @show_source_idx, error_index: 0 %>
+  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx, error_index: 0 %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show, error_index: 0 %>
 
   <% if @exception_wrapper.has_cause? %>
@@ -26,7 +26,7 @@
     </div>
 
     <div id="<%= wrapper.exception_id %>" class="hidden">
-      <%= render "rescues/source", source_extracts: wrapper.source_extracts, error_highlight_available: wrapper.error_highlight_available?, show_source_idx: wrapper.source_to_show_id, error_index: index %>
+      <%= render "rescues/source", source_extracts: wrapper.source_extracts, show_source_idx: wrapper.source_to_show_id, error_index: index %>
       <%= render "rescues/trace", traces: wrapper.traces, trace_to_show: wrapper.trace_to_show, error_index: index %>
     </div>
   <% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -18,7 +18,7 @@
     <% end %>
   </h2>
 
-  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx, error_highlight_available: nil %>
+  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>
   <%= render template: "rescues/_request_and_response" %>
 </main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
@@ -5,7 +5,7 @@
 <main role="main" id="container">
   <h2><%= h @exception_wrapper.message %></h2>
 
-  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx, error_highlight_available: nil %>
+  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>
   <%= render template: "rescues/_request_and_response" %>
 </main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
@@ -11,7 +11,7 @@
   </p>
   <pre><code><%= h @exception_wrapper.message %></code></pre>
 
-  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx, error_highlight_available: nil %>
+  <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
 
   <p><%= @exception_wrapper.sub_template_message %></p>
 


### PR DESCRIPTION
Before this commit, some calls to render were hard-coding error highlight as "not available".  This was causing some error pages to show the "you should install error highlight" message even though the right version of error highlight was installed.

This commit adds a delegate method to the DebugView class so that the debugging related templates can just ask whether or not error highlight is available via a method call.  That way we don't need to rely on passing locals everywhere.  The down side is that this change requires all "rescue" templates to be rendered within the context of a DebugView class (but I think that's OK)
