### PR TITLE
Fix deprecation message for connection pool methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -292,7 +292,7 @@ module ActiveRecord
           if roles.flatten.uniq.count > 1
             ActiveRecord.deprecator.warn(<<-MSG.squish)
               `#{method}` currently only applies to connection pools in the current
-              role (`#{ActiveRecord::Base.current_role}`). In Rails 7.1, this method
+              role (`#{ActiveRecord::Base.current_role}`). In Rails 7.2, this method
               will apply to all known pools, regardless of role. To affect only those
               connections belonging to a specific role, pass the role name as an
               argument. To switch to the new behavior, pass `:all` as the role name.


### PR DESCRIPTION
This deprecation was added in main as of 7.1 so the message shouldn't mention 7.1, it should mention the next version of Rails.