### PR TITLE
fix after_commit callback when record is destroyed twice

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -770,7 +770,7 @@ module ActiveRecord
     def destroy
       _raise_readonly_record_error if readonly?
       destroy_associations
-      @_trigger_destroy_callback = persisted? && destroy_row > 0
+      @_trigger_destroy_callback ||= persisted? && destroy_row > 0
       @destroyed = true
       freeze
     end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -795,6 +795,19 @@ class CallbacksOnDestroyUpdateActionRaceTest < ActiveRecord::TestCase
     assert_equal [:commit_on_destroy], TopicWithCallbacksOnDestroy.history
   end
 
+  def test_trigger_once_on_multiple_deletions_in_a_transaction
+    TopicWithCallbacksOnDestroy.clear_history
+    topic = TopicWithCallbacksOnDestroy.new
+    topic.save
+
+    TopicWithCallbacksOnDestroy.transaction do
+      topic.destroy
+      topic.destroy
+    end
+
+    assert_equal [:commit_on_destroy], TopicWithCallbacksOnDestroy.history
+  end
+
   def test_rollback_on_multiple_deletions
     TopicWithCallbacksOnDestroy.clear_history
     topic = TopicWithCallbacksOnDestroy.new


### PR DESCRIPTION
### Motivation / Background

Fixes #48291. When `destroy` is called twice on a persisted record inside a transaction, the after_commit callbacks fail to run. The second time `destroy` is called, `@_trigger_destroy_callback` is set to false because the record has already been deleted, even though the transaction hasn't completed yet, and the after_commit callbacks haven't had a chance to run from the first `destroy`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
