### PR TITLE
Add syntax for CTE materialization hint to ActiveRecord

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Allow CTE materialization hint via verbose `.with` argument syntax
+
+    ```ruby
+    Post.with(posts_with_comments: { query: Post.where("comments_count > ?", 0), materialized: true })
+    # => ActiveRecord::Relation
+    # WITH "posts_with_comments" AS MATERIALIZED (
+    #   SELECT "posts".* FROM "posts" WHERE (comments_count > 0)
+    # )
+    # SELECT "posts".* FROM "posts"
+    ```
+
+    The `:materialized` option may be set to `true` to request materialization, `false` to request
+    no materialization, or `nil` (the default) to omit any materialization hint.
+
+    *Jon Zeppieri*
+
 *   Fix mutation detection for serialized attributes backed by binary columns.
 
     *Jean Boussier*


### PR DESCRIPTION
### Motivation / Background

Following on the Arel work in #48261, this commit adds the ability to provide a materialization hint to a CTE in ActiveRecord. To support the hint, a more verbose syntax for CTE values is introduced:

```ruby
Post.with(posts_with_comments: { query: Post.where("comments_count > ?", 0), materialized: true })
```

The CTE value is described as a hash that contains a required `:query` key and an optional `:materialized` key. The set of available options could be expanded in the future to accommodate, for example, postgres's various options for recursive CTEs.

### Additional information

I don't know whether there's any appetite within the core team to expose this functionality in AR's public API. But if there is, this approach seemed like the most plausible choice, given the current `#with` interface. That said, I'm more than happy to talk about alternatives.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
