### PR TITLE
Preserve existing column default functions when altering table in SQLite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -534,6 +534,7 @@ module ActiveRecord
               if column.has_default?
                 type = lookup_cast_type_from_column(column)
                 default = type.deserialize(column.default)
+                default = -> { column.default_function } if default.nil?
               end
 
               column_options = {

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -297,6 +297,20 @@ module ActiveRecord
         assert_equal "Tester", TestModel.new.first_name
       end
 
+      def test_change_column_default_preserves_existing_column_default_function
+        skip unless current_adapter?(:SQLite3Adapter)
+
+        connection.change_column_default "test_models", "created_at", -> { "CURRENT_TIMESTAMP" }
+        TestModel.reset_column_information
+        assert_equal "CURRENT_TIMESTAMP", TestModel.columns_hash["created_at"].default_function
+
+        add_column "test_models", "edited_at", :datetime
+        connection.change_column_default "test_models", "edited_at", -> { "CURRENT_TIMESTAMP" }
+        TestModel.reset_column_information
+        assert_equal "CURRENT_TIMESTAMP", TestModel.columns_hash["created_at"].default_function
+        assert_equal "CURRENT_TIMESTAMP", TestModel.columns_hash["edited_at"].default_function
+      end
+
       def test_change_column_null_false
         add_column "test_models", "first_name", :string
         connection.change_column_null "test_models", "first_name", false


### PR DESCRIPTION
Fixes #48304.