### PR TITLE
Remove Action View Sanitizer Helper tests asserting on allowed tags and attributes

### DIFF
--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -46,17 +46,4 @@ class SanitizeHelperTest < ActionView::TestCase
   def test_sanitize_is_marked_safe
     assert_predicate sanitize("<html><script></script></html>"), :html_safe?
   end
-
-  def test_sanitized_allowed_tags_class_method
-    expected = Set.new(["strong", "em", "b", "i", "p", "code", "pre", "tt", "samp", "kbd", "var",
-      "sub", "sup", "dfn", "cite", "big", "small", "address", "hr", "br", "div", "span", "h1", "h2",
-      "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "abbr", "acronym", "a", "img",
-      "blockquote", "del", "ins"])
-    assert_equal(expected, self.class.sanitized_allowed_tags)
-  end
-
-  def test_sanitized_allowed_attributes_class_method
-    expected = Set.new(["href", "src", "width", "height", "alt", "cite", "datetime", "title", "class", "name", "xml:lang", "abbr"])
-    assert_equal(expected, self.class.sanitized_allowed_attributes)
-  end
 end


### PR DESCRIPTION
### Motivation / Background

Closes #48313.

rails-html-sanitizer 1.6.0 has been released with updated allowlists for tags and attributes. As a result, some tests that are too-tightly coupled are failing.

Equivalent tests exist upstream in rails-html-sanitizer, and leaving these here mean our tests are coupled to r-h-s and are liable to break as the allowlists evolve.

We can safely remove them.

Note that I'd prefer if #48293  was merged instead of this, but this is obviously a much smaller changeset so I'm making it available for review.

cc @zzak 