### PR TITLE
Backport (6.1): Remove Action View Sanitizer Helper tests asserting on allowed tags and attributes

### DIFF
--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -40,17 +40,4 @@ class SanitizeHelperTest < ActionView::TestCase
   def test_sanitize_is_marked_safe
     assert_predicate sanitize("<html><script></script></html>"), :html_safe?
   end
-
-  def test_sanitized_allowed_tags_class_method
-    expected = Set.new(["strong", "em", "b", "i", "p", "code", "pre", "tt", "samp", "kbd", "var",
-      "sub", "sup", "dfn", "cite", "big", "small", "address", "hr", "br", "div", "span", "h1", "h2",
-      "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "abbr", "acronym", "a", "img",
-      "blockquote", "del", "ins"])
-    assert_equal(expected, self.class.sanitized_allowed_tags)
-  end
-
-  def test_sanitized_allowed_attributes_class_method
-    expected = Set.new(["href", "src", "width", "height", "alt", "cite", "datetime", "title", "class", "name", "xml:lang", "abbr"])
-    assert_equal(expected, self.class.sanitized_allowed_attributes)
-  end
 end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -289,7 +289,7 @@ module ActiveRecord
 
         ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
 
-        column = connection.columns(:tests).find { |column| column.name == "some_id" }
+        column = connection.columns(:tests).find { |c| c.name == "some_id" }
         assert_equal :string, column.type
       ensure
         connection.drop_table :tests, if_exists: true


### PR DESCRIPTION
Backport of #48315 to 6-1-stable
