### PR TITLE
Fix ActionCable Redis configuration with sentinels

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -58,7 +58,7 @@ module ActionCable
         end
 
         def config_options
-          @config_options ||= @server.config.cable.symbolize_keys.merge(id: identifier)
+          @config_options ||= @server.config.cable.deep_symbolize_keys.merge(id: identifier)
         end
 
         class Listener < SubscriberMap


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This pull request addresses an integration bug between ActionCable and Redis >= 5.0 when using sentinels configuration. The bug causes issues because the sentinels configuration is a nested array of hashes, whereas the Redis client expects keys to be symbols. The proposed changes in this pull request modify the preparation of the Redis configuration to ensure that all keys are properly represented as symbols. This fix resolves the problem and improves the compatibility between ActionCable and Redis with sentinels.

cc: @byroot 

### Detail

It is possible to reproduce within this repo https://github.com/moofkit/actioncable-redis-sentinel-bug
```
$ bundle && bundle exec rails test
Running 1 tests in a single process (parallelization threshold is 50)
Run options: --seed 7348

# Running:

E

Error:
ActioncableTest#test_broadcasts_to_test_channel:
ArgumentError: unknown keywords: "host", "port"
    test/integration/actioncable_test.rb:5:in `block in <class:ActioncableTest>'

rails test test/integration/actioncable_test.rb:4

Finished in 0.043971s, 22.7423 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

The problem is [config for the cable](https://github.com/moofkit/actioncable-redis-sentinel-bug/blob/ca59d09d7dc992a0685ca8f1f01ae27644cbd47f/config/cable.yml#L4-L6) parsed from YAML file and sentinels are deep nested hash in the array. But redis client expecting keys to be symbols, in the result it raises error `ArgumentError: unknown keywords: "host", "port"` in the [redis-client](https://github.com/redis-rb/redis-client/blob/ae29d650c2f9a357727483989cb0b60439f63556/lib/redis_client/sentinel_config.rb#L111)

This issue can be fixed within application with this initializer code
```ruby
# config/initializers/action_cable.rb
require "action_cable/subscription_adapter/redis"

# https://github.com/rails/rails/blob/da309a582e04183a85340ec0e1ed59b2d69ca9c2/actioncable/lib/action_cable/subscription_adapter/redis.rb#LL18C21-L18C61
ActionCable::SubscriptionAdapter::Redis.redis_connector = lambda do |config|
  # BUG: it needs to symbolize keys for redis gem >= 5.0.0
  Redis.new(config.deep_symbolize_keys.except(:adapter, :channel_prefix))
end
```

A redis-client related discussion: https://github.com/redis-rb/redis-client/pull/121

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
