### PR TITLE
Fix decrementing counter caches for parent records using optimistic locking

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -97,7 +97,6 @@ module ActiveRecord
             lock_attribute_was = @attributes[locking_column]
 
             update_constraints = _query_constraints_hash
-            update_constraints[locking_column] = _lock_value_for_database(locking_column)
 
             attribute_names = attribute_names.dup if attribute_names.frozen?
             attribute_names << locking_column
@@ -123,16 +122,9 @@ module ActiveRecord
         end
 
         def destroy_row
-          return super unless locking_enabled?
+          affected_rows = super
 
-          locking_column = self.class.locking_column
-
-          delete_constraints = _query_constraints_hash
-          delete_constraints[locking_column] = _lock_value_for_database(locking_column)
-
-          affected_rows = self.class._delete_record(delete_constraints)
-
-          if affected_rows != 1
+          if locking_enabled? && affected_rows != 1
             raise ActiveRecord::StaleObjectError.new(self, "destroy")
           end
 
@@ -150,6 +142,13 @@ module ActiveRecord
         def _clear_locking_column
           self[self.class.locking_column] = nil
           clear_attribute_change(self.class.locking_column)
+        end
+
+        def _query_constraints_hash
+          return super unless locking_enabled?
+
+          locking_column = self.class.locking_column
+          super.merge(locking_column => _lock_value_for_database(locking_column))
         end
 
         module ClassMethods

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/topic"
+require "models/bulb"
 require "models/car"
 require "models/aircraft"
 require "models/wheel"
@@ -245,6 +246,15 @@ class CounterCacheTest < ActiveRecord::TestCase
 
     assert_difference "aircraft.reload.wheels_count", -1 do
       aircraft.wheels.first.destroy
+    end
+  end
+
+  test "removing association updates counter" do
+    michael = people(:michael)
+    car = cars(:honda)
+
+    assert_difference -> { michael.reload.cars_count }, -1 do
+      car.destroy
     end
   end
 

--- a/activerecord/test/fixtures/cars.yml
+++ b/activerecord/test/fixtures/cars.yml
@@ -2,8 +2,10 @@ honda:
   id: 1
   name: honda
   engines_count: 0
+  person_id: 1
 
 zyke:
   id: 2
   name: zyke
   engines_count: 0
+  person_id: 2

--- a/activerecord/test/fixtures/people.yml
+++ b/activerecord/test/fixtures/people.yml
@@ -6,6 +6,7 @@ michael:
   gender: M
   followers_count: 1
   friends_too_count: 1
+  cars_count: 1
 david:
   id: 2
   first_name: David
@@ -14,6 +15,7 @@ david:
   gender: M
   followers_count: 1
   friends_too_count: 1
+  cars_count: 1
 susan:
   id: 3
   first_name: Susan

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Car < ActiveRecord::Base
+  belongs_to :person, counter_cache: true
   has_many :bulbs
   has_many :all_bulbs, -> { unscope(where: :name) }, class_name: "Bulb"
   has_many :all_bulbs2, -> { unscope(:where) }, class_name: "Bulb"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -191,6 +191,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :cars, force: true do |t|
+    t.belongs_to :person
     t.string  :name
     t.integer :engines_count
     t.integer :wheels_count, default: 0, null: false
@@ -910,6 +911,7 @@ ActiveRecord::Schema.define do
     t.references :best_friend_of
     t.integer    :insures, null: false, default: 0
     t.timestamp :born_at
+    t.integer :cars_count, default: 0
     t.timestamps null: false
   end
 


### PR DESCRIPTION
Fixes #48320.

When used optimistic locking, it uses custom logic without calling `super` https://github.com/rails/rails/blob/e9ea600c24bb44317cf6176c34020a7d0e1060f3/activerecord/lib/active_record/locking/optimistic.rb#L125-L137 without a chance for counter cache to implement its logic. So I swapped the includes. Are there any  pitfalls this can introduce?