### PR TITLE
Exclude the vendor as including vendor will cause CI break after merge #48287

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -619,7 +619,7 @@ module Rails
       next if is_a?(Rails::Application)
 
       fixtures = config.root.join("test", "fixtures")
-      if fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s)
+      if fixtures_in_root_and_not_in_vendor?(fixtures)
         ActiveSupport.on_load(:active_record_fixtures) { self.fixture_paths |= ["#{fixtures}/"] }
       end
     end
@@ -725,6 +725,11 @@ module Rails
           end
           load_paths.uniq
         end
+      end
+
+      def fixtures_in_root_and_not_in_vendor?(fixtures)
+        fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s) &&
+          !fixtures.to_s.start_with?(Rails.root.join("vendor").to_s)
       end
 
       def build_request(env)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because #48287 break some CI in [my](https://git.thape.com.cn/Eric-Guo/coreui-pro-rails-starter/-/jobs/103123#L565) and other pipeline.

@rafaelfranca suggest [exclude the vendor folder](https://github.com/rails/rails/pull/48287#issuecomment-1563170637), I tested and it works.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.