### PR TITLE
Trick RDoc to pickup ActiveRecord::Core#values_at

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -705,6 +705,16 @@ module ActiveRecord
     end
 
     ##
+    # :method: values_at
+    #
+    # :call-seq: values_at(*methods)
+    #
+    # Returns an array of the values returned by the given methods.
+    #
+    #--
+    # Implemented by ActiveModel::Access#values_at.
+
+    ##
     # :method: slice
     #
     # :call-seq: slice(*methods)
@@ -714,16 +724,6 @@ module ActiveRecord
     #
     #--
     # Implemented by ActiveModel::Access#slice.
-
-    ##
-    # :method: values_at
-    #
-    # :call-seq: values_at(*methods)
-    #
-    # Returns an array of the values returned by the given methods.
-    #
-    #--
-    # Implemented by ActiveModel::Access#values_at.
 
     private
       # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of


### PR DESCRIPTION
Before

![Screenshot 2023-05-29 at 10 40 44](https://github.com/rails/rails/assets/277819/40779bd4-09dd-46f5-a05d-22ff99e49861)

(Notice the missing "V" methods)

After

<img width="574" alt="Screenshot 2023-05-29 at 10 40 25" src="https://github.com/rails/rails/assets/277819/b57f3734-0912-4923-acd4-e67af34dc417">

---

First, this came from #44544, something I found surprising was that these are the only methods documented on `ActiveModel::Model`. But my guess is that because the other methods are available by include, it makes sense to document them there -- while `ActiveModel::Access` is private?

/cc @jonathanhefner 

---

Second, I do not know why swapping the order here works. I've tried inspecting RDoc internals and using debug mode, but there was no apparent reason why the method was being dropped. Meanwhile, the same order works fine for `ActiveModel::Model`. 🤷 