### PR TITLE
Fix links for Renderers.add and Renderers.remove

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -3,12 +3,12 @@
 require "set"
 
 module ActionController
-  # See <tt>Renderers.add</tt>
+  # See Renderers.add
   def self.add_renderer(key, &block)
     Renderers.add(key, &block)
   end
 
-  # See <tt>Renderers.remove</tt>
+  # See Renderers.remove
   def self.remove_renderer(key)
     Renderers.remove(key)
   end


### PR DESCRIPTION
Remove the fixed-width tags to let RDoc autolink these two methods