### PR TITLE
Deprecate ActionController::MissingRenderer

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,6 @@
-*   Add `action_dispatch.verbose_redirect_logs` setting that logs where redirects were called from.
+*   Deprecate `ActionController::MissingRenderer`
+
+    *zzak*
 
     Similar to `active_record.verbose_query_logs` and `active_job.verbose_enqueue_logs`, this adds a line in your logs that shows where a redirect was called from.
 

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -2,7 +2,11 @@
 
 # :markup: markdown
 
+require "active_support/deprecation/constant_accessor"
+
 module ActionController
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
   # See Renderers.add
   def self.add_renderer(key, &block)
     Renderers.add(key, &block)
@@ -13,12 +17,14 @@ module ActionController
     Renderers.remove(key)
   end
 
-  # See `Responder#api_behavior`
-  class MissingRenderer < LoadError
+  class DeprecatedMissingRenderer < LoadError # :nodoc:
     def initialize(format)
       super "No renderer defined for format: #{format}"
     end
   end
+  deprecate_constant "MissingRenderer", "ActionController::DeprecatedMissingRenderer",
+    message: "ActionController::MissingRenderer is deprecated and will be removed in Rails 8.2.",
+    deprecator: ActionController.deprecator
 
   module Renderers
     extend ActiveSupport::Concern

--- a/actionpack/test/controller/metal/renderers_test.rb
+++ b/actionpack/test/controller/metal/renderers_test.rb
@@ -48,3 +48,11 @@ class RenderersMetalTest < ActionController::TestCase
     assert_equal "text/plain", @response.media_type
   end
 end
+
+class MissingRendererTest < ActionController::TestCase
+  test "MissingRenderer is deprecated" do
+    assert_deprecated ActionController.deprecator do
+      assert_equal ActionController::MissingRenderer, ActionController::DeprecatedMissingRenderer
+    end
+  end
+end


### PR DESCRIPTION
When working on #48327, I noticed the comment for this class references a method which has moved to the [responders gem](https://github.com/heartcombo/responders). Nothing else in Rails uses it internally, so I think we can move it to that gem and deprecate it from Rails.

I've opened a PR to move it in heartcombo/responders#245.

Inspiration for the constant deprecation path came from 3e2552db899160266f175f2fda61e44be258aecd but LMK if there is a better way! :bow: