### PR TITLE
Fix RDoc autolinks in ActionController::Metal

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -82,7 +82,7 @@ module ActionController
   # The +action+ method returns a valid Rack application for the \Rails
   # router to dispatch to.
   #
-  # == Rendering Helpers
+  # == \Rendering \Helpers
   #
   # +ActionController::Metal+ by default provides no utilities for rendering
   # views, partials, or other responses aside from explicitly calling of
@@ -100,7 +100,7 @@ module ActionController
   #     end
   #   end
   #
-  # == Redirection Helpers
+  # == Redirection \Helpers
   #
   # To add redirection helpers to your metal controller, do the following:
   #
@@ -113,7 +113,7 @@ module ActionController
   #     end
   #   end
   #
-  # == Other Helpers
+  # == Other \Helpers
   #
   # You can refer to the modules included in ActionController::Base to see
   # other features you can bring into your metal controller.
@@ -122,8 +122,8 @@ module ActionController
     abstract!
 
     # Returns the last part of the controller's name, underscored, without the ending
-    # <tt>Controller</tt>. For instance, PostsController returns <tt>posts</tt>.
-    # Namespaces are left out, so Admin::PostsController returns <tt>posts</tt> as well.
+    # <tt>Controller</tt>. For instance, +PostsController+ returns <tt>posts</tt>.
+    # Namespaces are left out, so +Admin::PostsController+ returns <tt>posts</tt> as well.
     #
     # ==== Returns
     # * <tt>string</tt>
@@ -197,7 +197,7 @@ module ActionController
 
     alias :response_code :status # :nodoc:
 
-    # Basic url_for that can be overridden for more robust functionality.
+    # Basic \url_for that can be overridden for more robust functionality.
     def url_for(string)
       string
     end


### PR DESCRIPTION
Removes unnecessary autolinks from the `ActionController::Metal` class, also add fixed-width to application controllers mentioned in the doc for `::controller_name`.