### PR TITLE
Add a tiny more detail about the middleware stack

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -265,7 +265,18 @@ module ActionController
       end
     end
 
-    # Alias for +middleware_stack+.
+    # The middleware stack used by this controller.
+    #
+    # By default uses a variation of ActionDispatch::MiddlewareStack which
+    # allows for the following syntax:
+    #
+    #   class PostsController < ApplicationController
+    #     use AuthenticationMiddleware, except: [:index, :show]
+    #   end
+    #
+    # Read more about {Rails middleware
+    # stack}[https://guides.rubyonrails.org/rails_on_rack.html#action-dispatcher-middleware-stack]
+    # in the guides.
     def self.middleware
       middleware_stack
     end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -4,6 +4,11 @@ require "active_support/inflector/methods"
 require "active_support/dependencies"
 
 module ActionDispatch
+  # = Action Dispatch \MiddlewareStack
+  #
+  # Read more about {Rails middleware
+  # stack}[https://guides.rubyonrails.org/rails_on_rack.html#action-dispatcher-middleware-stack]
+  # in the guides.
   class MiddlewareStack
     class Middleware
       attr_reader :args, :block, :klass


### PR DESCRIPTION
Previously this method mentioned it being an alias for a private method, so thinking that was intentional, let's just add a bit of something here and link to the guides to learn more.