### PR TITLE
:nail_care: Several fixes to AR::DatabaseConfigurations docs

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -9,13 +9,17 @@ require "active_record/database_configurations/connection_url_resolver"
 module ActiveRecord
   # = Active Record Database Configurations
   #
-  # ActiveRecord::DatabaseConfigurations returns an array of DatabaseConfig
+  # +ActiveRecord::DatabaseConfigurations+ returns an array of +DatabaseConfig+
   # objects that are constructed from the application's database
   # configuration hash or URL string.
   #
-  # The array of +DatabaseConfig+ objects in an application default to
-  # either a +HashConfig+ or +UrlConfig+. If you register a custom handler,
-  # objects will be created according to the conditions of the handler.
+  # The array of +DatabaseConfig+ objects in an application default to either a
+  # HashConfig or UrlConfig. You can retrieve your application's config by using
+  # ActiveRecord::Base.configurations.
+  #
+  # If you register a custom handler, objects will be created according to the
+  # conditions of the handler. See ::register_db_config_handler for more on
+  # registering custom handlers.
   class DatabaseConfigurations
     class InvalidConfigurationError < StandardError; end
 
@@ -73,8 +77,8 @@ module ActiveRecord
     # Collects the configs for the environment and optionally the specification
     # name passed in. To include replica configurations pass <tt>include_hidden: true</tt>.
     #
-    # If a name is provided a single DatabaseConfig object will be
-    # returned, otherwise an array of DatabaseConfig objects will be
+    # If a name is provided a single +DatabaseConfig+ object will be
+    # returned, otherwise an array of +DatabaseConfig+ objects will be
     # returned that corresponds with the environment and type requested.
     #
     # ==== Options
@@ -88,7 +92,7 @@ module ActiveRecord
     #   hash. Useful for selecting configs that use a custom db config handler or finding
     #   configs with hashes that contain a particular key.
     # * <tt>include_hidden:</tt> Determines whether to include replicas and configurations
-    #   hidden by +database_tasks: false+ in the returned list. Most of the time we're only
+    #   hidden by <tt>database_tasks: false</tt> in the returned list. Most of the time we're only
     #   iterating over the primary connections (i.e. migrations don't need to run for the
     #   write and read connection). Defaults to +false+.
     def configs_for(env_name: nil, name: nil, config_key: nil, include_hidden: false)
@@ -116,10 +120,10 @@ module ActiveRecord
       end
     end
 
-    # Returns a single DatabaseConfig object based on the requested environment.
+    # Returns a single +DatabaseConfig+ object based on the requested environment.
     #
     # If the application has multiple databases +find_db_config+ will return
-    # the first DatabaseConfig for the environment.
+    # the first +DatabaseConfig+ for the environment.
     def find_db_config(env)
       env = env.to_s
       configurations.find do |db_config|
@@ -143,8 +147,6 @@ module ActiveRecord
     end
 
     # Checks if the application's configurations are empty.
-    #
-    # Aliased to blank?
     def empty?
       configurations.empty?
     end

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   class DatabaseConfigurations
     # ActiveRecord::Base.configurations will return either a HashConfig or
-    # UrlConfig respectively. It will never return a DatabaseConfig object,
+    # UrlConfig respectively. It will never return a +DatabaseConfig+ object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
       attr_reader :env_name, :name

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   class DatabaseConfigurations
     # = Active Record Database Hash Config
     #
-    # A HashConfig object is created for each database configuration entry that
+    # A +HashConfig+ object is created for each database configuration entry that
     # is created from a hash.
     #
     # A hash config:
@@ -16,19 +16,23 @@ module ActiveRecord
     #   #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10
     #     @env_name="development", @name="primary", @config={database: "db_name"}>
     #
-    # ==== Options
-    #
-    # * <tt>:env_name</tt> - The Rails environment, i.e. "development".
-    # * <tt>:name</tt> - The db config name. In a standard two-tier
-    #   database configuration this will default to "primary". In a multiple
-    #   database three-tier database configuration this corresponds to the name
-    #   used in the second tier, for example "primary_readonly".
-    # * <tt>:config</tt> - The config hash. This is the hash that contains the
-    #   database adapter, name, and other important information for database
-    #   connections.
+    # See ActiveRecord::DatabaseConfigurations for more info.
     class HashConfig < DatabaseConfig
       attr_reader :configuration_hash
 
+
+      # Initialize a new +HashConfig+ object
+      #
+      # ==== Options
+      #
+      # * <tt>:env_name</tt> - The \Rails environment, i.e. "development".
+      # * <tt>:name</tt> - The db config name. In a standard two-tier
+      #   database configuration this will default to "primary". In a multiple
+      #   database three-tier database configuration this corresponds to the name
+      #   used in the second tier, for example "primary_readonly".
+      # * <tt>:config</tt> - The config hash. This is the hash that contains the
+      #   database adapter, name, and other important information for database
+      #   connections.
       def initialize(env_name, name, configuration_hash)
         super(env_name, name)
         @configuration_hash = configuration_hash.symbolize_keys.freeze
@@ -128,7 +132,7 @@ module ActiveRecord
       # If +configuration_hash[:schema_dump]+ is set to +false+ or +nil+
       # the schema will not be dumped.
       #
-      # If the config option is set that will be used. Otherwise Rails
+      # If the config option is set that will be used. Otherwise \Rails
       # will generate the filename from the database config name.
       def schema_dump(format = ActiveRecord.schema_format)
         if configuration_hash.key?(:schema_dump)

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   class DatabaseConfigurations
     # = Active Record Database Url Config
     #
-    # A UrlConfig object is created for each database configuration
+    # A +UrlConfig+ object is created for each database configuration
     # entry that is created from a URL. This can either be a URL string
     # or a hash with a URL in place of the config hash.
     #
@@ -19,20 +19,24 @@ module ActiveRecord
     #     @config={adapter: "postgresql", database: "foo", host: "localhost"},
     #     @url="postgres://localhost/foo">
     #
-    # ==== Options
+    # See ActiveRecord::DatabaseConfigurations for more info.
     #
-    # * <tt>:env_name</tt> - The Rails environment, i.e. "development".
-    # * <tt>:name</tt> - The db config name. In a standard two-tier
-    #   database configuration this will default to "primary". In a multiple
-    #   database three-tier database configuration this corresponds to the name
-    #   used in the second tier, for example "primary_readonly".
-    # * <tt>:url</tt> - The database URL.
-    # * <tt>:config</tt> - The config hash. This is the hash that contains the
-    #   database adapter, name, and other important information for database
-    #   connections.
     class UrlConfig < HashConfig
       attr_reader :url
 
+      # Initialize a new +UrlConfig+ object
+      #
+      # ==== Options
+      #
+      # * <tt>:env_name</tt> - The \Rails environment, i.e. "development".
+      # * <tt>:name</tt> - The db config name. In a standard two-tier
+      #   database configuration this will default to "primary". In a multiple
+      #   database three-tier database configuration this corresponds to the name
+      #   used in the second tier, for example "primary_readonly".
+      # * <tt>:url</tt> - The database URL.
+      # * <tt>:config</tt> - The config hash. This is the hash that contains the
+      #   database adapter, name, and other important information for database
+      #   connections.
       def initialize(env_name, name, url, configuration_hash = {})
         super(env_name, name, configuration_hash)
 


### PR DESCRIPTION
* Fix RDoc autolinks where it makes sense
* Fixed-width font for database_tasks option
* Remove duplicate "Also aliased as blank?"
* Link to AR::DatabaseConfigurations from config classes
* Link to AR::Base.configurations from DatabaseConfigurations
* Move options doc to initializer
