### PR TITLE
Use ✅ emoji instead of "X" for support table

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -389,47 +389,47 @@ module ActiveRecord
       # See also Instance Public methods below for more details.
       #
       # === Singular associations (one-to-one)
-      #                                     |            |  belongs_to  |
-      #   generated methods                 | belongs_to | :polymorphic | has_one
-      #   ----------------------------------+------------+--------------+---------
-      #   other                             |     O      |      O       |    O
-      #   other=(other)                     |     O      |      O       |    O
-      #   build_other(attributes={})        |     O      |              |    O
-      #   create_other(attributes={})       |     O      |              |    O
-      #   create_other!(attributes={})      |     O      |              |    O
-      #   reload_other                      |     O      |      O       |    O
-      #   other_changed?                    |     O      |      O       |
-      #   other_previously_changed?         |     O      |      O       |
+      #                                    |            |  belongs_to  |
+      #  generated methods                 | belongs_to | :polymorphic | has_one
+      #  ----------------------------------+------------+--------------+---------
+      #  other                             |     ✅     |      ✅      |    ✅
+      #  other=(other)                     |     ✅     |      ✅      |    ✅
+      #  build_other(attributes={})        |     ✅     |      ⬜️      |    ✅
+      #  create_other(attributes={})       |     ✅     |      ⬜️      |    ✅
+      #  create_other!(attributes={})      |     ✅     |      ⬜️      |    ✅
+      #  reload_other                      |     ✅     |      ✅      |    ✅
+      #  other_changed?                    |     ✅     |      ✅      |    ⬜️
+      #  other_previously_changed?         |     ✅     |      ✅      |    ⬜️
       #
       # === Collection associations (one-to-many / many-to-many)
-      #                                     |       |          | has_many
-      #   generated methods                 | habtm | has_many | :through
-      #   ----------------------------------+-------+----------+----------
-      #   others                            |   O   |    O     |    O
-      #   others=(other,other,...)          |   O   |    O     |    O
-      #   other_ids                         |   O   |    O     |    O
-      #   other_ids=(id,id,...)             |   O   |    O     |    O
-      #   others<<                          |   O   |    O     |    O
-      #   others.push                       |   O   |    O     |    O
-      #   others.concat                     |   O   |    O     |    O
-      #   others.build(attributes={})       |   O   |    O     |    O
-      #   others.create(attributes={})      |   O   |    O     |    O
-      #   others.create!(attributes={})     |   O   |    O     |    O
-      #   others.size                       |   O   |    O     |    O
-      #   others.length                     |   O   |    O     |    O
-      #   others.count                      |   O   |    O     |    O
-      #   others.sum(*args)                 |   O   |    O     |    O
-      #   others.empty?                     |   O   |    O     |    O
-      #   others.clear                      |   O   |    O     |    O
-      #   others.delete(other,other,...)    |   O   |    O     |    O
-      #   others.delete_all                 |   O   |    O     |    O
-      #   others.destroy(other,other,...)   |   O   |    O     |    O
-      #   others.destroy_all                |   O   |    O     |    O
-      #   others.find(*args)                |   O   |    O     |    O
-      #   others.exists?                    |   O   |    O     |    O
-      #   others.distinct                   |   O   |    O     |    O
-      #   others.reset                      |   O   |    O     |    O
-      #   others.reload                     |   O   |    O     |    O
+      #                                    |       |          | has_many
+      #  generated methods                 | habtm | has_many | :through
+      #  ----------------------------------+-------+----------+----------
+      #  others                            |   ✅  |    ✅    |    ✅
+      #  others=(other,other,...)          |   ✅  |    ✅    |    ✅
+      #  other_ids                         |   ✅  |    ✅    |    ✅
+      #  other_ids=(id,id,...)             |   ✅  |    ✅    |    ✅
+      #  others<<                          |   ✅  |    ✅    |    ✅
+      #  others.push                       |   ✅  |    ✅    |    ✅
+      #  others.concat                     |   ✅  |    ✅    |    ✅
+      #  others.build(attributes={})       |   ✅  |    ✅    |    ✅
+      #  others.create(attributes={})      |   ✅  |    ✅    |    ✅
+      #  others.create!(attributes={})     |   ✅  |    ✅    |    ✅
+      #  others.size                       |   ✅  |    ✅    |    ✅
+      #  others.length                     |   ✅  |    ✅    |    ✅
+      #  others.count                      |   ✅  |    ✅    |    ✅
+      #  others.sum(*args)                 |   ✅  |    ✅    |    ✅
+      #  others.empty?                     |   ✅  |    ✅    |    ✅
+      #  others.clear                      |   ✅  |    ✅    |    ✅
+      #  others.delete(other,other,...)    |   ✅  |    ✅    |    ✅
+      #  others.delete_all                 |   ✅  |    ✅    |    ✅
+      #  others.destroy(other,other,...)   |   ✅  |    ✅    |    ✅
+      #  others.destroy_all                |   ✅  |    ✅    |    ✅
+      #  others.find(*args)                |   ✅  |    ✅    |    ✅
+      #  others.exists?                    |   ✅  |    ✅    |    ✅
+      #  others.distinct                   |   ✅  |    ✅    |    ✅
+      #  others.reset                      |   ✅  |    ✅    |    ✅
+      #  others.reload                     |   ✅  |    ✅    |    ✅
       #
       # === Overriding generated methods
       #

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -392,44 +392,44 @@ module ActiveRecord
       #                                     |            |  belongs_to  |
       #   generated methods                 | belongs_to | :polymorphic | has_one
       #   ----------------------------------+------------+--------------+---------
-      #   other                             |     X      |      X       |    X
-      #   other=(other)                     |     X      |      X       |    X
-      #   build_other(attributes={})        |     X      |              |    X
-      #   create_other(attributes={})       |     X      |              |    X
-      #   create_other!(attributes={})      |     X      |              |    X
-      #   reload_other                      |     X      |      X       |    X
-      #   other_changed?                    |     X      |      X       |
-      #   other_previously_changed?         |     X      |      X       |
+      #   other                             |     O      |      O       |    O
+      #   other=(other)                     |     O      |      O       |    O
+      #   build_other(attributes={})        |     O      |              |    O
+      #   create_other(attributes={})       |     O      |              |    O
+      #   create_other!(attributes={})      |     O      |              |    O
+      #   reload_other                      |     O      |      O       |    O
+      #   other_changed?                    |     O      |      O       |
+      #   other_previously_changed?         |     O      |      O       |
       #
       # === Collection associations (one-to-many / many-to-many)
       #                                     |       |          | has_many
       #   generated methods                 | habtm | has_many | :through
       #   ----------------------------------+-------+----------+----------
-      #   others                            |   X   |    X     |    X
-      #   others=(other,other,...)          |   X   |    X     |    X
-      #   other_ids                         |   X   |    X     |    X
-      #   other_ids=(id,id,...)             |   X   |    X     |    X
-      #   others<<                          |   X   |    X     |    X
-      #   others.push                       |   X   |    X     |    X
-      #   others.concat                     |   X   |    X     |    X
-      #   others.build(attributes={})       |   X   |    X     |    X
-      #   others.create(attributes={})      |   X   |    X     |    X
-      #   others.create!(attributes={})     |   X   |    X     |    X
-      #   others.size                       |   X   |    X     |    X
-      #   others.length                     |   X   |    X     |    X
-      #   others.count                      |   X   |    X     |    X
-      #   others.sum(*args)                 |   X   |    X     |    X
-      #   others.empty?                     |   X   |    X     |    X
-      #   others.clear                      |   X   |    X     |    X
-      #   others.delete(other,other,...)    |   X   |    X     |    X
-      #   others.delete_all                 |   X   |    X     |    X
-      #   others.destroy(other,other,...)   |   X   |    X     |    X
-      #   others.destroy_all                |   X   |    X     |    X
-      #   others.find(*args)                |   X   |    X     |    X
-      #   others.exists?                    |   X   |    X     |    X
-      #   others.distinct                   |   X   |    X     |    X
-      #   others.reset                      |   X   |    X     |    X
-      #   others.reload                     |   X   |    X     |    X
+      #   others                            |   O   |    O     |    O
+      #   others=(other,other,...)          |   O   |    O     |    O
+      #   other_ids                         |   O   |    O     |    O
+      #   other_ids=(id,id,...)             |   O   |    O     |    O
+      #   others<<                          |   O   |    O     |    O
+      #   others.push                       |   O   |    O     |    O
+      #   others.concat                     |   O   |    O     |    O
+      #   others.build(attributes={})       |   O   |    O     |    O
+      #   others.create(attributes={})      |   O   |    O     |    O
+      #   others.create!(attributes={})     |   O   |    O     |    O
+      #   others.size                       |   O   |    O     |    O
+      #   others.length                     |   O   |    O     |    O
+      #   others.count                      |   O   |    O     |    O
+      #   others.sum(*args)                 |   O   |    O     |    O
+      #   others.empty?                     |   O   |    O     |    O
+      #   others.clear                      |   O   |    O     |    O
+      #   others.delete(other,other,...)    |   O   |    O     |    O
+      #   others.delete_all                 |   O   |    O     |    O
+      #   others.destroy(other,other,...)   |   O   |    O     |    O
+      #   others.destroy_all                |   O   |    O     |    O
+      #   others.find(*args)                |   O   |    O     |    O
+      #   others.exists?                    |   O   |    O     |    O
+      #   others.distinct                   |   O   |    O     |    O
+      #   others.reset                      |   O   |    O     |    O
+      #   others.reload                     |   O   |    O     |    O
       #
       # === Overriding generated methods
       #


### PR DESCRIPTION
Maybe this is just my ☕ brain this morning, but when looking at this made me think it could be misunderstood.

When I see the x though, I just think of 🙅‍♂️ .. but maybe we could replace it with a unicode check mark instead? ✅

---

I've updated the PR to use emoji instead!

Before

![Screenshot 2023-05-30 at 6 53 44](https://github.com/rails/rails/assets/277819/52277857-4536-423f-aef2-58f4237b2fd6)

After

![Screenshot 2023-05-30 at 6 53 26](https://github.com/rails/rails/assets/277819/8365a729-85f7-4d47-8895-06a732839ee0)

---

@skipkayhil FYI, this is another case where markdown would actually be nice here and output an html table instead of this giant code blob 😉 