### PR TITLE
Several AR::Associations API doc fixes

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -386,7 +386,7 @@ module ActiveRecord
       # For instance, +attributes+ and +connection+ would be bad choices for association names, because those names already exist in the list of +ActiveRecord::Base+ instance methods.
       #
       # == Auto-generated methods
-      # See also Instance Public methods below for more details.
+      # See also "Instance Public methods" below ( from #belongs_to ) for more details.
       #
       # === Singular associations (one-to-one)
       #                                     |            |  belongs_to  |

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -82,8 +82,9 @@ module ActiveRecord
       #   example, specifying <tt>{ author: :avatar }</tt> will preload a
       #   book's author, as well as that author's avatar.
       #
-      # +:associations+ has the same format as the +:include+ method in
-      # +ActiveRecord::QueryMethods+. So +associations+ could look like this:
+      # +:associations+ has the same format as the arguments to
+      # ActiveRecord::QueryMethods#includes. So +associations+ could look like
+      # this:
       #
       #   :books
       #   [ :books, :author ]

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 module ActiveRecord
   module Associations
     class Preloader

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -26,7 +26,7 @@ module ActiveRecord
   #
   # Child records are validated unless <tt>:validate</tt> is +false+.
   #
-  # == Callbacks
+  # == \Callbacks
   #
   # Association with autosave option defines several callbacks on your
   # model (around_save, before_save, after_create, after_update). Please note that


### PR DESCRIPTION
* [Unlink Callbacks heading from AR::AutosaveAssociation](https://github.com/rails/rails/commit/0677321b2a1a54b11ac6c22523c67e48e8400875)
* [Link to AR::QueryMethods#includes for associations option in AR::Associations::Preloader.new](https://github.com/rails/rails/commit/cfed245164c8e7db680bfccce1f33071cde0b530)
* [Link to the first method in the public instance methods list for AR::Associations](https://github.com/rails/rails/commit/8bcea6b07acd44ccb8a3dab29dba9b46ba3027ca)
* [Remove AR::Associations::Preloader from public API doc](https://github.com/rails/rails/commit/bc7a727c6d878890f5a9611eaebcbd2efb6fc506)

This removes the following previously internal API:

* AR::Associations::Preloader
* AR::Associations::Preloader::Association
* AR::Associations::Preloader::Association::LoaderQuery
* AR::Associations::Preloader::Association::LoaderRecords

Because there was a `:nodoc:` on both Preloader and Preloader::Association,
the assumption is that everything underthat is also private.

However, RDoc did not do the right thing.