### PR TITLE
Add rename option to serializable_hash method

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `serializable_hash` and `as_json` have a new `:rename` option.
+
+    It can be used to rename generated hash keys for attributes or methods:
+
+    ```ruby
+    person.serializable_hash(only: %w(name age), rename: { name: :first_name })
+      # => { "first_name" => "bob", "age" => 22 }
+    ```
+
+    *Dongcheol Park*
+
 *   Add a load hook for `ActiveModel::Model` (named `active_model`) to match the load hook for `ActiveRecord::Base` and
     allow for overriding aspects of the `ActiveModel::Model` class.
 

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -91,6 +91,7 @@ module ActiveModel
     #   person.serializable_hash(except: :name) # => {"age"=>22}
     #   person.serializable_hash(methods: :capitalized_name)
     #   # => {"name"=>"bob", "age"=>22, "capitalized_name"=>"Bob"}
+    #   person.serializable_hash(rename: {name: :first_name}) # => {"first_name"=>"bob", "age"=>22}
     #
     # Example with <tt>:include</tt> option
     #
@@ -143,6 +144,11 @@ module ActiveModel
         else
           records.serializable_hash(opts)
         end
+      end
+
+      options[:rename]&.each do |old_name, new_name|
+        old_name = old_name.to_s
+        hash[new_name.to_s] = hash.delete(old_name) if hash.key?(old_name)
       end
 
       hash

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -73,6 +73,12 @@ module ActiveModel
       #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
       #   #      "permalink" => "1-konata-izumi" }
       #
+      # To rename keys in the result hash, use <tt>:rename</tt>:
+      #
+      #   user.as_json(rename: { name: :full_name })
+      #   # => { "id" => 1, "full_name" => "Konata Izumi", "age" => 16,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true}
+      #
       # To include associations use <tt>:include</tt>:
       #
       #   user.as_json(include: :posts)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -86,6 +86,16 @@ class SerializationTest < ActiveModel::TestCase
     assert_raise(NoMethodError) { @user.serializable_hash(methods: [:nada]) }
   end
 
+  def test_method_serializable_hash_should_work_with_rename_option
+    expected = { "first_name" => "David", "gender" => "male", "email" => "david@example.com" }
+    assert_equal expected, @user.serializable_hash(rename: { name: :first_name })
+  end
+
+  def test_method_serializable_hash_should_work_with_rename_and_methods
+    expected = { "name" => "David", "gender" => "male", "email" => "david@example.com", "foo2" => "i_am_foo", "bar2" => "i_am_bar" }
+    assert_equal expected, @user.serializable_hash(methods: [:foo, :bar], rename: { foo: :foo2, bar: :bar2 })
+  end
+
   def test_should_use_read_attribute_for_serialization
     def @user.read_attribute_for_serialization(n)
       "Jon"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Hello contibutors 🤚 thank you for your efforts to keep the project alive.

### Motivation / Background
When I use `as_json` method to make the body of the response, There was one inconvenience.
As per Ruby's convention I usually put a question mark in the name of a method. (ex: has_value?)
It's not a problem inside Ruby, but it causes problems when used in other applications accessing the rails server.
To solve this, I had to manipulate the hash returned by `as_json`, which wasn't very clean.

### Detail
To solve the above problem I add a new option called `rename` to the `serializable_hash` method.
It can be used when you want to rename attributes or methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
