### PR TITLE
Allow an ActiveStorage attachment to be removed via a form post

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow an ActiveStorage attachment to be removed via a form post
+
+    Attachments can already be removed by updating the attachment to be nil such as:
+    ```ruby
+    User.find(params[:id]).update!(avatar: nil)
+    ```
+
+    However, a form cannot post a nil param, it can only post an empty string. But, posting an
+    empty string would result in an `ActiveSupport::MessageVerifier::InvalidSignature: mismatched digest`
+    error being raised, because it's being treated as a signed blob id.
+
+    Now, nil and an empty string are treated as a delete, which allows attachments to be removed via:
+    ```ruby
+    User.find(params[:id]).update!(params.require(:user).permit(:avatar))
+
+    ```
+
+    *Nate Matykiewicz*
+
 *   Remove mini_mime usage in favour of marcel.
 
     We have two libraries that are have similar usage. This change removes

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -61,7 +61,7 @@ module ActiveStorage
 
           def #{name}=(attachable)
             attachment_changes["#{name}"] =
-              if attachable.nil?
+              if attachable.nil? || attachable == ""
                 ActiveStorage::Attached::Changes::DeleteOne.new("#{name}", self)
               else
                 ActiveStorage::Attached::Changes::CreateOne.new("#{name}", self, attachable)


### PR DESCRIPTION
### Motivation / Background

We use ActiveStorage attachments via Direct Uploads, which set the attachment value to an ActiveStorage::Blob signed id. We also have the ability to remove an attachment (such as an avatar) in the UI via a "clear" button. This button simply sets the attachment to an empty string (via a hidden field tag), since a form cannot send a nil param. However, we found that this causes an `ActiveSupport::MessageVerifier::InvalidSignature: mismatched digest` error to be raised, because it's being treated as a signed blob id.

### Detail

This PR changes the `#{attachment}=` ActiveRecord method to treat an empty string just like it treats a nil, and use `ActiveStorage::Attached::Changes::DeleteOne` instead of `ActiveStorage::Attached::Changes::CreateOne`.

Now these two are treated the same:

```ruby
User.first.update!(avatar: nil)
User.first.update!(avatar: "")
```

### Additional information

Without this change, you have to do things like this in all of your controllers that accept direct uploads, which is quite tedious:

```ruby
def user_params
  params
    .require(:user)
    .permit(:first_name, :last_name, :avatar).tap do |permitted|
      permitted[:avatar] = nil if permitted[:avatar] == ''
    end
end
```

When adding tests, I simply copy/pasted the tests that test assigning `nil`, and modified them to be `""` tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
