### PR TITLE
Preserve timestamp when setting an `ActiveSupport::TimeWithZone` value to `timestamptz` attribute

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
@@ -13,7 +13,7 @@ module ActiveRecord
             return if value.blank?
 
             time = super
-            return time unless time.acts_like?(:time)
+            return time if time.is_a?(ActiveSupport::TimeWithZone) || !time.acts_like?(:time)
 
             # While in UTC mode, the PG gem may not return times back in "UTC" even if they were provided to Postgres in UTC.
             # We prefer times always in UTC, so here we convert back.

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -5,6 +5,7 @@ require "support/schema_dumping_helper"
 
 class DateTimePrecisionTest < ActiveRecord::TestCase
   if supports_datetime_with_precision?
+    include InTimeZone
     include SchemaDumpingHelper
     self.use_transactional_tests = false
 
@@ -209,6 +210,19 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
 
           date = ::Date.new(2001, 2, 3)
           assert_equal date, Foo.create!(happened_at: date).happened_at
+        end
+      end
+
+      def test_writing_a_time_with_zone_attribute_timestamptz
+        with_postgresql_datetime_type(:timestamptz) do
+          @connection.create_table(:foos, force: true) do |t|
+            t.datetime :happened_at
+          end
+
+          in_time_zone("Pacific Time (US & Canada)") do
+            time = Time.zone.now
+            assert_equal time.zone, Foo.new(happened_at: time).happened_at.zone
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/48346.

The regression was introduced in https://github.com/rails/rails/pull/45285, while trying to fix another issue. 
I returned back original condition https://github.com/rails/rails/pull/45285/files#diff-c6072f5254f1d8f3ba21a2b028367140e67974ed9e8616117ba6821df0cacdc2L16 from.