### PR TITLE
Fix `humanize` for strings ending with ` id`

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -139,7 +139,7 @@ module ActiveSupport
 
       result.tr!("_", " ")
       result.lstrip!
-      unless keep_id_suffix
+      if !keep_id_suffix && lower_case_and_underscored_word.end_with?("_id")
         result.delete_suffix!(" id")
       end
 

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -249,6 +249,8 @@ module InflectorTestCases
   UnderscoreToHuman = {
     "employee_salary" => "Employee salary",
     "employee_id"     => "Employee",
+    "employee id"     => "Employee id",
+    "employee id etc" => "Employee id etc",
     "underground"     => "Underground",
     "_id"             => "Id",
     "_external_id"    => "External"
@@ -259,6 +261,8 @@ module InflectorTestCases
     "employee_id"                => "Employee id",
     "employee_id_something_else" => "Employee id something else",
     "underground"               => "Underground",
+    "employee id"               => "Employee id",
+    "employee id etc"           => "Employee id etc",
     "_id"                       => "Id",
     "_external_id"              => "External id"
   }


### PR DESCRIPTION
Fixes #48343.

The regression was introduced in #41305.

cc @byroot 