### PR TITLE
Handle `sanitize_options` in `simple_format` helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   `simple_format` helper now handles a `:sanitize_options` - any extra options you want appending to the sanitize.
+
+    Before:
+    ```ruby
+      simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>")
+      # => "<p><a href=\"http://example.com\">Continue</a></p>"
+    ```
+
+    After:
+    ```ruby
+      simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>", {}, { sanitize_options: { attributes: %w[target href] } })
+      # => "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>"
+    ```
+
+    *Andrei Andriichuk*
+
 *   Add support for HTML5 standards-compliant sanitizers, and default to `Rails::HTML5::Sanitizer`
     in the Rails 7.1 configuration if it is supported.
 

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -291,6 +291,7 @@ module ActionView
       #
       # ==== Options
       # * <tt>:sanitize</tt> - If +false+, does not sanitize +text+.
+      # * <tt>:sanitize_options</tt> - Any extra options you want appended to the sanitize.
       # * <tt>:wrapper_tag</tt> - String representing the wrapper tag, defaults to <tt>"p"</tt>
       #
       # ==== Examples
@@ -315,10 +316,13 @@ module ActionView
       #
       #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false)
       #   # => "<p><blink>Blinkable!</blink> It's true.</p>"
+      #
+      #   simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>", {}, { sanitize_options: { attributes: %w[target href] } })
+      #   # => "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>"
       def simple_format(text, html_options = {}, options = {})
         wrapper_tag = options.fetch(:wrapper_tag, :p)
 
-        text = sanitize(text) if options.fetch(:sanitize, true)
+        text = sanitize(text, options.fetch(:sanitize_options, {})) if options.fetch(:sanitize, true)
         paragraphs = split_paragraphs(text)
 
         if paragraphs.empty?

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -53,6 +53,15 @@ class TextHelperTest < ActionView::TestCase
       simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: true })
   end
 
+  def test_simple_format_should_sanitize_input_when_sanitize_options_is_specified
+    assert_equal "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>",
+      simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>", {}, { sanitize_options: { attributes: %w[target href] } })
+  end
+
+  def test_simple_format_should_sanitize_input_when_sanitize_options_is_not_specified
+    assert_equal "<p><a href=\"http://example.com\">Continue</a></p>", simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>")
+  end
+
   def test_simple_format_should_not_sanitize_input_when_sanitize_option_is_false
     assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: false })
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

We needed to open the links in a new window along with the `simple_format` from `ActionView` already used on the project. The problem is that Rails removes target="_blank" by default.

This pull request is based on @Rubyist007 solution. 


```ruby
[1] pry(main)> simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>")
=> "<p><a href=\"http://example.com\">Continue</a></p>"
```

I noticed that `simple_format` uses sanitize, but doesn't allow options for this, however, adding the extra sanitize options such as `attributes: %w[target href]` will resolve my issue.

https://github.com/rails/rails/blob/fa77687831198ff38a01881fd6c2dc75bfd26ebf/actionview/lib/action_view/helpers/text_helper.rb#L321

### Details

This Pull Request introduces `sanitize_options` - Any extra options you want appending to the sanitize for the `simple_format` helper.
