### PR TITLE
Add composite primary key validity check on belongs_to, has_one, and has_many associations.

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -184,6 +184,22 @@ module ActiveRecord
     end
   end
 
+  class CompositePrimaryKeyMismatchError < ActiveRecordError # :nodoc:
+    attr_reader :reflection
+
+    def initialize(reflection = nil)
+      if reflection
+        if reflection.has_one? || reflection.collection?
+          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.active_record_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints.")
+        else
+          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.association_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints.")
+        end
+      else
+        super("Association primary key doesn't match with foreign key.")
+      end
+    end
+  end
+
   class AmbiguousSourceReflectionForThroughAssociation < ActiveRecordError # :nodoc:
     def initialize(klass, macro, association_name, options, possible_sources)
       example_options = options.dup

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -253,11 +253,11 @@ module ActiveRecord
       end
 
       def check_validity_of_inverse!
-        unless polymorphic?
-          if has_inverse? && inverse_of.nil?
+        if !polymorphic? && has_inverse?
+          if inverse_of.nil?
             raise InverseOfAssociationNotFoundError.new(self)
           end
-          if has_inverse? && inverse_of == self
+          if inverse_of == self
             raise InverseOfAssociationRecursiveError.new(self)
           end
         end
@@ -537,6 +537,14 @@ module ActiveRecord
 
       def check_validity!
         check_validity_of_inverse!
+
+        if !polymorphic? && klass.composite_primary_key?
+          if (has_one? || collection?) && Array(active_record_primary_key).length != Array(foreign_key).length
+            raise CompositePrimaryKeyMismatchError.new(self)
+          elsif belongs_to? && Array(association_primary_key).length != Array(foreign_key).length
+            raise CompositePrimaryKeyMismatchError.new(self)
+          end
+        end
       end
 
       def check_eager_loadable!

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -30,6 +30,7 @@ require "models/citation"
 require "models/tree"
 require "models/node"
 require "models/club"
+require "models/cpk"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -1744,6 +1745,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
   ensure
     ActiveRecord.belongs_to_required_validates_foreign_key = original_value
+  end
+
+  test "composite primary key malformed association" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      book = Cpk::BrokenBook.new(title: "Some book", order: Cpk::Order.new(id: [1, 2]))
+      book.save!
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Association Cpk::BrokenBook#order primary key ["shop_id", "id"]
+      doesn't match with foreign key order_id. Please specify query_constraints.
+    MESSAGE
   end
 end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3174,6 +3174,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  test "composite primary key malformed association" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      order = Cpk::BrokenOrder.new(id: [1, 2], books: [Cpk::Book.new(title: "Some book")])
+      order.save!
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Association Cpk::BrokenOrder#books primary key ["shop_id", "id"]
+      doesn't match with foreign key broken_order_id. Please specify query_constraints.
+    MESSAGE
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -18,6 +18,7 @@ require "models/department"
 require "models/club"
 require "models/membership"
 require "models/parrot"
+require "models/cpk"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -901,5 +902,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       car.build_special_bulb
       car.build_special_bulb
     end
+  end
+
+  test "composite primary key malformed association" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      order = Cpk::BrokenOrder.new(id: [1, 2], book: Cpk::Book.new(title: "Some book"))
+      order.save!
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Association Cpk::BrokenOrder#book primary key ["shop_id", "id"]
+      doesn't match with foreign key broken_order_id. Please specify query_constraints.
+    MESSAGE
   end
 end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -5,10 +5,13 @@ module Cpk
     self.table_name = :cpk_books
     self.primary_key = [:author_id, :number]
 
-    belongs_to :order
     belongs_to :author, class_name: "Cpk::Author"
   end
 
   class BestSeller < Book
+  end
+
+  class BrokenBook < Book
+    belongs_to :order
   end
 end

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -6,6 +6,11 @@ module Cpk
     self.primary_key = [:shop_id, :id]
 
     has_many :order_agreements, primary_key: :id
+    has_many :books, query_constraints: [:shop_id, :order_id]
+  end
+
+  class BrokenOrder < Order
     has_many :books
+    has_one :book
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -245,6 +245,7 @@ ActiveRecord::Schema.define do
     t.string :title
     t.integer :revision
     t.integer :order_id
+    t.integer :shop_id
   end
 
   create_table :cpk_authors, force: true do |t|


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because belongs_to associations with composite primary keys are broken.

### Detail

Raises `ActiveRecord::CompositePrimaryKeyMismatchError` when `belongs_to` foreign key and primary key don't have the same length.

### Additional information

This fixes an issue where autosave fails to update foreign key attributes here: https://github.com/rails/rails/blob/ced5e77936292cd557d71dadaf85c4cb0cf83df2/activerecord/lib/active_record/autosave_association.rb#L511-L515

I'm not sure if my fix is the best way to fix this problem, there might be an easier way around this than introducing an error and additional validation check. From my perspective, if a model has a composite primary key, its associations need query constraints to spell out the foreign key columns Active Record should use. Let me know what you think!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
