### PR TITLE
Signed id with polymorphic name purpose

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Generate and validate signed ids with a base purpose derived from the
+    class's polymorphic name
+
+    *Alexandre Chakroun*
+
 *   Use the first key in the `shards` hash from `connected_to` for the `default_shard`.
 
     Some applications may not want to use `:default` as a shard name in their connection model. Unfortunately Active Record expects there to be a `:default` shard because it must assume a shard to get the right connection from the pool manager. Rather than force applications to manually set this, `connects_to` can infer the default shard name from the hash of shards and will now assume that the first shard is your default.

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -90,7 +90,7 @@ module ActiveRecord
 
       # :nodoc:
       def combine_signed_id_purposes(purpose)
-        [ base_class.name.underscore, purpose.to_s ].compact_blank.join("/")
+        [ base_class.polymorphic_name.underscore, purpose.to_s ].compact_blank.join("/")
       end
     end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -22,6 +22,16 @@ class SignedIdTest < ActiveRecord::TestCase
       end
   end
 
+  class AccountPolymorphicName < ActiveRecord::Base
+    self.table_name = "accounts"
+
+    class << self
+      def polymorphic_name
+        "Account"
+      end
+    end
+  end
+
   fixtures :accounts, :toys, :companies
 
   setup do
@@ -195,5 +205,10 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "can get a signed ID in an after_create" do
     assert_not_nil GetSignedIDInCallback.create.signed_id_from_callback
+  end
+
+  test "uses the class polymorphic_name to build the base purpose" do
+    assert_equal @account.id, AccountPolymorphicName.find_signed!(@account.signed_id).id
+    assert_equal @account.id, Account.find_signed!(@account.becomes(AccountPolymorphicName).signed_id).id
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because moving an ActiveRecord class makes previously generated signed ids invalid.

### Detail

This Pull Request changes what base purpose is chosen for a signed id and uses `base_class.polymorphic_name` instead of `base_class.name`.
The rationale behind this proposal would be that `polymorphic_name` is the representation of the class/table in external systems.

### Additional information

I am not 100% sure `polymorphic_name` is the best fit, it is convenient because overriding it would solve multiple issues at once (polymorphic relations, signed ids) when having to move an ActiveRecord class.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
