### PR TITLE
Fix polymorphic association subquery

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix where on association with has_one/has_many polymorphic relations.
+
+    Before:
+    ```ruby
+    Treasure.where(price_estimates: PriceEstimate.all)
+    #=> SELECT (...) WHERE "treasures"."id" IN (SELECT "price_estimates"."estimate_of_id" FROM "price_estimates")
+    ```
+
+    Later:
+    ```ruby
+    Treasure.where(price_estimates: PriceEstimate.all)
+    #=> SELECT (...) WHERE "treasures"."id" IN (SELECT "price_estimates"."estimate_of_id" FROM "price_estimates" WHERE "price_estimates"."estimate_of_type" = 'Treasure')
+    ```
+
+    *Lázaro Nixon*
+
 *   Assign auto populated columns on Active Record record creation.
 
     Changes record creation logic to allow for the `auto_increment` column to be assigned

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -531,6 +531,10 @@ module ActiveRecord
         foreign_key
       end
 
+      def join_primary_type
+        type
+      end
+
       def join_foreign_key
         active_record_primary_key
       end
@@ -632,6 +636,10 @@ module ActiveRecord
 
       def polymorphic?
         options[:polymorphic]
+      end
+
+      def polymorphic_name
+        active_record.polymorphic_name
       end
 
       def add_as_source(seed)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :join_primary_key, :join_foreign_key, :join_foreign_type, to: :reflection
+    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, to: :reflection
 
     def initialize(klass, arel_table, reflection = nil)
       @klass = klass
@@ -61,6 +61,10 @@ module ActiveRecord
 
     def polymorphic_association?
       reflection&.polymorphic?
+    end
+
+    def polymorphic_name_association
+      reflection&.polymorphic_name
     end
 
     def through_association?

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -458,6 +458,11 @@ module ActiveRecord
       assert_equal essays(:david_modest_proposal), essay
     end
 
+    def test_where_on_association_with_collection_polymorphic_relation
+      treasures = Treasure.where(name: ["diamond", "emerald"], price_estimates: PriceEstimate.all)
+      assert_equal [treasures(:diamond)], treasures
+    end
+
     def test_where_with_strong_parameters
       author = authors(:david)
       params = ProtectedParams.new(name: author.name)

--- a/activerecord/test/fixtures/treasures.yml
+++ b/activerecord/test/fixtures/treasures.yml
@@ -8,3 +8,7 @@ sapphire:
 ruby:
   name: $LABEL
   looter: louis (Parrot)
+
+emerald:
+  id: 1
+  name: $LABEL


### PR DESCRIPTION
### Motivation / Background

Fix where on association with has_one/has_many polymorphic relations.

Before:
```ruby
Treasure.where(price_estimates: PriceEstimate.all)
#=> SELECT (...) WHERE "treasures"."id" IN (SELECT "price_estimates"."estimate_of_id" FROM "price_estimates")
```

Later:
```ruby
Treasure.where(price_estimates: PriceEstimate.all)
#=> SELECT (...) WHERE "treasures"."id" IN (SELECT "price_estimates"."estimate_of_id" FROM "price_estimates" WHERE "price_estimates"."estimate_of_type" = 'Treasure')
```

Fixes #47335

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
