### PR TITLE
Fix has_one autosaving for CPK associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -453,7 +453,9 @@ module ActiveRecord
 
             if (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, key)
               unless reflection.through_reflection
-                record[reflection.foreign_key] = key
+                Array(key).zip(Array(reflection.foreign_key)).each do |primary_key, foreign_key_column|
+                  record[foreign_key_column] = primary_key
+                end
                 association.set_inverse_instance(record)
               end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -486,6 +486,12 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert_equal true, squeak.mouse.present?
     assert_equal true, squeak.valid?
   end
+
+  test "composite primary key autosave" do
+    assert_nothing_raised do
+      Cpk::Order.create!(id: [1, 2], book: Cpk::Book.new(title: "Book", author_id: 3, number: 4))
+    end
+  end
 end
 
 class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes < ActiveRecord::TestCase

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -7,6 +7,7 @@ module Cpk
 
     has_many :order_agreements, primary_key: :id
     has_many :books, query_constraints: [:shop_id, :order_id]
+    has_one :book, query_constraints: [:shop_id, :order_id]
   end
 
   class BrokenOrder < Order


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because autosaving `has_one` relations with composite primary keys is currently broken.

### Detail

This Pull Request changes the Active Record autosave method that saves `has_one` associations (`save_has_one_association`) to support CPK associations.

### Additional information

This applies to any model with a `has_one` association with query constraints of more than one column.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
