### PR TITLE
Revert deprecation message for prepared statements

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -7,6 +7,12 @@
 
     *Nikita Vasilevsky*
 
+*   Remove the deprecation warning when `prepared_statements` configuration is set for the mysql2 adapter.
+
+    There is a known bug in `mysql2`. We don't want to encourage applications to migrate to `prepared_statements: true` until it's fixed.
+
+    *Eileen M. Uchitelle*
+
 *   Use the first key in the `shards` hash from `connected_to` for the `default_shard`.
 
     Some applications may not want to use `:default` as a shard name in their connection model. Unfortunately Active Record expects there to be a `:default` shard because it must assume a shard to get the right connection from the pool manager. Rather than force applications to manually set this, `connects_to` can infer the default shard name from the hash of shards and will now assume that the first shard is your default.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -192,9 +192,6 @@ module ActiveRecord
         end
 
         def default_prepared_statements
-          ActiveRecord.deprecator.warn(<<-MSG.squish)
-            The default value of `prepared_statements` for the mysql2 adapter will be changed from +false+ to +true+ in Rails 7.2.
-          MSG
           false
         end
 

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -42,38 +42,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  def test_mysql2_prepared_statements_default_deprecation_warning
-    fake_connection = Class.new do
-      def query_options
-        {}
-      end
-
-      def query(*)
-      end
-
-      def close
-      end
-    end.new
-
-    assert_deprecated(ActiveRecord.deprecator) do
-      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
-        fake_connection,
-        ActiveRecord::Base.logger,
-        nil,
-        { socket: File::NULL }
-      )
-    end
-
-    assert_not_deprecated(ActiveRecord.deprecator) do
-      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
-        fake_connection,
-        ActiveRecord::Base.logger,
-        nil,
-        { socket: File::NULL, prepared_statements: false }
-      )
-    end
-  end
-
   def test_mysql2_default_prepared_statements
     fake_connection = Class.new do
       def query_options


### PR DESCRIPTION
While we had hoped to turn prepared statements on for Rails 7.2, the bug that's preventing us from doing that is still present. See #43005.

Until this bug is fixed we should not be encouraging applications running mysql to change the `prepared_statements` in the config to `true`. In addition to this bug being present, Trilogy does not yet support `prepared_statements` (although work is in progress).

It will be better to implement this deprecation when mysql2 and trilogy can both handle `prepared_statements` without major bugs.