### PR TITLE
Correct directory-checking block in security.md

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -432,8 +432,7 @@ Simply pass a file name like "../../../etc/passwd" to download the server's logi
 ```ruby
 basename = File.expand_path('../../files', __dir__)
 filename = File.expand_path(File.join(basename, @file.public_filename))
-raise if basename !=
-     File.expand_path(File.join(File.dirname(filename), '../../../'))
+raise if basename != File.expand_path(File.dirname(filename))
 send_file filename, disposition: 'inline'
 ```
 


### PR DESCRIPTION
This Pull Request corrects one line in a code block.

In section _File Downloads_, the block that presents a solution against malicious file downloads expects that the path to a folder named 'file' (variable `basename`) matches the path to a folder which is 3 levels above, or else, it will raise an exception:

```ruby
raise if basename != File.expand_path(File.join(File.dirname(filename), '../../../'))
```

and that is impossible. It should instead be:

```ruby
raise if basename != File.expand_path(File.dirname(filename))
```

This bug goes as far back as v2.3 of the guide. I did not look further.