### PR TITLE
Support `VISUAL` env var, and prefer it over `EDITOR`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support `VISUAL` environment variable for commands which open an editor,
+    and prefer it over `EDITOR`.
+
+    *Summer ☀️*
+
 *   Add engine's `test/fixtures` path to `fixture_paths` in `on_load` hook if
     path exists and is under the Rails application root.
 

--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -8,11 +8,15 @@ module Rails
     module Helpers
       module Editor
         private
+          def editor
+            ENV["VISUAL"].to_s.empty? ? ENV["EDITOR"] : ENV["VISUAL"]
+          end
+
           def display_hint_if_system_editor_not_specified
-            if ENV["EDITOR"].to_s.empty?
-              say "No $EDITOR to open file in. Assign one like this:"
+            if editor.to_s.empty?
+              say "No $VISUAL or $EDITOR to open file in. Assign one like this:"
               say ""
-              say %(EDITOR="mate --wait" #{executable(current_subcommand)})
+              say %(VISUAL="mate --wait" #{executable(current_subcommand)})
               say ""
               say "For editors that fork and exit immediately, it's important to pass a wait flag;"
               say "otherwise, the file will be saved immediately with no chance to edit."
@@ -22,7 +26,7 @@ module Rails
           end
 
           def system_editor(file_path)
-            system(*Shellwords.split(ENV["EDITOR"]), file_path.to_s)
+            system(*Shellwords.split(editor), file_path.to_s)
           end
 
           def using_system_editor

--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -48,8 +48,8 @@ Set up Git to Diff Credentials:
     To disenroll from this feature, run `<%= executable(:diff) %> --disenroll`.
 
 Editing Credentials:
-    This will open a temporary file in `$EDITOR` with the decrypted contents to edit
-    the encrypted credentials.
+    This will open a temporary file in `$VISUAL` or `$EDITOR` with the decrypted
+    contents to edit the encrypted credentials.
 
     When the temporary file is next saved the contents are encrypted and written to
     `config/credentials.yml.enc` while the file itself is destroyed to prevent credentials

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -14,7 +14,7 @@ module Rails
       require_relative "credentials_command/diffing"
       include Diffing
 
-      desc "edit", "Open the decrypted credentials in `$EDITOR` for editing"
+      desc "edit", "Open the decrypted credentials in `$VISUAL` or `$EDITOR` for editing"
       def edit
         load_environment_config!
         load_generators

--- a/railties/lib/rails/commands/encrypted/USAGE
+++ b/railties/lib/rails/commands/encrypted/USAGE
@@ -16,7 +16,7 @@ Examples:
 
         <%= executable(:edit) %> config/encrypted_file.yml.enc
 
-    This opens a temporary file in `$EDITOR` with the decrypted contents for editing.
+    This opens a temporary file in `$VISUAL` or `$EDITOR` with the decrypted contents for editing.
 
     To print the decrypted contents of an encrypted file use:
 

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -12,7 +12,7 @@ module Rails
       class_option :key, aliases: "-k", type: :string,
         default: "config/master.key", desc: "The Rails.root relative path to the encryption key"
 
-      desc "edit", "Open the decrypted file in `$EDITOR` for editing"
+      desc "edit", "Open the decrypted file in `$VISUAL` or `$EDITOR` for editing"
       def edit(*)
         load_environment_config!
 

--- a/railties/lib/rails/commands/secrets/USAGE
+++ b/railties/lib/rails/commands/secrets/USAGE
@@ -53,8 +53,8 @@ Setup:
 Editing Secrets:
     After `<%= executable(:setup) %>`, run `<%= executable(:edit) %>`.
 
-    That command opens a temporary file in `$EDITOR` with the decrypted contents of
-    `config/secrets.yml.enc` to edit the encrypted secrets.
+    That command opens a temporary file in `$VISUAL` or `$EDITOR` with the decrypted
+    contents of `config/secrets.yml.enc` to edit the encrypted secrets.
 
     When the temporary file is next saved the contents are encrypted and written to
     `config/secrets.yml.enc` while the file itself is destroyed to prevent secrets

--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -9,7 +9,7 @@ module Rails
     class SecretsCommand < Rails::Command::Base # :nodoc:
       include Helpers::Editor
 
-      desc "edit", "**deprecated** Open the secrets in `$EDITOR` for editing"
+      desc "edit", "**deprecated** Open the secrets in `$VISUAL` or `$EDITOR` for editing"
       def edit
         Rails.deprecator.warn(<<~MSG.squish)
           `bin/rails secrets:edit` is deprecated in favor of credentials and will be removed in Rails 7.2.

--- a/railties/test/commands/secrets_test.rb
+++ b/railties/test/commands/secrets_test.rb
@@ -10,8 +10,16 @@ class Rails::Command::SecretsTest < ActiveSupport::TestCase
   setup :build_app
   teardown :teardown_app
 
-  test "edit without editor gives hint" do
-    assert_match "No $EDITOR to open file in", run_edit_command(editor: "")
+  test "edit without visual or editor gives hint" do
+    assert_match "No $VISUAL or $EDITOR to open file in", run_edit_command(visual: "", editor: "")
+  end
+
+  test "edit with visual but not editor does not give hint" do
+    assert_no_match "No $VISUAL or $EDITOR to open file in", run_edit_command(visual: "cat", editor: "")
+  end
+
+  test "edit with editor but not visual does not give hint" do
+    assert_no_match "No $VISUAL or $EDITOR to open file in", run_edit_command(visual: "", editor: "cat")
   end
 
   test "edit secrets" do
@@ -44,9 +52,11 @@ class Rails::Command::SecretsTest < ActiveSupport::TestCase
       end
     end
 
-    def run_edit_command(editor: "cat")
-      switch_env("EDITOR", editor) do
-        rails "secrets:edit", allow_failure: true
+    def run_edit_command(visual: "cat", editor: "cat")
+      switch_env("VISUAL", visual) do
+        switch_env("EDITOR", editor) do
+          rails "secrets:edit", allow_failure: true
+        end
       end
     end
 

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -251,8 +251,9 @@ namespace :all do
     # Permit the avatar param.
     substitute.call("app/controllers/users_controller.rb", /:admin/, ":admin, :avatar")
 
-    if ENV["EDITOR"]
-      `#{ENV["EDITOR"]} #{File.expand_path(app_name)}`
+    editor = ENV["VISUAL"] || ENV["EDITOR"]
+    if editor
+      `#{editor} #{File.expand_path(app_name)}`
     end
 
     puts "Booting a Rails server. Verify the release by:"


### PR DESCRIPTION
### Motivation/background

The [`Rails::Command::Helpers::Editor`](https://github.com/rails/rails/blob/95af5fce71cef4492d3ebf3bae6c2b5748f2d9e1/railties/lib/rails/command/helpers/editor.rb) module, used by the [`credentials`](https://github.com/rails/rails/blob/95af5fce71cef4492d3ebf3bae6c2b5748f2d9e1/railties/lib/rails/commands/credentials/credentials_command.rb#L11), [`encrypted`](https://github.com/rails/rails/blob/95af5fce71cef4492d3ebf3bae6c2b5748f2d9e1/railties/lib/rails/commands/encrypted/encrypted_command.rb#L10), and [`secrets`](https://github.com/rails/rails/blob/95af5fce71cef4492d3ebf3bae6c2b5748f2d9e1/railties/lib/rails/commands/secrets/secrets_command.rb#L10) commands to open a temporary file for editing in the user’s preferred editor, currently only uses the `EDITOR` environment variable to know which command to run to open that editor. It should also use the `VISUAL` environment variable, and it should prefer it over `EDITOR`.

See [this StackExchange answer](https://unix.stackexchange.com/a/4861) for some context:

> The `EDITOR` editor should be able to work without use of "advanced" terminal functionality (like old `ed` or `ex` mode of `vi`). It was used on teletype terminals.
> 
> A `VISUAL` editor could be a full screen editor as `vi` or `emacs`.
> 
> E.g. if you invoke an editor through bash (using `C-x C-e`), bash will try first `VISUAL` editor and then, if `VISUAL` fails (because terminal does not support a full-screen editor), it tries `EDITOR`.
> 
> Nowadays, you can leave `EDITOR` unset or set it to `vi -e`.

### Detail

This pull request changes `Rails::Command::Helpers::Editor` to first look for a value for `VISUAL`, then if `VISUAL` is empty, look for a value for `EDITOR`.

### Additional information

See [proposal in Ruby on Rails Discussions](https://discuss.rubyonrails.org/t/editor-command-helper-should-look-for-visual-env-var-before-editor/82928).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.