### PR TITLE
Fix link to ActionController::Cookies#cookies

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -92,7 +92,7 @@ module ActionDispatch
     include RequestCookieMethods
   end
 
-  # Read and write data to cookies through ActionController::Base#cookies.
+  # Read and write data to cookies through ActionController::Cookies#cookies.
   #
   # When reading cookie data, the data is read from the HTTP request header, Cookie.
   # When writing cookie data, the data is sent out in the HTTP response header, +Set-Cookie+.


### PR DESCRIPTION
The `cookies` method was not defined on ActionController::Base making the permalink to the method not work.
Changing it to ActionController::Cookies make the reference a link.

## Before

<img width="1003" alt="image" src="https://github.com/rails/rails/assets/28561/a62ddaa0-aa99-495c-92c2-4c4e1fa374d5">

## After

<img width="987" alt="image" src="https://github.com/rails/rails/assets/28561/e9f8b8fd-7802-4618-8e2a-1d6adf104f98">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
