### PR TITLE
Fix destroying belongs_to associations for CPK

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -501,7 +501,8 @@ module ActiveRecord
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?
-            self[reflection.foreign_key] = nil
+            foreign_key = Array(reflection.foreign_key)
+            foreign_key.each { |key| self[key] = nil }
             record.destroy
           elsif autosave != false
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1028,6 +1028,18 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_nil Pirate.find_by_id(id)
   end
 
+  # belongs_to for CPK
+  def test_autosave_cpk_association_should_destroy_parent_association_when_marked_for_destruction
+    book = Cpk::Book.new(title: "Book", author_id: 1, number: 2)
+    Cpk::Order.create!(id: [3, 4], book: book)
+
+    book.order.mark_for_destruction
+
+    assert book.save
+    assert_nil book.reload.order
+    assert_nil Cpk::Order.find_by(id: 4, shop_id: 3)
+  end
+
   def test_should_skip_validation_on_a_parent_association_if_marked_for_destruction
     @ship.pirate.catchphrase = ""
     assert_not_predicate @ship, :valid?

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -5,6 +5,7 @@ module Cpk
     self.table_name = :cpk_books
     self.primary_key = [:author_id, :number]
 
+    belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id]
     belongs_to :author, class_name: "Cpk::Author"
   end
 


### PR DESCRIPTION
### Motivation / Background

This PR handles destroying CPK associations when autosave is set and the parent association is marked for destruction. 

### Detail

This Pull Request changes the codepath in `#save_belongs_to_association` that handles destroying the parent association to handle a composite foreign key (the parent having a composite primary key).  It does so by ensuring that all parts of the foreign key (the parent's CPK) are set to nil before destroying the parent record.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
