### PR TITLE
Add ability to specify resulting key names for `as_json` `:methods` option

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add ability to specify resulting key names for `as_json` `:methods` option
+
+    ```ruby
+    user.as_json(methods: [:permalink, { unique_id: :nick }])
+    # => { "id" => 1, "name" => "Konata Izumi", "age" => 16, "nick" => "kozumi",
+    #      "permalink" => "1-konata-izumi", "unique_id" => "kozumi" }
+    ```
+
+    *fatkodima*
+
 *   Improve password length validation in ActiveModel::SecurePassword to consider byte size for BCrypt compatibility.
 
     The previous password length validation only considered the character count, which may not

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -135,7 +135,13 @@ module ActiveModel
 
       hash = serializable_attributes(attribute_names)
 
-      Array(options[:methods]).each { |m| hash[m.to_s] = send(m) }
+      Array(options[:methods]).each do |m|
+        if m.is_a?(Hash)
+          m.each { |key, method_name| hash[key.to_s] = send(method_name) }
+        else
+          hash[m.to_s] = send(m)
+        end
+      end
 
       serializable_add_includes(options) do |association, records, opts|
         hash[association.to_s] = if records.respond_to?(:to_ary)

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -82,6 +82,11 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(except: [:name, :email], methods: [:foo, :bar])
   end
 
+  def test_method_serializable_hash_should_work_with_methods_aliases
+    expected = { "foo" => "i_am_foo", "user_gender" => "male", "bar" => "i_am_bar" }
+    assert_equal expected, @user.serializable_hash(only: [], methods: [:foo, { user_gender: :gender }, :bar])
+  end
+
   def test_should_raise_NoMethodError_for_non_existing_method
     assert_raise(NoMethodError) { @user.serializable_hash(methods: [:nada]) }
   end


### PR DESCRIPTION
I recently had a need to specify an alternative name for the key when used ActiveModel's `as_json` method with `:methods` option. For example, I have a `User` model and I want to render its `nick` as a `unique_id`.

While this can be achieved by using `alias`/`alias_method` for methods (and `alias_attribute` for attributes) in the model itself, it does not always makes sense to have them in the model, because the name can be from a different domain (vocabulary etc) and so be confusing when defined there.

Now, this is possible with the following syntax:
```ruby
user.as_json(methods: [:permalink, { unique_id: :nick }])
# => { "id" => 1, "name" => "Konata Izumi", "age" => 16, "nick" => "kozumi",
#      "permalink" => "1-konata-izumi", "unique_id" => "kozumi" }
```

This works for attributes too:
```ruby
user.as_json(except: [:name], methods: { nickname: :name })
```