### PR TITLE
Add engine draw_paths to app

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add engine's draw paths to application route set, so that the application
+    can draw route files defined in engine paths.
+
+    *Gannon McGibbon*
+
 *   Support `VISUAL` environment variable for commands which open an editor,
     and prefer it over `EDITOR`.
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -586,6 +586,7 @@ module Rails
       routing_paths = paths["config/routes.rb"].existent
       external_paths = self.paths["config/routes"].paths
       routes.draw_paths.concat(external_paths)
+      app.routes.draw_paths.concat(external_paths)
 
       if routes? || routing_paths.any?
         app.routes_reloader.paths.unshift(*routing_paths)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -267,6 +267,34 @@ module RailtiesTest
       assert_nothing_raised { BukkitController }
     end
 
+    test "can draw routes in app routes from engines" do
+      @plugin.write "config/routes/testing.rb", <<~RUBY
+        Rails.application.routes.draw do
+          get "/testing", to: "test#action", as: :testing
+        end
+      RUBY
+
+      @plugin.write "config/routes.rb", <<~RUBY
+        Rails.application.routes.draw do
+          draw(:testing)
+        end
+      RUBY
+
+      @plugin.write "app/controllers/testing_controller.rb", <<-RUBY
+        class TestingController < ActionController::Base
+          def index
+            render plain: "test"
+          end
+        end
+      RUBY
+
+      boot_rails
+
+      get("/testing")
+
+      assert_equal("test", last_response.body)
+    end
+
     test "adds its views to view paths" do
       @plugin.write "app/controllers/bukkit_controller.rb", <<-RUBY
         class BukkitController < ActionController::Base


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because draw paths from engines aren't accessible in the application route set, so if you have routes in an engine that are added to the application route set, you cannot reference route files defined in the engine's draw paths.

### Detail

This Pull Request changes engine initialization to also append to the application route set.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
