### PR TITLE
Fix AV:TranslationHelperTest due to i18n v1.14.0 changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.14.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -129,9 +129,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_raise_arg_overrides_raise_config_option
     ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
+    translation_missing_message = <<~MSG
+      Translation missing. Options considered were:
+      - en.translations.missing
+    MSG
 
-    expected = "translation missing: en.translations.missing"
-    assert_equal expected, translate(:"translations.missing", raise: false)
+    assert_equal translation_missing_message.chomp, translate(:"translations.missing", raise: false)
   ensure
     ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
   end


### PR DESCRIPTION
Fixes #48387

There are several changes in the diff, so I'm not sure which one, but this fixes things.
https://github.com/ruby-i18n/i18n/compare/v1.13.0...v1.14.0