### PR TITLE
Add :public_id_column option to accepts_nested_attributes_for

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2706,10 +2706,6 @@ module ActionView
             association = @object.public_send(association_name)
           end
 
-          if @object.respond_to?(:nested_attributes_options)
-            options[:public_id_column] = @object.nested_attributes_options.dig(association_name.to_sym, :public_id_column)
-          end
-
           if association.respond_to?(:to_ary)
             explicit_child_index = options[:child_index]
             output = ActiveSupport::SafeBuffer.new
@@ -2737,11 +2733,7 @@ module ActionView
 
           @template.fields_for(name, object, fields_options) do |f|
             output = @template.capture(f, &block)
-            id_col = fields_options.delete(:public_id_column)
-            if id_col
-              id_val = f.object.send(id_col)
-            end
-            output.concat f.hidden_field(:id, {value: id_val}.compact) if output && emit_hidden_id && !f.emitted_hidden_id?
+            output.concat f.hidden_field(:id, value: f.object.to_param) if output && emit_hidden_id && !f.emitted_hidden_id?
             output
           end
         end

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -57,6 +57,23 @@ class FormHelperActiveRecordTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_nested_fields_for_with_existing_records_on_a_nested_association_with_public_id_column
+    project = @developer.projects.create!(name: "some-name")
+
+    form_for(@developer) do |f|
+      concat f.fields_for(:projects_with_public_id_column, project) { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/developers/123", "edit_developer_123", "edit_developer", method: "patch") do
+      '<input id="developer_projects_with_public_id_column_attributes_0_name" name="developer[projects_with_public_id_column_attributes][0][name]" type="text" value="some-name" />' \
+      '<input id="developer_projects_with_public_id_column_attributes_0_id" name="developer[projects_with_public_id_column_attributes][0][id]" type="hidden" value="some-name" autocomplete="off" />'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   private
     def hidden_fields(method = nil)
       txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -60,6 +60,10 @@ class FormHelperActiveRecordTest < ActionView::TestCase
   def test_nested_fields_for_with_existing_records_on_a_nested_association_with_public_id_column
     project = @developer.projects.create!(name: "some-name")
 
+    refute_nil project.public_id
+    refute_equal project.public_id, project.public_id
+    assert_equal project.public_id, project.to_param
+
     form_for(@developer) do |f|
       concat f.fields_for(:projects_with_public_id_column, project) { |cf|
         concat cf.text_field(:name)
@@ -68,7 +72,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
     expected = whole_form("/developers/123", "edit_developer_123", "edit_developer", method: "patch") do
       '<input id="developer_projects_with_public_id_column_attributes_0_name" name="developer[projects_with_public_id_column_attributes][0][name]" type="text" value="some-name" />' \
-      '<input id="developer_projects_with_public_id_column_attributes_0_id" name="developer[projects_with_public_id_column_attributes][0][id]" type="hidden" value="some-name" autocomplete="off" />'
+      %Q(<input id="developer_projects_with_public_id_column_attributes_0_id" name="developer[projects_with_public_id_column_attributes][0][id]" type="hidden" value="#{project.public_id}" autocomplete="off" />)
     end
 
     assert_dom_equal expected, @rendered

--- a/actionview/test/fixtures/db_definitions/sqlite.sql
+++ b/actionview/test/fixtures/db_definitions/sqlite.sql
@@ -35,6 +35,12 @@ CREATE TABLE 'projects' (
   'name' TEXT DEFAULT NULL
 );
 
+CREATE TABLE 'projects_with_public_id_column' (
+  'id' INTEGER PRIMARY KEY NOT NULL,
+  'name' TEXT DEFAULT NULL,
+  'public_id' TEXT NOT NULL
+);
+
 CREATE TABLE 'developers_projects' (
   'developer_id' INTEGER NOT NULL,
   'project_id' INTEGER NOT NULL,

--- a/actionview/test/fixtures/developer.rb
+++ b/actionview/test/fixtures/developer.rb
@@ -6,6 +6,6 @@ class Developer < ActiveRecord::Base
   has_many :topics, through: :replies
   accepts_nested_attributes_for :projects
 
-  has_and_belongs_to_many :projects_with_public_id_column, class_name: "Project"
-  accepts_nested_attributes_for :projects_with_public_id_column, public_id_column: :name
+  has_and_belongs_to_many :projects_with_public_id_column
+  accepts_nested_attributes_for :projects_with_public_id_column, public_id_column: :public_id
 end

--- a/actionview/test/fixtures/developer.rb
+++ b/actionview/test/fixtures/developer.rb
@@ -5,4 +5,7 @@ class Developer < ActiveRecord::Base
   has_many :replies
   has_many :topics, through: :replies
   accepts_nested_attributes_for :projects
+
+  has_and_belongs_to_many :projects_with_public_id_column, class_name: "Project"
+  accepts_nested_attributes_for :projects_with_public_id_column, public_id_column: :name
 end

--- a/actionview/test/fixtures/project_with_public_id_column.rb
+++ b/actionview/test/fixtures/project_with_public_id_column.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ProjectWithPublicIdColumn < ActiveRecord::Base
+  has_and_belongs_to_many :developers, -> { uniq }
+
+  validates :public_id, presence: true, uniqueness: {case_sensitive: false}
+
+  before_validation :set_public_id, on: :create
+
+  def set_public_id
+    self.public_id = "#{SecureRandom.hex(3)}-#{Time.now.to_i}"
+  end
+
+  def to_param
+    public_id
+  end
+end

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -236,6 +236,8 @@ module ActiveRecord
     # of hashes can be used with hashes generated from HTTP/HTML parameters,
     # where there may be no natural way to submit an array of hashes.
     #
+    # You may also pass a +public_id_column+ argument if your nested model has a public ID column that is not the same as your primary key column. If provided then the value within this column will populate the fields_for form `[id]` field.
+    #
     # === Saving
     #
     # All changes to models, including the destruction of those marked for
@@ -244,7 +246,6 @@ module ActiveRecord
     # by the parent's save method. See ActiveRecord::AutosaveAssociation.
     #
     # === Validating the presence of a parent model
-    #
     # The +belongs_to+ association validates the presence of the parent model
     # by default. You can disable this behavior by specifying <code>optional: true</code>.
     # This can be used, for example, when conditionally validating the presence
@@ -353,7 +354,7 @@ module ActiveRecord
       def accepts_nested_attributes_for(*attr_names)
         options = { allow_destroy: false, update_only: false }
         options.update(attr_names.extract_options!)
-        options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
+        options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only, :public_id_column)
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
 
         attr_names.each do |association_name|
@@ -430,9 +431,10 @@ module ActiveRecord
         attributes = attributes.with_indifferent_access
         existing_record = send(association_name)
 
-        if (options[:update_only] || !attributes["id"].blank?) && existing_record &&
-            (options[:update_only] || existing_record.id.to_s == attributes["id"].to_s)
-          assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
+        if (options[:update_only] || !attributes["id"].blank?)
+          && existing_record
+          && (options[:update_only] || existing_record.send(options[:public_id_column] || :id).to_s == attributes["id"].to_s)
+        assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy]) unless call_reject_if(association_name, attributes)
 
         elsif attributes["id"].present?
           raise_nested_attributes_record_not_found!(association_name, attributes["id"])
@@ -504,11 +506,13 @@ module ActiveRecord
 
         association = association(association_name)
 
+        public_id_column = options[:public_id_column] || association.klass.primary_key
+
         existing_records = if association.loaded?
           association.target
         else
           attribute_ids = attributes_collection.filter_map { |a| a["id"] || a[:id] }
-          attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
+          attribute_ids.empty? ? [] : association.scope.where(public_id_column => attribute_ids)
         end
 
         attributes_collection.each do |attributes|
@@ -521,12 +525,12 @@ module ActiveRecord
             unless reject_new_record?(association_name, attributes)
               association.reader.build(attributes.except(*UNASSIGNABLE_KEYS))
             end
-          elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes["id"].to_s }
+          elsif existing_record = existing_records.detect { |record| record.send(public_id_column).to_s == attributes["id"].to_s }
             unless call_reject_if(association_name, attributes)
               # Make sure we are operating on the actual object which is in the association's
               # proxy_target array (either by finding it, or adding it if not found)
               # Take into account that the proxy_target may have changed due to callbacks
-              target_record = association.target.detect { |record| record.id.to_s == attributes["id"].to_s }
+              target_record = association.target.detect { |record| record.send(public_id_column).to_s == attributes["id"].to_s }
               if target_record
                 existing_record = target_record
               else
@@ -611,8 +615,9 @@ module ActiveRecord
 
       def raise_nested_attributes_record_not_found!(association_name, record_id)
         model = self.class._reflect_on_association(association_name).klass.name
+        id_column = nested_attributes_options[association_name][:public_id_column] || "id"
         raise RecordNotFound.new("Couldn't find #{model} with ID=#{record_id} for #{self.class.name} with ID=#{id}",
-                                 model, "id", record_id)
+                                 model, id_column, record_id)
       end
   end
 end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -59,6 +59,17 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_equal "Tweetie", pirate.birds_with_reject_all_blank.first.name
   end
 
+  def test_should_edit_existing_records_with_public_id
+    pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
+    bird = pirate.birds_with_public_id_column.create!(name: "Original")
+
+    pirate.birds_with_public_id_column_attributes = [{id: "Original", name: "Updated"}]
+    pirate.save!
+
+    assert_equal 1, pirate.birds_with_public_id_column.count
+    assert_equal "Updated", bird.reload.name
+  end
+
   def test_should_raise_an_ArgumentError_for_non_existing_associations
     exception = assert_raise ArgumentError do
       Pirate.accepts_nested_attributes_for :honesty

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -41,6 +41,7 @@ class Pirate < ActiveRecord::Base
     before_remove: proc { |p, b| p.ship_log << "before_removing_proc_bird_#{b.id}" },
     after_remove: proc { |p, b| p.ship_log << "after_removing_proc_bird_#{b.id}" }
   has_many :birds_with_reject_all_blank, class_name: "Bird"
+  has_many :birds_with_public_id_column, class_name: "Bird"
 
   has_one :foo_bulb, -> { where name: "foo" }, foreign_key: :car_id, class_name: "Bulb"
 
@@ -53,6 +54,7 @@ class Pirate < ActiveRecord::Base
   accepts_nested_attributes_for :parrots_with_method_callbacks, :parrots_with_proc_callbacks,
     :birds_with_method_callbacks, :birds_with_proc_callbacks, allow_destroy: true
   accepts_nested_attributes_for :birds_with_reject_all_blank, reject_if: :all_blank
+  accepts_nested_attributes_for :birds_with_public_id_column, public_id_column: :name
 
   validates_presence_of :catchphrase
 

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -1081,6 +1081,17 @@ end
 
 As a convenience you can instead pass the symbol `:all_blank` which will create a proc that will reject records where all the attributes are blank excluding any value for `_destroy`.
 
+### Using a non-primary key as the ID attribute
+
+When your nested model has a public ID column that is not the same as your primary key column, then you can pass the `:public_id_column` option to `accepts_nested_attributes_for`. If provided then the data from within this DB column will populate the fields_for form `[id]` field.
+
+```ruby
+class Person < ApplicationRecord
+  has_many :addresses
+  accepts_nested_attributes_for :addresses, public_id_column: :public_id
+end
+```
+
 ### Adding Fields on the Fly
 
 Rather than rendering multiple sets of fields ahead of time you may wish to add them only when a user clicks on an "Add new address" button. Rails does not provide any built-in support for this. When generating new sets of fields you must ensure the key of the associated array is unique - the current JavaScript date (milliseconds since the [epoch](https://en.wikipedia.org/wiki/Unix_time)) is a common choice.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because I would like to use `accepts_nested_attributes_for` and `fields_for` with a public_id column instead of the PK. `fields_for` doesnt seem to honor `to_param` because it continues to place the PK in the hidden ID field.

### Detail

This Pull Request changes` accepts_nested_attributes_for` and `fields_for` behaviour by adding an additional option to `accepts_nested_attributes_for` called `:public_id_column`

This new argument is intended to allow to specify a public ID column to use for the value of the forms hidden `[id]` input rather than the default public key.

```ruby
class Post < ApplicationRecord
  accepts_nested_attributes_for :comments, public_id_column: :public_id
end
```

When used in views/forms with `fields_for` it should automatically output the following hidden ID field.

```html
<input 
  type="hidden"
  name="post[comments_attributes][0][id]" 
  value="value-of-the-public_id-column"
  ...etc...
>
```

I chose add an argument to `accepts_nested_attributes_for` because its a lot simpler to add an argument to this method rather than to change the basics of ActiveRecord::Base by adding a new method similar to how `to_param` works. Looking for productive feedback here if we want to take the route of defining a class method or something instead.

### Additional information

Discussion on reddit: https://www.reddit.com/r/rails/comments/13xulzr/how_can_i_use_accepts_nested_attributes_for/

Video walkthrough on how the [`brick` gem ](https://github.com/lorint/brick) is currently hacking in this functionality with `friendly_id`. https://www.reddit.com/r/rails/comments/13z4hfq/hey_uwestonganger_accepts_nested_attributes_for/

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
