### PR TITLE
Support nested array bind parameter for PostgreSQL parameter.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -62,6 +62,8 @@ module ActiveRecord
             quote(encode_array(value))
           when Range
             quote(encode_range(value))
+          when Array
+            "(#{value.map { |v| quote(v) }.join(', ')})"
           else
             super
           end

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -49,6 +49,12 @@ module ActiveRecord
             assert_deprecated(ActiveRecord.deprecator) { Post.where("title = ?", 0.seconds).count }
           end
         end
+
+        def test_where_with_two_dimensional_array_for_string_column_using_bind_parameters
+          values = [["hello", "misc post by bob"], ["hullo", "misc post by mary"], ["invalid", "not existing"]]
+          count = Post.where("(body, title) IN (?)", values).count
+          assert_equal 2, count
+        end
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -35,6 +35,11 @@ module ActiveRecord
           assert_equal "'[1,0]'", @conn.quote(type.serialize(range))
         end
 
+        def test_quote_array
+          values = [[1, "test1"], [2, "test2"]]
+          assert_equal "((1, 'test1'), (2, 'test2'))", @conn.quote(values)
+        end
+
         def test_quote_bit_string
           value = "'); SELECT * FROM users; /*\n01\n*/--"
           type = OID::Bit.new


### PR DESCRIPTION
### Motivation / Background

Add support for multi column where syntax (aka `WHERE (id, user) IN ((1, 'Josef'), (2, 'Jimmy'))`) for PostgreSQL adapter.

```ruby
values = [[1, 'Josef'], [2, 'Jimmy']]
User.where('(id, name) IN (?)', values).to_sql
# => SELECT "users".* FROM "users" WHERE ((id, name) IN ((1, 'Josef'),(2, 'Jimmy')))
```

currently this raises an exception

```
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4.3/lib/active_record/connection_adapters/abstract/quoting.rb:25:in `quote': can't quote Array (TypeError)
```

### Detail

It is possible to chain `OR` conditions like `WHERE (id = 1 AND user = 'Josef') OR (id = 2 AND user = 'Jimmy')`, but in my use case I do need to handle ten thousands of individual values. Per my testing this approach is heavy for PostgreSQL planner and affects planning time according to `EXPLAIN`.

- 1 000 conditions of 2 values combined by OR
  - Planning Time: 280.032 ms
- 10 000 conditions of 2 values combined by OR
  - Planning Time: 27598.735 ms

compared to multi-column WHERE
- 1 000 conditions of 2 values using "multi-where"
  - Planning Time: 8.722 ms
- 10 000 conditions of 2 values using "multi-where"
  - Planning Time: 131.082 ms


### Additional information

It is also easier to compose query this way. Using `or` query needs to be composed in iterative way.

```ruby
values = [ [1, 'Josef'], ... ] # array of 10 000 values
scope = User.all

values.each do |value|
  scope = scope.or(User.where(id: value[0], name: value[1])
end

scope.load # execute
```

_I had troubles even with this approach since `or` doesn't work properly when called without starting where chain already on scope. But I'm not 100% sure I wasn't doing something wrong. I had to do following actually._

```ruby
values = [ [1, 'Josef'], ... ] # array of 10 000 values
scope = User.all

# start where chain first
first_value = values.shift 
scope = scope.where(id: first_value[0], name: first_value[1])

# handle rest with or
values.each do |value|
  scope = scope.or(User.where(id: value[0], name: value[1])
end

scope.load # execute
```

If welcomed, this could be later turned into feature of hash version of where arguments and being supported across all adapters just using the most optimised way available.

```ruby
User.where([:id, :name] => [[1, 'Josef'], [2, 'Jimmy']])
# => uses multi-where when supported (PostgreSQL only) or OR chained combinations for the rest
```

### Tip

_for quick local test, I used following patch_

```ruby
module CustomPostgreSQLQuoting
  def quote(value)
    if value.is_a?(Array)
      "(#{value.map { |v| super(v) }.join(', ')})"
    else
      super
    end
  end
end

ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(CustomPostgreSQLQuoting)
```

related to https://github.com/rails/rails/pull/47410#issuecomment-1434957200 as well

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
