### PR TITLE
Revert "Switch to i18n master branch temporary to fix actionview test"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,10 +40,6 @@ gem "json", ">= 2.0.0"
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 
-# Workaround until a new version of i18n gem is released with
-# https://github.com/ruby-i18n/i18n/commit/3115f71e0d21f449204b5bea5256232402252d04
-gem "i18n", github: "ruby-i18n/i18n", branch: "master"
-
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,14 +15,6 @@ GIT
       event_emitter
       websocket
 
-GIT
-  remote: https://github.com/ruby-i18n/i18n.git
-  revision: 5d5c40f0dd25c421b09bfc856352cd28fecc1516
-  branch: master
-  specs:
-    i18n (1.14.0)
-      concurrent-ruby (~> 1.0)
-
 PATH
   remote: .
   specs:
@@ -273,6 +265,8 @@ GEM
       signet (>= 0.16, < 2.a)
     hashdiff (1.0.1)
     httpclient (2.8.3)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -589,7 +583,6 @@ DEPENDENCIES
   delayed_job_active_record
   error_highlight (>= 0.4.0)
   google-cloud-storage (~> 1.11)
-  i18n!
   image_processing (~> 1.2)
   importmap-rails
   jbuilder


### PR DESCRIPTION
This reverts commit 43f4792f16e479afb00b7fe7a9df1e4c7b26fad7.

### Detail

i18n 1.14.1 is available now https://rubygems.org/gems/i18n/versions/1.14.1