### PR TITLE
ActiveSupport::Deprecator stop using `Singleton`

### DIFF
--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -52,7 +52,6 @@ module ActiveSupport
     require "active_support/core_ext/module/deprecation"
     require "concurrent/atomic/thread_local_var"
 
-    include Singleton # :nodoc:
     include InstanceDelegator
     include Behavior
     include Reporting


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/47354

It does a bit more than just giving you a `.instance` method it also change the behavior of dup and clone, we don't need any of that, and `.instance` is deprecated anyway.

cc @yahonda @etiennebarrie @ioquatix @dpep