### PR TITLE
Remove :github gem source from template Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby <%= "\"#{gem_ruby_version}\"" -%>
 


### PR DESCRIPTION
The `:github` source was already supported in the oldest supported version of Bundler, 1.15.0:

https://github.com/rubygems/bundler/blob/v1.15.0/lib/bundler/dsl.rb#L253

It now has additional features like support for pull request URLs which the explicit Git source here breaks.

### Motivation / Background

I want to easily test Git gems from pull requests, in particular Rails, by simply using the github source provided by Bundler which allows to use pull request URLs since 2.3.0: https://github.com/rubygems/rubygems/pull/5126

### Detail

The `:github` source has been available in Bundler directly since 1.1: https://github.com/rubygems/bundler/commit/c2bac6dca4f7f4d123a3caa0e8f640172477c517
Bundler has been required at 1.1 since Rails 4.0.0: https://github.com/rails/rails/commit/37421523108684f7b17ed0a2f53d1b41e8c7ea7e
