### PR TITLE
improve quoted parameters in mime types

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   The `Mime::Type` now supports handling types with parameters and correctly handles quotes.
+    When parsing the accept header, the parameters before the q-parameter are kept and if a matching mime-type exists it is used.
+    To keep the current functionality, a fallback is created to look for the media-type without the parameters.
+
+    This change allows for custom MIME-types that are more complex like `application/vnd.api+json; profile="https://jsonapi.org/profiles/ethanresnick/cursor-pagination/" ext="https://jsonapi.org/ext/atomic"` for the [JSON API](https://jsonapi.org/).
+
+    *Nicolas Erni*
+
 *   The url_for helpers now support a new option called `path_params`.
     This is very useful in situations where you only want to add a required param that is part of the route's URL but for other route not append an extraneous query param.
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1100,6 +1100,10 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     def foos_wibble
       render plain: "ok"
     end
+
+    def foos_json_api
+      render plain: "ok"
+    end
   end
 
   def test_standard_json_encoding_works
@@ -1168,6 +1172,26 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     end
   ensure
     Mime::Type.unregister :wibble
+  end
+
+  def test_registering_custom_encoder_including_parameters
+    accept_header = 'application/vnd.api+json; profile="https://jsonapi.org/profiles/ethanresnick/cursor-pagination/"; ext="https://jsonapi.org/ext/atomic"'
+    Mime::Type.register accept_header, :json_api
+
+    ActionDispatch::IntegrationTest.register_encoder(:json_api,
+      param_encoder: -> params { params })
+
+    post_to_foos as: :json_api do
+      assert_response :success
+      assert_equal "/foos_json_api", request.path
+      assert_equal "application/vnd.api+json", request.media_type
+      assert_equal accept_header, request.accepts.first.to_s
+      assert_equal :json_api, request.format.ref
+      assert_equal Hash.new, request.request_parameters # Unregistered MIME Type can't be parsed.
+      assert_equal "ok", response.parsed_body
+    end
+  ensure
+    Mime::Type.unregister :json_api
   end
 
   def test_parsed_body_without_as_option

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -80,6 +80,18 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect, Mime::Type.parse(accept)
   end
 
+  test "parse arbitrary media type parameters with comma" do
+    accept = 'multipart/form-data; boundary="simple, boundary"'
+    expect = [Mime[:multipart_form]]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse arbitrary media type parameters with comma and additional media type" do
+    accept = 'multipart/form-data; boundary="simple, boundary", text/xml'
+    expect = [Mime[:multipart_form], Mime[:xml]]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
   # Accept header send with user HTTP_USER_AGENT: Sunrise/0.42j (Windows XP)
   test "parse broken acceptlines" do
     accept = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/*,,*/*;q=0.5"
@@ -109,6 +121,15 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   ensure
     Mime::Type.unregister(:foobar)
+  end
+
+  test "custom type with url parameter" do
+    accept = 'application/vnd.api+json; profile="https://jsonapi.org/profiles/example"'
+    type = Mime::Type.register(accept, :example_api)
+    assert_equal type, Mime[:example_api]
+    assert_equal [type], Mime::Type.parse(accept)
+  ensure
+    Mime::Type.unregister(:example_api)
   end
 
   test "register callbacks" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `Mime::Type` does not correctly handle quoted parameters. They can contain most characters, including a comma. Additionally, the current implementation ignored the parameters when loading the type, but not when registering it.

Fixes #48052

### Detail

This Pull Request changes `Mime::Type` to allow every character in a quoted parameter value, except `\r`, `\` and `"` as defined in [RFC 822 3.3](https://datatracker.ietf.org/doc/html/rfc822#section-3.3), except for escaped characters (see Current Limitations).

Additionally, the different parts of the Accept header are not simply split by `,`, but now factor in quotes.

In the current implementation `Mime::Type.register` kept the parameters, whereas `Mime::Type.parse` removed them. This PR now keeps all parameters before the `q` parameter (as defined in [RFC 7231 5.3.2](https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2)). If during the lookup no type with the parameter could be found, a type is searched for without parameters as a fallback. This is useful for example for `multipart/form-data; boundary="simple boundary"` and keeps the current behaviour.

### Current Limitations

Currently the following limitations exist, but I'm not sure if they are worth the effort:

* Quoted strings could contain escaped characters, including `\"`. My implementation does not allow a backslash to simplify the parsing and keeping it efficient.
* If there are whitespace-differences around the parameters they would not be considered as matching. E.g. `my/type;test="value"` would not match `my/type; test="value"`
* According to [RFC 7231 5.3.2](https://www.rfc-editor.org/rfc/rfc7231#section-5.3.2), the types with parameters have precedence over types without parameters. But sorting them according to this information would mean to split the types from the parameters, which introduces additional computational effort.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
