### PR TITLE
Remove unnecessary disabling of use_transactional_tests

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1333,8 +1333,6 @@ end
 class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
   fixtures :chefs, :cake_designers, :drink_designers
 
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -1504,8 +1502,6 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def create_member_with_organization
     organization = Organization.create
     member = Member.create
@@ -1549,8 +1545,6 @@ class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCas
 end
 
 class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @ship = Ship.create(name: "Nights Dirty Lightning")
@@ -1822,8 +1816,6 @@ module AutosaveAssociationOnACollectionAssociationTests
 end
 
 class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @association_name = :birds
@@ -1838,8 +1830,6 @@ class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @association_name = :autosaved_parrots
@@ -1855,8 +1845,6 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::T
 end
 
 class TestAutosaveAssociationOnAHasAndBelongsToManyAssociationWithAcceptsNestedAttributes < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @association_name = :parrots
@@ -1872,8 +1860,6 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociationWithAcceptsNestedA
 end
 
 class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -1937,8 +1923,6 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
 end
 
 class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -1960,8 +1944,6 @@ class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::Tes
 end
 
 class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -1988,8 +1970,6 @@ class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::
 end
 
 class TestAutosaveAssociationValidationsOnAHABTMAssociation < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -2011,8 +1991,6 @@ class TestAutosaveAssociationValidationsOnAHABTMAssociation < ActiveRecord::Test
 end
 
 class TestAutosaveAssociationValidationMethodsGeneration < ActiveRecord::TestCase
-  self.use_transactional_tests = false unless supports_savepoints?
-
   def setup
     super
     @pirate = Pirate.new


### PR DESCRIPTION
Setting `self.use_transactional_tests` to `false` doesn't wrap test execution in a transaction which means records created in tests will not be rolled back and may leak into other tests causing conflicts or resulting into intermittent test failures. 
So generally it is preferable to explicitly cleanup records for tests that have `use_transactional_tests` set to `false`
Like we are doing here:
https://github.com/rails/rails/blob/d75508a73cea0dcbfa76f34083569294ceda7f79/activerecord/test/cases/autosave_association_test.rb#L937-L940

However often it is easy to overlook the fact that we are adding a test to a test class with `use_transactional_tests` disabled and it's easy to forget to add a cleanup statement. So ideally we should not be disabling `use_transactional_tests` unless absolutely necessary. 

In our case the whole `autosave_association_test.rb` file doesn't seem to need `use_transactional_tests` to be disabled apart from only one test:
https://github.com/rails/rails/blob/d75508a73cea0dcbfa76f34083569294ceda7f79/activerecord/test/cases/autosave_association_test.rb#L1177-L1178

The test has to disable `use_transactional_tests` otherwise it will fail on `mysql2`, but it doesn't mean we should disable it for every other test class. 

So this PR removes all unnecessary `self.use_transactional_tests = false` statements to avoid leaking created objects between tests and potentially causing flakey test failures. 
We still have one statement left:
https://github.com/rails/rails/blob/d75508a73cea0dcbfa76f34083569294ceda7f79/activerecord/test/cases/autosave_association_test.rb#L929
for the test mentioned above. But other ones seems to be unnecessary. 

Also the `test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index` test can be refactored to remove the need for `use_transactional_tests = false` but I'd prefer this to be done in a separate PR 