### PR TITLE
Fix `#scope_for_create` for belongs_to associations with CPK

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -34,7 +34,7 @@ module ActiveRecord
 
       private
         def scope_for_create
-          super.except!(klass.primary_key)
+          super.except!(*Array(klass.primary_key))
         end
 
         def find_target

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -35,7 +35,7 @@ require "models/cpk"
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
            :developers_projects, :computers, :authors, :author_addresses,
-           :essays, :posts, :tags, :taggings, :comments, :sponsors, :members, :nodes
+           :essays, :posts, :tags, :taggings, :comments, :sponsors, :members, :nodes, :cpk_books
 
   def test_belongs_to
     client = Client.find(3)
@@ -354,6 +354,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     apple    = citibank.build_firm("name" => "Apple")
     citibank.save
     assert_equal apple.id, citibank.firm_id
+  end
+
+  def test_building_the_belonging_object_for_composite_primary_key
+    cpk_book = cpk_books(:cpk_great_author_first_book)
+    order = cpk_book.build_order
+    cpk_book.save
+
+    _shop_id, id = order.id
+    assert_equal id, cpk_book.order_id
   end
 
   def test_building_the_belonging_object_with_implicit_sti_base_class


### PR DESCRIPTION
### Motivation / Background

`#scope_for_create` for singular associations removes the primary key from the scope so that we don't assign PK columns when building an association.

However, removing the primary key from the scope doesn't currently handle composite primary keys. This PR fixes that.

### Detail

This Pull Request changes `SingularAssociation#scope_for_create` to wrap `klass.primary_key` in an Array and then splat it, which will ensure we actually remove the keys from the hash.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
