### PR TITLE
Added documentation for `ActiveRecord::Relation#pick` [skip ci]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2256,6 +2256,25 @@ irb> assoc.unscope(:includes).pluck(:id)
 
 [`pluck`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck
 
+### `pick`
+
+[`pick`][] can be used to pick the value(s) from the named column(s) in the current relation. It accepts a list of column names as an argument and returns the first row of the specified column values ​​with corresponding data type.
+`pick` is an short-hand for `relation.limit(1).pluck(*column_names).first`, which is primarily useful when you already have a relation that is limited to one row.
+
+`pick` makes it possible to replace code like:
+
+```ruby
+Customer.where(id: 1).pluck(:id).first
+```
+
+with:
+
+```ruby
+Customer.where(id: 1).pick(:id)
+```
+
+[`pick`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pick
+
 ### `ids`
 
 [`ids`][] can be used to pluck all the IDs for the relation using the table's primary key.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is no explanation of `ActiveRecord::Relation#pick` in the guide.

### Detail

This Pull Request changes to add the documentation for `ActiveRecord::Relation#pick` to the guide.

### Additional information

- api url: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck
- edge guide url: https://edgeguides.rubyonrails.org/active_record_querying.html#pluck

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
