### PR TITLE
Stop appending preload links once the head is already 1kB

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Stop generating `Link preload` headers once it has reached 1KB.
+
+    Some proxies have trouble handling large headers, but more importantly preload links
+    have diminishing returns so it's preferable not to go overboard with them.
+
+    If tighter control is needed, it's recommended to disable automatic generation of preloads
+    and to generate them manually from the controller or from a middleware.
+
+    *Jean Boussier*
+
 *   `simple_format` helper now handles a `:sanitize_options` - any extra options you want appending to the sanitize.
 
     Before:

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -648,8 +648,8 @@ class AssetTagHelperTest < ActionView::TestCase
         stylesheet_link_tag("http://example.com/style.css?#{i}")
         javascript_include_tag("http://example.com/all.js?#{i}")
       end
-      lines = @response.headers["Link"].split("\n")
-      assert_equal 2, lines.size
+      links = @response.headers["Link"].count(",")
+      assert_equal 14, links
     end
   end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48402

Some HTTP client and proxies have a 4kiB header limit, but more importantly including preload links has diminishing returns so it's best to not go overboard

1kB worth of preload links should be plenty.

cc @nateberkopec 