### PR TITLE
Fix defect in Enumerable#many introduced in rails/rails@d862dff

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -93,8 +93,8 @@ module Enumerable
   def many?
     cnt = 0
     if block_given?
-      any? do |element, *args|
-        cnt += 1 if yield element, *args
+      any? do |*args|
+        cnt += 1 if yield(*args)
         cnt > 1
       end
     else

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -278,6 +278,7 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal false, GenericEnumerable.new([ 1, 2 ]).many? { |x| x > 1 }
     assert_equal true,  GenericEnumerable.new([ 1, 2, 2 ]).many? { |x| x > 1 }
     assert_equal true,  GenericEnumerable.new([ 1, 2, 3]).each_with_index.many? { |x, i| x == i + 1 }
+    assert_equal true,  GenericEnumerable.new([ [1, 2], [3, 4] ]).many? { |x| x.sum > 1 }
   end
 
   def test_many_iterates_only_on_what_is_needed


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/48411

### Motivation / Background

https://github.com/rails/rails/pull/46448 introduced a fix to `Enumerable#many?` to handle previous enumerator methods. This changed `many?` to yield `element, *args`. However, this causes problems in the case that an element of the enumerable is an array, as now the array is being destructured, leading to unexpected behaviour.

### Detail

It seems from the discussion in the previous PR that `element, *args` was introduced as an aid to readability. But the method will work fine just with `*args`, so this PR changes it to that.

### Additional information

Is there a way we could solve this but retain the differentiation between the enumerable element and the previous parameters? Because I agree it's more readable. I tried a few things but couldn't find something workable.

Does this need a changelog? It was released in 7.0.5 but I am not sure if it qualifies as a "minor" bug or not.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
