### PR TITLE
Force turbo reload on error.

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="turbo-visit-control" content="reload">
   <title>Action Controller: Exception caught</title>
   <style>
     body {


### PR DESCRIPTION
Turbo frames on turbo-rails 1.4 don't break out of the frame to load the error response from the DebugView middleware like they used to.  

It requires the turbo-visit-control meta set to reload or it fails silently.

### Here how it used to fail (expected):

![noisy_fail](https://github.com/rails/rails/assets/1518299/9e38f9dc-0cb3-41d9-84fa-e44c9da3837a)

### Here how it fails now:

![silent_fail](https://github.com/rails/rails/assets/1518299/6d90e4ac-3a57-42ff-b228-28dbb4323dcc)


This change would make more sense in the Turbo-Rails repo, but it would require making making DebugView configurable from  an initializer, which would not necessarily be trivial. We could have a yield block in the header and one in the body and pass a file path or html through Rack env, but that seems overkill when all we need here is a meta tag. 

Considering that's it's just a meta tag, in dev and on crash only, the blast radius is pretty small and since Turbo-Rails now comes default, I figured it would make sense. If you don't agree I can look into making DebugView extendable. 



### Motivation / Background

I like to have failure be obvious and loud in dev. I was tricked into thinking something was working when the failure mode changed after upgrading. This brings back the loud failure.

### Detail

I made a minimal repro [here](https://gist.github.com/JoeDupuis/74eec3924b0fbc8ca4c1030b8a38c9d9) 
I had to split the inline gemfile to separate files, for some reason it wasn't working when using capybara.
### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. 
* [x] CHANGELOG N/A
