### PR TITLE
Add tests around has_one changing the target and validators

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -92,6 +92,10 @@ module ActiveRecord
           replace(record, false)
         end
 
+        def replace_keys(record, force: false)
+          # Has one association doesn't have foreign keys to replace.
+        end
+
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            set_new_record(record)
+            replace_keys(record, force: true)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/48330

When replacing the has_one target, it seems more correct to first delete the old record, so that if the associated model has a uniqueness validator, it won't fail.

Both the delete and the insert are in a single transaction, so if the new record fail to be saved, the transaction will be rolled back, which seems correct.

If `dependent: :destroy` isn't set, Active Record will try to orphan the record, which may or may not be valid depending on the schema and validators.

Co-Authored-By: @zzak

FYI: @nov, @yahonda @adrianna-chang-shopify 