### PR TITLE
Bump i18n to fix actionview failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
     hiredis (0.6.3)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -130,8 +130,8 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_raise_arg_overrides_raise_config_option
     ActionView::Helpers::TranslationHelper.raise_on_missing_translations = true
 
-    expected = "translation missing: en.translations.missing"
-    assert_equal expected, translate(:"translations.missing", raise: false)
+    expected = /translation missing: en.translations.missing/i
+    assert_match expected, translate(:"translations.missing", raise: false)
   ensure
     ActionView::Helpers::TranslationHelper.raise_on_missing_translations = false
   end


### PR DESCRIPTION
The most recent [build](https://buildkite.com/rails/rails/builds/97003) of 7-0-stable is still failing due to the i18n issue.