### PR TITLE
Raise if `exec_insert` and `insert` are used with an unsupported `returning` value

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -633,16 +633,18 @@ module ActiveRecord
           end
         end
 
-        def sql_for_insert(sql, _pk, binds, _returning)
-          [sql, binds]
+        def sql_for_insert(sql, _pk, binds, returning)
+          return [sql, binds] if supports_insert_returning? || returning.nil? || returning.empty?
+
+          raise ArgumentError, "Current adapter does not support returning determined columns from an insert statement"
         end
 
         def last_inserted_id(result)
           single_value_from_rows(result.rows)
         end
 
-        def returning_column_values(result)
-          [last_inserted_id(result)]
+        def returning_column_values(_result)
+          []
         end
 
         def single_value_from_rows(rows)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -174,7 +174,7 @@ module ActiveRecord
           end
 
           def returning_column_values(result)
-            result.rows.first
+            Array(result.rows.first)
           end
 
           def suppress_composite_primary_key(pk)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -21,8 +21,10 @@ module ActiveRecord
           ActiveRecord::Result.new(result.fields, result.to_a)
         end
 
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           sql = transform_query(sql)
+          # does nothing apart from validating `returning` for Trilogy
+          sql, binds = sql_for_insert(sql, pk, binds, returning)
           check_if_write_query(sql)
           mark_transaction_written_if_write(sql)
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1239,13 +1239,14 @@ module ActiveRecord
       attribute_names = attributes_for_create(attribute_names)
 
       returning_columns = self.class._returning_columns_for_insert
+      supports_returning = self.class.connection.supports_insert_returning?
 
       returning_values = self.class._insert_record(
         attributes_with_values(attribute_names),
-        returning_columns
+        supports_returning ? returning_columns : nil
       )
 
-      returning_columns.zip(returning_values).each do |column, value|
+      returning_columns.zip(Array(returning_values)).each do |column, value|
         _write_attribute(column, value) if !_read_attribute(column)
       end if returning_values
 

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/account"
 
 class DatabaseStatementsTest < ActiveRecord::TestCase
   def setup
@@ -20,6 +21,55 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
 
   def test_create_should_return_the_inserted_id
     assert_not_nil return_the_inserted_id(method: :create)
+  end
+
+  if current_adapter?(:PostgreSQLAdapter)
+    def test_exec_insert_returns_result_with_values_for_returning_columns
+      sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+      result = @connection.exec_insert(sql, returning: ["firm_id", "credit_limit", "status"])
+      returning_values = result.first.values_at("firm_id", "credit_limit")
+
+      assert_equal([42, 5000], returning_values)
+    end
+
+    def test_insert_returns_values_for_returning_columns
+      sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+      result = @connection.insert(sql, returning: ["firm_id", "credit_limit", "status"])
+
+      assert_equal([42, 5000, nil], result)
+    end
+  else
+    def test_exec_insert_raises_when_called_with_multiple_returning_when_not_supported
+      sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+      expected_message = "Current adapter does not support returning determined columns from an insert statement"
+
+      assert_raises ArgumentError, match: expected_message do
+        @connection.exec_insert(sql, returning: ["firm_id", "credit_limit"])
+      end
+    end
+
+    def test_insert_raises_when_called_with_multiple_returning_when_not_supported
+      sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+      expected_message = "Current adapter does not support returning determined columns from an insert statement"
+
+      assert_raises ArgumentError, match: expected_message do
+        @connection.insert(sql, returning: ["firm_id", "credit_limit"])
+      end
+    end
+  end
+
+  def test_insert_with_nil_returning_returns_last_insert_id_column_value
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    inserted_id = @connection.insert(sql, returning: nil)
+
+    assert_not_nil(inserted_id)
+    assert_equal(5000, Account.find(inserted_id).credit_limit)
+  end
+
+  def test_insert_with_empty_returning_returns_empty_array
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    result = @connection.insert(sql, returning: [])
+    assert_empty(result)
   end
 
   private


### PR DESCRIPTION
`exec_insert` and `insert` methods accept a `returning` argument, however only PostgreSQL adapter fully supports it. This commit adds a validation that raises in case if value passed as `returning` is not supported by the adapter.

Since now Rails doesn't allow using `returning` argument if adapter doesn't support RETURNING statement Rails itself as a caller of this method should explicitly pass `nil` for non-postgresql adapters to preserve the default return value which is the last inserted id


### Implementation details

Since `insert` method eventually calls into `exec_insert` and `exec_insert` calls into `sql_for_insert`  the validation only exists in the `sql_for_insert` method
