### PR TITLE
Revert "Merge pull request #48406 from rails/revert-46790-singular-as…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,3 @@
-*   Fix assignment into an `has_one` relationship deleting the old record before the new one is validated.
-
-    *Jean Boussier*
-
 *   Fix where on association with has_one/has_many polymorphic relations.
 
     Before:

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -87,6 +87,10 @@ module ActiveRecord
           replace(record, false)
         end
 
+        def replace_keys(record, force: false)
+          # Has one association doesn't have foreign keys to replace.
+        end
+
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            set_new_record(record)
+            replace_keys(record, force: true)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end


### PR DESCRIPTION
…sociation-refactor"

This reverts commit 66c967df4533ea8cdd2322b7c6d0b6a022b4ef48.

This commit was identified to be causing a behavior change, but the change was actually introduced in [another commit][1] (and the new behavior was [determined][2] to be desired anyway).

[1]: https://github.com/rails/rails/commit/9103b8580e26d04496027f387df495d752a05f52
[2]: https://github.com/rails/rails/commit/6be41aded8c067b2b4af3b05193e551f126fb0e3