### PR TITLE
[6-1-stable] Fix rubocop workflow

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,24 +5,18 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: rubocop
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle config set without 'default doc job cable storage ujs test db'
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
+        cache-version: 6-1-stable
+
     - name: Run RuboCop
       run: bundle exec rubocop --parallel

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -204,9 +204,6 @@ Lint/ErbNewArguments:
 Lint/RequireParentheses:
   Enabled: true
 
-Lint/ShadowingOuterLocalVariable:
-  Enabled: true
-
 Lint/RedundantStringCoercion:
   Enabled: true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    matrix (0.4.2)
     memoist (0.16.2)
     method_source (1.0.0)
     mini_magick (4.11.0)
@@ -340,6 +339,8 @@ GEM
     mustache (1.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    net-http (0.3.2)
+      uri
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     net-imap (0.2.3)
@@ -513,6 +514,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    uri (0.10.0.2)
     useragent (0.16.10)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -566,7 +568,6 @@ DEPENDENCIES
   dalli
   delayed_job
   delayed_job_active_record
-  digest (~> 3.1.0.pre)
   google-cloud-storage (~> 1.11)
   hiredis
   image_processing (~> 1.2)
@@ -574,15 +575,12 @@ DEPENDENCIES
   kindlerb (~> 1.2.0)
   libxml-ruby
   listen (~> 3.3)
-  matrix
   minitest (~> 5.15.0)
   minitest-bisect
   minitest-reporters
   minitest-retry
   mysql2 (~> 0.5)!
-  net-imap
-  net-pop
-  net-smtp
+  net-http
   nokogiri (>= 1.8.1)
   pg (>= 1.3.0.rc1)
   psych (~> 3.0)


### PR DESCRIPTION
This PR fixes a couple things:

* Backports ba97e9f to get rubocop green
* Fixes setup-ruby caching of bundler
* Updates the Gemfile.lock to work with Ruby 2.7 and Bundler 2.3.17 (bundled with)

The motivation here is that when this job fails, it can be surprising to contributors who want to backport a change to this stable branch and it fails. This change could also make a positive impact in the event of a release of this stable branch, for example see also (c9bacd2, 10742367) where there is still an effort to make stable branches green.

You can also see that the bundler cache for the rubocop workflow never worked, as there are no caches:
https://github.com/rails/rails/actions/caches?query=branch%3A6-1-stable++

By specifying `cache-version` we also ensure that we don't accidentally pick up the bundler cache from another stable branch. For example, if you look at the most [recent caches](https://github.com/rails/rails/actions/caches), you will see the only difference is the ruby version number. (`setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.1.4-wd-/home/runner/work/rails/rails-with--without-default doc job cable storage ujs test db-Gemfile.lock-<md5sha>`).
So we may want to backport a similar change to `7-0-stable`.