### PR TITLE
[7-0-stable] Fix flakey AS::EventedFileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -43,6 +43,10 @@ module ActiveSupport
       ObjectSpace.define_finalizer(self, @core.finalizer)
     end
 
+    def inspect
+      "#<ActiveSupport::EventedFileUpdateChecker:#{object_id} @files=#{@core.files.to_a.inspect}"
+    end
+
     def updated?
       if @core.restart?
         @core.thread_safely(&:restart)
@@ -66,7 +70,7 @@ module ActiveSupport
     end
 
     class Core
-      attr_reader :updated
+      attr_reader :updated, :files
 
       def initialize(files, dirs)
         @files = files.map { |file| Pathname(file).expand_path }.to_set
@@ -84,6 +88,10 @@ module ActiveSupport
         @mutex = Mutex.new
 
         start
+        # inotify / FSEvents file descriptors are inherited on fork, so
+        # we need to reopen them otherwise only the parent or the child
+        # will be notified.
+        # FIXME: this callback is keeping a reference on the instance
         @after_fork = ActiveSupport::ForkTracker.after_fork { start }
       end
 
@@ -105,6 +113,11 @@ module ActiveSupport
         @dtw, @missing = [*@dtw, *@missing].partition(&:exist?)
         @listener = @dtw.any? ? Listen.to(*@dtw, &method(:changed)) : nil
         @listener&.start
+
+        # Wait for the listener to be ready to avoid race conditions
+        # Unfortunately this isn't quite enough on macOS because the Darwin backend
+        # has an extra private thread we can't wait on.
+        @listener&.wait_for_state(:processing_events)
       end
 
       def stop

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -106,10 +106,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       [WeakRef.new(checker), Thread.list - threads_before_checker]
     end.value
 
-    # Calling `GC.start` 4 times should trigger a full GC run.
-    4.times do
-      GC.start
-    end
+    GC.start
+    listener_threads.each { |t| t.join(1) }
 
     assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
     assert_empty Thread.list & listener_threads


### PR DESCRIPTION
This catches the `7-0-stable` branch up on `AS::EventedFileUpdateChecker` flakiness tests fixes.

* #45061
* #47774
* #47748

Will also make a similar PR for `6-1-stable` since [that build](https://buildkite.com/rails/rails/builds/97030#01889d9b-37bd-4c16-8eda-609ff559509d/1096-1363) is also failing for the same reasons.