### PR TITLE
Remove custom `exec_insert` method from Trilogy adapter

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -103,6 +103,7 @@ module ActiveRecord
     autoload :Promise
     autoload :Relation
     autoload :Result
+    autoload :TrilogyResult
     autoload :StatementCache
     autoload :TableMetadata
     autoload :Type

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1198,8 +1198,13 @@ module ActiveRecord
         #
         # This is an internal hook to make possible connection adapters to build
         # custom result objects with connection-specific data.
-        def build_result(columns:, rows:, column_types: {})
-          ActiveRecord::Result.new(columns, rows, column_types)
+        def build_result(columns:, rows:, column_types: {}, raw_result: nil)
+          result_class.new(columns, rows, column_types, raw_result: raw_result)
+        end
+
+        # Abstraction to allow adapter-specific result classes with different capabilities.
+        def result_class
+          ActiveRecord::Result
         end
 
         # Perform any necessary initialization upon the newly-established

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -18,15 +18,7 @@ module ActiveRecord
           mark_transaction_written_if_write(sql)
 
           result = raw_execute(sql, name, async: async)
-          ActiveRecord::Result.new(result.fields, result.to_a)
-        end
-
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
-
-          raw_execute(to_sql(sql, binds), name)
+          build_result(columns: result.fields, rows: result.to_a, raw_result: result)
         end
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
@@ -52,8 +44,8 @@ module ActiveRecord
             end
           end
 
-          def last_inserted_id(result)
-            result.last_insert_id
+          def last_inserted_id(ar_result)
+            ar_result.last_insert_id
           end
 
           def sync_timezone_changes(conn)

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -157,6 +157,10 @@ module ActiveRecord
       end
 
       private
+        def result_class
+          ActiveRecord::TrilogyResult
+        end
+
         def text_type?(type)
           TYPE_MAP.lookup(type).is_a?(Type::String) || TYPE_MAP.lookup(type).is_a?(Type::Text)
         end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -46,11 +46,12 @@ module ActiveRecord
       end
     end
 
-    def initialize(columns, rows, column_types = {})
+    def initialize(columns, rows, column_types = {}, raw_result: nil)
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
       @column_types = column_types
+      @raw_result   = raw_result
     end
 
     # Returns true if this result set includes the column named +name+
@@ -192,7 +193,7 @@ module ActiveRecord
           end
       end
 
-      EMPTY = new([].freeze, [].freeze, {}.freeze).freeze
+      EMPTY = new([].freeze, [].freeze, {}.freeze, raw_result: nil).freeze
       private_constant :EMPTY
 
       EMPTY_ASYNC = FutureResult::Complete.new(EMPTY).freeze

--- a/activerecord/lib/active_record/trilogy_result.rb
+++ b/activerecord/lib/active_record/trilogy_result.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class TrilogyResult < Result
+    def last_insert_id
+      @raw_result.last_insert_id
+    end
+  end
+end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -122,7 +122,7 @@ module ActiveRecord
 
     def test_exec_query_returns_an_empty_result
       result = @connection.exec_query "INSERT INTO subscribers(nick) VALUES('me')"
-      assert_instance_of(ActiveRecord::Result, result)
+      assert_kind_of(ActiveRecord::Result, result)
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -48,7 +48,7 @@ module AsynchronousQueriesSharedTests
 
     @connection.select_all "SELECT * FROM posts"
     result = @connection.select_all "SELECT * FROM posts", async: true
-    assert_equal ActiveRecord::Result, result.class
+    assert_kind_of ActiveRecord::Result, result
   ensure
     ActiveRecord::Base.asynchronous_queries_tracker.finalize_session
     @connection.disable_query_cache!


### PR DESCRIPTION
`Trilogy` adapter has a custom implementation of `exec_insert` method which is a complete duplication of the abstract `exec_insert` with the **only difference**:  Trilogy's exec insert used to return an unwrapped result while abstract implementation returns `ActiveRecord::Result`. Though we believe it goes against the method signature as trilogy result and `AR::Result` do not implement the same interface. Changing the result type to be Active Record result causes only one issue - `last_insert_method` can not fetch the last inserted id value from `ActiveRecord::Result` as it doesn't provide such value.  In order to address it we are introducing a new `ActiveRecord::TrilogyResult` class which is a child class of `Result` with the only difference - it implements `last_insert_id` to be used by the `last_inserted_id` method. The `Result` itself had to be extended to store the reference to the `raw_result` 

### Alternative solutions for `last_inserted_id`

1. Instead of introducing new `TrilogyResult` class we could have added `last_inserted_id` method directly to the `Result` but it doesn't seem correct as not every adapter has such concept as `last_inserted_id`. For example being able to call `last_inserted_id` when using `PostgresqlAdapter` won't make much sense. 
2. We could have done the same what `mysql2` adapter does - reach into `@connection` to get the value:
https://github.com/rails/rails/blob/2a904bf58828e79c10e7838cb5a7550f8a1b5581/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb#L69 as Trilogy raw connection also provides `last_insert_id` method. Though it feels much lower-level to reach into the raw connection and relying on `Result` seems to be a much better abstraction