### PR TITLE
[6-1-stable] Fix flakey AS::EventedFileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -45,6 +45,10 @@ module ActiveSupport
       ObjectSpace.define_finalizer(self, @core.finalizer)
     end
 
+    def inspect
+      "#<ActiveSupport::EventedFileUpdateChecker:#{object_id} @files=#{@core.files.to_a.inspect}"
+    end
+
     def updated?
       if @core.restart?
         @core.thread_safely(&:restart)
@@ -68,7 +72,7 @@ module ActiveSupport
     end
 
     class Core
-      attr_reader :updated
+      attr_reader :updated, :files
 
       def initialize(files, dirs)
         @files = files.map { |file| Pathname(file).expand_path }.to_set
@@ -86,6 +90,10 @@ module ActiveSupport
         @mutex = Mutex.new
 
         start
+        # inotify / FSEvents file descriptors are inherited on fork, so
+        # we need to reopen them otherwise only the parent or the child
+        # will be notified.
+        # FIXME: this callback is keeping a reference on the instance
         @after_fork = ActiveSupport::ForkTracker.after_fork { start }
       end
 
@@ -107,6 +115,11 @@ module ActiveSupport
         @dtw, @missing = [*@dtw, *@missing].partition(&:exist?)
         @listener = @dtw.any? ? Listen.to(*@dtw, &method(:changed)) : nil
         @listener&.start
+
+        # Wait for the listener to be ready to avoid race conditions
+        # Unfortunately this isn't quite enough on macOS because the Darwin backend
+        # has an extra private thread we can't wait on.
+        @listener&.wait_for_state(:processing_events)
       end
 
       def stop

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -75,14 +75,23 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   test "can be garbage collected" do
-    previous_threads = Thread.list
-    checker_ref = WeakRef.new(ActiveSupport::EventedFileUpdateChecker.new([], tmpdir => ".rb") { })
-    listener_threads = Thread.list - previous_threads
+    # Use a separate thread to isolate objects and ensure they will be garbage collected.
+    checker_ref, listener_threads = Thread.new do
+      threads_before_checker = Thread.list
+      checker = ActiveSupport::EventedFileUpdateChecker.new([], tmpdir => ".rb") { }
 
-    wait # Wait for listener thread to start processing events.
-    GC.start
+      # Wait for listener thread to start processing events.
+      wait
 
-    assert_not_predicate checker_ref, :weakref_alive?
+      [WeakRef.new(checker), Thread.list - threads_before_checker]
+    end.value
+
+    # Calling `GC.start` 4 times should trigger a full GC run.
+    4.times do
+      GC.start
+    end
+
+    assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
     assert_empty Thread.list & listener_threads
   end
 

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -26,7 +26,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def wait
-    sleep 1
+    sleep 0.5
   end
 
   def touch(files)
@@ -43,11 +43,16 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     assert_not_predicate checker, :updated?
 
     # Pipes used for flow control across fork.
-    boot_reader,  boot_writer  = IO.pipe
+    boot_reader, boot_writer = IO.pipe
     touch_reader, touch_writer = IO.pipe
+    result_reader, result_writer = IO.pipe
 
     pid = fork do
       assert_not_predicate checker, :updated?
+
+      # The listen gem start multiple background threads that need to reach a ready state.
+      # Unfortunately, it doesn't look like there is a clean way to block until they are ready.
+      wait
 
       # Fork is booted, ready for file to be touched
       # notify parent process.
@@ -58,9 +63,16 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       IO.select([touch_reader])
 
       assert_predicate checker, :updated?
+    rescue Exception => ex
+      result_writer.write("#{ex.class.name}: #{ex.message}")
+      raise
+    ensure
+      result_writer.close
     end
 
     assert pid
+
+    result_writer.close
 
     # Wait for fork to be booted before touching files.
     IO.select([boot_reader])
@@ -72,6 +84,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     assert_predicate checker, :updated?
 
     Process.wait(pid)
+
+    assert_equal "", result_reader.read
   end
 
   test "can be garbage collected" do
@@ -86,10 +100,8 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
       [WeakRef.new(checker), Thread.list - threads_before_checker]
     end.value
 
-    # Calling `GC.start` 4 times should trigger a full GC run.
-    4.times do
-      GC.start
-    end
+    GC.start
+    listener_threads.each { |t| t.join(1) }
 
     assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
     assert_empty Thread.list & listener_threads


### PR DESCRIPTION
This catches `6-1-stable` branch up on `AS::EventedFileUpdateChecker` flakiness patches.

* #44220

Plus:

* #45061
* #47774
* #47748

Backported from #48427