### PR TITLE
[7-0-stable] Backport flakey fix for EncodedKeyCacheBehavior

### DIFF
--- a/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/encoded_key_cache_behavior.rb
@@ -6,7 +6,7 @@
 module EncodedKeyCacheBehavior
   Encoding.list.each do |encoding|
     define_method "test_#{encoding.name.underscore}_encoded_values" do
-      key = (+"foo").force_encoding(encoding)
+      key = (+"foo_#{encoding.name.underscore}").force_encoding(encoding)
       assert @cache.write(key, "1", raw: true)
       assert_equal "1", @cache.read(key, raw: true)
       assert_equal "1", @cache.fetch(key, raw: true)


### PR DESCRIPTION
A recent [build failed](https://buildkite.com/rails/rails/builds/97039#01889f1c-a6b7-4a6d-8182-a2530e75abe6/1186-1197) due to this, which looks like the same reason #46187 was merged to main.