### PR TITLE
Add `ActiveRecord.reload_attributes`

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -430,7 +430,11 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert # :nodoc:
-        @_returning_columns_for_insert ||= columns.filter_map do |c|
+        @_returning_columns_for_insert ||= _default_returning_columns_for_insert | _reload_attributes_on_create
+      end
+
+      def _default_returning_columns_for_insert # :nodoc:
+        @_default_returning_columns_for_insert ||= columns.filter_map do |c|
           c.name if connection.return_value_after_insert?(c)
         end
       end
@@ -560,6 +564,7 @@ module ActiveRecord
 
         def reload_schema_from_cache(recursive = true)
           @_returning_columns_for_insert = nil
+          @_default_returning_columns_for_insert = nil
           @arel_table = nil
           @column_names = nil
           @symbol_column_to_string_name_hash = nil

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Default < ActiveRecord::Base
+  reload_attributes :random_number_plus_two
 end

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -2,21 +2,40 @@
 
 ActiveRecord::Schema.define do
   create_table :defaults, force: true do |t|
-      t.integer :random_number, default: -> { "ABS(RANDOM())" }
-      t.string :ruby_on_rails, default: -> { "('Ruby ' || 'on ' || 'Rails')" }
-      t.date :modified_date, default: -> { "CURRENT_DATE" }
-      t.date :modified_date_function, default: -> { "DATE('now')" }
-      t.date :fixed_date, default: "2004-01-01"
-      t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
-      t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
-      t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
-      t.datetime :modified_time_function, default: -> { "DATETIME('now')" }
-      t.datetime :fixed_time, default: "2004-01-01 00:00:00.000000-00"
-      t.column :char1, "char(1)", default: "Y"
-      t.string :char2, limit: 50, default: "a varchar field"
-      t.text :char3, default: "a text field"
-      t.text :multiline_default, default: "--- []
+    t.integer :random_number, default: -> { "ABS(RANDOM())" }
+    t.integer :random_number_plus_two
+    t.string :ruby_on_rails, default: -> { "('Ruby ' || 'on ' || 'Rails')" }
+    t.date :modified_date, default: -> { "CURRENT_DATE" }
+    t.date :modified_date_function, default: -> { "DATE('now')" }
+    t.date :fixed_date, default: "2004-01-01"
+    t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_function, default: -> { "DATETIME('now')" }
+    t.datetime :fixed_time, default: "2004-01-01 00:00:00.000000-00"
+    t.column :char1, "char(1)", default: "Y"
+    t.string :char2, limit: 50, default: "a varchar field"
+    t.text :char3, default: "a text field"
+    t.text :multiline_default, default: "--- []
 
 "
-    end
+  end
+
+  execute <<_SQL
+    CREATE TRIGGER IF NOT EXISTS insert_defaults_trigger
+    AFTER INSERT ON defaults
+    BEGIN
+      UPDATE defaults
+      SET random_number_plus_two = NEW.random_number + 2
+      WHERE id = NEW.rowid;
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS update_defaults_trigger
+    AFTER UPDATE ON defaults
+    BEGIN
+      UPDATE defaults
+      SET random_number_plus_two = NEW.random_number + 2
+      WHERE id = NEW.rowid;
+    END;
+_SQL
 end


### PR DESCRIPTION
### Motivation / Background

PR #48241 detects when certain auto-populated columns should be appended to a `RETURNING` clause. However, in certain cases it may be necessary for the application to explicitly specify additional columns. e.g. Database Triggers.

This feature was discussed in #45736 and briefly with Matthew Draper in the Discord channel.

### Detail

This PR adds the ability for the application to specify those attributes with the `reload_attributes` class method.

### Additional information

Additionally a very minor edge case was handled. The application could try to assign a value to a virtual column which essentially results in a no-op. The values persisted in the database would be the same regardless. However, in doing so the value from `RETURNING` wasn't being reflected on the instance attributes after create. See the newly added test and removal of the `_read_attribute` check.

Performing this nil check with `_read_attribute` will also not be compatible when `RETURNING` is implemented on `UPDATE`.  As it is expected that the instance's attributes will be prepopulated with non-nil values. (See related PR here: https://github.com/rails/rails/pull/48628)

---

Paging: @nvasilevski