### PR TITLE
Backport: Fix the pg 1.5.0 deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,7 +372,7 @@ GEM
     parser (3.0.1.1)
       ast (~> 2.4.1)
     path_expander (1.1.0)
-    pg (1.3.0.rc1)
+    pg (1.5.3)
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -880,7 +880,7 @@ module ActiveRecord
               PG::TextDecoder::TimestampUtc :
               PG::TextDecoder::TimestampWithoutTimeZone
 
-            @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h)
+            @timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h)
             @connection.type_map_for_results.add_coder(@timestamp_decoder)
             @default_timezone = ActiveRecord::Base.default_timezone
           end


### PR DESCRIPTION
### Motivation / Background

It can remove hundreds of lines of deprecation warning backtraces from spamming the console or the logs.  It maintains forward compatibility with the `pg` gem, which will eventually require the new behavior.

### Detail

It's very small: just a single `**` for some keyword args.

### Additional information

* See the original issue for more context: #48046
* Backported PR: #48048 (from tiramizoo/pg-1-5-warning)

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
