### PR TITLE
Add better TypeError when assigning CPK

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -31,6 +31,7 @@ module ActiveRecord
       # Sets the primary key column's value.
       def id=(value)
         if self.class.composite_primary_key?
+          raise TypeError, "Expected value matching #{self.class.primary_key.inspect}, got #{value.inspect}." unless value.is_a?(Enumerable)
           @primary_key.zip(value) { |attr, value| _write_attribute(attr, value) }
         else
           _write_attribute(@primary_key, value)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -426,9 +426,11 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   def test_assigning_a_non_array_value_to_model_with_composite_primary_key_raises
     book = Cpk::Book.new
 
-    assert_raises(TypeError) do
+    error = assert_raises(TypeError) do
       book.id = 1
     end
+
+    assert_equal("Expected value matching [\"author_id\", \"number\"], got 1.", error.message)
   end
 
   def test_id_was_composite


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current error that gets raised when assigning a singular value to a model with a composite primary key looks a little odd to me. Specifically, it looks a bit like rails is crashing because `zip` inside of `id=` fails.

### Detail

This Pull Request changes the logic in assigning CPK IDs to check the type before attempting to zip and assign. This cleans up the stack trace and informs the developer of what the problem is with a little more context.

Before:
```
TypeError: wrong argument type Integer (must respond to :each)
    ~/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:34:in `zip'
    ~/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:34:in `id='
   ~/app/test/modes/my_test.rb:23:in `test_some_test'
```
After:
```
TypeError: Expected value matching ["shop_id", "id"], got 1.
    ~/rails/activerecord/lib/active_record/attribute_methods/primary_key.rb:34:in `id='
   ~/app/test/modes/my_test.rb:23:in `test_some_test'
```

### Additional information

There's a subtle difference in behaviour here where zip works with _any_ object that responds to `each`, whereas I'm now checking if the object includes `Enumerable`. I could instead check for `responds_to?(:each)`, but I believe it is slower, and we don't get much out of it.

We could also try doing `Array(value)` which would cast the assigned value to an array before assignment, but there already seems to be a contract in place where `TypeError` should be raised. This makes sense because partial assignment of ID columns isn't preferable.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
