### PR TITLE
Fix duplicate Content-Type header with Rack 2

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -108,7 +108,7 @@ module ActionDispatch
       end
 
       def try_files(filepath, content_type, accept_encoding:)
-        headers = { "content-type" => content_type }
+        headers = { Rack::CONTENT_TYPE => content_type }
 
         if compressible? content_type
           try_precompressed_files filepath, headers, accept_encoding: accept_encoding

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -199,6 +199,18 @@ module StaticTests
     assert_equal file_name, env["PATH_INFO"]
   end
 
+  def test_only_set_one_content_type
+    file_name = "/gzip/foo.zoo"
+    gzip_env = { "PATH_INFO" => file_name, "HTTP_ACCEPT_ENCODING" => "gzip", "REQUEST_METHOD" => "GET" }
+    response = @app.call(gzip_env)
+
+    env = { "PATH_INFO" => file_name, "REQUEST_METHOD" => "GET" }
+    default_response = @app.call(env)
+
+    assert_equal 1, response[1].slice("Content-Type", "content-type").size
+    assert_equal 1, default_response[1].slice("Content-Type", "content-type").size
+  end
+
   def test_serves_gzip_with_proper_content_type_fallback
     file_name = "/gzip/foo.zoo"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")


### PR DESCRIPTION
### Motivation / Background

Fixes #48225

Previously, `ActionDispatch::Static` would always merge a "content-type"
header into the headers returned from `Rack::Files`. However, this would
potentially lead to both a "Content-Type" header and a "content-type"
header when using Rack 2.

### Detail

This commit fixes the issue by using `Rack::CONTENT_TYPE` to determine
which version of the header to set in `ActionDispatch::Static`. In both
versions of Rack it will use the same version of the header as
`Rack::Files`.

The tests added have to use `@app.call` instead of
`get()`/`Rack::MockRequest` because `Rack::Response` actually does the
correct thing already by using `Rack::Util::HeaderHash` so it covers up
the issue in tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
