### PR TITLE
Fix ActiveRecord batching over composite primary keys

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -343,7 +343,9 @@ module ActiveRecord
         where_clause = predicate_builder[first_clause_column, first_clause_value, operator]
 
         cursor_positions.reverse_each do |column_name, value, operator|
-          where_clause = predicate_builder[column_name, value, operator].and(where_clause)
+          where_clause = predicate_builder[column_name, value, operator == :lteq ? :lt : :gt].or(
+            predicate_builder[column_name, value, :eq].and(where_clause)
+          )
         end
 
         relation.where(where_clause)


### PR DESCRIPTION
Follow up to #48268.

The formula for iterating using several columns:

If `(a, b)` is the current tuple for composite primary key and we iterate in ascending order, then the SQL conditions to get the *following tuple(s)* (lets name it `(x, y)`) is calculated via a formula:
```
(x, y) > (a, b) iff x > a OR (x = a AND y > b)
```

Similar formula when start from some tuple:
```
(x, y) >= (a, b) iff x > a OR (x = a AND y >= b)
``` 

The referenced PR lost the logic (it currently uses incorrect formula of `x >= a AND y > b`) from the PR, which introduced cpk batching (https://github.com/rails/rails/pull/47901) -https://github.com/rails/rails/pull/48268/files#diff-8facabeda611c44c59470e0f632a5805f152e40ec63ed7a75c76896e783ddb5dL307-L308 

I also updated tests to be more robust. 

cc @nvasilevski @eileencodes 