### PR TITLE
Add note about running tests at a specific line

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -396,6 +396,15 @@ $ cd actionmailer
 $ bin/test test/mail_layout_test.rb -n test_explicit_class_layout
 ```
 
+#### For a Specific Line
+
+Figuring out the name is not always easy, but if you know the line number your test starts at, this option is for you:
+
+```bash
+$ cd railties
+$ bin/test test/application/asset_debugging_test.rb:69
+```
+
 #### Running Tests with a Specific Seed
 
 Test execution is randomized with a randomization seed. If you are experiencing random


### PR DESCRIPTION
This was something I forgot over the years, and yet here we are.

While it is covered in the [testing guide](https://github.com/rails/rails/blob/18acbe8948e04088a3116ed3eb5df05ce72f0b20/guides/source/testing.md?plain=1#L92), I'm often referring to this guide when working on the framework.

Thanks to whoever pointed this out to me btw, I'm sorry I lost track of the original message.