### PR TITLE
Rack spec requires mutable headers

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -462,7 +462,6 @@ module ActionDispatch # :nodoc:
       # our last chance.
       commit! unless committed?
 
-      @headers.freeze
       @request.commit_cookie_jar! unless committed?
     end
 

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -86,36 +86,6 @@ module ActionController
         @response.stream.write "omg"
         assert_nil @response.headers["Content-Length"]
       end
-
-      def test_headers_cannot_be_written_after_web_server_reads
-        @response.stream.write "omg"
-        latch = Concurrent::CountDownLatch.new
-
-        t = Thread.new {
-          @response.each do
-            latch.count_down
-          end
-        }
-
-        latch.wait
-        assert_predicate @response.headers, :frozen?
-        assert_raises(FrozenError) do
-          @response.headers["Content-Length"] = "zomg"
-        end
-
-        @response.stream.close
-        t.join
-      end
-
-      def test_headers_cannot_be_written_after_close
-        @response.stream.close
-        # we can add data until it's actually written, which happens on `each`
-        @response.each { |x| }
-
-        assert_raises(FrozenError) do
-          @response.headers["Content-Length"] = "zomg"
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
[The rack spec requires the headers to be an unfrozen hash. ](https://github.com/rack/rack/blob/c8e98221830a0b972b1dc19f3b6784f65197f444/SPEC.rdoc?plain=1#L240)

[Rack::ETag was  making a copy of the headers](https://github.com/rack/rack/blob/2-2-stable/lib/rack/etag.rb#L29), so the freeze was not effective anyway.

Plus we are freezing the hash too early, preventing middlewares from modifying it. It causes crash with gems like rack-livereload. I started having crashes on some pages (like the internal http://localhost:3000/rails/info/routes) because of rack-livereload hitting the frozen hash after the rack 3 upgrade.


Also we're not consistent with the protection. We're not preventing users from adding cookies. The cookie jar is already flushed, therefore it doesn't try to change the headers and never triggers the frozen hash error.

So I believe we should just get rid of (freezing) it.

### Motivation / Background

Had some crash with Rack-livereload and tracked it down to Rails not following the Rack 3.0 spec.

### Additional information

Alternatively, we could keep everything frozen and make a copy ourselve before returning it (to the first middleware). That way we'd keep the protection for the rails part of the request lifecycle while following the Rack spec.

Since we're not protecting for cookies and sessions anyway, I don't think it's worth it. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
