### PR TITLE
Bounce emails can be sent with `deliver_now`

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `bounce_now_with` to send the bounce email without going through a mailer queue.
+
+    *Ronan Limon Duparcmeur*
+
 *   Support configured primary key types in generated migrations.
 
     *Nishiki Liu*

--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -101,11 +101,16 @@ module ActionMailbox
       inbound_email.delivered? || inbound_email.bounced?
     end
 
-
     # Enqueues the given +message+ for delivery and changes the inbound email's status to +:bounced+.
     def bounce_with(message)
       inbound_email.bounced!
       message.deliver_later
+    end
+
+    # Immediately sends the given +message+ and changes the inbound email's status to +:bounced+.
+    def bounce_now_with(message)
+      inbound_email.bounced!
+      message.deliver_now
     end
 
     private

--- a/actionmailbox/test/unit/mailbox/bouncing_test.rb
+++ b/actionmailbox/test/unit/mailbox/bouncing_test.rb
@@ -8,6 +8,12 @@ class BouncingWithReplyMailbox < ActionMailbox::Base
   end
 end
 
+class BouncingWithImmediateReplyMailbox < ActionMailbox::Base
+  def process
+    bounce_now_with BounceMailer.bounce(to: mail.from)
+  end
+end
+
 class ActionMailbox::Base::BouncingTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
 
@@ -16,9 +22,26 @@ class ActionMailbox::Base::BouncingTest < ActiveSupport::TestCase
       from: "sender@example.com", to: "replies@example.com", subject: "Bounce me"
   end
 
+  teardown do
+    ActionMailer::Base.deliveries.clear
+  end
+
   test "bouncing with a reply" do
     perform_enqueued_jobs only: ActionMailer::MailDeliveryJob do
       BouncingWithReplyMailbox.receive @inbound_email
+    end
+
+    assert @inbound_email.bounced?
+    assert_emails 1
+
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal %w[ sender@example.com ], mail.to
+    assert_equal "Your email was not delivered", mail.subject
+  end
+
+  test "bouncing now with a reply" do
+    assert_no_enqueued_emails do
+      BouncingWithImmediateReplyMailbox.receive @inbound_email
     end
 
     assert @inbound_email.bounced?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because I recently stumbled upon a use case where I needed to send a bounce email (with `ActionMailbox.bounce_with`, but without going through ActiveJob and a queue. Since this seems like a reasonable use case, I suggest adding an alternative method `bounce_now_with` to allow for the immediate delivery of the bounce email.

### Details

This Pull Request adds `ActionMailbox::Base#bounce_now_with` to provokes the sending of the bounce email without going through a queue.

```ruby
 # Enqueues the bounce email
MyMailbox.bounce_with MyMailer.my_method(args)

# Delivers the email immediately
MyMailbox.bounce_now_with MyMailer.my_method(args)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
