### PR TITLE
Use cache `:coder` option to specify `:message_pack`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -70,8 +70,7 @@
     *Jonathan Hefner*
 
 *   A new `7.1` cache format is available which includes an optimization for
-    bare string values such as view fragments. The `:message_pack` cache format
-    has also been modified to include this optimization.
+    bare string values such as view fragments.
 
     The `7.1` cache format is used by default for new apps, and existing apps
     can enable the format by setting `config.load_defaults 7.1` or by setting
@@ -84,18 +83,25 @@
     read caches from upgraded servers, leave the cache format unchanged on the
     first deploy, then enable the `7.1` cache format on a subsequent deploy.
 
+    The new `:message_pack` cache coder also includes this optimization.
+
     *Jonathan Hefner*
 
-*   `config.active_support.cache_format_version` now accepts `:message_pack` as
-    an option. `:message_pack` can reduce cache entry sizes and improve
+*   The `:coder` option for Active Support cache stores now supports a
+    `:message_pack` value:
+
+      ```ruby
+      config.cache_store = :redis_cache_store, { coder: :message_pack }
+      ```
+
+    The `:message_pack` coder can reduce cache entry sizes and improve
     performance, but requires the [`msgpack` gem](https://rubygems.org/gems/msgpack)
     (>= 1.7.0).
 
-    Cache entries written using the `6.1`, `7.0`, or `7.1` cache formats can be read
-    when using the `:message_pack` cache format. Additionally, cache entries
-    written using the `:message_pack` cache format can now be read when using
-    the `6.1`, `7.0`, or `7.1` cache formats. These behaviors makes it easy to migrate
-    between formats without invalidating the entire cache.
+    The `:message_pack` coder can read cache entries written by the default
+    coder, and the default coder can now read entries written by the
+    `:message_pack` coder. These behaviors make it easy to migrate between
+    coders without invalidating the entire cache.
 
     *Jonathan Hefner*
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -238,6 +238,12 @@ module ActiveSupport
       #   with a custom one. The +coder+ must respond to +dump+ and +load+.
       #   Using a custom coder disables automatic compression.
       #
+      #   Alternatively, you can specify <tt>coder: :message_pack</tt> to use a
+      #   preconfigured coder based on ActiveSupport::MessagePack that supports
+      #   automatic compression and includes a fallback mechanism to load old
+      #   cache entries from the default coder. However, this option requires
+      #   the +msgpack+ gem.
+      #
       # Any other specified options are treated as default options for the
       # relevant cache operations, such as #read, #write, and #fetch.
       def initialize(options = nil)
@@ -246,6 +252,7 @@ module ActiveSupport
         @options[:compress_threshold] = DEFAULT_COMPRESS_LIMIT unless @options.key?(:compress_threshold)
 
         @coder = @options.delete(:coder) { default_coder } || NullCoder
+        @coder = Cache::SerializerWithFallback[@coder] if @coder.is_a?(Symbol)
         @coder_supports_compression = @coder.respond_to?(:dump_compressed)
       end
 

--- a/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/object/with"
 module CacheStoreFormatVersionBehavior
   extend ActiveSupport::Concern
 
-  FORMAT_VERSIONS = [6.1, 7.0, 7.1, :message_pack]
+  FORMAT_VERSIONS = [6.1, 7.0, 7.1]
 
   included do
     test "format version affects default coder" do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2326,15 +2326,11 @@ The default value depends on the `config.load_defaults` target version:
 #### `config.active_support.cache_format_version`
 
 Specifies which serialization format to use for the cache. Possible values are
-`6.1`, `7.0`, `7.1`, and `:message_pack`.
+`6.1`, `7.0`, and `7.1`.
 
-The `6.1`, `7.0`, and `7.1` formats all use `Marshal`, but `7.0` uses a more
-efficient representation for cache entries, and `7.1` includes an additional
-optimization for bare string values such as view fragments.
-
-The `:message_pack` format uses `ActiveSupport::MessagePack`, and may further
-reduce cache entry sizes and improve performance, but requires the
-[`msgpack` gem](https://rubygems.org/gems/msgpack).
+The `6.1`, `7.0`, and `7.1` formats all use `Marshal` for the default coder, but
+`7.0` uses a more efficient representation for cache entries, and `7.1` includes
+an additional optimization for bare string values such as view fragments.
 
 All formats are backward and forward compatible, meaning cache entries written
 in one format can be read when using another format. This behavior makes it

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -402,8 +402,7 @@ module ApplicationTests
       rails %w(db:migrate)
 
       add_to_config <<~RUBY
-        config.cache_store = :file_store, #{app_path("tmp/cache").inspect}
-        config.active_support.cache_format_version = :message_pack
+        config.cache_store = :file_store, #{app_path("tmp/cache").inspect}, { coder: :message_pack }
       RUBY
 
       require "#{app_path}/config/environment"


### PR DESCRIPTION
In #48104, `:message_pack` was added as a supported value for the cache format version because the format version essentially specifies the default coder.  However, as an API, the format version could potentially be used to affect other aspects of serialization, such as the default compression format.

This commit removes `:message_pack` as a supported value for the format version, and, as a replacement, adds support for specifying `coder: :message_pack`:

  ```ruby
  # BEFORE
  config.active_support.cache_format_version = :message_pack

  # AFTER
  config.cache_store = :redis_cache_store, { coder: :message_pack }
  ```
