### PR TITLE
Test respond_to? :to_ary directly on RackBody

### DIFF
--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -319,11 +319,6 @@ module ActionController
         logger.info "Work complete"
         latch.count_down
       end
-
-      def buffer_do_not_respond_to_to_ary
-        response.stream.write "response.stream.respond_to? = #{response.stream.respond_to?(:to_ary)}"
-        response.stream.close
-      end
     end
 
     tests TestController
@@ -603,8 +598,13 @@ module ActionController
     end
 
     def test_response_buffer_do_not_respond_to_to_ary
-      get :buffer_do_not_respond_to_to_ary
-      assert_equal "response.stream.respond_to? = false", response.body
+      get :basic_stream
+      # `response.to_a` wraps the response with RackBody.
+      # RackBody is the body we return to Rack.
+      # Therefore we want to assert directly on it.
+      # The Rack spec requires bodies that cannot be
+      # buffered to return false to `respond_to?(:to_ary)`
+      assert_not response.to_a.last.respond_to? :to_ary
     end
   end
 


### PR DESCRIPTION
RackBody is the final body object returned by the Rack app (`Rails.application`). 
This PR tests that the RackBody conforms to the spec instead of testing on the underlying response.

The issue with testing on the underlying response is that we do have logic related to `:to_ary` inside the RackBody it could potentially be changed to intercept the call before reaching the response object.

This change might be a bit too paranoid?  The existing test would have catch that.  So maybe this change is not required? 

That being said, I do prefer testing the response directly in the test instead of parsing the response body. 

### Motivation / Background

I was trying to write a test to bridge the gap in coverage (streams were failing for a while).
[I originally went for an e2e solution](https://github.com/rails/rails/pull/48443), before scaling back to testing on the Rack response instead. 
