### PR TITLE
Add frozen string literal comment in ActiveRecord migration templates

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add frozen string literal comment in ActiveRecord migration templates
+
+    Adds a frozen string literal comment to `create_table_migration.rb.tt` and `migration.rb.tt` templates.
+
+    *Anton Ivanov*
+
 *   Allow composite primary key to be derived from schema
 
     Booting an application with a schema that contains composite primary keys

--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
 <%- if migration_action == 'add' -%>
   def change


### PR DESCRIPTION

Add "# frozen_string_literal: true" to generated migration files

### Detail

This commit introduces a small change to the way migration files are generated in our project. The addition of the "# frozen_string_literal: true" string at the start of each migration file ensures that all string literals within the file are frozen by default. This can have several benefits for our codebase, including improved performance and enhanced reliability.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
