### PR TITLE
Changed `ActiveRecord::Relation#pluck` guide to be more similar to the API docs for better clarity [skip ci]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2167,7 +2167,7 @@ irb> Customer.connection.select_all("SELECT first_name, created_at FROM customer
 
 ### `pluck`
 
-[`pluck`][] can be used to query single or multiple columns from the underlying table of a model. It accepts a list of column names as an argument and returns an array of values of the specified columns with the corresponding data type.
+[`pluck`][] can be used to pick the value(s) from the named column(s) in the current relation. It accepts a list of column names as an argument and returns an array of values of the specified columns with the corresponding data type.
 
 ```irb
 irb> Book.where(out_of_print: true).pluck(:id)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because this is a follow-up to the [PR here](https://github.com/rails/rails/pull/48404#discussion_r1228600196).
We discussed it in it and also changed `pluck` because we thought it would be clearer to use some of the wording from the API docs.

### Detail

This Pull Request changes is Changed `ActiveRecord::Relation#pluck` guide to be more similar to the API docs for better clarity.

### Additional information

this is a follow-up to the [PR here](https://github.com/rails/rails/pull/48404#discussion_r1228600196)

- API docs: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck
- edge guide: https://edgeguides.rubyonrails.org/active_record_querying.html#pluck

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
