### PR TITLE
Add notes about renderable option to guide

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -291,7 +291,7 @@ render MyRenderable.new
 
 This calls `render_in` on the provided object with the current view context.
 
-You can provide the object by using the `:renderable` option to `render`:
+You can also provide the object by using the `:renderable` option to `render`:
 
 ```ruby
 render renderable: MyRenderable.new

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -291,6 +291,12 @@ render MyRenderable.new
 
 This calls `render_in` on the provided object with the current view context.
 
+You can provide the object by using the `:renderable` option to `render`:
+
+```ruby
+render renderable: MyRenderable.new
+```
+
 #### Options for `render`
 
 Calls to the [`render`][controller.render] method generally accept six options:


### PR DESCRIPTION
#39869 added the ability to use `renderable` as an option for `render`. This PR updates the guides to include this form of passing an object.

I needed to use this form  of passing the object to work with Hotwire's `broadcast_action_to` method which is passing splatted args: https://github.com/hotwired/turbo-rails/blob/ea00f3732e21af9c2156cf74dabe95524b17c361/app/channels/turbo/streams/broadcasts.rb#L85-L87