### PR TITLE
Store `secret_key_base` in `Rails.config` for local environments.

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Store `secret_key_base` in `Rails.config` for local environments.
+
+    Rails `secrets` have been deprecated in favor of `credentials`.
+    For the local environments the `secret_key_base` is now stored in
+    `Rails.config.secret_key_base` instead of the soft deprecated
+    `Rails.application.secrets.secret_key_base`.
+
+    *Petrik de Heus*
+
 *   Enable force_ssl=true in production by default: Force all access to the app over SSL,
     use Strict-Transport-Security, and use secure cookies
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -728,7 +728,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_not_nil app.secrets.secret_key_base
+      assert_not_nil app.secret_key_base
       assert File.exist?(app_path("tmp/development_secret.txt"))
     end
 
@@ -834,14 +834,14 @@ module ApplicationTests
       assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 
-    test "secret_key_base is copied from config to secrets when not set" do
+    test "secret_key_base is copied from config.secret_key_base when set" do
       remove_file "config/secrets.yml"
       app_file "config/initializers/secret_token.rb", <<-RUBY
         Rails.application.config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c3"
       RUBY
 
       app "development"
-      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
+      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 
     test "custom secrets saved in config/secrets.yml are loaded in app secrets" do
@@ -892,18 +892,14 @@ module ApplicationTests
       assert_nil app.secrets.not_defined
     end
 
-    test "config.secret_key_base over-writes a blank secrets.secret_key_base" do
+    test "config.secret_key_base over-writes a blank app.secret_key_base" do
       app_file "config/initializers/secret_token.rb", <<-RUBY
         Rails.application.config.secret_key_base = "iaminallyoursecretkeybase"
       RUBY
-      app_file "config/secrets.yml", <<-YAML
-        development:
-          secret_key_base:
-      YAML
 
       app "development"
 
-      assert_equal "iaminallyoursecretkeybase", app.secrets.secret_key_base
+      assert_equal "iaminallyoursecretkeybase", app.secret_key_base
     end
 
     test "that nested keys are symbolized the same as parents for hashes more than one level deep" do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -259,7 +259,7 @@ module TestHelpers
       @app.config.session_store :cookie_store, key: "_myapp_session"
       @app.config.active_support.deprecation = :log
       @app.config.log_level = :info
-      @app.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
+      @app.config.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
 
       yield @app if block_given?
       @app.initialize!

--- a/railties/test/path_generation_test.rb
+++ b/railties/test/path_generation_test.rb
@@ -66,7 +66,7 @@ class PathGenerationTest < ActiveSupport::TestCase
         super
         app = self
         @routes = TestSet.new ->(c) { app.controller = c }
-        secrets.secret_key_base = "foo"
+        config.secret_key_base = "foo"
       end
       def app; routes; end
     }


### PR DESCRIPTION
Rails `secrets` have been deprecated in favor of `credentials`.
However, for the local environments `Rails.application.secrets` is still used to store `secret_key_base`.

We can store `secret_key_base` in `Rails.config.secret_key_base` instead.

This change allows us to deprecate calling `Rails.application.secrets`. See #48472.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
