### PR TITLE
Deprecate calling `Rails.application.secrets`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate calling `Rails.application.secrets`.
+
+    Rails `secrets` have been deprecated in favor of `credentials`.
+    Calling `Rails.application.secrets` should show a deprecation warning.
+
+    *Petrik de Heus*
+
 *   Store `secret_key_base` in `Rails.config` for local environments.
 
     Rails `secrets` have been deprecated in favor of `credentials`.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -435,6 +435,9 @@ module Rails
     attr_writer :config
 
     def secrets
+      Rails.deprecator.warn(<<~MSG.squish)
+        `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.
+      MSG
       @secrets ||= begin
         secrets = ActiveSupport::OrderedOptions.new
         files = config.paths["config/secrets"].existent
@@ -648,8 +651,8 @@ module Rails
 
           if File.exist?(key_file)
             config.secret_key_base = File.binread(key_file)
-          elsif secrets.secret_key_base
-            config.secret_key_base = secrets.secret_key_base
+          elsif secrets_secret_key_base
+            config.secret_key_base = secrets_secret_key_base
           else
             random_key = SecureRandom.hex(64)
             FileUtils.mkdir_p(key_file.dirname)
@@ -659,6 +662,12 @@ module Rails
         end
 
         config.secret_key_base
+      end
+
+      def secrets_secret_key_base
+        Rails.deprecator.silence do
+          secrets.secret_key_base
+        end
       end
 
       def build_request(env)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -685,7 +685,9 @@ module ApplicationTests
 
     test "Use key_generator when secret_key_base is set" do
       make_basic_app do |application|
-        application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
+        Rails.deprecator.silence do
+          application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
+        end
         application.config.session_store :disabled
       end
 
@@ -705,7 +707,9 @@ module ApplicationTests
 
     test "application verifier can be used in the entire application" do
       make_basic_app do |application|
-        application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
+        Rails.deprecator.silence do
+          application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
+        end
         application.config.session_store :disabled
       end
 
@@ -823,6 +827,14 @@ module ApplicationTests
       assert_equal "old message", app.message_verifiers["salt"].verify(old_message)
     end
 
+    test "secrets is deprecated" do
+      app "development"
+
+      assert_deprecated(Rails.deprecator) do
+        Rails.application.secrets.secret_key_base = "3b7cd727ee24e8444053437c36cc66c3"
+      end
+    end
+
     test "secrets.secret_key_base is used when config/secrets.yml is present" do
       app_file "config/secrets.yml", <<-YAML
         development:
@@ -830,7 +842,9 @@ module ApplicationTests
       YAML
 
       app "development"
-      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
+      Rails.deprecator.silence do
+        assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
+      end
       assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 


### PR DESCRIPTION
Rails `secrets` have [been deprecated](https://github.com/rails/rails/blob/01363bd7e789d07b8fcf30b5a8efe3c8ba4423ee/railties/lib/rails/commands/secrets/secrets_command.rb#L14-L17) in favor of `credentials`. Calling `Rails.application.secrets` should show a deprecation warning.

This requires #48470 which removes most internal calls to `Rails.application.secrets`.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
