### PR TITLE
Deprecate `#remove_connection` in favor of `#remove_connection_pool`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,39 @@
+*   Deprecate `#remove_connection` in favor of `#remove_connection_pool`.
+
+    Rails 7.2 will remove support for `#remove_connection` in favor of `#remove_connection_pool`. This deprecation also represents a change in behavior. `#remove_connection_pool` will not accept a `name` argument as it should always be called on the class that owns the pool an application wants removed. In addition it will no longer reset a subclass with it's own connection to the parent pool.
+
+    Previous behavior:
+
+    ```ruby
+    class ActiveRecord::Base
+    end
+
+    class Post < ActiveRecord::Base
+      establish_connection :post_db
+    end
+
+    Post.remove_connection
+    => would reassign Post to `ActiveRecord::Base`  and `Post.connected?` returns `true`.
+    ```
+
+    New behavior:
+
+    ```ruby
+    class ActiveRecord::Base
+    end
+
+    class Post < ActiveRecord::Base
+      establish_connection :post_db
+    end
+
+    Post.remove_connection
+    => Removes the pool keyed on `Post` and `Post.connected?` returns `nil`.
+    ```
+
+    If the `Post` class does not have its own connection and `Post.remove_connection` is called, the behavior is unchanged. Active Record will not remove the pool belonging to `ActiveRecord::Base`. To remove the parent pool, applications should call `ActiveRecord::Base.remove_connection` directly.
+
+    *Eileen M. Uchitelle*
+
 *   Allow composite primary key to be derived from schema
 
     Booting an application with a schema that contains composite primary keys

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 
       unless in_memory_db?
         def test_connect_with_url
-          original_connection = ActiveRecord::Base.remove_connection
+          original_connection = ActiveRecord::Base.remove_connection_pool
           tf = Tempfile.open "whatever"
           url = "sqlite3:#{tf.path}"
           ActiveRecord::Base.establish_connection(url)
@@ -54,7 +54,7 @@ module ActiveRecord
         end
 
         def test_connect_memory_with_url
-          original_connection = ActiveRecord::Base.remove_connection
+          original_connection = ActiveRecord::Base.remove_connection_pool
           url = "sqlite3::memory:"
           ActiveRecord::Base.establish_connection(url)
           assert ActiveRecord::Base.connection

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -455,7 +455,7 @@ module ActiveRecord
             end
           end
         ensure
-          ApplicationRecord.remove_connection
+          ApplicationRecord.remove_connection_pool
           ActiveRecord.application_record_class = nil
           Object.send(:remove_const, :ApplicationRecord)
           ActiveRecord::Base.establish_connection :arunit

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -536,7 +536,7 @@ module ActiveRecord
         assert_equal ActiveRecord::Base.default_shard, payloads[0][:shard]
         assert_equal :writing, payloads[0][:role]
       ensure
-        @connection_test_model_class.remove_connection
+        @connection_test_model_class.remove_connection_pool
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end
 
@@ -552,7 +552,7 @@ module ActiveRecord
         assert_equal :default, payloads[0][:shard]
         assert_equal :writing, payloads[0][:role]
       ensure
-        @connection_test_model_class.remove_connection
+        @connection_test_model_class.remove_connection_pool
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end
 

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -16,7 +16,7 @@ class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
     end
 
     teardown do
-      Bird.remove_connection
+      Bird.remove_connection_pool
     end
 
     test "inspect on Model class does not raise" do

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -10,7 +10,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
     def setup
       @per_test_teardown = []
-      @connection = ActiveRecord::Base.remove_connection.configuration_hash
+      @connection = ActiveRecord::Base.remove_connection_pool.configuration_hash
     end
 
     teardown do

--- a/activerecord/test/cases/primary_class_test.rb
+++ b/activerecord/test/cases/primary_class_test.rb
@@ -110,7 +110,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       assert_predicate ApplicationRecord, :application_record_class?
       assert_equal ActiveRecord::Base.connection, ApplicationRecord.connection
     ensure
-      ApplicationRecord.remove_connection
+      ApplicationRecord.remove_connection_pool
       ActiveRecord.application_record_class = nil
       Object.send(:remove_const, :ApplicationRecord)
       ActiveRecord::Base.establish_connection :arunit
@@ -126,7 +126,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       assert_predicate PrimaryClassTest::PrimaryAppRecord, :abstract_class?
       assert_equal ActiveRecord::Base.connection, PrimaryClassTest::PrimaryAppRecord.connection
     ensure
-      PrimaryClassTest::PrimaryAppRecord.remove_connection
+      PrimaryClassTest::PrimaryAppRecord.remove_connection_pool
       ActiveRecord.application_record_class = nil
       ActiveRecord::Base.establish_connection :arunit
     end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -287,7 +287,7 @@ class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
       assert NoConnection.connected?
       assert_equal "foo", NoConnection.primary_key
 
-      ActiveRecord::Base.connection_handler.remove_connection_pool("PrimaryKeyWithNoConnectionTest::NoConnection")
+      NoConnection.remove_connection_pool
       assert_nil NoConnection.connected?
 
       assert_equal "foo", NoConnection.primary_key

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -469,7 +469,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_cache_is_available_when_using_a_not_connected_connection
     skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
     db_config = ActiveRecord::Base.connection_db_config
-    original_connection = ActiveRecord::Base.remove_connection
+    original_connection = ActiveRecord::Base.remove_connection_pool
 
     ActiveRecord::Base.establish_connection(db_config)
     assert_not_predicate Task, :connected?

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -10,7 +10,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
 
   def setup
     @underlying = ActiveRecord::Base.connection
-    @connection_name = ActiveRecord::Base.remove_connection
+    @connection_name = ActiveRecord::Base.remove_connection_pool
 
     # Clear out connection info from other pids (like a fork parent) too
     ActiveRecord::ConnectionAdapters::PoolConfig.discard_pools!

--- a/activerecord/test/support/connection_helper.rb
+++ b/activerecord/test/support/connection_helper.rb
@@ -2,7 +2,7 @@
 
 module ConnectionHelper
   def run_without_connection
-    original_connection = ActiveRecord::Base.remove_connection
+    original_connection = ActiveRecord::Base.remove_connection_pool
     yield original_connection.configuration_hash
   ensure
     ActiveRecord::Base.establish_connection(original_connection)
@@ -10,7 +10,7 @@ module ConnectionHelper
 
   # Used to drop all cache query plans in tests.
   def reset_connection
-    original_connection = ActiveRecord::Base.remove_connection
+    original_connection = ActiveRecord::Base.remove_connection_pool
     ActiveRecord::Base.establish_connection(original_connection)
   end
 end


### PR DESCRIPTION
Rails 7.2 will remove support for `#remove_connection` in favor of `#remove_connection_pool`. This deprecation also represents a change in behavior. `#remove_connection_pool` will not accept a `name` argument as it should always be called on the class that owns the pool an application wants removed. In addition it will no longer reset a subclass with it's own connection to the parent pool.

Previous behavior:

```ruby
class ActiveRecord::Base
end

class Post < ActiveRecord::Base
  establish_connection :post_db
end

Post.remove_connection
=> would reassign Post to `ActiveRecord::Base`  and `Post.connected?` returns `true`.
```

New behavior:

```ruby
class ActiveRecord::Base
end

class Post < ActiveRecord::Base
  establish_connection :post_db
end

Post.remove_connection
=> Removes the pool keyed on `Post` and `Post.connected?` returns `nil`.
```

If the `Post` class does not have its own connection and `Post.remove_connection` is called, the behavior is unchanged. Active Record will not remove the pool belonging to `ActiveRecord::Base`. To remove the parent pool, applications should call `ActiveRecord::Base.remove_connection` directly.

I chose to add a new method instead of deprecating behavior in the current one because this behavior change isn't worth the overhead of a config option. I also think it's more likely to get feedback if this is a dealbreaker change.

I'm making this change because due to the current design of Active Record connection management, it does not make sense that `remove_connection` would reassign connections to the parent class. In a multi-db application this would be dangerous, we would not want to assign `AnimalsRecord` to `ActiveRecord::Base` if they are completely different databases. In addition it does not make sense to take a `name` argument when the `name` should be derived from the connection_specification_name on self.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

---

cc/ @matthewd in case you have strong opinions on this.

Background:
I noticed that this was added for manageiq in https://github.com/rails/rails/commit/6458610d0b95049bbc847cbc1039d6f5be8cc30c from this report https://github.com/rails/rails/issues/24959. I don't think we should keep supporting this because its behavior is really surprising given the current design of connection management.