### PR TITLE
Add unique option to belongs_to association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `unique` option to `belongs_to` association.
+
+    The unique option will validate the uniqueness of the association. It can be helpful in 1-1 relationships
+    to prevent duplicated records from being created by the "has one" side. ex: `Client.create!(account: existent_account)`.
+
+    Before:
+
+    ```ruby
+    class Client
+      belongs_to :account; validates_uniqueness_of(:account, allow_nil: true, message: :unique)
+    end
+    ```
+
+    Later:
+    ```ruby
+    class Client
+      belongs_to :account, unique: true
+    end
+    ```
+
+    *Lázaro Nixon*
+
 *   Added PostgreSQL migration commands for enum rename, add value, and rename value.
 
     `rename_enum` and `rename_enum_value` are reversible. Due to Postgres

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1844,6 +1844,8 @@ module ActiveRecord
         #   +:inverse_of+ to avoid an extra query during validation.
         #   NOTE: <tt>required</tt> is set to <tt>true</tt> by default and is deprecated. If
         #   you don't want to have association presence validated, use <tt>optional: true</tt>.
+        # [:unique]
+        #   When set to +true+, the association will also have its uniqueness validated.
         # [:default]
         #   Provide a callable (i.e. proc or lambda) to specify that the association should
         #   be initialized with a particular record before validation.
@@ -1866,6 +1868,7 @@ module ActiveRecord
         #   belongs_to :comment, touch: true
         #   belongs_to :company, touch: :employees_last_updated_at
         #   belongs_to :user, optional: true
+        #   belongs_to :user, unique: true
         #   belongs_to :account, default: -> { company.account }
         #   belongs_to :account, strict_loading: true
         def belongs_to(name, scope = nil, **options)

--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -8,6 +8,7 @@ en:
   errors:
     messages:
       required: "must exist"
+      unique: "must be unique"
       taken: "has already been taken"
 
   # Active Record models configuration

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -184,6 +184,19 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
+  def test_unique
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "ships"
+      def self.name; "Temp"; end
+      belongs_to :developer, unique: true
+    end
+
+    assert_raise(ActiveRecord::RecordInvalid) do
+      model.create! developer: developers(:david)
+      model.create! developer: developers(:david)
+    end
+  end
+
   def test_default
     david = developers(:david)
     jamis = developers(:jamis)
@@ -1714,53 +1727,53 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   class ShipRequired < ActiveRecord::Base
     self.table_name = "ships"
-    belongs_to :developer, required: true
+    belongs_to :developer, required: true, unique: true
   end
 
-  test "runs parent presence check if parent changed or nil" do
+  test "runs parent checks if parent changed or nil" do
     david = developers(:david)
     jamis = developers(:jamis)
 
     ship = ShipRequired.create!(name: "Medusa", developer: david)
     assert_equal david, ship.developer
 
-    assert_queries(2) do # UPDATE and SELECT to check developer presence
+    assert_queries(3) do # UPDATE and 2 SELECTS
       ship.update!(developer_id: jamis.id)
     end
 
     ship.update_column(:developer_id, nil)
     ship.reload
 
-    assert_queries(2) do # UPDATE and SELECT to check developer presence
+    assert_queries(3) do # UPDATE and 2 SELECTS
       ship.update!(developer_id: david.id)
     end
   end
 
-  test "skips parent presence check if parent has not changed" do
+  test "skips parent checks if parent has not changed" do
     david = developers(:david)
     ship = ShipRequired.create!(name: "Medusa", developer: david)
     ship.reload # unload developer association
 
-    assert_queries(1) do # UPDATE only, no SELECT to check developer presence
+    assert_queries(1) do # UPDATE only, no SELECTS
       ship.update!(name: "Leviathan")
     end
   end
 
-  test "runs parent presence check if parent has not changed and belongs_to_required_validates_foreign_key is set" do
+  test "runs parent checks if parent has not changed and belongs_to_required_validates_foreign_key is set" do
     original_value = ActiveRecord.belongs_to_required_validates_foreign_key
     ActiveRecord.belongs_to_required_validates_foreign_key = true
 
     model = Class.new(ActiveRecord::Base) do
       self.table_name = "ships"
       def self.name; "Temp"; end
-      belongs_to :developer, required: true
+      belongs_to :developer, required: true, unique: true
     end
 
     david = developers(:david)
     ship = model.create!(name: "Medusa", developer: david)
     ship.reload # unload developer association
 
-    assert_queries(2) do # UPDATE and SELECT to check developer presence
+    assert_queries(3) do # 1 UPDATE and 2 SELECTS
       ship.update!(name: "Leviathan")
     end
   ensure


### PR DESCRIPTION
Since version 7.0.5 https://github.com/rails/rails/commit/bdbe58b50461dc44c42df4d5427fa78aeb1debcb  we are able to properly keep integrity in `has_one` relationships, so when we create a new record `account.create_client(...)` it will prevent duplication, but we can still bypass it on the other side of the relationship using `Client.create!(..., account: existing_account)`. 

That said I'm proposing to add a new option `unique` to the `belongs_to` method. Here are some advantages of this approach...

- Unique indexes are not required.
- Different from unique indexes we can use it with an optional association.
- Take advantage of the new `belongs_to_required_validates_foreign_key`.
- Validation API, messages, etc...

Before:

```ruby    
class Client
  belongs_to :account; validates_uniqueness_of(:account, allow_nil: true, message: :unique)
end
```

Later:

  ```ruby
class Client
    belongs_to :account, unique: true
end
 ```

### Additional information

https://thoughtbot.com/blog/rails-has-one-limitations

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
