### PR TITLE
Improve error messages of `assert_changes` and `assert_no_changes`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Improve error messages of `assert_changes` and `assert_no_changes`
+
+    `assert_changes` error messages now display objects with `.inspect` to make it easier
+    to differentiate nil from empty strings, strings from symbols, etc.
+    `assert_no_changes` error messages now surface the actual value.
+
+    *pcreux*
+
 *   Fix `#to_fs(:human_size)` to correctly work with negative numbers.
 
     *Earlopain*

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -195,7 +195,7 @@ module ActiveSupport
         retval = _assert_nothing_raised_or_warn("assert_changes", &block)
 
         unless from == UNTRACKED
-          error = "Expected change from #{from.inspect}, got #{before}"
+          error = "Expected change from #{from.inspect}, got #{before.inspect}"
           error = "#{message}.\n#{error}" if message
           assert from === before, error
         end
@@ -203,12 +203,12 @@ module ActiveSupport
         after = exp.call
 
         error = "#{expression.inspect} didn't change"
-        error = "#{error}. It was already #{to}" if before == to
+        error = "#{error}. It was already #{to.inspect}" if before == to
         error = "#{message}.\n#{error}" if message
         refute_equal before, after, error
 
         unless to == UNTRACKED
-          error = "Expected change to #{to}, got #{after}\n"
+          error = "Expected change to #{to.inspect}, got #{after.inspect}\n"
           error = "#{message}.\n#{error}" if message
           assert to === after, error
         end
@@ -242,7 +242,7 @@ module ActiveSupport
         retval = _assert_nothing_raised_or_warn("assert_no_changes", &block)
 
         unless from == UNTRACKED
-          error = "Expected initial value of #{from.inspect}"
+          error = "Expected initial value of #{from.inspect}, got #{before.inspect}"
           error = "#{message}.\n#{error}" if message
           assert from === before, error
         end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -331,7 +331,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "Expected initial value of nil", error.message
+    assert_equal "Expected initial value of nil, got 0", error.message
   end
 
   def test_assert_no_changes_with_from_and_case_operator


### PR DESCRIPTION
### Motivation / Background

Make `assert_changes` error messages show objects with `.inspect` to make it easier to differentiate `nil` from empty strings, strings vs symbols, etc.

Make `assert_no_changes` error messages surface the actual value.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Let me know if I should update the CHANGELOG as this is a minor change.
