### PR TITLE
Fix setting inverses for composite primary key associations

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -336,7 +336,8 @@ module ActiveRecord
 
         # Returns true if record contains the foreign_key
         def foreign_key_for?(record)
-          record._has_attribute?(reflection.foreign_key)
+          foreign_key = Array(reflection.foreign_key)
+          foreign_key.all? { |key| record._has_attribute?(key) }
         end
 
         # This should be implemented to return the values of the relevant key(s) on the owner,

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -365,6 +365,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal id, cpk_book.order_id
   end
 
+  def test_belongs_to_with_inverse_association_for_composite_primary_key
+    author = Cpk::Author.new(name: "John")
+    book = author.books.build(number: 1, title: "The Rails Way")
+    order = Cpk::Order.new(book: book, status: "paid")
+    author.save!
+
+    _order_shop_id, order_id = order.id
+    assert order_id
+    assert_equal order_id, book.order_id
+  end
+
   def test_building_the_belonging_object_with_implicit_sti_base_class
     account = Account.new
     company = account.build_firm

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -26,6 +26,7 @@ require "models/contract"
 require "models/subscription"
 require "models/book"
 require "models/branch"
+require "models/cpk"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars, :books
@@ -600,6 +601,15 @@ class InverseHasManyTests < ActiveRecord::TestCase
     children.each do |child|
       assert_predicate child.association(:human), :loaded?
     end
+  end
+
+  def test_inverse_should_be_set_on_composite_primary_key_child
+    author = Cpk::Author.new(name: "John")
+    book = author.books.build(number: 1, title: "The Rails Way")
+    Cpk::Order.new(book: book, status: "paid")
+    author.save!
+
+    assert book.association(:order).loaded?
   end
 
   def test_raise_record_not_found_error_when_invalid_ids_are_passed


### PR DESCRIPTION
### Motivation / Background

Checking whether a record has a foreign key for a composite primary key association requires us to check whether all parts of the foreign key are present. Otherwise, the inverse association will not be set.

### Detail

Check all parts of the foreign key to determine `#foreign_key_for?`.

### Additional information

I added a more granular test to `inverse_associations_test.rb` that verifies that the CPK association on the child is loaded appropriately. I also added a more generic test in `belongs_to_associations_test.rb` that ensures that the `belongs_to` associations are saved properly as a result of the inverse association being set.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A)
