### PR TITLE
Apply scope to association subqueries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Apply scope to association subqueries. (belongs_to/has_one/has_many)
+
+    Given: `has_many :welcome_posts, -> { where(title: "welcome") }`
+
+    Before:
+    ```ruby
+    Author.where(welcome_posts: Post.all)
+    #=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts")
+    ```
+
+    Later:
+    ```ruby
+    Author.where(welcome_posts: Post.all)
+    #=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts" WHERE "posts"."title" = 'welcome')
+    ```
+
+    *Lázaro Nixon*
+
 *   Added PostgreSQL migration commands for enum rename, add value, and rename value.
 
     `rename_enum` and `rename_enum_value` are reversible. Due to Postgres

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -26,6 +26,7 @@ module ActiveRecord
           case value
           when Relation
             relation = value
+            relation = relation.merge(scope) if scope
             relation = relation.select(primary_key) if select_clause?
             relation = relation.where(primary_type => polymorphic_name) if polymorphic_clause?
             relation
@@ -46,6 +47,10 @@ module ActiveRecord
 
         def polymorphic_name
           associated_table.polymorphic_name_association
+        end
+
+        def scope
+          associated_table.scope
         end
 
         def select_clause?

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, to: :reflection
+    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, :scope, to: :reflection
 
     def initialize(klass, arel_table, reflection = nil)
       @klass = klass

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -463,6 +463,12 @@ module ActiveRecord
       assert_equal [treasures(:diamond)], treasures
     end
 
+    def test_where_on_association_with_scoped_relation
+      authors = Author.where(welcome_posts: Post.all)
+      assert_equal 1, authors.count
+      assert_equal authors(:david), authors.first
+    end
+
     def test_where_with_strong_parameters
       author = authors(:david)
       params = ProtectedParams.new(name: author.name)


### PR DESCRIPTION
### Motivation / Background

Apply scope to association subqueries. (belongs_to/has_one/has_many).

Given: 

```ruby
class Author < ApplicationRecord
  has_many :welcome_posts, -> { where(title: "welcome") } , class_name: "Post"
end
```

Before:

```ruby
Author.where(welcome_posts: Post.all)
#=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts")
```

Later:

```ruby
Author.where(welcome_posts: Post.all)
#=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts" WHERE "posts"."title" = 'welcome')
```
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
