### PR TITLE
Remove no connection primary key test

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -270,31 +270,6 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 end
 
-class PrimaryKeyWithNoConnectionTest < ActiveRecord::TestCase
-  class NoConnection < ActiveRecord::Base
-    self.abstract_class = true
-    self.primary_key = "foo"
-  end
-
-  self.use_transactional_tests = false
-
-  unless in_memory_db?
-    def test_set_primary_key_with_no_connection
-      NoConnection.establish_connection :arunit
-      # execute to fully establish a connection
-      NoConnection.connection.execute("SELECT 1")
-
-      assert NoConnection.connected?
-      assert_equal "foo", NoConnection.primary_key
-
-      ActiveRecord::Base.connection_handler.remove_connection_pool("PrimaryKeyWithNoConnectionTest::NoConnection")
-      assert_nil NoConnection.connected?
-
-      assert_equal "foo", NoConnection.primary_key
-    end
-  end
-end
-
 class PrimaryKeyWithAutoIncrementTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 


### PR DESCRIPTION
This test was added in https://github.com/rails/rails/commit/b3407c86cfccd2cc6258b8879e91600fe25c6e48 at a time when Rails was reading the `primary_keys` off a hash stored on `connection`. We no longer do that in Active Record so this test isn't really necessary. I'm removing it because it was flaky. I attempted to fix it in #48473 but realized today it's not testing the same thing it was before. After discussing it with Matthew, I've decided to remove it.
