### PR TITLE
Use _read_attribute when autosaving has_one associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -453,7 +453,7 @@ module ActiveRecord
           if autosave && record.marked_for_destruction?
             record.destroy
           elsif autosave != false
-            key = reflection.options[:primary_key] ? public_send(reflection.options[:primary_key]) : id
+            key = reflection.options[:primary_key] ? _read_attribute(reflection.options[:primary_key].to_s) : id
 
             if (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, key)
               unless reflection.through_reflection

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -798,6 +798,13 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_includes order.books, cpk_books(:cpk_great_author_second_book)
   end
 
+  def test_has_one_cpk_has_one_autosave_with_id
+    book = Cpk::Book.create!(author_id: 1, number: 3, shop_id: 2)
+    order = Cpk::OrderWithPrimaryKeyAssociatedBook.create!(book: book, shop_id: 2)
+
+    assert_equal(book.order.id, order.id)
+  end
+
   def test_assign_ids_for_through_a_belongs_to
     firm = Firm.new("name" => "Apple")
     firm.developer_ids = [developers(:david).id, developers(:jamis).id]

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -16,4 +16,8 @@ module Cpk
     has_many :books
     has_one :book
   end
+
+  class OrderWithPrimaryKeyAssociatedBook < Order
+    has_one :book, primary_key: :id, foreign_key: :order_id
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because composite primary key models do not autosave properly when their association primary key is set to `:id`. In models with composite primary keys, the `#id` accessor will return an array, where we actually want the id column value.

### Detail

This Pull Request changes has_one autosaving to use `_read_attribute` instead of `public_send` so that it won't use the `#id` accessor.

### Additional information

Are we concerned with this breaking behaviour of existing apps?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
