### PR TITLE
Eager load composite primary keys models

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -253,22 +253,24 @@ module ActiveRecord
             end
 
             if node.primary_key
-              key = aliases.column_alias(node, node.primary_key)
-              id = row[key]
+              keys = Array(node.primary_key).map { |column| aliases.column_alias(node, column) }
+              ids = keys.map { |key| row[key] }
             else
-              key = aliases.column_alias(node, node.reflection.join_primary_key.to_s)
-              id = nil # Avoid id-based model caching.
+              keys = Array(node.reflection.join_primary_key).map { |column| aliases.column_alias(node, column.to_s) }
+              ids = keys.map { nil } # Avoid id-based model caching.
             end
 
-            if row[key].nil?
+            if keys.any? { |key| row[key].nil? }
               nil_association = ar_parent.association(node.reflection.name)
               nil_association.loaded!
               next
             end
 
-            unless model = seen[ar_parent][node][id]
-              model = construct_model(ar_parent, node, row, model_cache, id, strict_loading_value)
-              seen[ar_parent][node][id] = model if id
+            ids.each do |id|
+              unless model = seen[ar_parent][node][id]
+                model = construct_model(ar_parent, node, row, model_cache, id, strict_loading_value)
+                seen[ar_parent][node][id] = model if id
+              end
             end
 
             construct(model, node, row, seen, model_cache, strict_loading_value)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1720,6 +1720,18 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal order, Cpk::OrderAgreement.eager_load(:order).find_by(id: order_agreement.id).order
   end
 
+  test "preloading has_many with cpk" do
+    order = Cpk::Order.create!(shop_id: 2)
+    order_agreement = Cpk::OrderAgreement.create!(order: order)
+    assert_equal [order_agreement], Cpk::Order.eager_load(:order_agreements).find_by(id: order.id).order_agreements
+  end
+
+  test "preloading has_one with cpk" do
+    order = Cpk::Order.create!(shop_id: 2)
+    book = Cpk::Book.create!(order: order, author_id: 1, number: 3)
+    assert_equal book, Cpk::Order.eager_load(:book).find_by(id: order.id).book
+  end
+
   private
     def find_all_ordered(klass, include = nil)
       klass.order("#{klass.table_name}.#{klass.primary_key}").includes(include).to_a

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -34,6 +34,7 @@ require "models/pirate"
 require "models/matey"
 require "models/parrot"
 require "models/sharded"
+require "models/cpk"
 
 class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
   fixtures :citations
@@ -1711,6 +1712,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
     blog_post = blog_posts.find { |post| post.id == expected_blog_post.id }
 
     assert_equal(expected_tag_ids.sort, blog_post.tags.map(&:id).sort)
+  end
+
+  test "preloading belongs_to with cpk" do
+    order = Cpk::Order.create!(shop_id: 2)
+    order_agreement = Cpk::OrderAgreement.create!(order: order)
+    assert_equal order, Cpk::OrderAgreement.eager_load(:order).find_by(id: order_agreement.id).order
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because eager loading models and associations with composite primary keys is currently broken.

### Detail

This Pull Request changes join dependency assignment to properly handle nodes with composite primary keys.

### Additional information

I also had to change `distinct_relation_for_primary_key` to handle composite keys for has_many/has_one relations. I chose to use `Array#transpose` because we basically have to turn `[[id], [other_id]]` into `[[id, other_id]]`, or `[[cpk_id_1, cpk_id_2], [other_cpk_id_1, other_cpk_id_2]]` into `[[cpk_id_1, other_cpk_id_1], [cpk_id_2, other_cpk_id_2]]` in the composite primary key case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I chose to include the patch for belongs_to and has_many/has_one in one PR. Happy to split it into two if needed.