### PR TITLE
Bugfix: Ensure has_one associations saved when part of CPK has changed

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -482,7 +482,10 @@ module ActiveRecord
       def association_foreign_key_changed?(reflection, record, key)
         return false if reflection.through_reflection?
 
-        record._has_attribute?(reflection.foreign_key) && record._read_attribute(reflection.foreign_key) != key
+        foreign_key = Array(reflection.foreign_key)
+        return false unless foreign_key.all? { |key| record._has_attribute?(key) }
+
+        foreign_key.map { |key| record._read_attribute(key) } != Array(key)
       end
 
       def inverse_polymorphic_association_changed?(reflection, record)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -376,6 +376,16 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal order_id, book.order_id
   end
 
+  def test_should_set_composite_foreign_key_on_association_when_key_changes_on_associated_record
+    book = Cpk::Book.create!(id: [1, 2], title: "The Well-Grounded Rubyist")
+    order = Cpk::Order.create!(id: [1, 2], book: book)
+
+    order.shop_id = 3
+    order.save!
+
+    assert_equal 3, book.shop_id
+  end
+
   def test_building_the_belonging_object_with_implicit_sti_base_class
     account = Account.new
     company = account.build_firm


### PR DESCRIPTION
### Motivation / Background

If a has_one association uses a composite primary key, and part of the composite primary key changes on the owner, these changes need to be reflected on the belonging object's foreign key.

This was not working previously, because `#_record_changed?` was not equipped to handle composite primary key associations, so we were not recognizing that the belonging object's foreign key needed to be updated when the owner's primary key changed.

### Detail

Maintain the same check as was previously used in `#_record_changed?`, but adjust it to accommodate composite primary | foreign keys. This means checking that the record has _all_ attributes that form the primary key on the owner, and then checking that the composite FK values don't match the owner's PK. This indicates that the record has changed, and that we should update its foreign key values accordingly.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A)
