### PR TITLE
Use `SHA256` digest instead of `MD4` that is legacy in OpenSSL 3

### DIFF
--- a/activesupport/test/rotation_coordinator_tests.rb
+++ b/activesupport/test/rotation_coordinator_tests.rb
@@ -97,20 +97,20 @@ module RotationCoordinatorTests
     test "#transitional swaps the first two rotations when enabled" do
       coordinator = make_coordinator.rotate(digest: "SHA1")
       coordinator.rotate(digest: "MD5")
-      coordinator.rotate(digest: "MD4")
+      coordinator.rotate(digest: "SHA256")
       coordinator.transitional = true
 
       codec = coordinator["salt"]
       sha1_codec = (make_coordinator.rotate(digest: "SHA1"))["salt"]
       md5_codec = (make_coordinator.rotate(digest: "MD5"))["salt"]
-      md4_codec = (make_coordinator.rotate(digest: "MD4"))["salt"]
+      sha256_codec = (make_coordinator.rotate(digest: "SHA256"))["salt"]
 
       assert_equal "message", roundtrip("message", codec, md5_codec)
       assert_nil roundtrip("message", codec, sha1_codec)
 
       assert_equal "message", roundtrip("message", sha1_codec, codec)
       assert_equal "message", roundtrip("message", md5_codec, codec)
-      assert_equal "message", roundtrip("message", md4_codec, codec)
+      assert_equal "message", roundtrip("message", sha256_codec, codec)
     end
 
     test "#transitional works with a single rotation" do
@@ -131,17 +131,17 @@ module RotationCoordinatorTests
         { digest: "SHA1" } if salt == "salt"
       end
       coordinator.rotate(digest: "MD5")  # (2) Then, everything upgraded to MD5
-      coordinator.rotate(digest: "MD4")  # (1) Originally, everything used MD4
+      coordinator.rotate(digest: "SHA256")  # (1) Originally, everything used SHA256
       coordinator.transitional = true
 
       sha1_coordinator = make_coordinator.rotate(digest: "SHA1")
       md5_coordinator = make_coordinator.rotate(digest: "MD5")
 
-      # "salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, MD5, MD4] => [MD5, SHA1, MD4])
+      # "salt" encodes with MD5 and can decode SHA1 (i.e. [SHA1, MD5, SHA256] => [MD5, SHA1, SHA256])
       assert_equal "message", roundtrip("message", coordinator["salt"], md5_coordinator["salt"])
       assert_equal "message", roundtrip("message", sha1_coordinator["salt"], coordinator["salt"])
 
-      # "other salt" encodes with MD5 and cannot decode SHA1 (i.e. [nil, MD5, MD4] => [MD5, MD4])
+      # "other salt" encodes with MD5 and cannot decode SHA1 (i.e. [nil, MD5, SHA256] => [MD5, SHA256])
       assert_equal "message", roundtrip("message", coordinator["other salt"], md5_coordinator["other salt"])
       assert_nil roundtrip("message", sha1_coordinator["other salt"], coordinator["other salt"])
     end


### PR DESCRIPTION
### Motivation / Background

Fix #48483

### Detail

This pull request updates the MD4 digest used in `MessageEncryptorsTest` because OpenSSL 3 moves `MD4` digests as legacy provider.

[Major changes between OpenSSL 3.0.0 and OpenSSL 3.0.1 [14 Dec 2021]
](https://www.openssl.org/news/openssl-3.0-notes.html
)
> Moved the EVP digests MD2, MD4, MDC2, WHIRLPOOL and RIPEMD-160 to the legacy provider.

Since Rails CI migrates from Debian 11 "bullseye" based Ruby 3.1 and 3.2 images to Debian 12 "bookworm" based ones, that supports OpenSSL 3, `MessageEncryptorsTest` raises `EVP_DigestSignInit: unsupported (OpenSSL::HMACError)` and `Digest initialization failed: initialization error (OpenSSL::Digest::DigestError)`

https://packages.debian.org/bookworm/openssl
> Package: openssl (3.0.9-1)

### Additional information

`SHA256` is listed as `Provided:` via `openssl list -digest-algorithms` output, so it is safe to use `SHA256` digest in the `MessageEncryptorsTest`.

```
  { 2.16.840.1.101.3.4.2.1, SHA-256, SHA2-256, SHA256 } @ default
```

```
$ openssl version
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)
$ openssl list -digest-algorithms
Legacy:
  RSA-MD4 => MD4
  RSA-MD5 => MD5
  RSA-RIPEMD160 => RIPEMD160
  RSA-SHA1 => SHA1
  RSA-SHA1-2 => RSA-SHA1
  RSA-SHA224 => SHA224
  RSA-SHA256 => SHA256
  RSA-SHA3-224 => SHA3-224
  RSA-SHA3-256 => SHA3-256
  RSA-SHA3-384 => SHA3-384
  RSA-SHA3-512 => SHA3-512
  RSA-SHA384 => SHA384
  RSA-SHA512 => SHA512
  RSA-SHA512/224 => SHA512-224
  RSA-SHA512/256 => SHA512-256
  RSA-SM3 => SM3
  BLAKE2b512
  BLAKE2s256
  id-rsassa-pkcs1-v1_5-with-sha3-224 => SHA3-224
  id-rsassa-pkcs1-v1_5-with-sha3-256 => SHA3-256
  id-rsassa-pkcs1-v1_5-with-sha3-384 => SHA3-384
  id-rsassa-pkcs1-v1_5-with-sha3-512 => SHA3-512
  MD4
  md4WithRSAEncryption => MD4
  MD5
  MD5-SHA1
  md5WithRSAEncryption => MD5
  ripemd => RIPEMD160
  RIPEMD160
  ripemd160WithRSA => RIPEMD160
  rmd160 => RIPEMD160
  SHA1
  sha1WithRSAEncryption => SHA1
  SHA224
  sha224WithRSAEncryption => SHA224
  SHA256
  sha256WithRSAEncryption => SHA256
  SHA3-224
  SHA3-256
  SHA3-384
  SHA3-512
  SHA384
  sha384WithRSAEncryption => SHA384
  SHA512
  SHA512-224
  sha512-224WithRSAEncryption => SHA512-224
  SHA512-256
  sha512-256WithRSAEncryption => SHA512-256
  sha512WithRSAEncryption => SHA512
  SHAKE128
  SHAKE256
  SM3
  sm3WithRSAEncryption => SM3
  ssl3-md5 => MD5
  ssl3-sha1 => SHA1
  whirlpool
Provided:
  { 2.16.840.1.101.3.4.2.10, SHA3-512 } @ default
  { 1.3.6.1.4.1.1722.12.2.2.8, BLAKE2S-256, BLAKE2s256 } @ default
  { 1.2.156.10197.1.401, SM3 } @ default
  { 2.16.840.1.101.3.4.2.8, SHA3-256 } @ default
  { 2.16.840.1.101.3.4.2.7, SHA3-224 } @ default
  { 2.16.840.1.101.3.4.2.2, SHA-384, SHA2-384, SHA384 } @ default
  { 2.16.840.1.101.3.4.2.3, SHA-512, SHA2-512, SHA512 } @ default
  { 2.16.840.1.101.3.4.2.5, SHA-512/224, SHA2-512/224, SHA512-224 } @ default
  { 2.16.840.1.101.3.4.2.12, SHAKE-256, SHAKE256 } @ default
  { 2.16.840.1.101.3.4.2.1, SHA-256, SHA2-256, SHA256 } @ default
  { 1.3.14.3.2.26, SHA-1, SHA1, SSL3-SHA1 } @ default
  { 2.16.840.1.101.3.4.2.9, SHA3-384 } @ default
  { 2.16.840.1.101.3.4.2.11, SHAKE-128, SHAKE128 } @ default
  MD5-SHA1 @ default
  { 1.3.36.3.2.1, RIPEMD, RIPEMD-160, RIPEMD160, RMD160 } @ default
  { 1.2.840.113549.2.5, MD5, SSL3-MD5 } @ default
  { 2.16.840.1.101.3.4.2.4, SHA-224, SHA2-224, SHA224 } @ default
  { 1.3.6.1.4.1.1722.12.2.1.16, BLAKE2B-512, BLAKE2b512 } @ default
  { 2.16.840.1.101.3.4.2.6, SHA-512/256, SHA2-512/256, SHA512-256 } @ default
  { KECCAK-KMAC-128, KECCAK-KMAC128 } @ default
  { KECCAK-KMAC-256, KECCAK-KMAC256 } @ default
  NULL @ default
$
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
