### PR TITLE
Added `foregin_key` to the allowed validation options for managing columns and tables in migration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added `foregin_key` to the allowed validation options for managing columns and tables in migration.
+
+    The `foregin_key` option is a valid value when managing tables and columns, so it is not treated as an error
+
+    *Shodai Suzuki*
+
 *   Added PostgreSQL migration commands for enum rename, add value, and rename value.
 
     `rename_enum` and `rename_enum_value` are reversible. Due to Postgres

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -84,7 +84,8 @@ module ActiveRecord
         :comment,
         :primary_key,
         :if_exists,
-        :if_not_exists
+        :if_not_exists,
+        :foregin_key
       ]
 
       def primary_key?

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -90,6 +90,11 @@ module ActiveRecord
           super
         end
 
+        def add_reference(table_name, ref_name, **options)
+          options[:_skip_validate_options] = true
+          super
+        end
+
         def add_index(table_name, column_name, **options)
           options[:name] = legacy_index_name(table_name, column_name) if options[:name].nil?
           super

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -266,6 +266,8 @@ module ActiveRecord
 
             add_column :tests, "last_name", :string, wrong_precision: true
 
+            add_reference :tests, :more_testings, foregin_key: true
+
             change_column :tests, :some_id, :float, wrong_index: true
 
             change_table :tests do |t|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because raise an error when adding columns in a new migration if `foregin_key` is included. 

### Detail

This Pull Request changes fix an error when adding columns in a new migration if `foregin_key` is included.
The error occurs in cases where `foregin_key` is specified such as `add_reference` in an old migration definition. For example, the bellow:

```ruby
class ChangeTableUsers < ActiveRecord::Migration[6.0]
  def change
    add_reference :users, :posts, foregin_key: true
  end
end

#=> eval error: Unknown key: :foregin_key. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :auto_increment, :charset, :as, :size, :unsigned, :first, :after, :type, :stored
```

An error is generated if an option other than the allowed option is entered. The `foregin_key` is not included in the allowed options, but it is necessary, so it was added.

Also, `add_reference` is now compatible with lower versions.

### Additional information

- Modified PR: https://github.com/rails/rails/pull/46178

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
