### PR TITLE
Don't show contents for EncryptedConfiguration#inspect

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Don't show contents for `EncryptedConfiguration#inspect`.
+
+    Before:
+    ```ruby
+    Rails.application.credentials.inspect
+    "#<ActiveSupport::EncryptedConfiguration:0x000000010d2b38e8 ... @config={:secret=>\"something secret\"} ... @key_file_contents=\"915e4ea054e011022398dc242\" ...>"
+    ```
+
+    After:
+    ```ruby
+    Rails.application.credentials.inspect
+    "#<ActiveSupport::EncryptedConfiguration:0x000000010d2b38e8>"
+    ```
+
+    *Petrik de Heus*
+
 *   `ERB::Util.html_escape_once` always returns an `html_safe` string.
 
     This method previously maintained the `html_safe?` property of a string on the return

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -76,6 +76,10 @@ module ActiveSupport
       @config ||= deserialize(read).deep_symbolize_keys
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
+
     private
       def deep_transform(hash)
         return hash unless hash.is_a?(Hash)

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -85,4 +85,13 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   test "raises key error when accessing config via bang method" do
     assert_raise(KeyError) { @credentials.something! }
   end
+
+  test "inspect does not show unencrypted attributes" do
+    secret = "something secret"
+    @credentials.write({ secret: secret }.to_yaml)
+    @credentials.config
+
+    assert_no_match(/#{secret}/, @credentials.inspect)
+    assert_match(/\A#<ActiveSupport::EncryptedConfiguration:0x[0-9a-f]+>\z/, @credentials.inspect)
+  end
 end


### PR DESCRIPTION
If anyone calls `Rails.application.credentials` in the console it will show the unencrypted contents of the credentials.

By overriding the `inspect` method to only show the class name we can avoid accidentally outputting sensitive information.

### Before:
```ruby
Rails.application.credentials.inspect
"#<ActiveSupport::EncryptedConfiguration:0x000000010d2b38e8 ... 
    @config={:secret=>\"something secret\"} ... 
    @key_file_contents=\"915e4ea054e011022398dc242\" ...>"
```

### After:
```ruby
Rails.application.credentials.inspect
"#<ActiveSupport::EncryptedConfiguration:0x000000010d2b38e8>"
```



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
