### PR TITLE
Don't show secrets for MessageEncryptor#inspect

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Don't show secrets for `MessageEncryptor#inspect`.
+
+    Before:
+
+    ```ruby
+    ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm").inspect
+    "#<ActiveSupport::MessageEncryptor:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
+    ```
+
+    After:
+
+    ```ruby
+    ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm").inspect
+    "#<ActiveSupport::MessageEncryptor:0x0000000104888038>"
+    ```
+
+    *Petrik de Heus*
+
 *   Don't show contents for `EncryptedConfiguration#inspect`.
 
     Before:
@@ -10,7 +28,6 @@
     ```ruby
     Rails.application.credentials.inspect
     "#<ActiveSupport::EncryptedConfiguration:0x000000010d2b38e8>"
-    ```
 
     *Petrik de Heus*
 

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -261,6 +261,10 @@ module ActiveSupport
       deserialize_with_metadata(decrypt(verify(message)), **options)
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
+
     private
       def sign(data)
         @verifier ? @verifier.create_message(data) : data

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -152,6 +152,11 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_equal "Ruby on Rails", encryptor.decrypt_and_verify(encrypted_message)
   end
 
+  def test_inspect_does_not_show_secrets
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
+    assert_match(/\A#<ActiveSupport::MessageEncryptor:0x[0-9a-f]+>\z/, encryptor.inspect)
+  end
+
   private
     def make_codec(**options)
       ActiveSupport::MessageEncryptor.new(@secret, **options)


### PR DESCRIPTION
If anyone calls a message encryptor in the console it will show the secret of the encryptor.

By overriding the `inspect` method to only show the class name we can avoid accidentally outputting sensitive information.

### Before:

```ruby
ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm").inspect
"#<ActiveSupport::MessageEncryptor:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
```

### After:

```ruby
ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm").inspect
"#<ActiveSupport::MessageEncryptor:0x0000000104888038>"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
