### PR TITLE
Don't show secret_key_base for `Rails.application.config#inspect`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Don't show secret_key_base for `Rails.application.config#inspect`.
+
+    Before:
+
+    ```ruby
+    Rails.application.config.inspect
+    "#<Rails::Application::Configuration:0x00000001132b02a0 @root=... @secret_key_base=\"b3c631c314c0bbca50c1b2843150fe33\" ... >"
+    ```
+
+    After:
+
+    ```ruby
+    Rails.application.config.inspect
+    "#<Rails::Application::Configuration:0x00000001132b02a0>"
+    ```
+
+    *Petrik de Heus*
+
 *   Deprecate calling `Rails.application.secrets`.
 
     Rails `secrets` have been deprecated in favor of `credentials`.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -527,6 +527,10 @@ module Rails
         f
       end
 
+      def inspect # :nodoc:
+        "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+      end
+
       class Custom # :nodoc:
         def initialize
           @configurations = Hash.new

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -781,6 +781,17 @@ module ApplicationTests
       end
     end
 
+    test "don't output secret_key_base when calling inspect" do
+      secret = "b3c631c314c0bbca50c1b2843150fe33"
+      add_to_config <<-RUBY
+        Rails.application.config.secret_key_base = "#{secret}"
+      RUBY
+      app "production"
+
+      assert_no_match(/#{secret}/, Rails.application.config.inspect)
+      assert_match(/\A#<Rails::Application::Configuration:0x[0-9a-f]+>\z/, Rails.application.config.inspect)
+    end
+
     test "Rails.application.key_generator supports specifying a secret base" do
       app "production"
 


### PR DESCRIPTION
When calling `Rails.application.config#inspect` it will show all attributes, including @secret_key_base after 21c34550549ed90f79565b333e06c7cee79c546e

By overriding the `inspect` method to only show the class name we can avoid accidentally outputting sensitive information.

Before:

```ruby
Rails.application.config.inspect
"#<Rails::Application::Configuration:0x00000001132b02a0 @root=... @secret_key_base=\"b3c631c314c0bbca50c1b2843150fe33\" ... >"
```

After:

```ruby
Rails.application.config.inspect
"#<Rails::Application::Configuration:0x00000001132b02a0>"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
