### PR TITLE
NullTransaction can have `nil` state

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -525,10 +525,10 @@ module ActiveRecord
                 begin
                   commit_transaction
                 rescue ActiveRecord::ConnectionFailed
-                  transaction.invalidate! unless transaction.state.completed?
+                  transaction.invalidate! unless transaction&.state&.completed?
                   raise
                 rescue Exception
-                  rollback_transaction(transaction) unless transaction.state.completed?
+                  rollback_transaction(transaction) unless transaction&.state&.completed?
                   raise
                 end
               end


### PR DESCRIPTION
Add safe navigation operator to ensure NullTransaction have same behavior than Transaction, causing issue with Database Cleaner gem (https://github.com/DatabaseCleaner/database_cleaner/issues/692).

