### PR TITLE
Remove unnecessary setters of `use_transactional_tests`

### DIFF
--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -26,8 +26,6 @@ require "models/sharded/blog_post_tag"
 require "models/sharded/blog"
 
 class DestroyAssociationAsyncTest < ActiveRecord::TestCase
-  self.use_transactional_tests = false
-
   include ActiveJob::TestHelper
 
   test "destroying a record destroys the has_many :through records using a job" do

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
@@ -5,7 +5,6 @@ require "support/schema_dumping_helper"
 
 class CharsetCollationTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
-  self.use_transactional_tests = false
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
@@ -3,8 +3,6 @@
 require "cases/helper"
 
 class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
-  self.use_transactional_tests = false
-
   def setup
     @schema_migration = ActiveRecord::Base.connection.schema_migration
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -5,7 +5,6 @@ require "support/schema_dumping_helper"
 
 class TableOptionsTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
-  self.use_transactional_tests = false
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -16,8 +16,6 @@ class PostgresqlLtree < ActiveRecord::Base
 end
 
 class PostgresqlDataTypeTest < ActiveRecord::PostgreSQLTestCase
-  self.use_transactional_tests = false
-
   def setup
     @connection = ActiveRecord::Base.connection
 

--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -49,8 +49,6 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  self.use_transactional_tests = false
-
   setup do
     @connection = ActiveRecord::Base.connection
   end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -7,7 +7,6 @@ require "support/connection_helper"
 module ActiveRecord
   module ConnectionAdapters
     class PostgreSQLAdapterPreventWritesTest < ActiveRecord::PostgreSQLTestCase
-      self.use_transactional_tests = false
       include DdlHelper
       include ConnectionHelper
 

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -9,7 +9,6 @@ class PostgresqlRange < ActiveRecord::Base
 end
 
 class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
-  self.use_transactional_tests = false
   include ConnectionHelper
   include InTimeZone
 

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -4,8 +4,6 @@ require "cases/helper"
 require "support/connection_helper"
 
 class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
-  self.use_transactional_tests = false
-
   include ConnectionHelper
 
   IS_REFERENTIAL_INTEGRITY_SQL = lambda do |sql|

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -713,7 +713,6 @@ end
 
 class SchemaWithDotsTest < ActiveRecord::PostgreSQLTestCase
   include PGSchemaHelper
-  self.use_transactional_tests = false
 
   setup do
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -7,8 +7,6 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
   class PostgresqlVirtualColumnTest < ActiveRecord::PostgreSQLTestCase
     include SchemaDumpingHelper
 
-    self.use_transactional_tests = false
-
     class VirtualColumn < ActiveRecord::Base
     end
 

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -131,8 +131,6 @@ class AsynchronousQueriesTest < ActiveRecord::TestCase
 end
 
 class AsynchronousQueriesWithTransactionalTest < ActiveRecord::TestCase
-  self.use_transactional_tests = true
-
   include AsynchronousQueriesSharedTests
 
   def setup

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -6,8 +6,6 @@ class TestRecord < ActiveRecord::Base
 end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase
-  self.use_transactional_tests = false
-
   def setup
     @connection = ActiveRecord::Base.connection
   end

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -4,7 +4,6 @@ require "cases/helper"
 
 class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
   if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-    self.use_transactional_tests = false
 
     class Bird < ActiveRecord::Base
     end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -7,8 +7,6 @@ module ActiveRecord
     class ReferencesStatementsTest < ActiveRecord::TestCase
       include ActiveRecord::Migration::TestHelper
 
-      self.use_transactional_tests = false
-
       def setup
         super
         @table_name = :test_models

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -4,8 +4,6 @@ require "cases/helper"
 require "cases/migration/helper"
 
 class MigratorTest < ActiveRecord::TestCase
-  self.use_transactional_tests = false
-
   # Use this class to sense if migrations have gone
   # up or down.
   class Sensor < ActiveRecord::Migration::Current

--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -4,8 +4,6 @@ require "cases/helper"
 require "cases/migration/helper"
 
 class MultiDbMigratorTest < ActiveRecord::TestCase
-  self.use_transactional_tests = false
-
   # Use this class to sense if migrations have gone
   # up or down.
   class Sensor < ActiveRecord::Migration::Current

--- a/activerecord/test/cases/primary_class_test.rb
+++ b/activerecord/test/cases/primary_class_test.rb
@@ -3,8 +3,6 @@
 require "cases/helper"
 
 class PrimaryClassTest < ActiveRecord::TestCase
-  self.use_transactional_tests = false
-
   def teardown
     clean_up_connection_handler
   end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -310,8 +310,6 @@ end
 class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
 
-  self.use_transactional_tests = false
-
   class Barcode < ActiveRecord::Base
   end
 
@@ -490,8 +488,6 @@ end
 
 class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
-
-  self.use_transactional_tests = false
 
   def setup
     @connection = ActiveRecord::Base.connection


### PR DESCRIPTION
I've removed `self.use_transactional_tests = false` from the tests here as they don't appear to be necessary. They were likely added when other tests were copied or just an assumption they were needed.
