### PR TITLE
Fix fixture_path deprecation

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -193,7 +193,7 @@ class QueryCacheTest < ActiveRecord::TestCase
             t.datetime :ending
           end
         end
-        ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_path, ["tasks"], {}, ActiveRecord::Base)
+        ActiveRecord::FixtureSet.create_fixtures(self.class.fixture_paths, ["tasks"], {}, ActiveRecord::Base)
       end
 
       ActiveRecord::Base.connection_pool.connections.each do |conn|


### PR DESCRIPTION
Replace `fixture_path` with `fixture_paths` to fix the deprecation warning for fixture paths.

Ex warning:

```
DEPRECATION WARNING: TestFixtures#fixture_path is deprecated and
will be removed in Rails 7.2. Use #fixture_paths instead.
If multiple fixture paths have been configured with #fixture_paths,
then #fixture_path will just return the first path.
```
