### PR TITLE
Autoload ActiveRecord::FixtureSet

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -49,6 +49,7 @@ module ActiveRecord
   autoload :Encryption
   autoload :Enum
   autoload :Explain
+  autoload :FixtureSet, "active_record/fixtures"
   autoload :Inheritance
   autoload :Integration
   autoload :InternalMetadata

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -6,9 +6,6 @@ require "zlib"
 require "set"
 require "active_support/dependencies"
 require "active_support/core_ext/digest/uuid"
-require "active_record/fixture_set/file"
-require "active_record/fixture_set/render_context"
-require "active_record/fixture_set/table_rows"
 require "active_record/test_fixtures"
 
 module ActiveRecord
@@ -473,6 +470,10 @@ module ActiveRecord
   #
   # Any fixtures labeled "_fixture" are safely ignored.
   class FixtureSet
+    require "active_record/fixture_set/file"
+    require "active_record/fixture_set/render_context"
+    require "active_record/fixture_set/table_rows"
+
     #--
     # An instance of FixtureSet is normally stored in a single YAML file and
     # possibly in a folder with the same name.


### PR DESCRIPTION
### Motivation / Background

When eager_load is enabled and something (like the frozen_record gem) tries to load yaml files that use `ActiveRecord::FixtureSet.identify(...)` we'll get an uninitialized constant error.

### Detail

With a new rails app, add the `frozen_record` gem and two files:
```
$ cat app/models/ice.rb
class Ice < FrozenRecord::Base
  self.base_path = Rails.root.join("db/data").to_s
end
$ cat db/data/ices.yml.erb
- y: <%= ActiveRecord::FixtureSet.identify(:fake) %>
```

Running `CI=true bin/rails test` will abort with an uninitialized constant error:

```
$ CI=1 bin/rails test
(erb):1:in `<main>': uninitialized constant ActiveRecord::FixtureSet (NameError)

_erbout = +''; _erbout.<< "- y: ".freeze; _erbout.<<(( ActiveRecord::FixtureSet.identify(:fake) ).to_s); _erbout.<< "\n".freeze
```

### Notes

It may be worth noting that this file is already autoloaded in this module for a different constant:
https://github.com/rails/rails/blob/df24e61cfb9a0e61f35989e35da487299d805e03/activerecord/lib/active_record.rb#L84

Simply adding the autoload line introduced a circular require
(fixtures.rb defines FixtureSet but before that it tries to load files beneath that namespace)
so I moved those requires down to after the class definition
as is done in
https://github.com/rails/rails/blob/7dd67dc285fcdbb788cbdcdcaf53f6ce588bf7e5/activesupport/lib/active_support/deprecation.rb#L35-L54


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
