### PR TITLE
Fix empty string saving for ranges

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -18,7 +18,7 @@ module ActiveRecord
           end
 
           def cast_value(value)
-            return if value == "empty"
+            return if ["empty", ""].include? value
             return value unless value.is_a?(::String)
 
             extracted = extract_bounds(value)

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -564,6 +564,20 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     assert_equal 0.5...Float::INFINITY, record.float_range
   end
 
+  def test_empty_string_range_values
+    record = PostgresqlRange.create!(
+      int4_range: "",
+      int8_range: "",
+      float_range: ""
+    )
+
+    record = PostgresqlRange.find(record.id)
+
+    assert_nil record.int4_range
+    assert_nil record.int8_range
+    assert_nil record.float_range
+  end
+
   private
     def assert_equal_round_trip(range, attribute, value)
       round_trip(range, attribute, value)


### PR DESCRIPTION
### Motivation / Background
Fixes https://github.com/rails/rails/issues/48486

Saving ranges with an empty range

### Detail

Simply return if the string is empty, the same as it's being done for an "empty" string.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
