### PR TITLE
Change new_framework_defaults_7_1.rb to use the right config for hash_digest_class

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Change new_framework_defaults_7_1.rb to use the right config for hash_digest_class.
+
+    new_framework_defaults_7_1.rb was being generated with the instruction to change
+    the hash_digest_class using Rails.application.config.active_record.encryption.hash_digest_class
+    but the correct way to set it is using ActiveRecord::Encryption.config.hash_digest_class.
+
+    *Carlos Ribeiro*
+
 *   Don't show secret_key_base for `Rails.application.config#inspect`.
 
     Before:

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -33,10 +33,10 @@
 # data encrypted with previous versions, you should not set the new default or the existing data
 # will fail to decrypt. In this case, if you load the new 7.1 defaults, you need to configure the
 # previous algorithm SHA-1:
-# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
+# ActiveRecord::Encryption.config.hash_digest_class = OpenSSL::Digest::SHA1
 # Alternatively, if you don't have data encrypted previously, you can configure the new digest for
 # Active Record Encryption with:
-# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+# ActiveRecord::Encryption.config.hash_digest_class = OpenSSL::Digest::SHA256
 
 # No longer run after_commit callbacks on the first of multiple Active Record
 # instances to save changes to the same database row within a transaction.


### PR DESCRIPTION
### Detail

Previously the template was using
Rails.application.config.active_record.encryption.hash_digest_class to set the hash digest class but the correct way to set it is using ActiveRecord::Encryption.config.hash_digest_class.

### Additional information

I found this while debugging https://github.com/rails/rails/issues/48204 and I noticed that the PR https://github.com/rails/rails/pull/44873 added an option to configure the hash_class used to encrypt the attribute by setting the `ActiveRecord::Encryption.config.hash_digest_class` on the initializer. But while debugging my issue, I found that the code to use this hash_digest_class wasn't using the different hash_digest_class that I set and I noticed that the ActiveRecord::Encryption was only configured only at the `active_record` railtie at

```ruby
    initializer "active_record_encryption.configuration" do |app|
      ActiveRecord::Encryption.configure \
         primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
         deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
         key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
         **config.active_record.encryption
```

and my `new_framework_defaults_7_1` was loaded after that. 

So I workaround this by changing the `new_framework_defaults_7_1` to set the digest via 
```ruby
ActiveRecord::Encryption.config.hash_digest_class = OpenSSL::Digest::SHA256
```
instead. 

IDK if this is a valid approach or if I was doing something wrong 😄 . probably @jorgemanrubia can give his thoughts 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
