### PR TITLE
Allow default CSP setup to work with empty sessions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -17,6 +17,7 @@
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+#   # For more on what value to use: https://guides.rubyonrails.org/security.html#adding-a-nonce
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id || SecureRandom.hex(16) }
 #   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -17,7 +17,7 @@
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id || SecureRandom.hex(16) }
 #   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
 #   # Report violations without enforcing the policy.


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/48463

Since https://github.com/rails/rails/pull/43227, the default CSP suggested in the initializer does not work with empty sessions. See [this comment](https://github.com/rails/rails/pull/43227#issuecomment-1191692615) for an example issue and workaround.

### Detail

This PR just adds a fallback in case the session has not been loaded. I also updated the railties test to match the config in the default initializer.
