### PR TITLE
Support queries using the `LIKE` operator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Support queries using the `LIKE` operator through `where.like(...)`.
+
+    ```ruby
+    User.where.like(name: "nixon")
+    #=> SELECT * FROM users WHERE name LIKE 'nixon'
+
+    User.where.like(name: %w(nixon DHH))
+    #=> SELECT * FROM users WHERE (name LIKE 'nixon' OR name LIKE 'DHH')
+
+    User.where.like.not(name: "nixon")
+    #=> SELECT * FROM users WHERE name NOT LIKE 'nixon'
+    ```
+
+    *Lazaro Nixon*
+
 *   Added PostgreSQL migration commands for enum rename, add value, and rename value.
 
     `rename_enum` and `rename_enum_value` are reversible. Due to Postgres

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -92,6 +92,21 @@ module ActiveRecord
         WhereClause.new(inverted_predicates)
       end
 
+      def match
+        matched_predicates = predicates.map do |x|
+          case x
+          when Arel::Nodes::Equality
+            x.left.matches(x.right)
+          when Arel::Nodes::HomogeneousIn
+            x.left.matches_any(x.right)
+          else
+            raise ArgumentError, "Unsupported argument type: #{x.class.name}."
+          end
+        end
+
+        WhereClause.new(matched_predicates)
+      end
+
       def self.empty
         @empty ||= new([]).freeze
       end

--- a/activerecord/lib/arel/nodes/matches.rb
+++ b/activerecord/lib/arel/nodes/matches.rb
@@ -3,6 +3,8 @@
 module Arel # :nodoc: all
   module Nodes
     class Matches < Binary
+      include FetchAttribute
+
       attr_reader :escape
       attr_accessor :case_sensitive
 
@@ -11,8 +13,16 @@ module Arel # :nodoc: all
         @escape = escape && Nodes.build_quoted(escape)
         @case_sensitive = case_sensitive
       end
+
+      def invert
+        Arel::Nodes::DoesNotMatch.new(left, right, escape, case_sensitive)
+      end
     end
 
-    class DoesNotMatch < Matches; end
+    class DoesNotMatch < Matches
+      def invert
+        Arel::Nodes::Matches.new(left, right, escape, case_sensitive)
+      end
+    end
   end
 end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -200,5 +200,27 @@ module ActiveRecord
 
       assert_equal expected.to_a, relation.to_a
     end
+
+    def test_like_with_string_value
+      assert_equal [posts(:thinking)], Post.where.like(title: "%ThInKiNg%")
+    end
+
+    def test_like_with_array_value
+      assert_equal [posts(:welcome), posts(:thinking)], Post.where.like(title: %w(%WeLcOme% %ThInKinG%))
+    end
+
+    def test_like_not_with_string_value
+      Post.where.like.not(title: "%ThInKiNg%").tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_not_includes relation, posts(:thinking)
+      end
+    end
+
+    def test_like_with_with_unscope
+      relation = Post.where.like(title: "%ThInKiNg%").unscope(where: :title)
+      expected = Post.all
+
+      assert_equal expected.to_a, relation.to_a
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Support queries using the `LIKE` operator through `where.like(...)`. 

```ruby
User.where.like(name: "nixon")
#=> SELECT * FROM users WHERE name LIKE 'nixon'

User.where.like(name: %w(nixon DHH))
#=> SELECT * FROM users WHERE (name LIKE 'nixon' OR name LIKE 'DHH')

User.where.like.not(name: "nixon")
#=> SELECT * FROM users WHERE name NOT LIKE 'nixon'
```

### More details

It is case-insensitive, on PostgreSQL, it will be `ILIKE`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.