### PR TITLE
:nail_care: Move `:enddoc: to the top of the file

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :enddoc:
+
 # Make double-sure the RAILS_ENV is not set to production,
 # so fixtures aren't loaded into that environment
 abort("Abort testing: Your Rails environment is running in production mode!") if Rails.env.production?
@@ -37,17 +39,15 @@ else
   end
 end
 
-# :enddoc:
-
 ActiveSupport.on_load(:action_controller_test_case) do
-  def before_setup # :nodoc:
+  def before_setup
     @routes = Rails.application.routes
     super
   end
 end
 
 ActiveSupport.on_load(:action_dispatch_integration_test) do
-  def before_setup # :nodoc:
+  def before_setup
     @routes = Rails.application.routes
     super
   end


### PR DESCRIPTION
This way we don't need the other `:nodoc:` statements

Pulled from #48512 to save time