### PR TITLE
update doc to use to_fs over deprecated to_s [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -42,7 +42,7 @@ module ActiveSupport
     #   range = (..100)            # => ..100
     #   range.to_fs(:db)           # => "<= '100'"
     #
-    # == Adding your own range formats to to_s
+    # == Adding your own range formats to to_fs
     # You can add your own formats to the Range::RANGE_FORMATS hash.
     # Use the format name as the hash key and a Proc instance.
     #


### PR DESCRIPTION
Update doc to use `to_fs` over deprecated `to_s`