### PR TITLE
Fix deprecation warning messages for `ActiveSupport::TestFixtures`

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -44,15 +44,15 @@ module ActiveRecord
 
       def fixture_path
         ActiveRecord.deprecator.warn(<<~WARNING)
-          TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.
-          If multiple fixture paths have been configured with #fixture_paths, then #fixture_path will just return
+          TestFixtures.fixture_path is deprecated and will be removed in Rails 7.2. Use .fixture_paths instead.
+          If multiple fixture paths have been configured with .fixture_paths, then .fixture_path will just return
           the first path.
         WARNING
         fixture_paths.first
       end
 
       def fixture_path=(path)
-        ActiveRecord.deprecator.warn("TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.")
+        ActiveRecord.deprecator.warn("TestFixtures.fixture_path= is deprecated and will be removed in Rails 7.2. Use .fixture_paths= instead.")
         self.fixture_paths = Array(path)
       end
 


### PR DESCRIPTION
### Motivation / Background

While reviewing @zzak 's [documentation improvements around fixture paths](https://github.com/rails/rails/pull/48512), I noticed a few minor inconsistencies with the deprecation messages.

### Detail

Minor fixes to the deprecation messages around `TestFixtures.fixture_path`, `TestFixtures.fixture_path=`, and `TestFixtures#fixture_path` to clarify which method is deprecated and which should be used instead. 

Ensure we refer to the class method vs instance method appropriately, and refer to the setter method in the deprecation method for `TestFixtures.fixture_path=`.

cc @andrewn617 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`