### PR TITLE
Wrap active_record_encryption.configuration on an after initialize

### DIFF
--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       included do
         mattr_reader :config, default: Config.new
         mattr_accessor :encrypted_attribute_declaration_listeners
-        mattr_reader :encrypted_attributes, default: Concurrent::Map.new
+        mattr_reader :encrypted_attributes, default: Concurrent::Array.new
       end
 
       class_methods do
@@ -49,20 +49,20 @@ module ActiveRecord
           end
         end
 
-        def install_encrypted_attributed_declared_hook()
+        def install_encrypted_attributed_declared_hook
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
-            encrypted_attributes.fetch_or_store(klass, []) << encrypted_attribute_name
+            encrypted_attributes << [klass, encrypted_attribute_name]
           end
         end
 
         def install_auto_filtered_parameters(app) # :nodoc:
-          encrypted_attributes.each do |klass, attributes|
-            attributes.each do |encrypted_attribute_name|
-              filter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
-              unless excluded_from_filter_parameters?(filter)
-                app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
-                klass.filter_attributes += [encrypted_attribute_name]
-              end
+          encrypted_attributes.each do |encrypted_attribute|
+            klass, encrypted_attribute_name = encrypted_attribute
+
+            filter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
+            unless excluded_from_filter_parameters?(filter)
+              app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
+              klass.filter_attributes += [encrypted_attribute_name]
             end
           end
         end

--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       included do
         mattr_reader :config, default: Config.new
         mattr_accessor :encrypted_attribute_declaration_listeners
-        mattr_reader :encrypted_attributes, default: Concurrent::Array.new
+        mattr_reader :encrypted_attributes_per_class, default: Concurrent::Map.new
       end
 
       class_methods do
@@ -51,18 +51,18 @@ module ActiveRecord
 
         def install_encrypted_attributed_declared_hook
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
-            encrypted_attributes << [klass, encrypted_attribute_name]
+            encrypted_attributes_per_class.fetch_or_store(klass, []) << encrypted_attribute_name
           end
         end
 
         def install_auto_filtered_parameters(app) # :nodoc:
-          encrypted_attributes.each do |encrypted_attribute|
-            klass, encrypted_attribute_name = encrypted_attribute
-
-            filter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
-            unless excluded_from_filter_parameters?(filter)
-              app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
-              klass.filter_attributes += [encrypted_attribute_name]
+          encrypted_attributes_per_class.each do |klass, attributes|
+            attributes.each do |encrypted_attribute_name|
+              filter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
+              unless excluded_from_filter_parameters?(filter)
+                app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
+                klass.filter_attributes += [encrypted_attribute_name]
+              end
             end
           end
         end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -357,30 +357,32 @@ To keep using the current cache store, you can turn off cache versioning entirel
     end
 
     initializer "active_record_encryption.configuration" do |app|
-      ActiveRecord::Encryption.configure \
-         primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
-         deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
-         key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
-         **config.active_record.encryption
+      config.after_initialize do |app|
+        ActiveRecord::Encryption.configure \
+            primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
+            deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
+            key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
+            **config.active_record.encryption
 
-      ActiveSupport.on_load(:active_record) do
-        # Support extended queries for deterministic attributes and validations
-        if ActiveRecord::Encryption.config.extend_queries
-          ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
-          ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+        ActiveSupport.on_load(:active_record) do
+          # Support extended queries for deterministic attributes and validations
+          if ActiveRecord::Encryption.config.extend_queries
+            ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
+            ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+          end
         end
-      end
 
-      ActiveSupport.on_load(:active_record_fixture_set) do
-        # Encrypt active record fixtures
-        if ActiveRecord::Encryption.config.encrypt_fixtures
-          ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
+        ActiveSupport.on_load(:active_record_fixture_set) do
+          # Encrypt active record fixtures
+          if ActiveRecord::Encryption.config.encrypt_fixtures
+            ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
+          end
         end
-      end
 
-      # Filtered params
-      if ActiveRecord::Encryption.config.add_to_filter_parameters
-        ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
+        # Filtered params
+        if ActiveRecord::Encryption.config.add_to_filter_parameters
+          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
+        end
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -357,6 +357,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
     end
 
     initializer "active_record_encryption.configuration" do |app|
+      ActiveRecord::Encryption.install_encrypted_attributed_declared_hook
+
       config.after_initialize do |app|
         ActiveRecord::Encryption.configure \
             primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
@@ -382,7 +384,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
         # Filtered params
         if ActiveRecord::Encryption.config.add_to_filter_parameters
-          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
+          ActiveRecord::Encryption.install_auto_filtered_parameters(app)
         end
       end
     end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -363,26 +363,27 @@ To keep using the current cache store, you can turn off cache versioning entirel
             deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
             key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
             **config.active_record.encryption
+
+
+        ActiveSupport.on_load(:active_record) do
+          # Support extended queries for deterministic attributes and validations
+          if ActiveRecord::Encryption.config.extend_queries
+            ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
+            ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+          end
         end
 
-      ActiveSupport.on_load(:active_record) do
-        # Support extended queries for deterministic attributes and validations
-        if ActiveRecord::Encryption.config.extend_queries
-          ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
-          ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+        ActiveSupport.on_load(:active_record_fixture_set) do
+          # Encrypt active record fixtures
+          if ActiveRecord::Encryption.config.encrypt_fixtures
+            ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
+          end
         end
-      end
 
-      ActiveSupport.on_load(:active_record_fixture_set) do
-        # Encrypt active record fixtures
-        if ActiveRecord::Encryption.config.encrypt_fixtures
-          ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
+        # Filtered params
+        if ActiveRecord::Encryption.config.add_to_filter_parameters
+          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
         end
-      end
-
-      # Filtered params
-      if ActiveRecord::Encryption.config.add_to_filter_parameters
-        ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -363,26 +363,26 @@ To keep using the current cache store, you can turn off cache versioning entirel
             deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
             key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
             **config.active_record.encryption
-
-        ActiveSupport.on_load(:active_record) do
-          # Support extended queries for deterministic attributes and validations
-          if ActiveRecord::Encryption.config.extend_queries
-            ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
-            ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
-          end
         end
 
-        ActiveSupport.on_load(:active_record_fixture_set) do
-          # Encrypt active record fixtures
-          if ActiveRecord::Encryption.config.encrypt_fixtures
-            ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
-          end
+      ActiveSupport.on_load(:active_record) do
+        # Support extended queries for deterministic attributes and validations
+        if ActiveRecord::Encryption.config.extend_queries
+          ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
+          ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
         end
+      end
 
-        # Filtered params
-        if ActiveRecord::Encryption.config.add_to_filter_parameters
-          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
+      ActiveSupport.on_load(:active_record_fixture_set) do
+        # Encrypt active record fixtures
+        if ActiveRecord::Encryption.config.encrypt_fixtures
+          ActiveRecord::Fixture.prepend ActiveRecord::Encryption::EncryptedFixtures
         end
+      end
+
+      # Filtered params
+      if ActiveRecord::Encryption.config.add_to_filter_parameters
+        ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
       end
     end
 

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -43,24 +43,26 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
 
   test "installing autofiltered parameters will add the encrypted attribute as a filter parameter using the dot notation" do
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
-    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
+    ActiveRecord::Encryption.install_encrypted_attributed_declared_hook
 
     NamedPirate = Class.new(Pirate) do
       self.table_name = "pirates"
     end
     NamedPirate.encrypts :catchphrase
+    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
 
     assert_includes application.config.filter_parameters, "named_pirate.catchphrase"
   end
 
   test "installing autofiltered parameters will work with unnamed classes" do
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
-    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
+    ActiveRecord::Encryption.install_encrypted_attributed_declared_hook
 
     Class.new(Pirate) do
       self.table_name = "pirates"
       encrypts :catchphrase
     end
+    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
 
     assert_includes application.config.filter_parameters, "catchphrase"
   end
@@ -69,12 +71,13 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     ActiveRecord::Encryption.config.excluded_from_filter_parameters = [:catchphrase]
 
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
-    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
+    ActiveRecord::Encryption.install_encrypted_attributed_declared_hook
 
     Class.new(Pirate) do
       self.table_name = "pirates"
       encrypts :catchphrase
     end
+    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
 
     assert_equal application.config.filter_parameters, []
 

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -170,6 +170,7 @@ class ActiveRecord::EncryptionTestCase < ActiveRecord::TestCase
     end
     ActiveRecord::Encryption.config.previous_schemes.clear
     ActiveRecord::Encryption.encrypted_attribute_declaration_listeners&.clear
+    ActiveRecord::Encryption.encrypted_attributes.clear
   end
 
   teardown do

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -170,7 +170,7 @@ class ActiveRecord::EncryptionTestCase < ActiveRecord::TestCase
     end
     ActiveRecord::Encryption.config.previous_schemes.clear
     ActiveRecord::Encryption.encrypted_attribute_declaration_listeners&.clear
-    ActiveRecord::Encryption.encrypted_attributes.clear
+    ActiveRecord::Encryption.encrypted_attributes_per_class.clear
   end
 
   teardown do

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Wrap active_record_encryption.configuration on an after initialize
+
+    After PR #44873, we can now configure `hash_digest_class` that will be used on
+    ActiveRecord::Encryption. But it wasn't being feasible to change it via an
+    initializer (like `new_framework_defaults_7_1.rb`). This wasn't working
+    because the railtie `active_record_encryption.configuration` was being configured
+    before the initializer was loaded. We changed this behave to configure
+    the active_record encryption after the initialize was loaded.
+
+    *Carlos Ribeiro*
+
 *   Don't show secret_key_base for `Rails.application.config#inspect`.
 
     Before:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Wrap active_record_encryption.configuration on an after initialize
+*   Support configuring the digest class in Active Record encryption via initializer.
 
     After PR #44873, we can now configure `hash_digest_class` that will be used on
     ActiveRecord::Encryption. But it wasn't being feasible to change it via an

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4331,6 +4331,16 @@ module ApplicationTests
       assert_match(/Cannot assign to `load_defaults`, it is a configuration method/, error.message)
     end
 
+    test "allows initializer to set active_record_encryption.configuration" do
+      app_file "config/initializers/active_record_encryption.rb", <<-RUBY
+        Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+      RUBY
+
+      app "development"
+
+      assert_equal OpenSSL::Digest::SHA256, ActiveRecord::Encryption.config.hash_digest_class
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4333,12 +4333,12 @@ module ApplicationTests
 
     test "allows initializer to set active_record_encryption.configuration" do
       app_file "config/initializers/active_record_encryption.rb", <<-RUBY
-        Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+        Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
       RUBY
 
       app "development"
 
-      assert_equal OpenSSL::Digest::SHA256, ActiveRecord::Encryption.config.hash_digest_class
+      assert_equal OpenSSL::Digest::SHA1, ActiveRecord::Encryption.config.hash_digest_class
     end
 
     private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This commit changes the active_record_encryption.configuration to be set on an after initialize block. After PR #44873, we can configure now hash_digest_class that will be used on ActiveRecord::Encryption. But the docs said that we could change it via an initializer by setting
Rails.application.config.active_record.encryption.hash_digest_class. This wasn't working because the railtie
"active_record_encryption.configuration" was being set before the initializer was loaded. This changes this behave to configure the active_record encryption after the initialize was loaded.

### Additional information

I found this while debugging https://github.com/rails/rails/issues/48204 and I noticed that the PR https://github.com/rails/rails/pull/44873 added an option to configure the hash_class used to encrypt the attribute by setting the `ActiveRecord::Encryption.config.hash_digest_class` on the initializer. But while debugging my issue, I found that the code to use this hash_digest_class wasn't using the different hash_digest_class that I set and I noticed that the ActiveRecord::Encryption was only configured only at the `active_record` railtie before the custom initializers I have.

```ruby
    initializer "active_record_encryption.configuration" do |app|
      ActiveRecord::Encryption.configure \
         primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
         deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
         key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
         **config.active_record.encryption
```

and my `new_framework_defaults_7_1` was loaded after that. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
