### PR TITLE
Update guides generation to use Nokogiri's HTML5 parser

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -94,7 +94,7 @@ module RailsGuides
       def generate_structure
         @headings_for_index = []
         if @body.present?
-          document = Nokogiri::HTML.fragment(@body).tap do |doc|
+          document = html_fragment(@body).tap do |doc|
             hierarchy = []
 
             doc.children.each do |node|
@@ -136,7 +136,7 @@ module RailsGuides
             end
           end
 
-          @index = Nokogiri::HTML.fragment(engine.render(raw_index)).tap do |doc|
+          @index = html_fragment(engine.render(raw_index)).tap do |doc|
             doc.at("ol")[:class] = "chapters"
           end.to_html
 
@@ -150,7 +150,7 @@ module RailsGuides
       end
 
       def generate_title
-        if heading = Nokogiri::HTML.fragment(@header).at(:h1)
+        if heading = html_fragment(@header).at(:h1)
           @title = "#{heading.text} — Ruby on Rails Guides"
         else
           @title = "Ruby on Rails Guides"
@@ -179,6 +179,14 @@ module RailsGuides
         @view.content_for(:page_title) { @title }
         @view.content_for(:index_section) { @index }
         @view.render(layout: @layout, html: @body.html_safe)
+      end
+
+      def html_fragment(html)
+        if defined?(Nokogiri::HTML5)
+          Nokogiri::HTML5.fragment(html)
+        else
+          Nokogiri::HTML4.fragment(html)
+        end
       end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Use Nokogiri::HTML5 to generate the guides. This doesn't meaningfully change the output, but will help ensure we're emitting valid HTML5 markup. A followup commit could reasonably rip out the W3C validator, I think.

Note that the most frequent changes to the output are:

- attribute values, most often data-clipboard-text. TheHTML5 spec prescribes entity-escaping fewer characters in attribute values than libxml2 did, and wraps attribute values in double-quotes. In particular `>` and `<` are not escaped per the HTML5 spec which may be surprising to look at if you're used to libxml2's output.
- linebreaks are different for some HTML elements, particularly lists and tables have fewer linebreaks between elements.


### Detail

This Pull Request replaces calls to `Nokogiri::HTML.fragment` with a call to a new private method, `html_fragment` which uses either `Nokogiri::HTML5.fragment` if HTML5 available, else `Nokogiri::HTML4.fragment`.


### Additional information

Part of an ongoing effort to update Rails to use HTML5.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
