### PR TITLE
Update Action Text to use HTML5 when available

### DIFF
--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -4,7 +4,7 @@ require "rails-html-sanitizer"
 
 module ActionText
   module ContentHelper
-    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.safe_list_sanitizer.new }
+    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.best_supported_vendor.safe_list_sanitizer.new }
     mattr_accessor(:allowed_tags) { sanitizer.class.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ] }
     mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
     mattr_accessor(:scrubber)

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -42,4 +42,18 @@ module ActionText
     autoload :Minification
     autoload :TrixConversion
   end
+
+  class << self
+    def html_document_class
+      return @html_document_class if defined?(@html_document_class)
+      @html_document_class =
+        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::Document : Nokogiri::HTML4::Document
+    end
+
+    def html_document_fragment_class
+      return @html_document_fragment_class if defined?(@html_document_fragment_class)
+      @html_document_fragment_class =
+        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::DocumentFragment : Nokogiri::HTML4::DocumentFragment
+    end
+  end
 end

--- a/actiontext/lib/action_text/fragment.rb
+++ b/actiontext/lib/action_text/fragment.rb
@@ -7,7 +7,7 @@ module ActionText
         case fragment_or_html
         when self
           fragment_or_html
-        when Nokogiri::HTML::DocumentFragment
+        when Nokogiri::XML::DocumentFragment # base class for all fragments
           new(fragment_or_html)
         else
           from_html(fragment_or_html)
@@ -30,7 +30,7 @@ module ActionText
     end
 
     def update
-      yield source = self.source.clone
+      yield source = self.source.dup
       self.class.new(source)
     end
 

--- a/actiontext/lib/action_text/html_conversion.rb
+++ b/actiontext/lib/action_text/html_conversion.rb
@@ -18,7 +18,7 @@ module ActionText
 
     private
       def document
-        Nokogiri::HTML::Document.new.tap { |doc| doc.encoding = "UTF-8" }
+        ActionText.html_document_class.new.tap { |doc| doc.encoding = "UTF-8" }
       end
   end
 end

--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -20,7 +20,7 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
 
     host! "loocalhoost"
     get message_path(message, format: :json)
-    content = Nokogiri::HTML::DocumentFragment.parse(response.parsed_body["content"])
+    content = ActionText.html_document_fragment_class.parse(response.parsed_body["content"])
     assert_select content, "img:match('src', ?)", %r"//loocalhoost/.+/racecar"
   end
 

--- a/actiontext/test/integration/job_render_test.rb
+++ b/actiontext/test/integration/job_render_test.rb
@@ -18,7 +18,7 @@ class ActionText::JobRenderTest < ActiveJob::TestCase
         perform_enqueued_jobs
       end
 
-      rendered = Nokogiri::HTML::DocumentFragment.parse(File.read(file))
+      rendered = ActionText.html_document_fragment_class.parse(File.read(file))
       assert_select rendered, "img:match('src', ?)", %r"//foo.example.com:9001/.+/racecar"
     end
   end


### PR DESCRIPTION
### Motivation / Background

Update Action Text to use the HTML5 sanitizer when available, and to parse markup using Nokogiri::HTML5 when available. Previously, Action Text used Nokogiri's HTML4 parsers for these operations.

### Detail

This pull request updates the default value for `ActionText::ContentHelper.sanitizer` from `Rails::Html::Sanitizer.safe_list_sanitizer.new` to `Rails::Html::Sanitizer.best_supported_vendor.safe_list_sanitizer.new`. The method `.best_supported_vendor` is available in rails-html-sanitizer v1.6.0 and later, which 500ccaae made the minimum for Action View.

This pull request also adds two new methods that return the "best supported" HTML document and document fragment classes: `ActionText.html_document_class` and `ActionText.html_document_fragment_class`. These methods are used internally where code previously referenced `Nokogiri::HTML` directly.

The change from `#clone` to `#dup` is necessary to work around an issue in Nokogiri where `#clone` is not defined properly for HTML5 fragment and the fragment does not have a parent Document. `#dup` behaves the way we expect, so this should be fine.


### Additional information

This is part of ongoing work to update Rails to use HTML5.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
