### PR TITLE
Update Action View and Action Dispatch to use HTML5 when available

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActionDispatch::Assertions#html_document` uses Nokogiri's HTML5 parser if it is available.
+
+    The HTML5 parser better represents what the DOM would be in a browser. Previously this test
+    helper always used Nokogiri's HTML4 parser.
+
+    *Mike Dalessio*
+
 *   The `with_routing` helper can now be called at the class level. When called at the class level, the routes will
     be setup before each test, and reset after every test. For example:
 

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -15,8 +15,10 @@ module ActionDispatch
     def html_document
       @html_document ||= if @response.media_type&.end_with?("xml")
         Nokogiri::XML::Document.parse(@response.body)
+      elsif defined?(Nokogiri::HTML5)
+        Nokogiri::HTML5::Document.parse(@response.body)
       else
-        Nokogiri::HTML::Document.parse(@response.body)
+        Nokogiri::HTML4::Document.parse(@response.body)
       end
     end
   end

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -177,9 +177,17 @@ module ActionView
       end
 
     private
+      def html_document_class
+        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::Document : Nokogiri::HTML4::Document
+      end
+
+      def html_document_fragment_class
+        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::DocumentFragment : Nokogiri::HTML4::DocumentFragment
+      end
+
       # Need to experiment if this priority is the best one: rendered => output_buffer
       def document_root_element
-        Nokogiri::HTML::Document.parse(@rendered.blank? ? @output_buffer.to_str : @rendered).root
+        html_document_class.parse(@rendered.blank? ? @output_buffer.to_str : @rendered).root
       end
 
       module Locals

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -986,7 +986,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   private
     def root_elem(rendered_content)
-      Nokogiri::HTML::DocumentFragment.parse(rendered_content).children.first # extract from nodeset
+      html_document_fragment_class.parse(rendered_content).children.first # extract from nodeset
     end
 
     def with_default_enforce_utf8(value)


### PR DESCRIPTION
### Motivation / Background

Update Action Dispatch Assertions' `html_document` to use the HTML5 parser if it's available, to better represent what an end user will see in their browser DOM.

Update Action View TestCase's private `document_root_element` and the form tag helper test to use HTML5 as well.

### Additional information

This is part of ongoing work to update Rails to use HTML5.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
