### PR TITLE
Update Active Job testing guide

### DIFF
--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -22,4 +22,8 @@ class ActiveJobTestCaseTest < ActiveJob::TestCase
   def test_set_test_adapter
     assert_kind_of ActiveJob::QueueAdapters::TestAdapter, queue_adapter
   end
+
+  def test_does_not_perform_enqueued_jobs_by_default
+    assert_nil queue_adapter.perform_enqueued_jobs
+  end
 end


### PR DESCRIPTION
The testing guide for Active Job currently implies that when you queue a job it will be performed:

![image](https://github.com/rails/rails/assets/509837/c864a0c2-ec53-45bb-9991-e8f55fb74ce6)


This isn't true; by default jobs are enqueued, not performed.

This PR fleshes out the docs a bit to show both examples, and adds a test to confirm the default behaviour.
