### PR TITLE
Fix unscope with multiple not conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix unscope with multiple not conditions
+
+    Before:
+    ```ruby
+    Post.where.not(body: "hello", title: "sti me").unscope(where: :title)
+    #=> SELECT * FROM posts WHERE NOT (body = 'hello' AND title = 'sti me')
+    ```
+    Later:
+    ```ruby
+    Post.where.not(body: "hello", title: "sti me").unscope(where: :title)
+    #=> SELECT * FROM posts WHERE NOT (body = 'hello')
+    ```
+
+    *Lázaro Nixon*
+
 *   Apply scope to association subqueries. (belongs_to/has_one/has_many)
 
     Given: `has_many :welcome_posts, -> { where(title: "welcome") }`

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -115,6 +115,20 @@ module ActiveRecord
       assert_equal expected_where_clause, relation.where_clause
     end
 
+    def test_not_eq_with_unscope
+      relation = Post.where.not(body: "hello").unscope(where: :body)
+      expected = Post.all
+
+      assert_equal expected.to_a, relation.to_a
+    end
+
+    def test_not_eq_with_unscope_grouping
+      relation = Post.where.not(body: "hello", title: "sti me").unscope(where: :title)
+      expected = Post.where.not(body: "hello")
+
+      assert_equal expected.to_a, relation.to_a
+    end
+
     def test_chaining_multiple
       relation = Post.where.not(author_id: [1, 2]).where.not(title: "ruby on rails")
       expected_where_clause =


### PR DESCRIPTION
### Motivation / Background

Fix unscope with multiple not conditions

Before:
```ruby
Post.where.not(body: "hello", title: "sti me").unscope(where: :title)
#=> SELECT * FROM posts WHERE NOT (body = 'hello' AND title = 'sti me')
```

Later:
```ruby
Post.where.not(body: "hello", title: "sti me").unscope(where: :title)
#=> SELECT * FROM posts WHERE NOT (body = 'hello')
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
