### PR TITLE
Fix devcontainer trilogy connection for tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,10 @@
 		}
 	},
 
+	"containerEnv": {
+		"MYSQL_SOCK": "/run/mysqld/mysqld.sock"
+	},
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 


### PR DESCRIPTION
Previously, executing Active Record tests against the trilogy adapter within a devcontainer would fail with the error message:

```
Trilogy::SyscallError::ENOENT: No such file or directory - trilogy_connect
- unable to connect to /tmp/mysql.sock (ActiveRecord::StatementInvalid)
```