### PR TITLE
Call proxy methods from `alias_attribute` generated methods

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -44,9 +44,66 @@ module ActiveRecord
         @generated_attribute_methods = const_set(:GeneratedAttributeMethods, GeneratedAttributeMethods.new)
         private_constant :GeneratedAttributeMethods
         @attribute_methods_generated = false
+        @alias_attributes_mass_generated = false
         include @generated_attribute_methods
 
         super
+      end
+
+      def alias_attribute(new_name, old_name)
+        super
+
+        if @alias_attributes_mass_generated
+          ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
+            generate_alias_attribute_methods(code_generator, new_name, old_name)
+          end
+        end
+      end
+
+      def eagerly_generate_alias_attribute_methods(_new_name, _old_name) # :nodoc:
+        # alias attributes in Active Record are lazily generated
+      end
+
+      def generate_alias_attributes # :nodoc:
+        return if @alias_attributes_mass_generated
+
+        generated_attribute_methods.synchronize do
+          return if @alias_attributes_mass_generated
+          ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
+            attribute_aliases.each do |new_name, old_name|
+              generate_alias_attribute_methods(code_generator, new_name, old_name)
+            end
+          end
+
+          @alias_attributes_mass_generated = true
+        end
+      end
+
+      def alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
+        method_name = pattern.method_name(new_name).to_s
+        target_name = pattern.method_name(old_name).to_s
+        parameters = pattern.parameters
+        old_name = old_name.to_s
+
+        method_defined = method_defined?(target_name) || private_method_defined?(target_name)
+        manually_defined = method_defined && self.instance_method(target_name).owner != generated_attribute_methods
+        reserved_method_name = ::ActiveRecord::AttributeMethods.dangerous_attribute_methods.include?(target_name)
+
+        if manually_defined && !reserved_method_name
+          aliased_method_redefined_as_well = method_defined_within?(method_name, self)
+          return if aliased_method_redefined_as_well
+
+          ActiveModel.deprecator.warn(
+            "#{self} model aliases `#{old_name}` and has a method called `#{target_name}` defined. " \
+            "Since Rails 7.2 `#{method_name}` will not be calling `#{target_name}` anymore. " \
+            "You may want to additionally define `#{method_name}` to preserve the current behavior."
+          )
+          super
+        else
+          define_proxy_call(code_generator, method_name, pattern.proxy_target, parameters, old_name,
+            namespace: :proxy_alias_attribute
+          )
+        end
       end
 
       # Generates all the attribute related methods for columns in the database
@@ -67,6 +124,7 @@ module ActiveRecord
         generated_attribute_methods.synchronize do
           super if defined?(@attribute_methods_generated) && @attribute_methods_generated
           @attribute_methods_generated = false
+          @alias_attributes_mass_generated = false
         end
       end
 
@@ -188,6 +246,7 @@ module ActiveRecord
           super
           child_class.initialize_generated_modules
           child_class.class_eval do
+            @alias_attributes_mass_generated = false
             @attribute_names = nil
           end
         end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -753,6 +753,7 @@ module ActiveRecord
         @strict_loading_mode = :all
 
         klass.define_attribute_methods
+        klass.generate_alias_attributes
       end
 
       def initialize_internals_callback

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -5,6 +5,7 @@ require "models/numeric_data"
 
 class NumericalityValidationTest < ActiveRecord::TestCase
   def setup
+    NumericData.generate_alias_attributes
     @model_class = NumericData.dup
   end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -36,6 +36,7 @@ class ReplyWithTitleObject < Reply
   validates_uniqueness_of :content, scope: :title
 
   def title; ReplyTitle.new; end
+  alias heading title
 end
 
 class TopicWithEvent < Topic

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -7,6 +7,8 @@ module Cpk
     # to be shared between different databases
     self.primary_key = [:shop_id, :id]
 
+    alias_attribute :id_value, :id
+
     has_many :order_agreements, primary_key: :id
     has_many :books, query_constraints: [:shop_id, :order_id]
     has_one :book, query_constraints: [:shop_id, :order_id]

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -144,6 +144,8 @@ end
 
 class TitlePrimaryKeyTopic < Topic
   self.primary_key = :title
+
+  alias_attribute :id_value, :id
 end
 
 module Web


### PR DESCRIPTION
This commit changes bodies of methods generated by `alias_attribute` on Active Record objects.

Previously the body of the `alias_attribute :new_title, :title` was `def new_title; title; end`. This commit changes it to `def new_title; attribute("title"); end`.

This allows for `alias_attribute` to be used to alias attributes named with a reserved names like `id`:
```ruby
  class Topic < ActiveRecord::Base
    self.primary_key = :title
    alias_attribute :id_value, :id
  end

  Topic.new.id_value # => 1
```

## Implementation details

### Body generation

Most of the methods for the alias attribute will now be generated by `define_proxy_call` unless the model redefines the `target_name` attribute method, for example:
```ruby
class Post < ApplicationRecord
 alias_attribute :subject, :title

 def title_was
  ...
 end
```

will issue a deprecation warning that asks for the `subject_was` to be overridden as well since next version of Rails will not make `subject_was` method to call into the `title_was`. This is a very unlikely situation and I genuinely expect no applications to ever see the deprecation warning but still something that does require a deprecation cycle. 


### Active Model changes

Even though we don't change the behavior of the Active Model alias attribute definition there are some code changes in this PR that were made to share some common code between Active Model and Active Record. If you find this unnecessary complicated feel free to speak up and we can consider an alternative which means no changes to Active Model but more duplication in Active Record. Some of the duplication will go away though when deprecation is removed

 