### PR TITLE
Revert "Merge pull request #48527 from ghiculescu/active-record-enum-id"

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -322,8 +322,6 @@ module ActiveRecord
           raise_conflict_error(enum_name, method_name, type: "class")
         elsif klass_method && method_defined_within?(method_name, Relation)
           raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
-        elsif klass_method && method_name == primary_key
-          raise_conflict_error(enum_name, method_name)
         elsif !klass_method && dangerous_attribute_method?(method_name)
           raise_conflict_error(enum_name, method_name)
         elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -497,8 +497,7 @@ class EnumTest < ActiveRecord::TestCase
       :save,     # generates #save!, which conflicts with an AR method
       :proposed, # same value as an existing enum
       :public, :private, :protected, # some important methods on Module and Class
-      :name, :parent, :superclass,
-      :id        # conflicts with AR querying
+      :name, :parent, :superclass
     ]
 
     conflicts.each_with_index do |value, i|
@@ -506,16 +505,6 @@ class EnumTest < ActiveRecord::TestCase
         klass.class_eval { enum "status_#{i}" => [value] }
       end
       assert_match(/You tried to define an enum named .* on the model/, e.message)
-    end
-  end
-
-  test "can use id as a value with a prefix or suffix" do
-    assert_nothing_raised do
-      Class.new(ActiveRecord::Base) do
-        self.table_name = "books"
-        enum status_1: [:id], _prefix: true
-        enum status_2: [:id], _suffix: true
-      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Railties tests have been failing since this change. The issue is that calling `primary_key` as the model is loaded requires either a connection to the database or a populated schema cache. This becomes an issue when an app loads models that do not have underlying tables, as shown in the failing Railties tests.

When eager loading an app using `rails/all`, `ActionMailbox::InboundEmail` will be loaded whether or not `rails g action_mailbox:install` has been run. This means the `primary_key` for `InboundEmail` will not be in the schema cache and a database connection will be required to boot the app.

### Detail

This reverts commit 8b36095881435e996db16604c52737e144b6bff3, reversing changes made to e05245db878077097d666f7667c0f9057f767583.

### Additional information

Example failures:
- https://buildkite.com/rails/rails/builds/97331
- https://buildkite.com/rails/rails/builds/97331#0188d9b0-1307-4136-b53c-2df31ee7d6ac/1224-1234

Ref #48524
Ref #48527

cc @ghiculescu @guilleiguaran
