### PR TITLE
Disallow `id` as an enum value in Active Record (v2)

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -322,6 +322,8 @@ module ActiveRecord
           raise_conflict_error(enum_name, method_name, type: "class")
         elsif klass_method && method_defined_within?(method_name, Relation)
           raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
+        elsif klass_method && method_name.to_sym == :id
+          raise_conflict_error(enum_name, method_name)
         elsif !klass_method && dangerous_attribute_method?(method_name)
           raise_conflict_error(enum_name, method_name)
         elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -497,7 +497,8 @@ class EnumTest < ActiveRecord::TestCase
       :save,     # generates #save!, which conflicts with an AR method
       :proposed, # same value as an existing enum
       :public, :private, :protected, # some important methods on Module and Class
-      :name, :parent, :superclass
+      :name, :parent, :superclass,
+      :id        # conflicts with AR querying
     ]
 
     conflicts.each_with_index do |value, i|
@@ -505,6 +506,16 @@ class EnumTest < ActiveRecord::TestCase
         klass.class_eval { enum "status_#{i}" => [value] }
       end
       assert_match(/You tried to define an enum named .* on the model/, e.message)
+    end
+  end
+
+  test "can use id as a value with a prefix or suffix" do
+    assert_nothing_raised do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status_1: [:id], _prefix: true
+        enum status_2: [:id], _suffix: true
+      end
     end
   end
 


### PR DESCRIPTION
Second attempt at https://github.com/rails/rails/pull/48527

This was reverted in https://github.com/rails/rails/pull/48534 because the call to `primary_key` broke railties tests.

The original issue was caused by a call to `#id` [here](https://github.com/rails/rails/blob/51f2e2f80b86e0c3769cf5272b7d97035730f19d/activerecord/lib/active_record/relation/predicate_builder.rb#L58). So I think it is fine for this check to only run where the value is `"id"`, as opposed to for any primary key.