### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -184,9 +184,9 @@
 
     *fatkodima*
 
-*   Add support for `Array#intersect?` to `ActiveRecord::Relation`.
+*   Add support for `Array#intersects?` to `ActiveRecord::Relation`.
 
-    `Array#intersect?` is only available on Ruby 3.1 or later.
+    `Array#intersects?` is only available on Ruby 3.1 or later.
 
     This allows the Rubocop `Style/ArrayIntersect` cop to work with `ActiveRecord::Relation` objects.
 


### PR DESCRIPTION
This corrects `intersect` with `intersects` (the actual name of the method) as per this comment here: https://github.com/rails/rails/pull/47670/files#r1236168967

### Motivation / Background

The method is incorrectly listed in the change log without an 's'.  This is likely to cause bugs as people look at documentation more frequently than source code for method names.

https://github.com/john-h-k/rails/blob/c837ae624bc96f46b49f4656c76cd935591a8a3f/activerecord/lib/active_record/relation/delegation.rb

