### PR TITLE
Support queries with regular expressions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Support queries with regular expressions on supported databases. (PostgreSQL/MySQL/SQLite)
+
+    ```ruby
+    Post.where(title: /ThInKiNg/)
+    #=> SELECT * FROM posts WHERE title REGEXP 'ThInKiNg'; --MySQL/SQLite
+    #=> SELECT * FROM posts WHERE title ~* 'ThInKiNg'; --PostgreSQL
+
+    Post.where.not(title: /ThInKiNg/)
+    #=> SELECT * FROM posts WHERE title NOT REGEXP 'ThInKiNg'; --MySQL/SQLite
+    #=> SELECT * FROM posts WHERE title !~* 'ThInKiNg'; --PostgreSQL
+    ```
+
+    *Lázaro Nixon*
+
 *   Apply scope to association subqueries. (belongs_to/has_one/has_many)
 
     Given: `has_many :welcome_posts, -> { where(title: "welcome") }`

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -694,6 +694,10 @@ module ActiveRecord
         def configure_connection
           @raw_connection.busy_timeout(self.class.type_cast_config_to_integer(@config[:timeout])) if @config[:timeout]
 
+          @raw_connection.create_function("regexp", 2) do |fn, pattern, value|
+            fn.result = Regexp.new(pattern, Regexp::IGNORECASE).match?(value) ? 1 : 0
+          end
+
           raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
         end
     end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -8,6 +8,7 @@ module ActiveRecord
     require "active_record/relation/predicate_builder/relation_handler"
     require "active_record/relation/predicate_builder/association_query_value"
     require "active_record/relation/predicate_builder/polymorphic_array_value"
+    require "active_record/relation/predicate_builder/regexp_handler"
 
     def initialize(table)
       @table = table
@@ -18,6 +19,7 @@ module ActiveRecord
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
+      register_handler(Regexp, RegexpHandler.new(self))
     end
 
     def build_from_hash(attributes, &block)

--- a/activerecord/lib/active_record/relation/predicate_builder/regexp_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/regexp_handler.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class RegexpHandler # :nodoc:
+      def initialize(predicate_builder)
+        @predicate_builder = predicate_builder
+      end
+
+      def call(attribute, value)
+        bind = predicate_builder.build_bind_attribute(attribute.name, value.source)
+        attribute.matches_regexp(bind, false)
+      end
+
+      private
+        attr_reader :predicate_builder
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/regexp.rb
+++ b/activerecord/lib/arel/nodes/regexp.rb
@@ -9,8 +9,16 @@ module Arel # :nodoc: all
         super(left, right)
         @case_sensitive = case_sensitive
       end
+
+      def invert
+        Arel::Nodes::NotRegexp.new(left, right, case_sensitive)
+      end
     end
 
-    class NotRegexp < Regexp; end
+    class NotRegexp < Regexp
+      def invert
+        Arel::Nodes::Regexp.new(left, right, case_sensitive)
+      end
+    end
   end
 end

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -33,6 +33,14 @@ module Arel # :nodoc: all
           collector << " IS NOT "
           visit o.right, collector
         end
+
+        def visit_Arel_Nodes_Regexp(o, collector)
+          infix_value o, collector, " REGEXP "
+        end
+
+        def visit_Arel_Nodes_NotRegexp(o, collector)
+          infix_value o, collector, " NOT REGEXP "
+        end
     end
   end
 end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -502,5 +502,16 @@ module ActiveRecord
       Comment.create!(label: :default, post: post, body: "Nice weather today")
       assert_equal [post], Post.joins(:comments).where(comments: { label: :default, body: "Nice weather today" }).to_a
     end
+
+    def test_where_with_regexp
+      assert_equal [posts(:thinking)], Post.where(title: /ThInKiNg/)
+    end
+
+    def test_where_not_with_regexp
+      Post.where.not(title: /ThInKiNg/).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_not_includes relation, posts(:thinking)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Support queries with regular expressions on supported databases. (PostgreSQL/MySQL/SQLite)

```ruby
Post.where(title: /ThInKiNg/)
#=> SELECT * FROM posts WHERE title REGEXP 'ThInKiNg'; --MySQL/SQLite
#=> SELECT * FROM posts WHERE title ~* 'ThInKiNg'; --PostgreSQL

Post.where.not(title: /ThInKiNg/)
#=> SELECT * FROM posts WHERE title NOT REGEXP 'ThInKiNg'; --MySQL/SQLite
#=> SELECT * FROM posts WHERE title !~* 'ThInKiNg'; --PostgreSQL    
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
