### PR TITLE
Added Dockerfile instructions to remove artifacts and node_modules

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -10,6 +10,9 @@
 /.env*
 !/.env*.erb
 
+# Ignore artifacts from setup-ruby GitHub Action
+/vendor/bundle
+
 # Ignore all default key files.
 /config/master.key
 /config/credentials/*.key


### PR DESCRIPTION
### Motivation / Background

I've tested Rails 7.1 Dockerfile template in Rails 7.0 app with MRSK on GitHub Actions and found that a bit more optimization can be applied.

### Detail

This Pull Request adds minor optimization to dockerignore template.

During the build process, the setup-ruby@v1 GitHub Action leaves artifacts in the ~/vendor/bundle folder, resulting in two full bundles in the final build: one in the default /usr/local/bundle directory specified in the Dockerfile template, and another in the /rails/vendor/bundle directory. By ignoring the /rails/vendor/bundle directory, we can significantly reduce the size of the final image. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
