### PR TITLE
Add GlobalID to the API docs

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -113,6 +113,13 @@ module Rails
             lib/rails/test_unit/*
             lib/rails/api/generator.rb
           )
+        },
+
+        "globalid" => {
+          dependency: true,
+          include: %w(
+            lib/global_id/*.rb
+          )
         }
       }
 
@@ -134,6 +141,16 @@ module Rails
         # no-op
       end
 
+      def define
+        super
+        Rake::Task[rdoc_task_name].enhance do
+          RDOC_FILES.each do |component, cfg|
+            FileUtils.rm_f(component) if cfg[:dependency]
+          end
+        end
+        self
+      end
+
       def configure_sdoc
         self.title    = "Ruby on Rails API"
         self.rdoc_dir = api_dir
@@ -149,6 +166,8 @@ module Rails
         rdoc_files.include(api_main)
 
         RDOC_FILES.each do |component, cfg|
+          symlink_component_root_dir(component) if cfg[:dependency]
+
           cdr = component_root_dir(component)
 
           Array(cfg[:include]).each do |pattern|
@@ -184,6 +203,12 @@ module Rails
 
       def api_main
         component_root_dir("railties") + "/RDOC_MAIN.md"
+      end
+
+      def symlink_component_root_dir(component)
+        spec = Bundler::CLI::Common.select_spec(component, :regex_match)
+        path = spec.full_gem_path
+        FileUtils.ln_sf(path, component)
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

GlobalID is a dependency of Active Job and Action Text. It adds `to_gid` and `to_sgid` methods to Active Model and Active Record classes.

Trying to find the documentation of these methods can be confusing as they are not present in the API docs.

### Detail

By symlinking the globalid gem from the Gemfile we can include it in the API documentation. After the `rdoc` task has run we can remove the symlink. I'd prefer to remove to symlink in an `ensure` block but that doesn't seem to be supported by Rake.

### Additional information

This could also be used to add all the `turbo-rails` methods to the API docs, like ` broadcast_append_to`  and `turbo_stream_from` (that is used in video demo on https://rubyonrails.org/.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
