### PR TITLE
Introduce `ActionMailer::FormBuilder`

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce `ActionMailer::FormBuilder`
+
+    Use the `default_form_builder` method in mailers to set the default form builder
+    for templates rendered by that mailer. Matches the behaviour in Action Controller.
+
+    *Alex Ghiculescu*
+
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Mailers are listed in alphabetical order on the mailer preview page now.

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -56,6 +56,7 @@ module ActionMailer
   autoload :MessageDelivery
   autoload :MailDeliveryJob
   autoload :QueuedDelivery
+  autoload :FormBuilder
 
   def self.eager_load!
     super

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -480,6 +480,7 @@ module ActionMailer
     include Rescuable
     include Parameterized
     include Previews
+    include FormBuilder
 
     abstract!
 

--- a/actionmailer/lib/action_mailer/form_builder.rb
+++ b/actionmailer/lib/action_mailer/form_builder.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ActionMailer
+  # = Action Mailer Form Builder
+  #
+  # Override the default form builder for all views rendered by this
+  # mailer and any of its descendants. Accepts a subclass of
+  # ActionView::Helpers::FormBuilder.
+  #
+  # While emails typically will not include forms, this can be used
+  # by views that are shared between controllers and mailers.
+  #
+  # For more information, see +ActionController::FormBuilder+.
+  module FormBuilder
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :_default_form_builder, instance_accessor: false
+    end
+
+    module ClassMethods
+      # Set the form builder to be used as the default for all forms
+      # in the views rendered by this mailer and its subclasses.
+      #
+      # ==== Parameters
+      # * <tt>builder</tt> - Default form builder, an instance of ActionView::Helpers::FormBuilder
+      def default_form_builder(builder)
+        self._default_form_builder = builder
+      end
+    end
+
+    # Default form builder for the mailer
+    def default_form_builder
+      self.class._default_form_builder
+    end
+  end
+end

--- a/actionmailer/test/fixtures/form_builder_mailer/welcome.html.erb
+++ b/actionmailer/test/fixtures/form_builder_mailer/welcome.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(url: "/") do |f| %>
+  <%= f.message %>
+<% end %>

--- a/actionmailer/test/form_builder_test.rb
+++ b/actionmailer/test/form_builder_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "mailers/form_builder_mailer"
+
+class MailerFormBuilderTest < ActiveSupport::TestCase
+  def test_default_form_builder_assigned
+    email = FormBuilderMailer.welcome
+    assert_includes(email.body.encoded, "hi from SpecializedFormBuilder")
+  end
+end

--- a/actionmailer/test/mailers/form_builder_mailer.rb
+++ b/actionmailer/test/mailers/form_builder_mailer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FormBuilderMailer < ActionMailer::Base
+  class SpecializedFormBuilder < ActionView::Helpers::FormBuilder
+    def message
+      "hi from SpecializedFormBuilder"
+    end
+  end
+
+  default_form_builder SpecializedFormBuilder
+
+  def welcome
+    mail(to: "email@example.com")
+  end
+end


### PR DESCRIPTION
ref: https://github.com/rails/rails/issues/48477

Using forms inside emails is not common, but it's possible, and it's also possible to share views between controllers and mailers. Currently if a controller sets a `default_form_builder` that's different from the global config, mailers that use the same views will not default to the same `FormBuilder`. To fix this, this PR adds a `default_form_builder` method for mailers that does the same thing as its controller sibling.
