### PR TITLE
Get rid of unnecessary `gem "minitest"` calls

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-gem "minitest" # make sure we get the gem, not stdlib
 require "minitest"
 require "active_support/testing/tagged_logging"
 require "active_support/testing/setup_and_teardown"

--- a/activesupport/lib/active_support/testing/autorun.rb
+++ b/activesupport/lib/active_support/testing/autorun.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-gem "minitest"
-
 require "minitest"
 
 Minitest.autorun


### PR DESCRIPTION
This patch simply removes unnecessary `gem` activations of minitest.

### Motivation / Background

minitest used to be a CRuby's stdlib from Rubies `>= 1.9.1` to `< 2.2.0`.
And the `gem 'minitest'` call in the Rails codebase was added at 6f74d36c4263a6cbbc6dc32a03edeed04faefbd9 because at that time `require 'minitest'` could load either a gem version or the stdlib one, and we wanted to make sure not to load the stdlib minitest.

2.years.since then, CRuby's bundled minitest had been removed in 2.2.0 at https://github.com/ruby/ruby/commit/7cda8222ca6fa109e531705579164f56f29f8068
and now that Ruby < 2.2 is no longer supported in Rails 7, we can just safely drop this `gem "minitest"` call in favor of simple `require` that is already written there.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`