### PR TITLE
Add support for unpersisted CPK has_one/has_many through associations

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -113,7 +113,7 @@ module ActiveRecord
         end
 
         def target_reflection_has_associated_record?
-          !(through_reflection.belongs_to? && owner[through_reflection.foreign_key].blank?)
+          !(through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? { |foreign_key_column| owner[foreign_key_column].blank? })
         end
 
         def update_through_counter?(method)

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -86,7 +86,9 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          through_reflection.belongs_to? && !owner[through_reflection.foreign_key].nil?
+          through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? do |foreign_key_column|
+            !owner[foreign_key_column].nil?
+          end
         end
 
         def ensure_mutable

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1631,6 +1631,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(expected_blog_post_ids.sort, blog_post_ids.sort)
   end
 
+  def test_loading_cpk_association_with_unpersisted_owner
+    order = Cpk::Order.create!(shop_id: 1)
+    book = Cpk::BookWithOrderAgreements.new(number: 2, author_id: 1, order: order)
+    order_agreement = Cpk::OrderAgreement.create!(order: order)
+
+    assert_equal([order_agreement], book.order_agreements.to_a)
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -22,6 +22,7 @@ require "models/customer"
 require "models/carrier"
 require "models/shop_account"
 require "models/customer_carrier"
+require "models/cpk"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
@@ -444,5 +445,13 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal other_carrier, account_carrier
   ensure
     CustomerCarrier.current_customer = nil
+  end
+
+  def test_loading_cpk_association_with_unpersisted_owner
+    order = Cpk::Order.create!(shop_id: 1)
+    book = Cpk::BookWithOrderAgreements.new(number: 2, author_id: 1, order: order)
+    order_agreement = Cpk::OrderAgreement.create!(order: order)
+
+    assert_equal(order_agreement, book.order_agreement)
   end
 end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -20,4 +20,9 @@ module Cpk
   class NullifiedBook < Book
     has_one :chapter, query_constraints: [:author_id, :book_number], dependent: :nullify
   end
+
+  class BookWithOrderAgreements < Book
+    has_many :order_agreements, through: :order
+    has_one :order_agreement, through: :order, source: :order_agreements
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `has_many` and `has_one` with composite primary key `through:` associations with unpersisted owner records don't currently work.

### Detail

This Pull Request changes `ActiveRecord::Associations::HasManyThroughAssociation` and `ActiveRecord::Associations:: ThroughAssociation` to support through reflections with array foreign keys.

### Additional information

Because of the unpersisted record, `owner[through_reflection.foreign_key]` doesn't raise when the foreign key is an array. I wonder if that's a bug, because I don't think it should ever work. In persisted records, this raises later when we ask the database for an attribute with an array name.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
