### PR TITLE
Fix to_s not using :default format with no args

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `to_s` with no arguments not respecting custom `:default` formats
+
+    *Hartley McGuire*
+
 *   Fix `ActiveSupport::Inflector.humanize(nil)` raising ``NoMethodError: undefined method `end_with?' for nil:NilClass``.
 
     *James Robinson*

--- a/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
@@ -15,7 +15,18 @@ class Date
         strftime(formatter)
       end
     elsif format == NOT_SET
-      to_default_s
+      if formatter = DATE_FORMATS[:default]
+        ActiveSupport::Deprecation.warn(
+          "Using a :default format for Date#to_s is deprecated. Please use Date#to_fs instead."
+        )
+        if formatter.respond_to?(:call)
+          formatter.call(self).to_s
+        else
+          strftime(formatter)
+        end
+      else
+        to_default_s
+      end
     else
       ActiveSupport::Deprecation.warn(
         "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_fs(#{format.inspect}) instead."

--- a/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
@@ -11,7 +11,18 @@ class DateTime
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
-      to_default_s
+      if formatter = ::Time::DATE_FORMATS[:default]
+        ActiveSupport::Deprecation.warn(
+          "Using a :default format for DateTime#to_s is deprecated. Please use DateTime#to_fs instead."
+        )
+        if formatter.respond_to?(:call)
+          formatter.call(self).to_s
+        else
+          strftime(formatter)
+        end
+      else
+        to_default_s
+      end
     else
       ActiveSupport::Deprecation.warn(
         "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_fs(#{format.inspect}) instead."

--- a/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
@@ -10,7 +10,14 @@ module ActiveSupport
         )
         formatter.call(first, last)
       elsif format == NOT_SET
-        super()
+        if formatter = RangeWithFormat::RANGE_FORMATS[:default]
+          ActiveSupport::Deprecation.warn(
+            "Using a :default format for Range#to_s is deprecated. Please use Range#to_fs instead."
+          )
+          formatter.call(first, last)
+        else
+          super()
+        end
       else
         ActiveSupport::Deprecation.warn(
           "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_fs(#{format.inspect}) instead."

--- a/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
@@ -11,7 +11,18 @@ class Time
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
-      to_default_s
+      if formatter = ::Time::DATE_FORMATS[:default]
+        ActiveSupport::Deprecation.warn(
+          "Using a :default format for Time#to_s is deprecated. Please use Time#to_fs instead."
+        )
+        if formatter.respond_to?(:call)
+          formatter.call(self).to_s
+        else
+          strftime(formatter)
+        end
+      else
+        to_default_s
+      end
     else
       ActiveSupport::Deprecation.warn(
         "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_fs(#{format.inspect}) instead."

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -221,7 +221,14 @@ module ActiveSupport
         )
         formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
       elsif format == NOT_SET
-        "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
+        if formatter = ::Time::DATE_FORMATS[:default]
+          ActiveSupport::Deprecation.warn(
+            "Using a :default format for TimeWithZone#to_s is deprecated. Please use TimeWithZone#to_fs instead."
+          )
+          formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+        else
+          "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
+        end
       else
         ActiveSupport::Deprecation.warn(
           "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -50,6 +50,18 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_to_s_default_is_deprecated
+    date = Date.new(2005, 2, 21)
+
+    Date::DATE_FORMATS[:default] = "%Y/%m/%d"
+
+    assert_deprecated do
+      assert_equal "2005/02/21", date.to_s
+    end
+  ensure
+    Date::DATE_FORMATS.delete(:default)
+  end
+
   def test_to_s_with_single_digit_day
     date = Date.new(2005, 2, 1)
     assert_equal "2005-02-01",          date.to_s

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -54,6 +54,18 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_to_s_default_is_deprecated
+    datetime = DateTime.new(2005, 2, 21, 14, 30, 0, 0)
+
+    Time::DATE_FORMATS[:default] = "%Y/%m/%d"
+
+    assert_deprecated do
+      assert_equal "2005/02/21", datetime.to_s
+    end
+  ensure
+    Time::DATE_FORMATS.delete(:default)
+  end
+
   def test_to_fs
     datetime = DateTime.new(2005, 2, 21, 14, 30, 0, 0)
     assert_equal "2005-02-21 14:30:00",                 datetime.to_fs(:db)

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -35,6 +35,20 @@ class RangeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_to_s_default_is_deprecated
+    number_range = (1..100)
+
+    ActiveSupport::RangeWithFormat::RANGE_FORMATS[:default] = -> (s, e) do
+      "s: #{s}, e: #{e}"
+    end
+
+    assert_deprecated do
+      assert_equal "s: 1, e: 100", number_range.to_s
+    end
+  ensure
+    ActiveSupport::RangeWithFormat::RANGE_FORMATS.delete(:default)
+  end
+
   def test_to_s_with_format_invalid_format
     number_range = (1..100)
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -642,6 +642,18 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_to_s_default_is_deprecated
+    time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
+
+    Time::DATE_FORMATS[:default] = "%Y/%m/%d"
+
+    assert_deprecated do
+      assert_equal "2005/02/21", time.to_s
+    end
+  ensure
+    Time::DATE_FORMATS.delete(:default)
+  end
+
   def test_to_fs
     time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
     assert_equal time.to_s,                         time.to_fs(:doesnt_exist)

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -133,6 +133,16 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "1999-12-31 19:00:00 -0500", @twz.to_s
   end
 
+  def test_to_s_default_is_deprecated
+    Time::DATE_FORMATS[:default] = "%Y/%m/%d"
+
+    assert_deprecated do
+      assert_equal "1999/12/31", @twz.to_s
+    end
+  ensure
+    Time::DATE_FORMATS.delete(:default)
+  end
+
   def test_to_fs
     assert_equal "1999-12-31 19:00:00 -0500", @twz.to_fs
   end


### PR DESCRIPTION
### Motivation / Background

Fixes #48545 

When `to_s` was [deprecated][1] for `to_fs`, warnings were added when explicit formats were passed to `to_s`. To determine whether a format argument was passed, the method signature was changed from `to_s(format = :default)` to `to_s(format = EMPTY_OBJECT)`. While this enabled being able to warn on formats passed, it changed the behavior of not passing any format for applications that customized the `:default` format for one of these classes.

### Detail

This commit restores the previous behavior for `:default` formats while keeping the existing warnings. Additionally, it will continue to not warn for applications using `to_s` without arguments that haven't set a custom `:default` format. However, for applications that have set a custom `:default` format, it will now warn that those classes should be migrated to `to_fs`.

[1]: https://github.com/rails/rails/commit/f9fbfe0ab3cfc31f72663b9f06286ab32224b886

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
