### PR TITLE
Fix EncryptedConfiguration not behaving like Hash

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `EncryptedConfiguration` returning incorrect values for some `Hash`
+    methods
+
+    *Hartley McGuire*
+
 *   Don't show secrets for `MessageEncryptor#inspect`.
 
     Before:

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -92,7 +92,7 @@ module ActiveSupport
       end
 
       def options
-        @options ||= ActiveSupport::InheritableOptions.new(deep_transform(config))
+        @options ||= deep_transform(config)
       end
 
       def deserialize(content)

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -45,6 +45,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_not @credentials.something.bad
     assert_equal "bar", @credentials.dig(:something, :nested, :foo)
     assert_equal "bar", @credentials.something.nested.foo
+    assert_equal [:something], @credentials.keys
     assert_equal [:good, :bad, :nested], @credentials.something.keys
     assert_equal ({ good: true, bad: false, nested: { foo: "bar" } }), @credentials.something
   end


### PR DESCRIPTION
### Motivation / Background

Fixes #48554

Previously, `EncryptedConfiguration` was [updated][1] to use `InheritableOptions` so that keys could be called like methods. It was later [updated again][2] to ensure that it behaved both like a `Hash` and `OrderedOptions`. In this second change, the `InheritableOptions` instance was accidentally nested with another `InheritableOptions` instance.

This continued to mostly work as expected because `InheritableOptions` will fall back to the inner `InheritableOptions` when the outer one doesn't have a key. However, any methods that try to treat the outer `InheritableOptions` like it should know about all of its keys will fail (for example, `#keys`, `#to_h`, `#to_json`, etc.)

### Detail

This commit fixes the issue by removing the extraneous outer `InheritableOptions` instance.

[1]: https://github.com/rails/rails/commit/a6a9fed1719a3cfe47eb1566ae4d6034374fd809
[2]: https://github.com/rails/rails/commit/80585daf2def5bf94854be69f81e24a16ce14c55

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
