### PR TITLE
Merge pull request #45837 from hahmed/ha/active-storage-fix-rotation-…

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix retrieving rotation value from FFmpeg on version 5.0+.
+
+    In FFmpeg version 5.0+ the rotation value has been removed from tags.
+    Instead the value can be found in side_data_list. Along with
+    this update it's possible to have values of -90, -270 to denote the video
+    has been rotated.
+
+    *Haroon Ahmed*
+
 ## Rails 7.0.5 (May 24, 2023) ##
 
 *   No changes.

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -16,7 +16,7 @@ module ActiveStorage
   #   ActiveStorage::Analyzer::VideoAnalyzer.new(blob).metadata
   #   # => { width: 640.0, height: 480.0, duration: 5.0, angle: 0, display_aspect_ratio: [4, 3], audio: true, video: true }
   #
-  # When a video's angle is 90 or 270 degrees, its width and height are automatically swapped for convenience.
+  # When a video's angle is 90, -90, 270 or -270 degrees, its width and height are automatically swapped for convenience.
   #
   # This analyzer requires the {FFmpeg}[https://www.ffmpeg.org] system library, which is not provided by Rails.
   class Analyzer::VideoAnalyzer < Analyzer
@@ -51,7 +51,11 @@ module ActiveStorage
       end
 
       def angle
-        Integer(tags["rotate"]) if tags["rotate"]
+        if tags["rotate"]
+          Integer(tags["rotate"])
+        elsif side_data && side_data[0] && side_data[0]["rotation"]
+          Integer(side_data[0]["rotation"])
+        end
       end
 
       def display_aspect_ratio
@@ -66,7 +70,7 @@ module ActiveStorage
       end
 
       def rotated?
-        angle == 90 || angle == 270
+        angle == 90 || angle == 270 || angle == -90 || angle == -270
       end
 
       def audio?
@@ -95,9 +99,12 @@ module ActiveStorage
         @display_height_scale ||= Float(display_aspect_ratio.last) / display_aspect_ratio.first if display_aspect_ratio
       end
 
-
       def tags
         @tags ||= video_stream["tags"] || {}
+      end
+
+      def side_data
+        @side_data ||= video_stream["side_data_list"] || {}
       end
 
       def video_stream

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -26,7 +26,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 480, metadata[:width]
     assert_equal 640, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal 90, metadata[:angle]
+    assert_includes [90, -90], metadata[:angle]
   end
 
   test "analyzing a video with rectangular samples" do


### PR DESCRIPTION
### Motivation / Background
This pull request backports #45837 to the 7-0-stable branch.
 
### Detail
I have opened this back port pull request because 7-0-stable CI has been red.
This commit addresses the following failure.

https://buildkite.com/rails/rails/builds/97419#0188e1f5-368b-4d81-8161-e58086d544fa/1187-1244

```ruby
Failure:
ActiveStorage::Analyzer::VideoAnalyzerTest#test_analyzing_a_rotated_video [/rails/activestorage/test/analyzer/video_analyzer_test.rb:26]:
Expected: 480
  Actual: 640.0
```

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
