### PR TITLE
Fix parallel testing (issue #48547)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -128,7 +128,7 @@ module ActiveRecord
         end
       end
 
-      def establish_connection(config, owner_name: Base, role: ActiveRecord::Base.current_role, shard: Base.current_shard)
+      def establish_connection(config, owner_name: Base, role: Base.current_role, shard: Base.current_shard, clobber: false)
         owner_name = determine_owner_name(owner_name, config)
 
         pool_config = resolve_pool_config(config, owner_name, role, shard)
@@ -142,7 +142,7 @@ module ActiveRecord
         # configuration.
         existing_pool_config = pool_manager.get_pool_config(role, shard)
 
-        if existing_pool_config && existing_pool_config.db_config == db_config
+        if !clobber && existing_pool_config && existing_pool_config.db_config == db_config
           # Update the pool_config's connection class if it differs. This is used
           # for ensuring that ActiveRecord::Base and the primary_abstract_class use
           # the same pool. Without this granular swapping will not work correctly.

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -28,6 +28,7 @@ module ActiveRecord
       def purge
         establish_connection(configuration_hash_without_database)
         connection.recreate_database(db_config.database, creation_options)
+        establish_connection
       end
 
       def charset

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -187,11 +187,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       ActiveRecord::Base.stub(:connection, @connection) do
-        assert_called_with(
-          ActiveRecord::Base,
-          :establish_connection,
-          [adapter: "mysql2", database: nil]
-        ) do
+        assert_called(ActiveRecord::Base, :establish_connection, times: 2) do
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
       end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -187,11 +187,7 @@ module ActiveRecord
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
       ActiveRecord::Base.stub(:connection, @connection) do
-        assert_called_with(
-          ActiveRecord::Base,
-          :establish_connection,
-          [adapter: "trilogy", database: nil]
-        ) do
+        assert_called(ActiveRecord::Base, :establish_connection, times: 2) do
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
       end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -769,6 +769,24 @@ module ApplicationTests
       assert_no_match "create_table(:users)", output
     end
 
+    def test_parallel_testing_when_schema_is_not_up_to_date
+      require "#{app_path}/config/environment"
+      Dir.chdir(app_path) do
+        use_mysql2
+
+        exercise_parallelization_regardless_of_machine_core_count(with: :processes)
+
+        rails "generate", "scaffold", "User", "name:string"
+        rails "db:create"
+        rails "db:migrate"
+
+        output = rails "test"
+
+        assert_match(/Finished in.*7 runs, 11 assertions, 0 failures, 0 errors, 0 skips/m, output)
+        assert_match %r{Running \d+ tests in parallel using \d+ processes}, output
+      end
+    end
+
     def test_parallelization_is_disabled_when_number_of_tests_is_below_threshold
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, threshold: 100)
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -517,6 +517,56 @@ module TestHelpers
       end
       database_name
     end
+
+    def use_mysql2(multi_db: false)
+      database_name = "railties_#{Process.pid}"
+      if multi_db
+        File.open("#{app_path}/config/database.yml", "w") do |f|
+          f.puts <<-YAML
+          default: &default
+            adapter: mysql2
+            pool: 5
+            username: root
+          <% if ENV['MYSQL_HOST'] %>
+            host: <%= ENV['MYSQL_HOST'] %>
+          <% end %>
+          <% if ENV['MYSQL_SOCK'] %>
+            socket: "<%= ENV['MYSQL_SOCK'] %>"
+          <% end %>
+          development:
+            primary:
+              <<: *default
+              database: #{database_name}_test
+            animals:
+              <<: *default
+              database: #{database_name}_animals_test
+              migrations_paths: db/animals_migrate
+          YAML
+        end
+      else
+        File.open("#{app_path}/config/database.yml", "w") do |f|
+          f.puts <<-YAML
+          default: &default
+            adapter: mysql2
+            pool: 5
+            username: root
+          <% if ENV['MYSQL_HOST'] %>
+            host: <%= ENV['MYSQL_HOST'] %>
+          <% end %>
+          <% if ENV['MYSQL_SOCK'] %>
+            socket: "<%= ENV['MYSQL_SOCK'] %>"
+          <% end %>
+          development:
+            <<: *default
+            database: #{database_name}_development
+          test:
+            <<: *default
+            database: #{database_name}_test
+          YAML
+        end
+      end
+      database_name
+    end
   end
 
   module Reload


### PR DESCRIPTION
Fixes 2 bugs in parallel testing.

The first bug was related to changes made in #45450 which meant that we were no longer replacing the connection in parallel testing because the config object is equal (we simply merge a new db name but the object id of the config stays the same). This bug only manifested in mysql and sqlite3 interestingly. It would fail on the internal metadata tables because they were missing in the schema version check.

To fix this I introduced a `clobber: true` kwarg onto the connection handler that allowsus to bypass the functionality that won't make a new connection if the config is the same. This is an easy way to fall back to the old behavior from before this change.

After implementing this fix I was still seeing failures in the mysql demo app I made due to the fact that `purge` was not re-establishing the connection to a config that had a database defined. Neither sqlite3 or postgresql were missing this.

I added a test for mysql2 so we don't have regressions in the future. I think this was missed because sqlite3 only demonstrates the bug if it was never successful on that worker and postgresql was fine.

Fixes #48547

cc/ @matthutchinson