### PR TITLE
[Fix #46653] `becomes` losing target class default value

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -44,6 +44,11 @@ module ActiveModel
       @value
     end
 
+    def _value
+      # Retrieve the value without marking it read
+      type_cast(value_before_type_cast)
+    end
+
     def original_value
       if assigned?
         original_attribute.original_value

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -808,11 +808,15 @@ module ActiveRecord
 
       became.send(:initialize) do |becoming|
         @attributes.reverse_merge!(becoming.instance_variable_get(:@attributes))
-        becoming.instance_variable_set(:@attributes, @attributes)
+        becoming_attributes = becoming.instance_variable_set(:@attributes, @attributes)
         becoming.instance_variable_set(:@mutations_from_database, @mutations_from_database ||= nil)
         becoming.instance_variable_set(:@new_record, new_record?)
         becoming.instance_variable_set(:@destroyed, destroyed?)
         becoming.errors.copy!(errors)
+        klass._default_attributes.to_h.each do |name, value|
+          next if value.nil? || becoming_attributes[name]._value || @attributes[name].changed?
+          becoming_attributes.write_from_database(name, value)
+        end
       end
 
       became

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -410,6 +410,32 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_empty reply.attributes_in_database
   end
 
+  def test_becomes_default_attribute_value
+    company = Company.new
+
+    client = company.becomes(SpecialClient)
+
+    assert_equal "Special", client.firm_name
+  end
+
+  def test_becomes_maintains_assigned_over_default
+    company = Company.new
+    company.firm_name = "Consultant"
+
+    client = company.becomes(SpecialClient)
+
+    assert_equal "Consultant", client.firm_name
+  end
+
+  def test_becomes_maintains_drity_nil_assignment_over_default
+    company = Company.create!(name: "Company A", firm_name: "Consultant")
+    company.firm_name = nil
+
+    client = company.becomes(SpecialClient)
+
+    assert_nil client.firm_name
+  end
+
   def test_becomes_includes_changed_attributes
     company = Company.new(name: "37signals")
     client = company.becomes(Client)

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -224,6 +224,7 @@ class LargeClient < Client
 end
 
 class SpecialClient < Client
+  attribute :firm_name, :string, default: "Special"
 end
 
 class VerySpecialClient < SpecialClient


### PR DESCRIPTION
### Motivation / Background

Fixes #46653

### Detail

`becomes` is coping the `@attributes` from the original instance but the defaults are not being applied from the target class during initialization. Following the comments from the linked issue this PR will apply the default value if an attribute is nil and hasn't been changed.

