### PR TITLE
Use id in composite primary key of cpk book and fix related bugs

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -41,9 +41,9 @@ module ActiveRecord
       # Queries the primary key column's value.
       def id?
         if self.class.composite_primary_key?
-          @primary_key.all? { |col| query_attribute(col) }
+          @primary_key.all? { |col| _query_attribute(col) }
         else
-          query_attribute(@primary_key)
+          _query_attribute(@primary_key)
         end
       end
 

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -13,27 +13,38 @@ module ActiveRecord
       def query_attribute(attr_name)
         value = self.public_send(attr_name)
 
-        case value
-        when true        then true
-        when false, nil  then false
-        else
-          if !type_for_attribute(attr_name) { false }
-            if Numeric === value || !value.match?(/[^0-9]/)
-              !value.to_i.zero?
-            else
-              return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
-              !value.blank?
-            end
-          elsif value.respond_to?(:zero?)
-            !value.zero?
-          else
-            !value.blank?
-          end
-        end
+        query_cast_attribute(attr_name, value)
+      end
+
+      def _query_attribute(attr_name) # :nodoc:
+        value = self._read_attribute(attr_name.to_s)
+
+        query_cast_attribute(attr_name, value)
       end
 
       alias :attribute? :query_attribute
       private :attribute?
+
+      private
+        def query_cast_attribute(attr_name, value)
+          case value
+          when true        then true
+          when false, nil  then false
+          else
+            if !type_for_attribute(attr_name) { false }
+              if Numeric === value || !value.match?(/[^0-9]/)
+                !value.to_i.zero?
+              else
+                return false if ActiveModel::Type::Boolean::FALSE_VALUES.include?(value)
+                !value.blank?
+              end
+            elsif value.respond_to?(:zero?)
+              !value.zero?
+            else
+              !value.blank?
+            end
+          end
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -328,7 +328,13 @@ module ActiveRecord
       primary_key_array = Array(primary_key)
 
       if loaded?
-        result = records.pluck(*primary_key_array)
+        result = records.map do |record|
+          if primary_key_array.one?
+            record._read_attribute(primary_key_array.first)
+          else
+            primary_key_array.map { |column| record._read_attribute(column) }
+          end
+        end
         return @async ? Promise::Complete.new(result) : result
       end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -367,7 +367,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   def test_belongs_to_with_inverse_association_for_composite_primary_key
     author = Cpk::Author.new(name: "John")
-    book = author.books.build(number: 1, title: "The Rails Way")
+    book = author.books.build(id: [nil, 1], title: "The Rails Way")
     order = Cpk::Order.new(book: book, status: "paid")
     author.save!
 

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1728,7 +1728,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   test "preloading has_one with cpk" do
     order = Cpk::Order.create!(shop_id: 2)
-    book = Cpk::Book.create!(order: order, author_id: 1, number: 3)
+    book = Cpk::Book.create!(order: order, id: [1, 3])
     assert_equal book, Cpk::Order.eager_load(:book).find_by(id: order.id).book
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1633,7 +1633,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_loading_cpk_association_with_unpersisted_owner
     order = Cpk::Order.create!(shop_id: 1)
-    book = Cpk::BookWithOrderAgreements.new(number: 2, author_id: 1, order: order)
+    book = Cpk::BookWithOrderAgreements.new(id: [1, 2], order: order)
     order_agreement = Cpk::OrderAgreement.create!(order: order)
 
     assert_equal([order_agreement], book.order_agreements.to_a)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -146,25 +146,14 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nullification_on_cpk_association
-    book = Cpk::Book.create!(author_id: 1, number: 2)
-    other_book = Cpk::Book.create!(author_id: 3, number: 4)
+    book = Cpk::Book.create!(id: [1, 2])
+    other_book = Cpk::Book.create!(id: [3, 4])
     order = Cpk::OrderWithNullifiedBook.create!(book: book)
 
     order.book = other_book
 
     assert_nil book.order_id
     assert_nil book.shop_id
-  end
-
-  def test_nullification_on_cpk_association_with_pk_column
-    chapter = Cpk::Chapter.create!(author_id: 1, number: 2)
-    other_chapter = Cpk::Chapter.create!(author_id: 1, number: 4)
-    book = Cpk::NullifiedBook.create!(chapter: chapter, number: 1, author_id: 1)
-
-    book.chapter = other_chapter
-
-    assert_nil chapter.book_number
-    assert_not_nil chapter.author_id
   end
 
   def test_natural_assignment_to_nil_after_destroy

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -449,7 +449,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_loading_cpk_association_with_unpersisted_owner
     order = Cpk::Order.create!(shop_id: 1)
-    book = Cpk::BookWithOrderAgreements.new(number: 2, author_id: 1, order: order)
+    book = Cpk::BookWithOrderAgreements.new(id: [1, 2], order: order)
     order_agreement = Cpk::OrderAgreement.create!(order: order)
 
     assert_equal(order_agreement, book.order_agreement)

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -605,7 +605,7 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
   def test_inverse_should_be_set_on_composite_primary_key_child
     author = Cpk::Author.new(name: "John")
-    book = author.books.build(number: 1, title: "The Rails Way")
+    book = author.books.build(id: [nil, 1], title: "The Rails Way")
     Cpk::Order.new(book: book, status: "paid")
     author.save!
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -489,7 +489,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
 
   test "composite primary key autosave" do
     assert_nothing_raised do
-      Cpk::Order.create!(id: [1, 2], book: Cpk::Book.new(title: "Book", author_id: 3, number: 4))
+      Cpk::Order.create!(id: [1, 2], book: Cpk::Book.new(title: "Book", id: [3, 4]))
     end
   end
 end
@@ -783,12 +783,12 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   end
 
   def test_assign_ids_with_cpk_for_two_models
-    books = [cpk_books(:cpk_great_author_first_book).id, cpk_books(:cpk_great_author_second_book).id]
+    book_ids = [cpk_books(:cpk_great_author_first_book).id, cpk_books(:cpk_great_author_second_book).id]
     order = cpk_orders(:cpk_groceries_order_1)
 
     assert_empty order.books
 
-    order.book_ids = books
+    order.book_ids = book_ids
     order.save
     order.reload
 
@@ -799,7 +799,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   end
 
   def test_has_one_cpk_has_one_autosave_with_id
-    book = Cpk::Book.create!(author_id: 1, number: 3, shop_id: 2)
+    book = Cpk::Book.create!(id: [1, 3], shop_id: 2)
     order = Cpk::OrderWithPrimaryKeyAssociatedBook.create!(book: book, shop_id: 2)
 
     assert_equal(book.order.id, order.id)
@@ -1069,7 +1069,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
   # belongs_to for CPK
   def test_autosave_cpk_association_should_destroy_parent_association_when_marked_for_destruction
-    book = Cpk::Book.new(title: "Book", author_id: 1, number: 2)
+    book = Cpk::Book.new(title: "Book", id: [1, 2])
     Cpk::Order.create!(id: [3, 4], book: book)
 
     book.order.mark_for_destruction

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -792,7 +792,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     order.save
     order.reload
 
-    assert_equal books, order.book_ids
+    assert_equal book_ids, order.book_ids
     assert_equal 2, order.books.length
     assert_includes order.books, cpk_books(:cpk_great_author_first_book)
     assert_includes order.books, cpk_books(:cpk_great_author_second_book)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1011,8 +1011,7 @@ class BasicsTest < ActiveRecord::TestCase
     new_book = book.dup
 
     assert_equal "The first book", new_book.title
-    assert_nil new_book.author_id
-    assert_nil new_book.number
+    assert_equal([nil, nil], new_book.id)
   end
 
   DeveloperSalary = Struct.new(:amount)

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -803,11 +803,11 @@ class EachTest < ActiveRecord::TestCase
 
   test ".find_each with multiple column ordering and using composite primary key" do
     Cpk::Book.insert_all!([
-      { author_id: 1, number: 1 },
-      { author_id: 2, number: 1 },
-      { author_id: 2, number: 2 }
+      { author_id: 1, id: 1 },
+      { author_id: 2, id: 1 },
+      { author_id: 2, id: 2 }
     ])
-    books = Cpk::Book.order(author_id: :asc, number: :desc).to_a
+    books = Cpk::Book.order(author_id: :asc, id: :desc).to_a
 
     index = 0
     Cpk::Book.find_each(batch_size: 1, order: [:asc, :desc]) do |book|
@@ -819,35 +819,35 @@ class EachTest < ActiveRecord::TestCase
 
   test ".in_batches should start from the start option when using composite primary key with multiple column ordering" do
     Cpk::Book.insert_all!([
-      { author_id: 1, number: 1 },
-      { author_id: 1, number: 2 },
-      { author_id: 1, number: 3 }
+      { author_id: 1, id: 1 },
+      { author_id: 1, id: 2 },
+      { author_id: 1, id: 3 }
     ])
-    second_book = Cpk::Book.order(author_id: :asc, number: :desc).second
+    second_book = Cpk::Book.order(author_id: :asc, id: :desc).second
     relation = Cpk::Book.in_batches(of: 1, start: second_book.id, order: [:asc, :desc]).first
     assert_equal second_book, relation.first
   end
 
   test ".in_batches should end at the finish option when using composite primary key with multiple column ordering" do
     Cpk::Book.insert_all!([
-      { author_id: 1, number: 1 },
-      { author_id: 1, number: 2 },
-      { author_id: 1, number: 3 }
+      { author_id: 1, id: 1 },
+      { author_id: 1, id: 2 },
+      { author_id: 1, id: 3 }
     ])
-    second_book = Cpk::Book.order(author_id: :asc, number: :desc).second
+    second_book = Cpk::Book.order(author_id: :asc, id: :desc).second
     relation = Cpk::Book.in_batches(of: 1, finish: second_book.id, order: [:asc, :desc]).to_a.last
     assert_equal second_book, relation.first
   end
 
   test ".in_batches with scope and multiple column ordering and using composite primary key" do
     Cpk::Book.insert_all!([
-      { author_id: 1, number: 1 },
-      { author_id: 1, number: 2 },
-      { author_id: 1, number: 3 }
+      { author_id: 1, id: 1 },
+      { author_id: 1, id: 2 },
+      { author_id: 1, id: 3 }
     ])
-    book1, book2 = Cpk::Book.order(author_id: :asc, number: :desc).first(2)
-    author_id, number = book1.id
-    relation = Cpk::Book.where("author_id >= ? AND number < ?", author_id, number).in_batches(of: 1, order: [:asc, :desc]).first
+    book1, book2 = Cpk::Book.order(author_id: :asc, id: :desc).first(2)
+    author_id, id = book1.id
+    relation = Cpk::Book.where("author_id >= ? AND id < ?", author_id, id).in_batches(of: 1, order: [:asc, :desc]).first
     assert_equal book2, relation.first
   end
 end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -394,7 +394,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_count_for_a_composite_primary_key_model
     book = cpk_books(:cpk_great_author_first_book)
-    assert_equal(1, Cpk::Book.where(author_id: book.author_id, number: book.number).count)
+    assert_equal(1, Cpk::Book.where(author_id: book.author_id, id: book.id).count)
   end
 
   def test_group_by_count_for_a_composite_primary_key_model
@@ -957,13 +957,13 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_for_a_composite_primary_key
-    assert_equal Cpk::Book.all.pluck([:author_id, :number]).sort, Cpk::Book.all.ids.sort
+    assert_equal Cpk::Book.all.pluck([:author_id, :id]).sort, Cpk::Book.all.ids.sort
   end
 
   def test_ids_for_a_composite_primary_key_with_scope
     book = cpk_books(:cpk_great_author_first_book)
 
-    assert_equal [[book.author_id, book.number]], Cpk::Book.all.where(title: book.title).ids
+    assert_equal [book.id], Cpk::Book.all.where(title: book.title).ids
   end
 
   def test_ids_for_a_composite_primary_key_on_loaded_relation
@@ -972,7 +972,7 @@ class CalculationsTest < ActiveRecord::TestCase
     relation.to_a
 
     assert_predicate relation, :loaded?
-    assert_equal [[book.author_id, book.number]], relation.ids
+    assert_equal [book.id], relation.ids
   end
 
   def test_ids_with_scope

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -158,11 +158,11 @@ class CoreTest < ActiveRecord::TestCase
   def test_composite_pk_models_added_to_a_set
     library = Set.new
     # with primary key present
-    library << Cpk::Book.new(author_id: 1, number: 2)
+    library << Cpk::Book.new(id: [1, 2])
 
     # duplicate
-    library << Cpk::Book.new(author_id: 1, number: 3)
-    library << Cpk::Book.new(author_id: 1, number: 3)
+    library << Cpk::Book.new(id: [1, 3])
+    library << Cpk::Book.new(id: [1, 3])
 
     # without primary key being set
     library << Cpk::Book.new(title: "Book A")
@@ -172,9 +172,9 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_composite_pk_models_equality
-    assert Cpk::Book.new(author_id: 1, number: 2) == Cpk::Book.new(author_id: 1, number: 2)
+    assert Cpk::Book.new(id: [1, 2]) == Cpk::Book.new(id: [1, 2])
 
-    assert_not Cpk::Book.new(author_id: 1, number: 2) == Cpk::Book.new(author_id: 1, number: 3)
+    assert_not Cpk::Book.new(id: [1, 2]) == Cpk::Book.new(id: [1, 3])
     assert_not Cpk::Book.new == Cpk::Book.new
     assert_not Cpk::Book.new(title: "Book A") == Cpk::Book.new(title: "Book B")
     assert_not Cpk::Book.new(author_id: 1) == Cpk::Book.new(author_id: 1)
@@ -182,9 +182,9 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_composite_pk_models_hash
-    assert_equal Cpk::Book.new(author_id: 1, number: 2).hash, Cpk::Book.new(author_id: 1, number: 2).hash
+    assert_equal Cpk::Book.new(id: [1, 2]).hash, Cpk::Book.new(id: [1, 2]).hash
 
-    assert_not_equal Cpk::Book.new(author_id: 1, number: 2).hash, Cpk::Book.new(author_id: 1, number: 3).hash
+    assert_not_equal Cpk::Book.new(id: [1, 2]).hash, Cpk::Book.new(id: [1, 3]).hash
     assert_not_equal Cpk::Book.new.hash, Cpk::Book.new.hash
     assert_not_equal Cpk::Book.new(title: "Book A").hash, Cpk::Book.new(title: "Book B").hash
     assert_not_equal Cpk::Book.new(author_id: 1).hash, Cpk::Book.new(author_id: 1).hash

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1691,15 +1691,16 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
       alice_cpk_book = cpk_books(:cpk_great_author_first_book)
 
       assert_not_empty(alice_cpk_book.id.compact)
-      assert_equal alice.id, alice_cpk_book.author_id
-      assert_not_nil alice_cpk_book.number
+      assert_equal alice_cpk_book.id.first, alice.id
+      assert_not_nil alice_cpk_book.id.last
     end
 
     def test_generates_composite_primary_key_ids
       assert_not_empty(cpk_orders(:cpk_groceries_order_1).id.compact)
 
-      assert_not_nil(cpk_books(:cpk_great_author_first_book).author_id)
-      assert_not_nil(cpk_books(:cpk_great_author_first_book).number)
+      cpk_books(:cpk_great_author_first_book).id.each do |id_column|
+        assert_not_nil(id_column)
+      end
     end
 
     def test_generates_composite_primary_key_with_unique_components

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1536,7 +1536,7 @@ class QueryConstraintsTest < ActiveRecord::TestCase
 
   def test_query_constraints_list_equals_to_composite_primary_key
     assert_equal(["shop_id", "id"], Cpk::Order.query_constraints_list)
-    assert_equal(["author_id", "number"], Cpk::Book.query_constraints_list)
+    assert_equal(["author_id", "id"], Cpk::Book.query_constraints_list)
   end
 
   def test_child_keeps_parents_query_constraints
@@ -1548,7 +1548,7 @@ class QueryConstraintsTest < ActiveRecord::TestCase
   end
 
   def test_child_keeps_parents_query_contraints_derived_from_composite_pk
-    assert_equal(["author_id", "number"], Cpk::BestSeller.query_constraints_list)
+    assert_equal(["author_id", "id"], Cpk::BestSeller.query_constraints_list)
   end
 
   def assert_uses_query_constraints_on_reload(object, columns)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -35,7 +35,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_read_attribute_with_composite_primary_key
-    book = Cpk::Book.new(author_id: 1, number: 2)
+    book = Cpk::Book.new(id: [1, 2])
     assert_equal [1, 2], book.read_attribute(:id)
   end
 
@@ -396,8 +396,6 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     book.save!
 
     assert_equal [1, 2], book.id
-    assert_equal 1, book.author_id
-    assert_equal 2, book.number
   ensure
     Cpk::Book.delete_all
   end
@@ -409,7 +407,7 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
       book.id = 1
     end
 
-    assert_equal("Expected value matching [\"author_id\", \"number\"], got 1.", error.message)
+    assert_equal("Expected value matching [\"author_id\", \"id\"], got 1.", error.message)
   end
 
   def test_id_was_composite
@@ -467,7 +465,7 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_model_with_a_composite_primary_key
-    assert_equal(["author_id", "number"], Cpk::Book.primary_key)
+    assert_equal(["author_id", "id"], Cpk::Book.primary_key)
     assert_equal(["shop_id", "id"], Cpk::Order.primary_key)
   end
 
@@ -476,11 +474,11 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_primary_key_values_present_for_a_composite_pk_model
-    assert_predicate Cpk::Book.new(author_id: 1, number: 1), :primary_key_values_present?
+    assert_predicate Cpk::Book.new(id: [1, 1]), :primary_key_values_present?
 
     assert_not_predicate Cpk::Book.new, :primary_key_values_present?
     assert_not_predicate Cpk::Book.new(author_id: 1), :primary_key_values_present?
-    assert_not_predicate Cpk::Book.new(number: 1), :primary_key_values_present?
+    assert_not_predicate Cpk::Book.new(id: [nil, 1]), :primary_key_values_present?
     assert_not_predicate Cpk::Book.new(title: "Book A"), :primary_key_values_present?
     assert_not_predicate Cpk::Book.new(author_id: 1, title: "Book A"), :primary_key_values_present?
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -112,12 +112,12 @@ module ActiveRecord
     end
 
     def test_where_with_tuple_syntax_on_composite_models
-      book_one = Cpk::Book.create!(author_id: 1, number: 2)
-      book_two = Cpk::Book.create!(author_id: 3, number: 4)
+      book_one = Cpk::Book.create!(id: [1, 2])
+      book_two = Cpk::Book.create!(id: [3, 4])
 
-      assert_equal [book_one], Cpk::Book.where([:author_id, :number] => [[1, 2]])
+      assert_equal [book_one], Cpk::Book.where([:author_id, :id] => [[1, 2]])
       assert_equal [book_one, book_two].sort, Cpk::Book.where(Cpk::Book.primary_key => [[1, 2], [3, 4]]).sort
-      assert_empty Cpk::Book.where([:author_id, :number] => [[1, 4], [3, 2]])
+      assert_empty Cpk::Book.where([:author_id, :id] => [[1, 4], [3, 2]])
     end
 
     def test_where_with_tuple_syntax_with_incorrect_arity
@@ -135,12 +135,12 @@ module ActiveRecord
     end
 
     def test_where_with_tuple_syntax_and_regular_syntax_combined
-      book_one = Cpk::Book.create!(author_id: 1, number: 2, title: "The Alchemist")
-      book_two = Cpk::Book.create!(author_id: 3, number: 4, title: "The Alchemist")
+      book_one = Cpk::Book.create!(id: [1, 2], title: "The Alchemist")
+      book_two = Cpk::Book.create!(id: [3, 4], title: "The Alchemist")
 
       assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist").sort
-      assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[1, 2], [3, 4]]).sort
-      assert_equal [book_two], Cpk::Book.where(title: "The Alchemist", [:author_id, :number] => [[3, 4]])
+      assert_equal [book_one, book_two].sort, Cpk::Book.where(title: "The Alchemist", [:author_id, :id] => [[1, 2], [3, 4]]).sort
+      assert_equal [book_two], Cpk::Book.where(title: "The Alchemist", [:author_id, :id] => [[3, 4]])
     end
 
     def test_belongs_to_shallow_where

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -986,10 +986,10 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   def test_restore_composite_id_after_rollback
-    book = Cpk::Book.create!(author_id: 1, number: 2)
+    book = Cpk::Book.create!(id: [1, 2])
 
     Cpk::Book.transaction do
-      book.update!(author_id: 42, number: 42)
+      book.update!(id: [42, 42])
       raise ActiveRecord::Rollback
     end
 
@@ -999,8 +999,8 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   def test_rollback_on_composite_key_model
-    Cpk::Book.create!(author_id: 1, number: 3, title: "Charlotte's Web")
-    book_two_unpersisted = Cpk::Book.new(author_id: 1, number: 3)
+    Cpk::Book.create!(id: [1, 3], title: "Charlotte's Web")
+    book_two_unpersisted = Cpk::Book.new(id: [1, 3])
 
     assert_raise(ActiveRecord::RecordNotUnique) do
       Cpk::Book.transaction do

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -819,8 +819,8 @@ class UniquenessWithCompositeKey < ActiveRecord::TestCase
   end
 
   def test_uniqueness_validation_for_model_with_composite_key
-    book_one = BookWithUniqueRevision.create!(author_id: 1, number: 42, title: "Author 1's book", revision: 36)
-    book_two = BookWithUniqueRevision.create!(author_id: 2, number: 42, title: "Author 2's book", revision: 37)
+    book_one = BookWithUniqueRevision.create!(id: [1, 42], title: "Author 1's book", revision: 36)
+    book_two = BookWithUniqueRevision.create!(id: [2, 42], title: "Author 2's book", revision: 37)
 
     assert_not_equal book_one.revision, book_two.revision
 

--- a/activerecord/test/models/cpk/chapter.rb
+++ b/activerecord/test/models/cpk/chapter.rb
@@ -5,7 +5,7 @@ module Cpk
     self.table_name = :cpk_chapters
     # explicit definition is to allow schema definition to be simplified
     # to be shared between different databases
-    self.primary_key = [:author_id, :number]
+    self.primary_key = [:author_id, :id]
 
     belongs_to :book, query_constraints: [:author_id, :book_number]
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -240,19 +240,19 @@ ActiveRecord::Schema.define do
     t.references :citation
   end
 
-  create_table :cpk_books, primary_key: [:author_id, :number], force: true do |t|
+  create_table :cpk_books, primary_key: [:author_id, :id], force: true do |t|
     t.integer :author_id
-    t.integer :number
+    t.integer :id
     t.string :title
     t.integer :revision
     t.integer :order_id
     t.integer :shop_id
   end
 
-  create_table :cpk_chapters, primary_key: [:author_id, :number], force: true do |t|
+  create_table :cpk_chapters, primary_key: [:author_id, :id], force: true do |t|
     t.integer :author_id
-    t.integer :number
-    t.integer :book_number
+    t.integer :id
+    t.integer :book_id
     t.string :title
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I think that our test models could be improved. Right now, we primary test composite primary key code with `Cpk::Book` and related models. This model uses `[:author_id, :number]` as a PK definition. In practice, most models (I think) would use `[:some_id, :id]`, so I've changed `cpk_books` to mirror this assumption. 

### Detail

This Pull Request changes `Cpk::Book` to use `id` instead of `number`, and as the second campsite key, and updated related tests. This also uncovered three bugs in our current implementation I've fixed as well.

### Additional information

Happy to introduce another model instead of doing this, but it seems much easier to model our test data closer to what we expect in the real world.

The last commit (70f3b3de1cbf761e67f527ed1525734882e08649), breaks a few attribute method test expectations. We might need to implement a special query method for ID dirty checking. WDYT?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
