### PR TITLE
Rename `Range#overlaps?` to `Range#overlap?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rename `Range#overlaps?` to `#overlap?` and add alias for backwards compatibility
+
+    *Christian Schmidt*
+
 *   Fix `EncryptedConfiguration` returning incorrect values for some `Hash`
     methods
 

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -2,5 +2,5 @@
 
 require "active_support/core_ext/range/conversions"
 require "active_support/core_ext/range/compare_range"
-require "active_support/core_ext/range/overlaps"
+require "active_support/core_ext/range/overlap"
 require "active_support/core_ext/range/each"

--- a/activesupport/lib/active_support/core_ext/range/overlap.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlap.rb
@@ -2,9 +2,11 @@
 
 class Range
   # Compare two ranges and see if they overlap each other
-  #  (1..5).overlaps?(4..6) # => true
-  #  (1..5).overlaps?(7..9) # => false
-  def overlaps?(other)
+  #  (1..5).overlap?(4..6) # => true
+  #  (1..5).overlap?(7..9) # => false
+  def overlap?(other)
     other.begin == self.begin || cover?(other.begin) || other.cover?(self.begin)
   end
+
+  alias :overlaps? :overlap?
 end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -41,28 +41,33 @@ class RangeTest < ActiveSupport::TestCase
     assert_instance_of Range, DateTime.new..DateTime::Infinity.new
   end
 
-  def test_overlaps_last_inclusive
-    assert((1..5).overlaps?(5..10))
+  def test_overlap_last_inclusive
+    assert((1..5).overlap?(5..10))
   end
 
-  def test_overlaps_last_exclusive
-    assert_not (1...5).overlaps?(5..10)
+  def test_overlap_last_exclusive
+    assert_not (1...5).overlap?(5..10)
   end
 
-  def test_overlaps_first_inclusive
-    assert((5..10).overlaps?(1..5))
+  def test_overlap_first_inclusive
+    assert((5..10).overlap?(1..5))
   end
 
-  def test_overlaps_first_exclusive
-    assert_not (5..10).overlaps?(1...5)
+  def test_overlap_first_exclusive
+    assert_not (5..10).overlap?(1...5)
   end
 
-  def test_overlaps_with_beginless_range
-    assert((1..5).overlaps?(..10))
+  def test_overlap_with_beginless_range
+    assert((1..5).overlap?(..10))
   end
 
-  def test_overlaps_with_two_beginless_ranges
-    assert((..5).overlaps?(..10))
+  def test_overlap_with_two_beginless_ranges
+    assert((..5).overlap?(..10))
+  end
+
+  def test_overlaps_alias
+    assert (1..5).overlaps?(5..10)
+    assert_not (1...5).overlaps?(6..10)
   end
 
   def test_should_include_identical_inclusive
@@ -168,16 +173,16 @@ class RangeTest < ActiveSupport::TestCase
     assert range.method(:include?) != range.method(:cover?)
   end
 
-  def test_overlaps_on_time
+  def test_overlap_on_time
     time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     time_range_2 = Time.utc(2005, 12, 10, 17, 00)..Time.utc(2005, 12, 10, 18, 00)
-    assert time_range_1.overlaps?(time_range_2)
+    assert time_range_1.overlap?(time_range_2)
   end
 
-  def test_no_overlaps_on_time
+  def test_no_overlap_on_time
     time_range_1 = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     time_range_2 = Time.utc(2005, 12, 10, 17, 31)..Time.utc(2005, 12, 10, 18, 00)
-    assert_not time_range_1.overlaps?(time_range_2)
+    assert_not time_range_1.overlap?(time_range_2)
   end
 
   def test_each_on_time_with_zone

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3198,19 +3198,19 @@ Active Support extends these methods so that the argument may be another range i
 
 NOTE: Defined in `active_support/core_ext/range/compare_range.rb`.
 
-### `overlaps?`
+### `overlap?`
 
-The method [`Range#overlaps?`][Range#overlaps?] says whether any two given ranges have non-void intersection:
+The method [`Range#overlap?`][Range#overlap?] says whether any two given ranges have non-void intersection:
 
 ```ruby
-(1..10).overlaps?(7..11)  # => true
-(1..10).overlaps?(0..7)   # => true
-(1..10).overlaps?(11..27) # => false
+(1..10).overlap?(7..11)  # => true
+(1..10).overlap?(0..7)   # => true
+(1..10).overlap?(11..27) # => false
 ```
 
-NOTE: Defined in `active_support/core_ext/range/overlaps.rb`.
+NOTE: Defined in `active_support/core_ext/range/overlap.rb`.
 
-[Range#overlaps?]: https://api.rubyonrails.org/classes/Range.html#method-i-overlaps-3F
+[Range#overlap?]: https://api.rubyonrails.org/classes/Range.html#method-i-overlaps-3F
 
 Extensions to `Date`
 --------------------


### PR DESCRIPTION
### Motivation
The method name `Range#overlaps?` uses a 3rd person verb which is inconsistent with e.g. `Range#include?` and `Range#cover?`.

### Detail
This pull request renames `Range#overlaps?` to `Range#overlap?` and adds an alias for backwards compatibility (similar to `String#starts_with?`).

### Checklist

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
