### PR TITLE
Fix error ActiveJob passed class with `permitted?`

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -90,7 +90,7 @@ module ActiveJob
           result = serialize_hash(argument)
           result[aj_hash_key] = symbol_keys
           result
-        when -> (arg) { arg.respond_to?(:permitted?) }
+        when -> (arg) { arg.respond_to?(:permitted?) && arg.respond_to?(:to_h) }
           serialize_indifferent_hash(argument.to_h)
         else
           if BigDecimal === argument && !ActiveJob.use_big_decimal_serializer

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -16,6 +16,11 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
 
   class ClassArgument; end
 
+  class MyClassWithPermitted
+    def self.permitted?
+    end
+  end
+
   setup do
     @person = Person.find("5")
   end
@@ -110,6 +115,11 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       { "a" => 1, "_aj_hash_with_indifferent_access" => true },
       ActiveJob::Arguments.serialize([parameters]).first
     )
+  end
+
+  # Regression test to #48561
+  test "serialize a class with permitted? defined" do
+    assert_arguments_unchanged MyClassWithPermitted
   end
 
   test "serialize a hash" do


### PR DESCRIPTION
### Motivation / Background

Fixes #48561

### Detail

This Pull Request fixes an error being raised when providing a class argument to ActiveJob for classes that implement `permitted?`. 

This code path is primarily intended for instances of `ActionController::Parameters`. However an application could define `permitted?` for it's own purposes resulting in an error. Adding the additional `to_h` narrows the criteria and in the event another type besides `Parameters` is passed will ensure it quacks right.

Co-authored-by: @sampatbadhe 
