### PR TITLE
Use `~=` instead of `IS NOT DISTINCT FROM` for the PostgreSQL geometric data types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -181,6 +181,8 @@ module ActiveRecord
 
       OID = PostgreSQL::OID # :nodoc:
 
+      USING_GEOMETRIC_SAME_AS_OPERATOR = %i(point polygon box circle).freeze
+
       include PostgreSQL::Quoting
       include PostgreSQL::ReferentialIntegrity
       include PostgreSQL::SchemaStatements
@@ -624,6 +626,15 @@ module ActiveRecord
         index.using == :btree || super
       end
 
+      def timestamps_condition(insert, unquoted_column_name, column_type)
+        column_name = quote_column_name(unquoted_column_name)
+        if USING_GEOMETRIC_SAME_AS_OPERATOR.include?(column_type.type)
+          "#{insert.model.quoted_table_name}.#{column_name} ~= excluded.#{column_name}"
+        else
+          "#{insert.model.quoted_table_name}.#{column_name} IS NOT DISTINCT FROM excluded.#{column_name}"
+        end
+      end
+
       def build_insert_sql(insert) # :nodoc:
         sql = +"INSERT #{insert.into} #{insert.values_list}"
 
@@ -634,7 +645,7 @@ module ActiveRecord
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
           else
-            sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column} IS NOT DISTINCT FROM excluded.#{column}" }
+            sql << insert.touch_model_timestamps_with_type_unless { |col_name, col_type| timestamps_condition(insert, col_name, col_type) }
             sql << insert.updatable_columns.map { |column| "#{column}=excluded.#{column}" }.join(",")
           end
         end

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -283,6 +283,19 @@ module ActiveRecord
           end.join
         end
 
+        def touch_model_timestamps_with_type_unless(&block)
+          return "" unless update_duplicates? && record_timestamps?
+
+          model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
+            if touch_timestamp_attribute?(column_name)
+              condition = insert_all.updatable_columns.index_with do
+                |key| model.type_for_attribute(key)
+              end.map(&block).join(" AND ")
+              "#{column_name}=(CASE WHEN (#{condition}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END),"
+            end
+          end.join
+        end
+
         def raw_update_sql
           insert_all.update_sql
         end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -10,6 +10,7 @@ require "models/ship"
 require "models/speedometer"
 require "models/subscription"
 require "models/subscriber"
+require "models/geometric_data"
 
 class ReadonlyNameBook < Book
   attr_readonly :name
@@ -654,6 +655,24 @@ class InsertAllTest < ActiveRecord::TestCase
                  Measurement.where(city_id: 1).pluck(:logdate, :peaktemp, :unitsales)
     assert_equal [[2.days.ago.to_date, 2, 2], [3.days.ago.to_date, 0, 0]],
                  Measurement.where(city_id: 2).pluck(:logdate, :peaktemp, :unitsales)
+  end
+
+  def test_upsert_with_geometric_data_type
+    skip unless supports_insert_on_duplicate_update? && current_adapter?(:PostgreSQLAdapter)
+
+    GeometricData.upsert_all([
+      identifier: "identifier1",
+      point_col: [1.1, 1.2], line_col: "{5.1, 5.2, 5.3}", lseg_col: "((0,0),(0,1))",
+      box_col: "((4,1), (4,5))", path_col: "((8,1), (4,5))",
+      polygon_col: "2.0, 3, 5.5, 7.0, 8.5, 11.0", circle_col: "((5.3, 10.4), 2)"],
+      unique_by: [:identifier])
+    GeometricData.upsert_all([identifier: "identifier2", point_col: [5.1, 5.2]], unique_by: :index_geometric_data_on_identifier)
+    GeometricData.upsert_all([identifier: "identifier3", polygon_col: "2.0, 3, 5.5, 7.0, 8.5, 11.0"])
+
+    assert_equal 3, GeometricData.count
+    assert_equal ActiveRecord::Point.new(5.1, 5.2), GeometricData.find_by(identifier: "identifier2").point_col
+    assert_equal "((2,3),(5.5,7),(8.5,11))", GeometricData.find_by(identifier: "identifier3").polygon_col
+    assert_equal "{5.1,5.2,5.3}", GeometricData.find_by(identifier: "identifier1").line_col
   end
 
   def test_insert_all_with_enum_values

--- a/activerecord/test/models/geometric_data.rb
+++ b/activerecord/test/models/geometric_data.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class GeometricData < ActiveRecord::Base
+  self.table_name = "geometric_data"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -838,6 +838,22 @@ ActiveRecord::Schema.define do
     end
   end
 
+  if ActiveRecord::TestCase.current_adapter?(:PostgreSQLAdapter)
+    create_table :geometric_data, force: true do |t|
+      t.string :identifier, null: false
+      t.point :point_col
+      t.line :line_col
+      t.lseg :lseg_col
+      t.box :box_col
+      t.path :path_col
+      t.polygon :polygon_col
+      t.circle :circle_col
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index ["identifier"], name: "index_geometric_data_on_identifier", unique: true
+    end
+  end
+
   create_table :orders, force: true do |t|
     t.string  :name
     t.integer :billing_customer_id


### PR DESCRIPTION
### Motivation / Background

The `~=` operator is available for 4 types point, box, polygon, circle, which represents the usual notion of equality. (other geometric data types, which are line, lseg, path, still work with `IS NOT DISTINCT FROM` / = operator)

A typical example of how `~=` works is: box '((3,4),(5,5))' ~=  box '((3,4),(5,5))' -> t; box '((3,4),(5,5))' ~=  box '((5,5),(3,4))' -> t 
Ref https://www.postgresql.org/docs/15/functions-geometry.html

<img width="1292" alt="Screenshot 2023-06-24 at 16 09 58" src="https://github.com/rails/rails/assets/1097697/0dd4b8c9-5096-4b5b-bcf8-8d726f09cafb">


Fixes #48497

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
