### PR TITLE
Update datetime_local_field.rb

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class DatetimeLocalField < DatetimeField # :nodoc:
         def initialize(object_name, method_name, template_object, options = {})
-          @include_seconds = options.delete(:include_seconds) { true }
+          @include_seconds = options.delete(:include_seconds) { false }
           super
         end
 


### PR DESCRIPTION
Defaulted datetime-local to not use seconds


### Motivation / Background

Input of `datetime-local` specifies that the [value must be excluding seconds](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local#value).  Although Chrome supports seconds, safari will validate client-side that the value is `not valid` and the form will not be submittable.



This Pull Request has been created because the default for rails should not error out in a popular browser.

### Detail

This Pull Request changes the default for `datetime-local` value conversion

### Additional information

<img width="770" alt="Screenshot 2023-06-24 at 6 54 09 AM" src="https://github.com/rails/rails/assets/287640/917cf010-82fb-4f95-a2fc-54b85f6ab193">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
