### PR TITLE
Implement default chronologically scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `chronologically` and `reverse_chronologically` scopes to `ActiveRecord::Base`.
+
+    ```ruby
+    Author.chronologically
+    #=> SELECT * FROM authors ORDER BY authors.id ASC
+
+    Author.reverse_chronologically
+    #=> SELECT * FROM authors ORDER BY authors.id DESC
+    ```
+
+    It uses the same logic as `first` and `last`, the order is defined
+    based on `implicit_order_column || query_constraints_list || primary_key`.
+
+    *Lázaro Nixon*
+
 *   Apply scope to association subqueries. (belongs_to/has_one/has_many)
 
     Given: `has_many :welcome_posts, -> { where(title: "welcome") }`

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -60,6 +60,7 @@ module ActiveRecord
   autoload :NestedAttributes
   autoload :NoTouching
   autoload :Normalization
+  autoload :DefaultScopes
   autoload :Persistence
   autoload :QueryCache
   autoload :QueryLogs

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -330,6 +330,7 @@ module ActiveRecord # :nodoc:
     include SignedId
     include Suppressor
     include Normalization
+    include DefaultScopes
     include Marshalling::Methods
   end
 

--- a/activerecord/lib/active_record/default_scopes.rb
+++ b/activerecord/lib/active_record/default_scopes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveRecord # :nodoc:
+  module DefaultScopes
+    extend ActiveSupport::Concern
+
+    included do
+      scope :chronologically, -> { ordered_relation }
+      scope :reverse_chronologically, -> { ordered_relation.reverse_order }
+    end
+  end
+end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1389,6 +1389,20 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Developer.all, developers
   end
 
+  def test_chronologicaly
+    relation = Developer.chronologically
+    expected = Developer.order(id: :asc)
+
+    assert_equal expected.to_a, relation.to_a
+  end
+
+  def test_reverse_chronologically
+    relation = Developer.reverse_chronologically
+    expected = Developer.order(id: :desc)
+
+    assert_equal expected.to_a, relation.to_a
+  end
+
   def test_all_with_conditions
     assert_equal Developer.all.merge!(order: "id desc").to_a, Developer.order("id desc").to_a
   end


### PR DESCRIPTION
### Motivation / Background

Add `chronologically` and `reverse_chronologically` scopes to `ActiveRecord::Base`.

```ruby
Author.chronologically
#=> SELECT * FROM authors ORDER BY authors.id ASC

Author.reverse_chronologically
#=> SELECT * FROM authors ORDER BY authors.id DESC
```

It uses the same logic as `first` and `last`, the order is defined based on `implicit_order_column || query_constraints_list || primary_key`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
