### PR TITLE
Introduce config.autoload_lib

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -101,6 +101,47 @@ WARNING: You cannot autoload code in the autoload paths while the application bo
 
 The autoload paths are managed by the `Rails.autoloaders.main` autoloader.
 
+config.autoload_lib(ignore:)
+----------------------------
+
+By default, the `lib` directory does not belong to the autoload paths of applications or engines.
+
+The configuration method `config.autoload_lib` adds the `lib` directory to `config.autoload_paths` and `config.eager_load_paths`. It has to be invoked from `config/application.rb` or `config/environments/*.rb`, and it is not available for engines.
+
+Normally, `lib` has subdirectories that should not be managed by the autoloaders. Please, pass their name relative to `lib` in the required `ignore` keyword argument. For example:
+
+```ruby
+config.autoload_lib(ignore: %w(assets tasks))
+```
+
+Why? While `assets` and `tasks` share the `lib` directory with regular code, their contents are not meant to be autoloaded or eager loaded. `Assets` and `Tasks` are not Ruby namespaces there. Same with generators if you have any:
+
+```ruby
+config.autoload_lib(ignore: %w(assets tasks generators))
+```
+
+`config.autoload_lib` is not available before 7.1, but you can still emulate it as long as the application uses Zeitwerk:
+
+```ruby
+# config/application.rb
+module MyApp
+  class Application < Rails::Application
+    lib = Rails.root.join("lib")
+
+    config.autoload_paths << lib
+    config.eager_load_paths << lib
+
+    Rails.autoloaders.main.ignore(
+      lib.join("assets"),
+      lib.join("tasks"),
+      lib.join("generators")
+    )
+
+    ...
+  end
+end
+```
+
 config.autoload_once_paths
 --------------------------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -212,6 +212,18 @@ Accepts an array of paths from which Rails will autoload constants that won't be
 
 Accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#autoload-paths).
 
+#### `config.autoload_lib(ignore:)`
+
+This method adds `lib` to `config.autoload_paths` and `config.eager_load_paths`.
+
+Normally, the `lib` directory has subdirectories that should not be autoloaded or eager loaded. Please, pass their name relative to `lib` in the required `ignore` keyword argument. For example,
+
+```ruby
+config.autoload_lib(ignore: %w(assets tasks generators))
+```
+
+Please, see more details in the [autoloading guide](autoloading_and_reloading_constants.html).
+
 #### `config.beginning_of_week`
 
 Sets the default beginning of week for the

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   The new method `config.autoload_lib(ignore:)` provides a simple way to
+    autoload from `lib`:
+
+    ```ruby
+    # config/application.rb
+    config.autoload_lib(ignore: %w(assets tasks))
+    ```
+
+    Please, see further details in the [autoloading
+    guide](https://guides.rubyonrails.org/v7.1/autoloading_and_reloading_constants.html).
+
+    *Xavier Noria*
+
 *   Don't show secret_key_base for `Rails.application.config#inspect`.
 
     Before:

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "ipaddr"
+require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/file_update_checker"
 require "active_support/configuration_file"
@@ -447,6 +448,18 @@ module Rails
         config
       rescue => e
         raise e, "Cannot load database configuration:\n#{e.message}", e.backtrace
+      end
+
+      def autoload_lib(ignore:)
+        lib = root.join("lib")
+
+        # Set as a string to have the same type as default autoload paths, for
+        # consistency.
+        autoload_paths << lib.to_s
+        eager_load_paths << lib.to_s
+
+        ignored_abspaths = Array.wrap(ignore).map { lib.join(_1) }
+        Rails.autoloaders.main.ignore(ignored_abspaths)
       end
 
       def colorize_logging

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2139,6 +2139,76 @@ module ApplicationTests
       end
     end
 
+    test "config.autoload_lib adds lib to the autoload and eager load paths (array ignore)" do
+      app_file "lib/x.rb", "X = true"
+      app_file "lib/tasks/x.rb", "Tasks::X = true"
+      app_file "lib/generators/x.rb", "Generators::X = true"
+
+      add_to_config "config.autoload_lib(ignore: %w(tasks generators))"
+
+      app "development"
+
+      Rails.application.config.tap do |config|
+        assert_includes config.autoload_paths, "#{app_path}/lib"
+        assert_includes config.eager_load_paths, "#{app_path}/lib"
+      end
+
+      assert X
+      assert_raises(NameError) { Tasks }
+      assert_raises(NameError) { Generators }
+    end
+
+    test "config.autoload_lib adds lib to the autoload and eager load paths (empty array ignore)" do
+      app_file "lib/x.rb", "X = true"
+      app_file "lib/tasks/x.rb", "Tasks::X = true"
+
+      add_to_config "config.autoload_lib(ignore: [])"
+
+      app "development"
+
+      Rails.application.config.tap do |config|
+        assert_includes config.autoload_paths, "#{app_path}/lib"
+        assert_includes config.eager_load_paths, "#{app_path}/lib"
+      end
+
+      assert X
+      assert Tasks::X
+    end
+
+    test "config.autoload_lib adds lib to the autoload and eager load paths (scalar ignore)" do
+      app_file "lib/x.rb", "X = true"
+      app_file "lib/tasks/x.rb", "Tasks::X = true"
+
+      add_to_config "config.autoload_lib(ignore: 'tasks')"
+
+      app "development"
+
+      Rails.application.config.tap do |config|
+        assert_includes config.autoload_paths, "#{app_path}/lib"
+        assert_includes config.eager_load_paths, "#{app_path}/lib"
+      end
+
+      assert X
+      assert_raises(NameError) { Tasks }
+    end
+
+    test "config.autoload_lib adds lib to the autoload and eager load paths (nil ignore)" do
+      app_file "lib/x.rb", "X = true"
+      app_file "lib/tasks/x.rb", "Tasks::X = true"
+
+      add_to_config "config.autoload_lib(ignore: nil)"
+
+      app "development"
+
+      Rails.application.config.tap do |config|
+        assert_includes config.autoload_paths, "#{app_path}/lib"
+        assert_includes config.eager_load_paths, "#{app_path}/lib"
+      end
+
+      assert X
+      assert Tasks::X
+    end
+
     test "load_database_yaml returns blank hash if configuration file is blank" do
       app_file "config/database.yml", ""
       app "development"


### PR DESCRIPTION
## Introduction

This patch introduces API to easily autoload and eager load from `lib`:

```ruby
# config/application.rb
config.autoload_lib(ignore: %w(assets tasks generators))
```

## Some history

The `lib` directory was in the autoload paths by default in the early versions of Rails. However, `lib` stores different kinds of files, and eager loading in production proved to be an issue. Some files in there are not meant to be autoloaded or eager loaded. Think generators, for example.

Because of that, `lib` was removed from the default autoload paths in Rails 3.

## app/lib

Since `lib` didn't have a good solution, the idea of using `app/lib` started to emerge.

New `app` subdirectories are added to the autoload and eager load paths automatically, and a posteriori you put there only regular code (not assets or tasks, for example), it worked out of the box.

However, I have a few remarks about `app/lib`:

* While `app/models` and `app/controllers` mean something, `app/lib` means nothing. They are at the same level, but naming is not quite consistent.
* `lib` is meant for things that are kind of tangential to the application core. What's in there feels better located in `lib` than under `app`, for me.
* Regardless, Rails programmers should be able to autoload from `lib`.
* In most projects I have consulted for, `lib` is added to the autoload paths by hand anyway. People want to autoload from `lib`, which is understandable. If we can, this use case should have first-class support from the framework.

## We have more options now

Zeitwerk is able to ignore files and directories, so now Rails programmers can autoload and eager load from `lib` with more control. For example:

```ruby
# config/application.rb
module MyApp
  class Application < Rails::Application
    lib = root.join("lib")

    config.autoload_paths << lib
    config.eager_load_paths << lib

    Rails.autoloaders.main.ignore(
      lib.join("assets"),
      lib.join("tasks"),
      lib.join("generators")
    )

    ...
  end
end
```

Technically, that is possible since Rails 6, but a better API is possible.

## `config.autoload_lib(ignore:)`

In API design, exceptional use cases may justify exceptional support. You design for the common case, and let the edge case be edge.

In this case, I believe `lib` deserves ad-hoc API that allows users to do exactly that in one shot:

```ruby
# config/application.rb
config.autoload_lib(ignore: %w(assets tasks generators))
```

Values passed to `ignore` are relative to `lib` because it does not make sense to ignore anything outside `lib` using this API, so you enforce that implicitly. As a bonus, the call is short and concise.

## Why no default arguments?

I wondered if those three should be a default, but look at this:

```ruby
# config/application.rb
config.autoload_lib
```

Is it obvious that there are directories being ignored? No, you open the file and see "autoload lib". That would be a misleading API. I believe a default makes sense when it is a no-brainer for _clients_, but in this case I don't think it is.

In this case, I believe it is better to be explicit and require that you think about what to ignore. Documentation already takes you there by example.

## Why not generated for new applications?

I believe we could eventually include that line in newly generated applications. However, I don't want to rush this, let's have the API out and see. If it works well, perhaps in a future version of Rails.

## Why not available for engines?

The `lib` directory in engines is generally speaking more similar to the `lib` directory of a gem than to the `lib` directory of an application. Having `lib` reloaded in engines is more tricky. By now, I prefer to let people that know what they do configure the autoloaders by hand.