### PR TITLE
Extract Select rendering methods into SelectRenderer module and simplify Action View base helper logic

### DIFF
--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -30,6 +30,7 @@ module ActionView
         autoload :RangeField
         autoload :SearchField
         autoload :Select
+        autoload :SelectRenderer
         autoload :TelField
         autoload :TextArea
         autoload :TextField

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -120,52 +120,6 @@ module ActionView
             value.to_s.gsub(/[\s.]/, "_").gsub(/[^-[[:word:]]]/, "").downcase
           end
 
-          def select_content_tag(option_tags, options, html_options)
-            html_options = html_options.stringify_keys
-            [:required, :multiple, :size].each do |prop|
-              html_options[prop.to_s] = options.delete(prop) if options.key?(prop) && !html_options.key?(prop.to_s)
-            end
-
-            add_default_name_and_id(html_options)
-
-            if placeholder_required?(html_options)
-              raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
-              options[:include_blank] ||= true unless options[:prompt]
-            end
-
-            value = options.fetch(:selected) { value() }
-            select = content_tag("select", add_options(option_tags, options, value), html_options)
-
-            if html_options["multiple"] && options.fetch(:include_hidden, true)
-              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
-            else
-              select
-            end
-          end
-
-          def placeholder_required?(html_options)
-            # See https://html.spec.whatwg.org/multipage/forms.html#attr-select-required
-            html_options["required"] && !html_options["multiple"] && html_options.fetch("size", 1).to_i == 1
-          end
-
-          def add_options(option_tags, options, value = nil)
-            if options[:include_blank]
-              content = (options[:include_blank] if options[:include_blank].is_a?(String))
-              label = (" " unless content)
-              option_tags = tag_builder.content_tag_string("option", content, value: "", label: label) + "\n" + option_tags
-            end
-
-            if value.blank? && options[:prompt]
-              tag_options = { value: "" }.tap do |prompt_opts|
-                prompt_opts[:disabled] = true if options[:disabled] == ""
-                prompt_opts[:selected] = true if options[:selected] == ""
-              end
-              option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), tag_options) + "\n" + option_tags
-            end
-
-            option_tags
-          end
-
           def name_and_id_index(options)
             if options.key?("index")
               options.delete("index") || ""

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -5,7 +5,6 @@ module ActionView
     module Tags # :nodoc:
       class Base # :nodoc:
         include Helpers::ActiveModelInstanceTag, Helpers::TagHelper, Helpers::FormTagHelper
-        include FormOptionsHelper
 
         attr_reader :object
 

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -35,22 +35,24 @@ module ActionView
 
         private
           def value
+            return unless object
+
             if @allow_method_names_outside_object
-              object.public_send @method_name if object && object.respond_to?(@method_name)
+              object.public_send @method_name if object.respond_to?(@method_name)
             else
-              object.public_send @method_name if object
+              object.public_send @method_name
             end
           end
 
           def value_before_type_cast
-            unless object.nil?
-              method_before_type_cast = @method_name + "_before_type_cast"
+            return unless object
 
-              if value_came_from_user? && object.respond_to?(method_before_type_cast)
-                object.public_send(method_before_type_cast)
-              else
-                value
-              end
+            method_before_type_cast = @method_name + "_before_type_cast"
+
+            if value_came_from_user? && object.respond_to?(method_before_type_cast)
+              object.public_send(method_before_type_cast)
+            else
+              value
             end
           end
 

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class CollectionCheckBoxes < Base # :nodoc:
         include CollectionHelpers
+        include FormOptionsHelper
 
         class CheckBoxBuilder < Builder # :nodoc:
           def check_box(extra_html_options = {})

--- a/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_radio_buttons.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class CollectionRadioButtons < Base # :nodoc:
         include CollectionHelpers
+        include FormOptionsHelper
 
         class RadioButtonBuilder < Builder # :nodoc:
           def radio_button(extra_html_options = {})

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class CollectionSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, collection, value_method, text_method, options, html_options)
           @collection   = collection
           @value_method = value_method

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class CollectionSelect < Base # :nodoc:
         include SelectRenderer
+        include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, collection, value_method, text_method, options, html_options)
           @collection   = collection

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/time/calculations"
+require "action_view/helpers/tags/select_renderer"
 
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class DateSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, options, html_options)
           @html_options = html_options
 

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class GroupedCollectionSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
           @collection          = collection
           @group_method        = group_method

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class GroupedCollectionSelect < Base # :nodoc:
         include SelectRenderer
+        include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
           @collection          = collection

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class Select < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, choices, options, html_options)
           @choices = block_given? ? template_object.capture { yield || "" } : choices
           @choices = @choices.to_a if @choices.is_a?(Range)

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class Select < Base # :nodoc:
         include SelectRenderer
+        include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, choices, options, html_options)
           @choices = block_given? ? template_object.capture { yield || "" } : choices

--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      module SelectRenderer # :nodoc:
+        private
+          def select_content_tag(option_tags, options, html_options)
+            html_options = html_options.stringify_keys
+            [:required, :multiple, :size].each do |prop|
+              html_options[prop.to_s] = options.delete(prop) if options.key?(prop) && !html_options.key?(prop.to_s)
+            end
+
+            add_default_name_and_id(html_options)
+
+            if placeholder_required?(html_options)
+              raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
+              options[:include_blank] ||= true unless options[:prompt]
+            end
+
+            value = options.fetch(:selected) { value() }
+            select = content_tag("select", add_options(option_tags, options, value), html_options)
+
+            if html_options["multiple"] && options.fetch(:include_hidden, true)
+              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
+            else
+              select
+            end
+          end
+
+          def placeholder_required?(html_options)
+            # See https://html.spec.whatwg.org/multipage/forms.html#attr-select-required
+            html_options["required"] && !html_options["multiple"] && html_options.fetch("size", 1).to_i == 1
+          end
+
+          def add_options(option_tags, options, value = nil)
+            if options[:include_blank]
+              content = (options[:include_blank] if options[:include_blank].is_a?(String))
+              label = (" " unless content)
+              option_tags = tag_builder.content_tag_string("option", content, value: "", label: label) + "\n" + option_tags
+            end
+
+            if value.blank? && options[:prompt]
+              tag_options = { value: "" }.tap do |prompt_opts|
+                prompt_opts[:disabled] = true if options[:disabled] == ""
+                prompt_opts[:selected] = true if options[:selected] == ""
+              end
+              option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), tag_options) + "\n" + option_tags
+            end
+
+            option_tags
+          end
+      end
+    end
+  end
+end

--- a/actionview/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_zone_select.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class TimeZoneSelect < Base # :nodoc:
         include SelectRenderer
+        include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, priority_zones, options, html_options)
           @priority_zones = priority_zones

--- a/actionview/lib/action_view/helpers/tags/time_zone_select.rb
+++ b/actionview/lib/action_view/helpers/tags/time_zone_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class TimeZoneSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, priority_zones, options, html_options)
           @priority_zones = priority_zones
           @html_options   = html_options

--- a/actionview/lib/action_view/helpers/tags/weekday_select.rb
+++ b/actionview/lib/action_view/helpers/tags/weekday_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class WeekdaySelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, options, html_options)
           @html_options = html_options
 

--- a/actionview/lib/action_view/helpers/tags/weekday_select.rb
+++ b/actionview/lib/action_view/helpers/tags/weekday_select.rb
@@ -7,6 +7,7 @@ module ActionView
     module Tags # :nodoc:
       class WeekdaySelect < Base # :nodoc:
         include SelectRenderer
+        include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, options, html_options)
           @html_options = html_options


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been made to help make the Action View Helper Tags a little bit better. This is purely a refactoring PR and does not introduce any changes to the behaviour of tags.

The reason I'm doing this is because I'm diving deep into these tags ([1](https://dev.julianpinzon.com/unlocking-the-power-of-forms-in-rails), [2](https://dev.julianpinzon.com/diving-deep-action-view-form-helpers)) in order to find some sort of abstraction ([this](https://dev.julianpinzon.com/the-potential-birth-of-attributebuilders) is one possible version) that might help make it easier to style form elements (input, select, label and text-area)

In doing so, I've discovered that the `Tags::Base` class is in need of some maintenance to make it easier to understand where the boundaries are drawn between different elements.

### Detail

This Pull Request:
- Simplifies some of the logic in the `Tags::Base` class
- Creates a new `SelectRenderer` module that contains three methods only used by `<select>` tags.
- Includes the FormOptionsHelper module only in `<select>` classes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
