### PR TITLE
Update deleted_at on destroy

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Timestamp `deleted_at` on destroy instead of actually deleting the record.
+
+    If suppliers table has a field named deleted_at:
+
+    ```ruby
+    supplier.destroy
+    #=> UPDATE "suppliers" SET "deleted_at" = ? WHERE "suppliers"."id" = ?
+
+    supplier.delete
+    #=> DELETE FROM "suppliers" WHERE "suppliers"."id" = ?
+    ```
+
+    Soft deletion can be turned off by setting:
+
+    ```ruby
+    config.active_record.soft_delete = false
+    ```
+
+    *Lázaro Nixon*
+
 *   Support decrypting data encrypted non-deterministically with a SHA1 hash digest.
 
     This adds a new Active Record encryption option to support decrypting data encrypted

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -27,7 +27,7 @@ require "models/default"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses,
-    :posts, :minivans, :clothing_items, :cpk_books
+    :posts, :comments, :minivans, :clothing_items, :cpk_books
 
   def test_populates_non_primary_key_autoincremented_column
     topic = TitlePrimaryKeyTopic.create!(title: "title pk topic")
@@ -819,6 +819,12 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal topic, topic.destroy!, "topic.destroy! did not return self"
     assert topic.frozen?, "topic not frozen after destroy!"
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
+  end
+
+  def test_destroy_with_soft_delete
+    comment = CommentWithSoftDelete.find(14)
+    assert_equal comment, comment.destroy, "comment.destroy did not return self"
+    assert comment.soft_deleted?, "comment not soft deleted"
   end
 
   def test_find_raises_record_not_found_exception

--- a/activerecord/test/fixtures/comments.yml
+++ b/activerecord/test/fixtures/comments.yml
@@ -71,3 +71,9 @@ recursive_association_comment:
   body: afrase
   type: Comment
   company: 15
+
+comment_with_soft_delete:
+  id: 14
+  post_id: 12
+  body: Comment with soft delete
+  type: CommentWithSoftDelete

--- a/activerecord/test/fixtures/posts.yml
+++ b/activerecord/test/fixtures/posts.yml
@@ -86,3 +86,10 @@ other_by_mary:
   body: hello
   type: Post
   tags_count: 1
+
+soft_delete_comments:
+  id: 12
+  author_id: 1
+  title: soft delete comments
+  body: hello
+  type: Post

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -44,6 +44,8 @@ class Comment < ActiveRecord::Base
 
   scope :oops_comments, -> { extending OopsExtension }
 
+  self.soft_delete = false
+
   # Should not be called if extending modules that having the method exists on an association.
   def self.greeting
     raise
@@ -100,4 +102,8 @@ class CommentWithAfterCreateUpdate < Comment
   after_create do
     update(body: "bar")
   end
+end
+
+class CommentWithSoftDelete < Comment
+  self.soft_delete = true
 end


### PR DESCRIPTION
### Motivation / Background

Timestamp `deleted_at` on destroy instead of actually deleting the record. 

If suppliers table has a field named deleted_at:

```ruby
supplier.destroy
#=> UPDATE "suppliers" SET "deleted_at" = ? WHERE "suppliers"."id" = ?

supplier.delete
#=> DELETE FROM "suppliers" WHERE "suppliers"."id" = ?
```
Soft deletion can be turned off by setting:
```ruby
config.active_record.soft_delete = false
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
