### PR TITLE
Fix Active Record encryption not picking up encryption settings with eager-loading

### DIFF
--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -332,6 +332,21 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_equal "Post 1", encrypted_post_class_sha_256.last.title
   end
 
+  test "encryption schemes are resolved when used, not when declared" do
+    OtherEncryptedPost = Class.new(Post) do
+      self.table_name = "posts"
+      encrypts :title
+    end
+
+    ActiveRecord::Encryption.configure \
+      primary_key: "the primary key",
+      deterministic_key: "the deterministic key",
+      key_derivation_salt: "the salt",
+      support_sha1_for_non_deterministic_encryption: true
+
+    assert OtherEncryptedPost.type_for_attribute(:title).scheme.previous_schemes.one?
+  end
+
   private
     def build_derived_key_provider_with(hash_digest_class)
       ActiveRecord::Encryption.with_encryption_context(key_generator: ActiveRecord::Encryption::KeyGenerator.new(hash_digest_class: hash_digest_class)) do

--- a/activerecord/test/cases/encryption/scheme_test.rb
+++ b/activerecord/test/cases/encryption/scheme_test.rb
@@ -4,7 +4,7 @@ require "cases/encryption/helper"
 require "models/book"
 
 class ActiveRecord::Encryption::SchemeTest < ActiveRecord::EncryptionTestCase
-  test "validates config options when declaring encrypted attributes" do
+  test "validates config options when using encrypted attributes" do
     assert_invalid_declaration deterministic: false, ignore_case: true
     assert_invalid_declaration key: "1234", key_provider: ActiveRecord::Encryption::DerivedSecretKeyProvider.new("my secret")
 
@@ -37,6 +37,6 @@ class ActiveRecord::Encryption::SchemeTest < ActiveRecord::EncryptionTestCase
     def declare_encrypts_with(options)
       Class.new(Book) do
         encrypts :name, **options
-      end
+      end.type_for_attribute(:name)
     end
 end


### PR DESCRIPTION
This deals with a problem where, when eager-loading is enabled, Active Record fails to pick up settings affecting encryption schemes.

The solution here is to resolve encryption schemes lazily, when the attribute type is used.

Follow-up to https://github.com/rails/rails/pull/48530

Fixes https://github.com/rails/rails/issues/48204#issuecomment-1607127334

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
