### PR TITLE
Add :report behavior to ActiveSupport::Deprecation

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `:report` behavior for Deprecation
+
+    Setting `config.active_support.deprecation = :report` uses the error
+    reporter to report deprecation warnings to `ActiveSupport::ErrorReporter`.
+
+    Deprecations are reported as handled errors, with a severity of `:warning`.
+
+    Useful to report deprecations happening in production to your bug tracker.
+
+    *Étienne Barrié*
+
 *   Rename `Range#overlaps?` to `#overlap?` and add alias for backwards compatibility
 
     *Christian Schmidt*

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -45,6 +45,12 @@ module ActiveSupport
       end,
 
       silence: ->(message, callstack, deprecator) { },
+
+      report: ->(message, callstack, deprecator) do
+        error = DeprecationException.new(message)
+        error.set_backtrace(callstack.map(&:to_s))
+        ActiveSupport.error_reporter.report(error)
+      end
     }
 
     # Behavior module allows to determine how to display deprecation messages.
@@ -55,6 +61,7 @@ module ActiveSupport
     # [+stderr+]  Log all deprecation warnings to <tt>$stderr</tt>.
     # [+log+]     Log all deprecation warnings to +Rails.logger+.
     # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
+    # [+report+]  Use +ActiveSupport::ErrorReporter+ to report deprecations.
     # [+silence+] Do nothing. On \Rails, set <tt>config.active_support.report_deprecations = false</tt> to disable all behaviors.
     #
     # Setting behaviors only affects deprecations that happen after boot time.
@@ -82,6 +89,7 @@ module ActiveSupport
       # [+stderr+]  Log all deprecation warnings to <tt>$stderr</tt>.
       # [+log+]     Log all deprecation warnings to +Rails.logger+.
       # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
+      # [+report+]  Use +ActiveSupport::ErrorReporter+ to report deprecations.
       # [+silence+] Do nothing.
       #
       # Setting behaviors only affects deprecations that happen after boot time.

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -273,6 +273,17 @@ class DeprecationTest < ActiveSupport::TestCase
     end
   end
 
+  test ":report_error behavior" do
+    @deprecator = ActiveSupport::Deprecation.new("horizon", "MyGem::Custom")
+    @deprecator.behavior = :report
+    report = assert_error_reported(ActiveSupport::DeprecationException) do
+      @deprecator.warn
+    end
+    assert_equal true, report.handled
+    assert_equal :warning, report.severity
+    assert_equal "application", report.source
+  end
+
   test "invalid behavior" do
     e = assert_raises(ArgumentError) do
       @deprecator.behavior = :invalid


### PR DESCRIPTION
This behavior uses the ErrorReporter to report a deprecation as a handled error with `:warning` severity.

### Motivation / Background

The error reporter is a great way to report on errors happening in production, with a way to declare the "error" as handled. In the lifecycle of an application, after upgrading to a new minor, deprecations can be slowly resolved and even marked as disallowed to prevent reintroduction, then deprecations can be configured to raise in development/test to make sure they don't reappear or are not ignored. But typically deprecations are completely silenced in production, with the `config.active_support.report_deprecations` configuration option.

At the very last step before upgrading to the subsequent minor, if tests are not fully trusted to cover all code paths, it would be nice to be able to report deprecations happening in production to the bug tracker the application uses.

### Detail

I debated whether to de-duplicate reports by somehow keeping track of backtraces or things like that. Ultimately I felt like this wasn't super useful since multiple worker processes will still report the same deprecation multiple times, and it would add complexity to the implementation.

By default, reported errors are marked as handled and have a severity of `:warning`. I wondered about using `:info` to denote that it's very low cause for concern, but since the terminology is "deprecation warning" I went with what's the default for handled errors.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
