### PR TITLE
DATABASE option for railties:install:migrations

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -699,6 +699,18 @@ If you have multiple engines that need migrations copied over, use
 $ bin/rails railties:install:migrations
 ```
 
+You can specify a custom path in the source engine for the migrations by specifying MIGRATIONS_PATH.
+
+```bash
+$ bin/rails railties:install:migrations MIGRATIONS_PATH=db_blourgh
+```
+
+If you have multiple databases you can also specify the target database by specifying DATABASE.
+
+```bash
+$ bin/rails railties:install:migrations DATABASE=animals
+```
+
 This command, when run for the first time, will copy over all the migrations
 from the engine. When run the next time, it will only copy over migrations that
 haven't been copied over already. The first run for this command will output

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `DATABASE` option to `railties:install:migrations`
+
+    This allows you to specify which database the migrations should be copied to
+    when running `rails railties:install:migrations`.
+
+    ```bash
+    $ rails railties:install:migrations DATABASE=animals
+    ```
+
+    *Matthew Hirst*
+
 *   The new method `config.autoload_lib(ignore:)` provides a simple way to
     autoload from `lib`:
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it is helpful to be able to specify which database you want
to install migrations to when using an engine with a Rails project that has multiple databases.

### Detail

This Pull Request adds a DATABASE option to the railties:install:migrations rake task.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
