### PR TITLE
Fix flaky tests without guaranteed sort

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -388,7 +388,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     speedometer.reload
 
-    assert_equal ["first", "second"], speedometer.minivans.map(&:name)
+    assert_equal ["first", "second"], speedometer.minivans.map(&:name).sort
     assert_equal ["blue", "blue"], speedometer.minivans.map(&:color)
   end
 
@@ -402,7 +402,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     speedometer.reload
 
-    assert_equal ["first", "second"], speedometer.minivans.map(&:name)
+    assert_equal ["first", "second"], speedometer.minivans.map(&:name).sort
     assert_equal ["blue", "blue"], speedometer.minivans.map(&:color)
   end
 
@@ -415,7 +415,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     speedometer.reload
 
-    assert_equal ["first", "second"], speedometer.minivans.map(&:name)
+    assert_equal ["first", "second"], speedometer.minivans.map(&:name).sort
     assert_equal ["blue", "blue"], speedometer.minivans.map(&:color)
   end
 
@@ -428,7 +428,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     speedometer.reload
 
-    assert_equal ["first", "second"], speedometer.minivans.map(&:name)
+    assert_equal ["first", "second"], speedometer.minivans.map(&:name).sort
     assert_equal ["blue", "blue"], speedometer.minivans.map(&:color)
   end
 
@@ -3113,7 +3113,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     bulb2 = car.bulbs.create!
 
-    assert_equal [bulb.id, bulb2.id], car.bulb_ids
+    assert_equal [bulb.id, bulb2.id], car.bulb_ids.sort
     assert_no_queries { car.bulb_ids }
   end
 

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -104,9 +104,9 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_on_disable_joins_through_a_through
-    rating_ids = Rating.where(comment: @comment).pluck(:id)
-    assert_equal rating_ids, assert_queries(1) { @author.ratings.pluck(:id) }
-    assert_equal rating_ids, assert_queries(3) { @author.no_joins_ratings.pluck(:id) }
+    rating_ids = Rating.where(comment: @comment).pluck(:id).sort
+    assert_equal rating_ids, assert_queries(1) { @author.ratings.pluck(:id).sort }
+    assert_equal rating_ids, assert_queries(3) { @author.no_joins_ratings.pluck(:id).sort }
   end
 
   def test_count_on_disable_joins_through_a_through


### PR DESCRIPTION
### Motivation / Background

These test assertions rely on database queries that lack an ORDER BY statement. On occasion the database will return results from these queries in an unexpected order resulting in a flaky test.


### Additional information

Further Reading... https://www.simplethread.com/chaos-order-randomizing-queries-uncover-order-dependency/

Here's the hacked together code (edits done via vim macros) I used to flush these out... https://github.com/rails/rails/compare/main...abaldwin88:rails:chaos_order


