### PR TITLE
Introduce ActiveRecord::Base#preload on a record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -32,6 +32,23 @@
 
     *Lázaro Nixon*
 
+*   Introduced ActiveRecord::Base#preload
+
+    Similar to .preload on a relation, but on a single, already loaded record.
+
+    ```ruby
+    # Instead of:
+    User.preload(:address, friends: [:address, :followers]).find(1)
+    # you may now use:
+    user = User.find(1)
+    user.preload(:address, friends: [:address, :followers])
+    ```
+
+    This API might be useful if you are looking to preload
+    relations on a record that has already been loaded.
+
+    *Kir Shatrov*
+
 *   Added PostgreSQL migration commands for enum rename, add value, and rename value.
 
     `rename_enum` and `rename_enum_value` are reversible. Due to Postgres

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -333,6 +333,16 @@ module ActiveRecord
       super
     end
 
+    # Similar to ActiveRecord::Relation#preload, but on a single, already loaded record.
+    # Instead of,
+    # User.preload(:address, friends: [:address, :followers]).find(1)
+    # you may do:
+    # user = User.find(1)
+    # user.preload(:address, friends: [:address, :followers])
+    def preload(associations)
+      ActiveRecord::Associations::Preloader.new(records: [self], associations: associations).call
+    end
+
     private
       def init_internals
         super

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -378,6 +378,23 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_empty(blog_post.reload.tags)
     assert_not_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id), :exists?
   end
+
+  def test_record_preload
+    ship = Ship.create!(name: "The good ship Dollypop")
+    ship.parts.create!(name: "Mast").tap do |part|
+      part.trinkets.create!(name: "Necklace")
+    end
+    ship.parts.create!(name: "Head").tap do |part|
+      part.trinkets.create!(name: "Golden Handle")
+    end
+
+    ship.reload
+
+    ship.preload(parts: [:trinkets])
+    assert_no_queries do
+      ship.parts.each(&:trinkets)
+    end
+  end
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase


### PR DESCRIPTION
Sometimes you might want to `preload` relations for a record that has already been loaded.
If you were to do it today, you'd either have to use private API (`ActiveRecord::Associations::Preloader`) or do something like

```
def method_that_wants_to_preload_and_receives_record(user)
  user = User.preload(:address, friends: [:address, :followers]).find(user.id)
end
```

However, that seems ugly and may result to unnecessary (but probably cached) query on `users` to find a record by a primary key.

It seems like an simple addition to introduce `preload` on a record that has already been loaded. That's what this PR does.