### PR TITLE
Add a rake task for checking various release related utilities

### DIFF
--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -100,7 +100,7 @@ npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
       sh "gem install --pre #{gem}"
     end
 
-    task push: :build do
+    task push: [:build, :check_utilities] do
       otp = ""
       begin
         otp = " --otp " + `ykman oath accounts code -s rubygems.org`.chomp
@@ -342,4 +342,22 @@ task :announce do
 
     puts ERB.new(template, trim_mode: "<>").result(binding)
   end
+end
+
+# Check that various utilities are working so that when we push gems it won't fail
+task :check_utilities do
+  # try getting an OTP from the yubikey for RubyGems
+  sh "ykman oath accounts code -s rubygems.org"
+
+  # try getting an OTP from the yubikey for npm
+  sh "ykman oath accounts code -s npmjs.com"
+
+  # make sure we're logged in to RubyGems.org
+  sh "gem login"
+
+  # make sure we're logged in to npm
+  sh "npm whoami"
+
+  # make sure gh is logged in
+  sh "gh auth status"
 end


### PR DESCRIPTION
This commit adds a rake task that checks various utilities are working before releasing Rails.  The problem we're trying to avoid is commands failing halfway through the release (for example maybe you're not logged in to npmjs). The check task is fairly opinionated, it requires that:

* Use a YubiKey for storing OTPs
  * The `ykman` utility is installed
  * The OTP name for RubyGems has `rubygems.org` in the name
  * The OTP name for NPM has `npmjs.com` in the name
* You are logged in to RubyGems
* You are logged in to npmjs
* You are logged in to the `gh` utility

If the task fails, then no gems will be pushed and it gives you an opportunity to fix your environment.  Basically I want to automate [this section](https://github.com/rails/rails/blob/main/RELEASING_RAILS.md#check-credentials-for-rubygems-npm-and-github) in our release documentation.

See [this blog post](https://tenderlovemaking.com/2021/10/26/publishing-gems-with-your-yubikey.html) for configuring your YubiKey.