### PR TITLE
Active Job: Correctly use the desired test adapter in tests

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   All tests now respect the `active_job.queue_adapter` config
+
+    Previously if you had set `config.active_job.queue_adapter` in your `config/application.rb`
+    or `config/environments/test.rb` file, the adapter you selected was previously not used consistently
+    across all tests. In some tests your adapter would be used, but other tests would use the `TestAdapter`.
+
+    In Rails 7.2, all tests will respect the `queue_adapter` config if provided. If no config is provided,
+    the `TestAdapter` will continue to be used.
+
+    See [#48585](https://github.com/rails/rails/pull/48585) for more details.
+
+    *Alex Ghiculescu*
+
 *   Make Active Job transaction aware when used conjointly with Active Record.
 
     A common mistake with Active Job is to enqueue jobs from inside a transaction,

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -15,7 +15,8 @@ module ActiveJob
   # = Active Job Queue adapter
   #
   # The +ActiveJob::QueueAdapter+ module is used to load the
-  # correct adapter. The default queue adapter is the +:async+ queue.
+  # correct adapter. The default queue adapter is +:async+,
+  # which loads the ActiveJob::QueueAdapters::AsyncAdapter.
   module QueueAdapter # :nodoc:
     extend ActiveSupport::Concern
 
@@ -24,21 +25,21 @@ module ActiveJob
       class_attribute :_queue_adapter, instance_accessor: false, instance_predicate: false
 
       delegate :queue_adapter, to: :class
-
-      self.queue_adapter = :async
     end
 
     # Includes the setter method for changing the active queue adapter.
     module ClassMethods
       # Returns the backend queue provider. The default queue adapter
-      # is the +:async+ queue. See QueueAdapters for more information.
+      # is +:async+. See QueueAdapters for more information.
       def queue_adapter
+        self.queue_adapter = :async if _queue_adapter.nil?
         _queue_adapter
       end
 
       # Returns string denoting the name of the configured queue adapter.
       # By default returns <tt>"async"</tt>.
       def queue_adapter_name
+        self.queue_adapter = :async if _queue_adapter_name.nil?
         _queue_adapter_name
       end
 

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -41,7 +41,7 @@ module ActiveJob
 
     initializer "active_job.set_configs" do |app|
       options = app.config.active_job
-      options.queue_adapter ||= :async
+      options.queue_adapter ||= (Rails.env.test? ? :test : :async)
 
       config.after_initialize do
         options.each do |k, v|

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -39,10 +39,12 @@ module ActiveJob
     end
 
     def before_setup # :nodoc:
-      test_adapter = queue_adapter_for_test
-
       queue_adapter_changed_jobs.each do |klass|
-        klass.enable_test_adapter(test_adapter)
+        if (queue_adapter_specific_to_this_test_class = queue_adapter_for_test)
+          klass.enable_test_adapter(queue_adapter_specific_to_this_test_class)
+        elsif klass._queue_adapter.nil?
+          klass.enable_test_adapter(ActiveJob::QueueAdapters::TestAdapter.new)
+        end
       end
 
       clear_enqueued_jobs
@@ -61,7 +63,6 @@ module ActiveJob
     # Override this method to specify a different adapter. The adapter must
     # implement the same interface as ActiveJob::QueueAdapters::TestAdapter.
     def queue_adapter_for_test
-      ActiveJob::QueueAdapters::TestAdapter.new
     end
 
     # Asserts that the number of enqueued jobs matches the given number.
@@ -118,6 +119,8 @@ module ActiveJob
     #     end
     #   end
     def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil, &block)
+      require_active_job_test_adapter!("assert_enqueued_jobs")
+
       if block_given?
         original_jobs = enqueued_jobs_with(only: only, except: except, queue: queue)
 
@@ -180,6 +183,8 @@ module ActiveJob
     #
     #   assert_enqueued_jobs 0, &block
     def assert_no_enqueued_jobs(only: nil, except: nil, queue: nil, &block)
+      require_active_job_test_adapter!("assert_no_enqueued_jobs")
+
       assert_enqueued_jobs 0, only: only, except: except, queue: queue, &block
     end
 
@@ -270,6 +275,8 @@ module ActiveJob
     #       end
     #     end
     def assert_performed_jobs(number, only: nil, except: nil, queue: nil, &block)
+      require_active_job_test_adapter!("assert_performed_jobs")
+
       if block_given?
         original_count = performed_jobs.size
 
@@ -338,6 +345,8 @@ module ActiveJob
     #
     #   assert_performed_jobs 0, &block
     def assert_no_performed_jobs(only: nil, except: nil, queue: nil, &block)
+      require_active_job_test_adapter!("assert_no_performed_jobs")
+
       assert_performed_jobs 0, only: only, except: except, queue: queue, &block
     end
 
@@ -394,6 +403,8 @@ module ActiveJob
     #     end
     #   end
     def assert_enqueued_with(job: nil, args: nil, at: nil, queue: nil, priority: nil, &block)
+      require_active_job_test_adapter!("assert_enqueued_with")
+
       expected = { job: job, args: args, at: at, queue: queue, priority: priority }.compact
       expected_args = prepare_args_for_assertion(expected)
       potential_matches = []
@@ -496,6 +507,8 @@ module ActiveJob
     #     end
     #   end
     def assert_performed_with(job: nil, args: nil, at: nil, queue: nil, priority: nil, &block)
+      require_active_job_test_adapter!("assert_performed_with")
+
       expected = { job: job, args: args, at: at, queue: queue, priority: priority }.compact
       expected_args = prepare_args_for_assertion(expected)
       potential_matches = []
@@ -604,7 +617,10 @@ module ActiveJob
     # If queue_adapter_for_test is overridden to return a different adapter,
     # +perform_enqueued_jobs+ will merely execute the block.
     def perform_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil, &block)
-      return flush_enqueued_jobs(only: only, except: except, queue: queue, at: at) unless block_given?
+      unless block_given?
+        require_active_job_test_adapter!("perform_enqueued_jobs (without a block)")
+        return flush_enqueued_jobs(only: only, except: except, queue: queue, at: at)
+      end
 
       return _assert_nothing_raised_or_warn("perform_enqueued_jobs", &block) unless using_test_adapter?
 
@@ -646,6 +662,12 @@ module ActiveJob
     end
 
     private
+      def require_active_job_test_adapter!(method)
+        unless using_test_adapter?
+          raise ArgumentError.new("#{method} requires the Active Job test adapter, you're using #{queue_adapter.class.name}.")
+        end
+      end
+
       def using_test_adapter?
         queue_adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter)
       end

--- a/activejob/test/cases/instrumentation_test.rb
+++ b/activejob/test/cases/instrumentation_test.rb
@@ -23,18 +23,20 @@ class InstrumentationTest < ActiveSupport::TestCase
     assert_equal 1, events.size
   end
 
-  test "retry emits an enqueue retry event" do
-    events = subscribed("enqueue_retry.active_job") do
-      perform_enqueued_jobs { RetryJob.perform_later("DefaultsError", 2) }
+  unless adapter_is?(:inline, :sneakers)
+    test "retry emits an enqueue retry event" do
+      events = subscribed("enqueue_retry.active_job") do
+        perform_enqueued_jobs { RetryJob.perform_later("DefaultsError", 2) }
+      end
+      assert_equal 1, events.size
     end
-    assert_equal 1, events.size
-  end
 
-  test "retry exhaustion emits a retry_stopped event" do
-    events = subscribed("retry_stopped.active_job") do
-      perform_enqueued_jobs { RetryJob.perform_later("CustomCatchError", 6) }
+    test "retry exhaustion emits a retry_stopped event" do
+      events = subscribed("retry_stopped.active_job") do
+        perform_enqueued_jobs { RetryJob.perform_later("CustomCatchError", 6) }
+      end
+      assert_equal 1, events.size
     end
-    assert_equal 1, events.size
   end
 
   test "discard emits a discard event" do

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -213,14 +213,14 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
-  def test_enqueue_at_job_logging
-    events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
-    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
-  rescue NotImplementedError
-    skip
+  unless adapter_is?(:inline, :sneakers)
+    def test_enqueue_at_job_logging
+      events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
+      assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
+      assert_equal(1, events.count)
+      key, * = events.first
+      assert_equal("enqueue_at.active_job", key)
+    end
   end
 
   def test_enqueue_at_job_log_error_when_callback_chain_is_halted
@@ -244,14 +244,14 @@ class LoggingTest < ActiveSupport::TestCase
     assert_equal("enqueue_at.active_job", key)
   end
 
-  def test_enqueue_in_job_logging
-    events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
-    assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
-  rescue NotImplementedError
-    skip
+  unless adapter_is?(:inline, :sneakers)
+    def test_enqueue_in_job_logging
+      events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
+      assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
+      assert_equal(1, events.count)
+      key, * = events.first
+      assert_equal("enqueue_at.active_job", key)
+    end
   end
 
   def test_enqueue_log_when_enqueue_error_is_set
@@ -290,10 +290,12 @@ class LoggingTest < ActiveSupport::TestCase
     assert_no_match(/Error performing RescueJob \(Job ID: .*?\) from .*? in .*ms: ArgumentError \(Hair too good\):\n.*\brescue_job\.rb:\d+:in .*perform'/, @logger.messages)
   end
 
-  def test_enqueue_retry_logging
-    perform_enqueued_jobs do
-      RetryJob.perform_later "DefaultsError", 2
-      assert_match(/Retrying RetryJob \(Job ID: .*?\) after \d+ attempts in 3 seconds, due to a DefaultsError.*\./, @logger.messages)
+  unless adapter_is?(:inline, :sneakers)
+    def test_enqueue_retry_logging
+      perform_enqueued_jobs do
+        RetryJob.perform_later "DefaultsError", 2
+        assert_match(/Retrying RetryJob \(Job ID: .*?\) after \d+ attempts in 3 seconds, due to a DefaultsError.*\./, @logger.messages)
+      end
     end
   end
 
@@ -302,18 +304,20 @@ class LoggingTest < ActiveSupport::TestCase
     assert_match(/Retrying RescueJob \(Job ID: .*?\) after \d+ attempts in 0 seconds\./, @logger.messages)
   end
 
-  def test_retry_stopped_logging
-    perform_enqueued_jobs do
-      RetryJob.perform_later "CustomCatchError", 6
+  unless adapter_is?(:inline, :sneakers)
+    def test_retry_stopped_logging
+      perform_enqueued_jobs do
+        RetryJob.perform_later "CustomCatchError", 6
+      end
+      assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a CustomCatchError.*, which reoccurred on \d+ attempts\./, @logger.messages)
     end
-    assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a CustomCatchError.*, which reoccurred on \d+ attempts\./, @logger.messages)
-  end
 
-  def test_retry_stopped_logging_without_block
-    perform_enqueued_jobs do
-      RetryJob.perform_later "DefaultsError", 6
-    rescue DefaultsError
-      assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a DefaultsError.*, which reoccurred on \d+ attempts\./, @logger.messages)
+    def test_retry_stopped_logging_without_block
+      perform_enqueued_jobs do
+        RetryJob.perform_later "DefaultsError", 6
+      rescue DefaultsError
+        assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a DefaultsError.*, which reoccurred on \d+ attempts\./, @logger.messages)
+      end
     end
   end
 

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -53,6 +53,19 @@ class QueueAdapterTest < ActiveJob::TestCase
     assert_equal base_queue_adapter, child_job_three.queue_adapter, "child_job_three's queue adapter should remain unchanged"
   end
 
+  test "should default to :async adapter if no adapters are set at all" do
+    ActiveJob::Base.disable_test_adapter
+    _queue_adapter_was = ActiveJob::Base._queue_adapter
+    _queue_adapter_name_was = ActiveJob::Base._queue_adapter_name
+    ActiveJob::Base._queue_adapter = ActiveJob::Base._queue_adapter_name = nil
+
+    assert_equal "async", ActiveJob::Base.queue_adapter_name
+    assert_kind_of ActiveJob::QueueAdapters::AsyncAdapter, ActiveJob::Base.queue_adapter
+  ensure
+    ActiveJob::Base._queue_adapter = _queue_adapter_was
+    ActiveJob::Base._queue_adapter_name = _queue_adapter_name_was
+  end
+
   test "should extract a reasonable name from a class instance" do
     child_job = Class.new(ActiveJob::Base)
     child_job.queue_adapter = ActiveJob::QueueAdapters::StubOneAdapter.new

--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -20,10 +20,37 @@ class ActiveJobTestCaseTest < ActiveJob::TestCase
   end
 
   def test_set_test_adapter
-    assert_kind_of ActiveJob::QueueAdapters::TestAdapter, queue_adapter
+    # The queue adapter the job uses depends on the Active Job config.
+    # See https://github.com/rails/rails/pull/48585 for logic.
+    expected = case ActiveJob::Base.queue_adapter_name.to_sym
+               when :test
+                 ActiveJob::QueueAdapters::TestAdapter
+               when :inline
+                 ActiveJob::QueueAdapters::InlineAdapter
+               when :async
+                 ActiveJob::QueueAdapters::AsyncAdapter
+               when :backburner
+                 ActiveJob::QueueAdapters::BackburnerAdapter
+               when :delayed_job
+                 ActiveJob::QueueAdapters::DelayedJobAdapter
+               when :queue_classic
+                 ActiveJob::QueueAdapters::QueueClassicAdapter
+               when :resque
+                 ActiveJob::QueueAdapters::ResqueAdapter
+               when :sidekiq
+                 ActiveJob::QueueAdapters::SidekiqAdapter
+               when :sneakers
+                 ActiveJob::QueueAdapters::SneakersAdapter
+               when :sucker_punch
+                 ActiveJob::QueueAdapters::SuckerPunchAdapter
+               else
+                 raise NotImplementedError.new
+    end
+
+    assert_kind_of expected, queue_adapter
   end
 
   def test_does_not_perform_enqueued_jobs_by_default
-    assert_nil queue_adapter.perform_enqueued_jobs
+    assert_nil ActiveJob::QueueAdapters::TestAdapter.new.perform_enqueued_jobs
   end
 end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -3,6 +3,7 @@
 require "helper"
 require "active_support/core_ext/time"
 require "active_support/core_ext/date"
+require "active_support/concern"
 require "zeitwerk"
 require "jobs/hello_job"
 require "jobs/logging_job"
@@ -14,2054 +15,2138 @@ require "jobs/inherited_job"
 require "jobs/multiple_kwargs_job"
 require "models/person"
 
+module DoNotPerformEnqueuedJobs
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      # /rails/activejob/test/adapters/test.rb sets these configs to true, but
+      # in this specific case we want to test enqueueing behaviour.
+      @perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
+      @perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
+      queue_adapter.perform_enqueued_jobs = queue_adapter.perform_enqueued_at_jobs = false
+    end
+
+    teardown do
+      queue_adapter.perform_enqueued_jobs = @perform_enqueued_jobs
+      queue_adapter.perform_enqueued_at_jobs = @perform_enqueued_at_jobs
+    end
+  end
+end
+
+
 class EnqueuedJobsTest < ActiveJob::TestCase
-  def test_assert_enqueued_jobs
-    assert_nothing_raised do
-      assert_enqueued_jobs 1 do
-        HelloJob.perform_later("david")
-      end
-    end
-  end
+  if adapter_is?(:test)
+    include DoNotPerformEnqueuedJobs
 
-  def test_repeated_enqueued_jobs_calls
-    assert_nothing_raised do
-      assert_enqueued_jobs 1 do
-        HelloJob.perform_later("abdelkader")
+    def test_assert_enqueued_jobs
+      assert_nothing_raised do
+        assert_enqueued_jobs 1 do
+          HelloJob.perform_later("david")
+        end
       end
     end
 
-    assert_nothing_raised do
-      assert_enqueued_jobs 2 do
-        HelloJob.perform_later("sean")
-        HelloJob.perform_later("yves")
+    def test_repeated_enqueued_jobs_calls
+      assert_nothing_raised do
+        assert_enqueued_jobs 1 do
+          HelloJob.perform_later("abdelkader")
+        end
       end
-    end
-  end
 
-  def test_assert_enqueued_jobs_message
-    HelloJob.perform_later("sean")
-    e = assert_raises Minitest::Assertion do
-      assert_enqueued_jobs 2 do
-        HelloJob.perform_later("sean")
-      end
-    end
-    assert_match "Expected: 2", e.message
-    assert_match "Actual: 1", e.message
-  end
-
-  def test_assert_enqueued_jobs_with_no_block
-    assert_nothing_raised do
-      HelloJob.perform_later("rafael")
-      assert_enqueued_jobs 1
-    end
-
-    assert_nothing_raised do
-      HelloJob.perform_later("aaron")
-      HelloJob.perform_later("matthew")
-      assert_enqueued_jobs 3
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_no_block
-    assert_nothing_raised do
-      assert_no_enqueued_jobs
-    end
-  end
-
-  def test_assert_no_enqueued_jobs
-    assert_nothing_raised do
-      assert_no_enqueued_jobs do
-        HelloJob.perform_now
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 2 do
-        HelloJob.perform_later("xavier")
+      assert_nothing_raised do
+        assert_enqueued_jobs 2 do
+          HelloJob.perform_later("sean")
+          HelloJob.perform_later("yves")
+        end
       end
     end
 
-    assert_match(/2 .* but 1/, error.message)
-  end
+    def test_assert_enqueued_jobs_message
+      HelloJob.perform_later("sean")
+      e = assert_raises Minitest::Assertion do
+        assert_enqueued_jobs 2 do
+          HelloJob.perform_later("sean")
+        end
+      end
+      assert_match "Expected: 2", e.message
+      assert_match "Actual: 1", e.message
+    end
 
-  def test_assert_enqueued_jobs_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 1 do
-        HelloJob.perform_later("cristian")
-        HelloJob.perform_later("guillermo")
+    def test_assert_enqueued_jobs_with_no_block
+      assert_nothing_raised do
+        HelloJob.perform_later("rafael")
+        assert_enqueued_jobs 1
+      end
+
+      assert_nothing_raised do
+        HelloJob.perform_later("aaron")
+        HelloJob.perform_later("matthew")
+        assert_enqueued_jobs 3
       end
     end
 
-    assert_match(/1 .* but 2/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs do
-        HelloJob.perform_later("jeremy")
+    def test_assert_no_enqueued_jobs_with_no_block
+      assert_nothing_raised do
+        assert_no_enqueued_jobs
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_only_option
-    assert_nothing_raised do
-      assert_enqueued_jobs 1, only: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_with_only_option_as_proc
-    assert_nothing_raised do
-      assert_enqueued_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" }) do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_with_except_option
-    assert_nothing_raised do
-      assert_enqueued_jobs 1, except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_with_except_option_as_proc
-    assert_nothing_raised do
-      assert_enqueued_jobs(1, except: ->(job) { job.fetch(:job).name == "LoggingJob" }) do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_with_only_and_except_option
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-        LoggingJob.perform_later
+    def test_assert_no_enqueued_jobs
+      assert_nothing_raised do
+        assert_no_enqueued_jobs do
+          HelloJob.perform_now
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_enqueued_jobs_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 2 do
+          HelloJob.perform_later("xavier")
+        end
+      end
 
-  def test_assert_enqueued_jobs_with_only_and_queue_option
-    assert_nothing_raised do
-      assert_enqueued_jobs 1, only: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :some_queue).perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.perform_later
+      assert_match(/2 .* but 1/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 1 do
+          HelloJob.perform_later("cristian")
+          HelloJob.perform_later("guillermo")
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs do
+          HelloJob.perform_later("jeremy")
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_option
+      assert_nothing_raised do
+        assert_enqueued_jobs 1, only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+          LoggingJob.perform_later
+        end
       end
     end
-  end
 
-  def test_assert_enqueued_jobs_with_except_and_queue_option
-    assert_nothing_raised do
-      assert_enqueued_jobs 1, except: LoggingJob, queue: :some_queue do
-        HelloJob.set(queue: :some_queue).perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_enqueued_jobs_with_only_and_except_and_queue_option
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :some_queue).perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.perform_later
+    def test_assert_enqueued_jobs_with_only_option_as_proc
+      assert_nothing_raised do
+        assert_enqueued_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" }) do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+          LoggingJob.perform_later
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_queue_option
-    assert_nothing_raised do
-      assert_enqueued_jobs 2, queue: :default do
-        HelloJob.perform_later
-        LoggingJob.perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.set(queue: :other_queue).perform_later
+    def test_assert_enqueued_jobs_with_except_option
+      assert_nothing_raised do
+        assert_enqueued_jobs 1, except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+          LoggingJob.perform_later
+        end
       end
     end
-  end
 
-  def test_assert_enqueued_job_with_priority_option
-    assert_enqueued_with(job: HelloJob, priority: 10) do
-      HelloJob.set(priority: 10).perform_later
+    def test_assert_enqueued_jobs_with_except_option_as_proc
+      assert_nothing_raised do
+        assert_enqueued_jobs(1, except: ->(job) { job.fetch(:job).name == "LoggingJob" }) do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+          LoggingJob.perform_later
+        end
+      end
     end
 
-    assert_raise ActiveSupport::TestCase::Assertion do
+    def test_assert_enqueued_jobs_with_only_and_except_option
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_and_queue_option
+      assert_nothing_raised do
+        assert_enqueued_jobs 1, only: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :some_queue).perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_enqueued_jobs_with_except_and_queue_option
+      assert_nothing_raised do
+        assert_enqueued_jobs 1, except: LoggingJob, queue: :some_queue do
+          HelloJob.set(queue: :some_queue).perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_enqueued_jobs_with_only_and_except_and_queue_option
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 1, only: HelloJob, except: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :some_queue).perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_queue_option
+      assert_nothing_raised do
+        assert_enqueued_jobs 2, queue: :default do
+          HelloJob.perform_later
+          LoggingJob.perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.set(queue: :other_queue).perform_later
+        end
+      end
+    end
+
+    def test_assert_enqueued_job_with_priority_option
       assert_enqueued_with(job: HelloJob, priority: 10) do
-        HelloJob.set(priority: 5).perform_later
+        HelloJob.set(priority: 10).perform_later
       end
-    end
-  end
 
-  def test_assert_enqueued_jobs_with_only_option_and_none_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 1, only: HelloJob do
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_except_option_and_none_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 1, except: LoggingJob do
-        LoggingJob.perform_later
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: HelloJob, priority: 10) do
+          HelloJob.set(priority: 5).perform_later
+        end
       end
     end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
+    def test_assert_enqueued_jobs_with_only_option_and_none_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 1, only: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
 
-  def test_assert_enqueued_jobs_with_only_and_except_option_and_none_sent
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
-        LoggingJob.perform_later
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_except_option_and_none_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 1, except: LoggingJob do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_and_except_option_and_none_sent
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_option_and_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 5, only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/5 .* but 1/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_except_option_and_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 5, except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/5 .* but 1/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_and_except_option_and_too_few_sent
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 5, only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_option_and_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 1, only: HelloJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_except_option_and_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_jobs 1, except: LoggingJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_and_except_option_and_too_many_sent
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_enqueued_jobs_with_only_option_as_array
+      assert_nothing_raised do
+        assert_enqueued_jobs 2, only: [HelloJob, LoggingJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_only_option_and_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 5, only: HelloJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
+    def test_assert_enqueued_jobs_with_except_option_as_array
+      assert_nothing_raised do
+        assert_enqueued_jobs 1, except: [HelloJob, LoggingJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
       end
     end
 
-    assert_match(/5 .* but 1/, error.message)
-  end
+    def test_assert_enqueued_jobs_with_only_and_except_option_as_array
+      error = assert_raise ArgumentError do
+        assert_enqueued_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
+      end
 
-  def test_assert_enqueued_jobs_with_except_option_and_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 5, except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_only_option
+      assert_nothing_raised do
+        assert_no_enqueued_jobs only: HelloJob do
+          LoggingJob.perform_later
+        end
       end
     end
 
-    assert_match(/5 .* but 1/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_only_and_except_option_and_too_few_sent
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 5, only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
+    def test_assert_no_enqueued_jobs_with_except_option
+      assert_nothing_raised do
+        assert_no_enqueued_jobs except: LoggingJob do
+          LoggingJob.perform_later
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_no_enqueued_jobs_with_only_and_except_option
+      error = assert_raise ArgumentError do
+        assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
 
-  def test_assert_enqueued_jobs_with_only_option_and_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 1, only: HelloJob do
-        2.times { HelloJob.perform_later("jeremy") }
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_only_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_except_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_only_and_except_option_failure
+      error = assert_raise ArgumentError do
+        assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_only_option_as_array
+      assert_nothing_raised do
+        assert_no_enqueued_jobs only: [HelloJob, RescueJob] do
+          LoggingJob.perform_later
+        end
       end
     end
 
-    assert_match(/1 .* but 2/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_except_option_and_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_jobs 1, except: LoggingJob do
-        2.times { HelloJob.perform_later("jeremy") }
+    def test_assert_no_enqueued_jobs_with_except_option_as_array
+      assert_nothing_raised do
+        assert_no_enqueued_jobs except: [HelloJob, RescueJob] do
+          HelloJob.perform_later
+          RescueJob.perform_later
+        end
       end
     end
 
-    assert_match(/1 .* but 2/, error.message)
-  end
+    def test_assert_no_enqueued_jobs_with_only_and_except_option_as_array
+      error = assert_raise ArgumentError do
+        assert_no_enqueued_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
+          LoggingJob.perform_later
+        end
+      end
 
-  def test_assert_enqueued_jobs_with_only_and_except_option_and_too_many_sent
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 1, only: HelloJob, except: HelloJob do
-        2.times { HelloJob.perform_later("jeremy") }
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_enqueued_jobs_with_queue_option
+      assert_nothing_raised do
+        assert_no_enqueued_jobs queue: :default do
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.set(queue: :other_queue).perform_later
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_enqueued_jobs_with_only_option_as_array
-    assert_nothing_raised do
-      assert_enqueued_jobs 2, only: [HelloJob, LoggingJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
+    def test_assert_no_enqueued_jobs_with_queue_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs queue: :other_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+        end
       end
-    end
-  end
 
-  def test_assert_enqueued_jobs_with_except_option_as_array
-    assert_nothing_raised do
-      assert_enqueued_jobs 1, except: [HelloJob, LoggingJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
-      end
+      assert_match(/0 .* but 1/, error.message)
     end
-  end
 
-  def test_assert_enqueued_jobs_with_only_and_except_option_as_array
-    error = assert_raise ArgumentError do
-      assert_enqueued_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
+    def test_assert_no_enqueued_jobs_with_only_and_queue_option
+      assert_nothing_raised do
+        assert_no_enqueued_jobs only: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.set(queue: :some_queue).perform_later
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_option
-    assert_nothing_raised do
-      assert_no_enqueued_jobs only: HelloJob do
-        LoggingJob.perform_later
+    def test_assert_no_enqueued_jobs_with_only_and_queue_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs only: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+          HelloJob.set(queue: :some_queue).perform_later
+          LoggingJob.set(queue: :some_queue).perform_later
+        end
       end
-    end
-  end
 
-  def test_assert_no_enqueued_jobs_with_except_option
-    assert_nothing_raised do
-      assert_no_enqueued_jobs except: LoggingJob do
-        LoggingJob.perform_later
-      end
+      assert_match(/0 .* but 1/, error.message)
     end
-  end
 
-  def test_assert_no_enqueued_jobs_with_only_and_except_option
-    error = assert_raise ArgumentError do
-      assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
-        LoggingJob.perform_later
+    def test_assert_no_enqueued_jobs_with_except_and_queue_option
+      assert_nothing_raised do
+        assert_no_enqueued_jobs except: LoggingJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+          HelloJob.set(queue: :other_queue).perform_later
+          LoggingJob.set(queue: :some_queue).perform_later
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs only: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
+    def test_assert_no_enqueued_jobs_with_except_and_queue_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_enqueued_jobs except: LoggingJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+          HelloJob.set(queue: :some_queue).perform_later
+          LoggingJob.set(queue: :some_queue).perform_later
+        end
       end
+
+      assert_match(/0 .* but 1/, error.message)
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_except_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
+    def test_assert_no_enqueued_jobs_with_only_and_except_and_queue_option
+      error = assert_raise ArgumentError do
+        assert_no_enqueued_jobs only: HelloJob, except: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later
+        end
       end
+
+      assert_match(/`:only` and `:except`/, error.message)
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_and_except_option_failure
-    error = assert_raise ArgumentError do
-      assert_no_enqueued_jobs only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_option_as_array
-    assert_nothing_raised do
-      assert_no_enqueued_jobs only: [HelloJob, RescueJob] do
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_except_option_as_array
-    assert_nothing_raised do
-      assert_no_enqueued_jobs except: [HelloJob, RescueJob] do
-        HelloJob.perform_later
-        RescueJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_and_except_option_as_array
-    error = assert_raise ArgumentError do
-      assert_no_enqueued_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_queue_option
-    assert_nothing_raised do
-      assert_no_enqueued_jobs queue: :default do
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.set(queue: :other_queue).perform_later
-      end
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_queue_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs queue: :other_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-      end
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_and_queue_option
-    assert_nothing_raised do
-      assert_no_enqueued_jobs only: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.set(queue: :some_queue).perform_later
-      end
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_and_queue_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs only: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-        HelloJob.set(queue: :some_queue).perform_later
-        LoggingJob.set(queue: :some_queue).perform_later
-      end
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_except_and_queue_option
-    assert_nothing_raised do
-      assert_no_enqueued_jobs except: LoggingJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-        HelloJob.set(queue: :other_queue).perform_later
-        LoggingJob.set(queue: :some_queue).perform_later
-      end
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_with_except_and_queue_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_enqueued_jobs except: LoggingJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-        HelloJob.set(queue: :some_queue).perform_later
-        LoggingJob.set(queue: :some_queue).perform_later
-      end
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_enqueued_jobs_with_only_and_except_and_queue_option
-    error = assert_raise ArgumentError do
-      assert_no_enqueued_jobs only: HelloJob, except: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_enqueued_with
-    assert_enqueued_with(job: LoggingJob, queue: "default") do
-      LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
-    end
-  end
-
-  def test_assert_enqueued_with_with_no_block
-    LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
-    assert_enqueued_with(job: LoggingJob, queue: "default")
-  end
-
-  def test_assert_enqueued_with_when_queue_name_is_symbol
-    assert_enqueued_with(job: LoggingJob, queue: :default) do
-      LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
-    end
-  end
-
-  def test_assert_no_enqueued_jobs_and_perform_now
-    assert_no_enqueued_jobs do
-      LoggingJob.perform_now(1, 2, 3, keyword: true)
-    end
-  end
-
-  def test_assert_enqueued_with_returns
-    job = assert_enqueued_with(job: LoggingJob) do
-      LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
-    end
-
-    assert_instance_of LoggingJob, job
-    assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at.to_f, 1
-    assert_equal "default", job.queue_name
-    assert_equal [1, 2, 3, { keyword: true }], job.arguments
-  end
-
-  def test_assert_enqueued_with_with_no_block_returns
-    LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
-    job = assert_enqueued_with(job: LoggingJob)
-
-    assert_instance_of LoggingJob, job
-    assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at.to_f, 1
-    assert_equal "default", job.queue_name
-    assert_equal [1, 2, 3, { keyword: true }], job.arguments
-  end
-
-  def test_assert_enqueued_with_failure
-    assert_raise ActiveSupport::TestCase::Assertion do
+    def test_assert_enqueued_with
       assert_enqueued_with(job: LoggingJob, queue: "default") do
-        NestedJob.perform_later
+        LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
       end
     end
 
-    assert_raise ActiveSupport::TestCase::Assertion do
-      LoggingJob.perform_later
-      assert_enqueued_with(job: LoggingJob) { }
-    end
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_with(job: NestedJob, queue: "low") do
-        NestedJob.perform_later
-      end
-    end
-
-    assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
-  end
-
-  def test_assert_enqueued_with_with_no_block_failure
-    assert_raise ActiveSupport::TestCase::Assertion do
-      NestedJob.perform_later
+    def test_assert_enqueued_with_with_no_block
+      LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
       assert_enqueued_with(job: LoggingJob, queue: "default")
     end
 
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      NestedJob.perform_later
-      assert_enqueued_with(job: NestedJob, queue: "low")
+    def test_assert_enqueued_with_when_queue_name_is_symbol
+      assert_enqueued_with(job: LoggingJob, queue: :default) do
+        LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later
+      end
     end
 
-    assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
-  end
+    def test_assert_no_enqueued_jobs_and_perform_now
+      assert_no_enqueued_jobs do
+        LoggingJob.perform_now(1, 2, 3, keyword: true)
+      end
+    end
 
-  def test_assert_enqueued_with_args
-    assert_raise ArgumentError do
-      assert_enqueued_with(class: LoggingJob) do
+    def test_assert_enqueued_with_returns
+      job = assert_enqueued_with(job: LoggingJob) do
+        LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
+      end
+
+      assert_instance_of LoggingJob, job
+      assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at.to_f, 1
+      assert_equal "default", job.queue_name
+      assert_equal [1, 2, 3, { keyword: true }], job.arguments
+    end
+
+    def test_assert_enqueued_with_with_no_block_returns
+      LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)
+      job = assert_enqueued_with(job: LoggingJob)
+
+      assert_instance_of LoggingJob, job
+      assert_in_delta 5.minutes.from_now.to_f, job.scheduled_at.to_f, 1
+      assert_equal "default", job.queue_name
+      assert_equal [1, 2, 3, { keyword: true }], job.arguments
+    end
+
+    def test_assert_enqueued_with_failure
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: LoggingJob, queue: "default") do
+          NestedJob.perform_later
+        end
+      end
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        LoggingJob.perform_later
+        assert_enqueued_with(job: LoggingJob) { }
+      end
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: NestedJob, queue: "low") do
+          NestedJob.perform_later
+        end
+      end
+
+      assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
+    end
+
+    def test_assert_enqueued_with_with_no_block_failure
+      assert_raise ActiveSupport::TestCase::Assertion do
+        NestedJob.perform_later
+        assert_enqueued_with(job: LoggingJob, queue: "default")
+      end
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        NestedJob.perform_later
+        assert_enqueued_with(job: NestedJob, queue: "low")
+      end
+
+      assert_match(/No enqueued job found with {:job=>NestedJob, :queue=>"low"}/, error.message)
+    end
+
+    def test_assert_enqueued_with_args
+      assert_raise ArgumentError do
+        assert_enqueued_with(class: LoggingJob) do
+          NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
+        end
+      end
+    end
+
+    def test_assert_enqueued_with_supports_matcher_procs
+      facets = {
+        job: HelloJob,
+        args: ["Rails"],
+        at: Date.tomorrow.noon,
+        queue: "important",
+      }
+
+      facets[:job].set(queue: facets[:queue], wait_until: facets[:at]).perform_later(*facets[:args])
+
+      facets.each do |facet, value|
+        matcher = ->(job_value) { job_value == value }
+        refuser = ->(job_value) { false }
+
+        assert_enqueued_with(**{ facet => matcher })
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_enqueued_with(**{ facet => refuser })
+        end
+      end
+    end
+
+    def test_assert_enqueued_with_time
+      now = Time.now
+      args = [{ argument1: [now] }]
+
+      assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: [now])
+      end
+    end
+
+    def test_assert_enqueued_with_date_time
+      now = DateTime.now
+      args = [{ argument1: [now] }]
+
+      assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: [now])
+      end
+    end
+
+    def test_assert_enqueued_with_time_with_zone
+      now = Time.now.in_time_zone("Tokyo")
+      args = [{ argument1: [now] }]
+
+      assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: [now])
+      end
+    end
+
+    def test_assert_enqueued_with_time_and_time_precision
+      time_with_zone = ActiveSupport::TimeWithZone.new(
+        Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r),
+        ActiveSupport::TimeZone["Tokyo"]
+      )
+
+      time = Time.at(946702800, 1234567, :nanosecond)
+      date_time = DateTime.new(2001, 2, 3, 4, 5, 6.123456, "+03:00")
+      args = [{ argument1: [time_with_zone, time, date_time] }]
+
+      assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: [time_with_zone, time, date_time])
+      end
+    end
+
+    def test_assert_enqueued_with_with_no_block_args
+      assert_raise ArgumentError do
         NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
+        assert_enqueued_with(class: LoggingJob)
       end
     end
-  end
 
-  def test_assert_enqueued_with_supports_matcher_procs
-    facets = {
-      job: HelloJob,
-      args: ["Rails"],
-      at: Date.tomorrow.noon,
-      queue: "important",
-    }
-
-    facets[:job].set(queue: facets[:queue], wait_until: facets[:at]).perform_later(*facets[:args])
-
-    facets.each do |facet, value|
-      matcher = ->(job_value) { job_value == value }
-      refuser = ->(job_value) { false }
-
-      assert_enqueued_with(**{ facet => matcher })
-
-      assert_raises ActiveSupport::TestCase::Assertion do
-        assert_enqueued_with(**{ facet => refuser })
+    def test_assert_enqueued_with_with_at_option
+      assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon) do
+        HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
       end
     end
-  end
 
-  def test_assert_enqueued_with_time
-    now = Time.now
-    args = [{ argument1: [now] }]
-
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: [now])
+    def test_assert_enqueued_with_with_relative_at_option
+      assert_enqueued_with(job: HelloJob, at: 5.minutes.from_now) do
+        HelloJob.set(wait: 5.minutes).perform_later
+      end
     end
-  end
 
-  def test_assert_enqueued_with_date_time
-    now = DateTime.now
-    args = [{ argument1: [now] }]
-
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: [now])
-    end
-  end
-
-  def test_assert_enqueued_with_time_with_zone
-    now = Time.now.in_time_zone("Tokyo")
-    args = [{ argument1: [now] }]
-
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: [now])
-    end
-  end
-
-  def test_assert_enqueued_with_time_and_time_precision
-    time_with_zone = ActiveSupport::TimeWithZone.new(
-      Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r),
-      ActiveSupport::TimeZone["Tokyo"]
-    )
-
-    time = Time.at(946702800, 1234567, :nanosecond)
-    date_time = DateTime.new(2001, 2, 3, 4, 5, 6.123456, "+03:00")
-    args = [{ argument1: [time_with_zone, time, date_time] }]
-
-    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: [time_with_zone, time, date_time])
-    end
-  end
-
-  def test_assert_enqueued_with_with_no_block_args
-    assert_raise ArgumentError do
-      NestedJob.set(wait_until: Date.tomorrow.noon).perform_later
-      assert_enqueued_with(class: LoggingJob)
-    end
-  end
-
-  def test_assert_enqueued_with_with_at_option
-    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon) do
+    def test_assert_enqueued_with_with_no_block_with_at_option
       HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+      assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
     end
-  end
 
-  def test_assert_enqueued_with_with_relative_at_option
-    assert_enqueued_with(job: HelloJob, at: 5.minutes.from_now) do
-      HelloJob.set(wait: 5.minutes).perform_later
+    def test_assert_enqueued_with_wait_until_with_performed
+      assert_enqueued_with(job: LoggingJob) do
+        perform_enqueued_jobs(only: HelloJob) do
+          HelloJob.set(wait_until: Date.tomorrow.noon).perform_later("david")
+          LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later("enqueue")
+        end
+      end
+      assert_enqueued_jobs 1
+      assert_performed_jobs 1
     end
-  end
 
-  def test_assert_enqueued_with_with_no_block_with_at_option
-    HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
-    assert_enqueued_with(job: HelloJob, at: Date.tomorrow.noon)
-  end
-
-  def test_assert_enqueued_with_wait_until_with_performed
-    assert_enqueued_with(job: LoggingJob) do
-      perform_enqueued_jobs(only: HelloJob) do
-        HelloJob.set(wait_until: Date.tomorrow.noon).perform_later("david")
-        LoggingJob.set(wait_until: Date.tomorrow.noon).perform_later("enqueue")
+    def test_assert_enqueued_with_with_hash_arg
+      assert_enqueued_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
+        MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
       end
     end
-    assert_enqueued_jobs 1
-    assert_performed_jobs 1
-  end
 
-  def test_assert_enqueued_with_with_hash_arg
-    assert_enqueued_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
-      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
-    end
-  end
-
-  def test_assert_enqueued_with_with_global_id_args
-    ricardo = Person.new(9)
-    assert_enqueued_with(job: HelloJob, args: [ricardo]) do
-      HelloJob.perform_later(ricardo)
-    end
-  end
-
-  def test_assert_enqueued_with_with_no_block_with_global_id_args
-    ricardo = Person.new(9)
-    HelloJob.perform_later(ricardo)
-    assert_enqueued_with(job: HelloJob, args: [ricardo])
-  end
-
-  def test_assert_enqueued_with_failure_with_global_id_args
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_with(job: HelloJob, args: [wilma]) do
+    def test_assert_enqueued_with_with_global_id_args
+      ricardo = Person.new(9)
+      assert_enqueued_with(job: HelloJob, args: [ricardo]) do
         HelloJob.perform_later(ricardo)
       end
     end
 
-    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
-  end
-
-  def test_show_jobs_that_are_enqueued_when_job_is_not_queued_at_all
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_with(job: MultipleKwargsJob, args: [wilma]) do
-        HelloJob.perform_later(ricardo)
-      end
-    end
-
-    assert_match(/No enqueued job found with {:job=>MultipleKwargsJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/No jobs of class MultipleKwargsJob were enqueued, job classes enqueued: HelloJob/, error.message)
-  end
-
-  def test_shows_no_jobs_enqueued_when_there_are_no_jobs
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_enqueued_with(job: HelloJob, args: []) do
-      end
-    end
-
-    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
-    assert_match(/No jobs were enqueued/, error.message)
-  end
-
-  def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-    error = assert_raise ActiveSupport::TestCase::Assertion do
+    def test_assert_enqueued_with_with_no_block_with_global_id_args
+      ricardo = Person.new(9)
       HelloJob.perform_later(ricardo)
-      assert_enqueued_with(job: HelloJob, args: [wilma])
+      assert_enqueued_with(job: HelloJob, args: [ricardo])
     end
 
-    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
-  end
+    def test_assert_enqueued_with_failure_with_global_id_args
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: HelloJob, args: [wilma]) do
+          HelloJob.perform_later(ricardo)
+        end
+      end
 
-  def test_assert_enqueued_with_does_not_change_jobs_count
-    HelloJob.perform_later
-    assert_enqueued_with(job: HelloJob) do
+      assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+      assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
+    end
+
+    def test_show_jobs_that_are_enqueued_when_job_is_not_queued_at_all
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: MultipleKwargsJob, args: [wilma]) do
+          HelloJob.perform_later(ricardo)
+        end
+      end
+
+      assert_match(/No enqueued job found with {:job=>MultipleKwargsJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+      assert_match(/No jobs of class MultipleKwargsJob were enqueued, job classes enqueued: HelloJob/, error.message)
+    end
+
+    def test_shows_no_jobs_enqueued_when_there_are_no_jobs
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_enqueued_with(job: HelloJob, args: []) do
+        end
+      end
+
+      assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
+      assert_match(/No jobs were enqueued/, error.message)
+    end
+
+    def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        HelloJob.perform_later(ricardo)
+        assert_enqueued_with(job: HelloJob, args: [wilma])
+      end
+
+      assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+      assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
+    end
+
+    def test_assert_enqueued_with_does_not_change_jobs_count
       HelloJob.perform_later
-    end
-
-    assert_equal 2, queue_adapter.enqueued_jobs.count
-  end
-
-  def test_assert_enqueued_with_with_no_block_does_not_change_jobs_count
-    HelloJob.perform_later
-    HelloJob.perform_later
-    assert_enqueued_with(job: HelloJob)
-
-    assert_equal 2, queue_adapter.enqueued_jobs.count
-  end
-
-  def test_assert_enqueued_jobs_with_performed
-    assert_enqueued_with(job: LoggingJob) do
-      perform_enqueued_jobs(only: HelloJob) do
-        HelloJob.perform_later("david")
-        LoggingJob.perform_later("enqueue")
+      assert_enqueued_with(job: HelloJob) do
+        HelloJob.perform_later
       end
+
+      assert_equal 2, queue_adapter.enqueued_jobs.count
     end
-    assert_enqueued_jobs 1
-    assert_performed_jobs 1
+
+    def test_assert_enqueued_with_with_no_block_does_not_change_jobs_count
+      HelloJob.perform_later
+      HelloJob.perform_later
+      assert_enqueued_with(job: HelloJob)
+
+      assert_equal 2, queue_adapter.enqueued_jobs.count
+    end
+
+    def test_assert_enqueued_jobs_with_performed
+      assert_enqueued_with(job: LoggingJob) do
+        perform_enqueued_jobs(only: HelloJob) do
+          HelloJob.perform_later("david")
+          LoggingJob.perform_later("enqueue")
+        end
+      end
+      assert_enqueued_jobs 1
+      assert_performed_jobs 1
+    end
   end
 end
 
 class PerformedJobsTest < ActiveJob::TestCase
-  def test_perform_enqueued_jobs_with_only_option_doesnt_leak_outside_the_block
-    assert_nil queue_adapter.filter
-    perform_enqueued_jobs only: HelloJob do
-      assert_equal HelloJob, queue_adapter.filter
-    end
-    assert_nil queue_adapter.filter
-  end
+  if adapter_is?(:test)
+    include DoNotPerformEnqueuedJobs
 
-  def test_perform_enqueued_jobs_without_block_with_only_option_doesnt_leak
-    perform_enqueued_jobs only: HelloJob
-
-    assert_nil queue_adapter.filter
-  end
-
-  def test_perform_enqueued_jobs_with_except_option_doesnt_leak_outside_the_block
-    assert_nil queue_adapter.reject
-    perform_enqueued_jobs except: HelloJob do
-      assert_equal HelloJob, queue_adapter.reject
-    end
-    assert_nil queue_adapter.reject
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_except_option_doesnt_leak
-    perform_enqueued_jobs except: HelloJob
-
-    assert_nil queue_adapter.reject
-  end
-
-  def test_perform_enqueued_jobs_with_queue_option_doesnt_leak_outside_the_block
-    assert_nil queue_adapter.queue
-    perform_enqueued_jobs queue: :some_queue do
-      assert_equal :some_queue, queue_adapter.queue
-    end
-    assert_nil queue_adapter.queue
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_queue_option_doesnt_leak
-    perform_enqueued_jobs queue: :some_queue
-
-    assert_nil queue_adapter.reject
-  end
-
-  def test_perform_enqueued_jobs_with_block
-    perform_enqueued_jobs do
-      HelloJob.perform_later("kevin")
-      LoggingJob.perform_later("bogdan")
-    end
-
-    assert_performed_jobs 2
-  end
-
-  def test_perform_enqueued_jobs_without_block
-    HelloJob.perform_later("kevin")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 2
-  end
-
-  def test_perform_enqueued_jobs_with_block_with_only_option
-    perform_enqueued_jobs only: LoggingJob do
-      HelloJob.perform_later("kevin")
-      LoggingJob.perform_later("bogdan")
-    end
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_only_option
-    HelloJob.perform_later("kevin")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs only: LoggingJob
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob
-  end
-
-  def test_perform_enqueued_jobs_with_block_with_except_option
-    perform_enqueued_jobs except: HelloJob do
-      HelloJob.perform_later("kevin")
-      LoggingJob.perform_later("bogdan")
-    end
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_except_option
-    HelloJob.perform_later("kevin")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs except: HelloJob
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob
-  end
-
-  def test_perform_enqueued_jobs_with_block_with_queue_option
-    perform_enqueued_jobs queue: :some_queue do
-      HelloJob.set(queue: :some_queue).perform_later("kevin")
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
-      LoggingJob.perform_later("bogdan")
-    end
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: HelloJob, queue: :some_queue
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_queue_option
-    HelloJob.set(queue: :some_queue).perform_later("kevin")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs queue: :some_queue
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: HelloJob, queue: :some_queue
-  end
-
-  def test_perform_enqueued_jobs_with_block_with_only_and_queue_options
-    perform_enqueued_jobs only: HelloJob, queue: :other_queue do
-      HelloJob.set(queue: :some_queue).perform_later("kevin")
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :other_queue).perform_later("bogdan")
-    end
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: HelloJob, queue: :other_queue
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_only_and_queue_options
-    HelloJob.set(queue: :some_queue).perform_later("kevin")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :other_queue).perform_later("bogdan")
-
-    perform_enqueued_jobs only: HelloJob, queue: :other_queue
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: HelloJob, queue: :other_queue
-  end
-
-  def test_perform_enqueued_jobs_with_block_with_except_and_queue_options
-    perform_enqueued_jobs except: HelloJob, queue: :other_queue do
-      HelloJob.set(queue: :other_queue).perform_later("kevin")
-      LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :other_queue).perform_later("bogdan")
-    end
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob, queue: :other_queue
-  end
-
-  def test_perform_enqueued_jobs_without_block_with_except_and_queue_options
-    HelloJob.set(queue: :other_queue).perform_later("kevin")
-    LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :other_queue).perform_later("bogdan")
-
-    perform_enqueued_jobs except: HelloJob, queue: :other_queue
-
-    assert_performed_jobs 1
-    assert_performed_jobs 1, only: LoggingJob, queue: :other_queue
-  end
-
-  def test_perform_enqueued_jobs_with_at_with_job_performed_now
-    HelloJob.perform_later("kevin")
-
-    perform_enqueued_jobs(at: Time.now)
-
-    assert_performed_jobs 1
-  end
-
-  def test_perform_enqueued_jobs_with_at_with_job_wait_in_past
-    HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
-
-    perform_enqueued_jobs(at: Time.now)
-
-    assert_performed_jobs 1
-  end
-
-  def test_perform_enqueued_jobs_with_at_with_job_wait_in_future
-    HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
-
-    perform_enqueued_jobs(at: Time.now)
-
-    assert_performed_jobs 0
-  end
-
-  def test_perform_enqueued_jobs_block_with_at_with_job_performed_now
-    perform_enqueued_jobs(at: Time.now) do
-      HelloJob.perform_later("kevin")
-    end
-
-    assert_performed_jobs 1
-  end
-
-  def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_past
-    perform_enqueued_jobs(at: Time.now) do
-      HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
-    end
-
-    assert_performed_jobs 1
-  end
-
-  def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_future
-    perform_enqueued_jobs(at: Time.now) do
-      HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
-    end
-
-    assert_performed_jobs 0
-  end
-
-  def test_perform_enqueued_jobs_properly_count_job_that_raises
-    RaisingJob.perform_later("NotImplementedError")
-
-    assert_raises(NotImplementedError) do
-      perform_enqueued_jobs(only: RaisingJob)
-    end
-
-    assert_equal(1, performed_jobs.size)
-  end
-
-  def test_perform_enqueued_jobs_dont_perform_retries
-    RaisingJob.perform_later
-
-    assert_nothing_raised do
-      perform_enqueued_jobs(only: RaisingJob)
-    end
-
-    assert_equal(1, performed_jobs.size)
-    assert_equal(1, enqueued_jobs.size)
-  end
-
-  def test_perform_enqueued_jobs_without_block_removes_from_enqueued_jobs
-    HelloJob.perform_later("rafael")
-    assert_equal(0, performed_jobs.size)
-    assert_equal(1, enqueued_jobs.size)
-    perform_enqueued_jobs
-    assert_equal(1, performed_jobs.size)
-    assert_equal(0, enqueued_jobs.size)
-  end
-
-  def test_perform_enqueued_jobs_without_block_works_with_other_helpers
-    NestedJob.perform_later
-    assert_equal(0, performed_jobs.size)
-    assert_equal(1, enqueued_jobs.size)
-    assert_enqueued_jobs(1) do
-      assert_enqueued_with(job: LoggingJob) do
-        perform_enqueued_jobs
+    def test_perform_enqueued_jobs_with_only_option_doesnt_leak_outside_the_block
+      assert_nil queue_adapter.filter
+      perform_enqueued_jobs only: HelloJob do
+        assert_equal HelloJob, queue_adapter.filter
       end
+      assert_nil queue_adapter.filter
     end
-    assert_equal(1, performed_jobs.size)
-    assert_equal(1, enqueued_jobs.size)
-  end
 
-  def test_perform_enqueued_jobs_without_block_only_performs_once
-    JobBuffer.clear
-    RescueJob.perform_later("no exception")
-    perform_enqueued_jobs
-    perform_enqueued_jobs
-    assert_equal(1, JobBuffer.values.size)
-  end
+    def test_perform_enqueued_jobs_without_block_with_only_option_doesnt_leak
+      perform_enqueued_jobs only: HelloJob
 
-  def test_assert_performed_jobs
-    assert_nothing_raised do
-      assert_performed_jobs 1 do
-        HelloJob.perform_later("david")
+      assert_nil queue_adapter.filter
+    end
+
+    def test_perform_enqueued_jobs_with_except_option_doesnt_leak_outside_the_block
+      assert_nil queue_adapter.reject
+      perform_enqueued_jobs except: HelloJob do
+        assert_equal HelloJob, queue_adapter.reject
       end
+      assert_nil queue_adapter.reject
     end
-  end
 
-  def test_repeated_performed_jobs_calls
-    assert_nothing_raised do
-      assert_performed_jobs 1 do
-        HelloJob.perform_later("abdelkader")
+    def test_perform_enqueued_jobs_without_block_with_except_option_doesnt_leak
+      perform_enqueued_jobs except: HelloJob
+
+      assert_nil queue_adapter.reject
+    end
+
+    def test_perform_enqueued_jobs_with_queue_option_doesnt_leak_outside_the_block
+      assert_nil queue_adapter.queue
+      perform_enqueued_jobs queue: :some_queue do
+        assert_equal :some_queue, queue_adapter.queue
       end
+      assert_nil queue_adapter.queue
     end
 
-    assert_nothing_raised do
-      assert_performed_jobs 2 do
-        HelloJob.perform_later("sean")
-        HelloJob.perform_later("yves")
-      end
-    end
-  end
+    def test_perform_enqueued_jobs_without_block_with_queue_option_doesnt_leak
+      perform_enqueued_jobs queue: :some_queue
 
-  def test_assert_performed_jobs_message
-    HelloJob.perform_later("sean")
-    e = assert_raises Minitest::Assertion do
-      assert_performed_jobs 2 do
-        HelloJob.perform_later("sean")
-      end
+      assert_nil queue_adapter.reject
     end
-    assert_match "Expected: 2", e.message
-    assert_match "Actual: 1", e.message
-  end
 
-  def test_assert_performed_jobs_with_no_block
-    assert_nothing_raised do
+    def test_perform_enqueued_jobs_with_block
       perform_enqueued_jobs do
-        HelloJob.perform_later("rafael")
-      end
-      assert_performed_jobs 1
-    end
-
-    assert_nothing_raised do
-      perform_enqueued_jobs do
-        HelloJob.perform_later("aaron")
-        HelloJob.perform_later("matthew")
-        assert_performed_jobs 3
-      end
-    end
-  end
-
-  def test_assert_no_performed_jobs_with_no_block
-    assert_nothing_raised do
-      assert_no_performed_jobs
-    end
-  end
-
-  def test_assert_no_performed_jobs
-    assert_nothing_raised do
-      assert_no_performed_jobs do
-        # empty block won't perform jobs
-      end
-    end
-  end
-
-  def test_assert_performed_jobs_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 2 do
-        HelloJob.perform_later("xavier")
-      end
-    end
-
-    assert_match(/2 .* but 1/, error.message)
-  end
-
-  def test_assert_performed_jobs_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1 do
-        HelloJob.perform_later("cristian")
-        HelloJob.perform_later("guillermo")
-      end
-    end
-
-    assert_match(/1 .* but 2/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs do
-        HelloJob.perform_later("jeremy")
-      end
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_option
-    assert_nothing_raised do
-      assert_performed_jobs 1, only: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_performed_jobs_with_only_option_as_proc
-    assert_nothing_raised do
-      assert_performed_jobs(1, only: ->(job) { job.is_a?(HelloJob) }) do
-        HelloJob.perform_later("jeremy")
+        HelloJob.perform_later("kevin")
         LoggingJob.perform_later("bogdan")
       end
-    end
-  end
 
-  def test_assert_performed_jobs_without_block_with_only_option
-    HelloJob.perform_later("jeremy")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 1, only: HelloJob
-  end
-
-  def test_assert_performed_jobs_without_block_with_only_option_as_proc
-    HelloJob.perform_later("jeremy")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" })
-  end
-
-  def test_assert_performed_jobs_without_block_with_only_option_failure
-    LoggingJob.perform_later("jeremy")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, only: HelloJob
+      assert_performed_jobs 2
     end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_except_option
-    assert_nothing_raised do
-      assert_performed_jobs 1, except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_performed_jobs_with_except_option_as_proc
-    assert_nothing_raised do
-      assert_performed_jobs(1, except: ->(job) { job.is_a?(HelloJob) }) do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("bogdan")
-      end
-    end
-  end
-
-  def test_assert_performed_jobs_without_block_with_except_option
-    HelloJob.perform_later("jeremy")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 1, except: HelloJob
-  end
-
-  def test_assert_performed_jobs_without_block_with_except_option_as_proc
-    HelloJob.perform_later("jeremy")
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs(1, except: ->(job) { job.fetch(:job).name == "HelloJob" })
-  end
-
-  def test_assert_performed_jobs_without_block_with_except_option_failure
-    HelloJob.perform_later("jeremy")
-    HelloJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, except: HelloJob
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_and_except_option
-    error = assert_raise ArgumentError do
-      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_performed_jobs_without_block_with_only_and_except_options
-    error = assert_raise ArgumentError do
-      HelloJob.perform_later("jeremy")
+    def test_perform_enqueued_jobs_without_block
+      HelloJob.perform_later("kevin")
       LoggingJob.perform_later("bogdan")
 
       perform_enqueued_jobs
 
-      assert_performed_jobs 1, only: HelloJob, except: HelloJob
+      assert_performed_jobs 2
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_option_as_array
-    assert_nothing_raised do
-      assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
+    def test_perform_enqueued_jobs_with_block_with_only_option
+      perform_enqueued_jobs only: LoggingJob do
+        HelloJob.perform_later("kevin")
+        LoggingJob.perform_later("bogdan")
       end
-    end
-  end
 
-  def test_assert_performed_jobs_with_except_option_as_array
-    assert_nothing_raised do
-      assert_performed_jobs 1, except: [LoggingJob, RescueJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob
+    end
+
+    def test_perform_enqueued_jobs_without_block_with_only_option
+      HelloJob.perform_later("kevin")
+      LoggingJob.perform_later("bogdan")
+
+      perform_enqueued_jobs only: LoggingJob
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob
+    end
+
+    def test_perform_enqueued_jobs_with_block_with_except_option
+      perform_enqueued_jobs except: HelloJob do
+        HelloJob.perform_later("kevin")
+        LoggingJob.perform_later("bogdan")
       end
-    end
-  end
 
-  def test_assert_performed_jobs_with_only_and_except_option_as_array
-    error = assert_raise ArgumentError do
-      assert_performed_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later("stewie")
-        RescueJob.perform_later("david")
-      end
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_perform_enqueued_jobs_without_block_with_except_option
+      HelloJob.perform_later("kevin")
+      LoggingJob.perform_later("bogdan")
 
-  def test_assert_performed_jobs_with_only_option_and_none_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, only: HelloJob do
-        LoggingJob.perform_later
-      end
+      perform_enqueued_jobs except: HelloJob
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob
     end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_except_option_and_none_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, except: LoggingJob do
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_and_except_option_and_none_sent
-    error = assert_raise ArgumentError do
-      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
-        LoggingJob.perform_later
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_option_and_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 5, only: HelloJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
-      end
-    end
-
-    assert_match(/5 .* but 1/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_except_option_and_too_few_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 5, except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
-      end
-    end
-
-    assert_match(/5 .* but 1/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_and_except_option_and_too_few_sent
-    error = assert_raise ArgumentError do
-      assert_performed_jobs 5, only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        4.times { LoggingJob.perform_later }
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_option_and_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, only: HelloJob do
-        2.times { HelloJob.perform_later("jeremy") }
-      end
-    end
-
-    assert_match(/1 .* but 2/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_except_option_and_too_many_sent
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, except: LoggingJob do
-        2.times { HelloJob.perform_later("jeremy") }
-      end
-    end
-
-    assert_match(/1 .* but 2/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_and_except_option_and_too_many_sent
-    error = assert_raise ArgumentError do
-      assert_performed_jobs 1, only: HelloJob, except: HelloJob do
-        2.times { HelloJob.perform_later("jeremy") }
-      end
-    end
-
-    assert_match(/`:only` and `:except`/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_queue_option
-    assert_performed_jobs 1, queue: :some_queue do
-      HelloJob.set(queue: :some_queue).perform_later("jeremy")
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    end
-  end
-
-  def test_assert_performed_jobs_with_queue_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later("jeremy")
+    def test_perform_enqueued_jobs_with_block_with_queue_option
+      perform_enqueued_jobs queue: :some_queue do
+        HelloJob.set(queue: :some_queue).perform_later("kevin")
         HelloJob.set(queue: :other_queue).perform_later("bogdan")
+        LoggingJob.perform_later("bogdan")
       end
-    end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_without_block_with_queue_option
-    HelloJob.set(queue: :some_queue).perform_later("jeremy")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 1, queue: :some_queue
-  end
-
-  def test_assert_performed_jobs_without_block_with_queue_option_failure
-    HelloJob.set(queue: :other_queue).perform_later("jeremy")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, queue: :some_queue
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_with_only_and_queue_options
-    assert_performed_jobs 1, only: HelloJob, queue: :some_queue do
-      HelloJob.set(queue: :some_queue).perform_later("jeremy")
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-    end
-  end
-
-  def test_assert_performed_jobs_with_only_and_queue_options_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, only: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :other_queue).perform_later("jeremy")
-        HelloJob.set(queue: :other_queue).perform_later("bogdan")
-        LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-      end
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_without_block_with_only_and_queue_options
-    HelloJob.set(queue: :some_queue).perform_later("jeremy")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 1, only: HelloJob, queue: :some_queue
-  end
-
-  def test_assert_performed_jobs_without_block_with_only_and_queue_options_failure
-    HelloJob.set(queue: :other_queue).perform_later("jeremy")
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_jobs 1
       assert_performed_jobs 1, only: HelloJob, queue: :some_queue
     end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
+    def test_perform_enqueued_jobs_without_block_with_queue_option
+      HelloJob.set(queue: :some_queue).perform_later("kevin")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      LoggingJob.perform_later("bogdan")
 
-  def test_assert_performed_jobs_with_except_and_queue_options
-    assert_performed_jobs 1, except: HelloJob, queue: :other_queue do
-      HelloJob.set(queue: :other_queue).perform_later("jeremy")
-      LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :other_queue).perform_later("jeremy")
+      perform_enqueued_jobs queue: :some_queue
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: HelloJob, queue: :some_queue
     end
-  end
 
-  def test_assert_performed_jobs_with_except_and_queue_options_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, except: HelloJob, queue: :other_queue do
-        HelloJob.set(queue: :other_queue).perform_later("jeremy")
+    def test_perform_enqueued_jobs_with_block_with_only_and_queue_options
+      perform_enqueued_jobs only: HelloJob, queue: :other_queue do
+        HelloJob.set(queue: :some_queue).perform_later("kevin")
+        HelloJob.set(queue: :other_queue).perform_later("bogdan")
+        LoggingJob.set(queue: :other_queue).perform_later("bogdan")
+      end
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: HelloJob, queue: :other_queue
+    end
+
+    def test_perform_enqueued_jobs_without_block_with_only_and_queue_options
+      HelloJob.set(queue: :some_queue).perform_later("kevin")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :other_queue).perform_later("bogdan")
+
+      perform_enqueued_jobs only: HelloJob, queue: :other_queue
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: HelloJob, queue: :other_queue
+    end
+
+    def test_perform_enqueued_jobs_with_block_with_except_and_queue_options
+      perform_enqueued_jobs except: HelloJob, queue: :other_queue do
+        HelloJob.set(queue: :other_queue).perform_later("kevin")
         LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-        LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        LoggingJob.set(queue: :other_queue).perform_later("bogdan")
+      end
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob, queue: :other_queue
+    end
+
+    def test_perform_enqueued_jobs_without_block_with_except_and_queue_options
+      HelloJob.set(queue: :other_queue).perform_later("kevin")
+      LoggingJob.set(queue: :some_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :other_queue).perform_later("bogdan")
+
+      perform_enqueued_jobs except: HelloJob, queue: :other_queue
+
+      assert_performed_jobs 1
+      assert_performed_jobs 1, only: LoggingJob, queue: :other_queue
+    end
+
+    def test_perform_enqueued_jobs_with_at_with_job_performed_now
+      HelloJob.perform_later("kevin")
+
+      perform_enqueued_jobs(at: Time.now)
+
+      assert_performed_jobs 1
+    end
+
+    def test_perform_enqueued_jobs_with_at_with_job_wait_in_past
+      HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
+
+      perform_enqueued_jobs(at: Time.now)
+
+      assert_performed_jobs 1
+    end
+
+    def test_perform_enqueued_jobs_with_at_with_job_wait_in_future
+      HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
+
+      perform_enqueued_jobs(at: Time.now)
+
+      assert_performed_jobs 0
+    end
+
+    def test_perform_enqueued_jobs_block_with_at_with_job_performed_now
+      perform_enqueued_jobs(at: Time.now) do
+        HelloJob.perform_later("kevin")
+      end
+
+      assert_performed_jobs 1
+    end
+
+    def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_past
+      perform_enqueued_jobs(at: Time.now) do
+        HelloJob.set(wait_until: Time.now - 100).perform_later("kevin")
+      end
+
+      assert_performed_jobs 1
+    end
+
+    def test_perform_enqueued_jobs_block_with_at_with_job_wait_in_future
+      perform_enqueued_jobs(at: Time.now) do
+        HelloJob.set(wait_until: Time.now + 100).perform_later("kevin")
+      end
+
+      assert_performed_jobs 0
+    end
+
+    def test_perform_enqueued_jobs_properly_count_job_that_raises
+      RaisingJob.perform_later("NotImplementedError")
+
+      assert_raises(NotImplementedError) do
+        perform_enqueued_jobs(only: RaisingJob)
+      end
+
+      assert_equal(1, performed_jobs.size)
+    end
+
+    def test_perform_enqueued_jobs_dont_perform_retries
+      RaisingJob.perform_later
+
+      assert_nothing_raised do
+        perform_enqueued_jobs(only: RaisingJob)
+      end
+
+      assert_equal(1, performed_jobs.size)
+      assert_equal(1, enqueued_jobs.size)
+    end
+
+    def test_perform_enqueued_jobs_without_block_removes_from_enqueued_jobs
+      HelloJob.perform_later("rafael")
+      assert_equal(0, performed_jobs.size)
+      assert_equal(1, enqueued_jobs.size)
+      perform_enqueued_jobs
+      assert_equal(1, performed_jobs.size)
+      assert_equal(0, enqueued_jobs.size)
+    end
+
+    def test_perform_enqueued_jobs_without_block_works_with_other_helpers
+      NestedJob.perform_later
+      assert_equal(0, performed_jobs.size)
+      assert_equal(1, enqueued_jobs.size)
+      assert_enqueued_jobs(1) do
+        assert_enqueued_with(job: LoggingJob) do
+          perform_enqueued_jobs
+        end
+      end
+      assert_equal(1, performed_jobs.size)
+      assert_equal(1, enqueued_jobs.size)
+    end
+
+    def test_perform_enqueued_jobs_without_block_only_performs_once
+      JobBuffer.clear
+      RescueJob.perform_later("no exception")
+      perform_enqueued_jobs
+      perform_enqueued_jobs
+      assert_equal(1, JobBuffer.values.size)
+    end
+
+    def test_assert_performed_jobs
+      assert_nothing_raised do
+        assert_performed_jobs 1 do
+          HelloJob.perform_later("david")
+        end
       end
     end
 
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_performed_jobs_without_block_with_except_and_queue_options
-    HelloJob.set(queue: :other_queue).perform_later("jeremy")
-    LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :other_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    assert_performed_jobs 1, except: HelloJob, queue: :other_queue
-  end
-
-  def test_assert_performed_jobs_without_block_with_except_and_queue_options_failure
-    HelloJob.set(queue: :other_queue).perform_later("jeremy")
-    LoggingJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_jobs 1, except: HelloJob, queue: :other_queue
-    end
-
-    assert_match(/1 .* but 0/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_only_option
-    assert_nothing_raised do
-      assert_no_performed_jobs only: HelloJob do
-        LoggingJob.perform_later
+    def test_repeated_performed_jobs_calls
+      assert_nothing_raised do
+        assert_performed_jobs 1 do
+          HelloJob.perform_later("abdelkader")
+        end
       end
-    end
-  end
 
-  def test_assert_no_performed_jobs_without_block_with_only_option
-    LoggingJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    assert_no_performed_jobs only: HelloJob
-  end
-
-  def test_assert_no_performed_jobs_without_block_with_only_option_failure
-    HelloJob.perform_later("bogdan")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs only: HelloJob
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_except_option
-    assert_nothing_raised do
-      assert_no_performed_jobs except: LoggingJob do
-        LoggingJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_no_performed_jobs_without_block_with_except_option
-    HelloJob.perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    assert_no_performed_jobs except: HelloJob
-  end
-
-  def test_assert_no_performed_jobs_without_block_with_except_option_failure
-    LoggingJob.perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs except: HelloJob
-    end
-
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_only_and_except_option
-    error = assert_raise ArgumentError do
-      assert_no_performed_jobs only: HelloJob, except: HelloJob do
-        LoggingJob.perform_later
+      assert_nothing_raised do
+        assert_performed_jobs 2 do
+          HelloJob.perform_later("sean")
+          HelloJob.perform_later("yves")
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_performed_jobs_message
+      HelloJob.perform_later("sean")
+      e = assert_raises Minitest::Assertion do
+        assert_performed_jobs 2 do
+          HelloJob.perform_later("sean")
+        end
+      end
+      assert_match "Expected: 2", e.message
+      assert_match "Actual: 1", e.message
+    end
 
-  def test_assert_no_performed_jobs_without_block_with_only_and_except_options
-    error = assert_raise ArgumentError do
+    def test_assert_performed_jobs_with_no_block
+      assert_nothing_raised do
+        perform_enqueued_jobs do
+          HelloJob.perform_later("rafael")
+        end
+        assert_performed_jobs 1
+      end
+
+      assert_nothing_raised do
+        perform_enqueued_jobs do
+          HelloJob.perform_later("aaron")
+          HelloJob.perform_later("matthew")
+          assert_performed_jobs 3
+        end
+      end
+    end
+
+    def test_assert_no_performed_jobs_with_no_block
+      assert_nothing_raised do
+        assert_no_performed_jobs
+      end
+    end
+
+    def test_assert_no_performed_jobs
+      assert_nothing_raised do
+        assert_no_performed_jobs do
+          # empty block won't perform jobs
+        end
+      end
+    end
+
+    def test_assert_performed_jobs_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 2 do
+          HelloJob.perform_later("xavier")
+        end
+      end
+
+      assert_match(/2 .* but 1/, error.message)
+    end
+
+    def test_assert_performed_jobs_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1 do
+          HelloJob.perform_later("cristian")
+          HelloJob.perform_later("guillermo")
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs do
+          HelloJob.perform_later("jeremy")
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_option
+      assert_nothing_raised do
+        assert_performed_jobs 1, only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_performed_jobs_with_only_option_as_proc
+      assert_nothing_raised do
+        assert_performed_jobs(1, only: ->(job) { job.is_a?(HelloJob) }) do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("bogdan")
+        end
+      end
+    end
+
+    def test_assert_performed_jobs_without_block_with_only_option
       HelloJob.perform_later("jeremy")
       LoggingJob.perform_later("bogdan")
 
       perform_enqueued_jobs
 
-      assert_no_performed_jobs only: HelloJob, except: HelloJob
+      assert_performed_jobs 1, only: HelloJob
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_performed_jobs_without_block_with_only_option_as_proc
+      HelloJob.perform_later("jeremy")
+      LoggingJob.perform_later("bogdan")
 
-  def test_assert_no_performed_jobs_with_only_option_as_array
-    assert_nothing_raised do
-      assert_no_performed_jobs only: [HelloJob, RescueJob] do
-        LoggingJob.perform_later
+      perform_enqueued_jobs
+
+      assert_performed_jobs(1, only: ->(job) { job.fetch(:job).name == "HelloJob" })
+    end
+
+    def test_assert_performed_jobs_without_block_with_only_option_failure
+      LoggingJob.perform_later("jeremy")
+      LoggingJob.perform_later("bogdan")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, only: HelloJob
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_except_option
+      assert_nothing_raised do
+        assert_performed_jobs 1, except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
       end
     end
-  end
 
-  def test_assert_no_performed_jobs_with_except_option_as_array
-    assert_nothing_raised do
-      assert_no_performed_jobs except: [HelloJob, RescueJob] do
-        HelloJob.perform_later
-        RescueJob.perform_later
-      end
-    end
-  end
-
-  def test_assert_no_performed_jobs_with_only_and_except_option_as_array
-    error = assert_raise ArgumentError do
-      assert_no_performed_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
-        LoggingJob.perform_later
+    def test_assert_performed_jobs_with_except_option_as_proc
+      assert_nothing_raised do
+        assert_performed_jobs(1, except: ->(job) { job.is_a?(HelloJob) }) do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("bogdan")
+        end
       end
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_performed_jobs_without_block_with_except_option
+      HelloJob.perform_later("jeremy")
+      LoggingJob.perform_later("bogdan")
 
-  def test_assert_no_performed_jobs_with_only_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs only: HelloJob do
+      perform_enqueued_jobs
+
+      assert_performed_jobs 1, except: HelloJob
+    end
+
+    def test_assert_performed_jobs_without_block_with_except_option_as_proc
+      HelloJob.perform_later("jeremy")
+      LoggingJob.perform_later("bogdan")
+
+      perform_enqueued_jobs
+
+      assert_performed_jobs(1, except: ->(job) { job.fetch(:job).name == "HelloJob" })
+    end
+
+    def test_assert_performed_jobs_without_block_with_except_option_failure
+      HelloJob.perform_later("jeremy")
+      HelloJob.perform_later("bogdan")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, except: HelloJob
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_and_except_option
+      error = assert_raise ArgumentError do
+        assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_performed_jobs_without_block_with_only_and_except_options
+      error = assert_raise ArgumentError do
         HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
+        LoggingJob.perform_later("bogdan")
+
+        perform_enqueued_jobs
+
+        assert_performed_jobs 1, only: HelloJob, except: HelloJob
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_option_as_array
+      assert_nothing_raised do
+        assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_except_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs except: LoggingJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
+    def test_assert_performed_jobs_with_except_option_as_array
+      assert_nothing_raised do
+        assert_performed_jobs 1, except: [LoggingJob, RescueJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_only_and_except_option_failure
-    error = assert_raise ArgumentError do
-      assert_no_performed_jobs only: HelloJob, except: HelloJob do
-        HelloJob.perform_later("jeremy")
-        LoggingJob.perform_later
+    def test_assert_performed_jobs_with_only_and_except_option_as_array
+      error = assert_raise ArgumentError do
+        assert_performed_jobs 2, only: [HelloJob, LoggingJob], except: [HelloJob, LoggingJob] do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later("stewie")
+          RescueJob.perform_later("david")
+        end
       end
+
+      assert_match(/`:only` and `:except`/, error.message)
     end
 
-    assert_match(/`:only` and `:except`/, error.message)
-  end
+    def test_assert_performed_jobs_with_only_option_and_none_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, only: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
 
-  def test_assert_no_performed_jobs_with_queue_option
-    assert_no_performed_jobs queue: :some_queue do
-      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      assert_match(/1 .* but 0/, error.message)
     end
-  end
 
-  def test_assert_no_performed_jobs_with_queue_option_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_no_performed_jobs queue: :some_queue do
+    def test_assert_performed_jobs_with_except_option_and_none_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, except: LoggingJob do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_and_except_option_and_none_sent
+      error = assert_raise ArgumentError do
+        assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_option_and_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 5, only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/5 .* but 1/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_except_option_and_too_few_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 5, except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/5 .* but 1/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_and_except_option_and_too_few_sent
+      error = assert_raise ArgumentError do
+        assert_performed_jobs 5, only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          4.times { LoggingJob.perform_later }
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_option_and_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, only: HelloJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_except_option_and_too_many_sent
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, except: LoggingJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/1 .* but 2/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_and_except_option_and_too_many_sent
+      error = assert_raise ArgumentError do
+        assert_performed_jobs 1, only: HelloJob, except: HelloJob do
+          2.times { HelloJob.perform_later("jeremy") }
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_queue_option
+      assert_performed_jobs 1, queue: :some_queue do
         HelloJob.set(queue: :some_queue).perform_later("jeremy")
+        HelloJob.set(queue: :other_queue).perform_later("bogdan")
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
+    def test_assert_performed_jobs_with_queue_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later("jeremy")
+          HelloJob.set(queue: :other_queue).perform_later("bogdan")
+        end
+      end
 
-  def test_assert_no_performed_jobs_without_block_with_queue_option
-    HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      assert_match(/1 .* but 0/, error.message)
+    end
 
-    perform_enqueued_jobs
+    def test_assert_performed_jobs_without_block_with_queue_option
+      HelloJob.set(queue: :some_queue).perform_later("jeremy")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
 
-    assert_no_performed_jobs queue: :some_queue
-  end
+      perform_enqueued_jobs
 
-  def test_assert_no_performed_jobs_without_block_with_queue_option_failure
-    HelloJob.set(queue: :some_queue).perform_later("jeremy")
+      assert_performed_jobs 1, queue: :some_queue
+    end
 
-    perform_enqueued_jobs
+    def test_assert_performed_jobs_without_block_with_queue_option_failure
+      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
 
-    error = assert_raise ActiveSupport::TestCase::Assertion do
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, queue: :some_queue
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_only_and_queue_options
+      assert_performed_jobs 1, only: HelloJob, queue: :some_queue do
+        HelloJob.set(queue: :some_queue).perform_later("jeremy")
+        HelloJob.set(queue: :other_queue).perform_later("bogdan")
+        LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+      end
+    end
+
+    def test_assert_performed_jobs_with_only_and_queue_options_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, only: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later("jeremy")
+          HelloJob.set(queue: :other_queue).perform_later("bogdan")
+          LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        end
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_without_block_with_only_and_queue_options
+      HelloJob.set(queue: :some_queue).perform_later("jeremy")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      assert_performed_jobs 1, only: HelloJob, queue: :some_queue
+    end
+
+    def test_assert_performed_jobs_without_block_with_only_and_queue_options_failure
+      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, only: HelloJob, queue: :some_queue
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_with_except_and_queue_options
+      assert_performed_jobs 1, except: HelloJob, queue: :other_queue do
+        HelloJob.set(queue: :other_queue).perform_later("jeremy")
+        LoggingJob.set(queue: :some_queue).perform_later("bogdan")
+        LoggingJob.set(queue: :other_queue).perform_later("jeremy")
+      end
+    end
+
+    def test_assert_performed_jobs_with_except_and_queue_options_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, except: HelloJob, queue: :other_queue do
+          HelloJob.set(queue: :other_queue).perform_later("jeremy")
+          LoggingJob.set(queue: :some_queue).perform_later("bogdan")
+          LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        end
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_performed_jobs_without_block_with_except_and_queue_options
+      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      LoggingJob.set(queue: :some_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :other_queue).perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      assert_performed_jobs 1, except: HelloJob, queue: :other_queue
+    end
+
+    def test_assert_performed_jobs_without_block_with_except_and_queue_options_failure
+      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      LoggingJob.set(queue: :some_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_jobs 1, except: HelloJob, queue: :other_queue
+      end
+
+      assert_match(/1 .* but 0/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_only_option
+      assert_nothing_raised do
+        assert_no_performed_jobs only: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_only_option
+      LoggingJob.perform_later("bogdan")
+
+      perform_enqueued_jobs
+
+      assert_no_performed_jobs only: HelloJob
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_only_option_failure
+      HelloJob.perform_later("bogdan")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs only: HelloJob
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_except_option
+      assert_nothing_raised do
+        assert_no_performed_jobs except: LoggingJob do
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_except_option
+      HelloJob.perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      assert_no_performed_jobs except: HelloJob
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_except_option_failure
+      LoggingJob.perform_later("jeremy")
+
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs except: HelloJob
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_only_and_except_option
+      error = assert_raise ArgumentError do
+        assert_no_performed_jobs only: HelloJob, except: HelloJob do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_only_and_except_options
+      error = assert_raise ArgumentError do
+        HelloJob.perform_later("jeremy")
+        LoggingJob.perform_later("bogdan")
+
+        perform_enqueued_jobs
+
+        assert_no_performed_jobs only: HelloJob, except: HelloJob
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_only_option_as_array
+      assert_nothing_raised do
+        assert_no_performed_jobs only: [HelloJob, RescueJob] do
+          LoggingJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_no_performed_jobs_with_except_option_as_array
+      assert_nothing_raised do
+        assert_no_performed_jobs except: [HelloJob, RescueJob] do
+          HelloJob.perform_later
+          RescueJob.perform_later
+        end
+      end
+    end
+
+    def test_assert_no_performed_jobs_with_only_and_except_option_as_array
+      error = assert_raise ArgumentError do
+        assert_no_performed_jobs only: [HelloJob, RescueJob], except: [HelloJob, RescueJob] do
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_only_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs only: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_except_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs except: LoggingJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_only_and_except_option_failure
+      error = assert_raise ArgumentError do
+        assert_no_performed_jobs only: HelloJob, except: HelloJob do
+          HelloJob.perform_later("jeremy")
+          LoggingJob.perform_later
+        end
+      end
+
+      assert_match(/`:only` and `:except`/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_queue_option
+      assert_no_performed_jobs queue: :some_queue do
+        HelloJob.set(queue: :other_queue).perform_later("jeremy")
+      end
+    end
+
+    def test_assert_no_performed_jobs_with_queue_option_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs queue: :some_queue do
+          HelloJob.set(queue: :some_queue).perform_later("jeremy")
+        end
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_without_block_with_queue_option
+      HelloJob.set(queue: :other_queue).perform_later("jeremy")
+
+      perform_enqueued_jobs
+
       assert_no_performed_jobs queue: :some_queue
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
+    def test_assert_no_performed_jobs_without_block_with_queue_option_failure
+      HelloJob.set(queue: :some_queue).perform_later("jeremy")
 
-  def test_assert_no_performed_jobs_with_only_and_queue_options
-    assert_no_performed_jobs only: HelloJob, queue: :some_queue do
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs queue: :some_queue
+      end
+
+      assert_match(/0 .* but 1/, error.message)
     end
-  end
 
-  def test_assert_no_performed_jobs_with_only_and_queue_options_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
+    def test_assert_no_performed_jobs_with_only_and_queue_options
       assert_no_performed_jobs only: HelloJob, queue: :some_queue do
-        HelloJob.set(queue: :some_queue).perform_later("bogdan")
+        HelloJob.set(queue: :other_queue).perform_later("bogdan")
         LoggingJob.set(queue: :some_queue).perform_later("jeremy")
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
+    def test_assert_no_performed_jobs_with_only_and_queue_options_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs only: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :some_queue).perform_later("bogdan")
+          LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        end
+      end
 
-  def test_assert_no_performed_jobs_without_block_with_only_and_queue_options
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+      assert_match(/0 .* but 1/, error.message)
+    end
 
-    perform_enqueued_jobs
+    def test_assert_no_performed_jobs_without_block_with_only_and_queue_options
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
 
-    assert_no_performed_jobs only: HelloJob, queue: :some_queue
-  end
+      perform_enqueued_jobs
 
-  def test_assert_no_performed_jobs_without_block_with_only_and_queue_options_failure
-    HelloJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_no_performed_jobs only: HelloJob, queue: :some_queue
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
-
-  def test_assert_no_performed_jobs_with_except_and_queue_options
-    assert_no_performed_jobs except: HelloJob, queue: :some_queue do
-      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+    def test_assert_no_performed_jobs_without_block_with_only_and_queue_options_failure
       HelloJob.set(queue: :some_queue).perform_later("bogdan")
-      LoggingJob.set(queue: :other_queue).perform_later("jeremy")
-    end
-  end
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
 
-  def test_assert_no_performed_jobs_with_except_and_queue_options_failure
-    error = assert_raise ActiveSupport::TestCase::Assertion do
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs only: HelloJob, queue: :some_queue
+      end
+
+      assert_match(/0 .* but 1/, error.message)
+    end
+
+    def test_assert_no_performed_jobs_with_except_and_queue_options
       assert_no_performed_jobs except: HelloJob, queue: :some_queue do
         HelloJob.set(queue: :other_queue).perform_later("bogdan")
         HelloJob.set(queue: :some_queue).perform_later("bogdan")
-        LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        LoggingJob.set(queue: :other_queue).perform_later("jeremy")
       end
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
+    def test_assert_no_performed_jobs_with_except_and_queue_options_failure
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs except: HelloJob, queue: :some_queue do
+          HelloJob.set(queue: :other_queue).perform_later("bogdan")
+          HelloJob.set(queue: :some_queue).perform_later("bogdan")
+          LoggingJob.set(queue: :some_queue).perform_later("jeremy")
+        end
+      end
 
-  def test_assert_no_performed_jobs_without_block_with_except_and_queue_options
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    HelloJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :other_queue).perform_later("jeremy")
+      assert_match(/0 .* but 1/, error.message)
+    end
 
-    perform_enqueued_jobs
+    def test_assert_no_performed_jobs_without_block_with_except_and_queue_options
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      HelloJob.set(queue: :some_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :other_queue).perform_later("jeremy")
 
-    assert_no_performed_jobs except: HelloJob, queue: :some_queue
-  end
+      perform_enqueued_jobs
 
-  def test_assert_no_performed_jobs_without_block_with_except_and_queue_options_failure
-    HelloJob.set(queue: :other_queue).perform_later("bogdan")
-    HelloJob.set(queue: :some_queue).perform_later("bogdan")
-    LoggingJob.set(queue: :some_queue).perform_later("jeremy")
-
-    perform_enqueued_jobs
-
-    error = assert_raise ActiveSupport::TestCase::Assertion do
       assert_no_performed_jobs except: HelloJob, queue: :some_queue
     end
 
-    assert_match(/0 .* but 1/, error.message)
-  end
+    def test_assert_no_performed_jobs_without_block_with_except_and_queue_options_failure
+      HelloJob.set(queue: :other_queue).perform_later("bogdan")
+      HelloJob.set(queue: :some_queue).perform_later("bogdan")
+      LoggingJob.set(queue: :some_queue).perform_later("jeremy")
 
-  def test_assert_performed_with
-    assert_performed_with(job: NestedJob, queue: "default") do
-      NestedJob.perform_later
+      perform_enqueued_jobs
+
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_no_performed_jobs except: HelloJob, queue: :some_queue
+      end
+
+      assert_match(/0 .* but 1/, error.message)
     end
-  end
 
-  def test_assert_performed_with_without_block
-    NestedJob.perform_later
-
-    perform_enqueued_jobs
-
-    assert_performed_with(job: NestedJob, queue: "default")
-  end
-
-  def test_assert_performed_with_when_queue_name_is_symbol
-    assert_performed_with(job: NestedJob, queue: :default) do
-      NestedJob.perform_later
+    def test_assert_performed_with
+      assert_performed_with(job: NestedJob, queue: "default") do
+        NestedJob.perform_later
+      end
     end
-  end
 
-  def test_assert_performed_with_returns
-    job = assert_performed_with(job: LoggingJob, queue: "default") do
+    def test_assert_performed_with_without_block
+      NestedJob.perform_later
+
+      perform_enqueued_jobs
+
+      assert_performed_with(job: NestedJob, queue: "default")
+    end
+
+    def test_assert_performed_with_when_queue_name_is_symbol
+      assert_performed_with(job: NestedJob, queue: :default) do
+        NestedJob.perform_later
+      end
+    end
+
+    def test_assert_performed_with_returns
+      job = assert_performed_with(job: LoggingJob, queue: "default") do
+        LoggingJob.perform_later(keyword: :sym)
+      end
+
+      assert_instance_of LoggingJob, job
+      assert_nil job.scheduled_at
+      assert_equal [{ keyword: :sym }], job.arguments
+      assert_equal "default", job.queue_name
+    end
+
+    def test_assert_performed_with_without_block_returns
       LoggingJob.perform_later(keyword: :sym)
+
+      perform_enqueued_jobs
+
+      job = assert_performed_with(job: LoggingJob, queue: "default")
+
+      assert_instance_of LoggingJob, job
+      assert_nil job.scheduled_at
+      assert_equal [{ keyword: :sym }], job.arguments
+      assert_equal "default", job.queue_name
     end
 
-    assert_instance_of LoggingJob, job
-    assert_nil job.scheduled_at
-    assert_equal [{ keyword: :sym }], job.arguments
-    assert_equal "default", job.queue_name
-  end
+    def test_assert_performed_with_failure
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: LoggingJob) do
+          HelloJob.perform_later
+        end
+      end
 
-  def test_assert_performed_with_without_block_returns
-    LoggingJob.perform_later(keyword: :sym)
-
-    perform_enqueued_jobs
-
-    job = assert_performed_with(job: LoggingJob, queue: "default")
-
-    assert_instance_of LoggingJob, job
-    assert_nil job.scheduled_at
-    assert_equal [{ keyword: :sym }], job.arguments
-    assert_equal "default", job.queue_name
-  end
-
-  def test_assert_performed_with_failure
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: LoggingJob) do
-        HelloJob.perform_later
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, queue: "low") do
+          HelloJob.set(queue: "important").perform_later
+        end
       end
     end
 
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, queue: "low") do
-        HelloJob.set(queue: "important").perform_later
+    def test_assert_performed_with_without_block_failure
+      HelloJob.perform_later
+
+      perform_enqueued_jobs
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: LoggingJob)
+      end
+
+      HelloJob.set(queue: "important").perform_later
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, queue: "low")
       end
     end
-  end
 
-  def test_assert_performed_with_without_block_failure
-    HelloJob.perform_later
-
-    perform_enqueued_jobs
-
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: LoggingJob)
-    end
-
-    HelloJob.set(queue: "important").perform_later
-
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, queue: "low")
-    end
-  end
-
-  def test_assert_performed_job_with_priority_option
-    assert_performed_with(job: HelloJob, priority: 10) do
-      HelloJob.set(priority: 10).perform_later
-    end
-
-    assert_raise ActiveSupport::TestCase::Assertion do
+    def test_assert_performed_job_with_priority_option
       assert_performed_with(job: HelloJob, priority: 10) do
-        HelloJob.set(priority: 5).perform_later
+        HelloJob.set(priority: 10).perform_later
+      end
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, priority: 10) do
+          HelloJob.set(priority: 5).perform_later
+        end
       end
     end
-  end
 
-  def test_assert_performed_with_with_at_option
-    assert_performed_with(job: HelloJob, at: Date.tomorrow.noon) do
-      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
-    end
-
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, at: Date.today.noon) do
+    def test_assert_performed_with_with_at_option
+      assert_performed_with(job: HelloJob, at: Date.tomorrow.noon) do
         HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
       end
-    end
-  end
 
-  def test_assert_performed_with_with_relative_at_option
-    assert_performed_with(job: HelloJob, at: 5.minutes.from_now) do
-      HelloJob.set(wait: 5.minutes).perform_later
-    end
-
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, at: 2.minutes.from_now) do
-        HelloJob.set(wait: 1.minute).perform_later
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, at: Date.today.noon) do
+          HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+        end
       end
     end
-  end
 
-  def test_assert_performed_with_without_block_with_at_option
-    HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+    def test_assert_performed_with_with_relative_at_option
+      assert_performed_with(job: HelloJob, at: 5.minutes.from_now) do
+        HelloJob.set(wait: 5.minutes).perform_later
+      end
 
-    perform_enqueued_jobs
-
-    assert_performed_with(job: HelloJob, at: Date.tomorrow.noon)
-
-    HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
-
-    perform_enqueued_jobs
-
-    assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, at: Date.today.noon)
-    end
-  end
-
-  def test_assert_performed_with_with_hash_arg
-    assert_performed_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
-      MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
-    end
-  end
-
-  def test_assert_performed_with_supports_matcher_procs
-    facets = {
-      job: HelloJob,
-      args: ["Rails"],
-      at: Date.tomorrow.noon,
-      queue: "important",
-    }
-
-    facets[:job].set(queue: facets[:queue], wait_until: facets[:at]).perform_later(*facets[:args])
-    perform_enqueued_jobs
-
-    facets.each do |facet, value|
-      matcher = ->(job_value) { job_value == value }
-      refuser = ->(job_value) { false }
-
-      assert_performed_with(**{ facet => matcher })
-
-      assert_raises ActiveSupport::TestCase::Assertion do
-        assert_performed_with(**{ facet => refuser })
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, at: 2.minutes.from_now) do
+          HelloJob.set(wait: 1.minute).perform_later
+        end
       end
     end
-  end
 
-  def test_assert_performed_with_time
-    now = Time.now
-    args = [{ argument1: { now: now }, argument2: now }]
+    def test_assert_performed_with_without_block_with_at_option
+      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
 
-    assert_performed_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+      perform_enqueued_jobs
+
+      assert_performed_with(job: HelloJob, at: Date.tomorrow.noon)
+
+      HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+
+      perform_enqueued_jobs
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, at: Date.today.noon)
+      end
     end
-  end
 
-  def test_assert_performed_with_date_time
-    now = DateTime.now
-    args = [{ argument1: { now: now }, argument2: now }]
-
-    assert_performed_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+    def test_assert_performed_with_with_hash_arg
+      assert_performed_with(job: MultipleKwargsJob, args: [{ argument1: 1, argument2: { a: 1, b: 2 } }]) do
+        MultipleKwargsJob.perform_later(argument2: { b: 2, a: 1 }, argument1: 1)
+      end
     end
-  end
 
-  def test_assert_performed_with_time_with_zone
-    now = Time.now.in_time_zone("Tokyo")
-    args = [{ argument1: { now: now }, argument2: now }]
+    def test_assert_performed_with_supports_matcher_procs
+      facets = {
+        job: HelloJob,
+        args: ["Rails"],
+        at: Date.tomorrow.noon,
+        queue: "important",
+      }
 
-    assert_performed_with(job: MultipleKwargsJob, args: args) do
-      MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+      facets[:job].set(queue: facets[:queue], wait_until: facets[:at]).perform_later(*facets[:args])
+      perform_enqueued_jobs
+
+      facets.each do |facet, value|
+        matcher = ->(job_value) { job_value == value }
+        refuser = ->(job_value) { false }
+
+        assert_performed_with(**{ facet => matcher })
+
+        assert_raises ActiveSupport::TestCase::Assertion do
+          assert_performed_with(**{ facet => refuser })
+        end
+      end
     end
-  end
 
-  def test_assert_performed_with_with_global_id_args
-    ricardo = Person.new(9)
-    assert_performed_with(job: HelloJob, args: [ricardo]) do
-      HelloJob.perform_later(ricardo)
+    def test_assert_performed_with_time
+      now = Time.now
+      args = [{ argument1: { now: now }, argument2: now }]
+
+      assert_performed_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+      end
     end
-  end
 
-  def test_assert_performed_with_without_block_with_global_id_args
-    ricardo = Person.new(9)
-    HelloJob.perform_later(ricardo)
-    perform_enqueued_jobs
-    assert_performed_with(job: HelloJob, args: [ricardo])
-  end
+    def test_assert_performed_with_date_time
+      now = DateTime.now
+      args = [{ argument1: { now: now }, argument2: now }]
 
-  def test_assert_performed_with_failure_with_global_id_args
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, args: [wilma]) do
+      assert_performed_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+      end
+    end
+
+    def test_assert_performed_with_time_with_zone
+      now = Time.now.in_time_zone("Tokyo")
+      args = [{ argument1: { now: now }, argument2: now }]
+
+      assert_performed_with(job: MultipleKwargsJob, args: args) do
+        MultipleKwargsJob.perform_later(argument1: { now: now }, argument2: now)
+      end
+    end
+
+    def test_assert_performed_with_with_global_id_args
+      ricardo = Person.new(9)
+      assert_performed_with(job: HelloJob, args: [ricardo]) do
         HelloJob.perform_later(ricardo)
       end
     end
-    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
-  end
 
-  def test_assert_performed_with_without_block_failure_with_global_id_args
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-    HelloJob.perform_later(ricardo)
-    perform_enqueued_jobs
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, args: [wilma])
+    def test_assert_performed_with_without_block_with_global_id_args
+      ricardo = Person.new(9)
+      HelloJob.perform_later(ricardo)
+      perform_enqueued_jobs
+      assert_performed_with(job: HelloJob, args: [ricardo])
     end
 
-    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
-  end
-
-  def test_assert_performed_says_no_jobs_performed
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: HelloJob, args: [])
+    def test_assert_performed_with_failure_with_global_id_args
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, args: [wilma]) do
+          HelloJob.perform_later(ricardo)
+        end
+      end
+      assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+      assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
     end
 
-    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
-    assert_match(/No jobs were performed/, error.message)
-  end
+    def test_assert_performed_with_without_block_failure_with_global_id_args
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+      HelloJob.perform_later(ricardo)
+      perform_enqueued_jobs
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, args: [wilma])
+      end
 
-  def test_assert_performed_when_not_matching_the_class_shows_alteratives
-    ricardo = Person.new(9)
-    wilma = Person.new(11)
-    HelloJob.perform_later(ricardo)
-    perform_enqueued_jobs
-    error = assert_raise ActiveSupport::TestCase::Assertion do
-      assert_performed_with(job: MultipleKwargsJob, args: [wilma])
+      assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+      assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
     end
 
-    assert_match(/No performed job found with {:job=>MultipleKwargsJob, :args=>\[#<Person.* @id=11>\]}/, error.message)
-    assert_match(/No jobs of class MultipleKwargsJob were performed, job classes performed: HelloJob/, error.message)
-  end
+    def test_assert_performed_says_no_jobs_performed
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, args: [])
+      end
 
-  def test_assert_performed_with_does_not_change_jobs_count
-    assert_performed_with(job: HelloJob) do
+      assert_match(/No performed job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
+      assert_match(/No jobs were performed/, error.message)
+    end
+
+    def test_assert_performed_when_not_matching_the_class_shows_alteratives
+      ricardo = Person.new(9)
+      wilma = Person.new(11)
+      HelloJob.perform_later(ricardo)
+      perform_enqueued_jobs
+      error = assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: MultipleKwargsJob, args: [wilma])
+      end
+
+      assert_match(/No performed job found with {:job=>MultipleKwargsJob, :args=>\[#<Person.* @id=11>\]}/, error.message)
+      assert_match(/No jobs of class MultipleKwargsJob were performed, job classes performed: HelloJob/, error.message)
+    end
+
+    def test_assert_performed_with_does_not_change_jobs_count
+      assert_performed_with(job: HelloJob) do
+        HelloJob.perform_later
+      end
+
+      assert_performed_with(job: HelloJob) do
+        HelloJob.perform_later
+      end
+
+      assert_equal 0, queue_adapter.enqueued_jobs.count
+      assert_equal 2, queue_adapter.performed_jobs.count
+    end
+
+    def test_assert_performed_with_without_block_does_not_change_jobs_count
       HelloJob.perform_later
-    end
+      perform_enqueued_jobs
+      assert_performed_with(job: HelloJob)
 
-    assert_performed_with(job: HelloJob) do
       HelloJob.perform_later
+      perform_enqueued_jobs
+      assert_performed_with(job: HelloJob)
+
+      assert_equal 0, queue_adapter.enqueued_jobs.count
+      assert_equal 2, queue_adapter.performed_jobs.count
     end
 
-    assert_equal 0, queue_adapter.enqueued_jobs.count
-    assert_equal 2, queue_adapter.performed_jobs.count
-  end
+    test "perform_enqueued_jobs doesn't raise if discard_on ActiveJob::DeserializationError" do
+      RetryJob.perform_later Person.new(404), 1
 
-  def test_assert_performed_with_without_block_does_not_change_jobs_count
-    HelloJob.perform_later
-    perform_enqueued_jobs
-    assert_performed_with(job: HelloJob)
-
-    HelloJob.perform_later
-    perform_enqueued_jobs
-    assert_performed_with(job: HelloJob)
-
-    assert_equal 0, queue_adapter.enqueued_jobs.count
-    assert_equal 2, queue_adapter.performed_jobs.count
-  end
-
-  test "perform_enqueued_jobs doesn't raise if discard_on ActiveJob::DeserializationError" do
-    RetryJob.perform_later Person.new(404), 1
-
-    assert_nothing_raised do
-      perform_enqueued_jobs(only: RetryJob)
-    end
-  end
-
-  test "TestAdapter respect max attempts" do
-    perform_enqueued_jobs(only: RaisingJob) do
-      assert_raises(RaisingJob::MyError) do
-        RaisingJob.perform_later
+      assert_nothing_raised do
+        perform_enqueued_jobs(only: RetryJob)
       end
     end
 
-    assert_equal 2, queue_adapter.performed_jobs.count
+    test "TestAdapter respect max attempts" do
+      perform_enqueued_jobs(only: RaisingJob) do
+        assert_raises(RaisingJob::MyError) do
+          RaisingJob.perform_later
+        end
+      end
+
+      assert_equal 2, queue_adapter.performed_jobs.count
+    end
+  end
+end
+
+class NotTestAdapterTest < ActiveJob::TestCase
+  unless adapter_is?(:test)
+    setup do
+      @adapter = queue_adapter.class.name
+    end
+
+    test "assert_enqueued_jobs raises" do
+      assert_raises ArgumentError, match: "assert_enqueued_jobs requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_enqueued_jobs(0) { }
+      end
+    end
+
+    test "assert_no_enqueued_jobs raises" do
+      assert_raises ArgumentError, match: "assert_no_enqueued_jobs requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_no_enqueued_jobs { }
+      end
+    end
+
+    test "assert_performed_jobs raises" do
+      assert_raises ArgumentError, match: "assert_performed_jobs requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_performed_jobs(0) { }
+      end
+    end
+
+    test "assert_no_performed_jobs raises" do
+      assert_raises ArgumentError, match: "assert_no_performed_jobs requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_no_performed_jobs { }
+      end
+    end
+
+    test "assert_enqueued_with raises" do
+      assert_raises ArgumentError, match: "assert_enqueued_with requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_enqueued_with { }
+      end
+    end
+
+    test "assert_performed_with raises" do
+      assert_raises ArgumentError, match: "assert_performed_with requires the Active Job test adapter, you're using #{@adapter}" do
+        assert_performed_with { }
+      end
+    end
+
+    test "perform_enqueued_jobs without a block" do
+      assert_raises ArgumentError, match: "perform_enqueued_jobs (without a block) requires the Active Job test adapter, you're using #{@adapter}" do
+        perform_enqueued_jobs
+      end
+    end
+
+    test "perform_enqueued_jobs with a block does not raise" do
+      assert_nothing_raised do
+        perform_enqueued_jobs { }
+      end
+    end
   end
 end
 
@@ -2092,17 +2177,17 @@ class OverrideQueueAdapterTest < ActiveJob::TestCase
 end
 
 class InheritedJobTest < ActiveJob::TestCase
-  def test_queue_adapter_is_test_adapter
-    assert_instance_of ActiveJob::QueueAdapters::TestAdapter, InheritedJob.queue_adapter
+  def test_queue_adapter_is_inline_adapter_because_it_is_set_on_the_job_class
+    assert_instance_of ActiveJob::QueueAdapters::InlineAdapter, InheritedJob.queue_adapter
   end
 end
 
 class QueueAdapterJobTest < ActiveJob::TestCase
-  def test_queue_adapter_is_test_adapter
+  def test_queue_adapter_is_is_inline_adapter_because_it_is_set_on_the_job_class
     Zeitwerk.with_loader do |loader|
       loader.push_dir("test/jobs")
       loader.setup
-      assert_instance_of ActiveJob::QueueAdapters::TestAdapter, QueueAdapterJob.queue_adapter
+      assert_instance_of ActiveJob::QueueAdapters::InlineAdapter, QueueAdapterJob.queue_adapter
     ensure
       loader.unload
     end

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -81,6 +81,17 @@ Upgrading from Rails 7.1 to Rails 7.2
 
 For more information on changes made to Rails 7.2 please see the [release notes](7_2_release_notes.html).
 
+### All tests now respect the `active_job.queue_adapter` config
+
+If you have set `config.active_job.queue_adapter` in your `config/application.rb` or `config/environments/test.rb` file,
+the adapter you selected was previously not used consistently across all tests. In some tests your adapter would be
+used, but other tests would use the `TestAdapter`.
+
+In Rails 7.2, all tests will respect the `queue_adapter` config if provided. This may cause test errors, if you had
+set the `queue_adapter` config to something other than `:test`, but written tests in a way that was dependent on the `TestAdapter`.
+
+If no config is provided, the `TestAdapter` will continue to be used.
+
 Upgrading from Rails 7.0 to Rails 7.1
 -------------------------------------
 

--- a/railties/test/application/active_job_adapter_test.rb
+++ b/railties/test/application/active_job_adapter_test.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveJobAdapterTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      @old = ENV["PARALLEL_WORKERS"]
+      ENV["PARALLEL_WORKERS"] = "0"
+
+      build_app
+    end
+
+    def teardown
+      ENV["PARALLEL_WORKERS"] = @old
+
+      teardown_app
+    end
+
+    test "config set via application.rb" do
+      add_to_config "config.active_job.queue_adapter = :inline"
+      make_inline_test_file
+      assert_successful_test_run "integration/config_test.rb"
+    end
+
+    test "config set via environment config" do
+      add_to_config "config.active_job.queue_adapter = :async"
+      app_file "config/environments/test.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_job.queue_adapter = :inline
+        end
+      RUBY
+      make_inline_test_file
+      assert_successful_test_run "integration/config_test.rb"
+    end
+
+    test "config is set for production, but test uses defaults" do
+      app_file "config/environments/production.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_job.queue_adapter = :sidekiq
+        end
+      RUBY
+      make_test_test_file
+      assert_successful_test_run "integration/config_test.rb"
+    end
+
+    private
+      def make_inline_test_file
+        app_file "test/integration/config_test.rb", <<-RUBY
+        require "test_helper"
+
+        class RailsConfigUnitTest < ActiveSupport::TestCase
+          test "the Inline Active Job adapter is used in unit tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigIntegrationTest < ActionDispatch::IntegrationTest
+          test "the Inline Active Job adapter is used in integration tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+
+            # ActionDispatch::IntegrationTest includes ActiveJob::TestHelper,
+            # which adds a bunch of assertions. But these assertions only work
+            # if the test adapter is TestAdapter. So for other test adapters,
+            # we raise an error if the method is called.
+            assert_raise ArgumentError, "assert_enqueued_jobs requires the Active Job test adapter, you're using ActiveJob::QueueAdapters::InlineAdapter" do
+              assert_no_enqueued_jobs {}
+            end
+          end
+        end
+
+        class RailsConfigJobTest < ActiveJob::TestCase
+          test "the Inline Active Job adapter is used in job tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+
+            # ActiveJob::TesTCase includes ActiveJob::TestHelper,
+            # which adds a bunch of assertions. But these assertions only work
+            # if the test adapter is TestAdapter. So for other test adapters,
+            # we raise an error if the method is called.
+            assert_raise ArgumentError, "assert_enqueued_jobs requires the Active Job test adapter, you're using ActiveJob::QueueAdapters::InlineAdapter" do
+              assert_no_enqueued_jobs {}
+            end
+          end
+        end
+
+        class RailsConfigMailerTest < ActionMailer::TestCase
+          test "the Inline Active Job adapter is used in mailer tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+
+            # ActionMailer::TestHelper includes ActiveJob::TestHelper
+            # So this just asserts that we haven't broken Action Mailer assertions that
+            # depend on Active Job:
+            assert_emails(0) {}
+            assert_emails(0)
+          end
+        end
+
+        class RailsConfigHelperTest < ActionView::TestCase
+          test "the Inline Active Job adapter is used in helper tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigControllerTest < ActionController::TestCase
+          test "the Inline Active Job adapter is used in controller tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigSystemTest < ActionDispatch::SystemTestCase
+          test "the Inline Active Job adapter is used in system tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::InlineAdapter), adapter
+            assert_equal :inline, Rails.application.config.active_job.queue_adapter
+          end
+        end
+        RUBY
+      end
+
+      def make_test_test_file
+        app_file "test/integration/config_test.rb", <<-RUBY
+        require "test_helper"
+
+        class RailsConfigUnitTest < ActiveSupport::TestCase
+          test "the Test Active Job adapter is used in unit tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigIntegrationTest < ActionDispatch::IntegrationTest
+          test "the Test Active Job adapter is used in integration tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+
+            assert_nothing_raised do
+              assert_no_enqueued_jobs {}
+            end
+          end
+        end
+
+        class RailsConfigJobTest < ActiveJob::TestCase
+          test "the Test Active Job adapter is used in job tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+
+            assert_nothing_raised do
+              assert_no_enqueued_jobs {}
+            end
+          end
+        end
+
+        class RailsConfigMailerTest < ActionMailer::TestCase
+          test "the Test Active Job adapter is used in mailer tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+
+            assert_emails(0) {}
+            assert_emails(0)
+          end
+        end
+
+        class RailsConfigHelperTest < ActionView::TestCase
+          test "the Test Active Job adapter is used in helper tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigControllerTest < ActionController::TestCase
+          test "the Test Active Job adapter is used in controller tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+          end
+        end
+
+        class RailsConfigSystemTest < ActionDispatch::SystemTestCase
+          test "the Test Active Job adapter is used in system tests" do
+            adapter = ActiveJob::Base.queue_adapter
+            assert adapter.is_a?(ActiveJob::QueueAdapters::TestAdapter), adapter
+            assert_equal :test, Rails.application.config.active_job.queue_adapter
+          end
+        end
+        RUBY
+      end
+
+      def assert_successful_test_run(name)
+        result = run_test_file(name)
+        assert_equal 0, $?.to_i, result
+        result
+      end
+
+      def run_test_file(name)
+        rails "test", "#{app_path}/test/#{name}", allow_failure: true
+      end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Currently if you set `config.active_job.queue_adapter = (anything)` in `config/application.rb` or `config/environments/test.rb`, this config will be respected by some test cases but not others.

Specifically, in `ActionDispatch::IntegrationTest`, `ActionMailer::TestCase`, and `ActiveJob::TestCase`, the test adapter will still be `TestAdapter`, while in other test cases it will be `InlineAdapter`.

I think you'd expect that if you set the test adapter for an environment, that test adapter would be available everywhere in that environment. For example, you might want to use the Delayed Job test adapter in your test environment so that you can have your test code more closely match production. The feedback on https://github.com/rails/rails/issues/37270 echoes this, but the workaround suggested there of disabling the test adapter on specific klasses is not reliable.

### Detail

The logic to determine which queue adapter a job uses is quite confusing.

Here is how it works on `main` currently:

1. If running in a test, and the test class includes `ActiveJob::TestHelper` and overrides `queue_adapter_for_test`, then the `queue_adapter_for_test` adapter is used.
2. Otherwise, if running in a test, and the test class includes `ActiveJob::TestHelper`, then the `:test` adapter is used.
3. Otherwise, if `self.queue_adapter` is set on the job class, that adapter is used.
4. Otherwise, if `self.queue_adapter` is set on the job's superclass (eg. `ApplicationJob`), that adapter is used. 
5. Fall back to `Rails.application.config.active_job.queue_adapter` as configured by the user.
6. If not configured by the user, `Rails.application.config.active_job.queue_adapter` defaults to `:async`.
7. Fall back to `:async` if no Rails config set (eg. using Active Job as a standalone).

As noted above, only some of the built in test classes include `ActiveJob::TestHelper`. Also, setting a queue adapter on a specific job class is rare (typically you would not want different jobs to be performed by different backends). So in practice, in development/production, option 5 is used. And in test, options 2 and 5 are used, depending on the type of test.

This PR changes the logic to work as follows:

1. If `self.queue_adapter` is set on the job class, that adapter is used.
2. Otherwise, if `self.queue_adapter` is set on the job's superclass (eg. `ApplicationJob`), that adapter is used. 
3. If running in a test, and the test class includes `ActiveJob::TestHelper` and overrides `queue_adapter_for_test`, then the `queue_adapter_for_test` adapter is used.
4. Fall back to `Rails.application.config.active_job.queue_adapter` as configured by the user.
5. If not configured by the user, `Rails.application.config.active_job.queue_adapter` defaults to `:test` if `Rails.env.test?`, otherwise it defaults to `:async`.
6. If running in a test, and the test class includes `ActiveJob::TestHelper`, and no other adapter has been set (eg. using Active Job as a standalone), then use `:test`.
7. Otherwise, fall back to `:async`.

The key changes are:

- Now, if you set a `queue_adapter` on a job class, that will always be respected.
- The `queue_adapter_for_test` override still works, but it no longer takes priority over a queue adapter set on a specific job class. Since I think both of these techniques are rare, and the impact of this change only exists in a test environment, I think it is a relatively safe change.
- The default queue adapter in Rails config is now env-dependent. (It's `:test` in the `test` environment, and `:async` in all others.)

The default rails environment templates suggest [setting a specific queue adapter only in production](https://github.com/rails/rails/blob/f46d3452ae30c46d3e213c687decbbca0cee9119/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L79C12-L79C12). For users who do that, there will be no changes to behaviour with this PR.

For users who are more granular, by setting per-job queue adapters, things should continue to work as expected with this PR.

**The real change is for users who set a default queue adapter across all environments (as in this issue: https://github.com/rails/rails/issues/37270). For them, this PR solves the issue where some tests use the desired queue adapter, and other tests don't.**

### Additional information

Fixes: https://github.com/rails/rails/issues/37270

ref: https://github.com/bensheldon/good_job/issues/846
ref: https://github.com/rails/rails/issues/26360 - this PR changes the behavior here, which I think was overzealous.

I extracted out some other PRs to fix internal issues while working on this: https://github.com/rails/rails/pull/48623, https://github.com/rails/rails/pull/48626. I also extracted https://github.com/rails/rails/pull/48599 out as a non-controversial fix prior to this PR.



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
