### PR TITLE
Remove support for Rails 6.1 cache format

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -34,7 +34,7 @@ module ActiveSupport
       autoload :LocalCache, "active_support/cache/strategy/local_cache"
     end
 
-    @format_version = 6.1
+    @format_version = 7.1
 
     class << self
       attr_accessor :format_version
@@ -671,7 +671,7 @@ module ActiveSupport
         def default_coder
           case Cache.format_version
           when 6.1
-            Cache::SerializerWithFallback[:marshal_6_1]
+            raise NotImplementedError, "Rails 6.1 cache format it no longer supported, applications must transition to newer formats before upgrading Rails"
           when 7.0
             Cache::SerializerWithFallback[:marshal_7_0]
           when 7.1

--- a/activesupport/lib/active_support/cache/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/cache/serializer_with_fallback.rb
@@ -33,8 +33,6 @@ module ActiveSupport
             MessagePackWithFallback._load(dumped)
           when Marshal71WithFallback.dumped?(dumped)
             Marshal71WithFallback._load(dumped)
-          when Marshal61WithFallback.dumped?(dumped)
-            Marshal61WithFallback._load(dumped)
           else
             Cache::Store.logger&.warn("Unrecognized payload prefix #{dumped.byteslice(0).inspect}; deserializing as nil")
             nil
@@ -129,29 +127,6 @@ module ActiveSupport
           end
         end
 
-        module Marshal61WithFallback
-          include SerializerWithFallback
-          extend self
-
-          MARSHAL_SIGNATURE = "\x04\x08".b.freeze
-
-          def dump(entry)
-            Marshal.dump(entry)
-          end
-
-          def dump_compressed(entry, threshold)
-            Marshal.dump(entry.compressed(threshold))
-          end
-
-          def _load(dumped)
-            Marshal.load(dumped)
-          end
-
-          def dumped?(dumped)
-            dumped.start_with?(MARSHAL_SIGNATURE)
-          end
-        end
-
         module Marshal71WithFallback
           include SerializerWithFallback
           extend self
@@ -218,7 +193,6 @@ module ActiveSupport
 
         SERIALIZERS = {
           passthrough: PassthroughWithFallback,
-          marshal_6_1: Marshal61WithFallback,
           marshal_7_0: Marshal70WithFallback,
           marshal_7_1: Marshal71WithFallback,
           message_pack: MessagePackWithFallback,

--- a/activesupport/test/cache/behaviors/cache_store_compression_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_compression_behavior.rb
@@ -59,7 +59,7 @@ module CacheStoreCompressionBehavior
 
       assert_uncompressed SMALL_STRING
       assert_uncompressed SMALL_OBJECT
-      assert_uncompressed LARGE_STRING
+      assert_uncompressed [LARGE_STRING]
       assert_uncompressed LARGE_OBJECT
     end
 
@@ -68,7 +68,7 @@ module CacheStoreCompressionBehavior
 
       assert_uncompressed SMALL_STRING, compress_threshold: 1.megabyte
       assert_uncompressed SMALL_OBJECT, compress_threshold: 1.megabyte
-      assert_uncompressed LARGE_STRING, compress_threshold: 1.megabyte
+      assert_uncompressed [LARGE_STRING], compress_threshold: 1.megabyte
       assert_uncompressed LARGE_OBJECT, compress_threshold: 1.megabyte
 
       @cache = lookup_store(compress: true, compress_threshold: 1.megabyte)
@@ -85,8 +85,8 @@ module CacheStoreCompressionBehavior
     end
 
     test "compression ignores incompressible data" do
-      assert_uncompressed "", compress: true, compress_threshold: 1
-      assert_uncompressed [*0..127].pack("C*"), compress: true, compress_threshold: 1
+      assert_uncompressed [""], compress: true, compress_threshold: 1
+      assert_uncompressed [[*0..127].pack("C*")], compress: true, compress_threshold: 1
     end
   end
 

--- a/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/object/with"
 module CacheStoreFormatVersionBehavior
   extend ActiveSupport::Concern
 
-  FORMAT_VERSIONS = [6.1, 7.0, 7.1]
+  FORMAT_VERSIONS = [7.0, 7.1]
 
   included do
     test "format version affects default coder" do

--- a/activesupport/test/cache/serializer_with_fallback_test.rb
+++ b/activesupport/test/cache/serializer_with_fallback_test.rb
@@ -45,7 +45,7 @@ class CacheSerializerWithFallbackTest < ActiveSupport::TestCase
     end
   end
 
-  (FORMATS - [:passthrough, :marshal_6_1, :marshal_7_0]).each do |format|
+  (FORMATS - [:passthrough, :marshal_7_0]).each do |format|
     test "#{format.inspect} serializer preserves version with bare string" do
       entry = ActiveSupport::Cache::Entry.new("abc", version: "123")
       assert_entry entry, roundtrip(format, entry)
@@ -94,7 +94,7 @@ class CacheSerializerWithFallbackTest < ActiveSupport::TestCase
     end
   end
 
-  [:passthrough, :marshal_6_1, :marshal_7_0].each do |format|
+  [:passthrough, :marshal_7_0].each do |format|
     test "#{format.inspect} serializer dumps bare string in a backward compatible way" do
       string = +"abc"
       string.instance_variable_set(:@baz, true)


### PR DESCRIPTION
The 6.1 format directly Marshal the AS::Cache::Entry class which prevent us from changing its internal representation.

Removing support for it would unblock various refactors and cleanup.

cc @jonathanhefner 

@matthewd: do you think we need to go through a deprecation for this? (I assume so but not 100% sure).

If we can't remove it right now, we should deprecate is ASAP so this stop hindering us.