### PR TITLE
[7-0-stable] Fix rubocop warning

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -87,7 +87,7 @@ module ActionController
 
       allow_other_host = response_options.delete(:allow_other_host) { _allow_other_host }
 
-      self.status        = _extract_redirect_to_status(options, response_options)
+      self.status = _extract_redirect_to_status(options, response_options)
 
       redirect_to_location = _compute_redirect_to_location(request, options)
       _ensure_url_is_http_header_safe(redirect_to_location)


### PR DESCRIPTION
Backports f1cdfc0 to fix rubocop on `7-0-stable` branch