### PR TITLE
[6-1-stable] Fix rubocop

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -63,7 +63,7 @@ module ActionController
       raise ActionControllerError.new("Cannot redirect to nil!") unless options
       raise AbstractController::DoubleRenderError if response_body
 
-      self.status        = _extract_redirect_to_status(options, response_options)
+      self.status = _extract_redirect_to_status(options, response_options)
 
       redirect_to_location = _compute_redirect_to_location(request, options)
       _ensure_url_is_http_header_safe(redirect_to_location)

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -453,7 +453,6 @@ class RedirectTest < ActionController::TestCase
 
     assert_equal msg, error.message
   end
-
 end
 
 module ModuleTest


### PR DESCRIPTION
Similar to #48588 for `6-1-stable` branch.

Fixes the rubocop build:
https://github.com/rails/rails/actions/runs/5383348950/jobs/9769989203

However, f1cdfc0 didn't apply cleanly so did it by hand. :pray:

---

Reproduced locally:

```
Offenses:

actionpack/lib/action_controller/metal/redirecting.rb:66:26: C: Layout/SpaceAroundOperators: Operator = should be surrounded by a single space.
      self.status        = _extract_redirect_to_status(options, response_options)
                         ^
actionpack/test/controller/redirect_test.rb:456:1: C: Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body end.

2863 files inspected, 2 offenses detected, 2 offenses auto-correctable
```