### PR TITLE
Add support for :prefix option in relations.

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -50,4 +50,37 @@
 
     *Yogesh Khater*
 
+*   Allows for configuring a custom prefix for Blob keys.
+
+    ```ruby
+    Rails.application.configure do
+      config.active_storage.blob_prefix = 'active_storage'
+    end
+    ```
+
+    This will store Blobs in a path like active_storage/<random_key>
+
+    You may also configure an additional level of prefix on each relation.
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_one_attached :avatar, prefix: 'avatars'
+    end
+    ```
+
+    This will store Blobs in a path like active_storage/avatars/<random_key>
+
+    Or even generate it using information on the record:
+
+    ```ruby
+    class User < ActiveRecord::Base
+      belongs_to :tenant
+      has_one_attached :avatar, prefix: -> (record, attachment) { record.tenant.name }
+    end
+    ```
+
+    This will store Blobs in a path like active_storage/account_1/<random_key>
+
+    *Gonzalo Rodríguez-Baltanás Díaz*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -186,7 +186,10 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # Always refer to blobs using the signed_id or a verified form of the key.
   def key
     # We can't wait until the record is first saved to have a key for it
-    self[:key] ||= self.class.generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)
+    self[:key] ||= [
+      Rails.application.config.active_storage.blob_prefix.to_s,
+      self.class.generate_unique_secure_token.to_s
+    ].reject(&:blank?).join("/")
   end
 
   # Returns an ActiveStorage::Filename instance of the filename that can be

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -62,6 +62,8 @@ module ActiveStorage
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline,     default: []
 
+  mattr_accessor :blob_prefix
+
   mattr_accessor :supported_image_processing_methods, default: [
     "adaptive_blur",
     "adaptive_resize",

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -97,11 +97,32 @@ module ActiveStorage
       #     has_one_attached :avatar, strict_loading: true
       #   end
       #
+      # If you need the attachment to be stored under a particular prefix/folder you can use the
+      # +:prefix+ option. For example, in order to store all these files inside the avatars folder you
+      # may do:
+      #
+      #   class User < ActiveRecord::Base
+      #     has_one_attached :avatar, prefix: 'avatars'
+      #   end
+      #
+      # The value could be a proc as well:
+      #   class User < ActiveRecord::Base
+      #     belongs_to :tenant
+      #     has_one_attached :avatar, prefix: -> (record, attachment) { record.tenant_id }
+      #   end
+      #
+      # You may also configure a global prefix for all blobs that will be included in
+      # addition to the per reflection prefix
+      #
+      #   Rails.application.configure do
+      #     config.active_storage.blob_prefix = 'active_storage'
+      #   end
+      #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_one_attached</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false, prefix: nil)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -143,7 +164,7 @@ module ActiveStorage
           :has_one_attached,
           name,
           nil,
-          { dependent: dependent, service_name: service },
+          { dependent: dependent, service_name: service, prefix: prefix },
           self
         )
         yield reflection if block_given?
@@ -195,11 +216,32 @@ module ActiveStorage
       #     has_many_attached :photos, strict_loading: true
       #   end
       #
+      # If you need the attachment to be stored under a particular prefix/folder you can use the
+      # +:prefix+ option. For example, in order to store all these files inside the avatars folder you
+      # may do:
+      #
+      #   class User < ActiveRecord::Base
+      #     has_many_attached :photos, prefix: 'photos'
+      #   end
+      #
+      # The value could be a proc as well:
+      #   class User < ActiveRecord::Base
+      #     belongs_to :tenant
+      #     has_many_attached :photos, prefix: -> (record, attachment) { record.tenant_id }
+      #   end
+      #
+      # You may also configure a global prefix for all blobs that will be included in
+      # addition to the per reflection prefix
+      #
+      #   Rails.application.configure do
+      #     config.active_storage.blob_prefix = 'active_storage'
+      #   end
+      #
       # Note: Active Storage relies on polymorphic associations, which in turn store class names in the database.
       # When renaming classes that use <tt>has_many</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false, prefix: nil)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -243,7 +285,7 @@ module ActiveStorage
           :has_many_attached,
           name,
           nil,
-          { dependent: dependent, service_name: service },
+          { dependent: dependent, service_name: service, prefix: prefix },
           self
         )
         yield reflection if block_given?

--- a/activestorage/lib/active_storage/reflection.rb
+++ b/activestorage/lib/active_storage/reflection.rb
@@ -10,6 +10,10 @@ module ActiveStorage
       def named_variants
         @named_variants ||= {}
       end
+
+      def prefix
+        options[:prefix]
+      end
     end
 
     # Holds all the metadata about a has_one_attached attachment as it was

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -23,6 +23,13 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 2, @user.highlights_blobs.count
   end
 
+  test "attaching existing blobs to an existing record, with global prefix" do
+    Rails.configuration.active_storage.stub(:blob_prefix, "active_storage") do
+      @user.highlights.attach create_blob(filename: "funky.jpg")
+      assert_match(/active_storage\//, @user.highlights.first.key)
+    end
+  end
+
   test "attaching existing blobs from signed IDs to an existing record" do
     @user.highlights.attach create_blob(filename: "funky.jpg").signed_id, create_blob(filename: "town.jpg").signed_id
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
@@ -42,6 +49,18 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     @user.highlights.attach fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4")
     assert_equal "racecar.jpg", @user.highlights.first.filename.to_s
     assert_equal "video.mp4", @user.highlights.second.filename.to_s
+  end
+
+  test "attaching new blobs from uploaded files to an existing record, with global prefix" do
+    Rails.configuration.active_storage.stub(:blob_prefix, "active_storage") do
+      @user.highlights.attach fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4")
+      assert_match(/active_storage\//, @user.highlights.first.key)
+    end
+  end
+
+  test "attaching new blobs from uploaded files to an existing record, with custom relation prefix" do
+    @user.highlights_with_prefix.attach fixture_file_upload("racecar.jpg")
+    assert_match(/Josh\//, @user.highlights_with_prefix.first.key)
   end
 
   test "attaching existing blobs to an existing, changed record" do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -50,6 +50,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_not_nil @user.avatar_blob
   end
 
+  test "attaching an existing blob to an existing record, with_global_prefix" do
+    Rails.configuration.active_storage.stub(:blob_prefix, "active_storage") do
+      @user.avatar.attach create_blob(filename: "funky.jpg")
+      assert_equal "funky.jpg", @user.avatar.filename.to_s
+
+      assert_match(/active_storage\//, @user.avatar.key)
+    end
+  end
+
   test "attaching an existing blob from a signed ID to an existing record" do
     @user.avatar.attach create_blob(filename: "funky.jpg").signed_id
     assert_equal "funky.jpg", @user.avatar.filename.to_s
@@ -71,7 +80,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from a Hash to an existing record passes record" do
     hash = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" }
     blob = ActiveStorage::Blob.build_after_unfurling(**hash)
-    arguments = hash.merge(record: @user, service_name: nil)
+    arguments = hash.merge(record: @user, service_name: nil, key: String)
     assert_called_with(ActiveStorage::Blob, :build_after_unfurling, [], **arguments, returns: blob) do
       @user.avatar.attach hash
     end
@@ -80,6 +89,18 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from an uploaded file to an existing record" do
     @user.avatar.attach fixture_file_upload("racecar.jpg")
     assert_equal "racecar.jpg", @user.avatar.filename.to_s
+  end
+
+  test "attaching a new blob from an uploaded file to an existing record, with global prefix" do
+    Rails.configuration.active_storage.stub(:blob_prefix, "active_storage") do
+      @user.avatar.attach fixture_file_upload("racecar.jpg")
+      assert_match(/active_storage\//, @user.avatar.key)
+    end
+  end
+
+  test "attaching a new blob from an uploaded file to an existing record, with custom relation prefix" do
+    @user.avatar_with_prefix.attach fixture_file_upload("racecar.jpg")
+    assert_match(/Josh\//, @user.avatar_with_prefix.key)
   end
 
   test "attaching StringIO attachable to an existing record" do
@@ -96,7 +117,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     def upload.open
       @io ||= StringIO.new("")
     end
-    arguments = { io: upload.open, filename: upload.original_filename, content_type: upload.content_type, record: @user, service_name: nil }
+    arguments = { io: upload.open, key: String, filename: upload.original_filename, content_type: upload.content_type, record: @user, service_name: nil }
     blob = ActiveStorage::Blob.build_after_unfurling(**arguments)
     assert_called_with(ActiveStorage::Blob, :build_after_unfurling, [], returns: blob, **arguments) do
       @user.avatar.attach upload

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -10,6 +10,14 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
     assert_equal :has_one_attached, reflection.macro
     assert_equal :purge_later, reflection.options[:dependent]
 
+    reflection = User.reflect_on_attachment(:avatar_with_prefix)
+    assert_equal :has_one_attached, reflection.macro
+    assert_instance_of Proc, reflection.options[:prefix]
+
+    reflection = User.reflect_on_attachment(:highlights_with_prefix)
+    assert_equal :has_many_attached, reflection.macro
+    assert_instance_of Proc, reflection.options[:prefix]
+
     reflection = User.reflect_on_attachment(:cover_photo)
     assert_equal :local, reflection.options[:service_name]
 
@@ -39,8 +47,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio vlogs ], reflections.collect(&:name)
-    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_prefix avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_prefix highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio vlogs ], reflections.collect(&:name)
+    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -130,6 +130,7 @@ class User < ActiveRecord::Base
   validates :name, presence: true
 
   has_one_attached :avatar
+  has_one_attached :avatar_with_prefix, prefix: -> (record, _attachment) { record.name }
   has_one_attached :cover_photo, dependent: false, service: :local
   has_one_attached :avatar_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
@@ -147,6 +148,7 @@ class User < ActiveRecord::Base
   has_one_attached :name_pronunciation_audio
 
   has_many_attached :highlights
+  has_many_attached :highlights_with_prefix, prefix: -> (record, _attachment) { record.name }
   has_many_attached :vlogs, dependent: false, service: :local
   has_many_attached :highlights_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]


### PR DESCRIPTION
### Motivation / Background

Our application is multi-tenant and storing files in S3 was an organizational issue due to ActiveStorage storing the files at the root level in a flat structure. Instead we would like some semantic structure, for example we would like to have all files related  to active storage to be in the active_storage top folder, and then for each tenant our of application we will further namespace. Example of the intended structure:

S3/active_storage/tenant_id/some_file_uid
S3/active_storage/tenant_id/some_file_uid

This Pull Request has been created in order to support this kind of structure.

Allows for configuring a custom prefix for Blob keys.

```
    Rails.application.configure do
      config.active_storage.blob_prefix = 'active_storage'
    end
```

This will store Blobs in a path like active_storage/<random_key>. You may also configure an additional level of prefix on each relation.

```
    class User < ActiveRecord::Base
      has_one_attached :avatar, prefix: 'avatars'
    end
```

This will store Blobs in a path like active_storage/avatars/<random_key>. Or even generate it using information on the record:

```
    class User < ActiveRecord::Base
      belongs_to :tenant
      has_one_attached :avatar, prefix: -> (record, attachment) { record.tenant.name }
    end
```

This will store Blobs in a path like active_storage/account_1/<random_key>

### Detail

This Pull Request changes to Active Storage. Particularly it makes the association macros determine the blob id, if given the option `:prefix`.

### Additional information

We are using this in production right now. Working fine so far. We do not use direct upload. Unsure if this may affect it.

Other people interested in this sort of functionality:
* https://github.com/rails/rails/issues/38161
* https://github.com/rails/rails/issues/32790

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
