### PR TITLE
Accept keyword-like named columns for PostgreSQL partial indexes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -875,6 +875,13 @@ module ActiveRecord
           super
         end
 
+        def add_index_options(table_name, column_name, **options) # :nodoc:
+          if (where = options[:where]) && table_exists?(table_name) && column_exists?(table_name, where)
+            options[:where] = quote_column_name(where)
+          end
+          super
+        end
+
         def quoted_include_columns_for_index(column_names) # :nodoc:
           return quote_column_name(column_names) if column_names.is_a?(Symbol)
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -322,6 +322,14 @@ module ActiveRecord
         end
       end
 
+      def test_partial_index_on_column_named_like_keyword
+        with_example_table('id serial primary key, number integer, "primary" boolean') do
+          @connection.add_index "ex", "id", name: "partial", where: "primary" # "primary" is a keyword
+          index = @connection.indexes("ex").find { |idx| idx.name == "partial" }
+          assert_equal '"primary"', index.where
+        end
+      end
+
       def test_include_index
         with_example_table do
           @connection.add_index "ex", %w{ id }, name: "include", include: :number


### PR DESCRIPTION
Fixes #48571 (see there for the description).