### PR TITLE
Document and test lib & config.add_autoload_paths_to_load_path

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -208,6 +208,7 @@ config.add_autoload_paths_to_load_path = false
 
 That may speed up legitimate `require` calls a bit since there are fewer lookups. Also, if your application uses [Bootsnap](https://github.com/Shopify/bootsnap), that saves the library from building unnecessary indexes, leading to lower memory usage.
 
+The `lib` directory is not affected by this flag, it is added to `$LOAD_PATH` always.
 
 Reloading
 ---------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -168,6 +168,8 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `true`               |
 | 7.1                   | `false`              |
 
+The `lib` directory is not affected by this flag, it is added to `$LOAD_PATH` always.
+
 #### `config.after_initialize`
 
 Takes a block which will be run _after_ Rails has finished initializing the application. That includes the initialization of the framework itself, engines, and all the application's initializers in `config/initializers`. Note that this block _will_ be run for rake tasks. Useful for configuring values set up by other initializers:

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -71,6 +71,8 @@ module Rails
       def inherited(base)
         super
         Rails.app_class = base
+        # lib has to be added to $LOAD_PATH unconditionally, even if it's in the
+        # autoload paths and config.add_autoload_paths_to_load_path is false.
         add_lib_to_load_path!(find_root(base.called_from))
         ActiveSupport.run_load_hooks(:before_configuration, base)
       end
@@ -386,7 +388,7 @@ module Rails
     # Rails application, you will need to add lib to $LOAD_PATH on your own in case
     # you need to load files in lib/ during the application configuration as well.
     def self.add_lib_to_load_path!(root) # :nodoc:
-      path = File.join root, "lib"
+      path = File.join(root, "lib")
       if File.exist?(path) && !$LOAD_PATH.include?(path)
         $LOAD_PATH.unshift(path)
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2118,6 +2118,18 @@ module ApplicationTests
       assert_empty Rails.configuration.paths.load_paths - $LOAD_PATH
     end
 
+    test "lib is added to $LOAD_PATH regardless of config.add_autoload_paths_to_load_path" do
+      # Like Rails::Application.add_lib_to_load_path! does.
+      lib = File.join(app_path, "lib")
+
+      add_to_config "config.autoload_paths << '#{lib}'"
+
+      app "development"
+
+      assert_not Rails.configuration.add_autoload_paths_to_load_path # precondition
+      assert_includes $LOAD_PATH, lib
+    end
+
     test "autoload paths can be set in the config file of the environment" do
       app_dir "custom_autoload_path"
       app_dir "custom_autoload_once_path"


### PR DESCRIPTION
Rails adds `lib` to `$LOAD_PATH` when `Rails::Application` is subclassed ([source](https://github.com/rails/rails/blob/5c5b78dfa7d4ab0db884d10d3a4f02f5883c9b68/railties/lib/rails/application.rb#L74)), but if `lib` belongs to the autoload paths, this does not square with  `config.add_autoload_paths_to_load_path`.

I believe adding `lib` to `$LOAD_PATH` unconditionally is the right thing to do:

1. It is an important convention in Ruby projects.
2. Apps may have generators in `lib/generators`, which Rails loads with `require`.
3. This has been the case always (backwards compatibility).

So, this patch documents this exception and adds test coverage for it.

Thanks to @chaadow for bringing this to my attention.

/cc @byroot 