### PR TITLE
Fix Railties failing for tests using Webpacker

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -19,6 +19,10 @@ require "active_support/testing/method_call_assertions"
 require "active_support/test_case"
 require "minitest/retry"
 
+# OpenSSL 3.0 has disabled some cryptographic functions used by Webpack 4 (which
+# Webpacker is locked to). This configuration is necessary to re enable them
+ENV["NODE_OPTIONS"] = "--openssl-legacy-provider"
+
 if ENV["BUILDKITE"]
   Minitest::Retry.use!(verbose: false, retry_count: 1)
 end


### PR DESCRIPTION
### Motivation / Background

There were recently some changes to the base ruby Docker images that required us to [update][1] the version of Node.js we use in our images. In addition, the base image change brought OpenSSL 3.0 instead of the previous 1.x version. Since the change in base image, there have been failing railties tests for 6-1-stable:

```
** Execute webpacker:compile
Compiling...
Compilation failed:
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/rails/railties/test/isolation/assets/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:471:10)

    at /rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:503:5
    at /rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:358:12
    at /rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:373:3

    at iterateNormalLoaders (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /rails/railties/test/isolation/assets/node_modules/babel-loader/lib/index.js:44:71 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

### Detail

The issue is that OpenSSL has disabled some older crypto functions by default, and the version of Webpack required by Webpacker tries to use one of those older functions. We can re enable support for these old crypto functions by passing NODE_OPTIONS=--openssl-legacy-provider for Rails 6.1 (and newer versions will never have this problem as they do not use Webpacker)

isolation/abstract_unit was chosen as the place to add it because it's a common file used by all of the places that create temporary Rails projects and try to compile assets.

### Additional information

I initially proposed this as a [change to the Buildkite configuration][2], but Matthew suggested that the Rails repo would be a better place for it since this could help other people who run Rails tests as well.

[1]: https://github.com/rails/buildkite-config/commit/e7964c6d299951b80cc3a4041ad64d3ee7815e7a
[2]: https://github.com/rails/buildkite-config/pull/56

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
