### PR TITLE
Deprecate active_support.cache_format_version = 6.1

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -105,6 +105,14 @@ module ActiveSupport
   end
 
   def self.cache_format_version=(value)
+    if value == 6.1
+      ActiveSupport.deprecator.warn <<~EOM
+        Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
+
+        Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+        for more information on how to upgrade.
+      EOM
+    end
     Cache.format_version = value
   end
 


### PR DESCRIPTION
Closes: https://github.com/rails/rails/pull/48586

Once we finally get rid of it, we're no longer constrained on the `Entry` internal representation as other coders don't directly marshal the instance.
