### PR TITLE
Make `perform_enqueued_jobs` compatible with all Active Job adapters

### DIFF
--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -623,3 +623,17 @@ class AnotherTestHelperMailerTest < ActionMailer::TestCase
     assert_equal "a value", @test_var
   end
 end
+
+class AdapterIsNotTestAdapterTest < ActionMailer::TestCase
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::InlineAdapter.new
+  end
+
+  def test_can_send_email_using_any_active_job_adapter
+    assert_nothing_raised do
+      assert_emails 1 do
+        TestHelperMailer.test.deliver_now
+      end
+    end
+  end
+end

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `perform_enqueued_jobs` is now compatible with all Active Job adapters
+
+    This means that methods that depend on it, like Action Mailer's `assert_emails`,
+    will work correctly even if the test adapter is not used.
+
+    *Alex Ghiculescu*
+
 *   Allow queue adapters to provide a custom name by implementing `queue_adapter_name`
 
     *Sander Verdonschot*

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -2059,6 +2059,20 @@ class PerformedJobsTest < ActiveJob::TestCase
   end
 end
 
+class AdapterIsNotTestAdapterTest < ActiveJob::TestCase
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::InlineAdapter.new
+  end
+
+  def test_perform_enqueued_jobs_just_yields
+    JobBuffer.clear
+    perform_enqueued_jobs do
+      HelloJob.perform_later("kevin")
+    end
+    assert_equal(1, JobBuffer.values.size)
+  end
+end
+
 class OverrideQueueAdapterTest < ActiveJob::TestCase
   class CustomQueueAdapter < ActiveJob::QueueAdapters::TestAdapter; end
 


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/issues/37270 describes a common Active Job issue where if you try to set an adapter other than `:test` as your adapter in a test environment, you get some confusing results.

The [most popular workaround](https://github.com/rails/rails/issues/37270#issuecomment-567900541) on the issue is to add this to a setup block:

```ruby
(ActiveJob::Base.descendants << ActiveJob::Base).each(&:disable_test_adapter)
```

This solves some issues, but causes others. https://github.com/bensheldon/good_job/issues/846 is an example of an issue it causes. If you call `assert_emails` in an integration test, it will crash [here](https://github.com/rails/rails/blob/48e17e5ce75a02a331e6b48769d9c75243269696/activejob/lib/active_job/test_helper.rb#L603) because only the test adapter defines `perform_enqueued_jobs`.

I think we should fix the issue of Active Job adapters being inconsistent across tests fully, and https://github.com/rails/rails/pull/48585 is my work in progress for that. But I wanted to extract this fix from that PR since I think it's useful in isolation.

### Detail

With this PR, `perform_enqueued_jobs` will yield if a block is given but the test adapter is not being used. This is the minimum required to make that method compatible with any adapter.

### Additional information

ref: https://github.com/bensheldon/good_job/issues/846, https://github.com/rails/rails/issues/37270

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
