### PR TITLE
Add a missing "require" activesupport:

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support"
+
 # == Attribute Accessors per Thread
 #
 # Extends the module object with class/module and instance accessors for


### PR DESCRIPTION
Add a missing "require" activesupport:

- The `::ActiveSupport::IsolatedExecutionState` constant can't be autoloaded otherwise.

 https://github.com/rails/rails/blob/5b2523edaa131eec7b18780b7916760828262df4/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb#L51

