### PR TITLE
Emit warning when using 6.1 cache format as well

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -105,14 +105,6 @@ module ActiveSupport
   end
 
   def self.cache_format_version=(value)
-    if value == 6.1
-      ActiveSupport.deprecator.warn <<~EOM
-        Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
-
-        Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
-        for more information on how to upgrade.
-      EOM
-    end
     Cache.format_version = value
   end
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -671,6 +671,12 @@ module ActiveSupport
         def default_coder
           case Cache.format_version
           when 6.1
+            ActiveSupport.deprecator.warn <<~EOM
+              Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
+
+              Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+              for more information on how to upgrade.
+            EOM
             Cache::SerializerWithFallback[:marshal_6_1]
           when 7.0
             Cache::SerializerWithFallback[:marshal_7_0]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4246,6 +4246,18 @@ module ApplicationTests
         Rails.cache.instance_variable_get(:@coder)
     end
 
+    test "ActiveSupport::Cache.format_version 6.1 is deprecated" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal 6.1, ActiveSupport::Cache.format_version
+
+      assert_deprecated(ActiveSupport.deprecator) do
+        ActiveSupport::Cache::Store.new
+      end
+    end
+
     test "raise_on_invalid_cache_expiration_time is false with 7.0 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "7.0"'


### PR DESCRIPTION
### Motivation / Background

Ref #48598 

A deprecation warning was [added][1] to ensure that applications manually setting `config.active_support.cache_format_version` to `6.1` will be aware that they need to migrate. However, if an app is not using a `config.load_defaults` of `7.0` or greater, this warning will never be triggered.

### Detail

This commit adds an additional warning where the configuration is used to cover this case as well.

[1]: https://github.com/rails/rails/commit/2ba3ac29c36f4c6d23b1dd302584f15739ff2aff

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
