### PR TITLE
Support stale state detections in CPK through associations

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -81,7 +81,9 @@ module ActiveRecord
         # to try to properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.belongs_to?
-            owner[through_reflection.foreign_key] && owner[through_reflection.foreign_key].to_s
+            Array(through_reflection.foreign_key).map do |foreign_key_column|
+              owner[foreign_key_column] && owner[foreign_key_column].to_s
+            end
           end
         end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1639,6 +1639,17 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal([order_agreement], book.order_agreements.to_a)
   end
 
+  def test_cpk_stale_target
+    order = Cpk::Order.create!(shop_id: 1)
+    book = Cpk::BookWithOrderAgreements.create!(id: [1, 2], order: order)
+    Cpk::OrderAgreement.create!(order: order)
+
+    book.order_agreements.load
+    book.order = Cpk::Order.new
+
+    assert_predicate(book.association(:order_agreements), :stale_target?)
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -454,4 +454,15 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(order_agreement, book.order_agreement)
   end
+
+  def test_cpk_stale_target
+    order = Cpk::Order.create!(shop_id: 1)
+    book = Cpk::BookWithOrderAgreements.create!(id: [1, 2], order: order)
+    Cpk::OrderAgreement.create!(order: order)
+
+    book.order_agreement
+    book.order = Cpk::Order.new
+
+    assert_predicate(book.association(:order_agreement), :stale_target?)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because stale stack checking for `has_many` / `has_one` through relations doesn't currently work for composite primary key relations. 

### Detail

This Pull Request changes stale states so that they are tracked as an array of columns to properly check through associations with composite primary keys.

### Additional information

My tests might be too close to the implementation. Let me know if I should improve that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
