### PR TITLE
Add option apply_on_subqueries to associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Add option to merge association scopes to subqueries.
+
+    It removes a breaking change introduced by #48487. Conditions that were not applied in
+    previous versions would be applied giving people different results.
+
+    Set the option on an association:
+
+    ```ruby
+    class Author < ApplicationRecord
+      has_many :welcome_posts, -> { where(title: "welcome") } , class_name: "Post"
+      has_many :welcome_posts_scoped, -> { where(title: "Welcome") }, class_name: "Post", apply_on_subqueries: true
+    end
+    ```
+
+    Then the association scope will be merged into the subquery.
+
+    ```ruby
+    Author.where(welcome_posts: Post.all)
+    #=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts")
+
+    Author.where(welcome_posts_scoped: Post.all)
+    #=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts" WHERE "posts"."title" = 'welcome')
+    ```
+
+    *Lázaro Nixon*
+
 *   Support decrypting data encrypted non-deterministically with a SHA1 hash digest.
 
     This adds a new Active Record encryption option to support decrypting data encrypted

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1502,6 +1502,9 @@ module ActiveRecord
         # [:ensuring_owner_was]
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
+        # [:apply_on_subqueries]
+        #   When set to +true+ and a relation is used as a where parameter, the association scope will be merged
+        #   into the generated subquery, so you don't need to repeat those conditions on the relation.
         #
         # Option examples:
         #   has_many :comments, -> { order("posted_on") }
@@ -1681,6 +1684,9 @@ module ActiveRecord
         # [:ensuring_owner_was]
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
+        # [:apply_on_subqueries]
+        #   When set to +true+ and a relation is used as a where parameter, the association scope will be merged
+        #   into the generated subquery, so you don't need to repeat those conditions on the relation.
         #
         # Option examples:
         #   has_one :credit_card, dependent: :destroy  # destroys the associated credit card
@@ -1853,6 +1859,9 @@ module ActiveRecord
         # [:ensuring_owner_was]
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
+        # [:apply_on_subqueries]
+        #   When set to +true+ and a relation is used as a where parameter, the association scope will be merged
+        #   into the generated subquery, so you don't need to repeat those conditions on the relation.
         #
         # Option examples:
         #   belongs_to :firm, foreign_key: "client_of"

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -19,7 +19,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
     self.extensions = []
 
     VALID_OPTIONS = [
-      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints
+      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate,
+      :inverse_of, :strict_loading, :query_constraints, :apply_on_subqueries
     ].freeze # :nodoc:
 
     def self.build(model, name, scope, options, &block)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -328,6 +328,10 @@ module ActiveRecord
         message << " named `:#{name}` cannot be lazily loaded."
       end
 
+      def apply_on_subqueries?
+        options[:apply_on_subqueries] || false
+      end
+
       protected
         def actual_source_reflection # FIXME: this is a horrible name
           self

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -26,6 +26,7 @@ module ActiveRecord
           case value
           when Relation
             relation = value
+            relation = relation.merge(scope) if merge_scope?
             relation = relation.select(primary_key) if select_clause?
             relation = relation.where(primary_type => polymorphic_name) if polymorphic_clause?
             relation
@@ -48,12 +49,20 @@ module ActiveRecord
           associated_table.polymorphic_name_association
         end
 
+        def scope
+          associated_table.scope
+        end
+
         def select_clause?
           value.select_values.empty?
         end
 
         def polymorphic_clause?
           primary_type && !value.where_values_hash.has_key?(primary_type)
+        end
+
+        def merge_scope?
+          associated_table.apply_on_subqueries? && scope
         end
 
         def convert_to_id(value)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class TableMetadata # :nodoc:
-    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, to: :reflection
+    delegate :join_primary_key, :join_primary_type, :join_foreign_key, :join_foreign_type, :scope, to: :reflection
 
     def initialize(klass, arel_table, reflection = nil)
       @klass = klass
@@ -69,6 +69,10 @@ module ActiveRecord
 
     def through_association?
       reflection&.through_reflection?
+    end
+
+    def apply_on_subqueries?
+      reflection&.apply_on_subqueries?
     end
 
     def reflect_on_aggregation(aggregation_name)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -463,6 +463,18 @@ module ActiveRecord
       assert_equal [treasures(:diamond)], treasures
     end
 
+    def test_where_on_association_merging_scope
+      authors = Author.where(welcome_posts_scoped: Post.all)
+      assert_equal 1, authors.count
+      assert_equal authors(:david), authors.first
+    end
+
+    def test_where_on_association_not_merging_scope
+      authors = Author.where(welcome_posts: Post.all)
+      assert_operator authors.count, :>, 1
+      assert_equal authors(:david), authors.first
+    end
+
     def test_where_with_strong_parameters
       author = authors(:david)
       params = ProtectedParams.new(name: author.name)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -77,6 +77,7 @@ class Author < ActiveRecord::Base
 
   has_many :thinking_posts, -> { where(title: "So I was thinking") }, dependent: :delete_all, class_name: "Post"
   has_many :welcome_posts, -> { where(title: "Welcome to the weblog") }, class_name: "Post"
+  has_many :welcome_posts_scoped, -> { where(title: "Welcome to the weblog") }, class_name: "Post", apply_on_subqueries: true
 
   has_many :welcome_posts_with_one_comment,
            -> { where(title: "Welcome to the weblog").where(comments_count: 1) },


### PR DESCRIPTION
### Motivation / Background

Add option to merge association scopes to subqueries.

It removes a breaking change introduced by #48487. Conditions that were not applied in
previous versions would be applied giving people different results.

Set the option on an association:

```ruby
class Author < ApplicationRecord
  has_many :welcome_posts, -> { where(title: "welcome") } , class_name: "Post"
  has_many :welcome_posts_scoped, -> { where(title: "Welcome") }, class_name: "Post", apply_on_subqueries: true
end
```

Then the association scope will be merged into the subquery.

```ruby
Author.where(welcome_posts: Post.all)
#=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts")

Author.where(welcome_posts_scoped: Post.all)
#=> SELECT (...) WHERE "authors"."id" IN (SELECT "posts"."author_id" FROM "posts" WHERE "posts"."title" = 'welcome')    
```

### Additional information

https://github.com/rails/rails/pull/48487#issuecomment-1612150489

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
