### PR TITLE
Introduce `ActiveSupport::Duration#in_time_duration`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce `ActiveSupport::Duration#in_time_duration`
+
+    ```ruby
+    1.5.hours.in_time_duration => "00:01:30.00"
+    ```
+
+    *Steve Polito*
+
 *   Rename `Range#overlaps?` to `#overlap?` and add alias for backwards compatibility
 
     *Christian Schmidt*

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -417,6 +417,19 @@ module ActiveSupport
       in_seconds / SECONDS_PER_YEAR.to_f
     end
 
+    # Returns the duration as a string in the format "HH:MM:SS.milliseconds"
+    #
+    #   1.5.hours.in_time_duration => "00:01:30.00"
+    def in_time_duration
+      prefix       = "-" if value.negative?
+      hours        = in_hours.abs.to_i.to_s.rjust(2, "0")
+      minutes      = ((in_seconds.abs / SECONDS_PER_MINUTE) % SECONDS_PER_MINUTE).to_i.to_s.rjust(2, "0")
+      seconds      = (in_seconds.abs % SECONDS_PER_MINUTE).to_i.to_s.rjust(2, "0")
+      milliseconds = (value.abs % 1).round(2).to_s.delete_prefix("0.").ljust(2, "0")
+
+      "#{prefix}#{hours}:#{minutes}:#{seconds}.#{milliseconds}"
+    end
+
     # Returns +true+ if +other+ is also a Duration instance, which has the
     # same parts as this one.
     def eql?(other)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -81,6 +81,30 @@ class DurationTest < ActiveSupport::TestCase
     assert_in_delta 1.0, 365.days.in_years
   end
 
+  def test_in_time_duration
+    assert_equal "-25:01:01.00", (-1.day - 1.hour - 1.minute - 1.second).in_time_duration
+    assert_equal "00:00:00.00", 0.seconds.in_time_duration
+    assert_equal "00:00:00.66", 0.66.seconds.in_time_duration
+    assert_equal "00:00:00.67", 0.666.seconds.in_time_duration
+    assert_equal "00:00:00.12", 0.123.seconds.in_time_duration
+    assert_equal "00:00:00.00", (1.second - 1.second).in_time_duration
+    assert_equal "00:00:01.00", 1.second.in_time_duration
+    assert_equal "00:01:01.00", (1.minute + 1.second).in_time_duration
+    assert_equal "00:00:59.00", (1.minute - 1.second).in_time_duration
+    assert_equal "00:01:00.00", 1.minute.in_time_duration
+    assert_equal "00:01:59.00", (2.minutes - 1.second).in_time_duration
+    assert_equal "00:59:59.00", (1.hour - 1.second).in_time_duration
+    assert_equal "01:00:00.00", 1.hour.in_time_duration
+    assert_equal "01:59:59.00", (2.hours - 1.second).in_time_duration
+    assert_equal "23:59:59.00", (1.day - 1.second).in_time_duration
+    assert_equal "24:00:00.00", 1.day.in_time_duration
+    assert_equal "25:01:01.00", (1.day + 1.hour + 1.minute + 1.second).in_time_duration
+    assert_equal "36:00:00.00", 1.5.days.in_time_duration
+    assert_equal "01:30:00.00", 1.5.hours.in_time_duration
+    assert_equal "00:01:30.00", 1.5.minutes.in_time_duration
+    assert_equal "00:00:01.50", 1.5.seconds.in_time_duration
+  end
+
   def test_eql
     assert 1.minute.eql?(1.minute)
     assert 1.minute.eql?(60.seconds)


### PR DESCRIPTION
### Motivation / Background

It's common to represent duration in the format "HH:MM:SS.milliseconds". For example, media players or time tracking. Prior to this commit, it was not possible to return duration in this format/

### Detail

Returns the duration as a string in the format "HH:MM:SS.milliseconds". Supports negative values, as well as decimal points with 2 points for precision, while accounting for rounding.

```ruby
-1.hours.in_time_duration
# => "-01:00:00.00"
1.5.hours.in_time_duration 
# => "00:01:30.00"
0.66.seconds.in_time_duration
# => "00:00:00.66"
0.666.seconds.in_time_duration
# => "00:00:00.67"
```

### Additional information

- In an effort to support negative durations, we call [abs](https://docs.ruby-lang.org/en/master/Numeric.html#method-i-abs) on all values.
- The string will always return 11 characters: 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
