### PR TITLE
Warn on an unnecessary table_name= invocation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Warn on an unnecessary `self.table_name =` configuration
+
+    This commit adds a warning when `self.table_name =` is explicitly configured to the same
+    value as would have been derived by convention and asks to remove the unnecessary config.
+
+    *Nikita Vasilevsky*
+
 *   Support decrypting data encrypted non-deterministically with a SHA1 hash digest.
 
     This adds a new Active Record encryption option to support decrypting data encrypted

--- a/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
+++ b/activerecord/test/cases/associations/eager_load_includes_full_sti_class_test.rb
@@ -6,7 +6,6 @@ require "models/tagging"
 
 module Namespaced
   class Post < ActiveRecord::Base
-    self.table_name = "posts"
     has_one :tagging, as: :taggable, class_name: "Tagging"
   end
 end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -79,7 +79,6 @@ class DeveloperWithSymbolsForKeys < ActiveRecord::Base
 end
 
 class SubDeveloper < Developer
-  self.table_name = "developers"
   has_and_belongs_to_many :special_projects,
     join_table: "developers_projects",
     foreign_key: "project_id",

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -524,6 +524,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "posts", PostRecord.table_name
   end
 
+  def test_unnecessary_table_name_assignment_warns
+    message = /Unnecessary `self.table_name=` invocation, the table name for Topic can be derived from the model name./
+    assert_logged(message) do
+      Topic.table_name = "topics"
+    end
+  end
+
   def test_null_fields
     assert_nil Topic.find(1).parent_id
     assert_nil Topic.create("title" => "Hey you").parent_id
@@ -1952,4 +1959,20 @@ class BasicsTest < ActiveRecord::TestCase
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
+
+  private
+    def assert_logged(message)
+      old_logger = ActiveRecord::Base.logger
+      log = StringIO.new
+      ActiveRecord::Base.logger = Logger.new(log)
+
+      begin
+        yield
+
+        log.rewind
+        assert_match message, log.read
+      ensure
+        ActiveRecord::Base.logger = old_logger
+      end
+    end
 end

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -363,8 +363,6 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     end
 
     class BookThatWillFailToEncryptName < UnencryptedBook
-      self.table_name = "encrypted_books"
-
       encrypts :name, key_provider: FailingKeyProvider.new
     end
 end

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -150,14 +150,10 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
     end
 
     class EncryptedAuthor1 < Author
-      self.table_name = "authors"
-
       encrypts :name, encryptor: TestEncryptor.new("1" => "2")
     end
 
     class EncryptedAuthor2 < Author
-      self.table_name = "authors"
-
       encrypts :name, encryptor: TestEncryptor.new("2" => "3"), previous: { encryptor: TestEncryptor.new("1" => "2") }
     end
 

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -570,7 +570,6 @@ end
 
 class InheritanceAttributeTest < ActiveRecord::TestCase
   class Company < ActiveRecord::Base
-    self.table_name = "companies"
     attribute :type, :string, default: "InheritanceAttributeTest::Startup"
   end
 
@@ -616,7 +615,6 @@ class InheritanceAttributeMappingTest < ActiveRecord::TestCase
   ActiveRecord::Type.register :omg_sti, OmgStiType
 
   class Company < ActiveRecord::Base
-    self.table_name = "companies"
     attribute :type, :omg_sti
   end
 
@@ -624,7 +622,6 @@ class InheritanceAttributeMappingTest < ActiveRecord::TestCase
   class Empire < Company; end
 
   class Sponsor < ActiveRecord::Base
-    self.table_name = "sponsors"
     attribute :sponsorable_type, :omg_sti
 
     belongs_to :sponsorable, polymorphic: true

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -683,8 +683,6 @@ class QueryCacheMutableParamTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   class JsonObj < ActiveRecord::Base
-    self.table_name = "json_objs"
-
     attribute :payload, :json
   end
 

--- a/activerecord/test/cases/reserved_word_test.rb
+++ b/activerecord/test/cases/reserved_word_test.rb
@@ -18,7 +18,6 @@ class ReservedWordTest < ActiveRecord::TestCase
   end
 
   class Values < ActiveRecord::Base
-    Values.table_name = "values"
   end
 
   class Distinct < ActiveRecord::Base

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -6,6 +6,9 @@ require "models/numeric_data"
 class NumericalityValidationTest < ActiveRecord::TestCase
   def setup
     @model_class = NumericData.dup
+    def @model_class.model_name
+      @model_name ||= ActiveModel::Name.new(self, nil, "NumericData")
+    end
   end
 
   attr_reader :model_class

--- a/activerecord/test/models/author_encrypted.rb
+++ b/activerecord/test/models/author_encrypted.rb
@@ -3,14 +3,10 @@
 require "models/author"
 
 class EncryptedAuthor < Author
-  self.table_name = "authors"
-
   validates :name, uniqueness: true
   encrypts :name, previous: { deterministic: true }
 end
 
 class EncryptedAuthorWithKey < Author
-  self.table_name = "authors"
-
   encrypts :name, key: "some secret key!"
 end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -5,8 +5,6 @@ class UnencryptedBook < ActiveRecord::Base
 end
 
 class EncryptedBook < ActiveRecord::Base
-  self.table_name = "encrypted_books"
-
   encrypts :name, deterministic: true
 end
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -267,8 +267,6 @@ class PoorDeveloperCalledJamis < ActiveRecord::Base
 end
 
 class InheritedPoorDeveloperCalledJamis < DeveloperCalledJamis
-  self.table_name = "developers"
-
   default_scope -> { where(salary: 50000) }
 end
 
@@ -287,8 +285,6 @@ module SalaryDefaultScope
 end
 
 class ModuleIncludedPoorDeveloperCalledJamis < DeveloperCalledJamis
-  self.table_name = "developers"
-
   include SalaryDefaultScope
 end
 

--- a/activerecord/test/models/doubloon.rb
+++ b/activerecord/test/models/doubloon.rb
@@ -9,6 +9,4 @@ end
 
 class Doubloon < AbstractDoubloon
   # This uses an abstract class that defines attributes and associations.
-
-  self.table_name = "doubloons"
 end

--- a/activerecord/test/models/numeric_data.rb
+++ b/activerecord/test/models/numeric_data.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class NumericData < ActiveRecord::Base
-  self.table_name = "numeric_data"
   # Decimal columns with 0 scale being automatically treated as integers
   # is deprecated, and will be removed in a future version of Rails.
   attribute :world_population, :big_integer

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -218,7 +218,6 @@ class AbstractStiPost < Post
 end
 
 class SubStiPost < StiPost
-  self.table_name = Post.table_name
 end
 
 class SubAbstractStiPost < AbstractStiPost; end

--- a/activerecord/test/models/post_encrypted.rb
+++ b/activerecord/test/models/post_encrypted.rb
@@ -3,8 +3,6 @@
 require "models/post"
 
 class EncryptedPost < Post
-  self.table_name = "posts"
-
   # We want to modify the key for testing purposes
   class MutableDerivedSecretKeyProvider < ActiveRecord::Encryption::DerivedSecretKeyProvider
     attr_accessor :keys

--- a/activerecord/test/models/tag.rb
+++ b/activerecord/test/models/tag.rb
@@ -9,8 +9,6 @@ class Tag < ActiveRecord::Base
 end
 
 class OrderedTag < Tag
-  self.table_name = "tags"
-
   has_many :ordered_taggings, -> { order("taggings.id DESC") }, foreign_key: "tag_id", class_name: "Tagging"
   has_many :tagged_posts, through: :ordered_taggings, source: "taggable", source_type: "Post"
 end


### PR DESCRIPTION
This commit adds a warning when `self.table_name =` is explicitly configured to the same value as would have been derived by convention and asks to remove the unnecessary config.

I couldn't find a lot of examples where Rails issues any kind of notifications to help applications follow the "convention over configuration" principle but at the same time I'm struggling to find any argument against Rails being helpful in certain cases. 
Generally we may be concerned about adding non-functional checks and degrading performance but in case of `table_name=` it can only impact boot time which will unlikely be noticeable

