### PR TITLE
Improve performance of ActiveSupport::JSON.encode

### DIFF
--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -179,7 +179,7 @@ class JsonSerializationTest < ActiveModel::TestCase
   end
 
   test "custom as_json should be honored when generating json" do
-    def @contact.as_json(options); { name: name, created_at: created_at }; end
+    def @contact.as_json(options = nil); { name: name, created_at: created_at }; end
     json = @contact.to_json
 
     assert_match %r{"name":"Konata Izumi"}, json

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -149,8 +149,8 @@ class JsonSerializationTest < ActiveRecord::TestCase
     @contact = ContactSti.new(@contact.attributes)
     assert_equal "ContactSti", @contact.type
 
-    def @contact.serializable_hash(options = {})
-      super({ except: %w(age) }.merge!(options))
+    def @contact.serializable_hash(options = nil)
+      super({ except: %w(age) }.merge!(options || {}))
     end
 
     json = @contact.to_json

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -35,7 +35,10 @@ module ActiveSupport
 
         # Encode the given object into a JSON string
         def encode(value)
-          stringify jsonify value.as_json(options.dup)
+          unless options.empty?
+            value = value.as_json(options.dup)
+          end
+          stringify jsonify value
         end
 
         private

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -67,7 +67,7 @@ module ActiveSupport
             :ESCAPE_REGEX_WITHOUT_HTML_ENTITIES
 
           # Convert an object into a "JSON-ready" representation composed of
-          # primitives like Hash, Array, String, Numeric,
+          # primitives like Hash, Array, String, Symbol, Numeric,
           # and +true+/+false+/+nil+.
           # Recursively calls #as_json to the object to recursively build a
           # fully JSON-ready object.
@@ -81,14 +81,15 @@ module ActiveSupport
           # calls.
           def jsonify(value)
             case value
-            when String
+            when String, Integer, Symbol, nil, true, false
               value
-            when Numeric, NilClass, TrueClass, FalseClass
+            when Numeric
               value.as_json
             when Hash
               result = {}
               value.each do |k, v|
-                result[jsonify(k)] = jsonify(v)
+                k = k.to_s unless Symbol === k || String === k
+                result[k] = jsonify(v)
               end
               result
             when Array

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -36,6 +36,26 @@ module JSONTest
     end
   end
 
+  class RomanNumeral < Numeric
+    def initialize(str)
+      @str = str
+    end
+
+    def as_json(options = nil)
+      @str
+    end
+  end
+
+  class CustomNumeric < Numeric
+    def initialize(str)
+      @str = str
+    end
+
+    def to_json(options = nil)
+      @str
+    end
+  end
+
   module EncodingTestCases
     TrueTests     = [[ true,  %(true)  ]]
     FalseTests    = [[ false, %(false) ]]
@@ -46,7 +66,10 @@ module JSONTest
                      [ 1.0 / 0.0,   %(null) ],
                      [ -1.0 / 0.0,  %(null) ],
                      [ BigDecimal("0.0") / BigDecimal("0.0"),  %(null) ],
-                     [ BigDecimal("2.5"), %("#{BigDecimal('2.5')}") ]]
+                     [ BigDecimal("2.5"), %("#{BigDecimal('2.5')}") ],
+                     [ RomanNumeral.new("MCCCXXXVII"), %("MCCCXXXVII") ],
+                     [ [CustomNumeric.new("123")], %([123]) ]
+    ]
 
     StringTests   = [[ "this is the <string>",     %("this is the \\u003cstring\\u003e")],
                      [ 'a "string" with quotes & an ampersand', %("a \\"string\\" with quotes \\u0026 an ampersand") ],


### PR DESCRIPTION
This about doubles the performance of `.to_json`/`ActiveSupport::JSON.encode` (with most impact when data is already JSON-ready, and no options are passed, but should be faster in all cases). The change should be mostly transparent to users. I've split this into three commits for easier digesting.

## [Avoid extra pass on AS::JSON.dump with no options](https://github.com/rails/rails/commit/047da67ba31ec241e82ff630bdf446d8953fe754)

JSONGemEncoder.encode previously would always perform two passes. First it would call `.as_json(options)`, but then would perform a second pass "jsonify" to recursively call `.as_json` (this time without options) until the data converges into a "JSON-ready" representation.

When options are not given, the second pass should be equivalent to the first, so we can detect that, and only perform the "jsonify" step.

The only user-visible effect of this should be that we will pass no options to `as_json` instead of an empty Hash, but implementations of `as_json` should already be expected to accept that (EDIT: though there was one test case each in ActiveModel and ActiveRecord which this broke).

This could be considered a "light" version of what was done in https://github.com/rails/rails/pull/34633 from @tenderlove and @eileencodes from a few years back (I think that's still a great idea and may still be a future implementation, but a wider change than this PR).

## [Escape JSON output instead of string inputs](https://github.com/rails/rails/commit/306490b07c95b1960c0316120d1133c563478456)

Rails performs additional escaping of strings compared to the JSON gem, and will escape U+2028, U+2029, <, >, and &. In JSON, the only places those characters are valid is inside of a JSON string, so it should be equivalent (and faster) to perform the escaping on the output.

This has the most performance impact, which is nice as it should improve all `.to_json` calls regardless of input. This escaping is still quite expensive and something I intend to continue looking into (either adjusting our rules for escaping or having a faster implementation of the escaping further upstream).

## [Consider Symbol "JSON-ready", improve jsonify](https://github.com/rails/rails/commit/c9bf6a176d733f90f40ddacfc84fa8a72af6fde8)

Previously jsonify would call `.as_json` for Integer, nil, true, and false, even though those types are considered "JSON-ready" (looks like this was introduced in https://github.com/rails/rails/pull/26933). Technically a user could have overridden `.as_json` for these types but I can't imagine a use case and I don't think we should support that.

I left the same behaviour of calling `.as_json` for generic "Numeric" as that can have user subclasses where one may have implemented `as_json`. This behaviour is also used for Float (which coerces `NaN`/`Infinity`/`-Infinity` into `nil`).

This also adds Symbol to the list of "JSON-ready" types, to avoid unnecessarily casting them to strings (possible as we no longer perform escaping on input). The output of `jsonify` should never be user visible before it is passed through `JSON.generate`, so I don't think this can be seen by users.

This also corrects our handling of Hash to call `to_s` on all keys, matching the behaviour of `.as_json` and JSON's requirement that keys are `Strings` (`Symbol`s are also permitted as the JSON gem knows to convert them to a string).


## Benchmark

Tested using the `twitter.json` from [nativejson-benchmark](https://github.com/miloyip/nativejson-benchmark#json-data), which is somewhat unicode-heavy but otherwise IMO pretty typical.

(JSON and RapidJSON included just for comparison/scale)

``` ruby
source_data = ::JSON.parse(File.read("twitter.json"))
source_data_sym = source_data.deep_symbolize_keys.deep_dup
```

**Rails main**

```
 source_data.to_json     26.103  (± 0.0%) i/s -    132.000  in   5.056999s
source_data_sym.to_json
                         24.311  (± 0.0%) i/s -    122.000  in   5.018373s
JSON.generate(source_data)
                        474.026  (± 0.8%) i/s -      2.392k in   5.046540s
RapidJSON.generate(source_data)
                        716.922  (± 4.6%) i/s -      3.618k in   5.057603s
```

**this branch**

```
 source_data.to_json     61.344  (± 0.0%) i/s -    310.000  in   5.053787s
source_data_sym.to_json
                         63.068  (± 1.6%) i/s -    318.000  in   5.042746s
JSON.generate(source_data)
                        470.431  (± 2.3%) i/s -      2.392k in   5.087858s
RapidJSON.generate(source_data)
                        704.303  (± 3.4%) i/s -      3.520k in   5.004222s
```

---

cc @matthewd @byroot 