### PR TITLE
Add lower bound to Listen gem requirement

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improve error message when EventedFileUpdateChecker is used without a
+    compatible version of the Listen gem
+
+    *Hartley McGuire*
+
 *   Add `:report` behavior for Deprecation
 
     Setting `config.active_support.deprecation = :report` uses the error

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "listen"
+gem "listen", "~> 3.5"
 require "listen"
 
 require "set"


### PR DESCRIPTION
### Motivation / Background

Ref #48620

An issue was recently opened with the following error message:

```
.../activesupport-7.0.6/lib/active_support/evented_file_update_checker.rb:120:in `start': undefined method `wait_for_state' for #<Listen::Listener ...>
```

The issue is that the user was using Listen 3.0.8, however the `wait_for_state` method was [added][1] in Listen 3.3.0

### Detail

We can make the error message a little better by defining a lower bound on Listen 3.3.0 (like we do for other optional dependencies):

```
.../bundler/rubygems_integration.rb:280:in `block (2 levels) in replace_gem': can't activate listen (~> 3.3), already activated listen-3.0.8. Make sure all dependencies are added to Gemfile. (Gem::LoadError)
```

There is definitely still room for improvement here, but this should be much more helpful in figuring out that the issue is a bad Listen version and not a bug in Rails.

[1]: https://github.com/guard/listen/commit/12b4fc54a965f6a07c71bd53207ce8be8b0d7869

### Additional Information

If this is backport worthy, we would need to backport #47002 as well

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
