### PR TITLE
Fix incorrect arguments for Active Job test job [internal]

### DIFF
--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -515,6 +515,12 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_no_enqueued_jobs_and_perform_now
+    assert_no_enqueued_jobs do
+      LoggingJob.perform_now(1, 2, 3, keyword: true)
+    end
+  end
+
   def test_assert_enqueued_with_returns
     job = assert_enqueued_with(job: LoggingJob) do
       LoggingJob.set(wait_until: 5.minutes.from_now).perform_later(1, 2, 3, keyword: true)

--- a/activejob/test/jobs/logging_job.rb
+++ b/activejob/test/jobs/logging_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class LoggingJob < ActiveJob::Base
-  def perform(dummy)
-    logger.info "Dummy, here is it: #{dummy}"
+  def perform(*dummy)
+    logger.info "Dummy, here is it: #{dummy.join(" ")}"
   end
 
   def job_id


### PR DESCRIPTION
This is an internal fix, not user facing. I noticed it while working on https://github.com/rails/rails/pull/48585.

Currently the `LoggingJob` does not accept more than one argument. But there's [a few tests](https://github.com/rails/rails/blob/f46d3452ae30c46d3e213c687decbbca0cee9119/activejob/test/cases/test_helper_test.rb#L518-L537) that call it with multiple arguments and assert that it is queued correctly. Those tests pass because the job is not performed, but if the job was performed, they'd fail.

This PR just fixes `LoggingJob` to accept a splat of arguments, and adds a test to ensure that it works correctly.
