### PR TITLE
Document generated scopes for `has_one_attached` and `has_many_attached`

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -9,6 +9,48 @@ module ActiveStorage
   module Attached::Model
     extend ActiveSupport::Concern
 
+    ##
+    # :method: *_attachment
+    #
+    # Returns the attachment for the +has_one_attached+.
+    #
+    #   User.last.avatar_attachment
+
+    ##
+    # :method: *_attachments
+    #
+    # Returns the attachments for the +has_many_attached+.
+    #
+    #   Gallery.last.photos_attachments
+
+    ##
+    # :method: *_blob
+    #
+    # Returns the blob for the +has_one_attached+ attachment.
+    #
+    #   User.last.avatar_blob
+
+    ##
+    # :method: *_blobs
+    #
+    # Returns the blobs for the +has_many_attached+ attachments.
+    #
+    #   Gallery.last.photos_blobs
+
+    ##
+    # :method: with_attached_*
+    #
+    # Includes the attached blobs in your query to avoid N+1 queries.
+    #
+    # If +ActiveStorage.track_variants+ is enabled, it will also include the
+    # variants record and their attached blobs.
+    #
+    #   User.with_attached_avatar
+    #
+    # Use the plural form for +has_many_attached+:
+    #
+    #   Gallery.with_attached_photos
+
     class_methods do
       # Specifies the relation between a single attachment and the model.
       #


### PR DESCRIPTION
`has_one_attached` and `has_many_attached` generate several scopes and relations:

* `with_attached_*`
* `*_attachment`
* `*_attachments`
* `*_blob`
* `*_blobs`

But these are all undocumented.

We can document these methods similar to ee58c8e6be using the `:method:` directive.

<img width="1035" alt="image" src="https://github.com/rails/rails/assets/28561/68137c45-4eae-49c1-a26e-0019c9f3d280">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
