### PR TITLE
PostgreSQL reload virtual columns on update via RETURNING clause

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecated `ActiveRecord::ConnectionAdapters::Column#auto_populated?` in favor of
+    `auto_populated_on_insert?`
+
+    *Rafael Mendonça França*
+
 *   Reload virtual columns on update in PostgreSQL
 
     Automatically reload virtual columns on `update` when using PostgreSQL. This is done by issuing a single

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   Reload virtual columns on update in PostgreSQL
+
+    Automatically reload virtual columns on `update` when using PostgreSQL. This is done by issuing a single
+    UPDATE query that includes a RETURNING clause.
+
+    Given a `Post` model represented by the following schema:
+
+    ```ruby
+    create_table :posts do |t|
+      t.integer :upvotes_count
+      t.integer :downvotes_count
+      t.virtual :total_votes_count, type: :integer, as: "upvotes_count + downvotes_count", stored: true
+    end
+    ```
+
+    `total_votes_count` will reflect the sum of upvotes and downvotes after `update` is successfully called.
+    Prior to this change calling `reload` would have been necessary to obtain the new value calculated by
+    the database.
+
+    ```ruby
+    post = Post.find(1)
+    post.update(upvotes_count: 2, downvotes_count: 2)
+    # Calling `post.reload` no longer necessary
+    post.total_votes => 4
+    ```
+
+    *Alex Baldwin*
+
 *   Reset the optimistic locking column when a transaction is rolled back.
 
     Previously, when a record with optimistic locking was successfully saved

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -251,7 +251,7 @@ module ActiveRecord
             changed_attribute_names_to_save
           else
             attribute_names.reject do |attr_name|
-              if column_for_attribute(attr_name).auto_populated?
+              if column_for_attribute(attr_name).auto_populated_on_insert?
                 !attribute_changed?(attr_name)
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -259,6 +259,17 @@ module ActiveRecord
         intent.affected_rows
       end
 
+      # Executes the update statement and returns an ActiveRecord::Result
+      # Some adapters support the `returning` keyword argument
+      def update_with_result(arel, name = nil, binds = [], returning:) # :nodoc:
+        arel.returning(returning.map { |column| Arel.sql(quote_column_name(column)) })
+
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+
+        intent.execute!
+        intent.cast_result
+      end
+
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel, name = nil, binds = [])
         intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -587,6 +587,10 @@ module ActiveRecord
         false
       end
 
+      def supports_update_returning?
+        false
+      end
+
       def supports_insert_on_duplicate_skip?
         false
       end
@@ -612,7 +616,11 @@ module ActiveRecord
       end
 
       def return_value_after_insert?(column) # :nodoc:
-        column.auto_populated?
+        column.auto_populated_on_insert?
+      end
+
+      def return_value_after_update?(column)
+        column.auto_populated_on_update?
       end
 
       def async_enabled? # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -179,7 +179,7 @@ module ActiveRecord
       end
 
       def return_value_after_insert?(column) # :nodoc:
-        supports_insert_returning? ? column.auto_populated? : column.auto_increment?
+        supports_insert_returning? ? column.auto_populated_on_insert? : column.auto_increment?
       end
 
       # See https://dev.mysql.com/doc/refman/8.0/en/invisible-indexes.html for more details on MySQL feature.

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -75,6 +75,11 @@ module ActiveRecord
         auto_incremented_by_db? || default_function
       end
 
+      def auto_populated?
+        auto_populated_on_insert?
+      end
+      deprecate auto_populated?: :auto_populated_on_insert?, deprecator: ActiveRecord.deprecator
+
       def auto_populated_on_update?
         virtual?
       end

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -71,8 +71,12 @@ module ActiveRecord
         false
       end
 
-      def auto_populated?
+      def auto_populated_on_insert?
         auto_incremented_by_db? || default_function
+      end
+
+      def auto_populated_on_update?
+        virtual?
       end
 
       def ==(other)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -282,6 +282,7 @@ module ActiveRecord
       def supports_insert_returning?
         true
       end
+      alias supports_update_returning? supports_insert_returning?
 
       def supports_insert_on_conflict?
         true

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -473,6 +473,12 @@ module ActiveRecord
         end
       end
 
+      def _returning_columns_for_update(connection)
+        @_returning_columns_for_update ||= columns.filter_map do |c|
+          c.name if connection.return_value_after_update?(c)
+        end
+      end
+
       # Returns the column object for the named attribute.
       # Returns an ActiveRecord::ConnectionAdapters::NullColumn if the
       # named attribute does not exist.
@@ -578,6 +584,7 @@ module ActiveRecord
 
         def reload_schema_from_cache(recursive = true)
           @_returning_columns_for_insert = nil
+          @_returning_columns_for_update = nil
           @arel_table = nil
           @column_names = nil
           @symbol_column_to_string_name_hash = nil

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -261,21 +261,18 @@ module ActiveRecord
       end
 
       def _update_record(values, constraints) # :nodoc:
-        constraints = constraints.map { |name, value| predicate_builder[name, value] }
-
-        default_constraint = build_default_constraint
-        constraints << default_constraint if default_constraint
-
-        if current_scope = self.global_current_scope
-          constraints << current_scope.where_clause.ast
-        end
-
-        um = Arel::UpdateManager.new(arel_table)
-        um.set(values.transform_keys { |name| arel_table[name] })
-        um.wheres = constraints
+        um = _build_update_manager(values, constraints)
 
         with_connection do |c|
           c.update(um, "#{self} Update")
+        end
+      end
+
+      def _update_record_with_result(values, constraints, returning) # :nodoc:
+        um = _build_update_manager(values, constraints)
+
+        with_connection do |c|
+          c.update_with_result(um, "#{self} Update", returning: returning)
         end
       end
 
@@ -330,6 +327,22 @@ module ActiveRecord
 
           default_where_clause = default_scoped(all_queries: true).where_clause
           default_where_clause.ast unless default_where_clause.empty?
+        end
+
+        def _build_update_manager(values, constraints)
+          constraints = constraints.map { |name, value| predicate_builder[name, value] }
+
+          default_constraint = build_default_constraint
+          constraints << default_constraint if default_constraint
+
+          if current_scope = self.global_current_scope
+            constraints << current_scope.where_clause.ast
+          end
+
+          Arel::UpdateManager.new(arel_table).tap do |update_manager|
+            update_manager.set(values.transform_keys { |name| arel_table[name] })
+            update_manager.wheres = constraints
+          end
         end
     end
 
@@ -916,10 +929,36 @@ module ActiveRecord
       end
 
       def _update_row(attribute_names, attempted_action = "update")
-        self.class._update_record(
-          attributes_with_values(attribute_names),
-          _query_constraints_hash
-        )
+        returning_columns = self.class.with_connection do |c|
+          if c.supports_update_returning?
+            self.class._returning_columns_for_update(c)
+          else
+            []
+          end
+        end
+
+        if returning_columns.present?
+          result = self.class._update_record_with_result(
+            attributes_with_values(attribute_names),
+            _query_constraints_hash,
+            returning_columns
+          )
+
+          returning_values = result.rows.first
+
+          returning_columns.zip(returning_values).each do |column, value|
+            _write_attribute(column, value)
+          end if returning_values.present?
+
+          result.affected_rows
+        else
+          result = self.class._update_record(
+            attributes_with_values(attribute_names),
+            _query_constraints_hash,
+          )
+
+          result
+        end
       end
 
       def create_or_update(**, &block)

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -30,6 +30,13 @@ module Arel # :nodoc: all
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
           maybe_visit o.comment, collector
+
+          if o.returning.empty?
+            collector
+          else
+            collector << " RETURNING "
+            visit o.returning, collector
+          end
         end
 
         # In the simple case, PostgreSQL allows us to place FROM or JOINs directly into the UPDATE

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -183,6 +183,56 @@ module Arel
         }, compile(query)
       end
 
+      test "insert statements render RETURNING" do
+        manager = InsertManager.new
+        manager.into @table
+        manager.insert [[@table[:name], "hello"]]
+        manager.returning @table[:id]
+
+        assert_like %{
+          INSERT INTO "users" ("name") VALUES ('hello') RETURNING "users"."id"
+        }, compile(manager.ast)
+      end
+
+      test "delete statements render RETURNING" do
+        manager = DeleteManager.new
+        manager.from @table
+        manager.where @table[:name].eq("hello")
+        manager.returning @table[:id]
+
+        assert_like %{
+          DELETE FROM "users" WHERE "users"."name" = 'hello' RETURNING "users"."id"
+        }, compile(manager.ast)
+      end
+
+      test "update statements render RETURNING" do
+        manager = UpdateManager.new
+        manager.table @table
+        manager.set [[@table[:name], "hello"]]
+        manager.returning @table[:id]
+
+        assert_like %{
+          UPDATE "users" SET "name" = 'hello' RETURNING "users"."id"
+        }, compile(manager.ast)
+      end
+
+      test "update statements with joins render RETURNING" do
+        posts = Table.new(:posts)
+        join_source = Arel::Nodes::JoinSource.new(
+          @table,
+          [@table.create_join(posts)]
+        )
+
+        manager = UpdateManager.new
+        manager.table join_source
+        manager.set [[@table[:name], "hello"]]
+        manager.returning @table[:id]
+
+        assert_like %{
+          UPDATE "users" SET "name" = 'hello' FROM CROSS JOIN "posts" RETURNING "users"."id"
+        }, compile(manager.ast)
+      end
+
       test "Nodes::Cube should know how to visit with array arguments" do
         node = Arel::Nodes::Cube.new([@table[:name], @table[:bool]])
         assert_like %{

--- a/activerecord/test/cases/connection_adapters/column_test.rb
+++ b/activerecord/test/cases/connection_adapters/column_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ColumnTest < ActiveRecord::TestCase
+      def test_auto_populated_is_deprecated_in_favor_of_auto_populated_on_insert
+        column = Column.new("token", Type::Value.new, nil, nil, true, "gen_random_uuid()")
+
+        assert_deprecated(/auto_populated_on_insert\?/, ActiveRecord.deprecator) do
+          assert_equal column.auto_populated_on_insert?, column.auto_populated?
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -316,7 +316,7 @@ class Sqlite3DefaultExpressionTest < ActiveRecord::TestCase
       assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-      assert_match %r/t\.integer\s+"random_number",\s+default: -> { "ABS\(RANDOM\(\)\)" }/, output
+      assert_match %r/t\.integer\s+"random_number",\s+default: -> { "ABS\(RANDOM\(\) % 100\)" }/, output
     end
   end
 end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -7,6 +7,7 @@ require "models/parrot"
 require "models/person"   # For optimistic locking
 require "models/aircraft"
 require "models/numeric_data"
+require "models/default"
 
 class DirtyTest < ActiveRecord::TestCase
   include InTimeZone
@@ -992,6 +993,13 @@ class DirtyTest < ActiveRecord::TestCase
     assert parrot.breed_changed?(from: :african, to: :australian)
     assert parrot.breed_changed?(from: 0, to: 1)
   end
+
+  def test_virtual_column_loaded_change_on_update
+    record_with_defaults = Default.create(random_number: 105)
+    record_with_defaults.update!(random_number: 140)
+
+    assert_equal [1050, 1400], record_with_defaults.previous_changes[:virtual_stored_number]
+  end if current_adapter?(:PostgreSQLAdapter)
 
   private
     def with_partial_writes(klass, on = true)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -40,7 +40,7 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_populates_autoincremented_id_pk_regardless_of_its_position_in_columns_list
-    auto_populated_column_names = AutoId.columns.select(&:auto_populated?).map(&:name)
+    auto_populated_column_names = AutoId.columns.select(&:auto_populated_on_insert?).map(&:name)
 
     # It's important we test a scenario where tables has more than one auto populated column
     # and the first column is not the primary key. Otherwise it will be a regular test not asserting this special case.
@@ -91,6 +91,21 @@ class PersistenceTest < ActiveRecord::TestCase
         assert_not_nil record.id
       end
     end
+
+    def test_fills_auto_populated_columns_on_update
+      record_with_defaults = Default.create
+
+      record_with_defaults.update!(random_number: 105)
+      assert_equal 1050,  record_with_defaults.virtual_stored_number
+    end
+
+    def test_returning_columns_on_update_does_not_include_id
+      record_with_defaults = Default.create
+
+      sql = capture_sql { record_with_defaults.update!(random_number: 105) }.first
+
+      assert_equal false, (/RETURNING.*id/).match?(sql)
+    end
   elsif current_adapter?(:SQLite3Adapter)
     def test_fills_auto_populated_columns_on_creation
       record = Default.create
@@ -103,6 +118,17 @@ class PersistenceTest < ActiveRecord::TestCase
       assert_not_nil record.modified_time
       assert_not_nil record.modified_time_without_precision
       assert_not_nil record.modified_time_function
+    end
+
+    def test_does_not_fill_auto_populated_columns_on_update
+      # NOTE: When support for reload via RETURNING on update is added to sqlite this
+      #       test can be replaced with: test_fills_auto_populated_columns_on_update
+      record_with_defaults = Default.create
+      record_with_defaults.update!(random_number: 105)
+
+      assert_not_equal 1050, record_with_defaults.virtual_stored_number
+      record_with_defaults.reload
+      assert_equal 1050, record_with_defaults.virtual_stored_number
     end
   elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
     def test_fills_auto_populated_columns_on_creation
@@ -906,6 +932,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal topic, topic.delete, "topic.delete did not return self"
     assert_predicate topic, :frozen?, "topic not frozen after delete"
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
+  end
+
+  def test_update_does_run_callbacks
+    record = Default.create
+    record.update!(char1: "B")
+
+    assert_equal true, record.after_update_commit_called
   end
 
   def test_delete_doesnt_run_callbacks

--- a/activerecord/test/models/default.rb
+++ b/activerecord/test/models/default.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class Default < ActiveRecord::Base
+  attr_accessor :after_update_commit_called
+
+  after_update_commit do |record|
+    record.after_update_commit_called = true
+  end
 end

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -2,7 +2,8 @@
 
 ActiveRecord::Schema.define do
   create_table :defaults, force: true do |t|
-      t.integer :random_number, default: -> { "ABS(RANDOM())" }
+      t.virtual :virtual_stored_number, type: :integer, as: "random_number * 10", stored: true if supports_virtual_columns?
+      t.integer :random_number, default: -> { "ABS(RANDOM() % 100)" }
       t.string :ruby_on_rails, default: -> { "('Ruby ' || 'on ' || 'Rails')" }
       t.date :modified_date, default: -> { "CURRENT_DATE" }
       t.date :modified_date_function, default: -> { "DATE('now')" }


### PR DESCRIPTION
Extends Active Record to automatically reload virtual columns on update when using PostgreSQL. This is done by issuing a single UPDATE query that includes a RETURNING clause.

### Motivation

Saves an extra round trip to the database for reload and removes a developer pitfall around stale values.

### Detail

Given a `Post` model represented by the following schema:
```ruby
create_table :posts do |t|
  t.integer :upvotes_count
  t.integer :downvotes_count
  t.virtual :total_votes_count, type: :integer, as: "upvotes_count + downvotes_count", stored: true
end
```
`total_votes_count` will reflect the sum of upvotes and downvotes after `update` is successfully called. Prior to this change calling `reload` would have been necessary to obtain the value calculated by the database.
```ruby
post = Post.find(1)
post.update(upvotes_count: 2, downvotes_count: 2)
# Calling `post.reload` no longer necessary
post.total_votes => 4
```

* At this moment MySQL and SQLite adapters do not support this behavior

### Additional information

* Follow-up from PR #48241
* Related to PR #48434
* Closes #48423 when using Postgresql

CC: @nvasilevski

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

