### PR TITLE
Disable database prepared statements when query logs are enabled

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Disable database prepared statements when query logs are enabled
+
+    Prepared Statements and Query Logs are incompatible features due to query logs making every query unique.
+
+    *zzak, Jean Boussier*
+
 *   Support decrypting data encrypted non-deterministically with a SHA1 hash digest.
 
     This adds a new Active Record encryption option to support decrypting data encrypted

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -174,6 +174,9 @@ module ActiveRecord
     autoload :SQLiteDatabaseTasks, "active_record/tasks/sqlite_database_tasks"
   end
 
+  singleton_class.attr_accessor :disable_prepared_statements
+  self.disable_prepared_statements = false
+
   # Lazily load the schema cache. This option will load the schema cache
   # when a connection is established rather than on boot. If set,
   # +config.active_record.use_schema_cache_dump+ will be set to false.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -160,7 +160,7 @@ module ActiveRecord
         @statements = build_statement_pool
         self.lock_thread = nil
 
-        @prepared_statements = self.class.type_cast_config_to_boolean(
+        @prepared_statements = !ActiveRecord.disable_prepared_statements && self.class.type_cast_config_to_boolean(
           @config.fetch(:prepared_statements) { default_prepared_statements }
         )
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -396,6 +396,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
             db_host:      ->(context) { context[:connection].pool.db_config.host },
             database:     ->(context) { context[:connection].pool.db_config.database }
           )
+          ActiveRecord.disable_prepared_statements = true
 
           if app.config.active_record.query_log_tags.present?
             ActiveRecord::QueryLogs.tags = app.config.active_record.query_log_tags

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -158,6 +158,23 @@ module ActiveRecord
       end
     end
 
+    unless in_memory_db?
+      def test_disable_prepared_statements
+        original_prepared_statements = ActiveRecord.disable_prepared_statements
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash.merge(prepared_statements: true))
+
+        assert_predicate ActiveRecord::Base.connection, :prepared_statements?
+
+        ActiveRecord.disable_prepared_statements = true
+        ActiveRecord::Base.establish_connection(db_config.configuration_hash.merge(prepared_statements: true))
+        assert_not_predicate ActiveRecord::Base.connection, :prepared_statements?
+      ensure
+        ActiveRecord.disable_prepared_statements = original_prepared_statements
+        ActiveRecord::Base.establish_connection :arunit
+      end
+    end
+
     def test_table_alias
       def @connection.test_table_alias_length() 10; end
       class << @connection

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1345,6 +1345,8 @@ The default value depends on the `config.load_defaults` target version:
 Specifies whether or not to enable adapter-level query comments. Defaults to
 `false`.
 
+NOTE: When this is set to `true` database prepared statements will be automatically disabled.
+
 #### `config.active_record.query_log_tags`
 
 Define an `Array` specifying the key/value tags to be inserted in an SQL


### PR DESCRIPTION
Fixes #48398

Prepared Statements and Query Logs are incompatible features due to query logs making every query unique.

Marginalia [explains](https://github.com/basecamp/marginalia#prepared-statements) the situation pretty well:

> Be careful when using Marginalia with prepared statements. If you use a component like request_id then every query will be unique and so ActiveRecord will create a new prepared statement for each potentially exhausting system resources. Disable prepared statements if you wish to use components with high cardinality values.