### PR TITLE
[7-0-stable] Backport: "Warm-up to avoid autoloads interfering with class serial"

### DIFF
--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -232,6 +232,9 @@ class ExecutorTest < ActiveSupport::TestCase
 
     executor.register_hook(hook)
 
+    # Warm-up to trigger any pending autoloads
+    executor.wrap { }
+
     before = RubyVM.stat(:class_serial)
     executor.wrap { }
     executor.wrap { }


### PR DESCRIPTION
This is just a shot in the dark, but my gut tells me this commit fixes this flaky test.

Most recently failed today in CI:
https://buildkite.com/rails/rails/builds/97733#018919b9-fd8e-4fef-8536-671e68ffd2ac/1080-2620

/cc @matthewd 