### PR TITLE
Make all cache stores return a boolean for `#delete`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Make all cache stores return a boolean for `#delete`
+
+    Previously the `RedisCacheStore#delete` would return `1` if the entry
+    exists and `0` otherwise. Now it returns true if the entry exists and false
+    otherwise, just like the other stores.
+
+    The `FileStore` would return `nil` if the entry doesn't exists and returns
+    `false` now as well.
+
+    *Petrik de Heus*
+
 *   Active Support cache stores now support replacing the default compressor via
     a `:compressor` option. The specified compressor must respond to `deflate`
     and `inflate`. For example:
@@ -53,8 +64,6 @@
     ActiveSupport::KeyGenerator::Aes256Gcm(secret).inspect
     "#<ActiveSupport::KeyGenerator:0x0000000104888038>"
     ```
-
-    *Petrik de Heus*
 
 *   Improve error message when EventedFileUpdateChecker is used without a
     compatible version of the Listen gem

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -653,7 +653,8 @@ module ActiveSupport
         end
       end
 
-      # Deletes an entry in the cache. Returns +true+ if an entry is deleted.
+      # Deletes an entry in the cache. Returns +true+ if an entry is deleted
+      # and +false+ otherwise.
       #
       # Options are passed to the underlying cache implementation.
       def delete(name, options = nil)

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -128,6 +128,8 @@ module ActiveSupport
               raise if File.exist?(key)
               false
             end
+          else
+            false
           end
         end
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -370,7 +370,7 @@ module ActiveSupport
         # Delete an entry from the cache.
         def delete_entry(key, **options)
           failsafe :delete_entry, returning: false do
-            redis.then { |c| c.del key }
+            redis.then { |c| c.del(key) == 1 }
           end
         end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -419,8 +419,13 @@ module CacheStoreBehavior
     key = SecureRandom.alphanumeric
     @cache.write(key, "bar")
     assert @cache.exist?(key)
-    assert @cache.delete(key)
+    assert_same true, @cache.delete(key)
     assert_not @cache.exist?(key)
+  end
+
+  def test_delete_returns_false_if_not_exist
+    key = SecureRandom.alphanumeric
+    assert_same false, @cache.delete(key)
   end
 
   def test_delete_multi


### PR DESCRIPTION
`Rails.cache.delete('key')` is [supposed](https://github.com/rails/rails/blob/e552fca4a6f44db6035abfdf5a48e965fdff29f2/activesupport/lib/active_support/cache.rb#L586) to return `true` if an entry exists (and `false` otherwise?). This is how most stores behave.

However, the `RedisCacheStore` would return a `1` when deleting an entry that does exist and a `0` otherwise.
As `0` is truthy this is unexpected behaviour.

`RedisCacheStore` now returns `true` if the entry exists and `false` otherwise, making it consistent with the other cache stores.

Similarly the `FileCacheStore` now returns `false` instead of `nil` if the entry doesn't exist.

A test is added to make sure this behaviour applies to all stores.

The documentation for `delete` has been updated to make the behaviour explicit.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
