### PR TITLE
Fix deprecation warnings in Active Support tests

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -224,6 +224,12 @@ module ActiveSupport
       private
         def default_coder
           if Cache.format_version == 6.1
+            ActiveSupport.deprecator.warn <<~EOM
+              Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
+
+              Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+              for more information on how to upgrade.
+            EOM
             Cache::SerializerWithFallback[:passthrough]
           else
             super

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -10,7 +10,13 @@ class FileStoreTest < ActiveSupport::TestCase
 
   def lookup_store(options = {})
     cache_dir = options.delete(:cache_dir) { @cache_dir }
-    ActiveSupport::Cache.lookup_store(:file_store, cache_dir, options)
+    if ActiveSupport.cache_format_version == 6.1
+      assert_deprecated(ActiveSupport.deprecator) do
+        ActiveSupport::Cache.lookup_store(:file_store, cache_dir, options)
+      end
+    else
+      ActiveSupport::Cache.lookup_store(:file_store, cache_dir, options)
+    end
   end
 
   def setup

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -45,7 +45,16 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def lookup_store(*addresses, **options)
-    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, *addresses, { namespace: @namespace, pool: false, socket_timeout: 60 }.merge(options))
+    cache = nil
+
+    if ActiveSupport.cache_format_version == 6.1
+      assert_deprecated(ActiveSupport.deprecator) do
+        cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, *addresses, { namespace: @namespace, pool: false, socket_timeout: 60 }.merge(options))
+      end
+    else
+      cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, *addresses, { namespace: @namespace, pool: false, socket_timeout: 60 }.merge(options))
+    end
+
     (@_stores ||= []) << cache
     cache
   end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -10,7 +10,13 @@ class MemoryStoreTest < ActiveSupport::TestCase
   end
 
   def lookup_store(options = {})
-    ActiveSupport::Cache.lookup_store(:memory_store, options)
+    if ActiveSupport.cache_format_version == 6.1
+      assert_deprecated(ActiveSupport.deprecator) do
+        ActiveSupport::Cache.lookup_store(:memory_store, options)
+      end
+    else
+      ActiveSupport::Cache.lookup_store(:memory_store, options)
+    end
   end
 
   include CacheStoreBehavior

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -146,7 +146,13 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
 
     def lookup_store(options = {})
-      ActiveSupport::Cache.lookup_store(:redis_cache_store, { timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+      if ActiveSupport.cache_format_version == 6.1
+        assert_deprecated(ActiveSupport.deprecator) do
+          ActiveSupport::Cache.lookup_store(:redis_cache_store, { timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+        end
+      else
+        ActiveSupport::Cache.lookup_store(:redis_cache_store, { timeout: 0.1, namespace: @namespace, pool: false }.merge(options))
+      end
     end
 
     teardown do


### PR DESCRIPTION
### Motivation / Background

These were introduced when the cache_format_version warning was [moved][1] to initialization of an ActiveSupport::Cache.

### Detail

7.0 was chosen as the new default cache_format in tests because other tests started to fail when 7.1 was made the default.

This also uncovered that the moved deprecation warning did not cover the MemCacheStore since it overrides the `default_coder` method for the 6.1 format.

[1]: https://github.com/rails/rails/commit/088551c802bb4005a667aaa33814cfbb1feb3927

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
