### PR TITLE
fix: Raise an exception on `has_one` failed to autosave

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -460,7 +460,7 @@ module ActiveRecord
               end
 
               saved = record.save(validate: !autosave)
-              raise ActiveRecord::Rollback if !saved && autosave
+              raise(RecordInvalid.new(record)) if !saved && autosave
               saved
             end
           end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1579,6 +1579,20 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_save_and_raise_record_invalid_if_a_callback_cancelled_saving
+    pirate = Pirate.new(catchphrase: "Arr")
+    ship = pirate.build_ship(name: "The Vile Serpent")
+    ship.cancel_save_from_callback = true
+
+    assert_no_difference "Pirate.count" do
+      assert_no_difference "Ship.count" do
+        assert_raises(ActiveRecord::RecordInvalid) do
+          pirate.save!
+        end
+      end
+    end
+  end
+
   def test_should_rollback_any_changes_if_an_exception_occurred_while_saving
     before = [@pirate.catchphrase, @pirate.ship.name]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/36833
Fixes https://github.com/rails/rails/issues/48633

Previously, failure to autosave a `has_one` association returned `nil` instead of raising an exception.

```ruby
class Supplier < ActiveRecord::Base
  has_one :account, autosave: true
end

class Account < ActiveRecord::Base
  before_save { throw(:abort) }
end

supplier = Supplier.new
supplier.build_account
supplier.save! # => nil
```

But it's counter-intuitive for `save!` to fail without raising an exception.

### Detail

This pull request changes the `save_has_one_association` to raise `ActiveRecord::RecordInvalid` instead of `ActiveRecord::Rollback`. This allows it to raise an exception if it fails to autosave the `has_one` association with `save!`.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

This pull request is very similar to [the pull request for `has_many` association](https://github.com/rails/rails/pull/36210).

Also, it seems that the reason why `ActiveRecord::Rollback` was raised was to return `false` while rolling back with `save`, but there is also no problem with `ActiveRecord::RecordInvalid`.
https://github.com/rails/rails/commit/f2aacd51405724cdf7cfd36a439c9dbfce16973a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
