### PR TITLE
Fix flaky encryption tests

### DIFF
--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -179,6 +179,6 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
         self.table_name = "authors"
 
         encrypts :name
-      end
+      end.tap { |c| c.type_for_attribute(:name) }
     end
 end

--- a/activerecord/test/models/author_encrypted.rb
+++ b/activerecord/test/models/author_encrypted.rb
@@ -8,9 +8,11 @@ class EncryptedAuthor < Author
   validates :name, uniqueness: true
   encrypts :name, previous: { deterministic: true }
 end
+EncryptedAuthor.type_for_attribute(:name)
 
 class EncryptedAuthorWithKey < Author
   self.table_name = "authors"
 
   encrypts :name, key: "some secret key!"
 end
+EncryptedAuthorWithKey.type_for_attribute(:name)

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -9,6 +9,7 @@ class EncryptedBook < ActiveRecord::Base
 
   encrypts :name, deterministic: true
 end
+EncryptedBook.type_for_attribute(:name)
 
 class EncryptedBookWithDowncaseName < ActiveRecord::Base
   self.table_name = "encrypted_books"
@@ -16,9 +17,11 @@ class EncryptedBookWithDowncaseName < ActiveRecord::Base
   validates :name, uniqueness: true
   encrypts :name, deterministic: true, downcase: true
 end
+EncryptedBookWithDowncaseName.type_for_attribute(:name)
 
 class EncryptedBookThatIgnoresCase < ActiveRecord::Base
   self.table_name = "encrypted_books"
 
   encrypts :name, deterministic: true, ignore_case: true
 end
+EncryptedBookThatIgnoresCase.type_for_attribute(:name)


### PR DESCRIPTION
`4f365720d1b87b7a8fe7d8d77c157b63d853e334` introduced lazy loading
encryption schemes. Schemes for attributes are loaded when the attribute
type is used.

This change introduced some flakiness to the tests:

```bash
ARCONN=mysql2 bin/test test/cases/encryption/encryption_schemes_test.rb test/cases/encryption/encrypted_fixtures_test.rb -n "/^(?:ActiveRecord::Encryption::EncryptionSchemesTest#(?:test_returns_ciphertext_all_the_previous_schemes_fail_to_decrypt_and_support_for_unencrypted_data_is_on)|ActiveRecord::Encryption::EncryptableFixtureTest#(?:test_preserved_columns_due_to_ignore_case:_true_gets_encrypted_automatically))$/" --seed 39616

...

.E

 Error:
    ActiveRecord::Encryption::EncryptableFixtureTest#test_preserved_columns_due_to_ignore_case:_true_gets_encrypted_automatically:
    ActiveRecord::Encryption::Errors::Decryption: Couldn't find a match for ruby for rails ({"1"=>"2"})
        /Users/petrik/Projects/All/_forks/rails/activerecord/test/cases/encryption/encryption_schemes_test.rb:144:in `decrypt'
```


By calling the attribute type in the test models the schemes are eager
loaded and the flakiness is hopefully fixed. (The original commit added
a similar call for the type).

cc: @jorgemanrubia 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
