### PR TITLE
Add a new option `existing` to `has_one` to run validations before deleting

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a new option `existing` to `has_one` to run validations before deleting an existing associated object.
+
+    *Takumi Shotoku*
+
 *   Disable database prepared statements when query logs are enabled
 
     Prepared Statements and Query Logs are incompatible features due to query logs making every query unique.

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1681,6 +1681,12 @@ module ActiveRecord
         # [:ensuring_owner_was]
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
+        # [:existing]
+        #   Controls behavior when there are existing associated object.
+        #
+        #   * <tt>nil</tt> Delete an existing associated object before saving a new one (default).
+        #     Be careful to run validations after an existing record is deleted.
+        #   * <tt>:replace_after_validation</tt> If the new object is valid, delete an existing associated object and save the new one.
         #
         # Option examples:
         #   has_one :credit_card, dependent: :destroy  # destroys the associated credit card

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -8,6 +8,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.valid_options(options)
       valid = super
+      valid += [:existing]
       valid += [:as, :foreign_type] if options[:as]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid += [:through, :source, :source_type] if options[:through]

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -66,7 +66,7 @@ module ActiveRecord
             save &&= owner.persisted?
 
             transaction_if(save) do
-              remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record
+              remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record && (options[:existing] != :replace_after_validation || record.valid?)
 
               if record
                 set_owner_attributes(record)

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -59,10 +59,10 @@ module ActiveRecord
             # Returns an ActiveModel::Errors object if validation has already run
             errors = record.instance_variable_get(:@errors)
             saved = if errors
-                      errors.empty? && record.save(validate: false)
-                    else
-                      record.save
-                    end
+              errors.empty? && record.save(validate: false)
+            else
+              record.save
+            end
             replace_keys(record, force: true)
             raise RecordInvalid.new(record) if !saved && raise_error
             record


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Uniqueness validators no longer works on `create_association` when using `dependent: :destroy` option in the commit below.
refs: bdbe58b, 3255411

However, we often expect validation errors as well.
refs #48330, #48632

### Detail

This commit adds new option `existing` to `has_one` to run validations before deleting an existing record.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
