### PR TITLE
Introduce config for Action Text sanitizer

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Use `Rails::HTML5::SafeListSanitizer` by default in the Rails 7.1 configuration if it is
+    supported.
+
+    Action Text's sanitizer can be configured by setting
+    `config.action_text.sanitizer_vendor`. Supported values are `Rails::HTML4::Sanitizer` or
+    `Rails::HTML5::Sanitizer`.
+
+    The Rails 7.1 configuration will set this to `Rails::HTML5::Sanitizer` when it is supported, and
+    fall back to `Rails::HTML4::Sanitizer`. Previous configurations default to
+    `Rails::HTML4::Sanitizer`.
+
+    *Mike Dalessio*
+
 *   Attachables now can override default attachment missing template.
 
     When rendering Action Text attachments where the underlying attachable model has

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -4,7 +4,7 @@ require "rails-html-sanitizer"
 
 module ActionText
   module ContentHelper
-    mattr_accessor(:sanitizer) { Rails::Html::Sanitizer.best_supported_vendor.safe_list_sanitizer.new }
+    mattr_accessor(:sanitizer, default: Rails::HTML4::Sanitizer.safe_list_sanitizer.new)
     mattr_accessor(:allowed_tags) { sanitizer.class.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ] }
     mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
     mattr_accessor(:scrubber)

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -82,5 +82,11 @@ module ActionText
     initializer "action_text.configure" do |app|
       ActionText::Attachment.tag_name = app.config.action_text.attachment_tag_name
     end
+
+    initializer "action_text.sanitizer_vendor" do |app|
+      if klass = app.config.action_text.delete(:sanitizer_vendor)
+        ActionText::ContentHelper.sanitizer = klass.safe_list_sanitizer.new
+      end
+    end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -63,6 +63,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.allow_deprecated_parameters_hash_equality`](#config-action-controller-allow-deprecated-parameters-hash-equality): `false`
 - [`config.action_dispatch.debug_exception_log_level`](#config-action-dispatch-debug-exception-log-level): `:error`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
+- [`config.action_text.sanitizer_vendor`](#config-action-text-sanitizer-vendor): `Rails::HTML::Sanitizer.best_supported_vendor`
 - [`config.action_view.sanitizer_vendor`](#config-action-view-sanitizer-vendor): `Rails::HTML::Sanitizer.best_supported_vendor`
 - [`config.active_job.use_big_decimal_serializer`](#config-active-job-use-big-decimal-serializer): `true`
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
@@ -2820,6 +2821,17 @@ has no effect if Sprockets is not used. The default value is `true`.
 #### `config.action_text.attachment_tag_name`
 
 Accepts a string for the HTML tag used to wrap attachments. Defaults to `"action-text-attachment"`.
+
+#### `config.action_text.sanitizer_vendor`
+
+Configures the HTML sanitizer used by Action Text by setting `ActionText::ContentHelper.sanitizer` to an instance of the class returned from the vendor's `.safe_list_sanitizer` method. The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is                 | Which parses markup as |
+|-----------------------|--------------------------------------|------------------------|
+| (original)            | `Rails::HTML4::Sanitizer`            | HTML4                  |
+| 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
+
+NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to use `Rails::HTML4::Sanitizer`.
 
 ### Configuring a Database
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -319,6 +319,10 @@ module Rails
             if respond_to?(:action_view)
               action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
             end
+
+            if respond_to?(:action_text)
+              action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+            end
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -184,12 +184,22 @@
 # Configure Action View to use HTML5 standards-compliant sanitizers when they are supported on your
 # platform.
 #
-# `Rails::HTML::Sanitizer.best_supported_vendor` will return `Rails::HTML5::Sanitizer` if it's
-# supported, else fall back to `Rails::HTML4::Sanitizer`.
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action View to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
 #
-# In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer`.
+# In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #
 # Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+
+# Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
+# platform.
+#
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action Text to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
+#
+# In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
+#
+# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -23,6 +23,8 @@ end
 
 class ::MyOtherMailObserver < ::MyMailObserver; end
 
+class ::MySanitizerVendor < ::Rails::HTML::Sanitizer; end
+
 class MyLogRecorder < Logger
   def initialize
     @io = StringIO.new
@@ -4479,6 +4481,27 @@ module ApplicationTests
       app "development"
 
       assert_equal OpenSSL::Digest::SHA1, ActiveRecord::Encryption.config.hash_digest_class
+    end
+
+    test "sanitizer_vendor is set to best supported vendor in new apps" do
+      app "development"
+
+      assert_equal Rails::HTML::Sanitizer.best_supported_vendor, ActionView::Helpers::SanitizeHelper.sanitizer_vendor
+    end
+
+    test "sanitizer_vendor is set to HTML4 in upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app "development"
+
+      assert_equal Rails::HTML4::Sanitizer, ActionView::Helpers::SanitizeHelper.sanitizer_vendor
+    end
+
+    test "sanitizer_vendor is set to a specific vendor" do
+      add_to_config "config.action_view.sanitizer_vendor = ::MySanitizerVendor"
+      app "development"
+
+      assert_equal ::MySanitizerVendor, ActionView::Helpers::SanitizeHelper.sanitizer_vendor
     end
 
     private


### PR DESCRIPTION
### Motivation / Background

#48523 changed the behavior of Action Text to use the HTML5 safe list sanitizer when available, else fall back to the HTML4 safe list sanitizer. At @rafaelfranca's suggestion, this PR introduces `config.action_text.sanitizer_vendor` (very similar to `config.action_view.sanitizer_vendor`) and a Rails 7.1 default to control that behavior change.

This PR also backfills test coverage for `config.action_view.sanitizer_vendor`.

### Detail

This PR introduces `config.action_text.sanitizer_vendor`, which behaves the same way as `config.action_view.sanitizer_vendor`.

### Additional information

I'm curious if the maintainers think we really need two config params for Action View and Action Text, or if we should merge these into something like `config.sanitizer_vendor` for all of Rails.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
