### PR TITLE
Fix Action View collection caching to store fragments as bare strings

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -89,15 +89,25 @@ module ActionView
       # If the partial is not already cached it will also be
       # written back to the underlying cache store.
       def fetch_or_cache_partial(cached_partials, template, order_by:)
-        order_by.index_with do |cache_key|
+        entries_to_write = {}
+
+        keyed_partials = order_by.index_with do |cache_key|
           if content = cached_partials[cache_key]
             build_rendered_template(content, template)
           else
-            yield.tap do |rendered_partial|
-              collection_cache.write(cache_key, rendered_partial.body)
+            rendered_partial = yield
+            if fragment = rendered_partial.body&.to_str
+              entries_to_write[cache_key] = fragment
             end
+            rendered_partial
           end
         end
+
+        unless entries_to_write.empty?
+          collection_cache.write_multi(entries_to_write)
+        end
+
+        keyed_partials
       end
   end
 end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/48611

Individual fragments have been cached as bare string since forever, but somehow fragment cached via collection caching were stored as `ActionView::OutputBuffer` instances.

This is both bad for performance, but also can cause issues on Rails upgrades if the internal representation of `AV::OutputBuffer` changes.

I think we should consider this PR as a bug fix, and backport it accordingly.

cc @matthewd, @matthutchinson, @skipkayhil 