### PR TITLE
Update streaming_template_renderer.rb

### DIFF
--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -46,7 +46,7 @@ module ActionView
       return [super.body] unless layout_name && template.supports_streaming?
 
       locals ||= {}
-      layout   = layout_name && find_layout(layout_name, locals.keys, [formats.first])
+      layout   = find_layout(layout_name, locals.keys, [formats.first])
 
       Body.new do |buffer|
         delayed_render(buffer, template, layout, view, locals)


### PR DESCRIPTION
Micro optimization for ActionView.
Remove extra `layout_name` check on the `render_template` method. At that point, `layout_name` due to the condition `layout_name && template.supports_streaming?` so there's no need to check for it once again when creating the `layout` variable.