### PR TITLE
Fix has_many_inversing records with same references

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -407,14 +407,14 @@ module ActiveRecord
               records -= records_to_destroy
             end
 
-            records.each do |record|
-              next if record.destroyed?
-
+            records.reject(&:destroyed?).each do |record|
+              if autosave != false && (new_record_before_save || record.new_record?)
+                association.set_inverse_instance(record)
+              end
+            end.each do |record|
               saved = true
 
               if autosave != false && (new_record_before_save || record.new_record?)
-                association.set_inverse_instance(record)
-
                 if autosave
                   saved = association.insert_record(record, false)
                 elsif !reflection.nested?

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "models/human"
 require "models/face"
 require "models/interest"
+require "models/skill"
 require "models/zine"
 require "models/club"
 require "models/sponsor"
@@ -690,6 +691,31 @@ class InverseHasManyTests < ActiveRecord::TestCase
     comment.update!(post_id: post2.id)
 
     assert_equal post2, comment.post
+  end
+
+  def test_has_many_inversing_with_same_references_should_not_violate_not_null_constraint
+    with_has_many_inversing(Skill) do
+      human = Human.new
+      zine = Zine.new
+      human.skills.build(zine: zine)
+      human.skills.build(zine: zine)
+      human.save!
+
+      assert_equal 2, Skill.where(human: human).count
+    end
+  end
+
+  def test_has_many_inversing_with_same_references_should_not_have_excess_queries_when_nulls_allowed
+    with_has_many_inversing(Interest) do
+      human = Human.new
+      zine = Zine.new
+      human.interests.build(zine: zine)
+      human.interests.build(zine: zine)
+
+      assert_queries(4) do
+        human.save!
+      end
+    end
   end
 end
 

--- a/activerecord/test/models/human.rb
+++ b/activerecord/test/models/human.rb
@@ -27,6 +27,7 @@ class Human < ActiveRecord::Base
   has_one :confused_face, class_name: "Face", inverse_of: :cnffused_human
   has_many :secret_interests, class_name: "Interest", inverse_of: :secret_human
   has_one :mixed_case_monkey
+  has_many :skills, inverse_of: :human
 
   attribute :add_callback_called, :boolean, default: false
 

--- a/activerecord/test/models/skill.rb
+++ b/activerecord/test/models/skill.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Skill < ActiveRecord::Base
+  belongs_to :human, inverse_of: :skills
+  belongs_to :zine, inverse_of: :skills
+end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -2,4 +2,5 @@
 
 class Zine < ActiveRecord::Base
   has_many :interests, inverse_of: :zine
+  has_many :skills, inverse_of: :zine
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1305,6 +1305,12 @@ ActiveRecord::Schema.define do
     t.integer :zine_id
   end
 
+  create_table :skills, force: true do |t|
+    t.string :topic
+    t.references :human, null: false
+    t.references :zine, null: false
+  end
+
   create_table :zines, force: true do |t|
     t.string :title
   end


### PR DESCRIPTION
### Motivation / Background

Resolves #47559

Properly handle an intermediate model with has_many_inversing when creating two records with the same references.

- Prevents database error when references have a NOT NULL constraint
- When NULLS are permitted avoid an extra UPDATE statement by inserting the correct values from the outset

### Detail

```rb
ActiveRecord::Base.has_many_inversing = true

class Comment < ActiveRecord::Base
  belongs_to :post, inverse_of: :comments
  belongs_to :author, inverse_of: :comments
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Author < ActiveRecord::Base
  has_many :comments
end

post = Post.new
author = Author.new
post.comments.build(author: author)
post.comments.build(author: author)
post.save!
```

Before:
```sql
BEGIN
  INSERT INTO "posts" DEFAULT VALUES RETURNING "id"
  INSERT INTO "authors" DEFAULT VALUES RETURNING "id"
  INSERT INTO "comments" ("post_id", "author_id") VALUES ($1, $2) RETURNING "id"  [["post_id", 1], ["author_id", 1]]
  -- Error if NOT NULL constraint on post_id
  INSERT INTO "comments" ("author_id") VALUES ($1) RETURNING "id"  [["author_id", 1]]
  UPDATE "comments" SET "post_id" = $1 WHERE "comments"."id" = $2  [["post_id", 1], ["id", 2]]
COMMIT
```

After:
```sql
BEGIN
  INSERT INTO "posts" DEFAULT VALUES RETURNING "id"
  INSERT INTO "authors" DEFAULT VALUES RETURNING "id"
  INSERT INTO "comments" ("post_id", "author_id") VALUES ($1, $2) RETURNING "id"  [["post_id", 1], ["author_id", 1]]
  INSERT INTO "comments" ("post_id", "author_id") VALUES ($1, $2) RETURNING "id"  [["post_id", 1], ["author_id", 1]]
COMMIT
```

`insert_record` within `save_collection_association` will trigger a recursive call. By fully processing `set_inverse_instance` for each layer we ensure associations are up to date before `INSERT INTO comments` statements are sent to the database.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
