### PR TITLE
Make has_many through singular associations build CPK records

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -118,7 +118,9 @@ module ActiveRecord
           target = through_association.target
 
           if inverse && target && !target.is_a?(Array)
-            attributes[inverse.foreign_key] = target.id
+            Array(target.id).zip(Array(inverse.foreign_key)).map do |primary_key_value, foreign_key_column|
+              attributes[foreign_key_column] = primary_key_value
+            end
           end
 
           super

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1650,6 +1650,14 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate(book.association(:order_agreements), :stale_target?)
   end
 
+  def test_cpk_association_build_through_singular
+    order = Cpk::OrderWithSingularBookChapters.create!(id: [1, 2])
+    book = order.create_book!(id: [3, 4])
+    chapter = order.chapters.build
+
+    assert_equal(chapter.book, book)
+  end
+
   private
     def make_model(name)
       Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -7,7 +7,7 @@ module Cpk
     belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id]
     belongs_to :author, class_name: "Cpk::Author"
 
-    has_many :chapters, query_constraints: [:author_id, :book_number]
+    has_many :chapters, query_constraints: [:author_id, :book_id]
   end
 
   class BestSeller < Book
@@ -18,7 +18,7 @@ module Cpk
   end
 
   class NullifiedBook < Book
-    has_one :chapter, query_constraints: [:author_id, :book_number], dependent: :nullify
+    has_one :chapter, query_constraints: [:author_id, :book_id], dependent: :nullify
   end
 
   class BookWithOrderAgreements < Book

--- a/activerecord/test/models/cpk/chapter.rb
+++ b/activerecord/test/models/cpk/chapter.rb
@@ -7,6 +7,6 @@ module Cpk
     # to be shared between different databases
     self.primary_key = [:author_id, :id]
 
-    belongs_to :book, query_constraints: [:author_id, :book_number]
+    belongs_to :book, query_constraints: [:author_id, :book_id]
   end
 end

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -24,4 +24,8 @@ module Cpk
   class OrderWithNullifiedBook < Order
     has_one :book, query_constraints: [:shop_id, :order_id], dependent: :nullify
   end
+
+  class OrderWithSingularBookChapters < Order
+    has_many :chapters, through: :book
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because composite primary key records cannot be build when using `has_many` through singular (`has_one`) associations.

### Detail

This Pull Request changes `build_record` on `ActiveRecord::Associations::ThroughAssociation` to support composite primary key associations.

### Additional information

I noticed some odd behaviour for `build_record` that I'll be submitting fixes for in separate patches.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
