### PR TITLE
Fix a bug that prevented #pretty_print from displaying records unsaved in collection association.

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1107,6 +1107,11 @@ module ActiveRecord
         super
       end
 
+      def pretty_print(pp) # :nodoc:
+        load_target if find_from_target?
+        super
+      end
+
       delegate_methods = [
         QueryMethods,
         SpawnMethods,

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pp"
 require "cases/helper"
 require "models/computer"
 require "models/developer"
@@ -448,6 +449,15 @@ class AssociationProxyTest < ActiveRecord::TestCase
     andreas = Developer.new name: "Andreas", log: "new developer added"
     assert_not_predicate andreas.audit_logs, :loaded?
     assert_match(/message: "new developer added"/, andreas.audit_logs.inspect)
+    assert_predicate andreas.audit_logs, :loaded?
+  end
+
+  def test_pretty_print_does_not_reload_a_not_yet_loaded_target
+    andreas = Developer.new(log: "new developer added")
+    assert_not_predicate andreas.audit_logs, :loaded?
+    out = StringIO.new
+    PP.pp(andreas.audit_logs, out)
+    assert_match(/message: "new developer added"/, out.string)
     assert_predicate andreas.audit_logs, :loaded?
   end
 


### PR DESCRIPTION


### Motivation / Background

The change in PR #43302 introduced a bug where unsaved records are not displayed in pretty_print. The following code will not show unsaved records until this PR is merged.

```ruby
post = Post.create!
post.comments.build

pp(post.comments) #=> expected "[#<Comment:0x000000014c0b48a0 ...>]", got "[]"
```

### Detail

Fixed to call `#load_target` before display as well as [`#inspect`](https://github.com/alpaca-tc/rails/blob/fe6b96afd/activerecord/lib/active_record/associations/collection_proxy.rb#L1105-L1108).

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
