### PR TITLE
Fix typo in activerecord tests (hash_many -> has_many)

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -793,7 +793,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
-  def test_with_hash_many_inversing_does_not_add_duplicate_associated_objects
+  def test_with_has_many_inversing_does_not_add_duplicate_associated_objects
     with_has_many_inversing(Interest) do
       human = Human.new
       interest = Interest.new(human: human)


### PR DESCRIPTION
changes `hash_many` -> `has_many` in activerecord test
