### PR TITLE
Fix de-duplication of unsaved records for `ActiveRecord::Associations::CollectionProxy#<<`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -87,7 +87,7 @@ module ActiveRecord
       def reset
         super
         @target = []
-        @replaced_or_added_targets = Set.new
+        @replaced_or_added_targets = Set.new.compare_by_identity
         @association_ids = nil
       end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -802,6 +802,26 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
+  def test_with_has_many_inversing_does_not_add_unsaved_duplicate_records_when_collection_is_loaded
+    with_has_many_inversing(Interest) do
+      human = Human.create!
+      human.interests.load
+      interest = Interest.new(human: human)
+      human.interests << interest
+      assert_equal 1, human.interests.size
+    end
+  end
+
+  def test_with_has_many_inversing_does_not_add_saved_duplicate_records_when_collection_is_loaded
+    with_has_many_inversing(Interest) do
+      human = Human.create!
+      human.interests.load
+      interest = Interest.create!(human: human)
+      human.interests << interest
+      assert_equal 1, human.interests.size
+    end
+  end
+
   def test_recursive_model_has_many_inversing
     with_has_many_inversing do
       main = Branch.create!


### PR DESCRIPTION
### Motivation / Background

Currently, there is a bug that changes the duplicity elimination depending on whether the association is `#loaded?` or not as the followings, but this change will fix it.

```ruby
human = Human.create!
interest = Interest.new(human: human)
human.interests << interest
human.interests.size #=> 1
```

```ruby
human = Human.create!
interest = Interest.new(human: human)
human.interests.load
human.interests << interest
human.interests.size #=> expected 1, got 2
```

### Detail

The existing process was attempting to detect duplicates by storing added records in `Set.new`. 
When a record is added to `Set.new`, the identity is calculated using [`ActiveRecord::Core#hash`](https://github.com/rails/rails//blob/f256e1f085f25f1c2cc4e4d1a533c6b103ff7aee/activerecord/lib/active_record/core.rb#L564-L572), but this value changes before and after saving, so duplicates were not detected before and after saving even for the same object.

### Additional information

This PR fixed the problem by using the `#object_id` of the record to detect duplicates. Note that when storing a new object obtained by `ActiveRecord::Base.find` etc., duplicates are not eliminated because the `#object_id` is different. 
This is the same behavior as the current `ActiveRecord::Associations::CollectionProxy#<<`.

The mechanism to eliminate the duplicate nature of newly added records using `Set.new` was added in https://github.com/rails/rails/pull/42524.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
