### PR TITLE
Fix test flakiness introduced in encryption tests

### DIFF
--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -179,6 +179,6 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
         self.table_name = "authors"
 
         encrypts :name
-      end
+      end.tap { |klass| klass.type_for_attribute(:name) }
     end
 end

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -152,6 +152,16 @@ module ActiveRecord::Encryption
   end
 end
 
+# We eager load encrypted attribute types as they are declared, so that they pick up the
+# default encryption setup for tests. Because we load those lazily when used, this prevents
+# side effects where some tests modify encryption config settings affecting others.
+#
+# Notice that we clear the declaration listeners when each test start, so this will only affect
+# the classes loaded before tests starts, not those declared during tests.
+ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, attribute_name|
+  klass.type_for_attribute(attribute_name)
+end
+
 class ActiveRecord::EncryptionTestCase < ActiveRecord::TestCase
   include ActiveRecord::Encryption::EncryptionHelpers, ActiveRecord::Encryption::PerformanceHelpers
 


### PR DESCRIPTION
This fixes some flakiness I introduced with 4f365720d1b87b7a8fe7d8d77c157b63d853e334.

We'll make sure we eager load all the encrypted attribute types declared before tests start, to prevent local encryption settings changes in tests from interfering with other tests.

Kudos to @p8 for tracking this one down and seeing how to fix it. This PR is just a generalization of his solution from #48641.

I'm sorry I missed this one with that commit 🙏.

Fixes #48605
Closes #48641

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
