### PR TITLE
Fix AS::Cache 7.1 format to properly compress bare strings

### DIFF
--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -29,6 +29,8 @@ ActiveSupport.deprecator.silence do
   ActiveSupport.to_time_preserves_timezone = ENV.fetch("PRESERVE_TIMEZONES", "1") == "1"
 end
 
+ActiveSupport::Cache.format_version = 7.1
+
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 


### PR DESCRIPTION
The bare string and compression features weren't working properly together.

I discovered this while trying to fix deprecation warnings.

FYI: @jonathanhefner 