### PR TITLE
Document return value of `Rails.cache.delete_multi`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -591,7 +591,8 @@ module ActiveSupport
         end
       end
 
-      # Deletes multiple entries in the cache.
+      # Deletes multiple entries in the cache. Returns the number of deleted
+      # entries.
       #
       # Options are passed to the underlying cache implementation.
       def delete_multi(names, options = nil)


### PR DESCRIPTION
`delete_multi` returns the number of deleted entries.
This is behavior is asserted in the following test:

https://github.com/rails/rails/blob/495cbe9f8fec01ed3f2c0128dda39ca07bad00b3/activesupport/test/cache/behaviors/cache_store_behavior.rb#L433

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
