### PR TITLE
Fix MemCacheStore not warning on 6.1 cache format

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -224,6 +224,12 @@ module ActiveSupport
       private
         def default_coder
           if Cache.format_version == 6.1
+            ActiveSupport.deprecator.warn <<~EOM
+              Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.
+
+              Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+              for more information on how to upgrade.
+            EOM
             Cache::SerializerWithFallback[:passthrough]
           else
             super

--- a/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_format_version_behavior.rb
@@ -55,7 +55,11 @@ module CacheStoreFormatVersionBehavior
 
   private
     def with_format(format_version, &block)
-      ActiveSupport.deprecator.silence do
+      if format_version == 6.1
+        assert_deprecated(ActiveSupport.deprecator) do
+          ActiveSupport::Cache.with(format_version: format_version, &block)
+        end
+      else
         ActiveSupport::Cache.with(format_version: format_version, &block)
       end
     end


### PR DESCRIPTION
### Motivation / Background

While working on fixing some deprecation warnings introduced when the 6.1 cache_format deprecation was [moved][1] to be on usage, I found that the MemCacheStore actually has its own `default_coder` method.

### Detail

This adds the warning to MemCacheStore's `default_coder` method so that every cache store will warn on using the 6.1 format.

[1]: https://github.com/rails/rails/commit/088551c802bb4005a667aaa33814cfbb1feb3927

cc @byroot

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
