### PR TITLE
Make Active Support Cache treat deserialization errors like cache misses

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -30,6 +30,10 @@ module ActiveSupport
       expires_in: [:expire_in, :expired_in]
     }.freeze
 
+    # Raised by coders when the cache entry can't be deserialized.
+    # This error is treated as a cache miss.
+    DeserializationError = Class.new(StandardError)
+
     module Strategy
       autoload :LocalCache, "active_support/cache/strategy/local_cache"
     end
@@ -732,6 +736,8 @@ module ActiveSupport
 
         def deserialize_entry(payload)
           payload.nil? ? nil : @coder.load(payload)
+        rescue DeserializationError
+          nil
         end
 
         # Reads multiple entries from the cache implementation. Subclasses MAY


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48611

This help treating caches entries as expandable.

Because Marshal will hapily serialize almost everything, It's not uncommon to inadvertently cache a class that's not particularly stable, and cause deserialization errors on rollout when the implementation changes.

E.g. https://github.com/sporkmonger/addressable/pull/508

FYI: @jonathanhefner @matthewd @matthutchinson