### PR TITLE
Improve performance of JSON HTML entity escaping

### DIFF
--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -13,9 +13,15 @@ class ErbUtilTest < ActiveSupport::TestCase
     end
   end
 
-  ERB::Util::JSON_ESCAPE.each do |given, expected|
+  {
+    "&" => '\u0026',
+    ">" => '\u003e',
+    "<" => '\u003c',
+    "\u2028" => '\u2028',
+    "\u2029" => '\u2029'
+  }.each do |given, expected|
     define_method "test_json_escape_#{expected.gsub(/\W/, '')}" do
-      assert_equal ERB::Util::JSON_ESCAPE[given], json_escape(given)
+      assert_equal expected, json_escape(given)
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/erb/util.rb
+++ b/activesupport/lib/active_support/core_ext/erb/util.rb
@@ -38,9 +38,7 @@ end
 class ERB
   module Util
     HTML_ESCAPE = { "&" => "&amp;",  ">" => "&gt;",   "<" => "&lt;", '"' => "&quot;", "'" => "&#39;" }
-    JSON_ESCAPE = { "&" => '\u0026', ">" => '\u003e', "<" => '\u003c', "\u2028" => '\u2028', "\u2029" => '\u2029' }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+)|(#[xX][\dA-Fa-f]+));)/
-    JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 
     # Following XML requirements: https://www.w3.org/TR/REC-xml/#NT-Name
     TAG_NAME_START_CODEPOINTS = "@:A-Z_a-z\u{C0}-\u{D6}\u{D8}-\u{F6}\u{F8}-\u{2FF}\u{370}-\u{37D}\u{37F}-\u{1FFF}" \
@@ -124,7 +122,12 @@ class ERB
     # JSON gem, do not provide this kind of protection by default; also some gems
     # might override +to_json+ to bypass Active Support's encoder).
     def json_escape(s)
-      result = s.to_s.gsub(JSON_ESCAPE_REGEXP, JSON_ESCAPE)
+      result = s.to_s.dup
+      result.gsub!(">", '\u003e')
+      result.gsub!("<", '\u003c')
+      result.gsub!("&", '\u0026')
+      result.gsub!("\u2028", '\u2028')
+      result.gsub!("\u2029", '\u2029')
       s.html_safe? ? result.html_safe : result
     end
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -39,33 +39,21 @@ module ActiveSupport
             value = value.as_json(options.dup)
           end
           json = stringify(jsonify(value))
+
+          # Rails does more escaping than the JSON gem natively does (we
+          # escape \u2028 and \u2029 and optionally >, <, & to work around
+          # certain browser problems).
           if Encoding.escape_html_entities_in_json
-            json.gsub! ESCAPE_REGEX_WITH_HTML_ENTITIES, ESCAPED_CHARS
-          else
-            json.gsub! ESCAPE_REGEX_WITHOUT_HTML_ENTITIES, ESCAPED_CHARS
+            json.gsub!(">", '\u003e')
+            json.gsub!("<", '\u003c')
+            json.gsub!("&", '\u0026')
           end
+          json.gsub!("\u2028", '\u2028')
+          json.gsub!("\u2029", '\u2029')
           json
         end
 
         private
-          # Rails does more escaping than the JSON gem natively does (we
-          # escape \u2028 and \u2029 and optionally >, <, & to work around
-          # certain browser problems).
-          ESCAPED_CHARS = {
-            "\u2028" => '\u2028',
-            "\u2029" => '\u2029',
-            ">"      => '\u003e',
-            "<"      => '\u003c',
-            "&"      => '\u0026',
-            }
-
-          ESCAPE_REGEX_WITH_HTML_ENTITIES = /[\u2028\u2029><&]/u
-          ESCAPE_REGEX_WITHOUT_HTML_ENTITIES = /[\u2028\u2029]/u
-
-          # Mark these as private so we don't leak encoding-specific constructs
-          private_constant :ESCAPED_CHARS, :ESCAPE_REGEX_WITH_HTML_ENTITIES,
-            :ESCAPE_REGEX_WITHOUT_HTML_ENTITIES
-
           # Convert an object into a "JSON-ready" representation composed of
           # primitives like Hash, Array, String, Symbol, Numeric,
           # and +true+/+false+/+nil+.


### PR DESCRIPTION
This improves `.to_json` performance to be another ~2x faster (now ~4.5 faster than Rails 7.0)

In this case (likely not others!), running `gsub!` 5 times with string arguments seems to be faster than running it once with a regex and Hash.

When there are matches to the regex (there are characters to escape) this is faster in part because CRuby will allocate a new match object and string as a key to lookup in the map hash provided. It's possible that could be optimized upstream, but at the moment this avoids those allocations.

Surprisingly (at least to me) this is still much faster when there is no replacement needed: in my test ~3x faster on a short ~200 byte string, and ~5x faster on a pre-escaped ~600k twitter.json.

## Benchmarks

### Just escaping

<details>
<summary>script</summary>

``` ruby
require "rails/all"
require "benchmark/ips"
require "json_escape"


source_file = ENV["FILE"] || "twitter.json"
json = File.read(source_file).freeze

ESCAPED_CHARS = {
  "\u2028" => '\u2028',
  "\u2029" => '\u2029',
  ">"      => '\u003e',
  "<"      => '\u003c',
  "&"      => '\u0026',
}

escaped_json = json.gsub(/[\u2028\u2029><&]/u, ESCAPED_CHARS).freeze

Benchmark.ips do |x|
  x.report("original") do
    s = json.dup
    s.gsub!(/[\u2028\u2029><&]/u, ESCAPED_CHARS)
  end
  x.report("original (noop)") do
    s = escaped_json.dup
    s.gsub!(/[\u2028\u2029><&]/u, ESCAPED_CHARS)
  end
  x.report("gsub(str) x 5") do
    s = json.dup
    s.gsub!(">", '\u003e')
    s.gsub!("<", '\u003c')
    s.gsub!("&", '\u0026')
    s.gsub!("\u2028", '\u2028')
    s.gsub!("\u2029", '\u2029')
  end
  x.report("gsub(str) x 5 (noop)") do
    s = escaped_json.dup
    s.gsub!(">", '\u003e')
    s.gsub!("<", '\u003c')
    s.gsub!("&", '\u0026')
    s.gsub!("\u2028", '\u2028')
    s.gsub!("\u2029", '\u2029')
  end
  x.report("gsub(ascii_re) + gsub(utf8)") do
    s = json.dup
    s.gsub!(/[<>&]/, ESCAPED_CHARS)
    s.gsub!("\u2028", '\u2028')
    s.gsub!("\u2029", '\u2029')
  end
  x.report("gsub(ascii_re) + gsub(utf8) (noop)") do
    s = escaped_json.dup
    s.gsub!(/[<>&]/, ESCAPED_CHARS)
    s.gsub!("\u2028", '\u2028')
    s.gsub!("\u2029", '\u2029')
  end
  x.report("json_escape gem") do
    JsonEscape.json_escape(json)
  end
  x.compare!
end
```

`short.json` is

```
{"locale":"en","featureFlags":["redactedredactedredact","redactedredactedredac","redactedredactedre","redactedredactedred","redactedredact","redactedredactedredacted","redactedredactedredactedr"]}
```

</details>

```
$ FILE=twitter.json be ruby benchmark_escaping2.rb
Warming up --------------------------------------
            original     9.000  i/100ms
     original (noop)    10.000  i/100ms
       gsub(str) x 5    44.000  i/100ms
gsub(str) x 5 (noop)   229.000  i/100ms
gsub(ascii_re) + gsub(utf8)
                        25.000  i/100ms
gsub(ascii_re) + gsub(utf8) (noop)
                        32.000  i/100ms
     json_escape gem   919.000  i/100ms
Calculating -------------------------------------
            original     94.573  (± 0.0%) i/s -    477.000  in   5.043877s
     original (noop)    100.715  (± 0.0%) i/s -    510.000  in   5.063885s
       gsub(str) x 5    496.012  (± 7.9%) i/s -      2.464k in   5.002329s
gsub(str) x 5 (noop)      2.302k (± 0.7%) i/s -     11.679k in   5.074632s
gsub(ascii_re) + gsub(utf8)
                        257.878  (± 0.8%) i/s -      1.300k in   5.041332s
gsub(ascii_re) + gsub(utf8) (noop)
                        321.248  (± 0.6%) i/s -      1.632k in   5.080333s
     json_escape gem      8.958k (± 0.3%) i/s -     45.031k in   5.026965s

Comparison:
     json_escape gem:     8958.0 i/s
gsub(str) x 5 (noop):     2301.5 i/s - 3.89x  slower
       gsub(str) x 5:      496.0 i/s - 18.06x  slower
gsub(ascii_re) + gsub(utf8) (noop):      321.2 i/s - 27.88x  slower
gsub(ascii_re) + gsub(utf8):      257.9 i/s - 34.74x  slower
     original (noop):      100.7 i/s - 88.94x  slower
            original:       94.6 i/s - 94.72x  slower
```

```
$ FILE=short.json be ruby benchmark_escaping2.rb
Warming up --------------------------------------
            original    26.846k i/100ms
     original (noop)    27.998k i/100ms
       gsub(str) x 5    82.923k i/100ms
gsub(str) x 5 (noop)    83.683k i/100ms
gsub(ascii_re) + gsub(utf8)
                       103.509k i/100ms
gsub(ascii_re) + gsub(utf8) (noop)
                       103.445k i/100ms
     json_escape gem     1.424M i/100ms
Calculating -------------------------------------
            original    279.761k (± 1.6%) i/s -      1.423M in   5.087410s
     original (noop)    279.118k (± 2.1%) i/s -      1.400M in   5.017966s
       gsub(str) x 5    835.196k (± 0.5%) i/s -      4.229M in   5.063709s
gsub(str) x 5 (noop)    832.362k (± 0.9%) i/s -      4.184M in   5.027225s
gsub(ascii_re) + gsub(utf8)
                          1.028M (± 0.7%) i/s -      5.175M in   5.035134s
gsub(ascii_re) + gsub(utf8) (noop)
                          1.032M (± 0.5%) i/s -      5.172M in   5.014163s
     json_escape gem     14.476M (± 0.7%) i/s -     72.617M in   5.016768s

Comparison:
     json_escape gem: 14475588.1 i/s
gsub(ascii_re) + gsub(utf8) (noop):  1031551.3 i/s - 14.03x  slower
gsub(ascii_re) + gsub(utf8):  1027913.4 i/s - 14.08x  slower
       gsub(str) x 5:   835196.3 i/s - 17.33x  slower
gsub(str) x 5 (noop):   832361.5 i/s - 17.39x  slower
            original:   279761.3 i/s - 51.74x  slower
     original (noop):   279117.6 i/s - 51.86x  slower
```

`json_escape` is the same escaping implemented in C (please don't use this gem, if it's something we need we should find a different home for it)

On a short string, performing the ASCII portion of escaping as a regex and then the unicode portion as strings seems optimal, but it's not that much faster than the 5 gsub! approach, so I stick with that for simplicity and for the significantly better performance on long strings.

### to_json

Using the same benchmark as #48614. `JSON.generate` and `RapidJSON.generate` are for scale, they don't perform the extra escaping described here.

**Before:**
```
Calculating -------------------------------------
 source_data.to_json     74.671  (± 1.3%) i/s -    378.000  in   5.062521s
source_data_sym.to_json
                         76.969  (± 0.0%) i/s -    385.000  in   5.002087s
JSON.generate(source_data)
                        576.164  (± 1.2%) i/s -      2.916k in   5.061908s
RapidJSON.generate(source_data)
                        852.714  (± 3.2%) i/s -      4.316k in   5.067053s
```

**After:**

```
Calculating -------------------------------------
 source_data.to_json    142.762  (± 2.1%) i/s -    715.000  in   5.010974s
source_data_sym.to_json
                        150.613  (± 2.0%) i/s -    756.000  in   5.021137s
JSON.generate(source_data)
                        575.412  (± 1.0%) i/s -      2.915k in   5.066603s
RapidJSON.generate(source_data)
                        873.174  (± 2.9%) i/s -      4.368k in   5.006853s
```

About 2x faster than #48614 and 4.5x faster than Rails 7.0.


## Next?

This is much faster but escaping still has an impact on performance (though it's no longer the majority). One thing we could do is rewrite the escaping in a C extension (ideally upstreaming it into a standard library). However I think first we need to confirm that this is really how we should be escaping in 2023 and beyond.

@matthewd and I looked into this and we may only need to escape [`<script`, `</script>`, and `<!--`](https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements) (assuming we're only targeting HTML5 vs this was likely intended for XHTML). The quirk of JSON/JavaScript interop which required our handling of U+2028 and U+2029 is also [no longer a concern as of ES2019](https://github.com/tc39/proposal-json-superset) which is now [widely available](https://caniuse.com/mdn-javascript_builtins_json_json_superset).

That's all outside the scope of this PR though, which provides a performance gain without any change to escaping behaviour.