### PR TITLE
Fix flaky time test

### DIFF
--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -14,6 +14,8 @@ class YamlSerializationTest < ActiveRecord::TestCase
       topic = Topic.new(written_on: DateTime.now)
       assert_nothing_raised { topic.to_yaml }
     end
+  ensure
+    Topic.reset_column_information
   end
 
   def test_roundtrip


### PR DESCRIPTION
A combination of 3 tests using the `Topic` model and working with timezones would cause the time test to fail. I noticed that one of the tests required to reproduce changes the configured timezone for `Topic` but doesn't reset column information. Adding that fixes the flaky test.

Fixes #48664
