### PR TITLE
Refactor CollectionAssociation to improve thread-safety; Fixes #48671

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -85,7 +85,8 @@ module ActiveRecord
       end
 
       def reset
-        super
+        @loaded = false
+        @stale_state = nil
         @target = []
         @replaced_or_added_targets = Set.new
         @association_ids = nil
@@ -330,7 +331,8 @@ module ActiveRecord
           return persisted if memory.empty?
 
           persisted.map! do |record|
-            if mem_record = memory.delete(record)
+            mem_index = memory.index(record)
+            if mem_index && (mem_record = memory[mem_index])
 
               ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save - mem_record.class._attr_readonly).each do |name|
                 mem_record._write_attribute(name, record[name])


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to resolve race conditions in threaded code when loading instances of `CollectionAssociation` on an object which is shared across threads, as described in issue #48671

### Detail

This Pull Request changes the implementation of two methods to prevent them from mutating an instance variable in ways that would violate the expectations of other methods which rely on the state of that variable. 

Specifically, in the current state, the instance variable `@target` is:

1. Initialized as `nil`, then subsequently reinitialized to an empty array (many methods depend on it being enumerable and will raise errors if called during the window of time in which it is `nil`)
2. Mutated by calling `delete` on each of its elements prior to overwriting it with a new value (creating a window of time where it contains partial data or no data)

Both of these situations present a race condition when the object is shared by multiple threads.

The changes in this pull request:
1. Resolve the first issue by replacing a call to `super` with explicit initializations appropriate to the subclass
2. Resolve the second issue by replacing the call to `delete` with an index lookup, which makes the reassignment behavior atomic.

### Additional information

**Performance**: the array lookup in `merge_target_lists` could be done in other ways; the `index` lookup measures at least as fast as `delete` on my hardware; other approaches using enumerable methods like `detect` would be slower.

**Testing:** although the linked issue includes a test script that can demonstrate the problem, the nature of it is timing-dependent in a way that makes it difficult to write explicit tests to reproduce, and the changes are straightforward. I think that a lack of regression in existing tests should be sufficient verification.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~Tests are added or updated if you fix a bug or add a feature.~
* [x] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
