### PR TITLE
Fix has_one through singular building with inverse.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix has_one through singular building with inverse.
+
+    Allows building of records from an association with a has_one through a
+    singular association with inverse. For belongs_to through associations,
+    linking the foreign key to the primary key model isn't needed.
+    For has_one, we cannot build records due to the association not being mutable.
+
+    *Gannon McGibbon*
+
 *   Disable database prepared statements when query logs are enabled
 
     Prepared Statements and Query Logs are incompatible features due to query logs making every query unique.

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -114,12 +114,14 @@ module ActiveRecord
         end
 
         def build_record(attributes)
-          inverse = source_reflection.inverse_of
-          target = through_association.target
+          if source_reflection.collection?
+            inverse = source_reflection.inverse_of
+            target = through_association.target
 
-          if inverse && target && !target.is_a?(Array)
-            Array(target.id).zip(Array(inverse.foreign_key)).map do |primary_key_value, foreign_key_column|
-              attributes[foreign_key_column] = primary_key_value
+            if inverse && target && !target.is_a?(Array)
+              Array(target.id).zip(Array(inverse.foreign_key)).map do |primary_key_value, foreign_key_column|
+                attributes[foreign_key_column] = primary_key_value
+              end
             end
           end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -100,6 +100,14 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate member_detail_with_two_associations.member, :new_record?
   end
 
+  def test_building_works_with_has_one_through_belongs_to
+    new_member = Member.create!(name: "Joe")
+    new_member.create_current_membership!
+    new_club = new_member.build_club
+
+    assert_equal(new_member.club, new_club)
+  end
+
   def test_creating_multiple_associations_creates_through_record
     member_type = MemberType.create!
     member = Member.create!

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -8,7 +8,7 @@ end
 
 class CurrentMembership < Membership
   belongs_to :member
-  belongs_to :club
+  belongs_to :club, inverse_of: :membership
 end
 
 class SuperMembership < Membership


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `has_one` `through:` behaviour is currently broken and crashed when trying to link build records.

### Detail

This Pull Request changes `ActiveRecord::Associations::ThroughAssociation` so that built record linking to inverse is skipped when the source reflection is singular (`has_one` / `belongs_to`). The code is only meant for collection associations.

### Additional information

I also noticed while debugging this that `record.build_<association>` does not include an attributes hash by default: https://github.com/rails/rails/blob/1d4c28858e6395d4cbf79c22af2442e65deca696/activerecord/lib/active_record/associations/builder/singular_association.rb#L32

Whereas `record.<association>s.build` does: https://github.com/rails/rails/blob/1d4c28858e6395d4cbf79c22af2442e65deca696/activerecord/lib/active_record/associations/collection_proxy.rb#L318

This might be a bug, but singular association code seems to account for this, so I didn't bother to fix. It seems `ActiveRecord::Associations::ThroughAssociation#build_record` was the only code path where we assumed `attributes` is a hash.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
