### PR TITLE
Fix queries for deterministically encrypted attributed for data migrated from 7.0

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -72,8 +72,8 @@ module ActiveRecord
           end
 
           def global_previous_schemes_for(scheme)
-            ActiveRecord::Encryption.config.previous_schemes.collect do |previous_scheme|
-              scheme.merge(previous_scheme)
+            ActiveRecord::Encryption.config.previous_schemes.filter_map do |previous_scheme|
+              scheme.merge(previous_scheme) if scheme.compatible_with?(previous_scheme)
             end
           end
 

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -36,7 +36,7 @@ module ActiveRecord
       end
 
       def deterministic?
-        @deterministic
+        !!@deterministic
       end
 
       def fixed?
@@ -63,6 +63,10 @@ module ActiveRecord
         else
           block.call
         end
+      end
+
+      def compatible_with?(other_scheme)
+        deterministic? == other_scheme.deterministic?
       end
 
       private

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -367,13 +367,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
           **config.active_record.encryption
 
         auto_filtered_parameters.enable if ActiveRecord::Encryption.config.add_to_filter_parameters
-      end
 
-      ActiveSupport.on_load(:active_record) do
-        # Support extended queries for deterministic attributes and validations
-        if ActiveRecord::Encryption.config.extend_queries
-          ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
-          ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+        ActiveSupport.on_load(:active_record) do
+          # Support extended queries for deterministic attributes and validations
+          if ActiveRecord::Encryption.config.extend_queries
+            ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
+            ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+          end
         end
       end
 

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -101,7 +101,7 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
   test "deterministic encryption is fixed by default: it will always use the oldest scheme to encrypt data" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
     ActiveRecord::Encryption.config.deterministic_key = "12345"
-    ActiveRecord::Encryption.config.previous = [{ downcase: true }, { downcase: false }]
+    ActiveRecord::Encryption.config.previous = [{ downcase: true, deterministic: true }, { downcase: false, deterministic: true }]
 
     encrypted_author_class = Class.new(Author) do
       self.table_name = "authors"
@@ -113,10 +113,25 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
     assert_equal "stephen king", author.name
   end
 
+  test "don't use global previous schemes with a different deterministic nature" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = false
+    ActiveRecord::Encryption.config.deterministic_key = "12345"
+    ActiveRecord::Encryption.config.previous = [{ downcase: true, deterministic: false }, { downcase: false, deterministic: true }]
+
+    encrypted_author_class = Class.new(Author) do
+      self.table_name = "authors"
+
+      encrypts :name, deterministic: true, downcase: false
+    end
+
+    author = encrypted_author_class.create!(name: "STEPHEN KING")
+    assert_equal "STEPHEN KING", author.name
+  end
+
   test "deterministic encryption will use the newest encryption scheme to encrypt data when setting it to { fixed: false }" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
     ActiveRecord::Encryption.config.deterministic_key = "12345"
-    ActiveRecord::Encryption.config.previous = [{ downcase: true }, { downcase: false }]
+    ActiveRecord::Encryption.config.previous = [{ downcase: true, deterministic: true }, { downcase: false, deterministic: true }]
 
     encrypted_author_class = Class.new(Author) do
       self.table_name = "authors"
@@ -126,6 +141,38 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
 
     author = encrypted_author_class.create!(name: "STEPHEN KING")
     assert_equal "STEPHEN KING", author.name
+  end
+
+  test "use global previous schemes when performing queries" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = false
+    ActiveRecord::Encryption.config.deterministic_key = "12345"
+    ActiveRecord::Encryption.config.previous = [{ downcase: true, deterministic: true }, { downcase: false, deterministic: true }]
+
+    encrypted_author_class = Class.new(Author) do
+      self.table_name = "authors"
+
+      encrypts :name, deterministic: true, downcase: false
+    end
+
+    author = encrypted_author_class.create!(name: "STEPHEN KING")
+    assert_equal author, encrypted_author_class.find_by_name("STEPHEN KING")
+    assert_equal author, encrypted_author_class.find_by_name("stephen king")
+  end
+
+  test "don't use global previous schemes with a different deterministic nature when performing queries" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = false
+    ActiveRecord::Encryption.config.deterministic_key = "12345"
+    ActiveRecord::Encryption.config.previous = [{ downcase: true, deterministic: false }, { downcase: false, deterministic: true }]
+
+    encrypted_author_class = Class.new(Author) do
+      self.table_name = "authors"
+
+      encrypts :name, deterministic: true, downcase: false
+    end
+
+    author = encrypted_author_class.create!(name: "STEPHEN KING")
+    assert_equal author, encrypted_author_class.find_by_name("STEPHEN KING")
+    assert_nil encrypted_author_class.find_by_name("stephen king")
   end
 
   private

--- a/activerecord/test/cases/encryption/uniqueness_validations_test.rb
+++ b/activerecord/test/cases/encryption/uniqueness_validations_test.rb
@@ -23,7 +23,7 @@ class ActiveRecord::Encryption::UniquenessValidationsTest < ActiveRecord::Encryp
   end
 
   test "uniqueness validations work when using old encryption schemes" do
-    ActiveRecord::Encryption.config.previous = [ { downcase: true } ]
+    ActiveRecord::Encryption.config.previous = [ { downcase: true, deterministic: true } ]
 
     OldEncryptionBook = Class.new(UnencryptedBook) do
       self.table_name = "encrypted_books"


### PR DESCRIPTION
#48530 introduced a problem for the system that extends AR queries involving deterministically encrypted attributes. The problem is that this option added the same "previous scheme" for all the attributes, when the only intended ones were the "non deterministic" ones. A side effect of this is that, when encrypting query param values, it was using the wrong encryption scheme.

Fixes https://github.com/rails/rails/issues/48204#issuecomment-1623301440

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
