### PR TITLE
Don't show secrets for Active Record's `Cipher::Aes256Gcm#inspect`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Don't show secrets for Active Record's `Cipher::Aes256Gcm#inspect`.
+
+    Before:
+
+    ```ruby
+    ActiveRecord::Encryption::Cipher::Aes256Gcm.new(secret).inspect
+    "#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
+    ```
+
+    After:
+
+    ```ruby
+    ActiveRecord::Encryption::Cipher::Aes256Gcm(secret).inspect
+    "#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x0000000104888038>"
+    ```
+
+    *Petrik de Heus*
+
 *   Fix has_one through singular building with inverse.
 
     Allows building of records from an association with a has_one through a

--- a/activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb
+++ b/activerecord/lib/active_record/encryption/cipher/aes256_gcm.rb
@@ -79,6 +79,10 @@ module ActiveRecord
           raise ActiveRecord::Encryption::Errors::Decryption
         end
 
+        def inspect # :nodoc:
+          "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+        end
+
         private
           def generate_iv(cipher, clear_text)
             if @deterministic

--- a/activerecord/test/cases/encryption/cipher/aes256_gcm_test.rb
+++ b/activerecord/test/cases/encryption/cipher/aes256_gcm_test.rb
@@ -36,6 +36,11 @@ class ActiveRecord::Encryption::Aes256GcmTest < ActiveRecord::EncryptionTestCase
     assert_not_equal cipher.encrypt("Some text").headers.iv, cipher.encrypt("Some other text").headers.iv
   end
 
+  test "inspect_does not show secrets" do
+    cipher = ActiveRecord::Encryption::Cipher::Aes256Gcm.new(@key)
+    assert_match(/\A#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x[0-9a-f]+>\z/, cipher.inspect)
+  end
+
   private
     def assert_cipher_encrypts(cipher, content_to_encrypt)
       encrypted_content = cipher.encrypt(content_to_encrypt)


### PR DESCRIPTION
### Motivation / Background

If anyone calls a cypher in the console it will show the secret of the encryptor.

By overriding the `inspect` method to only show the class name we can avoid accidentally outputting sensitive information.

### Detail

Before:

```ruby
ActiveRecord::Encryption::Cipher::Aes256Gcm.new(secret).inspect
"#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
```

After:

```ruby
ActiveRecord::Encryption::Cipher::Aes256Gcm(secret).inspect
"#<ActiveRecord::Encryption::Cipher::Aes256Gcm:0x0000000104888038>"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
