### PR TITLE
Don't show secrets for `MessageVerifier#inspect` and `KeyGenerator#inspect`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Don't show secrets for `ActiveSupport::KeyGenerator#inspect`.
+
+    Before:
+
+    ```ruby
+    ActiveSupport::KeyGenerator.new(secret).inspect
+    "#<ActiveSupport::KeyGenerator:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
+    ```
+
+    After:
+
+    ```ruby
+    ActiveSupport::KeyGenerator::Aes256Gcm(secret).inspect
+    "#<ActiveSupport::KeyGenerator:0x0000000104888038>"
+    ```
+
+    *Petrik de Heus*
+
 *   Improve error message when EventedFileUpdateChecker is used without a
     compatible version of the Listen gem
 

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -41,6 +41,10 @@ module ActiveSupport
     def generate_key(salt, key_size = 64)
       OpenSSL::PKCS5.pbkdf2_hmac(@secret, salt, @iterations, key_size, @hash_digest_class.new)
     end
+
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
   end
 
   # = Caching Key Generator

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -301,6 +301,10 @@ module ActiveSupport
       deserialize_with_metadata(decode(extract_encoded(message)), **options)
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
+
     private
       def sign_encoded(encoded)
         digest = generate_digest(encoded)

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -59,6 +59,10 @@ else
       assert_raises(ArgumentError) { ActiveSupport::KeyGenerator.hash_digest_class = InvalidDigest }
       assert_raises(ArgumentError) { ActiveSupport::KeyGenerator.hash_digest_class = InvalidDigest.new }
     end
+
+    test "inspect does not show secrets" do
+      assert_match(/\A#<ActiveSupport::KeyGenerator:0x[0-9a-f]+>\z/, @generator.inspect)
+    end
   end
 
   class CachingKeyGeneratorTest < ActiveSupport::TestCase

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -109,6 +109,10 @@ class MessageVerifierTest < ActiveSupport::TestCase
     assert_equal "Secret should not be nil.", exception.message
   end
 
+  test "inspect does not show secrets" do
+    assert_match(/\A#<ActiveSupport::MessageVerifier:0x[0-9a-f]+>\z/, @verifier.inspect)
+  end
+
   private
     def make_codec(**options)
       ActiveSupport::MessageVerifier.new(@secret, **options)


### PR DESCRIPTION
### Motivation / Background

If anyone calls a cypher in the console it will show the secret of the encryptor.

By overriding the inspect method to only show the class name we can avoid accidentally outputting sensitive information.

### Detail

Before:

```ruby
ActiveSupport::MessageVerifier.new(secret).inspect
"#<ActiveSupport::MessageVerifier:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
ActiveSupport::KeyGenerator.new(secret).inspect
"#<ActiveSupport::KeyGenerator:0x0000000104888038 ... @secret=\"\\xAF\\bFh]LV}q\\nl\\xB2U\\xB3 ... >"
```

After:

```ruby
ActiveSupport::MessageVerifier::Aes256Gcm(secret).inspect
"#<ActiveSupport::MessageVerifier:0x0000000104888038>"
ActiveSupport::KeyGenerator::Aes256Gcm(secret).inspect
"#<ActiveSupport::KeyGenerator:0x0000000104888038>"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
