### PR TITLE
Deprecate `name` argument in `remove_connection`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `name` argument on `#remove_connection`.
+
+    The `name` argument is deprecated on `#remove_connection` without replacement. `#remove_connection` should be called directly on the class that established the connection.
+
+    *Eileen M. Uchitelle*
+
 *   Fix has_one through singular building with inverse.
 
     Allows building of records from an association with a has_one through a

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -293,6 +293,14 @@ module ActiveRecord
     end
 
     def remove_connection(name = nil)
+      if name
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
+          The name argument for `#remove_connection` is deprecated without replacement
+          and will be removed in Rails 7.2. `#remove_connection` should always be called
+          on the connection class directly, which makes the name argument obsolete.
+        MSG
+      end
+
       name ||= @connection_specification_name if defined?(@connection_specification_name)
       # if removing a connection that has a pool, we reset the
       # connection_specification_name so it will use the parent

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -279,6 +279,20 @@ module ActiveRecord
         assert_same klass2.connection, ActiveRecord::Base.connection
       end
 
+      def test_remove_connection_with_name_argument_is_deprecated
+        klass2 = Class.new(Base) { def self.name; "klass2"; end }
+
+        assert_same klass2.connection, ActiveRecord::Base.connection
+
+        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.db_config.configuration_hash)
+        assert_same klass2.connection, pool.connection
+        assert_not_same klass2.connection, ActiveRecord::Base.connection
+
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Base.remove_connection("klass2")
+        end
+      end
+
       class ApplicationRecord < ActiveRecord::Base
         self.abstract_class = true
       end


### PR DESCRIPTION
The `name` argument is not useful as `remove_connection` should be called on the class that established the connection. Allowing `name` to be passed here doesn't match how any of the other methods behave on the connection classes. While this behavior has been around for a long time, I'm not sure anyone is using this as it's not documented when to use name, nor are there any tests.