### PR TITLE
Introduce `config.dom_testing_default_html_version` and use Rails::Dom::Testing to parse HTML in test helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ PATH
       net-imap
       net-pop
       net-smtp
-      rails-dom-testing (~> 2.0)
+      rails-dom-testing (~> 2.2)
     actionpack (7.1.0.alpha)
       actionview (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
@@ -51,7 +51,7 @@ PATH
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
+      rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
     actiontext (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
@@ -64,7 +64,7 @@ PATH
       activesupport (= 7.1.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
-      rails-dom-testing (~> 2.0)
+      rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
     activejob (7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
@@ -382,8 +382,9 @@ GEM
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "net-imap"
   s.add_dependency "net-pop"
   s.add_dependency "net-smtp"
-  s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_dependency "rails-dom-testing", "~> 2.2"
 end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -2,10 +2,12 @@
 
     *Matija Čupić*
 
-*   `ActionDispatch::Assertions#html_document` uses Nokogiri's HTML5 parser if it is available.
+*   `config.dom_testing_default_html_version` controls the HTML parser used by
+    `ActionDispatch::Assertions#html_document`.
 
-    The HTML5 parser better represents what the DOM would be in a browser. Previously this test
-    helper always used Nokogiri's HTML4 parser.
+    The Rails 7.1 default configuration opts into the HTML5 parser when it is supported, to better
+    represent what the DOM would be in a browser user agent. Previously this test helper always used
+    Nokogiri's HTML4 parser.
 
     *Mike Dalessio*
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack-session", ">= 1.0.1"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.6"
-  s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_dependency "rails-dom-testing", "~> 2.2"
   s.add_dependency "actionview", version
 
   s.add_development_dependency "activemodel", version

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -15,10 +15,8 @@ module ActionDispatch
     def html_document
       @html_document ||= if @response.media_type&.end_with?("xml")
         Nokogiri::XML::Document.parse(@response.body)
-      elsif defined?(Nokogiri::HTML5)
-        Nokogiri::HTML5::Document.parse(@response.body)
       else
-        Nokogiri::HTML4::Document.parse(@response.body)
+        Rails::Dom::Testing.html_document.parse(@response.body)
       end
     end
   end

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -11,9 +11,6 @@ module ActionDispatch
       def response_parser; -> body { body }; end
     end
 
-    # :nodoc:
-    HTMLResponseParser = defined?(::Nokogiri::HTML5) ? ::Nokogiri::HTML5 : ::Nokogiri::HTML
-
     @encoders = { identity: IdentityEncoder.new }
 
     attr_reader :response_parser
@@ -55,7 +52,7 @@ module ActionDispatch
       @encoders[mime_name] = new(mime_name, param_encoder, response_parser)
     end
 
-    register_encoder :html, response_parser: -> body { HTMLResponseParser.parse(body) }
+    register_encoder :html, response_parser: -> body { Rails::Dom::Testing.html_document.parse(body) }
     register_encoder :json, response_parser: -> body { JSON.parse(body) }
   end
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -56,6 +56,16 @@
 
     *Mike Dalessio*
 
+*   `config.dom_testing_default_html_version` controls the HTML parser used by
+    `ActionView::TestCase#document_root_element`, which creates the DOM used by the assertions in
+    Rails::Dom::Testing.
+
+    The Rails 7.1 default configuration opts into the HTML5 parser when it is supported, to better
+    represent what the DOM would be in a browser user agent. Previously this test helper always used
+    Nokogiri's HTML4 parser.
+
+    *Mike Dalessio*
+
 *   Add support for the HTML picture tag. It supports passing a String, an Array or a Block.
     Supports passing properties directly to the img tag via the `:image` key.
     Since the picture tag requires an img tag, the last element you provide will be used for the img tag.

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.11"
   s.add_dependency "rails-html-sanitizer", "~> 1.6"
-  s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_dependency "rails-dom-testing", "~> 2.2"
 
   s.add_development_dependency "actionpack",  version
   s.add_development_dependency "activemodel", version

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -177,17 +177,9 @@ module ActionView
       end
 
     private
-      def html_document_class
-        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::Document : Nokogiri::HTML4::Document
-      end
-
-      def html_document_fragment_class
-        defined?(Nokogiri::HTML5) ? Nokogiri::HTML5::DocumentFragment : Nokogiri::HTML4::DocumentFragment
-      end
-
       # Need to experiment if this priority is the best one: rendered => output_buffer
       def document_root_element
-        html_document_class.parse(@rendered.blank? ? @output_buffer.to_str : @rendered).root
+        Rails::Dom::Testing.html_document.parse(@rendered.blank? ? @output_buffer.to_str : @rendered).root
       end
 
       module Locals

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -986,7 +986,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   private
     def root_elem(rendered_content)
-      html_document_fragment_class.parse(rendered_content).children.first # extract from nodeset
+      Rails::Dom::Testing.html_document_fragment.parse(rendered_content).children.first # extract from nodeset
     end
 
     def with_default_enforce_utf8(value)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -84,6 +84,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.raise_on_invalid_cache_expiration_time`](#config-active-support-raise-on-invalid-cache-expiration-time): `true`
 - [`config.active_support.use_message_serializer_for_metadata`](#config-active-support-use-message-serializer-for-metadata): `true`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
+- [`config.dom_testing_default_html_version`](#config-dom-testing-default-html-version): `defined?(Nokogiri::HTML5) ? :html5 : :html4`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
 - [`config.precompile_filter_parameters`](#config-precompile-filter-parameters): `true`
 
@@ -310,6 +311,19 @@ Sets the format used in responses when errors occur in the development environme
 #### `config.disable_sandbox`
 
 Controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to `false`.
+
+#### `config.dom_testing_default_html_version`
+
+Controls whether an HTML4 parser or an HTML5 parser is used by default by the test helpers in Action View, Action Dispatch, and `rails-dom-testing`.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `:html4`             |
+| 7.1                   | `:html5` (see NOTE)  |
+
+NOTE: Nokogiri's HTML5 parser is not supported on JRuby, so on JRuby platforms Rails will fall back to `:html4`.
 
 #### `config.eager_load`
 
@@ -2087,7 +2101,7 @@ Configures the set of HTML sanitizers used by Action View by setting `ActionView
 | (original)            | `Rails::HTML4::Sanitizer`            | HTML4                  |
 | 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
 
-NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to use `Rails::HTML4::Sanitizer`.
+NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
 
 ### Configuring Action Mailbox
 
@@ -2867,7 +2881,7 @@ Configures the HTML sanitizer used by Action Text by setting `ActionText::Conten
 | (original)            | `Rails::HTML4::Sanitizer`            | HTML4                  |
 | 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
 
-NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to use `Rails::HTML4::Sanitizer`.
+NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
 
 ### Configuring a Database
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -22,7 +22,7 @@ module Rails
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :rake_eager_load, :server_timing, :log_file_size
+                    :rake_eager_load, :server_timing, :log_file_size, :dom_testing_default_html_version
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -80,6 +80,7 @@ module Rails
         @permissions_policy                      = nil
         @rake_eager_load                         = false
         @server_timing                           = false
+        @dom_testing_default_html_version        = :html4
       end
 
       # Loads default configuration values for a target version. This includes
@@ -269,6 +270,7 @@ module Rails
 
           self.add_autoload_paths_to_load_path = false
           self.precompile_filter_parameters = true
+          self.dom_testing_default_html_version = defined?(Nokogiri::HTML5) ? :html5 : :html4
 
           if Rails.env.local?
             self.log_file_size = 100 * 1024 * 1024

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -208,3 +208,12 @@
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests
 # Rails.application.config.action_dispatch.debug_exception_log_level = :error
+
+# Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
+# parsers.
+#
+# Nokogiri::HTML5 isn't supported on JRuby, so JRuby applications must set this to :html4.
+#
+# In previous versions of Rails, these test helpers always used an HTML4 parser.
+#
+# Rails.application.config.dom_testing_default_html_version = :html5

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4532,6 +4532,21 @@ module ApplicationTests
       )
     end
 
+    test "dom testing uses the HTML5 parser in new apps if it is supported" do
+      app "development"
+      expected = defined?(Nokogiri::HTML5) ? :html5 : :html4
+
+      assert_equal(expected, Rails.application.config.dom_testing_default_html_version)
+    end
+
+    test "dom testing uses the HTML4 parser in upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app "development"
+
+      assert_equal(:html4, Rails.application.config.dom_testing_default_html_version)
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Motivation / Background

Some early users of Rails edge reported test breakage due to the change in #48523 that updated test helpers to use Nokogiri's HTML5 parser.

After discussing with Rafael, he suggested that we introduce a Rails config parameter so users may opt into this change at their convenience, essentially wrapping a config param around the changes in #48523.

This PR takes that idea a step further and groups all the test helpers from `ActionView::TestCase`, `ActionDispatch::Assertions`, and everything in `Rails::Dom::Testing` under a single config param:

```
config.dom_testing_default_html_version
```

As a result, by setting this config to either `:html4` or `:html5`, a developer can control the HTML parser used by all the test helpers in Action View, Action Dispatch, and Rails::Dom::Testing; and some assertions support overriding that default for individual tests.

### Detail

- new config parameter `config.dom_testing_default_html_version`, which is injected into `Dom::Rails::Testing` via the railstie in https://github.com/rails/rails-dom-testing/pull/109
  - the value of that param is `:html5` in Rails 7.1, and `:html4` in earlier config versions
  - though, on JRuby, where Nokogiri::HTML5 is not supported, this will always be `:html4`
- Action View and Dispatch test helpers use `Rails::Dom::Testing.html_document` or `.html_document_fragment` to ensure the desired HTML parser is used
  - Update dependency on `rails-dom-testing` to `~> 2.2`

### Additional information

Note that integration testing across gems like this is challenging, but I have actually fired up a Rails app using this PR and https://github.com/rails/rails-dom-testing/pull/109 together, and it worked as expected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
