### PR TITLE
HasOne `create_association` should raise if association already exists

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -100,6 +100,10 @@ module ActiveRecord
           self.target = record
         end
 
+        def create_new_record(record)
+          set_new_record(record)
+        end
+
         def update_counters(by)
           if require_counter_update? && foreign_key_present?
             if target && !stale_target?

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           self.target = record
         end
 
-        def create_new_record(record, save = true)
+        def create_new_record(record)
           raise_on_type_mismatch!(record) if record
 
           return target unless load_target || record

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -106,6 +106,13 @@ module ActiveRecord
               target.destroy
             end
           else
+            if target.persisted?
+              raise RecordNotSaved.new(
+                "Failed to remove existing associated #{reflection.name}. "\
+                "Please set options[:dependent] to :delete or :destroy to override.",
+                target
+              )
+            end
             nullify_owner_attributes(target)
             remove_inverse_instance(target)
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -105,25 +105,26 @@ module ActiveRecord
             if target.persisted?
               target.destroy
             end
+          when :nullify
+            nullify_owner_attributes(target)
+            remove_inverse_instance(target)
           else
-            if target.persisted?
+            if target.persisted? && owner.persisted?
               raise RecordNotSaved.new(
                 "Failed to remove existing associated #{reflection.name}. "\
                 "Please set options[:dependent] to :delete or :destroy to override.",
                 target
               )
             end
-            nullify_owner_attributes(target)
-            remove_inverse_instance(target)
+          end
 
-            if target.persisted? && owner.persisted? && !target.save
-              set_owner_attributes(target)
-              raise RecordNotSaved.new(
-                "Failed to remove the existing associated #{reflection.name}. " \
-                "The record failed to save after its foreign key was set to nil.",
-                target
-              )
-            end
+          if method.nil? && target.persisted? && owner.persisted? && !target.save
+            set_owner_attributes(target)
+            raise RecordNotSaved.new(
+              "Failed to remove the existing associated #{reflection.name}. " \
+              "The record failed to save after its foreign key was set to nil.",
+              target
+            )
           end
         end
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -61,13 +61,6 @@ module ActiveRecord
 
           return target unless load_target || record
 
-          if target.present? && target.persisted? && owner.persisted?
-            raise RecordNotSaved.new(
-              "Failed to save the new associated #{reflection.name}.",
-              record
-            )
-          end
-
           assigning_another_record = target != record
           if assigning_another_record || record.has_changes_to_save?
             save &&= owner.persisted?
@@ -89,6 +82,21 @@ module ActiveRecord
           end
 
           self.target = record
+        end
+
+        def create_new_record(record, save = true)
+          raise_on_type_mismatch!(record) if record
+
+          return target unless load_target || record
+
+          if target.present? && target.persisted? && owner.persisted?
+            raise RecordNotSaved.new(
+              "Failed to save the new associated #{reflection.name}.",
+              record
+            )
+          end
+
+          set_new_record(record)
         end
 
         # The reason that the save param for replace is false, if for create (not just build),

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -55,7 +55,8 @@ module ActiveRecord
 
         def _create_record(attributes, raise_error = false, &block)
           reflection.klass.transaction do
-            record = build(attributes, &block)
+            record = build_record(attributes, &block)
+            create_new_record(record)
             saved = record.save
             replace_keys(record, force: true)
             raise RecordInvalid.new(record) if !saved && raise_error

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -582,8 +582,10 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_equal ships(:black_pearl), pirate.ship
     assert_equal pirate.id, pirate.ship.pirate_id
-    assert_equal "Failed to save the new associated ship.", error.message
-    assert_equal new_ship, error.record
+    assert_equal "Failed to remove the existing associated ship. " \
+                 "The record failed to save after its foreign key was set to nil.", error.message
+    assert_equal pirate.ship, error.record
+    assert_not_equal new_ship, error.record
   end
 
   def test_replacement_failure_due_to_new_record_should_raise_error

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -313,9 +313,6 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     bulb = pirate.create_foo_bulb
     assert_not_equal scope, bulb.scope_after_initialize.where_values_hash
-
-    bulb = pirate.create_foo_bulb!
-    assert_not_equal scope, bulb.scope_after_initialize.where_values_hash
   end
 
   def test_create_association
@@ -546,15 +543,6 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_equal "Failed to save the new associated ship.", error.message
     assert_equal pirate.ship, orig_ship
-  end
-
-  def test_create_association_replaces_existing_with_dependent_option
-    pirate = pirates(:blackbeard).becomes(DestructivePirate)
-    orig_ship = pirate.dependent_ship
-
-    new_ship = pirate.create_dependent_ship
-    assert_predicate new_ship, :new_record?
-    assert_predicate orig_ship, :destroyed?
   end
 
   def test_creation_failure_due_to_new_record_should_raise_error

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -533,7 +533,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal new_account.firm_name, "Account"
   end
 
-  def test_create_association_replacement_failure_without_dependent_option
+  def test_create_association_wont_replace_existing
     pirate = pirates(:blackbeard)
     orig_ship = pirate.ship
 
@@ -544,7 +544,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal "Failed to save the new associated ship.", error.message
-    assert_nil pirate.ship
+    assert_equal pirate.ship, orig_ship
   end
 
   def test_create_association_replaces_existing_with_dependent_option
@@ -573,17 +573,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   def test_replacement_failure_due_to_existing_record_should_raise_error
     pirate = pirates(:blackbeard)
     pirate.ship.name = nil
+    new_ship = ships(:interceptor)
 
     assert_not_predicate pirate.ship, :valid?
     error = assert_raise(ActiveRecord::RecordNotSaved) do
-      pirate.ship = ships(:interceptor)
+      pirate.ship = new_ship
     end
 
     assert_equal ships(:black_pearl), pirate.ship
     assert_equal pirate.id, pirate.ship.pirate_id
-    assert_equal "Failed to remove the existing associated ship. " \
-                 "The record failed to save after its foreign key was set to nil.", error.message
-    assert_equal pirate.ship, error.record
+    assert_equal "Failed to save the new associated ship.", error.message
+    assert_equal new_ship, error.record
   end
 
   def test_replacement_failure_due_to_new_record_should_raise_error

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -118,6 +118,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm = companies(:rails_core)
     old_account_id = firm.account.id
     firm.account = Account.new(credit_limit: 5)
+    firm.save
     # account is dependent with nullify, therefore its firm_id should be nil
     assert_nil Account.find(old_account_id).firm_id
   end
@@ -616,6 +617,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     bulb = car.create_bulb
     assert_equal car.id, bulb.car_id
 
+    car.bulb.destroy!
+
     bulb = car.create_bulb car_id: car.id + 1
     assert_equal car.id, bulb.car_id
   end
@@ -957,7 +960,9 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     content.create_content_position!
 
     assert_no_difference -> { ContentPosition.count } do
-      content.create_content_position!
+      assert_raises ActiveRecord::RecordNotSaved do
+        content.create_content_position!
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -338,7 +338,8 @@ class InverseHasOneTests < ActiveRecord::TestCase
 
   def test_parent_instance_should_be_shared_with_newly_created_child
     human = Human.first
-    face = human.create_face(description: "haunted")
+    face = human.build_face(description: "haunted")
+    face.save
     assert_not_nil face.human
     assert_equal human.name, face.human.name, "Name of human should be the same before changes to parent instance"
     human.name = "Bongo"
@@ -349,7 +350,8 @@ class InverseHasOneTests < ActiveRecord::TestCase
 
   def test_parent_instance_should_be_shared_with_newly_created_child_via_bang_method
     human = Human.first
-    face = human.create_face!(description: "haunted")
+    face = human.build_face(description: "haunted")
+    face.save
     assert_not_nil face.human
     assert_equal human.name, face.human.name, "Name of human should be the same before changes to parent instance"
     human.name = "Bongo"

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -123,7 +123,8 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_polymorphic_has_one_create_model_with_inheritance
-    tagging = tags(:misc).create_tagging(taggable: posts(:thinking))
+    tagging = tags(:misc).build_tagging(taggable: posts(:thinking))
+    tagging.save
     assert_equal "Post", tagging.taggable_type
   end
 
@@ -169,7 +170,8 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
 
   def test_create_polymorphic_has_one_with_scope
     old_count = Tagging.count
-    tagging = posts(:welcome).create_tagging(tag: tags(:misc))
+    tagging = posts(:welcome).build_tagging(tag: tags(:misc))
+    tagging.save
     assert_equal "Post", tagging.taggable_type
     assert_equal old_count + 1, Tagging.count
   end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -578,7 +578,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
   def test_target_merging_recognizes_updated_in_memory_records
     member = members(:blarpy_winkup)
-    membership = member.create_membership!(favorite: false)
+    membership = member.build_membership(favorite: false)
 
     assert_empty member.favorite_memberships
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -451,7 +451,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
 
   def test_store_association_with_a_polymorphic_relationship
     num_tagging = Tagging.count
-    tags(:misc).create_tagging(taggable: posts(:thinking))
+    tags(:misc).build_tagging(taggable: posts(:thinking)).save
     assert_equal num_tagging + 1, Tagging.count
   end
 


### PR DESCRIPTION
The goal is to raise an exception when calling `create_association` which would replace an already persisted association.

Here is a failing test report as well:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "active_support/testing/assertions"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :authors, force: true

  create_table :books, force: true do |t|
    t.integer :author_id
  end
end

class Author < ActiveRecord::Base
  has_one :book
end

class Book < ActiveRecord::Base
  belongs_to :author
  validates :author_id, uniqueness: true
end

class BugTest < Minitest::Test
  include ActiveSupport::Testing::Assertions

  def test_association_stuff
    author = Author.create!
    author.create_book!

    assert_no_difference -> { Book.count } do
      assert_raises ActiveRecord::RecordNotSaved do
        author.create_book!
      end
    end
  end
end
```