### PR TITLE
[ci-skip][Doc] Fix `require` paths for "Using Separate Files" in Testing Guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1578,7 +1578,7 @@ These helpers can then be explicitly required as needed and included as needed
 
 ```ruby
 require "test_helper"
-require "test_helpers/multiple_assertions"
+require "helpers/multiple_assertions"
 
 class NumberTest < ActiveSupport::TestCase
   include MultipleAssertions
@@ -1593,7 +1593,7 @@ or they can continue to be included directly into the relevant parent classes
 
 ```ruby
 # test/test_helper.rb
-require "test_helpers/sign_in_helper"
+require "helpers/sign_in_helper"
 
 class ActionDispatch::IntegrationTest
   include SignInHelper


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found simple errors in the sample codes.

### Detail

This Pull Request changes the path for `require` as follows.

```diff
- require "test_helpers/multiple_assertions"
+ require "helpers/multiple_assertions"
```

In my local app, changing `test_helpers/` to the actual `helpers/` is needed to `include` my test helper.

I'd backport this to 7-0-stable as well if merged.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
