### PR TITLE
[Fix #48685] Make the encryptor agnostic of the type of data to decrypt

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Make `ActiveRecord::Encryption::Encryptor` agnostic of the serialization format used for encrypted data.
+
+    Previously, the encryptor instance only allowed an encrypted value serialized as a `String` to be passed to the message serializer.
+
+    Now, the encryptor lets the configured `message_serializer` decide which types of serialized encrypted values are supported. A custom serialiser is therefore allowed to serialize `ActiveRecord::Encryption::Message` objects using a type other than `String`.
+
+    The default `ActiveRecord::Encryption::MessageSerializer` already ensures that only `String` objects are passed for deserialization.
+
+    *Maxime Réty*
+
 *   The object returned by `explain` now responds to `pluck`, `first`,
     `last`, `average`, `count`, `maximum`, `minimum`, and `sum`. Those
     new methods run `EXPLAIN` on the corresponding queries:

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -100,7 +100,6 @@ module ActiveRecord
         end
 
         def deserialize_message(message)
-          raise Errors::Encoding unless message.is_a?(String)
           serializer.load message
         rescue ArgumentError, TypeError, Errors::ForbiddenClass
           raise Errors::Encoding

--- a/activerecord/test/cases/encryption/encryptor_test.rb
+++ b/activerecord/test/cases/encryption/encryptor_test.rb
@@ -12,7 +12,13 @@ class ActiveRecord::Encryption::EncryptorTest < ActiveRecord::EncryptionTestCase
     assert_encrypt_text("my secret text")
   end
 
-  test "decrypt and invalid string will raise a Decryption error" do
+  test "trying to decrypt something else than a string will raise a Decryption error" do
+    assert_raises(ActiveRecord::Encryption::Errors::Decryption) do
+      @encryptor.decrypt(:it_can_only_decrypt_strings)
+    end
+  end
+
+  test "decrypt an invalid string will raise a Decryption error" do
     assert_raises(ActiveRecord::Encryption::Errors::Decryption) do
       @encryptor.decrypt("some test that does not make sense")
     end

--- a/activerecord/test/cases/encryption/message_serializer_test.rb
+++ b/activerecord/test/cases/encryption/message_serializer_test.rb
@@ -29,13 +29,13 @@ class ActiveRecord::Encryption::MessageSerializerTest < ActiveRecord::Encryption
     assert_nothing_raised { @serializer.load(class_loading_payload) }
   end
 
-  test "detects random JSON data and raises an invalid dencryption error" do
+  test "detects random JSON data and raises a decryption error" do
     assert_raises ActiveRecord::Encryption::Errors::Decryption do
       @serializer.load JSON.dump("hey there")
     end
   end
 
-  test "detects random JSON hashes and raises an invalid decryption error" do
+  test "detects random JSON hashes and raises a decryption error" do
     assert_raises ActiveRecord::Encryption::Errors::Decryption do
       @serializer.load JSON.dump({ some: "other data" })
     end
@@ -44,6 +44,12 @@ class ActiveRecord::Encryption::MessageSerializerTest < ActiveRecord::Encryption
   test "detects JSON hashes with a 'p' key that is not encoded in base64" do
     assert_raises ActiveRecord::Encryption::Errors::Encoding do
       @serializer.load JSON.dump({ p: "some data not encoded" })
+    end
+  end
+
+  test "raises a TypeError when trying to deserialize other data types" do
+    assert_raises TypeError do
+      @serializer.load(:it_can_only_deserialize_strings)
     end
   end
 

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -145,7 +145,7 @@ To encrypt Action Text fixtures, you should place them in `fixtures/action_text/
 
 ### Supported Types
 
-`active_record.encryption` will serialize values using the underlying type before encrypting them, but *they must be serializable as strings*. Structured types like `serialized` are supported out of the box.
+`active_record.encryption` will serialize values using the underlying type before encrypting them, but, unless using a custom `message_serializer`, *they must be serializable as strings*. Structured types like `serialized` are supported out of the box.
 
 If you need to support a custom type, the recommended way is using a [serialized attribute](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html). The declaration of the serialized attribute should go **before** the encryption declaration:
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix https://github.com/rails/rails/issues/48685.

### Detail

[Fix #48685] Make the encryptor agnostic of the type of data to decrypt
    
The default message serializer will raise a `TypeError` when invoking `JSON.parse` on any non-`String` input. This error will subsequently be translated into an `ActiveRecord::Encryption::Errors::Encoding` error and then a `ActiveRecord::Encryption::Errors::Decryption` error by the encryptor, which does not change the current behavior at the encryptor level.

This change clarifies that it is the role of the underlying serializer to accept or reject the data to decrypt depending on its type. This behavior mirrors what is done at encryption, where the serializer asserts that the input is an `ActiveRecord::Encryption::Message`.

This change is a no-op when using the default `MessageSerializer` class, but it enables the use a wider variety of custom serializers.

By being agnostic of the type of data to decrypt at the encryptor level, it is now possible to serialize and store messages in a binary format (e.g. in a `bytea` column in PostgreSQL). A custom message serializer is now able to decrypt binary values coming from the database (`String`) or from user input (`ActiveModel::Type::Binary::Data`) without having an exception raised at the encryptor level because the type is not `String`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
