### PR TITLE
Prevent `#merge_target_lists` from clearing id column on composite primary key records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -333,7 +333,11 @@ module ActiveRecord
             if mem_record = memory.delete(record)
 
               ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save - mem_record.class._attr_readonly).each do |name|
-                mem_record._write_attribute(name, record[name])
+                if name == "id" && mem_record.class.composite_primary_key?
+                  mem_record.class.primary_key.zip(record[name]) { |attr, value| mem_record._write_attribute(attr, value) }
+                else
+                  mem_record._write_attribute(name, record[name])
+                end
               end
 
               mem_record

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -79,6 +79,16 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal "Deck", ship.parts[0].name
   end
 
+  def test_loading_cpk_association_when_persisted_and_in_memory_differ
+    order = Cpk::Order.create!(id: [1, 2], status: "paid")
+    book = order.books.create!(id: [3, 4], title: "Book")
+
+    Cpk::Book.find(book.id).update_columns(title: "A different title")
+    order.books.load
+
+    assert_equal [3, 4], book.id
+  end
+
   def test_include_with_order_works
     assert_nothing_raised { Account.all.merge!(order: "id", includes: :firm).first }
     assert_nothing_raised { Account.all.merge!(order: :id, includes: :firm).first }


### PR DESCRIPTION
### Motivation / Background

This PR addresses a bug with composite primary key models where loading a collection association causes the `id` column to be set to `nil` while merging persisted and in-memory records.

### Detail

When merging persisted and in-memory records in `#merge_target_list`, we use `record[name]` to get the value of the attribute. For records with a composite primary key, the full CPK is returned from `record["id"]`, which is incompatible with `#_write_attribute`: we attempt to assign an Array to the `id` column, which results in the column being set to nil.

When dealing with a record with a composite primary key, we need to write each part of the primary key individually via `#_write_attribute`.

### Additional information

One alternative to calling `#_write_attribute` for each part of the primary key would be to simply delegate to the `id=` method, which is already capable of assigning each part of the CPK accordingly and ultimately delegates to `#_write_attribute`:
https://github.com/rails/rails/blob/a5fc471b3f4bbd02e6be38dae023526a49e7d049/activerecord/lib/active_record/attribute_methods/primary_key.rb#L32-L39

However, this duplicates the check to `composite_primary_key?`, and I felt it would be more appropriate to go through `#_write_attribute` directly in both branches of the conditional.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
