### PR TITLE
Try to fix big decimal related encoding errors on Ruby 2.7

### DIFF
--- a/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb
@@ -6,7 +6,7 @@ require "bigdecimal/util"
 module ActiveSupport
   module BigDecimalWithDefaultFormat # :nodoc:
     def to_s(format = "F")
-      super(format)
+      super(format).force_encoding(Encoding::US_ASCII)
     end
   end
 end


### PR DESCRIPTION
First, this failure seems to occur frequently:
https://buildkite.com/rails/rails/builds/97896#01893375-a2aa-4c8e-9d4b-42c9392a6171/1079-1090

There was also a somewhat related discovery here:
https://github.com/rails/rails/pull/47493/files#diff-9c10b17f0ee079f3e5294d17264e7e06986f6192cff165f6628fe99886c38c24R19

Let's see what happens in CI!