### PR TITLE
Use a consistent format when testing BigDecimal.to_s

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -427,8 +427,9 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
 
     assert_equal "1000010.0", BigDecimal("1000010").to_s
     assert_equal "1000010.0", BigDecimal("1000010").to_fs
-    assert_equal "10000 10.0", BigDecimal("1000010").to_s("5F")
-    assert_equal "10000 10.0", BigDecimal("1000010").to_fs("5F")
+
+    assert_equal "0.10000 1", BigDecimal("0.100001").to_s("5F")
+    assert_equal "0.10000 1", BigDecimal("0.100001").to_fs("5F")
 
     assert_raises TypeError do
       1.to_s({})


### PR DESCRIPTION
The previous examples were causing failures in CI, after ruby/bigdecimal#264 was merged.

For example:

```
Failure:
NumericExtFormattingTest#test_default_to_fs [/rails/activesupport/test/core_ext/numeric_ext_test.rb:446]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"10000 10.0"
+# encoding: US-ASCII
+#    valid: true
+"10 00010.0"
```

The recommendation was to adjust the test to deal with the upstream change more flexibly.