### PR TITLE
[Fix #48694] Ensure `ArgumentError` is always raised on structurally incompatible relations with `#or`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2027,11 +2027,8 @@ module ActiveRecord
         values = other.values
         STRUCTURAL_VALUE_METHODS.reject do |method|
           v1, v2 = @values[method], values[method]
-          if v1.is_a?(Array)
-            next true unless v2.is_a?(Array)
-            v1 = v1.uniq
-            v2 = v2.uniq
-          end
+          v1 = v1.uniq if v1.is_a?(Array)
+          v2 = v2.uniq if v2.is_a?(Array)
           v1 == v2
         end
       end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -174,6 +174,14 @@ module ActiveRecord
         Post.left_outer_joins(:author).left_outer_joins(:author).or(Post.left_outer_joins(:author))
         Post.from("posts").or(Post.from("posts"))
       end
+
+      assert_raises ArgumentError do
+        Post.where(id: 1).or(Post.joins(:author))
+      end
+
+      assert_raises ArgumentError do
+        Post.joins(:author).or(Post.where(id: 1))
+      end
     end
   end
 

--- a/activerecord/test/cases/relation/structural_compatibility_test.rb
+++ b/activerecord/test/cases/relation/structural_compatibility_test.rb
@@ -26,6 +26,11 @@ module ActiveRecord
       right = Post.order("id desc").where(id: [2, 3])
 
       assert_not left.structurally_compatible?(right)
+
+      left = Post.joins(:author).where("id = 1")
+      right = Post.where(id: [2, 3])
+
+      assert_not left.structurally_compatible?(right)
     end
 
     def test_incompatible_unscope


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #48694.

### Detail

This Pull Request changes `#structurally_incompatible_values_for` to always compare the relation value methods in the two relations when using `#or` and raise when they're incompatible. I've pretty much just reverted the changes [in this PR](https://github.com/rails/rails/pull/39634), meaning that the tests added/amended there will begin to fail.

The only tests introduced in that PR seem to be when unscoping ordering inside `#or` but the related changes allow for any incompatible structure so long as it's not explicitly set inside inside `#or`. This 'fix' is pending feedback on whether such cases should raise an error or whether the changes introduced in that PR are valid.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
