### PR TITLE
Add a load hook for `ActiveModel::Model`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a load hook for `ActiveModel::Model` (named `active_model`) to match the load hook for `ActiveRecord::Base` and
+    allow for overriding aspects of the `ActiveModel::Model` class.
+
+    *Lewis Buckley*
+
 *   Improve password length validation in ActiveModel::SecurePassword to consider byte size for BCrypt compatibility.
 
     The previous password length validation only considered the character count, which may not

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -65,4 +65,6 @@ module ActiveModel
     #--
     # Implemented by ActiveModel::Access#values_at.
   end
+
+  ActiveSupport.run_load_hooks(:active_model, Model)
 end

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -76,4 +76,12 @@ class ModelTest < ActiveModel::TestCase
       SimpleModel.new(hello: "world")
     end
   end
+
+  def test_load_hook_is_called
+    value = "not loaded"
+
+    ActiveSupport.on_load(:active_model) { value = "loaded" }
+
+    assert_equal "loaded", value
+  end
 end

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1505,6 +1505,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActionView::TestCase`               | `action_view_test_case`              |
 | `ActiveJob::Base`                    | `active_job`                         |
 | `ActiveJob::TestCase`                | `active_job_test_case`               |
+| `ActiveModel::Model`                 | `active_model`                       |
 | `ActiveRecord::Base`                 | `active_record`                      |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |


### PR DESCRIPTION


### Motivation / Background

`ActiveRecord::Base` has a dedicated ActiveSupport load hook. This adds a hook for `ActiveModel::Model`, so that when ActiveModel is being used without ActiveRecord, it can still be modified.

Kredis would be able to use this hook [here](https://github.com/rails/kredis/blob/6e4f77ca7745efe0878bb408c1242db58d99caf8/lib/kredis/railtie.rb#L25-L27). Instead of:

```rb
config.after_initialize do
  ActiveModel::Model.include Kredis::Attributes if defined?(ActiveModel::Model)
end
```

we could write

```rb
ActiveSupport.on_load(:active_model) do
  include Kredis::Attributes
end
```

This change would help fix a reported issue at https://github.com/rails/kredis/issues/60.

### Detail

See the motivating issue at https://github.com/rails/kredis/issues/60 and additional comment by @fxn here: https://github.com/rails/kredis/issues/60#issuecomment-1045966571

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
