### PR TITLE
AbstractController#internal_methods: ignore action_methods

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -75,9 +75,14 @@ module AbstractController
       # (ActionController::Metal and ActionController::Base are defined as abstract)
       def internal_methods
         controller = self
+        methods = []
 
-        controller = controller.superclass until controller.abstract?
-        controller.public_instance_methods(true)
+        until controller.abstract?
+          methods += controller.public_instance_methods(false)
+          controller = controller.superclass
+        end
+
+        controller.public_instance_methods(true) - methods
       end
 
       # A list of method names that should be considered actions. This

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -14,9 +14,16 @@ class EmptyController < ActionController::Base
 end
 
 class SimpleController < ActionController::Base
+  def status
+    head :ok
+  end
+
   def hello
     self.response_body = "hello"
   end
+end
+
+class ChildController < SimpleController
 end
 
 class NonEmptyController < ActionController::Base
@@ -112,10 +119,16 @@ class ControllerInstanceTests < ActiveSupport::TestCase
     assert_predicate @empty, :performed?
   end
 
-  def test_action_methods
+  def test_empty_controller_action_methods
     @empty_controllers.each do |c|
       assert_equal Set.new, c.class.action_methods, "#{c.controller_path} should be empty!"
     end
+  end
+
+  def test_action_methods_with_inherited_shadowed_internal_method
+    assert_includes ActionController::Base.instance_methods, :status
+    assert_equal Set.new(["status", "hello"]), SimpleController.action_methods
+    assert_equal Set.new(["status", "hello"]), ChildController.action_methods
   end
 
   def test_temporary_anonymous_controllers


### PR DESCRIPTION
This PR fixes `AbstractController#internal_methods` to exclude `action_methods`.

### Motivation / Background

I tried enabling [`raise_on_missing_callback_actions`](https://github.com/rails/rails/pull/43487) and I found out that `MyController#action_methods` is missing a method that `MyController` actually defines. It only happens when a method is also defined by an ancestor abstract controller.

xref https://github.com/rails/rails/pull/48559#issuecomment-1624321279

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
