### PR TITLE
Update inconsistent documentation for `#structurally_compatible?`, `#and` and `#or`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1109,13 +1109,19 @@ module ActiveRecord
 
     # Checks whether the given relation is structurally compatible with this relation, to determine
     # if it's possible to use the #and and #or methods without raising an error. Structurally
-    # compatible is defined as: they must be scoping the same model, and they must differ only by
-    # #where (if no #group has been defined) or #having (if a #group is present).
+    # compatible is defined as: the given relation must be scoping the same model, and it must differ
+    # from the current relation only by #where (if no #group has been defined) or #having (if a #group is present).
     #
     #    Post.where("id = 1").structurally_compatible?(Post.where("author_id = 3"))
     #    # => true
     #
     #    Post.joins(:comments).structurally_compatible?(Post.where("id = 1"))
+    #    # => true
+    #
+    #    Post.joins(:comments).structurally_compatible?(Post.joins(:comments).where("id = 1"))
+    #    # => true
+    #
+    #    Post.where("id = 1").structurally_compatible?(Post.joins(:comments))
     #    # => false
     #
     def structurally_compatible?(other)
@@ -1125,9 +1131,9 @@ module ActiveRecord
     # Returns a new relation, which is the logical intersection of this relation and the one passed
     # as an argument.
     #
-    # The two relations must be structurally compatible: they must be scoping the same model, and
-    # they must differ only by #where (if no #group has been defined) or #having (if a #group is
-    # present).
+    # The two relations must be structurally compatible: the given relation must be scoping the same model,
+    # and it must differ from the current relation only by #where (if no #group has been defined) or
+    # #having (if a #group is present).
     #
     #    Post.where(id: [1, 2]).and(Post.where(id: [2, 3]))
     #    # SELECT `posts`.* FROM `posts` WHERE `posts`.`id` IN (1, 2) AND `posts`.`id` IN (2, 3)
@@ -1157,9 +1163,9 @@ module ActiveRecord
     # Returns a new relation, which is the logical union of this relation and the one passed as an
     # argument.
     #
-    # The two relations must be structurally compatible: they must be scoping the same model, and
-    # they must differ only by #where (if no #group has been defined) or #having (if a #group is
-    # present).
+    # The two relations must be structurally compatible: the given relation must be scoping the same model,
+    # and it must differ from the current relation only by #where (if no #group has been defined) or
+    # #having (if a #group is present).
     #
     #    Post.where("id = 1").or(Post.where("author_id = 3"))
     #    # SELECT `posts`.* FROM `posts` WHERE ((id = 1) OR (author_id = 3))


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to update some inconsistent documentation for the public methods  `ActiveRecord::QueryMethods#structurally_compatible?`, `ActiveRecord::QueryMethods#and?` and `ActiveRecord::QueryMethods#or?`.

### Detail

In https://github.com/rails/rails/pull/39634, `#structurally_incompatible_values_for` was updated so that a given relation is only considered structurally incompatible to the current relation if it explicitly uses multi value relation value methods that either vary from (eg. joining on a different table) or are not included in the current relation.

The public method `#structurally_compatible?` was affected by this change but currently has an example in its documentation that is inconsistent with the current functionality:

**Expected:**
https://github.com/rails/rails/blob/a5fc471b3f4bbd02e6be38dae023526a49e7d049/activerecord/lib/active_record/relation/query_methods.rb#L1011-L1012

**Actual**
```ruby
Post.joins(:comments).structurally_compatible?(Post.where("id = 1"))
# => true
```

The descriptions for `#structurally_compatible?`, `#and` and `#or` also imply that the two relations need to include the exact same relation value methods, which is no longer true.

This PR simply updates the documentation for these methods so that:
1. The 'new' functionality is reflected in the descriptions.
2. The incorrect result for the example in `#structurally_compatible?` is fixed.

I've also added 2 more examples to `#structurally_compatible?` to make the expected output clearer.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Originally, I opened this issue https://github.com/rails/rails/issues/48694 and a PR https://github.com/rails/rails/pull/48695 to address it by reverting the changes in https://github.com/rails/rails/pull/39634. However, I concluded that:
- The changes and reasoning in https://github.com/rails/rails/pull/39634 make sense in that a majority of the time the given relation will probably just vary by `#where`. I was a bit on the fence at first cause I felt like consistently raising an error here might prevent unexpected query results and provide a more meaningful error than the ones you might get due to a malformed query (like referencing a table in the given relation that's only been joined to in the current relation), but at the same time I can see how that approach can be considered to be a bit too heavy handed.
- https://github.com/rails/rails/pull/39634 was merged 3 years ago and I don't see any other open issues relating to it, so I think it's more reasonable to just update the documentation at this point than to revert the changes in that PR which might result in breaking changes on apps running on edge or when upgrading to the version this commit ends up in.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
