### PR TITLE
Stop deep duping query values of serialized attributes

### DIFF
--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -55,6 +55,10 @@ module ActiveRecord
         coder.respond_to?(:object_class) && value.is_a?(coder.object_class)
       end
 
+      def immutable_value(value) # :nodoc:
+        deserialize(serialize(value))
+      end
+
       private
         def default_value?(value)
           value == coder.load(nil)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -724,6 +724,45 @@ class QueryCacheMutableParamTest < ActiveRecord::TestCase
   end
 end
 
+class QuerySerializedParamTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  fixtures :topics
+
+  class YAMLObj < ActiveRecord::Base
+    self.table_name = "yaml_objs"
+
+    serialize :payload
+  end
+
+  def setup
+    @use_yaml_unsafe_load_was = ActiveRecord.use_yaml_unsafe_load
+    ActiveRecord.use_yaml_unsafe_load = true
+    ActiveRecord::Base.connection.create_table("yaml_objs", force: true) do |t|
+      t.text "payload"
+    end
+
+    ActiveRecord::Base.connection.enable_query_cache!
+  end
+
+  def teardown
+    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.connection.drop_table("yaml_objs", if_exists: true)
+
+    ActiveRecord.use_yaml_unsafe_load = @use_yaml_unsafe_load_was
+  end
+
+  def test_query_serialized_active_record
+    topic = Topic.first
+    assert_not_nil topic
+
+    obj = YAMLObj.create!(payload: { topic: topic })
+
+    # This is absolutely terrible, no-one should ever do this
+    assert_equal obj, YAMLObj.where(payload: { topic: topic }).first
+  end
+end
+
 class QueryCacheExpiryTest < ActiveRecord::TestCase
   fixtures :tasks, :posts, :categories, :categories_posts
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48652
Ref: https://github.com/rails/rails/pull/46048
Ref: https://github.com/rails/rails/issues/46044
Ref: https://github.com/rails/rails/pull/34303
Ref: https://github.com/rails/rails/pull/39160

This deep_dup was introduced to prevent the value stored in the query cache to be later mutated.

The problem is that `ActiveRecord::Base#dup` will return a copy of the record but with the primary key set to nil. One could argue that `#dup` shouldn't behave this way, but I think this ship has sailed (or has it?).

My initial fix was to instead call `type.cast` so that we'd dup serialized types in a more correct way. However there is a test that explictly ensure this doesn't happen: https://github.com/rails/rails/pull/39160

The reason isn't 100% clear to me, but if I get it correctly, it's to avoid a potentially costly operation upfront.

So instead we can call `deserialize(serialize(value))` for serialized attributes only.

This isn't very performant, but honestly it's kind of a miracle this even work. Querying by a serialized attribute is a very weird idea.
