### PR TITLE
Delegate `StubConnection#pubsub` and `StubConnection#config` to `ActionCable.server`

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add a `@server` instance variable referencing the `ActionCable.server`
+    singleton to `ActionCable::Channel::ConnectionStub`
+
+    This lets us delegate the `pubsub` and `config` method calls
+    to the server. This fixes `NoMethodError` errors when testing
+    channel logic that call `pubsub` (e.g. `stop_stream_for`).
+
+    *Julian Foo*
+
 *   Added `health_check_path` and `health_check_application` config to
     mount a given health check rack app on a given path.
     Useful when mounting Action Cable standalone.

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -47,9 +47,12 @@ module ActionCable
     end
 
     class ConnectionStub
-      attr_reader :transmissions, :identifiers, :subscriptions, :logger, :config
+      attr_reader :server, :transmissions, :identifiers, :subscriptions, :logger
+
+      delegate :pubsub, :config, to: :server
 
       def initialize(identifiers = {})
+        @server = ActionCable.server
         @transmissions = []
 
         identifiers.each do |identifier, val|
@@ -59,7 +62,6 @@ module ActionCable
         @subscriptions = ActionCable::Connection::Subscriptions.new(self)
         @identifiers = identifiers.keys
         @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
-        @config = ActionCable::Server::Configuration.new
       end
 
       def transmit(cable_message)

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -88,6 +88,10 @@ class StreamsTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_from "test_#{params[:id] || 0}"
   end
+
+  def unsubscribed
+    stop_stream_from "test_#{params[:id] || 0}"
+  end
 end
 
 class StreamsTestChannelTest < ActionCable::Channel::TestCase
@@ -101,6 +105,13 @@ class StreamsTestChannelTest < ActionCable::Channel::TestCase
     subscribe id: 42
 
     assert_has_stream "test_42"
+  end
+
+  def test_unsubscribe_from_stream
+    subscribe
+    unsubscribe
+
+    assert_no_streams
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Previously, `ActionCable::Channel::ConnectionStub` would throw a `NoMethodError` when the channel under test calls `stop_stream_from`, as shown in the test case below:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "actioncable", "~> 7.0.0"
end

require "minitest/autorun"
require "action_cable"

ActionCable.server.config.cable = { "adapter" => "test" }

class ChatChannel < ActionCable::Channel::Base
  def subscribed
    stream_from "test"
  end 

  def unsubscribed
    stop_stream_from "test"
  end 
end

class ChatChannelTest < ActionCable::Channel::TestCase
  test "unsubscribe" do
    stub_connection

    subscribe
    unsubscribe # raises a NoMethodError

    assert_no_streams
  end 
end
```

This happens because `stop_stream_from` [calls `pubsub` when unsubscribing from a channel](https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/actioncable/lib/action_cable/channel/streams.rb#L109), which is missing from the [`ConnectionStub` implementation](https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/actioncable/lib/action_cable/channel/test_case.rb#L47).

### Detail

This PR fixes this issue by assigning the `ActionCable.server` singleton to a `@server` instance variable in
`ActionCable::Channel::ConnectionStub`. 

This lets us delegate the `config` and `pubsub` method calls to it, hence fixing the `NoMethodError` issue.

I updated `config` to be delegated to `@server` as well since [`config` defaults to `ActionCable::Server::Configuration.new`](https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/actioncable/lib/action_cable/server/base.rb#L15).

We do something similar in `ActionCable::TestHelper#pubsub_adapter` as well: https://github.com/rails/rails/blob/13cff7e197ae6b22b0e9ab438fdc412bdf9939e1/actioncable/lib/action_cable/test_helper.rb#L133-L135

### Additional information

I'm not sure if I should add a changelog entry for this. But, I added it anyway since I feel adding`@server = ActionCable.server` qualifies as a behavior change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
