### PR TITLE
Remove connected? check from db_runtime payload

### DIFF
--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -33,7 +33,7 @@ module ActiveRecord
         end
 
         def cleanup_view_runtime
-          if logger && logger.info? && ActiveRecord::Base.connected?
+          if logger && logger.info?
             db_rt_before_render = ActiveRecord::RuntimeRegistry.reset
             self.db_runtime = (db_runtime || 0) + db_rt_before_render
             runtime = super
@@ -47,9 +47,8 @@ module ActiveRecord
 
         def append_info_to_payload(payload)
           super
-          if ActiveRecord::Base.connected?
-            payload[:db_runtime] = (db_runtime || 0) + ActiveRecord::RuntimeRegistry.reset
-          end
+
+          payload[:db_runtime] = (db_runtime || 0) + ActiveRecord::RuntimeRegistry.reset
         end
     end
   end


### PR DESCRIPTION
The check for `Base.connected?` was added in
https://github.com/rails/rails/commit/4ecdf24bdedfdd1cca1f079259ff2490e2074067. At the time this change was made, we were calling
`Base.connection.reset_runtime` so it made sense to check if the database was connected. Since
https://github.com/rails/rails/commit/dd61a817dea85990f13664d74bca15bc5796b76e we have stored that information in a thread instead, negating the need to check `Base.connected?`.

The problem with checking `Base.connected?` is that in a multi-db application this will return `false` for any model running a query not inheriting from `Base`, leaving the `db_runtime` payload `nil`. Since the information we need is stored in a thread rather than on the connection directly we can remove the `Base.connected?` check.

Fixes #48687