### PR TITLE
Change form template to use button tag

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -32,6 +32,6 @@
 
 <% end -%>
   <div>
-    <%%= form.submit %>
+    <%%= form.button %>
   </div>
 <%% end %>


### PR DESCRIPTION
Rails 7 uses Turbo/Stimulus by default. Turbo adds disabled attributes when submitting form (see https://github.com/hotwired/turbo/pull/386). As the PR describes, we can change submission text when form is submitted.

```
button                  .show-when-disabled { display: none; }
button[disabled]        .show-when-disabled { display: initial; }

button                  .show-when-enabled { display: initial; }
button[disabled]        .show-when-enabled { display: none; }
```

```
<button>
  <span class="show-when-enabled">Submit</span>
  <span class="show-when-disabled">Submitting...</span>
</button>
```

This is only possible with the button tag. Because input tag does not allow child elements.

It also seems like that button tags are preferred way nowadays.

> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button
> Note: While <input> elements of type button are still perfectly valid
> HTML, the newer <button> element is now the favored way to create
> buttons. Given that a <button>'s label text is inserted between the
> opening and closing tags, you can include HTML in the label, even
> images.