### PR TITLE
Refactor Active Record Schema Cache to not hold a connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -12,6 +12,8 @@ module ActiveRecord
     autoload :PoolConfig
     autoload :PoolManager
     autoload :SchemaCache
+    autoload :BoundSchemaReflection, "active_record/connection_adapters/schema_cache"
+    autoload :SchemaReflection, "active_record/connection_adapters/schema_cache"
     autoload :Deduplicable
 
     autoload_at "active_record/connection_adapters/abstract/schema_definitions" do

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -41,9 +41,17 @@ module ActiveRecord
       SIMPLE_INT = /\A\d+\z/
       COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}
 
-      attr_accessor :pool
+      attr_reader :pool
       attr_reader :visitor, :owner, :logger, :lock
       alias :in_use? :owner
+
+      def pool=(value)
+        return if value.eql?(@pool)
+        @schema_cache = nil
+        @pool = value
+
+        @pool.schema_reflection.load!(self) if ActiveRecord.lazily_load_schema_cache
+      end
 
       set_callback :checkin, :after, :enable_lazy_transactions!
 
@@ -327,12 +335,7 @@ module ActiveRecord
       end
 
       def schema_cache
-        @pool.get_schema_cache(self)
-      end
-
-      def schema_cache=(cache)
-        cache.connection = self
-        @pool.set_schema_cache(cache)
+        @schema_cache ||= BoundSchemaReflection.new(@pool.schema_reflection, self)
       end
 
       # this method must only be called while holding connection pool's mutex
@@ -729,12 +732,6 @@ module ActiveRecord
       # rid of a connection that belonged to its parent.
       def discard!
         # This should be overridden by concrete adapters.
-        #
-        # Prevent @raw_connection's finalizer from touching the socket, or
-        # otherwise communicating with its server, when it is collected.
-        if schema_cache.connection == self
-          schema_cache.connection = nil
-        end
       end
 
       # Reset the state of this connection, directing the DBMS to clear

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -6,7 +6,12 @@ module ActiveRecord
       include Mutex_m
 
       attr_reader :db_config, :role, :shard
-      attr_accessor :schema_cache, :connection_class
+      attr_writer :schema_reflection
+      attr_accessor :connection_class
+
+      def schema_reflection
+        @schema_reflection ||= SchemaReflection.new(db_config.lazy_schema_cache_path)
+      end
 
       INSTANCES = ObjectSpace::WeakMap.new
       private_constant :INSTANCES

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -432,8 +432,7 @@ module ActiveRecord
         end
 
         def test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool
-          @pool.schema_cache = @pool.connection.schema_cache
-          @pool.schema_cache.add("posts")
+          @pool.connection.schema_cache.add("posts")
 
           rd, wr = IO.pipe
           rd.binmode
@@ -442,7 +441,7 @@ module ActiveRecord
           pid = fork {
             rd.close
             pool = @handler.retrieve_connection_pool(@connection_name)
-            wr.write Marshal.dump pool.schema_cache.size
+            wr.write Marshal.dump pool.connection.schema_cache.size
             wr.close
             exit!
           }
@@ -450,7 +449,7 @@ module ActiveRecord
           wr.close
 
           Process.waitpid pid
-          assert_equal @pool.schema_cache.size, Marshal.load(rd.read)
+          assert_equal @pool.connection.schema_cache.size, Marshal.load(rd.read)
           rd.close
         end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -266,14 +266,14 @@ module ApplicationTests
           require "#{app_path}/config/environment"
         end
 
-        assert_not_nil ActiveRecord::Base.connection_pool.schema_cache
+        assert_not_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
 
         assert_raises ActiveRecord::ConnectionNotEstablished do
           ActiveRecord::Base.connection.execute("SELECT 1")
         end
 
         assert_raises ActiveRecord::ConnectionNotEstablished do
-          ActiveRecord::Base.connection_pool.schema_cache.columns("posts")
+          ActiveRecord::Base.connection.schema_reflection.columns("posts")
         end
       end
     end
@@ -288,7 +288,7 @@ module ApplicationTests
       RUBY
 
       require "#{app_path}/config/environment"
-      assert ActiveRecord::Base.connection_pool.schema_cache.data_sources("posts")
+      assert ActiveRecord::Base.connection_pool.schema_reflection.data_sources(:__unused__, "posts")
     end
 
     test "does not expire schema cache dump if check_schema_cache_dump_version is false and the database unhealthy" do
@@ -303,7 +303,7 @@ module ApplicationTests
       with_unhealthy_database do
         require "#{app_path}/config/environment"
 
-        assert ActiveRecord::Base.connection_pool.schema_cache.data_sources("posts")
+        assert ActiveRecord::Base.connection_pool.schema_reflection.data_sources(:__unused__, "posts")
         assert_raises ActiveRecord::ConnectionNotEstablished do
           ActiveRecord::Base.connection.execute("SELECT 1")
         end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -234,8 +234,7 @@ module TestHelpers
       # We need to change the `database_version` to match what is expected for MySQL
       dump_path = File.join(app_path, "db/schema_cache.yml")
       if File.exist?(dump_path)
-        schema_cache = ActiveRecord::ConnectionAdapters::SchemaCache.load_from(dump_path)
-        schema_cache.connection = Struct.new(:schema_version).new(schema_cache.version)
+        schema_cache = ActiveRecord::ConnectionAdapters::SchemaCache._load_from(dump_path)
         schema_cache.instance_variable_set(:@database_version, ActiveRecord::ConnectionAdapters::AbstractAdapter::Version.new("8.8.8"))
         File.write(dump_path, YAML.dump(schema_cache))
       end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/47582
Fix: https://github.com/bensheldon/good_job/issues/796
Fix: https://github.com/rails/rails/pull/38577
Maybe: https://github.com/rails/rails/issues/46797 ?

This is mostly a rebase of @matthewd's https://github.com/rails/rails/compare/main...matthewd:rails:schema-reflection, I initially went with my own implementation, but it ended up very similar, just less elegant, so I decided to rebase it instead.

### Context

A big problem with the current `SchemaCache` implementation is that it holds a reference to a connection, and uses it to lazily query the schema when the information is missing.

This cause issues in multi-threaded contexts because all the connections of a pool share the same schema, so they are constantly setting themselves as the connection the schema cache should use, and you can end up in situation where Thread#1 query the schema cache, which end up using the connection currently attributed to Thread#2.

For a very long time this worked more or less by accident, because all connection adapters would have an internal Monitor.

However in https://github.com/rails/rails/pull/46519 we got rid of this synchronization, revealing the pre-existing issue. Previously it would work™, but still wasn't ideal because of unexpected the connection sharing between threads.

### Solution

The idea here is to refactor the schema cache so that it doesn't hold a reference onto any connection. 

And instead of a SchemaCache, connections now have access to a SchemaReflection. Now the connection that needs a schema information is always provided as an argument, so that in case of a miss, it can be used to populate the cache.

That should fix the database thread safety issues that were witnessed.

However note that at this stage, the underlying `SchemaCache` isn't synchronized, so in case of a race condition, the same schema query can be performed more than once. It could make sense to add synchronization in a followup.