### PR TITLE
Re-establish connection at end of test

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -291,6 +291,8 @@ module ActiveRecord
         assert_deprecated(ActiveRecord.deprecator) do
           ActiveRecord::Base.remove_connection("klass2")
         end
+      ensure
+        ActiveRecord::Base.establish_connection :arunit
       end
 
       class ApplicationRecord < ActiveRecord::Base


### PR DESCRIPTION
Fix flaky tests where we needed to re-establish the connection after removing it at the end of the test.

Fixes #48710