### PR TITLE
Doc and spec cookies.delete returning the cookie value

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -382,6 +382,8 @@ module ActionDispatch
       # Removes the cookie on the client machine by setting the value to an empty string
       # and the expiration date in the past. Like <tt>[]=</tt>, you can pass in
       # an options hash to delete cookies with extra data such as a <tt>:path</tt>.
+      #
+      # Returns the value of the cookie, or +nil+ if the cookie does not exist.
       def delete(name, options = {})
         return unless @cookies.has_key? name.to_s
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -554,6 +554,17 @@ class CookiesTest < ActionController::TestCase
     assert_set_cookie_header "user_name=; path=/beaten; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
+  def test_delete_cookie_return_value
+    request.cookies[:user_name] = "Joe"
+    return_value = request.cookies.delete(:user_name)
+    assert_equal "Joe", return_value
+  end
+
+  def test_delete_unexisting_cookie_return_value
+    return_value = request.cookies.delete(:no_such_cookie)
+    assert_nil return_value
+  end
+
   def test_delete_unexisting_cookie
     request.cookies.clear
     get :delete_cookie


### PR DESCRIPTION
Doc and spec `cookies.delete` returning the cookie value.

I didn't want to rely on this behaviour since it was undocumented and (AFAIK) untested.