### PR TITLE
Fix `Enumerable#sum` for `Enumerator#lazy`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Enumerable#sum` for `Enumerator#lazy`.
+
+    *fatkodima*, *Matthew Draper*, *Jonathan Hefner*
+
 *   Improve error message when EventedFileUpdateChecker is used without a
     compatible version of the Listen gem
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -156,6 +156,19 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_typed_equal 0.0, GenericEnumerable.new([]).sum(0.0), Float
   end
 
+  def test_lazy_sums
+    nums = [1, 2, 3]
+    called = 0
+
+    sum = nums.lazy.map do |num|
+      called += 1
+      num
+    end.sum
+
+    assert_equal nums.sum, sum
+    assert_equal nums.size, called
+  end
+
   def test_range_sums
     assert_equal 20, (1..4).sum { |i| i * 2 }
     assert_equal 10, (1..4).sum


### PR DESCRIPTION
Fixes #48712.

The problem was that `.first` method call, used in the condition, evaluated lazy enumerator, and thus lead to the problematic behavior.