### PR TITLE
Allow `type` to be optional

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -650,7 +650,7 @@ module ActiveSupport
           @mutex     = Mutex.new
         end
 
-        def compile(type)
+        def compile(type = nil)
           if type.nil?
             @all_callbacks || @mutex.synchronize do
               final_sequence = CallbackSequence.new


### PR DESCRIPTION

### Motivation / Background

In https://github.com/rails/rails/pull/45952, a change was made to ActiveSupport to "accept an optional parameter to specify the types of callbacks that the user would want to run." However, the parameter is mandatory. This has broken downstream gems, such as `activerecord-import`: https://github.com/zdennis/activerecord-import/issues/787

### Detail

Rather than fix the issue in the dependencies, I think it would be easier/safer to just set this argument to `nil`, for backwards compatibility.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
