### PR TITLE
Improve cpk validation check

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -190,9 +190,9 @@ module ActiveRecord
     def initialize(reflection = nil)
       if reflection
         if reflection.has_one? || reflection.collection?
-          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.active_record_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints.")
+          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.active_record_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints, or primary_key and foreign_key values.")
         else
-          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.association_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints.")
+          super("Association #{reflection.active_record}##{reflection.name} primary key #{reflection.association_primary_key} doesn't match with foreign key #{reflection.foreign_key}. Please specify query_constraints, or primary_key and foreign_key values.")
         end
       else
         super("Association primary key doesn't match with foreign key.")

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -542,7 +542,7 @@ module ActiveRecord
       def check_validity!
         check_validity_of_inverse!
 
-        if !polymorphic? && klass.composite_primary_key?
+        if !polymorphic? && (klass.composite_primary_key? || active_record.composite_primary_key?)
           if (has_one? || collection?) && Array(active_record_primary_key).length != Array(foreign_key).length
             raise CompositePrimaryKeyMismatchError.new(self)
           elsif belongs_to? && Array(association_primary_key).length != Array(foreign_key).length

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -805,7 +805,7 @@ module ActiveRecord
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
         if options[:query_constraints]
-          (klass || self.klass).query_constraints_list
+          (klass || self.klass).composite_query_constraints_list
         elsif primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s
         else

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1795,10 +1795,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       book.save!
     end
 
-    # TODO: Improve this message
-    assert_equal(<<~MESSAGE.chomp, error.message)
-      Association Cpk::BrokenBookWithNonCpkOrder#order primary key  doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints.
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Association Cpk::BrokenBookWithNonCpkOrder#order primary key ["id"]
+      doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints.
     MESSAGE
+  end
+
+  test "association with query constraints assigns id on replacement" do
+    book = Cpk::NonCpkBook.create!(id: 1, author_id: 2, non_cpk_order: Cpk::NonCpkOrder.new)
+    other_order = Cpk::NonCpkOrder.create!
+    book.non_cpk_order = other_order
+
+    assert_equal(other_order.id, book.order_id)
   end
 end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1785,7 +1785,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenBook#order primary key ["shop_id", "id"]
-      doesn't match with foreign key order_id. Please specify query_constraints.
+      doesn't match with foreign key order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 
@@ -1797,7 +1797,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenBookWithNonCpkOrder#order primary key ["id"]
-      doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints.
+      doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1777,7 +1777,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord.belongs_to_required_validates_foreign_key = original_value
   end
 
-  test "composite primary key malformed association" do
+  test "composite primary key malformed association class" do
     error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
       book = Cpk::BrokenBook.new(title: "Some book", order: Cpk::Order.new(id: [1, 2]))
       book.save!
@@ -1786,6 +1786,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenBook#order primary key ["shop_id", "id"]
       doesn't match with foreign key order_id. Please specify query_constraints.
+    MESSAGE
+  end
+
+  test "composite primary key malformed association owner class" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      book = Cpk::BrokenBookWithNonCpkOrder.new(title: "Some book", order: Cpk::NonCpkOrder.new(id: 1))
+      book.save!
+    end
+
+    # TODO: Improve this message
+    assert_equal(<<~MESSAGE.chomp, error.message)
+      Association Cpk::BrokenBookWithNonCpkOrder#order primary key  doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints.
     MESSAGE
   end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3182,7 +3182,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenOrder#books primary key ["shop_id", "id"]
-      doesn't match with foreign key broken_order_id. Please specify query_constraints.
+      doesn't match with foreign key broken_order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 
@@ -3194,7 +3194,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
     Association Cpk::BrokenOrderWithNonCpkBooks#books primary key [\"shop_id\", \"id\"]
-    doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints.
+    doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3174,7 +3174,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  test "composite primary key malformed association" do
+  test "composite primary key malformed association class" do
     error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
       order = Cpk::BrokenOrder.new(id: [1, 2], books: [Cpk::Book.new(title: "Some book")])
       order.save!
@@ -3183,6 +3183,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenOrder#books primary key ["shop_id", "id"]
       doesn't match with foreign key broken_order_id. Please specify query_constraints.
+    MESSAGE
+  end
+
+  test "composite primary key malformed association owner class" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      order = Cpk::BrokenOrderWithNonCpkBooks.new(id: [1, 2], books: [Cpk::NonCpkBook.new(title: "Some book")])
+      order.save!
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+    Association Cpk::BrokenOrderWithNonCpkBooks#books primary key [\"shop_id\", \"id\"]
+    doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints.
     MESSAGE
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -958,7 +958,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  test "composite primary key malformed association" do
+  test "composite primary key malformed association class" do
     error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
       order = Cpk::BrokenOrder.new(id: [1, 2], book: Cpk::Book.new(title: "Some book"))
       order.save!
@@ -967,6 +967,18 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenOrder#book primary key ["shop_id", "id"]
       doesn't match with foreign key broken_order_id. Please specify query_constraints.
+    MESSAGE
+  end
+
+  test "composite primary key malformed association owner class" do
+    error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
+      order = Cpk::BrokenOrderWithNonCpkBooks.new(id: [1, 2], book: Cpk::NonCpkBook.new(title: "Some book"))
+      order.save!
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Association Cpk::BrokenOrderWithNonCpkBooks#book primary key [\"shop_id\", \"id\"]
+      doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints.
     MESSAGE
   end
 end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -966,7 +966,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenOrder#book primary key ["shop_id", "id"]
-      doesn't match with foreign key broken_order_id. Please specify query_constraints.
+      doesn't match with foreign key broken_order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 
@@ -978,7 +978,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Association Cpk::BrokenOrderWithNonCpkBooks#book primary key [\"shop_id\", \"id\"]
-      doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints.
+      doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
 end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -3,7 +3,6 @@
 module Cpk
   class Book < ActiveRecord::Base
     self.table_name = :cpk_books
-
     belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id]
     belongs_to :author, class_name: "Cpk::Author"
 
@@ -23,6 +22,8 @@ module Cpk
 
   class NonCpkBook < Book
     self.primary_key = :id
+
+    belongs_to :non_cpk_order, query_constraints: [:order_id]
   end
 
   class NullifiedBook < Book

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -17,6 +17,14 @@ module Cpk
     belongs_to :order
   end
 
+  class BrokenBookWithNonCpkOrder < Book
+    belongs_to :order, class_name: "Cpk::NonCpkOrder", query_constraints: [:shop_id, :order_id]
+  end
+
+  class NonCpkBook < Book
+    self.primary_key = :id
+  end
+
   class NullifiedBook < Book
     has_one :chapter, query_constraints: [:author_id, :book_id], dependent: :nullify
   end

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -17,6 +17,15 @@ module Cpk
     has_one :book
   end
 
+  class BrokenOrderWithNonCpkBooks < Order
+    has_many :books, class_name: "Cpk::NonCpkBook"
+    has_one :book, class_name: "Cpk::NonCpkBook"
+  end
+
+  class NonCpkOrder < Order
+    self.primary_key = :id
+  end
+
   class OrderWithPrimaryKeyAssociatedBook < Order
     has_one :book, primary_key: :id, foreign_key: :order_id
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the composite primary key validation check is incomplete. It only checks for one side of the association having a CPK. It should actually check both sides so that more edge cases are caught.

### Detail

This Pull Request changes the CPK validation check condition to include `active_record.composite_primary_key?`, which account for CPK owners of associations (not just CPK association classes). 

### Additional information

This PR also changes a few other things in other commits. It improves the CPK validation check error message, and changes `<reflection>.association_primary_key` behaviour to better support CPK. The fix for belongs_to assignment included in the `#association_primary_key` change commit doesn't appear to be released, so I don't think a changelog is needed there. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
