### PR TITLE
Remove unused suppress_composite_primary_key on HABTM join model class

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -45,11 +45,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
         def self.retrieve_connection
           left_model.retrieve_connection
         end
-
-        private
-          def self.suppress_composite_primary_key(pk)
-            pk unless pk.is_a?(Array)
-          end
       }
 
       join_model.name                = "HABTM_#{association_name.to_s.camelize}"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `.suppress_composite_primary_key` appears to be dead code. Since it was intended to be private, it _should_ be safe to remove without deprecation (but I'm happy to add one if we decide otherwise).

### Detail

This Pull Request removes `.suppress_composite_primary_key` from join model classes for has_and_belongs_to_many associations.

### Additional information

There's another method with the same name here: https://github.com/rails/rails/blob/50e3ae083683a8a5e38fee4d7952e1576e3ffc31/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L180

but it appears to be used in sequence lookup. Sequences don't support CPK AFAIK, so I guess we can leave that one as-is.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
