### PR TITLE
[7-0-stable] Backport: Use a consistent format when testing BigDecimal.to_s

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -443,8 +443,9 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
 
     assert_equal "1000010.0", BigDecimal("1000010").to_s
     assert_equal "1000010.0", BigDecimal("1000010").to_fs
-    assert_equal "10000 10.0", BigDecimal("1000010").to_s("5F")
-    assert_equal "10000 10.0", BigDecimal("1000010").to_fs("5F")
+
+    assert_equal "0.10000 1", BigDecimal("0.100001").to_s("5F")
+    assert_equal "0.10000 1", BigDecimal("0.100001").to_fs("5F")
 
     assert_raises TypeError do
       1.to_s({})


### PR DESCRIPTION
This backports #48693 to `7-0-stable` branch