### PR TITLE
Fix index_errors and provide :nested_attributes_order mode

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `index_errors` having incorrect index in association validation errors.
+
+    *lulalala*
+
+*   Add `index_errors: :nested_attributes_order` mode.
+
+    This indexes the association validation errors based on the order received by nested attributes setter, and respects the `reject_if` configuration. This enables API to provide enough information to the frontend to map the validation errors back to their respective form fields.
+
+    *lulalala*
+
 *   Association option `query_constraints` is deprecated in favor of `foreign_key`.
 
     *Nikita Vasilevsky*

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1506,6 +1506,13 @@ module ActiveRecord
         #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
         #   This is an optional option. By default Rails will attempt to derive the value automatically.
         #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        # [:index_errors]
+        #   Allows differentiation of multiple validation errors from the association records, by including
+        #   an index in the error attribute name, e.g. `roles[2].level`.
+        #   When set to +true+, the index is based on association order, i.e. database order, with yet to be
+        #   persisted new records placed at the end.
+        #   When set to +:nested_attributes_order+, the index is based on the record order received by
+        #   nested attributes setter, when accepts_nested_attributes_for is used.
         #
         # Option examples:
         #   has_many :comments, -> { order("posted_on") }
@@ -1519,6 +1526,7 @@ module ActiveRecord
         #   has_many :subscribers, through: :subscriptions, disable_joins: true
         #   has_many :comments, strict_loading: true
         #   has_many :comments, query_constraints: [:blog_id, :post_id]
+        #   has_many :comments, index_errors: :nested_attributes_order
         def has_many(name, scope = nil, **options, &extension)
           reflection = Builder::HasMany.build(self, name, scope, options, &extension)
           Reflection.add_reflection self, name, reflection

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -28,6 +28,8 @@ module ActiveRecord
     # If you need to work on all current children, new and existing records,
     # +load_target+ and the +loaded+ flag are your friends.
     class CollectionAssociation < Association # :nodoc:
+      attr_accessor :nested_attributes_target
+
       # Implements the reader method, e.g. foo.items for Foo.has_many :items
       def reader
         ensure_klass_exists!

--- a/activerecord/lib/active_record/associations/nested_error.rb
+++ b/activerecord/lib/active_record/associations/nested_error.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Validation error class to wrap association records' errors,
+# with index_errors support.
+module ActiveRecord
+  module Associations
+    class NestedError < ::ActiveModel::NestedError
+      def initialize(association, inner_error)
+        @base = association.owner
+        @association = association
+        @inner_error = inner_error
+        super(@base, inner_error, { attribute: compute_attribute(inner_error) })
+      end
+
+      private
+        attr_reader :association
+
+        def compute_attribute(inner_error)
+          association_name = association.reflection.name
+
+          attribute =
+            if index_errors_setting && index
+              "#{association_name}[#{index}]"
+            else
+              association_name
+            end
+
+          attribute = :"#{attribute}.#{inner_error.attribute}" if inner_error.attribute != :base
+          attribute.to_sym
+        end
+
+        def index_errors_setting
+          @index_errors_setting ||=
+            association.options.fetch(:index_errors, ActiveRecord.index_nested_attribute_errors)
+        end
+
+        def index
+          @index ||= ordered_records&.find_index(inner_error.base)
+        end
+
+        def ordered_records
+          case index_errors_setting
+          when true # default is association order
+            association.target
+          when :nested_attributes_order
+            association.nested_attributes_target
+          end
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/associations/nested_error.rb
+++ b/activerecord/lib/active_record/associations/nested_error.rb
@@ -18,15 +18,11 @@ module ActiveRecord
         def compute_attribute(inner_error)
           association_name = association.reflection.name
 
-          attribute =
-            if index_errors_setting && index
-              "#{association_name}[#{index}]"
-            else
-              association_name
-            end
-
-          attribute = :"#{attribute}.#{inner_error.attribute}" if inner_error.attribute != :base
-          attribute.to_sym
+          if index_errors_setting && index
+            "#{association_name}[#{index}].#{inner_error.attribute}".to_sym
+          else
+            "#{association_name}.#{inner_error.attribute}".to_sym
+          end
         end
 
         def index_errors_setting

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -514,7 +514,7 @@ module ActiveRecord
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 
-        attributes_collection.each do |attributes|
+        records = attributes_collection.map do |attributes|
           if attributes.respond_to?(:permitted?)
             attributes = attributes.to_h
           end
@@ -537,11 +537,14 @@ module ActiveRecord
               end
 
               assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
+              existing_record
             end
           else
             raise_nested_attributes_record_not_found!(association_name, attributes["id"])
           end
         end
+
+        association.nested_attributes_target = records
       end
 
       # Takes in a limit and checks if the attributes_collection has too many

--- a/activerecord/test/cases/associations/nested_error_test.rb
+++ b/activerecord/test/cases/associations/nested_error_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/guitar"
+require "models/tuning_peg"
+
+class AssociationsNestedErrorInAssociationOrderTest < ActiveRecord::TestCase
+  test "index in association order" do
+    guitar = Guitar.create!
+    guitar.tuning_pegs.create!(pitch: 1)
+    peg2 = guitar.tuning_pegs.create!(pitch: 2)
+    peg2.pitch = nil
+    guitar.valid?
+
+    error = guitar.errors.objects.first
+
+    assert_equal ActiveRecord::Associations::NestedError, error.class
+    assert_equal peg2.errors.objects.first, error.inner_error
+    assert_equal :'tuning_pegs[1].pitch', error.attribute
+    assert_equal :not_a_number, error.type
+    assert_equal "is not a number", error.message
+    assert_equal guitar, error.base
+  end
+end
+
+class AssociationsNestedErrorInNestedAttributesOrderTest < ActiveRecord::TestCase
+  def setup
+    tuning_peg_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "tuning_pegs"
+      def self.name; "TuningPeg"; end
+
+      validates_numericality_of :pitch
+    end
+
+    @guitar_class = Class.new(ActiveRecord::Base) do
+      has_many :tuning_pegs, index_errors: :nested_attributes_order, anonymous_class: tuning_peg_class
+      accepts_nested_attributes_for :tuning_pegs, reject_if: lambda { |attrs| attrs[:pitch]&.odd? }
+
+      def self.name; "Guitar"; end
+    end
+  end
+
+  test "index in nested attributes order" do
+    guitar = @guitar_class.create!
+    guitar.tuning_pegs.create!(pitch: 1)
+    peg2 = guitar.tuning_pegs.create!(pitch: 2)
+    guitar.update(tuning_pegs_attributes: [{ id: peg2.id, pitch: nil }])
+
+    error = guitar.errors.objects.first
+
+    assert_equal ActiveRecord::Associations::NestedError, error.class
+    assert_equal peg2.errors.objects.first, error.inner_error
+    assert_equal :'tuning_pegs[0].pitch', error.attribute
+    assert_equal :not_a_number, error.type
+    assert_equal "is not a number", error.message
+    assert_equal guitar, error.base
+  end
+
+  test "index unaffected by reject_if" do
+    guitar = @guitar_class.create!
+
+    guitar.update(
+      tuning_pegs_attributes: [
+        { pitch: 1 }, # rejected
+        { pitch: nil },
+      ]
+    )
+
+    error = guitar.errors.objects.first
+
+    assert_equal ActiveRecord::Associations::NestedError, error.class
+    assert_equal :'tuning_pegs[1].pitch', error.attribute
+    assert_equal :not_a_number, error.type
+    assert_equal "is not a number", error.message
+    assert_equal guitar, error.base
+  end
+end


### PR DESCRIPTION
1. Fix #24390, a bug on indexing association validation errors.
1. Add`index_errors: :nested_attributes_order` mode for an alternative ordering of errors.

### Motivation / Background

GitLab is using `index_errors` but has to [workaround its bug](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/51623#note_490919557), which is #24390. That bug is about association validation error having the incorrect index because the indexing can be computed from an incomplete collection of association records. The fix would be to index from the full association collection.

@tijwelch first created https://github.com/rails/rails/pull/24728, however @markedmondson  pointed out that [`reject_if` would not work properly](https://github.com/rails/rails/pull/24728#issuecomment-321361869). Also, from the discussions I found that people have two different interpretations of what "indexing" means: 

1. to index by association order (based on database order), which is the current behavior
2. to index by nested attributes order (and `reject_if` is only applicable here)

Those two are conflicting goals. To cater to both of them, this PR also adds a new ordering mode called `nested_attributes_order`. This mode is more applicable to GitLab's use case, where the frontend could pass nested attributes in arbitrary order, and still want the error index to match such order.

### Detail

This Pull Request adds a new class called `ActiveRecord::Associations::NestedError`, which handles the calculation of index. The original index logic exists in `AutosaveAssociation` and is moved into this class. Base on `index_errors` setting, it would choose whether to index based on `association.target` order or nested attributes order.

For nested attributes order, when nested_attributes are assigned (via a setter like `roles_attributes=`), the array of the corresponding records will be stored in the association object as `nested_attributes_target`. The `NestedError` can then access this array to compute the index. The `reject_if` would also work since if something is rejected, the `nested_attributes_target` would have `nil` in its place as a placeholder, therefore maintaining the overall index.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
