### PR TITLE
Add migration generator for drop table action

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add support for drop table via rails migration: `rails generate migration drop_users`.
+
+    The output of the command will be:
+
+    ```ruby
+    class DropUsers< ActiveRecord::Migration[7.0]
+      def change
+        drop_table :users
+      end
+    end
+    ```
+
+    *Klemen Nagode*
+
 *   Don't show secrets for Active Record's `Cipher::Aes256Gcm#inspect`.
 
     Before:

--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -39,6 +39,9 @@ module ActiveRecord
           when /^create_(.+)/
             @table_name = normalize_table_name($1)
             @migration_template = "create_table_migration.rb"
+          when /^drop_(.+)/
+            @table_name = normalize_table_name($1)
+            @migration_template = "drop_table_migration.rb"
           end
         end
 

--- a/activerecord/lib/rails/generators/active_record/migration/templates/drop_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/drop_table_migration.rb.tt
@@ -1,0 +1,5 @@
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+  def change
+    drop_table :<%= table_name %>
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Prior this change `rails generate migration drop_users` generated migration file with empty `def change` body. [A lot of users are surprised](https://stackoverflow.com/questions/4020131/rails-db-migration-how-to-drop-a-table) about this not yet being implemented. 

```
class DropUsers< ActiveRecord::Migration[7.0]
  def change
  end
end
```

### Details

This PR improve codebase in order to generate proper drop migration:
```
class DropUsers< ActiveRecord::Migration[7.0]
  def change
     drop_table :users
  end
end
```

Note: Implementation does not contain tests because there is no base code for migration generators yet - it would require quite some efforts to add this. If someone knows how test for such a thing should be written, please give me some hints.

### Checklist
 Before submitting the PR make sure the following are checked:
 
 * [x]  This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
 * [x]  Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
 * [ ]  Tests are added or updated if you fix a bug or add a feature.
 * [ ]  CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

