### PR TITLE
Eagerly cast serialized query attributes

### DIFF
--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -4,10 +4,6 @@ module ActiveModel
   module Type
     module Helpers # :nodoc: all
       module Mutable
-        def immutable_value(value)
-          value.deep_dup
-        end
-
         def cast(value)
           deserialize(serialize(value))
         end
@@ -17,6 +13,10 @@ module ActiveModel
         # cast value.
         def changed_in_place?(raw_old_value, new_value)
           raw_old_value != serialize(new_value)
+        end
+
+        def mutable? # :nodoc:
+          true
         end
       end
     end

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -133,8 +133,12 @@ module ActiveModel
       def assert_valid_value(_)
       end
 
-      def immutable_value(value) # :nodoc:
-        value
+      def serialized? # :nodoc:
+        false
+      end
+
+      def mutable? # :nodoc:
+        false
       end
 
       def as_json(*)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -65,8 +65,7 @@ module ActiveRecord
     end
 
     def build_bind_attribute(column_name, value)
-      type = table.type(column_name)
-      Relation::QueryAttribute.new(column_name, type.immutable_value(value), type)
+      Relation::QueryAttribute.new(column_name, value, table.type(column_name))
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -55,6 +55,10 @@ module ActiveRecord
         coder.respond_to?(:object_class) && value.is_a?(coder.object_class)
       end
 
+      def serialized? # :nodoc:
+        true
+      end
+
       private
         def default_value?(value)
           value == coder.load(nil)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48652
Ref: https://github.com/rails/rails/pull/46048
Ref: https://github.com/rails/rails/issues/46044
Ref: https://github.com/rails/rails/pull/34303
Ref: https://github.com/rails/rails/pull/39160
Close: https://github.com/rails/rails/pull/48705

This deep_dup was introduced to prevent the value stored in the query cache to be later mutated.

The problem is that `ActiveRecord::Base#dup` will return a copy of the record but with the primary key set to nil. One could argue that `#dup` shouldn't behave this way, but I think this ship has sailed (or has it?).

My initial fix was to instead always call `type.cast` eagerly so that we'd dup serialized types in a more correct way. However there is a test that explictly ensure this doesn't happen: https://github.com/rails/rails/pull/39160

The reason isn't 100% clear to me, but if I get it correctly, it's to avoid a potentially costly operation upfront.

So instead we only eagerly cast serialized attributes only, so protect against future mutations.

Mutable types are still deep duped.
