### PR TITLE
Prevent extra newlines after table generation block in shema.rb

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
           foreign_keys_string = foreign_keys_stream.string
           stream.puts if foreign_keys_string.length > 0
-          
+
           stream.print foreign_keys_string
         end
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -122,7 +122,7 @@ module ActiveRecord
       def tables(stream)
         sorted_tables = @connection.tables.sort
 
-        not_ignored_tables = sorted_tables.reject{|table_name| ignored?(table_name) }
+        not_ignored_tables = sorted_tables.reject { |table_name| ignored?(table_name) }
 
         not_ignored_tables.each_with_index do |table_name, index|
           table(table_name, stream)
@@ -131,7 +131,7 @@ module ActiveRecord
 
         # dump foreign keys at the end to make sure all dependent tables exist.
         if @connection.supports_foreign_keys?
-          foreign_keys_stream = StringIO.new 
+          foreign_keys_stream = StringIO.new
           not_ignored_tables.each do |tbl|
             foreign_keys(tbl, foreign_keys_stream)
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -122,15 +122,24 @@ module ActiveRecord
       def tables(stream)
         sorted_tables = @connection.tables.sort
 
-        sorted_tables.each do |table_name|
-          table(table_name, stream) unless ignored?(table_name)
+        not_ignored_tables = sorted_tables.reject{|table_name| ignored?(table_name) }
+
+        not_ignored_tables.each_with_index do |table_name, index|
+          table(table_name, stream)
+          stream.puts if index < not_ignored_tables.count - 1
         end
 
         # dump foreign keys at the end to make sure all dependent tables exist.
-        if @connection.use_foreign_keys?
-          sorted_tables.each do |tbl|
-            foreign_keys(tbl, stream) unless ignored?(tbl)
+        if @connection.supports_foreign_keys?
+          foreign_keys_stream = StringIO.new 
+          not_ignored_tables.each do |tbl|
+            foreign_keys(tbl, foreign_keys_stream)
           end
+
+          foreign_keys_string = foreign_keys_stream.string
+          stream.puts if foreign_keys_string.length > 0
+          
+          stream.print foreign_keys_string
         end
       end
 
@@ -191,7 +200,6 @@ module ActiveRecord
           unique_keys_in_create(table, tbl) if @connection.supports_unique_keys?
 
           tbl.puts "  end"
-          tbl.puts
 
           stream.print tbl.string
         rescue => e


### PR DESCRIPTION
…when there are no foreign keys or indexes.  This will produce valid code without linting issues (issue: Trailing whitespace detected)


### Motivation / Background

Schema generator was generating files with linting issues (Trailing whitespace detected) **when there is no foreign_keys in the database**. Developer who care about linting has to manually fix those issues after every schema dump operation (e.g. `rails db:migrate`). 

Example of schema file **with linting issue** (extra newline on L6): 
```
ActiveRecord::Schema[7.0].define(version: 2023_03_14_145511) do
  create_table "action_logs", force: :cascade do |t|
    t.string "action", null: false
    t.index ["deleted_at"], name: "index_action_logs_on_deleted_at"
  end

end
```

Example of schema file **without** linting issues: 

```
ActiveRecord::Schema[7.0].define(version: 2023_03_14_145511) do
  create_table "action_logs", force: :cascade do |t|
    t.string "action", null: false
    t.index ["deleted_at"], name: "index_action_logs_on_deleted_at"
  end
end
```

### Details
We should NOT attach a newline after last table definition. Extra newline is needed only if foreign keys definitions exists in the database. 

### Checklist
 Before submitting the PR make sure the following are checked:
 
 * [x]  This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
 * [x]  Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
 * [ ]  Tests are added or updated if you fix a bug or add a feature.
 * [ ]  CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
