### PR TITLE
Allow `accepts_nested_attributes_for` to accept associated record attributes with custom primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Allow `accepts_nested_attributes_for` to accept associated record attributes
+    with custom primary keys
+
+    ```ruby
+    class Owner < ApplicationRecord
+      has_many :pets
+      accepts_nested_attributes_for :pets
+    end
+
+    class Pet < ApplicationRecord
+      self.primary_key = :pet_id # custom primary key name
+      belongs_to :owner
+    end
+    ```
+
+    Before:
+
+    ```ruby
+    owner.update(pets_attributes: { id: 2, name: "parrot" }) # works
+    owner.update(pets_attributes: { pet_id: 2, name: "parrot" }) # does not work
+    ```
+
+    After - both variants are working
+
+    *fatkodima*
+
 *   Fix incrementation of in memory counter caches when associations overlap
 
     When two associations had a similarly named counter cache column, Active Record

--- a/activerecord/test/fixtures/treaties.yml
+++ b/activerecord/test/fixtures/treaties.yml
@@ -1,0 +1,4 @@
+peace:
+  treaty_id: 1
+  name: Peace
+  owner_id: 2

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -5,6 +5,7 @@ class Owner < ActiveRecord::Base
   has_many :pets, -> { order "pets.name desc" }
   has_many :toys, through: :pets
   has_many :persons, through: :pets
+  has_one :treaty
 
   belongs_to :last_pet, class_name: "Pet"
   scope :including_last_pet, -> {
@@ -21,6 +22,7 @@ class Owner < ActiveRecord::Base
   after_commit :execute_blocks
 
   accepts_nested_attributes_for :pets, allow_destroy: true
+  accepts_nested_attributes_for :treaty
 
   def blocks
     @blocks ||= []

--- a/activerecord/test/models/treaty.rb
+++ b/activerecord/test/models/treaty.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Treaty < ActiveRecord::Base
+  belongs_to :owner
   has_and_belongs_to_many :countries
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1324,6 +1324,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :treaties, force: true, id: false do |t|
+    t.belongs_to :owner
     t.string :treaty_id, primary_key: true
     t.string :name
   end


### PR DESCRIPTION
Fixes #48714.

Currently, when we have an `accepts_nested_attributes_for` for a child relation with a custom primary key, when assigning child attributes we must use `"id"` key with a value to provide a primary key, which can be confusing (as in the linked issue).

Example:
```ruby
class Owner < ApplicationRecord
  has_many :pets
  accepts_nested_attributes_for :pets
end

class Pet < ApplicationRecord
  self.primary_key = :pet_id # custom primary key name
  belongs_to :owner
end
```

Before:

```ruby
owner.update(pets_attributes: { id: 2, name: "parrot" }) # works, because we used "id" as a key
owner.update(pets_attributes: { pet_id: 2, name: "parrot" }) # does not work
```

After - both variants are working