### PR TITLE
Fix documentation error for Delegated Types in Rails Guide

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2885,13 +2885,13 @@ Entry.create! entryable: Message.new(subject: "hello!")
 
 ### Adding further delegation
 
-We can expand our `Entry` delegator and enhance further by defining `delegates` and use polymorphism to the subclasses.
+We can expand our `Entry` delegator and enhance it further by defining `delegate` and using polymorphism on the subclasses.
 For example, to delegate the `title` method from `Entry` to it's subclasses:
 
 ```ruby
 class Entry < ApplicationRecord
   delegated_type :entryable, types: %w[ Message Comment ]
-  delegates :title, to: :entryable
+  delegate :title, to: :entryable
 end
 
 class Message < ApplicationRecord


### PR DESCRIPTION
### Motivation / Background

The Rails Guide for Delegated Types incorrectly references `delegates`.

This Pull Request has been created to correct that error.

### Detail

This Pull Request changes the references from `delegates` to `delegate`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
