### PR TITLE
Remove RDoc auto-link from Template text

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -4,7 +4,7 @@ require "thread"
 require "delegate"
 
 module ActionView
-  # = Action View Template
+  # = Action View \Template
   class Template
     extend ActiveSupport::Autoload
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because RDoc auto-links the word `Template` in the documentation for Action View Template API docs and it shouldn't. 

### Detail

This Pull Request escapes the auto-link, so `Action View Template` shows in API docs without `Template` showing as hyperlink text.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
