### PR TITLE
Restores functionality to the missing method when using enums and fixes #48651

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.joins!(association)
-          if @scope.table_name == reflection.table_name
+          if @scope.values.size > 1
             self.not(association => { reflection.association_primary_key => nil })
           else
             self.not(reflection.table_name => { reflection.association_primary_key => nil })
@@ -108,7 +108,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
-          if @scope.table_name == reflection.table_name
+          if @scope.values.size > 1
             @scope.where!(association => { reflection.association_primary_key => nil })
           else
             @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -7,10 +7,11 @@ require "models/human"
 require "models/essay"
 require "models/comment"
 require "models/categorization"
+require "models/book"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
-    fixtures :posts, :comments, :authors, :humans, :essays, :author_addresses
+    fixtures :posts, :comments, :authors, :humans, :essays, :author_addresses, :books
 
     def test_associated_with_association
       Post.where.associated(:author).tap do |relation|
@@ -47,6 +48,10 @@ module ActiveRecord
       assert_equal Author.find(1).posts.count, Post.where.associated(:author).merge(Author.where(id: 1)).count
     end
 
+    def test_associated_with_enum
+      assert_equal Author.find(2), Author.where.associated(:reading_listing).first
+    end
+
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
@@ -76,6 +81,10 @@ module ActiveRecord
       # This query does not make much logical sense, but it is testing
       # that the generated SQL query is valid.
       assert_equal Author.find(1).posts.count, Post.where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_with_enum
+      assert_equal Author.find(2), Author.joins(:reading_listing).where.missing(:unread_listing).first
     end
 
     def test_not_inverts_where_clause

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -15,6 +15,7 @@ class Author < ActiveRecord::Base
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"
   has_one  :post_about_thinking, -> { where("posts.title like '%thinking%'") }, class_name: "Post"
   has_one  :post_about_thinking_with_last_comment, -> { where("posts.title like '%thinking%'").includes(:last_comment) }, class_name: "Post"
+
   has_many :comments, through: :posts do
     def ratings
       Rating.joins(:comment).merge(self)
@@ -171,6 +172,8 @@ class Author < ActiveRecord::Base
   has_many :best_hardbacks, through: :books, source: :format_record, source_type: "BestHardback"
   has_many :published_books, class_name: "PublishedBook"
   has_many :unpublished_books, -> { where(status: [:proposed, :written]) }, class_name: "Book"
+  has_one :unread_listing, -> { unread }, class_name: "Book", foreign_key: :last_read
+  has_one :reading_listing, -> { reading }, class_name: "Book", foreign_key: :last_read
   has_many :subscriptions,        through: :books
   has_many :subscribers, -> { order("subscribers.nick") }, through: :subscriptions
   has_many :distinct_subscribers, -> { select("DISTINCT subscribers.*").order("subscribers.nick") }, through: :subscriptions, source: :subscriber


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of the bug raised in issue [48651](https://github.com/rails/rails/issues/48651). 

Say you have the following models in Rails 7.0.6, and have used an enum in one and aliases in the other.

```Ruby
class Publisher < ApplicationRecord
  belongs_to :listing

  enum name: {
    foo: 0,
    bar: 1
  }
end

class Listing < ApplicationRecord
  has_many :publishers, dependent: :destroy
  has_one :foo_listing, -> { foo }, class_name: Publisher.name
  has_one :bar_listing, -> { bar }, class_name: Publisher.name
end
```

If you have an instance of Listing that has a foo publisher but not a bar publisher and call:

 ```Ruby 
Listing.joins(:foo_listing).where.missing(:bar_listing)
```

It returns nothing whereas one would expect it to return the Listing you created that only has a `:foo_listing`

Please see bug fix if more detail is needed linked above. 

### Detail

This Pull Request changes the missing method in `active_record/relation/query_methods.rb`

Adds another conditional check in the missing query method  in ActiveRecord. This extra check makes sure that the values in `:joins` are different than the values in `:left_outer_joins`.  When they are it is likely that you are using an enum.  I do this checking first for the existence of values in `:joins` and `:left_outer_joins`.  Then I compare the size of the intersection of the two Arrays to the size of the `:joins` Array. If they are different then it implements the scope method excluding the desired enum alias.  The `size` method was used to keep this performant.  This passes all checks in ActiveRecord, including those from [47940](https://github.com/rails/rails/issues/47909) and [45015](https://github.com/rails/rails/pull/45015).

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

* [ X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ X] Tests are added or updated if you fix a bug or add a feature.
* [ X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
