### PR TITLE
Add test for nested content_tags with data attributes outside of erb

### DIFF
--- a/actionview/test/fixtures/test/_content_tag_nested_in_content_tag_with_data_attributes_out_of_erb.erb
+++ b/actionview/test/fixtures/test/_content_tag_nested_in_content_tag_with_data_attributes_out_of_erb.erb
@@ -1,0 +1,4 @@
+<%= content_tag 'div', data: { controller: "read-more", 'read-more-more-text-value': "Read more", 'read-more-less-text-value': "Read less" } do %>
+  <%= content_tag('p', 'Content text', class: 'content-class', data: { 'test-name': "content" }) %>
+  <%= content_tag('button', 'Read more', class: 'expand-button', data: { action: 'read-more#toggle'}) %>
+<% end %>

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -298,6 +298,11 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/builder_tag_nested_in_content_tag")
   end
 
+  def test_content_tag_nested_in_content_tag_with_data_attributes_out_of_erb
+    assert_equal "<div data-controller=\"read-more\" data-read-more-more-text-value=\"Read more\" data-read-more-less-text-value=\"Read less\"\>\n  <p class=\"content-class\" data-test-name=\"content\">Content text</p>\n  <button class=\"expand-button\" data-action=\"read-more#toggle\">Read more</button>\n</div>",
+                  view.render("test/content_tag_nested_in_content_tag_with_data_attributes_out_of_erb")
+  end
+
   def test_content_tag_with_escaped_array_class
     str = content_tag("p", "limelight", class: ["song", "play>"])
     assert_equal "<p class=\"song play&gt;\">limelight</p>", str


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the existing `actionview` `content_tag` tests document how to use `content_tag` outside of erb views with data attributes. But for those who need to use nested `content_tag` and data attributes outside of erb views, it can be time consuming to find out how to do that.

When I had to do this in a project, it took me longer than I wanted. Hopefully adding this test with an explicit example of how to achieve that will others some time. As more and more people get up to speed with Stimulus, I believe this addition is helpful for the community.

### Detail

This Pull Request adds a new test for using nested `content_tag` with data-attributes outside of erb views.

### Additional information

I'm open to feedback on how to make the tests more readable.

Thank you @mike-burns for pairing with me when I was working on this!

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
