### PR TITLE
Discard connection in ensure, not rescue

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Discard connections which may have been left in a transaction due to a thread being killed.
+
+    If a thread is killed while in a transaction, it is possible for the connection to be reused while unexpectedly left in that transaction.
+
+    Connections are now discarded in this case.
+
+    *Nick Dower*
 *   Fix incrementation of in memory counter caches when associations overlap
 
     When two associations had a similarly named counter cache column, Active Record

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -525,10 +525,8 @@ module ActiveRecord
               end
             end
           end
-        rescue Exception
+        ensure
           @connection.throw_away! unless transaction&.state&.completed?
-
-          raise
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

Partially Fixes #48164. Followup to #48200.

### Detail

`within_new_transaction` currently discards connections if an error is raised which may have left the connection in a transaction. This change updates that logic to discard connections in an `ensure` block to handle cases where an error is not raised, for instance if the thread is killed.

### Additional information

Replaces #48224.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
