### PR TITLE
`ActionDispatch::Request` responds to `turbo_frame?`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,8 @@
-*   `ActionDispatch::Assertions#html_document` uses Nokogiri's HTML5 parser if it is available.
+* Adds `ActionDispatch::Request#turbo_frame?` for easy detection of Turbo Frames requests.
+
+  *Ahmed Khattab*
+
+* `ActionDispatch::Assertions#html_document` uses Nokogiri's HTML5 parser if it is available.
 
     The HTML5 parser better represents what the DOM would be in a browser. Previously this test
     helper always used Nokogiri's HTML4 parser.

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -295,8 +295,7 @@ module ActionDispatch
     end
     alias :xhr? :xml_http_request?
 
-    # Returns true if the request's "Turbo-Frame" header contains
-    # "Frame-Name" (case-insensitive).
+    # Returns true if the request's "Turbo-Frame" header is present
     def turbo_frame?
       get_header("Turbo-Frame").present?
     end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -295,6 +295,12 @@ module ActionDispatch
     end
     alias :xhr? :xml_http_request?
 
+    # Returns true if the request's "Turbo-Frame" header contains
+    # "Frame-Name" (case-insensitive).
+    def turbo_frame?
+      get_header("Turbo-Frame").present?
+    end
+
     # Returns the IP address of client as a +String+.
     def ip
       @ip ||= super

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -693,6 +693,14 @@ class RequestProtocol < BaseRequestTest
     assert_predicate request, :xhr?
   end
 
+  test "turbo frame request" do
+    request = stub_request
+    assert_not_predicate request, :turbo_frame?
+
+    request = stub_request "Turbo-Frame" => "Frame-Name"
+    assert_predicate request, :turbo_frame?
+  end
+
   test "reports ssl" do
     assert_not_predicate stub_request, :ssl?
     assert_predicate stub_request("HTTPS" => "on"), :ssl?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

With the release of HOTWire and the introduction of Turbo-Frames, sometimes, controllers to check the type of the request and differenciate between a Turbo-Stream or Turbo-Frame response, for example. You might have an initial content load via Turbo-Frame, and subsequent Turbo-Stream requests to update parts of the page. At our company, we needed a way to check in such scenario, and we had to do `request.headers["turbo-frame"].present?`, and at first, we thought this was baked into Rails, imagine our surprise. 

We have currently extended `ActionDispatch::Controller` to add support for it in our codebase.
 
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because applications using HOTWire (sometimes) need to check whether the the incoming request is a Turbo-Frame or a Turbo-Stream request, or accepts both. Such that, it can serve correct content based on the content type. 

### Detail

This Pull Request adds an extra method named `turbo_frame?` on `ActionDispatch::Request` object. This would allow developers to determine if a request originated inside a Turbo-Frame, more the Rails way. Instead of doing something like

```ruby
def action 
 if request.headers["turbo-frame"].present?
    # do something
 else
    # do something else
 end 
end
```

into something that feels Rails-y 

```ruby
def action 
 if request.turbo_frame?
    # do something
 else
    # do something else
 end 
end
```
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
