### PR TITLE
Implemented ActiveRecord::Base.pretty_print to work with PP.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Implemented ActiveRecord::Base.pretty_print to work with PP.
+
+    ```ruby
+    pp User
+    # => User(
+    #     id: integer,
+    #     first_name: string,
+    #     last_name: string,
+    #     birth_at: datetime,
+    #     email: string,
+    #     address: string,
+    #     active: boolean,
+    #     parent_id: integer,
+    #     type: string,
+    #     created_at: datetime,
+    #     updated_at: datetime)
+    ```
+
+    *osyo*
+
 *   Specify callback in `has_secure_token`
 
     ```ruby

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -345,6 +345,24 @@ module ActiveRecord
         end
       end
 
+      # Takes a PP and prettily prints this Model class to it, allowing you to get a nice result from <tt>pp User</tt>
+      # when pp is required.
+      def pretty_print(pp)
+        return super if custom_inspect_method_defined? || self == Base || abstract_class? || !connected? || !table_exists?
+        pp.group(1, "#{self.name}(", ")") do
+          attr_list = attribute_types.map { |name, type| [name, type.type] }
+          pp.seplist(attr_list, proc { pp.text "," }) do |name, type|
+            pp.breakable " "
+            pp.group(1) do
+              pp.text name
+              pp.text ":"
+              pp.breakable
+              pp.text type
+            end
+          end
+        end
+      end
+
       # Override the default class equality method to provide support for decorated models.
       def ===(object) # :nodoc:
         object.is_a?(self)
@@ -416,6 +434,10 @@ module ActiveRecord
           rescue TypeError
             raise ActiveRecord::StatementInvalid
           end
+        end
+
+        def custom_inspect_method_defined?
+          self.method(:inspect).owner != ActiveRecord::Base.method(:inspect).owner
         end
     end
 

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -56,6 +56,83 @@ class CoreTest < ActiveRecord::TestCase
     assert_match(/virtual_field: 1/, relation.inspect)
   end
 
+  def test_pretty_print_class
+    actual = +""
+    PP.pp(Topic, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      Topic(
+       id: integer,
+       title: string,
+       author_name: string,
+       author_email_address: string,
+       written_on: datetime,
+       bonus_time: time,
+       last_read: date,
+       content: text,
+       important: text,
+       binary_content: binary,
+       approved: boolean,
+       replies_count: integer,
+       unique_replies_count: integer,
+       parent_id: integer,
+       parent_title: string,
+       type: string,
+       group: string,
+       created_at: datetime,
+       updated_at: datetime)
+    EOS
+  end
+
+  def test_pretty_print_class_activerecord_base
+    actual = +""
+    PP.pp(ActiveRecord::Base, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      ActiveRecord::Base
+    EOS
+  end
+
+  def test_pretty_print_class_abstract_class
+    actual = +""
+    PP.pp(LoosePerson, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      LoosePerson(abstract)
+    EOS
+  end
+
+  def test_pretty_print_class_not_connected
+    dummy_class = Class.new(Topic) do
+      def self.connected?
+        false
+      end
+    end
+    actual = +""
+    PP.pp(dummy_class, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      #{dummy_class} (call '#{dummy_class}.connection' to establish a connection)
+    EOS
+  end
+
+  def test_pretty_print_class_without_table
+    actual = +""
+    PP.pp(NonExistentTable, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      NonExistentTable(Table doesn't exist)
+    EOS
+  end
+
+  def test_pretty_print_class_overridden_by_inspect
+    subtopic = Class.new(Topic) do
+      def self.inspect
+        "inspecting topic"
+      end
+    end
+    actual = +""
+    PP.pp(subtopic, StringIO.new(actual))
+    assert_equal <<~EOS, actual
+      inspecting topic
+    EOS
+  end
+
   def test_pretty_print_new
     topic = Topic.new
     actual = +""


### PR DESCRIPTION
### Motivation / Background

When checking what columns are defined in an arbitrary model, you may use `console` or other tools to output the model class.
However, when a model has many columns, it can be difficult to read when displayed on a single line.

```ruby
p User
# => User(id: integer, first_name: string, last_name: string, birth_at: datetime, email: string, address: string, active: boolean, parent_id: integer, type: string, created_at: datetime, updated_at: datetime)
```

NOTE: [implement ActiveRecord::Base#pretty_print by notEthan · Pull Request #15172 · rails/rails](https://github.com/rails/rails/pull/15172)

### Detail

Define `ActiveRecord::Base.pretty_print` to support `pp` output.

```ruby
pp User
# => User(
#     id: integer,
#     first_name: string,
#     last_name: string,
#     birth_at: datetime,
#     email: string,
#     address: string,
#     active: boolean,
#     parent_id: integer,
#     type: string,
#     created_at: datetime,
#     updated_at: datetime)
```

The format and implementation are based on [`ActiveRecord::Base#pretty_print`](https://github.com/rails/rails/blob/e18791c0bf2e03d3e6380f69b44e946564c6f873/activerecord/lib/active_record/core.rb#L682-L705) and [`ActiveRecord::Base.inspect`](https://github.com/rails/rails/blob/e18791c0bf2e03d3e6380f69b44e946564c6f873/activerecord/lib/active_record/core.rb#L332-L346).

Note: Output of `ActiveRecord::Base#pretty_print` is as follows.

```ruby
pp User.new
# => #<User:0x00007f0431d6dc88
#     id: nil,
#     first_name: nil,
#     last_name: nil,
#     birth_at: nil,
#     email: nil,
#     address: nil,
#     active: nil,
#     parent_id: nil,
#     type: nil,
#     created_at: nil,
#     updated_at: nil>
```


### Additional information

I also found the following problem when implementing `ActiveRecord::Base#pretty_print` and have addressed it.
* [pretty_print will use #inspect if a subclass redefines it by notEthan · Pull Request #18474 · rails/rails](https://github.com/rails/rails/pull/18474)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
