### PR TITLE
Fix ActionText::ContentHelper allowed tags and attrs

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -9,6 +9,12 @@
     fall back to `Rails::HTML4::Sanitizer`. Previous configurations default to
     `Rails::HTML4::Sanitizer`.
 
+    As a result of this change, the defaults for `ActionText::ContentHelper.allowed_tags` and
+    `.allowed_attributes` are applied at runtime, so the value of these attributes is now 'nil'
+    unless set by the application. You may call `sanitizer_allowed_tags` or
+    `sanitizer_allowed_attributes` to inspect the tags and attributes being allowed by the
+    sanitizer.
+
     *Mike Dalessio*
 
 *   Attachables now can override default attachment missing template.

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -5,8 +5,8 @@ require "rails-html-sanitizer"
 module ActionText
   module ContentHelper
     mattr_accessor(:sanitizer, default: Rails::HTML4::Sanitizer.safe_list_sanitizer.new)
-    mattr_accessor(:allowed_tags) { sanitizer.class.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ] }
-    mattr_accessor(:allowed_attributes) { sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES }
+    mattr_accessor(:allowed_tags)
+    mattr_accessor(:allowed_attributes)
     mattr_accessor(:scrubber)
 
     def render_action_text_content(content)
@@ -15,7 +15,12 @@ module ActionText
     end
 
     def sanitize_action_text_content(content)
-      sanitizer.sanitize(content.to_html, tags: allowed_tags, attributes: allowed_attributes, scrubber: scrubber).html_safe
+      sanitizer.sanitize(
+        content.to_html,
+        tags: sanitizer_allowed_tags,
+        attributes: sanitizer_allowed_attributes,
+        scrubber: scrubber,
+      ).html_safe
     end
 
     def render_action_text_attachments(content)
@@ -47,6 +52,14 @@ module ActionText
       end
 
       render(**options).chomp
+    end
+
+    def sanitizer_allowed_tags
+      allowed_tags || (sanitizer.class.allowed_tags + [ ActionText::Attachment.tag_name, "figure", "figcaption" ])
+    end
+
+    def sanitizer_allowed_attributes
+      allowed_attributes || (sanitizer.class.allowed_attributes + ActionText::Attachment::ATTRIBUTES)
     end
   end
 end


### PR DESCRIPTION

### Motivation / Background

ActionText::ContentHelper "allowed tags" and "allowed attributes" are being set to the HTML4 defaults before the sanitizer configuration could be applied as a result of the change in #48644.

Also, backfill some light tests for sanitization.

h/t to @georgeclaghorn for pointing this issue out in https://github.com/rails/rails/commit/44d3b44d9d7f42658bda1037f6c7713d02d4b1c0#r121659686


### Detail

This change implements resolution of allowed tags and attributes at runtime (as opposed to initialization-time), via new methods `sanitizer_allowed_tags` and `sanitizer_allowed_attributes`, so that when a `sanitizer` is set, that sanitizer's defaults take effect (unless the developer has explicitly set `allowed_tags` or `allowed_attributes`).

A side effect of this change is that, unless explicitly set, `allowed_tags` and `allowed_attributes` readers will return `nil` (where they previously returned the allowed tags and attributes).


### Additional information

An alternative solution is to implement custom readers for `allowed_tags` and `allowed_attributes` rather than implement `sanitizer_allowed_tags` and `_attributes`.

However, this solution feels unwieldy to me since it requires implementing both class and instance readers (essentially everything that `mattr_reader` implements), and so my personal preference was for this simpler approach.

But if the maintainers would prefer to implement mattr readers, I'll do that.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
