### PR TITLE
Removes non-essential rubocop:disable

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -205,7 +205,7 @@ module Enumerable
   #   { a: 1, b: 2 }.sole # => Enumerable::SoleItemExpectedError: multiple items found
   def sole
     case count
-    when 1   then return first # rubocop:disable Style/RedundantReturn
+    when 1   then first
     when 0   then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "no item found"
     when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "multiple items found"
     end

--- a/railties/lib/rails/all.rb
+++ b/railties/lib/rails/all.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/RedundantBegin
-
 require "rails"
 
 %w(
@@ -16,8 +14,6 @@ require "rails"
   action_text/engine
   rails/test_unit/railtie
 ).each do |railtie|
-  begin
-    require railtie
-  rescue LoadError
-  end
+  require railtie
+rescue LoadError
 end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -242,7 +242,6 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
       run_routes_command([ "--expanded" ])
     end
 
-    # rubocop:disable Layout/TrailingWhitespace
     assert_equal <<~MESSAGE, output
       --[ Route 1 ]--------------
       Prefix            | cart


### PR DESCRIPTION
### Motivation / Background

I actually found an unnecessary `rubocop:disable` when I was practicing reading Railites files.

I know that maybe this PR will not be accepted, but I carefully checked the whole Codebase and found that these three `rubocop:disable` are unnecessary.

For me, after installing Rubocop, I should follow the rules as much as possible, and avoid using disables to break the rules.

That's the motivation for this PR.

### Detail

Remove the `rubocop:disable` and make sure the test is all passed

### Additional information

No.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
