### PR TITLE
Fix serialization of non-ASCII-only bare strings

### DIFF
--- a/activesupport/lib/active_support/cache/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/cache/serializer_with_fallback.rb
@@ -76,8 +76,8 @@ module ActiveSupport
           return if !signature
 
           packed = [signature, entry.expires_at || -1.0, version&.bytesize || -1].pack(BARE_STRING_TEMPLATE)
-          packed << version if version
-          packed << value
+          packed << version.b if version
+          packed << value.b
         end
 
         def try_load_bare_string(dumped)

--- a/activesupport/test/cache/serializer_with_fallback_test.rb
+++ b/activesupport/test/cache/serializer_with_fallback_test.rb
@@ -72,6 +72,16 @@ class CacheSerializerWithFallbackTest < ActiveSupport::TestCase
       end
     end
 
+    test "#{format.inspect} serializer handles non-ASCII-only bare string" do
+      entry = ActiveSupport::Cache::Entry.new("ümlaut")
+      assert_entry entry, roundtrip(format, entry)
+    end
+
+    test "#{format.inspect} serializer handles non-ASCII-only version with bare string" do
+      entry = ActiveSupport::Cache::Entry.new("abc", version: "ümlaut")
+      assert_entry entry, roundtrip(format, entry)
+    end
+
     test "#{format.inspect} serializer dumps bare string with reduced overhead when possible" do
       string = "abc"
       options = { version: "123", expires_in: 123 }


### PR DESCRIPTION
To use a binary-encoded string as a byte buffer, appended strings should be force-encoded as binary.  Otherwise, appending a non-ASCII-only string will raise `Encoding::CompatibilityError`.

Fixes #48748.
