### PR TITLE
Fix Action Text sanitizer initialization

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -83,8 +83,8 @@ module ActionText
       ActionText::Attachment.tag_name = app.config.action_text.attachment_tag_name
     end
 
-    initializer "action_text.sanitizer_vendor" do |app|
-      if klass = app.config.action_text.delete(:sanitizer_vendor)
+    config.after_initialize do |app|
+      if klass = app.config.action_text.sanitizer_vendor
         ActionText::ContentHelper.sanitizer = klass.safe_list_sanitizer.new
       end
     end


### PR DESCRIPTION

### Motivation / Background

Using `initializer` in the engine _may_ run the block before application initializers. Instead, use `config.after_initialize` to ensure that application initializers take effect properly.

Also, don't bother deleting the config value, since that pattern isn't needed here (as it is in other railties like action_view/railtie.rb).

See similar fix for Action View in #48747.

### Detail

Replace `initializer` with `config.after_initialize`.

### Additional information

I'm not sure how to test this behavior properly other than to set up an application and run the code. I would love to learn how to better test initializer order.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
