### PR TITLE
Lazily deserialize cache entries

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   When using cache format version >= 7.1 or a custom serializer, expired and
+    version-mismatched cache entries can now be detected without deserializing
+    their values.
+
+    *Jonathan Hefner*
+
 *   Make all cache stores return a boolean for `#delete`
 
     Previously the `RedisCacheStore#delete` would return `1` if the entry

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2413,8 +2413,9 @@ Specifies which serialization format to use for the cache. Possible values are
 
 `7.0` serializes cache entries more efficiently.
 
-`7.1` further improves efficiency, and includes an optimization for bare string
-values such as view fragments.
+`7.1` further improves efficiency, and allows expired and version-mismatched
+cache entries to be detected without deserializing their values. It also
+includes an optimization for bare string values such as view fragments.
 
 All formats are backward and forward compatible, meaning cache entries written
 in one format can be read when using another format. This behavior makes it


### PR DESCRIPTION
This adds a cache optimization such that expired and version-mismatched cache entries can be detected without deserializing their values.  This optimization is enabled when using cache format version >= 7.1 or a custom serializer.