### PR TITLE
Update tests to support changes in Rack 3.1 (head).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,11 @@ gem "web-console", require: false
 
 # Action Pack and railties
 rack_version = ENV.fetch("RACK", "~> 3.0")
-gem "rack", rack_version
+if rack_version != "head"
+  gem "rack", rack_version
+else
+  gem "rack", git: "https://github.com/rack/rack.git", branch: "main"
+end
 
 # Active Job
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
     raabro (1.4.0)
     racc (1.6.2)
     rack (3.0.8)
-    rack-cache (1.13.0)
+    rack-cache (1.14.0)
       rack (>= 0.4)
     rack-session (2.0.0)
       rack (>= 3.0.0)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -381,6 +381,7 @@ module CookieAssertions
       key.downcase!
 
       if value
+        value.downcase!
         attributes[key] = value
       else
         attributes[key] = true
@@ -416,6 +417,35 @@ module CookieAssertions
     end
 
     cookies
+  end
+
+  def assert_set_cookie_attributes(name, attributes, header = @response.headers["Set-Cookie"])
+    cookies = parse_set_cookies_headers(header)
+    attributes = parse_set_cookie_attributes(attributes) if attributes.is_a?(String)
+
+    assert cookies.key?(name), "No cookie found with the name '#{name}', found cookies: #{cookies.keys.join(', ')}"
+    cookie = cookies[name]
+
+    attributes.each do |key, value|
+      assert cookie.key?(key), "No attribute '#{key}' found for cookie '#{name}'"
+      assert_equal value, cookie[key]
+    end
+  end
+
+  def assert_not_set_cookie_attributes(name, attributes, header = @response.headers["Set-Cookie"])
+    cookies = parse_set_cookies_headers(header)
+    attributes = parse_set_cookie_attributes(attributes) if attributes.is_a?(String)
+
+    assert cookies.key?(name), "No cookie found with the name '#{name}'"
+    cookie = cookies[name]
+
+    attributes.each do |key, value|
+      if value == true
+        assert_nil cookie[key]
+      else
+        assert_not_equal value, cookie[key]
+      end
+    end
   end
 
   def assert_set_cookie_header(expected, header = @response.headers["Set-Cookie"])

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -487,7 +487,8 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
       get "/get_with_params", params: { foo: "bar" }
 
-      assert_empty request.env["rack.input"].string
+      input = request.env["rack.input"]
+      assert(input.nil? || input.read == "")
       assert_equal "foo=bar", request.env["QUERY_STRING"]
       assert_equal "foo=bar", request.query_string
       assert_equal "bar", request.parameters["foo"]

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1238,7 +1238,7 @@ class CookieCsrfTokenStorageStrategyControllerTest < ActionController::TestCase
 
   def test_csrf_token_cookie_has_same_site_lax
     get :cookie
-    assert_match "SameSite=Lax", @response.headers["Set-Cookie"]
+    assert_set_cookie_attributes("csrf_token", "SameSite=Lax")
   end
 
   include CookieAssertions

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -424,7 +424,7 @@ class CookiesTest < ActionController::TestCase
     error = assert_raise ArgumentError do
       get :authenticate
     end
-    assert_match "Invalid SameSite value: :funky", error.message
+    assert_match(/Invalid :?Same_?Site value: :funky/i, error.message)
   end
 
   def test_setting_cookie_with_same_site_strict

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -392,21 +392,21 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   test "default same_site derives SameSite from env" do
     with_test_route_set do
       get "/set_session_value"
-      assert_match %r/SameSite=Lax/, headers["Set-Cookie"]
+      assert_set_cookie_attributes("_myapp_session", "SameSite=Lax")
     end
   end
 
   test "explicit same_site sets SameSite" do
     with_test_route_set(same_site: :strict) do
       get "/set_session_value"
-      assert_match %r/SameSite=Strict/, headers["Set-Cookie"]
+      assert_set_cookie_attributes("_myapp_session", "SameSite=Strict")
     end
   end
 
   test "explicit nil same_site omits SameSite" do
     with_test_route_set(same_site: nil) do
       get "/set_session_value"
-      assert_no_match %r/SameSite=/, headers["Set-Cookie"]
+      assert_not_set_cookie_attributes("_myapp_session", "SameSite")
     end
   end
 

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -146,13 +146,15 @@ module StaticTests
     end
   end
 
+  JAVASCRIPT_MIME_TYPE = Rack::Mime::MIME_TYPES[".js"]
+
   def test_serves_gzip_files_when_header_set
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")
     assert_gzip  file_name, response
-    assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "accept-encoding",        response.headers["Vary"]
-    assert_equal "gzip",                   response.headers["Content-Encoding"]
+    assert_equal JAVASCRIPT_MIME_TYPE, response.headers["Content-Type"]
+    assert_equal "accept-encoding", response.headers["Vary"]
+    assert_equal "gzip", response.headers["Content-Encoding"]
 
     response = get(file_name, "HTTP_ACCEPT_ENCODING" => "Gzip")
     assert_gzip file_name, response
@@ -176,9 +178,9 @@ module StaticTests
   def test_serves_brotli_files_when_header_set
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "br")
-    assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "accept-encoding",        response.headers["Vary"]
-    assert_equal "br",                     response.headers["Content-Encoding"]
+    assert_equal JAVASCRIPT_MIME_TYPE, response.headers["Content-Type"]
+    assert_equal "accept-encoding", response.headers["Vary"]
+    assert_equal "br", response.headers["Content-Encoding"]
 
     response = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip")
     assert_not_equal "br", response.headers["Content-Encoding"]
@@ -187,9 +189,9 @@ module StaticTests
   def test_serves_brotli_files_before_gzip_files
     file_name = "/gzip/application-a71b3024f80aea3181c09774ca17e712.js"
     response  = get(file_name, "HTTP_ACCEPT_ENCODING" => "gzip, deflate, sdch, br")
-    assert_equal "application/javascript", response.headers["Content-Type"]
-    assert_equal "accept-encoding",        response.headers["Vary"]
-    assert_equal "br",                     response.headers["Content-Encoding"]
+    assert_equal JAVASCRIPT_MIME_TYPE, response.headers["Content-Type"]
+    assert_equal "accept-encoding", response.headers["Vary"]
+    assert_equal "br", response.headers["Content-Encoding"]
   end
 
   def test_does_not_modify_path_info

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -14,13 +14,11 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal "/", env.delete("PATH_INFO")
     assert_equal "", env.delete("SCRIPT_NAME")
     assert_equal "", env.delete("QUERY_STRING")
-    assert_equal "0", env.delete("CONTENT_LENGTH")
 
     assert_equal "test.host", env.delete("HTTP_HOST")
     assert_equal "0.0.0.0", env.delete("REMOTE_ADDR")
     assert_equal "Rails Testing", env.delete("HTTP_USER_AGENT")
 
-    assert_equal "", env.delete("rack.input").string
     assert_kind_of StringIO, env.delete("rack.errors")
   end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -808,7 +808,6 @@ en:
         end
       RUBY
 
-      require "rack/file"
       boot_rails
 
       env = Rack::MockRequest.env_for("/")


### PR DESCRIPTION
A few small changes required for Rack 3.1, which removed deprecated code paths and introduced some changes that affect Rails:

- Optional `rack.input` (which also implies optional `CONTENT_LENGTH`).
- JavaScript's mime type was updated to reflect the latest standards.
- `rack-cache` was updated for Rack 3+.
- `rack/file.rb` was finally removed.

I have tested this locally. We could introduce tests for `RACK=head` if that seems reasonable, but I'm sure we can release Rack 3.1 soon.

Regarding the JavaScript mime type: https://stackoverflow.com/questions/21098865/text-javascript-vs-application-javascript