### PR TITLE
[Docs] Improve `set_load_path` documentation

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3435,7 +3435,7 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `action_mailer.compile_config_methods`: Initializes methods for the config settings specified so that they are quicker to access.
 
-* `set_load_path`: This initializer runs before `bootstrap_hook`. Adds paths specified by `config.load_paths` and all autoload paths to `$LOAD_PATH`.
+* `set_load_path`: This initializer runs before `bootstrap_hook`. Adds paths specified by `config.paths.load_paths` to `$LOAD_PATH`. And unless you set `config.add_autoload_paths_to_load_path` to `false`, it will also add all autoload paths specified by `config.autoload_paths`, `config.eager_load_paths`, `config.autoload_once_paths`.
 
 * `set_autoload_paths`: This initializer runs before `bootstrap_hook`. Adds all sub-directories of `app` and paths specified by `config.autoload_paths`, `config.eager_load_paths` and `config.autoload_once_paths` to `ActiveSupport::Dependencies.autoload_paths`.
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I needed to add a custom folder to `$LOAD_PATH` in my Rails project and I wanted to do it using the framework tools, however when I checked the documentation, I was given incorrect information that didn't work on the current release. More specifically, the existing documentation erroneously mentions `config.load_path` which was removed in Rails 3 and now replaced by `config.paths.load_paths`.

### Detail

In addition to updating the outdated reference from `config.load_path` to `config.paths.load_paths`, the new documentation explicitly lists all "autoload paths" for the reader which can otherwise only be known by checking the code, and mentions the `add_autoload_paths_to_load_path` config toggle.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] N/A ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] N/A ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
