### PR TITLE
Support `include?` and `member?` on composite primary key relations

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -355,7 +355,12 @@ module ActiveRecord
       if loaded? || offset_value || limit_value || having_clause.any?
         records.include?(record)
       else
-        record.is_a?(klass) && exists?(record.id)
+        id = if record.class.composite_primary_key?
+          record.class.primary_key.zip(record.id).to_h
+        else
+          record.id
+        end
+        record.is_a?(klass) && exists?(id)
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -475,6 +475,22 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_include_on_unloaded_relation_with_composite_primary_key
+    assert_sql(/1 AS one.*LIMIT/) do
+      book = cpk_books(:cpk_great_author_first_book)
+      assert Cpk::Book.where(title: "The first book").include?(book)
+    end
+  end
+
+  def test_include_on_loaded_relation_with_composite_primary_key
+    books = Cpk::Book.where(title: "The first book").load
+    great_author_book = cpk_books(:cpk_great_author_first_book)
+
+    assert_no_queries do
+      assert books.include?(great_author_book)
+    end
+  end
+
   def test_member_on_unloaded_relation_with_match
     assert_sql(/1 AS one.*LIMIT/) do
       assert_equal true, Customer.where(name: "David").member?(customers(:david))
@@ -527,6 +543,22 @@ class FinderTest < ActiveRecord::TestCase
 
     assert_no_queries do
       assert_equal false, customers.member?(mary)
+    end
+  end
+
+  def test_member_on_unloaded_relation_with_composite_primary_key
+    assert_sql(/1 AS one.*LIMIT/) do
+      book = cpk_books(:cpk_great_author_first_book)
+      assert Cpk::Book.where(title: "The first book").member?(book)
+    end
+  end
+
+  def test_member_on_loaded_relation_with_composite_primary_key
+    books = Cpk::Book.where(title: "The first book").load
+    great_author_book = cpk_books(:cpk_great_author_first_book)
+
+    assert_no_queries do
+      assert books.member?(great_author_book)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

`include` and `member?` delegate to `exists?` with the record's primary key to determine if an unloaded relation contains a given record. If the primary key is composite, `exists?` believes we are passing where-style conditions and fails. Support for `include?` will allow us to use `assert_includes` / `refute_includes` assertions on composite primary key models.

### Detail

This commit fixes the issue by turning the record's composite primary key into a hash of column / value pairs that `exists?` can accept.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
