### PR TITLE
[7-0-stable] Add lower bound to Listen gem requirement

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improve error message when EventedFileUpdateChecker is used without a
+    compatible version of the Listen gem
+
+    *Hartley McGuire*
+
 ## Rails 7.0.6 (June 29, 2023) ##
 
 *   Fix `EncryptedConfiguration` returning incorrect values for some `Hash`

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "listen"
+gem "listen", "~> 3.5"
 require "listen"
 
 require "set"

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+gem "listen"
+require "listen"
+
 require "set"
 require "pathname"
 require "concurrent/atomic/atomic_boolean"
-require "listen"
 require "active_support/fork_tracker"
 
 module ActiveSupport


### PR DESCRIPTION
Backports #48622 and #47002 to 7-0-stable

This is useful because #47774 was backported, and `wait_for_state` isn't available until `listen` 3.3

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
