### PR TITLE
Add expires_in to generates_token_for instance method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Additional optional parameter `expires_in` to `generates_token_for` instance method.
+
+    ```ruby
+    class User < ApplicationRecord
+      generates_token_for :password_reset, expires_in: 15.minutes { ... }
+    end
+
+    user = User.first
+    user.generate_token_for(:password_reset) # Expires in 15 minutes
+    user.generate_token_for(:password_reset, expires_in: 2.days) # Same purpose, but expires in 2 days
+    ```
+
+    *Lázaro Nixon*
+
 *   Specify callback in `has_secure_token`
 
     ```ruby

--- a/activerecord/lib/active_record/token_for.rb
+++ b/activerecord/lib/active_record/token_for.rb
@@ -25,8 +25,8 @@ module ActiveRecord
         block ? [model.id, model.instance_eval(&block).as_json] : [model.id]
       end
 
-      def generate_token(model)
-        message_verifier.generate(payload_for(model), expires_in: expires_in, purpose: full_purpose)
+      def generate_token(model, expires_in_value = nil)
+        message_verifier.generate(payload_for(model), expires_in: expires_in_value || expires_in, purpose: full_purpose)
       end
 
       def resolve_token(token)
@@ -107,8 +107,8 @@ module ActiveRecord
     #
     # Use ClassMethods::generates_token_for to define a token purpose and
     # behavior.
-    def generate_token_for(purpose)
-      self.class.token_definitions.fetch(purpose).generate_token(self)
+    def generate_token_for(purpose, expires_in: nil)
+      self.class.token_definitions.fetch(purpose).generate_token(self, expires_in)
     end
   end
 end

--- a/activerecord/test/cases/token_for_test.rb
+++ b/activerecord/test/cases/token_for_test.rb
@@ -25,6 +25,7 @@ class TokenForTest < ActiveRecord::TestCase
     @user = User.create!(password_digest: "$2a$4$#{"x" * 22}#{"y" * 31}")
     @lookup_token = @user.generate_token_for(:lookup)
     @password_reset_token = @user.generate_token_for(:password_reset)
+    @password_reset_token_extended = @user.generate_token_for(:password_reset, expires_in: 2.days)
   end
 
   teardown do
@@ -76,6 +77,11 @@ class TokenForTest < ActiveRecord::TestCase
     assert_raises(ActiveSupport::MessageVerifier::InvalidSignature) do
       User.find_by_token_for!(:password_reset, @password_reset_token)
     end
+  end
+
+  test "finds record when token was generated with custom expiration" do
+    travel 1.day
+    assert_equal @user, User.find_by_token_for(:password_reset, @password_reset_token_extended)
   end
 
   test "tokens do not expire by default" do


### PR DESCRIPTION
### Motivation / Background

Sometimes we want to generate a token for the same purpose but with a different expiration, ex: Invitation (first password reset) vs regular password reset

So I am introducing an optional parameter `expires_in` to `generates_token_for` instance method that can override the default expiration.

```ruby
class User < ApplicationRecord
  generates_token_for :password_reset, expires_in: 15.minutes { ... }
end

user = User.first
user.generate_token_for(:password_reset) # Expires in 15 minutes
user.generate_token_for(:password_reset, expires_in: 2.days) # Same purpose, but expires in 2 days
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
