### PR TITLE
Fix `StatementCache::Substitute` with serialized type

### DIFF
--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -10,7 +10,9 @@ module ActiveRecord
 
         # The query attribute value may be mutated before we actually "compile" the query.
         # To avoid that if the type uses a serializer we eagerly compute the value for database
-        if @type.serialized? && !value_before_type_cast.is_a?(StatementCache::Substitute)
+        if value_before_type_cast.is_a?(StatementCache::Substitute)
+          # we don't need to serialize StatementCache::Substitute
+        elsif @type.serialized?
           value_for_database
         elsif @type.mutable? # If the type is simply mutable, we deep_dup it.
           @value_before_type_cast = @value_before_type_cast.deep_dup

--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
         # The query attribute value may be mutated before we actually "compile" the query.
         # To avoid that if the type uses a serializer we eagerly compute the value for database
-        if @type.serialized?
+        if @type.serialized? && !value_before_type_cast.is_a?(StatementCache::Substitute)
           value_for_database
         elsif @type.mutable? # If the type is simply mutable, we deep_dup it.
           @value_before_type_cast = @value_before_type_cast.deep_dup

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -737,7 +737,7 @@ class QuerySerializedParamTest < ActiveRecord::TestCase
 
   def setup
     @use_yaml_unsafe_load_was = ActiveRecord.use_yaml_unsafe_load
-    ActiveRecord.use_yaml_unsafe_load = true
+
     ActiveRecord::Base.connection.create_table("yaml_objs", force: true) do |t|
       t.text "payload"
     end
@@ -753,6 +753,8 @@ class QuerySerializedParamTest < ActiveRecord::TestCase
   end
 
   def test_query_serialized_active_record
+    ActiveRecord.use_yaml_unsafe_load = true
+
     topic = Topic.first
     assert_not_nil topic
 
@@ -766,6 +768,13 @@ class QuerySerializedParamTest < ActiveRecord::TestCase
     assert_equal obj, relation.first
 
     assert_nil YAMLObj.where(payload: { topic: topic }).first
+  end
+
+  def test_query_serialized_string
+    ActiveRecord.use_yaml_unsafe_load = false
+
+    obj = YAMLObj.create!(payload: 'payload')
+    assert_equal obj, YAMLObj.find_by!(payload: 'payload')
   end
 end
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -773,8 +773,8 @@ class QuerySerializedParamTest < ActiveRecord::TestCase
   def test_query_serialized_string
     ActiveRecord.use_yaml_unsafe_load = false
 
-    obj = YAMLObj.create!(payload: 'payload')
-    assert_equal obj, YAMLObj.find_by!(payload: 'payload')
+    obj = YAMLObj.create!(payload: "payload")
+    assert_equal obj, YAMLObj.find_by!(payload: "payload")
   end
 end
 


### PR DESCRIPTION
Fixes regression from: https://github.com/rails/rails/pull/48730/

At the time of calling `value_for_database` in `ActiveRecord::Relation::QueryAttribute`'s [initialize](https://github.com/Shopify/rails/blob/29205d7928a2c530aceffde25cb1173c3133857a/activerecord/lib/active_record/relation/query_attribute.rb#L8), the value could be a `StatementCache::Substitute`, in which case, `value_for_database` would not work as expected. 

In our code base, we saw a mismatch in the expected type while type-checking on a custom coder's `self.dump` method.

This PR adds a test for serializing a string value. When `ActiveRecord.use_yaml_unsafe_load = false`, we can see that calling `value_for_database` leads to the `ActiveRecord::Coders::YAMLColumn` coder dumping a `StatementCache::Substitute`, instead of the actual value. 

This PR tries to address the issue by just adding a check to skip calling `value_for_database` in ActiveRecord::Relation::QueryAttribute's initialize if the value is a `StatementCache::Substitute`. Though, we wonder if there's generally a better way to prevent serializing the wrong value and/or calling `value_for_database` on a `StatementCache::Substitute` or similar classes, since `value_for_database` is callable from anywhere in a ActiveRecord::Relation::QueryAttribute.
