### PR TITLE
Call `other.value_for_database` in ActiveRecord::Relation::QueryAttribute == check

### DIFF
--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -49,7 +49,7 @@ module ActiveRecord
       end
 
       def ==(other)
-        super && value_for_database == value_for_database
+        super && value_for_database == other.value_for_database
       end
       alias eql? ==
 


### PR DESCRIPTION
I think this method is meant to check that `value_for_database == other.value_for_database` instead of `value_for_database == value_for_database` since the second will always be true.