### PR TITLE
Prevent header wrapping in email preview

### DIFF
--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -44,6 +44,13 @@
     content: "\00a0"; // &nbsp;
   }
 
+  th {
+    font-weight: inherit;
+    color: #7f7f7f;
+    text-align: right;
+    white-space: nowrap;
+  }
+
   iframe {
     border: 0;
     width: 100%;
@@ -134,7 +141,7 @@
           <table>
           <% @email.header_fields.each do |field| %>
             <tr>
-              <td align="right" style="color: #7f7f7f"><%= field.name %>:</td>
+              <th><%= field.name %>:</th>
               <td><%= field.value %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
### Motivation / Background
In the all header view in email previews, header names may wrap if the header value is very long (see screenshot). Header names are usually short, so I suggest we don't wrap those.

### Screenshot
#### Before
<img width="668" alt="image" src="https://github.com/rails/rails/assets/111346/d1949ad5-2a3d-4c3a-9f25-cd55b3b272a4">

#### After
<img width="731" alt="image" src="https://github.com/rails/rails/assets/111346/72cb2aea-55bd-4e38-8e78-307d500dc512">


### Checklist
* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
