### PR TITLE
Prevent inspecting transmit data if not necessary

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -212,9 +212,11 @@ module ActionCable
         # Transmit a hash of data to the subscriber. The hash will automatically be wrapped in a JSON envelope with
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil) # :doc:
-          status = "#{self.class.name} transmitting #{data.inspect.truncate(300)}"
-          status += " (via #{via})" if via
-          logger.debug(status)
+          logger.debug do
+            status = "#{self.class.name} transmitting #{data.inspect.truncate(300)}"
+            status += " (via #{via})" if via
+            status
+          end
 
           payload = { channel_class: self.class.name, data: data, via: via }
           ActiveSupport::Notifications.instrument("transmit.action_cable", payload) do

--- a/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+++ b/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
@@ -30,14 +30,14 @@ module ActionCable
       end
 
       %i( debug info warn error fatal unknown ).each do |severity|
-        define_method(severity) do |message|
-          log severity, message
+        define_method(severity) do |message = nil, &block|
+          log severity, message, &block
         end
       end
 
       private
-        def log(type, message) # :doc:
-          tag(@logger) { @logger.send type, message }
+        def log(type, message, &block) # :doc:
+          tag(@logger) { @logger.send type, message, &block }
         end
     end
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

[Currently](https://github.com/rails/rails/blob/0ccde297a1db34703ebf332ce21ceeb9e2fcb6ac/actioncable/lib/action_cable/channel/base.rb#L215) on every call to `ActionCable::Channel::Base#transmit`, debug log message is generated that inspects the provided `data` object. The message is generated even if the logger's level is above `WARN`. This patch makes it so the message is generated only when it can be logged.

### Detail
In a [very similar scenario](https://github.com/rails/rails/blob/0ccde297a1db34703ebf332ce21ceeb9e2fcb6ac/actioncable/lib/action_cable/server/broadcasting.rb#L45) in `ActionCable::Server::Broadcasting::Broadcaster#broadcast` debug method with a block is used. To use the same call in `ActionCable::Channel::Base#transmit`, TaggedLoggerProxy must pass block to the wrapped logger.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [*] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [*] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [*] Tests are added or updated if you fix a bug or add a feature.
* [*] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
