### PR TITLE
Improve readability of case sensitivity description

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -738,9 +738,9 @@ details about multiple column indexes or [the PostgreSQL manual][] for examples
 of unique constraints that refer to a group of columns.
 
 There is also a `:case_sensitive` option that you can use to define whether the
-uniqueness constraint will be case sensitive, case insensitive, or respects
-default database collation. This option defaults to respects default database
-collation.
+uniqueness constraint will be case sensitive, case insensitive, or if it should
+respect the default database collation. This option defaults to respecting the
+default database collation.
 
 ```ruby
 class Person < ApplicationRecord


### PR DESCRIPTION
### Motivation / Background

This pull request is meant to improve the readability and grammar of the paragraph explaining case sensitivity with regards to uniqueness constraints as part of the validations guide.