### PR TITLE
Fix inconsistencies writing credentials values

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -4,6 +4,7 @@ require "yaml"
 require "active_support/encrypted_file"
 require "active_support/ordered_options"
 require "active_support/core_ext/object/inclusion"
+require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/module/delegation"
 
 module ActiveSupport
@@ -42,7 +43,6 @@ module ActiveSupport
       end
     end
 
-    delegate :[], :fetch, to: :config
     delegate_missing_to :options
 
     def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
@@ -84,7 +84,7 @@ module ActiveSupport
       def deep_transform(hash)
         return hash unless hash.is_a?(Hash)
 
-        h = ActiveSupport::InheritableOptions.new
+        h = ActiveSupport::OrderedOptions.new
         hash.each do |k, v|
           h[k] = deep_transform(v)
         end

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -56,6 +56,16 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal @credentials.config, {}
   end
 
+  test "writing with element assignment and reading with element reference" do
+    @credentials[:foo] = 42
+    assert_equal 42, @credentials[:foo]
+  end
+
+  test "writing with dynamic accessor and reading with element reference" do
+    @credentials.foo = 42
+    assert_equal 42, @credentials[:foo]
+  end
+
   test "change configuration by key file" do
     @credentials.write({ something: { good: true } }.to_yaml)
     @credentials.change do |config_file|


### PR DESCRIPTION
Using [] or the dynamic accessors don't result in the same value because `[]` is delegated to `config` (the decrypted deserialized YAML), whereas `[]=` and the dynamic accessors are delegated to `options`, an ActiveSupport::OrderedOptions instance.

### Motivation / Background

With the deprecation of secrets, we want to fix [ejson-rails](https://github.com/Shopify/ejson-rails) to write to credentials instead. Doing so showed that merging a hash directly into `Rails.application.credentials` resulted in credentials not being readable with element reference (`[]`). Reducing the reproduction steps showed simple failures like:

```ruby
Rails.application.credentials.foo = 42
Rails.application.credentials[:foo] # => nil
```

or even more surprising:
```ruby
Rails.application.credentials[:foo] = 42
Rails.application.credentials[:foo] # => nil
```

### Detail

The reason is that `[]` and `fetch` are delegated to `config` (the decrypted deserialized YAML configuration), whereas the dynamic accessor (e.g. `foo=`) and the element assignment (`[]=`) would write directly to `options` (the config transformed into an OrderedOptions instance).

<details>
<summary>Bug reproduction script</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  # Activate the gem you are reporting the issue against.
  gem "activesupport", "~> 7.0.0"
  # gem "activesupport", path: "activesupport" # run locally
  gem "debug"
end

require "minitest/autorun"
require "tmpdir"
require "fileutils"
require "active_support"
require "active_support/core_ext/hash/keys" # missing from active_support/encrypted_configuration
require "active_support/encrypted_configuration"

class BugTest < Minitest::Test
  def setup
    super
    @tmpdir = Dir.mktmpdir
    @credentials = ActiveSupport::EncryptedConfiguration.new(
      config_path: "#@tmpdir/credentials",
      key_path: "#@tmpdir/key",
      env_key: "RAILS_KEY",
      raise_if_missing_key: false,
    )
  end

  def teardown
    super
    FileUtils.remove_entry(@tmpdir)
  end

  def test_dynamic_accessors_write_to_the_same_objects
    @credentials.foo = 42
    assert_equal 42, @credentials.foo
    assert_equal 42, @credentials[:foo] # fails
  end

  def test_dynamic_accessors_write_to_the_same_objects_nested
    set_credentials(bar: { baz: 42 })
    @credentials.bar.baz = 21
    assert_equal 21, @credentials.bar.baz
    assert_equal 21, @credentials[:bar][:baz] # fails
  end

  def test_dynamic_accessors_dont_prevent_updating_with_element_assignment
    set_credentials(baz: 42)
    @credentials.baz
    @credentials[:baz] = 21
    assert_equal 21, @credentials.baz
    assert_equal 21, @credentials[:baz] # fails
  end


  def test_dynamic_accessors_dont_prevent_updating_with_element_assignment_nested
    set_credentials(bar: { baz: 42 })
    @credentials.bar.baz
    @credentials[:bar][:baz] = 21
    assert_equal 21, @credentials[:bar][:baz]
    assert_equal 21, @credentials.bar.baz # fails
  end


  private
    def set_credentials(contents)
      File.binwrite(@credentials.key_path, ActiveSupport::EncryptedConfiguration.generate_key)
      @credentials.write(YAML.dump(contents))
    end
end
```

</details>



### Additional information

* I changed an instance of `InheritableOptions` with `OrderedOptions` (since it wasn't passing a parent, it was unnecessary).
* I also added a require that the test script showed was missing.
* Do I need a changelog? I doubt anyone was happily using the buggy behavior that wasn't writing, any usage that was working before is still working.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
