### PR TITLE
Detect if the editor is missing a wait flag and print a warning

### DIFF
--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -8,6 +8,8 @@ module Rails
     module Helpers
       module Editor
         private
+          EDITOR_DURATION_THRESHOLD = 1.second
+
           def editor
             ENV["VISUAL"].to_s.empty? ? ENV["EDITOR"] : ENV["VISUAL"]
           end
@@ -26,7 +28,15 @@ module Rails
           end
 
           def system_editor(file_path)
+            edit_start_time = Time.now.to_i
             system(*Shellwords.split(editor), file_path.to_s)
+            edit_end_time = Time.now.to_i
+            if edit_end_time - edit_start_time <= EDITOR_DURATION_THRESHOLD
+              say "It seems that the editor exited immediately. If this was unintentional, you"
+              say "may need to pass a wait flag to your editor command, so you have a chance"
+              say "to edit the file:"
+              say %(VISUAL="mate --wait" #{executable(current_subcommand)})
+            end
           end
 
           def using_system_editor

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -30,6 +30,18 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     end
   end
 
+  test "immediate exit does give wait flag hint" do
+    run_edit_command(visual: "", editor: "cat").tap do |output|
+      assert_match "It seems that the editor exited immediately.", output
+    end
+  end
+
+  test "delayed exit does not give wait flag hint" do
+    run_edit_command(visual: "", editor: "nano").tap do |output|
+      assert_no_match "It seems that the editor exited immediately.", output
+    end
+  end
+
   test "edit credentials" do
     # Run twice to ensure credentials can be reread after first edit pass.
     2.times do


### PR DESCRIPTION
### Motivation / Background

The current code for commands such as `credentials:edit` detects whether $EDITOR or $VISUAL are set, and tells the developer to set them to something like `EDITOR=mate --wait` if they are not. On systems where $EDITOR is set, but it launches a forking process, the message is not displayed and may never be seen by the developer.

### Description

This change detects whether the editor for commands like `credentials:edit` exits in less than one second, such as when `EDITOR` is set to `mate` without the wait flag. This is a sign that the editor process is forking and exited immediately, and that the developer didn't have a chance to edit the file.

If an immediate exit is detected, a message is printed that the editor command should be changed to wait instead of exiting.