### PR TITLE
Only show SMTP envelope recipient when relevant

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   In mailer preview, only show SMTP-To if it differs from the union of To, Cc and Bcc.
+
+    *Christian Schmidt*
+
 *   Enable YJIT by default on new applications running Ruby 3.3+
 
     Adds a `config/initializers/enable_yjit.rb` initializer that enables YJIT

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -61,14 +61,14 @@
 <body>
 <header>
   <dl>
-    <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
+    <% if Array(@email.from) != Array(@email.smtp_envelope_from) %>
       <dt>SMTP-From:</dt>
       <dd id="smtp_from"><%= @email.smtp_envelope_from %></dd>
     <% end %>
 
-    <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
+    <% if Set[*@email.to, *@email.cc, *@email.bcc] != Set[*@email.smtp_envelope_to] %>
       <dt>SMTP-To:</dt>
-      <dd id="smtp_to"><%= @email.smtp_envelope_to %></dd>
+      <dd id="smtp_to"><%= @email.smtp_envelope_to.join(", ") %></dd>
     <% end %>
 
     <dt>From:</dt>


### PR DESCRIPTION
### Motivation
The SMTP envelope recipient usually reflects the `To`, `Cc` and `Bcc` email headers. The mailer preview only shows SMTP the envelope recipient (SMTP-To) if it differs from `To`, but it does not take Cc and Bcc into account.

Screenshot:
![image](https://github.com/rails/rails/assets/111346/5ea59067-4c5c-480e-b550-e22ecfdc306c)

### Detail
This Pull Request extends the check for SMTP-To to cover also `Cc` and `Bcc`, so it is only displayed in the rare event that the envelope recipient has been manually overriden.

Also, show the list of email addresses without array brackets and quotes.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

