### PR TITLE
Do not use `alias_attribute` to alias an association

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -34,10 +34,6 @@ module ActiveRecord
       assert_equal [authors(:bob)], Author.joins(:categories).where(categories: categories(:technology))
     end
 
-    def test_where_with_aliased_association
-      assert_equal [comments(:does_it_hurt)], Comment.where(entry: posts(:thinking))
-    end
-
     def test_type_cast_is_not_evaluated_at_relation_build_time
       posts = nil
 

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -28,8 +28,6 @@ class Comment < ActiveRecord::Base
   has_many :children, class_name: "Comment", inverse_of: :parent
   belongs_to :parent, class_name: "Comment", counter_cache: :children_count, inverse_of: :children
 
-  alias_attribute :entry, :post
-
   enum label: [:default, :child]
 
   class ::OopsError < RuntimeError; end


### PR DESCRIPTION
For reference, the code I'm proposing to remove was added in https://github.com/rails/rails/pull/40835

Using `alias_attribute` to alias an association is not an indented use case. This commit removes `alias_attribute` calls to alias an association along with the relevant tests. However, it doesn't mean that the commit brakes any current behaviors.

Currently running Active Record tests result in a bunch of deprecation warnings issued related to `alias_attribute :entry, :post` definition. 
Example: 
```
DEPRECATION WARNING: Comment model aliases `post` and has a method called `post_changed?` defined. In Rails 7.2 `entry_changed?` will not call `post_changed?` anymore.
```

This is a falsey warning so in order to get rid of it we have two options:
- Fix the code that issues the warning to account for `alias_attribute` being used to alias an association
- Remove `alias_attribute` usages to alias an association so the warning goes away with them

Since aliasing an association using `alias_attribute` is not an intended use case I'm leaning towards removing it from the test suite. 
