### PR TITLE
Fix child association loading in `:n_plus_one_only` mode

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -303,7 +303,7 @@ module ActiveRecord
 
       def find_from_target?
         loaded? ||
-          owner.strict_loading? ||
+          (owner.strict_loading? && owner.strict_loading_all?) ||
           reflection.strict_loading? ||
           owner.new_record? ||
           target.any? { |record| record.new_record? || record.changed? }

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -704,6 +704,11 @@ module ActiveRecord
       @strict_loading_mode == :n_plus_one_only
     end
 
+    # Returns +true+ if the record uses strict_loading with +:all+ mode enabled.
+    def strict_loading_all?
+      @strict_loading_mode == :all
+    end
+
     # Marks this record as read only.
     #
     #   customer = Customer.first

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -86,6 +86,18 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_n_plus_one_only_mode_does_not_eager_load_child_associations
+    developer = Developer.first
+    developer.strict_loading!(mode: :n_plus_one_only)
+    developer.projects.first
+
+    assert_not_predicate developer.projects, :loaded?
+
+    assert_nothing_raised do
+      developer.projects.first.firm
+    end
+  end
+
   def test_strict_loading
     Developer.all.each { |d| assert_not d.strict_loading? }
     Developer.strict_loading.each { |d| assert_predicate d, :strict_loading? }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes #49473

Strict loading in `:n_plus_one_only` mode is designed to prevent performance issues when deeply traversing associations. It allows `Person.find(1).posts`, but _not_ `Person.find(1).posts.map(&:category)`. This fix avoids the surprise that occurs when `person.posts.first` eagerly loads the whole association rather than allowing the user to manage the child association.

This fixes a serious ordering issue. Without strict loading, `person.posts.first` is guaranteed to return the first post in primary key order. On the other hand, `person.posts.load.first` is nondeterministic. The database is not guaranteed to return in a consistent order, in particular under load with other operations occurring. This is a rude surprise when trying to use `:n_plus_one_only` mode.

### Detail

Before:

```ruby
person = Person.find(1)
person.strict_loading!(mode: :n_plus_one_only)
person.posts.first
# SELECT * FROM posts WHERE person_id = 1; -- non-deterministic order
```

After:

```ruby
person = Person.find(1)
person.strict_loading!(mode: :n_plus_one_only)
person.posts.first # this is 1+1, not N+1
# SELECT * FROM posts WHERE person_id = 1 ORDER BY id LIMIT 1;
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
