### PR TITLE
Fix: Do not execute selenium driver_path if it is a string.

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -33,9 +33,9 @@ module ActionDispatch
       def preload
         case type
         when :chrome
-          ::Selenium::WebDriver::Chrome::Service.driver_path&.call
+          ::Selenium::WebDriver::Chrome::Service.driver_path.try(:call)
         when :firefox
-          ::Selenium::WebDriver::Firefox::Service.driver_path&.call
+          ::Selenium::WebDriver::Firefox::Service.driver_path.try(:call)
         end
       end
 

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -28,6 +28,14 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
+  test "initializing the driver with a headless chrome and custom path" do
+    original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
+    ::Selenium::WebDriver::Chrome::Service.driver_path = "bin/test"
+    ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_chrome, screen_size: [1400, 1400])
+  ensure
+    ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
+  end
+
   test "initializing the driver with a headless firefox" do
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_firefox, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
     assert_equal :selenium, driver.instance_variable_get(:@driver_type)
@@ -35,6 +43,14 @@ class DriverTest < ActiveSupport::TestCase
     assert_instance_of Selenium::WebDriver::Firefox::Options, driver.instance_variable_get(:@browser).options
     assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
+  end
+
+  test "initializing the driver with a headless firefox and custom path" do
+    original_driver_path = ::Selenium::WebDriver::Firefox::Service.driver_path
+    ::Selenium::WebDriver::Firefox::Service.driver_path = "bin/test"
+    ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_firefox, screen_size: [1400, 1400])
+  ensure
+    ::Selenium::WebDriver::Firefox::Service.driver_path = original_driver_path
   end
 
   test "initializing the driver with a cuprite" do


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/commit/af2129b4c74732c88ffce76e5c55c805cb9431f6#diff-b39ef19c83412a9c4f132238a266be37e0bc7ed6f1e9d3fc4f98684ba3f6dabc the try calls were improperly replaced by &.

### Detail

The driver path can be a string (a filesystem path), here is an example from selenium specs: https://github.com/SeleniumHQ/selenium/blob/1d459cd52850d3d5189c3003a9dfa2b53b98cacd/rb/lib/selenium/webdriver/safari.rb#L36

### Additional information

I'm not sure about the test as it is kind of hackish

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
