### PR TITLE
Added test for --no-skip-docker command line argument

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1085,6 +1085,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bin/docker-entrypoint"
   end
 
+  def test_no_skip_docker
+    run_generator [destination_root, "--no-skip-docker"]
+
+    assert_file ".dockerignore"
+    assert_file "Dockerfile"
+    assert_file "bin/docker-entrypoint"
+  end
+
   def test_system_tests_directory_generated
     run_generator
 


### PR DESCRIPTION
### Detail
#46762 Added the default Dockerfiles for new rails applications. These files can be skipped via the `--skip-docker` argument.
Right now we only have a test for `--skip-docker`. So this PR introduces tests for the `--no-skip-docker` command line argument.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
