### PR TITLE
Tweak `alias_attribute` deprecation message

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -95,7 +95,7 @@ module ActiveRecord
 
           ActiveModel.deprecator.warn(
             "#{self} model aliases `#{old_name}` and has a method called `#{target_name}` defined. " \
-            "Since Rails 7.2 `#{method_name}` will not be calling `#{target_name}` anymore. " \
+            "Starting in Rails 7.2 `#{method_name}` will not be calling `#{target_name}` anymore. " \
             "You may want to additionally define `#{method_name}` to preserve the current behavior."
           )
           super

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1156,7 +1156,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "#alias_attribute with an overridden original method issues a deprecation" do
     message = <<~MESSAGE.gsub("\n", " ")
     AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehavior model aliases `title` and has a method called
-    `title_was` defined. Since Rails 7.2 `subject_was` will not be calling `title_was` anymore.
+    `title_was` defined. Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
     You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 
@@ -1183,7 +1183,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "#alias_attribute with an overridden original method from a module issues a deprecation" do
     message = <<~MESSAGE.gsub("\n", " ")
     AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehaviorFromModule model aliases `title` and has a method
-    called `title_was` defined. Since Rails 7.2 `subject_was` will not be calling `title_was` anymore.
+    called `title_was` defined. Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
     You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 


### PR DESCRIPTION
Addresses https://github.com/rails/rails/pull/48533#issuecomment-1648055838

A tiny tweak to the deprecation message. It might be a good time to double check the whole message. Should it actually be "Starting **from**" ?
