### PR TITLE
Fix `#previously_new_record?` on destroyed records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `#previously_new_record?` to return true for destroyed records.
+
+    Before, if a record was created and then destroyed, `#previously_new_record?` would return true.
+    Now, any UPDATE or DELETE to a record is considered a change, and will result in `#previously_new_record?`
+    returning false.
+
+    *Adrianna Chang*
+
 *   Specify callback in `has_secure_token`
 
     ```ruby

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -661,7 +661,7 @@ module ActiveRecord
     end
 
     # Returns true if this object was just created -- that is, prior to the last
-    # save, the object didn't exist in the database and new_record? would have
+    # update or delete, the object didn't exist in the database and new_record? would have
     # returned true.
     def previously_new_record?
       @previously_new_record
@@ -760,6 +760,7 @@ module ActiveRecord
     def delete
       _delete_row if persisted?
       @destroyed = true
+      @previously_new_record = false
       freeze
     end
 
@@ -775,6 +776,7 @@ module ActiveRecord
       destroy_associations
       @_trigger_destroy_callback ||= persisted? && destroy_row > 0
       @destroyed = true
+      @previously_new_record = false
       freeze
     end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -968,6 +968,14 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal false, Topic.find(1).previously_new_record?
   end
 
+  def test_previously_new_record_on_destroyed_record
+    topic = Topic.create
+    assert_predicate topic, :previously_new_record?
+
+    topic.destroy
+    assert_not_predicate topic, :previously_new_record?
+  end
+
   def test_previously_persisted_returns_boolean
     assert_equal false, Topic.new.previously_persisted?
     assert_equal false, Topic.new.destroy.previously_persisted?


### PR DESCRIPTION
### Motivation / Background

Ref: #48794
cc @eizengan

Based on the [documentation](https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-previously_new_record-3F) for `#previously_new_record?`:
> Returns true if this object was just created – that is, prior to the last save, the object didn't exist in the database and new_record? would have returned true.

IMO a record that was previously created and has since been destroyed and removed from the database should no longer be considered "just created", although one could argue that a `DELETE` is different from a "save".

### Detail

Set `@previously_new_record` to `false` in `#destroy` and `#delete` methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

