### PR TITLE
Introduce `capture_emails` and `capture_broadcasts`

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -13,17 +13,12 @@
 
     *Joé Dupuis*
 
-*   `assert_broadcasts` now returns the messages that were broadcast.
+*   Introduce the `capture_broadcasts` test helper.
 
-    This makes it easier to do further analysis on those messages:
+    Returns all messages broadcast in a block.
 
     ```ruby
-    message = assert_broadcasts("test", 1) do
-      ActionCable.server.broadcast "test", "message"
-    end
-    assert_equal "message", message
-
-    messages = assert_broadcasts("test", 2) do
+    messages = capture_broadcasts("test") do
       ActionCable.server.broadcast "test", { message: "one" }
       ActionCable.server.broadcast "test", { message: "two" }
     end

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -52,12 +52,6 @@ module ActionCable
 
         actual_count = new_messages.size
         assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
-
-        if new_messages.size == 1
-          ActiveSupport::JSON.decode(new_messages.first)
-        else
-          new_messages.map { |m| ActiveSupport::JSON.decode(m) }
-        end
       else
         actual_count = broadcasts(stream).size
         assert_equal number, actual_count, "#{number} broadcasts to #{stream} expected, but #{actual_count} were sent"
@@ -86,6 +80,22 @@ module ActionCable
     #
     def assert_no_broadcasts(stream, &block)
       assert_broadcasts stream, 0, &block
+    end
+
+    # Returns the messages that are broadcasted in the block.
+    #
+    #   def test_broadcasts
+    #     messages = capture_broadcasts('messages') do
+    #       ActionCable.server.broadcast 'messages', { text: 'hi' }
+    #       ActionCable.server.broadcast 'messages', { text: 'how are you?' }
+    #     end
+    #     assert_equal 2, messages.length
+    #     assert_equal({ text: 'hi' }, messages.first)
+    #     assert_equal({ text: 'how are you?' }, messages.last)
+    #   end
+    #
+    def capture_broadcasts(stream, &block)
+      new_broadcasts_from(broadcasts(stream), stream, "capture_broadcasts", &block).map { |m| ActiveSupport::JSON.decode(m) }
     end
 
     # Asserts that the specified message has been sent to the stream.

--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -14,13 +14,13 @@ class TransmissionsTest < ActionCable::TestCase
     end
   end
 
-  def test_assert_broadcasts_returns_broadcast_messages_if_block_given
-    message = assert_broadcasts("test", 1) do
+  def test_capture_broadcasts
+    messages = capture_broadcasts("test") do
       ActionCable.server.broadcast "test", "message"
     end
-    assert_equal "message", message
+    assert_equal "message", messages.first
 
-    messages = assert_broadcasts("test", 2) do
+    messages = capture_broadcasts("test") do
       ActionCable.server.broadcast "test", { message: "one" }
       ActionCable.server.broadcast "test", { message: "two" }
     end

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -86,18 +86,13 @@
 
     *Sean Doyle*
 
-*   `assert_emails` now returns the emails that were sent.
+*   Introduce the `capture_emails` test helper.
 
-    This makes it easier to do further analysis on those emails:
+    Returns all emails that are sent in a block.
 
     ```ruby
-    def test_emails_more_thoroughly
-      email = assert_emails 1 do
-        ContactMailer.welcome.deliver_now
-      end
-      assert_email "Hi there", email.subject
-
-      emails = assert_emails 2 do
+    def test_emails
+      emails = capture_emails do
         ContactMailer.welcome.deliver_now
         ContactMailer.welcome.deliver_later
       end

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -95,16 +95,17 @@ class TestHelperMailerTest < ActionMailer::TestCase
     end
   end
 
-  def test_assert_emails_returns_the_emails_that_were_sent_if_a_block_is_given
+  def test_capture_emails
     assert_nothing_raised do
-      email = assert_emails 1 do
+      emails = capture_emails do
         TestHelperMailer.test.deliver_now
       end
+      email = emails.first
       assert_instance_of Mail::Message, email
       assert_equal "Hello, Earth", email.body.to_s
       assert_equal "Hi!", email.subject
 
-      emails = assert_emails 2 do
+      emails = capture_emails do
         TestHelperMailer.test.deliver_now
         TestHelperMailer.test.deliver_now
       end


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/47025#issuecomment-1647788766, https://github.com/rails/rails/pull/47793#issuecomment-1647790178

Addresses @dhh feedback that there should be no side effects on `assert_emails` and `assert_broadcasts`.

Neither of those PRs have been included in a Rails release yet so I think it is fine to make a breaking change to them.
