### PR TITLE
Clarify on how to return records in order of ids in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -18,7 +18,9 @@ module ActiveRecord
     #   Person.find([1])        # returns an array for the object with ID = 1
     #   Person.where("administrator = 1").order("created_on DESC").find(1)
     #
-    # NOTE: The returned records are in the same order as the ids you provide.
+    # NOTE: The returned records are in the same order as the ids you provide,
+    # but only if there is no order on the scope.
+    #
     # If you want the results to be sorted by database, you can use ActiveRecord::QueryMethods#where
     # method and provide an explicit ActiveRecord::QueryMethods#order option.
     # But ActiveRecord::QueryMethods#where method doesn't raise ActiveRecord::RecordNotFound.


### PR DESCRIPTION
#### Motivation

I was bitten by a subtle bug where code was depending on the order of records being returned by `.find`, however turns out `reorder("")` does not actually clear the order scope, which meant that the order of results was not the order of the ids being passed in.

This change makes it clearer what is required to have records be returned in order.