### PR TITLE
Change lanes to update callbacks when an autosaved record already exists

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -926,6 +926,10 @@ module ActiveRecord
       # Creates a record with values matching those of the instance attributes
       # and returns its id.
       def _create_record(attribute_names = self.attribute_names)
+        if !new_record?
+          return _update_record
+        end
+
         attribute_names = attributes_for_create(attribute_names)
 
         self.class.with_connection do |connection|

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -381,6 +381,40 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
   end
 end
 
+class TestAutosaveAssociationCallbacksOnAHasOneAssociation < ActiveRecord::TestCase
+  class SpecialAccount < Account
+    belongs_to :firm, class_name: "Company", inverse_of: :account
+
+    before_create :update_firm_status
+    after_update :update_firm_name
+    after_create :update_account_status
+
+    def update_firm_status
+      firm.update!(status: :suspended)
+    end
+
+    def update_firm_name
+      firm.update!(name: "Toyota")
+    end
+
+    def update_account_status
+      update(status: "excellent")
+    end
+  end
+
+  def test_should_not_create_duplicate_records_on_before_create
+    firm = Firm.create!(name: "Fujitsu")
+
+    assert_difference "Account.count", +1 do
+      account = SpecialAccount.create!(credit_limit: 0, firm: firm)
+
+      assert_equal "suspended", firm.status
+      assert_equal "Toyota", account.firm.name
+      assert_equal "excellent", account.status
+    end
+  end
+end
+
 class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   fixtures :companies, :posts, :tags, :taggings
 


### PR DESCRIPTION
### Motivation / Background

This address the bug identified in #47171, which is occurs when an autosave is triggered in a before_create, resulting in a the create callbacks occurring twice. The second time on a record that was already persisted, but since there are no attributes changed (it's a clean record), the new record receives the default values.

Now when an autosave occurs in a before_create, we run the update callbacks as well as any create callbacks to avoid confusing situation.

### Alternatives Considered

#### 1) Call an aliased method `_update_record_without_callbacks` and return

This would avoid creating the duplicate record, but may surprise the developer if any `after_*` callbacks they were expecting didn't occur.

We wanted to retain that same guarantee.

#### 2) Raise if the record is already persisted

The previous behavior of creating multiple records may have simply gone unnoticed to users, and raising would be a breaking change.

We could roll out that behavior behind a flag and deprecation warning, but we wanted to try and solve for this edge-case.

#### 3) Return if record is already persisted and no dirty changes

Similar to the second option, silently allowing this behavior to change could have unexpected consequences.

The interesting thing was also non of the Active Record tests failed if we just stopped the callback chain there.

### Additional information

Fixes #47171