### PR TITLE
Revert singular association breaking changes

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -92,10 +92,6 @@ module ActiveRecord
           replace(record, false)
         end
 
-        def replace_keys(record, force: false)
-          # Has one association doesn't have foreign keys to replace.
-        end
-
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -54,13 +54,11 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false, &block)
-          reflection.klass.transaction do
-            record = build(attributes, &block)
-            saved = record.save
-            set_new_record(record)
-            raise RecordInvalid.new(record) if !saved && raise_error
-            record
-          end
+          record = build_record(attributes, &block)
+          saved = record.save
+          set_new_record(record)
+          raise RecordInvalid.new(record) if !saved && raise_error
+          record
         end
     end
   end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            replace_keys(record, force: true)
+            set_new_record(record)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -20,8 +20,6 @@ require "models/club"
 require "models/membership"
 require "models/parrot"
 require "models/cpk"
-require "models/user"
-require "models/content"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -917,47 +915,6 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       car.build_special_bulb
     end
   end
-
-  class InvalidPost < Post
-    validate :always_fail
-
-    def always_fail
-      errors.add(:base, "Oops")
-    end
-  end
-
-  test "preserve old record if new one is invalid" do
-    author = Author.create!(id: 33, name: "Hank Moody")
-    author.create_post!(id: 1234, title: "Some title", body: "Some content")
-
-    assert_no_difference -> { Post.count } do
-      assert_raises ActiveRecord::RecordNotSaved do
-        author.post = InvalidPost.new(title: "Some title", body: "Some content")
-      end
-      author.save!
-    end
-  end
-
-  class SpecialContentPosition < ActiveRecord::Base
-    self.table_name = "content_positions"
-    belongs_to :content, class_name: name + "::SpecialContentPosition"
-    validates :content_id, presence: true, uniqueness: true
-  end
-
-  class SpecialContent < ActiveRecord::Base
-    self.table_name = "content"
-    has_one :content_position, dependent: :destroy, foreign_key: :content_id, class_name: SpecialContentPosition.name
-  end
-
-  test "uniqueness validator doesn't prevent from replacing the old record if dependent: :destroy is set" do
-    content = SpecialContent.create!
-    content.create_content_position!
-
-    assert_no_difference -> { ContentPosition.count } do
-      content.create_content_position!
-    end
-  end
-
   test "composite primary key malformed association class" do
     error = assert_raises(ActiveRecord::CompositePrimaryKeyMismatchError) do
       order = Cpk::BrokenOrder.new(id: [1, 2], book: Cpk::Book.new(title: "Some book"))


### PR DESCRIPTION
Pumping the breaks on the recent changes to singular create associations.

This reverts the tests added in #48416 (which added back the behavior from #46790), and the original breaking change from #46386.

While this breaks the behavior expected from #46737 and #47554, it restores the original behavior expected of `create_record` on a singular association which has persisted for many years. Due to this change, reports came in about the uniqueness validation failing, such as #48632 and #48330, as well as breaking many tests in one of the applications at work.

This lead to attempts to circumvent this breaking change like #48643, and others to try and prevent the support of the original behavior by raising in #48683.

These are hard problems to solve, and after discussing with @matthewd, the best path forward is to revert and start from scratch. Then we can discuss future changes to this behavior over new PRs.

---

There is an equivalent PR for `7-0-stable` at #48809

/cc @byroot 