### PR TITLE
[7-0-stable] Revert singular association breaking changes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Revert breaking changes to `has_one` relationship deleting the old record before the new one is validated.
+
+    *zzak*
+
 *   Fix support for Active Record instances being uses in queries.
 
     As of `7.0.5`, query arguments were deep duped to avoid mutations impacting
@@ -21,6 +25,10 @@
 *   Preserve timestamp when setting an `ActiveSupport::TimeWithZone` value to `timestamptz` attribute.
 
     *fatkodima*
+
+*   Fix assignment into an `has_one` relationship deleting the old record before the new one is validated.
+
+    *Jean Boussier*
 
 *   Fix where on association with has_one/has_many polymorphic relations.
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -87,10 +87,6 @@ module ActiveRecord
           replace(record, false)
         end
 
-        def replace_keys(record, force: false)
-          # Has one association doesn't have foreign keys to replace.
-        end
-
         def remove_target!(method)
           case method
           when :delete

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -54,13 +54,11 @@ module ActiveRecord
         end
 
         def _create_record(attributes, raise_error = false, &block)
-          reflection.klass.transaction do
-            record = build(attributes, &block)
-            saved = record.save
-            set_new_record(record)
-            raise RecordInvalid.new(record) if !saved && raise_error
-            record
-          end
+          record = build_record(attributes, &block)
+          saved = record.save
+          set_new_record(record)
+          raise RecordInvalid.new(record) if !saved && raise_error
+          record
         end
     end
   end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -57,7 +57,7 @@ module ActiveRecord
           reflection.klass.transaction do
             record = build(attributes, &block)
             saved = record.save
-            replace_keys(record, force: true)
+            set_new_record(record)
             raise RecordInvalid.new(record) if !saved && raise_error
             record
           end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1428,15 +1428,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.id, client.client_of
   end
 
-  def test_should_set_foreign_key_on_create_association_with_unpersisted_owner
-    tagging = Tagging.new
-    tag = tagging.create_tag
-
-    assert_not_predicate tagging, :persisted?
-    assert_predicate tag, :persisted?
-    assert_equal tag.id, tagging.tag_id
-  end
-
   def test_self_referential_belongs_to_with_counter_cache_assigning_nil
     comment = Comment.create! post: posts(:thinking), body: "fuu"
     comment.parent = nil


### PR DESCRIPTION
For the `7-0-stable` branch, this reverts the tests added in #48425, and the original breaking change from #46790.

While this breaks the behavior expected from #46737 and #47554, it restores the original behavior expected of `create_record` on a singular association which has persisted for many years. Due to this change, reports came in about the uniqueness validation failing, such as #48632 and #48330, as well as breaking many tests in one of the applications at work.

This lead to attempts to circumvent this breaking change like #48643, and others to try and prevent the support of the original behavior by raising in #48683.

These are hard problems to solve, and after discussing with @matthewd, the best path forward is to revert and start from scratch. Then we can discuss future changes to this behavior over new PRs.


---

There is an equivalent PR for `main` at #48808

/cc @byroot