### PR TITLE
Add Rack::Lint to ActionDispatch::Callbacks tests

### DIFF
--- a/actionpack/test/dispatch/callbacks_test.rb
+++ b/actionpack/test/dispatch/callbacks_test.rb
@@ -39,8 +39,16 @@ class DispatcherTest < ActiveSupport::TestCase
 
   private
     def dispatch(&block)
-      ActionDispatch::Callbacks.new(block || DummyApp.new).call(
-        "rack.input" => StringIO.new("")
-      )
+      app = block || DummyApp.new
+      env = Rack::MockRequest.env_for("", {})
+      wrap_in_rack_lint(ActionDispatch::Callbacks, app, env)
+    end
+
+    def wrap_in_rack_lint(klass, app, env)
+      Rack::Lint.new(
+        klass.new(
+          Rack::Lint.new(app)
+        )
+      ).call(env)
     end
 end


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

This adds additional test coverage for ActionDispatch::Callbacks by validating that its input and output follow the Rack SPEC.

- https://github.com/skipkayhil/tmp-rails/issues/1

### Detail

`ActionDispatch::Callbacks` makes no changes to the input or output of the Rack app itself, so these tests are trivial.

### Additional information

The `"rack.input" => StringIO.new("")` header value raised the following error:

```
Rack::Lint::LintError: rack.input #<StringIO:0x00007fd7513fe550> does not have ASCII-8BIT as its external encoding
```

Since this header is not required for the test, it is now removed.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
