### PR TITLE
Add Rack::Lint to AssumeSSL middleware tests

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -14,7 +14,7 @@ module ActionDispatch
 
     def call(env)
       env["HTTPS"] = "on"
-      env["HTTP_X_FORWARDED_PORT"] = 443
+      env["HTTP_X_FORWARDED_PORT"] = "443"
       env["HTTP_X_FORWARDED_PROTO"] = "https"
       env["rack.url_scheme"] = "https"
 

--- a/actionpack/test/dispatch/assume_ssl_test.rb
+++ b/actionpack/test/dispatch/assume_ssl_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class AssumeSSLTest < ActiveSupport::TestCase
+  test "sets expected headers" do
+    app = lambda { |_env| [ 200, {}, [] ] }
+    env = Rack::MockRequest.env_for("", {})
+
+    Rack::Lint.new(
+      ActionDispatch::AssumeSSL.new(
+        Rack::Lint.new(app)
+      )
+    ).call(env)
+
+    assert_equal "on", env["HTTPS"]
+    assert_equal "443", env["HTTP_X_FORWARDED_PORT"]
+    assert_equal "https", env["HTTP_X_FORWARDED_PROTO"]
+    assert_equal "https", env["rack.url_scheme"]
+  end
+end


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

- https://github.com/skipkayhil/tmp-rails/issues/1

### Detail

There was no test file for ActionDispatch::AssumeSSL, so this change
adds one and validating that its input and output follow the Rack SPEC.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
