### PR TITLE
Add Rack::Lint to ContentSecurityPolicy::Middleware tests

### DIFF
--- a/actionpack/lib/action_dispatch/constants.rb
+++ b/actionpack/lib/action_dispatch/constants.rb
@@ -8,12 +8,16 @@ module ActionDispatch
     if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
       VARY = "Vary"
       CONTENT_ENCODING = "Content-Encoding"
+      CONTENT_SECURITY_POLICY = "Content-Security-Policy"
+      CONTENT_SECURITY_POLICY_REPORT_ONLY = "Content-Security-Policy-Report-Only"
       LOCATION = "Location"
       FEATURE_POLICY = "Feature-Policy"
       X_REQUEST_ID = "X-Request-Id"
     else
       VARY = "vary"
       CONTENT_ENCODING = "content-encoding"
+      CONTENT_SECURITY_POLICY = "content-security-policy"
+      CONTENT_SECURITY_POLICY_REPORT_ONLY = "content-security-policy-report-only"
       LOCATION = "location"
       FEATURE_POLICY = "feature-policy"
       X_REQUEST_ID = "x-request-id"

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -25,10 +25,6 @@ module ActionDispatch # :nodoc:
   #   end
   class ContentSecurityPolicy
     class Middleware
-      CONTENT_TYPE = "Content-Type"
-      POLICY = "Content-Security-Policy"
-      POLICY_REPORT_ONLY = "Content-Security-Policy-Report-Only"
-
       def initialize(app)
         @app = app
       end
@@ -57,14 +53,15 @@ module ActionDispatch # :nodoc:
       private
         def header_name(request)
           if request.content_security_policy_report_only
-            POLICY_REPORT_ONLY
+            ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY
           else
-            POLICY
+            ActionDispatch::Constants::CONTENT_SECURITY_POLICY
           end
         end
 
         def policy_present?(headers)
-          headers[POLICY] || headers[POLICY_REPORT_ONLY]
+          headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY] ||
+            headers[ActionDispatch::Constants::CONTENT_SECURITY_POLICY_REPORT_ONLY]
         end
     end
 


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

### Detail

This adds additional test coverage to `ContentSecurityPolicy::Middleware` to validate that its input and output follow the Rack SPEC.

The changes made are because of:
- [Response Headers must be lower case](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md#response-headers-must-be-lower-case)

Added tests to ensure that CSP headers set by an app are not overridden, regardless of the casing.
An example of this is Sidekiq: https://github.com/sidekiq/sidekiq/blob/b3225ce/lib/sidekiq/web/application.rb#L353


### Additional information

- https://github.com/skipkayhil/tmp-rails/issues/1
- https://github.com/rails/rails/issues/48815

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
