### PR TITLE
Add Rack::Lint to ActionableExceptions tests

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -38,10 +38,14 @@ module ActionDispatch # :nodoc:
       # For `Rack::Headers` (Rack 3+):
       require "rack/headers"
       Headers = ::Rack::Headers
+
+      LOCATION = "location"
     rescue LoadError
       # For `Rack::Utils::HeaderHash`:
       require "rack/utils"
       Headers = ::Rack::Utils::HeaderHash
+
+      LOCATION = "Location"
     end
 
     # To be deprecated:
@@ -81,7 +85,6 @@ module ActionDispatch # :nodoc:
 
     CONTENT_TYPE = "Content-Type"
     SET_COOKIE   = "Set-Cookie"
-    LOCATION     = "Location"
     NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304]
 
     cattr_accessor :default_charset, default: "utf-8"

--- a/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
@@ -32,13 +32,13 @@ module ActionDispatch
         if uri.relative? || uri.scheme == "http" || uri.scheme == "https"
           body = ""
         else
-          return [400, { "Content-Type" => "text/plain; charset=utf-8" }, ["Invalid redirection URI"]]
+          return [400, { Rack::CONTENT_TYPE => "text/plain; charset=utf-8" }, ["Invalid redirection URI"]]
         end
 
         [302, {
-          "Content-Type" => "text/html; charset=#{Response.default_charset}",
-          "Content-Length" => body.bytesize.to_s,
-          "Location" => location,
+          Rack::CONTENT_TYPE => "text/html; charset=#{Response.default_charset}",
+          Rack::CONTENT_LENGTH => body.bytesize.to_s,
+          ActionDispatch::Response::LOCATION => location,
         }, [body]]
       end
   end


### PR DESCRIPTION
### Motivation / Background

Ref skipkayhil#5

This adds additional test coverage to ActionableExceptions to validate that its behavior conforms to the Rack SPEC.

### Detail

The changes neccesary were to ensure that Response headers are downcased when using Rack 3. For Content-Type and Content-Length, this is trivial because Rack provides constants who's casing is dependent on the version (Rack 2 is mixed, and Rack 3 is downcased). Since Rack does not include a LOCATION constant, the Response::LOCATION constant was updated to have a downcased value when using Rack 3.

Additionally, there was some missing coverage for invalid redirect URLs which was addressed as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
