### PR TITLE
Warn if non-AR object passed to `FinderMethods#include?`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -352,6 +352,17 @@ module ActiveRecord
     # compared to the records in memory. If the relation is unloaded, an
     # efficient existence query is performed, as in #exists?.
     def include?(record)
+      if !record.is_a?(klass)
+        message = <<~MSG.squish
+          `#{self.class}#include?` expects an Active Record instance as an argument but got `#{record.class}`.
+          Starting in Rails 7.2 `#{self.class}#include?` will raise on any value passed other than an Active Record
+          instance of a correct class.
+        MSG
+        ActiveRecord.deprecator.warn(message)
+        # since it's not an AR record we know it can't be part of the relation
+        return false
+      end
+
       if loaded? || offset_value || limit_value || having_clause.any?
         records.include?(record)
       else
@@ -360,7 +371,8 @@ module ActiveRecord
         else
           record.id
         end
-        record.is_a?(klass) && exists?(id)
+
+        exists?(id)
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -411,6 +411,22 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_include_with_non_AR_object_returns_false_and_warns
+    customer_name = customers(:david).name
+    assert_no_queries do
+      result = nil
+      expected_message = <<~MSG.squish
+      `Customer::ActiveRecord_Relation#include?` expects an Active Record instance as an argument but got `String`.
+          Starting in Rails 7.2 `Customer::ActiveRecord_Relation#include?` will raise on any value passed other than
+          an Active Record instance of a correct class.
+      MSG
+      assert_deprecated(expected_message, ActiveRecord.deprecator) do
+        result = Customer.where(name: customer_name).include?("I am not an AR instance")
+      end
+      assert_equal false, result
+    end
+  end
+
   def test_include_on_unloaded_relation_with_match
     assert_sql(/1 AS one.*LIMIT/) do
       assert_equal true, Customer.where(name: "David").include?(customers(:david))
@@ -428,7 +444,16 @@ class FinderTest < ActiveRecord::TestCase
     assert Customer.exists?(topic.id)
 
     assert_no_queries do
-      assert_equal false, Customer.where(name: "David").include?(topic)
+      result = nil
+      expected_message = <<~MSG.squish
+      `Customer::ActiveRecord_Relation#include?` expects an Active Record instance as an argument but got `Topic`.
+          Starting in Rails 7.2 `Customer::ActiveRecord_Relation#include?` will raise on any value passed other than
+          an Active Record instance of a correct class.
+      MSG
+      assert_deprecated(expected_message, ActiveRecord.deprecator) do
+        result = Customer.where(name: "David").include?(topic)
+      end
+      assert_equal false, result
     end
   end
 
@@ -506,10 +531,20 @@ class FinderTest < ActiveRecord::TestCase
   def test_member_on_unloaded_relation_with_mismatched_class
     topic = topics(:first)
     assert Customer.exists?(topic.id)
+    result = nil
 
     assert_no_queries do
-      assert_equal false, Customer.where(name: "David").member?(topic)
+      expected_message = <<~MSG.squish
+      `Customer::ActiveRecord_Relation#include?` expects an Active Record instance as an argument but got `Topic`.
+          Starting in Rails 7.2 `Customer::ActiveRecord_Relation#include?` will raise on any value passed other than
+          an Active Record instance of a correct class.
+      MSG
+      assert_deprecated(expected_message, ActiveRecord.deprecator) do
+        result = Customer.where(name: "David").member?(topic)
+      end
     end
+
+    assert_equal(false, result)
   end
 
   def test_member_on_unloaded_relation_with_offset


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/rails/rails/pull/48761 which leads to a `NoMethodError` when a non Active Record object passed to `include?` or `member?` since only Active Record objects respond to `composite_primary_key?`.

We are also using it as an opportunity to reconsider the future API of the method and completely disallow non Active Record objects to be passed to avoid bugs related to the method returning `false` while not actually performing the check.

In my opinion current behavior of the method is not optimal since it gracefully returns `false` for any garbage value being passed to it. This when combined with poor tests coverage may lead to bugs while it could have been avoided by method refusing to provide any meaningful return value and raise instead. 

So I'm proposing in Rails 7.2 the method will behave as follows: 

```ruby
alice = customers(:alice)
bob = customers(:bob)
customer_relation = Customer.where(name: "Alice")

customer_relation.include?(alice) # => true, which means we can reliably tell that `alice` record is represented by the relation 

customer_relation.include?(bob) # => false, which means we can reliably tell that `bob` is not part of the given customers relation

customer_relation.include?("i'm just a string") # => raises `ArgumentError`, which means we can't reliably answer the question as we can't derive what is being asked
```

But until then we will just issue a warning
