### PR TITLE
Return `false` early when a non-AR object passed to `FinderMethods#include?`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -352,6 +352,10 @@ module ActiveRecord
     # compared to the records in memory. If the relation is unloaded, an
     # efficient existence query is performed, as in #exists?.
     def include?(record)
+      # The existing implementation relies on receiving an Active Record instance as the input parameter named record.
+      # Any non-Active Record object passed to this implementation is guaranteed to return `false`.
+      return false unless record.is_a?(klass)
+
       if loaded? || offset_value || limit_value || having_clause.any?
         records.include?(record)
       else
@@ -360,7 +364,8 @@ module ActiveRecord
         else
           record.id
         end
-        record.is_a?(klass) && exists?(id)
+
+        exists?(id)
       end
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -411,6 +411,34 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_include_when_non_AR_object_passed_on_unloaded_relation
+    assert_no_queries do
+      assert_equal false, Customer.where(name: "David").include?("I'm not an AR object")
+    end
+  end
+
+  def test_include_when_non_AR_object_passed_on_loaded_relation
+    customers = Customer.where(name: "David").load
+
+    assert_no_queries do
+      assert_equal false, customers.include?("I'm not an AR object")
+    end
+  end
+
+  def test_member_when_non_AR_object_passed_on_unloaded_relation
+    assert_no_queries do
+      assert_equal false, Customer.where(name: "David").member?("I'm not an AR object")
+    end
+  end
+
+  def test_member_when_non_AR_object_passed_on_loaded_relation
+    customers = Customer.where(name: "David").load
+
+    assert_no_queries do
+      assert_equal false, customers.member?("I'm not an AR object")
+    end
+  end
+
   def test_include_on_unloaded_relation_with_match
     assert_sql(/1 AS one.*LIMIT/) do
       assert_equal true, Customer.where(name: "David").include?(customers(:david))


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/rails/rails/pull/48761 which leads to a `NoMethodError` when a non Active Record object passed to `include?` or `member?` since only Active Record objects respond to `composite_primary_key?`.

### Alternative solution

I decided to put the early `return` at the top before even performing the `loaded? || offset_value || limit_value || having_clause.any?` checks. I don't think this will impact performance in any noticeable way but if you have concerns feel free to speak up and we will move the check to the `else` branch
