### PR TITLE
Add `ActiveSupport::MessageVerifier#expired?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `ActiveSupport::MessageVerifier#expired?`
+
+    Returns `true` if a message has expired, `false` if it is still valid.
+
+    ```ruby
+    verifier = ActiveSupport::MessageVerifier.new("secret")
+    message = verifier.generate("hello", expires_at: Time.now.tomorrow)
+    verifier.expired?(message) # false
+    # 24 hours later...
+    verifier.expired?(message) # true
+    ```
+
+    *Alex Ghiculescu*
+
 *   Make all cache stores return a boolean for `#delete`
 
     Previously the `RedisCacheStore#delete` would return `1` if the entry

--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -72,7 +72,7 @@ module ActiveSupport
           hash = envelope["_rails"]
 
           if hash["exp"] && Time.now.utc >= parse_expiry(hash["exp"])
-            throw :invalid_message_content, "expired"
+            throw :expired_message, "expired"
           end
 
           if hash["pur"] != purpose&.to_s


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I'd like to add support for https://github.com/rails/globalid/issues/141. As noted in that issue, the `expired?` method needs to be added to Active Support first. This PR adds it.

### Detail

```ruby
verifier = ActiveSupport::MessageVerifier.new("secret")
message = verifier.generate("hello", expires_at: Time.now.tomorrow)
verifier.expired?(message) # false
# 24 hours later...
verifier.expired?(message) # true
```
