### PR TITLE
Sort SchemaCache members when dumping it

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -278,10 +278,10 @@ module ActiveRecord
       end
 
       def encode_with(coder) # :nodoc:
-        coder["columns"]          = @columns
-        coder["primary_keys"]     = @primary_keys
-        coder["data_sources"]     = @data_sources
-        coder["indexes"]          = @indexes
+        coder["columns"]          = @columns.sort.to_h
+        coder["primary_keys"]     = @primary_keys.sort.to_h
+        coder["data_sources"]     = @data_sources.sort.to_h
+        coder["indexes"]          = @indexes.sort.to_h
         coder["version"]          = @version
         coder["database_version"] = @database_version
       end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/42717

This allow to result to be consistent, allowing to use its digest for cache keys and such.

FYI: @justin808 