### PR TITLE
Add Rack::Lint to ActionDispatch::Executor tests

### DIFF
--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -36,40 +36,16 @@ class ExecutorTest < ActiveSupport::TestCase
     body.close
   end
 
-  def test_returned_body_object_behaves_like_underlying_object
-    body = call_and_return_body do
-      b = MyBody.new
-      b << "hello"
-      b << "world"
-      [200, { "Content-Type" => "text/html" }, b]
-    end
-    assert_equal 2, body.size
-    assert_equal "hello", body[0]
-    assert_equal "world", body[1]
-    assert_equal "foo", body.foo
-    assert_equal "bar", body.bar
-  end
-
   def test_it_calls_close_on_underlying_object_when_close_is_called_on_body
     close_called = false
     body = call_and_return_body do
       b = MyBody.new do
         close_called = true
       end
-      [200, { "Content-Type" => "text/html" }, b]
+      [200, { "content-type" => "text/html" }, b]
     end
     body.close
     assert close_called
-  end
-
-  def test_returned_body_object_responds_to_all_methods_supported_by_underlying_object
-    body = call_and_return_body do
-      [200, { "Content-Type" => "text/html" }, MyBody.new]
-    end
-    assert_respond_to body, :size
-    assert_respond_to body, :each
-    assert_respond_to body, :foo
-    assert_respond_to body, :bar
   end
 
   def test_run_callbacks_are_called_before_close
@@ -127,12 +103,15 @@ class ExecutorTest < ActiveSupport::TestCase
     executor.to_run { total += 1; ran += 1 }
     executor.to_complete { total += 1; completed += 1 }
 
-    stack = middleware(proc { [200, {}, "response"] })
+    app = proc { [200, {}, []] }
+    env = Rack::MockRequest.env_for("", {})
+
+    stack = middleware(app)
 
     requests_count = 5
 
     requests_count.times do
-      stack.call({})
+      stack.call(env)
     end
 
     assert_equal (requests_count * 2) - 1, total
@@ -142,13 +121,14 @@ class ExecutorTest < ActiveSupport::TestCase
 
   private
     def call_and_return_body(&block)
-      app = middleware(block || proc { [200, {}, "response"] })
-      _, _, body = app.call("rack.input" => StringIO.new(""))
+      app = block || proc { [200, {}, []] }
+      env = Rack::MockRequest.env_for("", {})
+      _, _, body = middleware(app).call(env)
       body
     end
 
     def middleware(inner_app)
-      ActionDispatch::Executor.new(inner_app, executor)
+      Rack::Lint.new(ActionDispatch::Executor.new(Rack::Lint.new(inner_app), executor))
     end
 
     def executor


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

### Detail

This adds additional test coverage to `ActionDispatch::Executor` to validate that its input and output follow the Rack SPEC.

This also removes some tests that were asserting the body object passed to `ActionDispatch::Executor` and not the Rack SPEC. See also https://github.com/rack/rack/issues/2100.

### Additional information

- https://github.com/skipkayhil/tmp-rails/issues/1

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
