### PR TITLE
Add ActionDispatch::Cookies middleware test with Rack::Lint

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -80,6 +80,22 @@ class CookieJarTest < ActiveSupport::TestCase
   end
 end
 
+class CookiesMiddlewareTest < ActiveSupport::TestCase
+  def test_sets_expected_cookie_header
+    request = ActionDispatch::Request.empty
+    request.cookie_jar[:foo] = "bar"
+    env = Rack::MockRequest.env_for("", request.env)
+
+    _status, headers, _body = Rack::Lint.new(
+      ActionDispatch::Cookies.new(
+        Rack::Lint.new(lambda { |_env| [ 200, {}, [] ] })
+      )
+    ).call(env)
+
+    assert_equal "foo=bar; path=/", headers["set-cookie"]
+  end
+end
+
 class CookiesTest < ActionController::TestCase
   include CookieAssertions
 


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/skipkayhil/tmp-rails/issues/1

This adds an additional test to the `ActionDispatch::Cookies` middleware test suite to ensure that the middleware sets the expected cookie header when the request contains a cookie jar. Additionally, the test wraps the middleware in `Rack::Lint` to ensure that `ActionDispatch::Cookies` complies with the Rack SPEC, specifically with the [changes](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) in migrating from Rack 2 to Rack 3.

### Detail

The existing tests in `actionpack/test/dispatch/cookies_test.rb` verify cookies behaviour at the unit-test level, but we're missing a test that explicitly tests the middleware piece. This PR adds that test, wrapping it in `Rack::Lint` to also validate Rack SPEC compliance. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
