### PR TITLE
Add Rack::Lint to ActionDispatch::MiddlewareStack tests

### DIFF
--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -200,10 +200,14 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
 
     ActiveSupport::Notifications.subscribed(subscriber, "process_middleware.action_dispatch") do
-      app = @stack.build(proc { |env| [200, {}, []] })
+      app = Rack::Lint.new(
+        @stack.build(Rack::Lint.new(proc { |env| [200, {}, []] }))
+      )
 
-      env = {}
-      app.call(env)
+      env = Rack::MockRequest.env_for("", {})
+      assert_nothing_raised do
+        app.call(env)
+      end
     end
 
     assert_equal 2, events.count


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

This adds additional test coverage to `ActionDispatch::MiddlewareStack` to validate that its input and output follow the Rack SPEC.

### Detail

In this case, no changes are required, and the additional test will ensure this middleware remains compliant with the Rack SPEC.


### Additional information

- https://github.com/skipkayhil/tmp-rails/issues/1


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
