### PR TITLE
Make `ActionDispatch::SSL` compatible with Rack 3.0

### DIFF
--- a/actionpack/lib/action_dispatch/constants.rb
+++ b/actionpack/lib/action_dispatch/constants.rb
@@ -14,6 +14,7 @@ module ActionDispatch
       FEATURE_POLICY = "Feature-Policy"
       X_REQUEST_ID = "X-Request-Id"
       SERVER_TIMING = "Server-Timing"
+      STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security"
     else
       VARY = "vary"
       CONTENT_ENCODING = "content-encoding"
@@ -23,6 +24,7 @@ module ActionDispatch
       FEATURE_POLICY = "feature-policy"
       X_REQUEST_ID = "x-request-id"
       SERVER_TIMING = "server-timing"
+      STRICT_TRANSPORT_SECURITY = "strict-transport-security"
     end
   end
 end

--- a/actionpack/test/dispatch/ssl_test.rb
+++ b/actionpack/test/dispatch/ssl_test.rb
@@ -3,13 +3,16 @@
 require "abstract_unit"
 
 class SSLTest < ActionDispatch::IntegrationTest
-  HEADERS = { "Content-Type" => "text/html" }
-
   attr_accessor :app
 
   def build_app(headers: {}, ssl_options: {})
-    headers = HEADERS.merge(headers)
-    ActionDispatch::SSL.new lambda { |env| [200, headers, []] }, **ssl_options.reverse_merge(hsts: { subdomains: true })
+    app = lambda { |env| [200, headers, []] }
+    Rack::Lint.new(
+      ActionDispatch::SSL.new(
+        Rack::Lint.new(app),
+        **ssl_options.reverse_merge(hsts: { subdomains: true }),
+      )
+    )
   end
 end
 
@@ -128,9 +131,9 @@ class StrictTransportSecurityTest < SSLTest
     self.app = build_app ssl_options: { hsts: hsts }, headers: headers
     get url
     if expected.nil?
-      assert_nil response.headers["Strict-Transport-Security"]
+      assert_nil response.headers["strict-transport-security"]
     else
-      assert_equal expected, response.headers["Strict-Transport-Security"]
+      assert_equal expected, response.headers["strict-transport-security"]
     end
   end
 
@@ -143,7 +146,8 @@ class StrictTransportSecurityTest < SSLTest
   end
 
   test "defers to app-provided header" do
-    assert_hsts "app-provided", headers: { "Strict-Transport-Security" => "app-provided" }
+    headers = { ActionDispatch::Constants::STRICT_TRANSPORT_SECURITY => "app-provided" }
+    assert_hsts "app-provided", headers: headers
   end
 
   test "hsts: true enables default settings" do
@@ -180,82 +184,94 @@ class StrictTransportSecurityTest < SSLTest
 end
 
 class SecureCookiesTest < SSLTest
-  DEFAULT = %(id=1; path=/\ntoken=abc; path=/; secure; HttpOnly)
-
-  def get(**options)
-    self.app = build_app(**options)
-    super "https://example.org"
-  end
-
-  def assert_cookies(*expected)
-    assert_equal expected, response.headers["Set-Cookie"].split("\n")
+  DEFAULT = if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
+    %(id=1; path=/\ntoken=abc; path=/; secure; HttpOnly)
+  else
+    ["id=1; path=/", "token=abc; path=/; secure; HttpOnly"]
   end
 
   def test_flag_cookies_as_secure
-    get headers: { "Set-Cookie" => DEFAULT }
+    get headers: { Rack::SET_COOKIE => DEFAULT }
     assert_cookies "id=1; path=/; secure", "token=abc; path=/; secure; HttpOnly"
   end
 
-  def test_flag_cookies_as_secure_with_single_cookie_in_array
-    get headers: { "Set-Cookie" => ["id=1"] }
-    assert_cookies "id=1; secure"
-  end
-
-  def test_flag_cookies_as_secure_with_multiple_cookies_in_array
-    get headers: { "Set-Cookie" => ["id=1", "problem=def"] }
-    assert_cookies "id=1; secure", "problem=def; secure"
-  end
-
   def test_flag_cookies_as_secure_at_end_of_line
-    get headers: { "Set-Cookie" => "problem=def; path=/; HttpOnly; secure" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/; HttpOnly; secure" }
     assert_cookies "problem=def; path=/; HttpOnly; secure"
   end
 
   def test_flag_cookies_as_secure_with_more_spaces_before
-    get headers: { "Set-Cookie" => "problem=def; path=/; HttpOnly;  secure" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/; HttpOnly;  secure" }
     assert_cookies "problem=def; path=/; HttpOnly;  secure"
   end
 
   def test_flag_cookies_as_secure_with_more_spaces_after
-    get headers: { "Set-Cookie" => "problem=def; path=/; secure;  HttpOnly" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/; secure;  HttpOnly" }
     assert_cookies "problem=def; path=/; secure;  HttpOnly"
   end
 
   def test_flag_cookies_as_secure_with_has_not_spaces_before
-    get headers: { "Set-Cookie" => "problem=def; path=/;secure; HttpOnly" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/;secure; HttpOnly" }
     assert_cookies "problem=def; path=/;secure; HttpOnly"
   end
 
   def test_flag_cookies_as_secure_with_has_not_spaces_after
-    get headers: { "Set-Cookie" => "problem=def; path=/; secure;HttpOnly" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/; secure;HttpOnly" }
     assert_cookies "problem=def; path=/; secure;HttpOnly"
   end
 
   def test_flag_cookies_as_secure_with_ignore_case
-    get headers: { "Set-Cookie" => "problem=def; path=/; Secure; HttpOnly" }
+    get headers: { Rack::SET_COOKIE => "problem=def; path=/; Secure; HttpOnly" }
     assert_cookies "problem=def; path=/; Secure; HttpOnly"
   end
 
   def test_cookies_as_not_secure_with_secure_cookies_disabled
-    get headers: { "Set-Cookie" => DEFAULT }, ssl_options: { secure_cookies: false }
-    assert_cookies(*DEFAULT.split("\n"))
+    get headers: { Rack::SET_COOKIE => DEFAULT }, ssl_options: { secure_cookies: false }
+    assert_cookies("id=1; path=/", "token=abc; path=/; secure; HttpOnly")
   end
 
   def test_cookies_as_not_secure_with_exclude
     excluding = { exclude: -> request { /example/.match?(request.domain) } }
-    get headers: { "Set-Cookie" => DEFAULT }, ssl_options: { redirect: excluding }
+    get headers: { Rack::SET_COOKIE => DEFAULT }, ssl_options: { redirect: excluding }
 
-    assert_cookies(*DEFAULT.split("\n"))
+    assert_cookies("id=1; path=/", "token=abc; path=/; secure; HttpOnly")
     assert_response :ok
   end
 
   def test_no_cookies
     get
-    assert_nil response.headers["Set-Cookie"]
+    assert_nil response.headers[Rack::SET_COOKIE]
   end
 
   def test_keeps_original_headers_behavior
-    get headers: { "Connection" => "close" }
-    assert_equal "close", response.headers["Connection"]
+    get headers: { "connection" => "close" }
+    assert_equal "close", response.headers["connection"]
   end
+
+  # Array-based headers are only supported in Rack 3+
+  if Gem::Version.new(Rack::RELEASE) >= Gem::Version.new("3")
+    def test_flag_cookies_as_secure_with_single_cookie_in_array
+      get headers: { Rack::SET_COOKIE => ["id=1"] }
+      assert_cookies "id=1; secure"
+    end
+
+    def test_flag_cookies_as_secure_with_multiple_cookies_in_array
+      get headers: { Rack::SET_COOKIE => ["id=1", "problem=def"] }
+      assert_cookies "id=1; secure", "problem=def; secure"
+    end
+  end
+
+  private
+    def get(**options)
+      self.app = build_app(**options)
+      super "https://example.org"
+    end
+
+    def assert_cookies(*expected)
+      cookies = response.headers[Rack::SET_COOKIE]
+      if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
+        cookies = cookies.split("\n")
+      end
+      assert_equal expected, cookies
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Ref: https://github.com/skipkayhil/tmp-rails/issues/1
Related: https://github.com/rails/rails/pull/46594

Rack 3 now requires response header values to be an Array when handling multiple values. Newline encoded headers are no longer supported. (ref: https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#rack-2--rack-3-compatibility)

This commit updates `ActionDispatch::SSL#flag_cookies_as_secure!` to be Rack-3 compliant by setting the `set-cookie` header to an Array rather than a newline-separated String if the current Rack version is 3+.

Additionally, this commit adds `Rack::Lint` to the Rack app in the middleware test suite so that we can ensure all of the tests are compliant with the Rack SPEC.

### Detail

Without the changes to `ActionDispatch::SSL#flag_cookies_as_secure!`, we see `Rack::Lint` raise:
```
Error:
SecureCookiesTest#test_cookies_as_not_secure_with_secure_cookies_disabled:
Rack::Lint::LintError: invalid header value set-cookie: "id=1; path=/\ntoken=abc; path=/; secure; HttpOnly"
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:670:in `check_header_value'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:657:in `block in check_headers'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:637:in `each'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:637:in `check_headers'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:73:in `response'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
    /Users/adriannachang/src/github.com/rails/actionpack/lib/action_dispatch/middleware/ssl.rb:87:in `call'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-test-2.1.0/lib/rack/test.rb:360:in `process_request'
    /Users/adriannachang/.gem/ruby/3.2.1/gems/rack-test-2.1.0/lib/rack/test.rb:153:in `request'
    /Users/adriannachang/src/github.com/rails/actionpack/lib/action_dispatch/testing/integration.rb:288:in `process'
    /Users/adriannachang/src/github.com/rails/actionpack/lib/action_dispatch/testing/integration.rb:16:in `get'
    /Users/adriannachang/src/github.com/rails/actionpack/lib/action_dispatch/testing/integration.rb:379:in `get'
    /Users/adriannachang/src/github.com/rails/actionpack/test/dispatch/ssl_test.rb:266:in `get'
    /Users/adriannachang/src/github.com/rails/actionpack/test/dispatch/ssl_test.rb:241:in `test_cookies_as_not_secure_with_secure_cookies_disabled'


bin/test test/dispatch/ssl_test.rb:240
```

Note that we also need to ensure that response headers are downcased for Rack 3, since mixed case headers are no longer supported in the new release. I've taken the approach we settled on in https://github.com/skipkayhil/tmp-rails/issues/1, where we set the casing of the header depending on the Rack version. Rack exposes constants for certain headers (e.g. `RACK::CONTENT_TYPE`), but other headers like location aren't exposed as constants in Rack, so I've defined them inline in `ActionDispatch::SSL`. Other PRs, e.g. https://github.com/rails/rails/pull/48813, are defining these types of constants in `ActionDispatch::Response` -- I can take the same approach if we decide that's the way to go :) 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
