### PR TITLE
Add Rack::Lint to Static tests

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -50,6 +50,14 @@ module ActionDispatch
       "identity" => nil
     }
 
+    if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3")
+      VARY = "Vary"
+      CONTENT_ENCODING = "Content-Encoding"
+    else
+      VARY = "vary"
+      CONTENT_ENCODING = "content-encoding"
+    end
+
     def initialize(root, index: "index", headers: {}, precompressed: %i[ br gzip ], compressible_content_types: /\A(?:text\/|application\/javascript)/)
       @root = root.chomp("/").b
       @index = index
@@ -128,10 +136,10 @@ module ActionDispatch
             if content_encoding == "identity"
               return precompressed_filepath, headers
             else
-              headers["vary"] = "accept-encoding"
+              headers[VARY] = "accept-encoding"
 
               if accept_encoding.any? { |enc, _| /\b#{content_encoding}\b/i.match?(enc) }
-                headers["content-encoding"] = content_encoding
+                headers[CONTENT_ENCODING] = content_encoding
                 return precompressed_filepath, headers
               end
             end


### PR DESCRIPTION
The test refactor was split out from the Rack::Lint change to make them both easier to review.

Ref skipkayhil#5

---

[Refactor StaticTests to use single app builder](https://github.com/rails/rails/commit/f880da0f24f72629563e194d72e6418a1ecaaaa5)

This commit refactors the StaticTests class in preparation for adding
Rack::Lint to the tests.

The first change is inlining the StaticTests module into the StaticTest
class. It was originally extracted into a module when Static was
[changed][1] to support passing multiple root paths, but support for
multiple paths has since been [removed][2].

The second change is to move all Rack App creation into a single method.
This will make it extremely easy to add Rack::Lint to the App in a
followup commit.

[1]: https://github.com/rails/rails/commit/401cd97923fb52c8f8c458b8cb276b338e0b20f3
[2]: https://github.com/rails/rails/commit/d5ad92ced1786b742c3ecce3cb60d851c7200bc9

--- 

[Add Rack::Lint to Static tests](https://github.com/rails/rails/commit/b580df616b1d6d32cc7dee1505f8ae84d0444e04)

This adds additional test coverage to Static to validate that its
behavior conforms to the Rack SPEC.

The test changes are just downcasing headers where appropriate:
- the Static `headers` params is purely user configured headers, so its
  reasonable to expect these shoud be correct for an application's Rack
  version
- header assertions can use downcased headers because Rack::MockRequest
  returns a Rack::Response, which uses Rack::Headers internally (so
  either casing will work)

Additionally, the unconditionally downcased headers in the Static
middleware were updated to be conditional based on the Rack version to
ensure that this middleware remains fully compatible with other Rack 2
middleware.