### PR TITLE
Add Rack::Lint to `ActionDispatch::ServerTiming` tests

### DIFF
--- a/actionpack/lib/action_dispatch/constants.rb
+++ b/actionpack/lib/action_dispatch/constants.rb
@@ -11,12 +11,14 @@ module ActionDispatch
       LOCATION = "Location"
       FEATURE_POLICY = "Feature-Policy"
       X_REQUEST_ID = "X-Request-Id"
+      SERVER_TIMING = "Server-Timing"
     else
       VARY = "vary"
       CONTENT_ENCODING = "content-encoding"
       LOCATION = "location"
       FEATURE_POLICY = "feature-policy"
       X_REQUEST_ID = "x-request-id"
+      SERVER_TIMING = "server-timing"
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/server_timing.rb
+++ b/actionpack/lib/action_dispatch/middleware/server_timing.rb
@@ -4,8 +4,6 @@ require "active_support/notifications"
 
 module ActionDispatch
   class ServerTiming
-    SERVER_TIMING_HEADER = "Server-Timing"
-
     class Subscriber # :nodoc:
       include Singleton
       KEY = :action_dispatch_server_timing_events
@@ -67,8 +65,10 @@ module ActionDispatch
         "%s;dur=%.2f" % [event_name, events_collection.sum(&:duration)]
       end
 
-      header_info.prepend(headers[SERVER_TIMING_HEADER]) if headers[SERVER_TIMING_HEADER].present?
-      headers[SERVER_TIMING_HEADER] = header_info.join(", ")
+      if headers[ActionDispatch::Constants::SERVER_TIMING].present?
+        header_info.prepend(headers[ActionDispatch::Constants::SERVER_TIMING])
+      end
+      headers[ActionDispatch::Constants::SERVER_TIMING] = header_info.join(", ")
 
       response
     end


### PR DESCRIPTION
### Motivation / Background

To ensure Rails is and remains compliant with [the Rack 3 spec](https://github.com/rack/rack/blob/6d16306192349e665e4ec820a9bfcc0967009b6a/UPGRADE-GUIDE.md) we can add `Rack::Lint` to the Rails middleware tests.

This adds additional test coverage to `ActionDispatch::ServerTiming` to validate that its input and output follow the Rack SPEC.

### Detail

The `Server-Timing` header definition was moved to `ActionDispatch::Constants` and is now downcased to match the Rack 3 SPEC.

The tests that rely on a `Concurrent::CyclicBarrier` ("events are tracked by thread") were changed since passing the required proc in the env is not compatible with the SPEC:

```
Rack::Lint::LintError: env variable proc has non-string value
```

The same can be achieved by invoking the proc as a child Rack app.

### Additional information

- https://github.com/skipkayhil/tmp-rails/issues/1

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
