### PR TITLE
Raise if unable to cast a string to a date [fixes #48802]

### DIFF
--- a/actionview/test/fixtures/replies.yml
+++ b/actionview/test/fixtures/replies.yml
@@ -4,7 +4,7 @@ witty_retort:
   developer_id: 1
   content: Birdman is better!
   created_at: <%= 6.hours.ago.to_fs(:db) %>
-  updated_at: nil
+  updated_at: null
 
 another:
   id: 2
@@ -12,4 +12,4 @@ another:
   developer_id: 1
   content: Nuh uh!
   created_at: <%= 1.hour.ago.to_fs(:db) %>
-  updated_at: nil
+  updated_at: null

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise an `ArgumentError` when attempting to cast a non-datetime string value in `ActiveModel::Type::DateTime`.
+    Previously, it would produce `nil` without error.
+
+    *Eddie Lebow*
+
 *   Add a load hook for `ActiveModel::Model` (named `active_model`) to match the load hook for `ActiveRecord::Base` and
     allow for overriding aspects of the `ActiveModel::Model` class.
 

--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -53,7 +53,6 @@ module ActiveModel
       private
         def cast_value(value)
           return apply_seconds_precision(value) unless value.is_a?(::String)
-          return if value.empty?
 
           fast_string_to_time(value) || fallback_string_to_time(value)
         end
@@ -65,11 +64,9 @@ module ActiveModel
         end
 
         def fallback_string_to_time(string)
-          time_hash = begin
-            ::Date._parse(string)
-          rescue ArgumentError
-          end
-          return unless time_hash
+          time_hash = ::Date._parse(string)
+
+          raise ArgumentError, "Could not parse time from string #{string}" if time_hash.blank?
 
           time_hash[:sec_fraction] = microseconds(time_hash)
 

--- a/activemodel/test/cases/type/date_time_test.rb
+++ b/activemodel/test/cases/type/date_time_test.rb
@@ -8,10 +8,11 @@ module ActiveModel
       def test_type_cast_datetime_and_timestamp
         type = Type::DateTime.new
         assert_nil type.cast(nil)
-        assert_nil type.cast("")
-        assert_nil type.cast("  ")
-        assert_nil type.cast("ABC")
-        assert_nil type.cast(" " * 129)
+
+        assert_raises(ArgumentError, match: /Could not parse/) { type.cast("") }
+        assert_raises(ArgumentError, match: /Could not parse/) { type.cast("  ") }
+        assert_raises(ArgumentError, match: /Could not parse/) { type.cast("ABC") }
+        assert_raises(ArgumentError, match: /exceeds the limit/) { type.cast(" " * 129) }
 
         datetime_string = ::Time.now.utc.strftime("%FT%T")
         assert_equal datetime_string, type.cast(datetime_string).strftime("%FT%T")
@@ -21,7 +22,7 @@ module ActiveModel
         ["UTC", "US/Eastern"].each do |zone|
           with_timezone_config default: zone do
             type = Type::DateTime.new
-            assert_equal ::Time.utc(2013, 9, 4, 0, 0, 0), type.cast("Wed, 04 Sep 2013 03:00:00 EAT")
+            assert_equal ::DateTime.new(2013, 9, 4, 0, 0, 0.005, 0), type.cast("Wed, 04 Sep 2013 03:00:00.0050 EAT")
           end
         end
       end

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -178,7 +178,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
       end
 
       assert_nil Foo.create!(happened_at: nil).happened_at
-      assert_nil Foo.create!(happened_at: "").happened_at
+      assert_raises(ArgumentError, match: /Could not parse/) { Foo.create!(happened_at: "") }
     end
 
     def test_writing_a_date_attribute

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -37,9 +37,7 @@ class DateTimeTest < ActiveRecord::TestCase
 
   def test_assign_empty_date_time
     task = Task.new
-    task.starting = ""
     task.ending = nil
-    assert_nil task.starting
     assert_nil task.ending
   end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -83,7 +83,6 @@ module ActiveRecord
       topics(:first).update!(parent_id: 0, written_on: nil, bonus_time: nil, last_read: nil)
       assert_empty Topic.where(parent_id: Object.new)
       assert_empty Topic.where(parent_id: "not-a-number")
-      assert_empty Topic.where(written_on: "")
       assert_empty Topic.where(bonus_time: "")
       assert_empty Topic.where(last_read: "")
     end


### PR DESCRIPTION
This prevents possible data loss where a non-nil value could be silently cast as `nil`.

### Motivation / Background

See #48802.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
