### PR TITLE
Use connection.schema_version inside ActiveRecord::SchemaCache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -130,7 +130,7 @@ module ActiveRecord
 
           if self.class.check_schema_cache_dump_version
             begin
-              current_version = connection.migration_context.current_version
+              current_version = connection.schema_version
 
               if new_cache.version(connection) != current_version
                 warn "Ignoring #{@cache_path} because it has expired. The current schema version is #{current_version}, but the one in the schema cache file is #{new_cache.schema_version}."
@@ -375,7 +375,7 @@ module ActiveRecord
       end
 
       def version(connection)
-        @version ||= connection.migration_context.current_version
+        @version ||= connection.schema_version
       end
 
       def schema_version


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because at GitHub we are trying to upgrade our Rails version with the latest changes in `main`. While doing so, we detected an issue where schema `.dump` files generated by a previous version of Rails would be ignored with a message like this:

```
Ignoring db/schema/schema.dump because it has expired. The current schema version is 0, but the one in the schema cache file is abcdv1.
```

The version number `abcdv1` comes from a custom implementation of `ActiveRecord::ConnectionAdapters::AbstractAdapter#schema_version` that we need to use because we don't use standard migrations. However the latest changes in Rails around `ActiveRecord::SchemaCache` don't use this method but `ActiveRecord::ConnectionAdapters::AbstractAdapter#migration_context.current_version`.

I believe the changes around this part of the code were introduced here https://github.com/rails/rails/pull/48716

### Detail

This Pull Request changes calls to `connection.migration_context.current_version` with `connection.schema_version` inside `ActiveRecord::SchemaVersion` and `ActiveRecord::SchemaReflection`. By default `#schema_version` uses `migration_context.current_version`, so everything should work as before, but for cases where an app is using custom `schema_version` numbers, this fix would allow them to upgrade without issues.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
