### PR TITLE
Fix TestRequest coercing SERVER_PORT to be an int

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_request.rb
+++ b/actionpack/lib/action_dispatch/testing/test_request.rb
@@ -32,7 +32,7 @@ module ActionDispatch
     end
 
     def port=(number)
-      set_header("SERVER_PORT", number.to_i)
+      set_header("SERVER_PORT", number)
     end
 
     def request_uri=(uri)

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -91,25 +91,28 @@ class TestRequestTest < ActiveSupport::TestCase
     assert_equal "POST", req.request_method
   end
 
-  test "setter methods" do
+  test "setter methods work and do not change Rack SPEC conformity" do
     req = ActionDispatch::TestRequest.create({})
     get = "GET"
 
     [
-      "request_method=", "host=", "request_uri=", "path=", "if_modified_since=", "if_none_match=",
+      "request_method=", "host=", "request_uri=", "if_modified_since=", "if_none_match=",
       "remote_addr=", "user_agent=", "accept="
     ].each do |method|
       req.send(method, get)
     end
 
-    req.port = 8080
+    req.path = "/get"
+    req.port = "8080"
     req.accept = "hello goodbye"
+
+    Rack::Lint.new(->(_) { [200, {}, []] }).call(req.env)
 
     assert_equal(get, req.get_header("REQUEST_METHOD"))
     assert_equal(get, req.get_header("HTTP_HOST"))
-    assert_equal(8080, req.get_header("SERVER_PORT"))
+    assert_equal("8080", req.get_header("SERVER_PORT"))
     assert_equal(get, req.get_header("REQUEST_URI"))
-    assert_equal(get, req.get_header("PATH_INFO"))
+    assert_equal("/get", req.get_header("PATH_INFO"))
     assert_equal(get, req.get_header("HTTP_IF_MODIFIED_SINCE"))
     assert_equal(get, req.get_header("HTTP_IF_NONE_MATCH"))
     assert_equal(get, req.get_header("REMOTE_ADDR"))


### PR DESCRIPTION
### Motivation / Background

Ref skipkayhil#5

In both Rack 2 and Rack 3, all headers must be strings. SERVER_PORT has an additional requirement that it must be an Integer (represented as a string).

### Detail

When using #port= on a TestRequest, the value passed has been coerced into an integer since it was [introduced][1]. Since this is explicitly incorrect per both Rack 2 and Rack SPEC, the coercion is removed.

This does have the potential to change the value for users who are checking TestRequest#headers directly, but if they are using Request#port the value will not change because #port also coerces values to ints.

[1]: https://github.com/rails/rails/commit/61960e7b37767140e9af68bd5373e06dce08492d

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
