### PR TITLE
Removed unnecessary --no-skip-* app generator test

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -814,13 +814,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "importmap-rails"
   end
 
-  def test_no_skip_javascript_option_with_no_skip_javascript_argument
-    run_generator [destination_root, "--no-skip-javascript"]
-    assert_gem "stimulus-rails"
-    assert_gem "turbo-rails"
-    assert_gem "importmap-rails"
-  end
-
   def test_hotwire
     run_generator_and_bundler [destination_root]
     assert_gem "turbo-rails"
@@ -883,11 +876,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--css=postcss"]
     assert_no_gem "jsbundling-rails"
     assert_gem "importmap-rails"
-  end
-
-  def test_dev_gems
-    run_generator [destination_root, "--no-skip-dev-gems"]
-    assert_gem "web-console"
   end
 
   def test_skip_dev_gems
@@ -1083,14 +1071,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".dockerignore"
     assert_no_file "Dockerfile"
     assert_no_file "bin/docker-entrypoint"
-  end
-
-  def test_no_skip_docker
-    run_generator [destination_root, "--no-skip-docker"]
-
-    assert_file ".dockerignore"
-    assert_file "Dockerfile"
-    assert_file "bin/docker-entrypoint"
   end
 
   def test_system_tests_directory_generated


### PR DESCRIPTION
### Motivation / Background

As per the discussion in #48822, we are currently having some unnecessary tests for --no-skip-* arguments in app generator tests. Since the --no-* behavior is [implemented](https://github.com/rails/thor/blob/5fb6206a6d2d7bfb40bcb851c2e118ba39f69757/lib/thor/parser/options.rb#L253) and [tested](https://github.com/rails/thor/blob/5fb6206a6d2d7bfb40bcb851c2e118ba39f69757/spec/parser/options_spec.rb#L399-L401) by Thor. Based on build time AppGeneratorTest is [one of the longest-running tests](https://buildkite.com/rails/rails/builds/98298#01899662-c3b9-48ba-812a-dd3ee4388752/1066-12267) in the longest running framework suite (railties), so we should avoid adding unnecessary tests, especially expensive tests.

### Detail

This PR removes the unnecessary test for --no-* from app_generator_test.rb.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @jonathanhefner 