### PR TITLE
Add `Rack::Lint` to `ActionDispatch::ShowExceptions` tests

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -44,8 +44,8 @@ module ActionDispatch
       end
 
       def render_format(status, content_type, body)
-        [status, { "Content-Type" => "#{content_type}; charset=#{ActionDispatch::Response.default_charset}",
-                  "Content-Length" => body.bytesize.to_s }, [body]]
+        [status, { Rack::CONTENT_TYPE => "#{content_type}; charset=#{ActionDispatch::Response.default_charset}",
+                  Rack::CONTENT_LENGTH => body.bytesize.to_s }, [body]]
       end
 
       def render_html(status)

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -71,7 +71,8 @@ module ActionDispatch
       end
 
       def pass_response(status)
-        [status, { "Content-Type" => "text/html; charset=#{Response.default_charset}", "Content-Length" => "0" }, []]
+        [status, { Rack::CONTENT_TYPE => "text/html; charset=#{Response.default_charset}",
+                  Rack::CONTENT_LENGTH => "0" }, []]
       end
   end
 end

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -33,18 +33,17 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  ProductionApp = ActionDispatch::ShowExceptions.new(Boomer.new, ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public"))
+  def setup
+    @app = build_app
+  end
 
   test "skip exceptions app if not showing exceptions" do
-    @app = ProductionApp
     assert_raise RuntimeError do
       get "/", env: { "action_dispatch.show_exceptions" => :none }
     end
   end
 
   test "rescue with error page" do
-    @app = ProductionApp
-
     get "/", env: { "action_dispatch.show_exceptions" => :all }
     assert_response 500
     assert_equal "500 error fixture\n", body
@@ -74,8 +73,6 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     old_locale, I18n.locale = I18n.locale, :da
 
     begin
-      @app = ProductionApp
-
       get "/", env: { "action_dispatch.show_exceptions" => :all }
       assert_response 500
       assert_equal "500 localized error fixture\n", body
@@ -89,15 +86,11 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
   end
 
   test "sets the HTTP charset parameter" do
-    @app = ProductionApp
-
     get "/", env: { "action_dispatch.show_exceptions" => :all }
-    assert_equal "text/html; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "text/html; charset=utf-8", response.headers["content-type"]
   end
 
   test "show registered original exception for wrapped exceptions" do
-    @app = ProductionApp
-
     get "/not_found_original_exception", env: { "action_dispatch.show_exceptions" => :all }
     assert_response 404
     assert_match(/404 error/, body)
@@ -108,10 +101,11 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       assert_kind_of AbstractController::ActionNotFound, env["action_dispatch.exception"]
       assert_equal "/404", env["PATH_INFO"]
       assert_equal "/not_found_original_exception", env["action_dispatch.original_path"]
-      [404, { "Content-Type" => "text/plain" }, ["YOU FAILED"]]
+      [404, { "content-type" => "text/plain" }, ["YOU FAILED"]]
     end
 
-    @app = ActionDispatch::ShowExceptions.new(Boomer.new, exceptions_app)
+    @app = build_app(exceptions_app)
+
     get "/not_found_original_exception", env: { "action_dispatch.show_exceptions" => :all }
     assert_response 404
     assert_equal "YOU FAILED", body
@@ -122,23 +116,28 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       [404, { ActionDispatch::Constants::X_CASCADE => "pass" }, []]
     end
 
-    @app = ActionDispatch::ShowExceptions.new(Boomer.new, exceptions_app)
+    @app = build_app(exceptions_app)
+
     get "/method_not_allowed", env: { "action_dispatch.show_exceptions" => :all }
     assert_response 405
     assert_equal "", body
   end
 
   test "bad params exception is returned in the correct format" do
-    @app = ProductionApp
-
     get "/bad_params", env: { "action_dispatch.show_exceptions" => :all }
-    assert_equal "text/html; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "text/html; charset=utf-8", response.headers["content-type"]
     assert_response 400
     assert_match(/400 error/, body)
 
     get "/bad_params.json", env: { "action_dispatch.show_exceptions" => :all }
-    assert_equal "application/json; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "application/json; charset=utf-8", response.headers["content-type"]
     assert_response 400
     assert_equal("{\"status\":400,\"error\":\"Bad Request\"}", body)
   end
+
+  private
+    def build_app(exceptions_app = nil)
+      exceptions_app ||= ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")
+      Rack::Lint.new(ActionDispatch::ShowExceptions.new(Rack::Lint.new(Boomer.new), exceptions_app))
+    end
 end


### PR DESCRIPTION
### Motivation / Background

This wraps test coverage for `ActionDispatch::ShowExpections` in `Rack::Lint` middleware in order to validate that both `ActionDispatch::ShowExceptions` and `ActionDispatch::PublicExceptions` conform to the Rack SPEC.

It also ensures that the response headers returned by the *Exceptions middleware respect casing (mixed case for Rack 2, lower case for Rack 3).

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
