### PR TITLE
Use `old_name` as part of the method cache namespace for `alias_attribute` methods generation

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -101,7 +101,7 @@ module ActiveRecord
           super
         else
           define_proxy_call(code_generator, method_name, pattern.proxy_target, parameters, old_name,
-            namespace: :proxy_alias_attribute
+            namespace: "proxy_alias_attribute_for_#{old_name}"
           )
         end
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1153,6 +1153,23 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  ToBeLoadedFirst = Class.new(ActiveRecord::Base) do
+    self.table_name = "topics"
+    alias_attribute :subject, :author_name
+  end
+
+  ToBeLoadedSecond = Class.new(ActiveRecord::Base) do
+    self.table_name = "topics"
+    alias_attribute :subject, :title
+  end
+
+  test "aliases to the same attribute name do not conflict with each other" do
+    first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
+    assert_equal("author 1", first_model_object.subject)
+    second_model_object = ToBeLoadedSecond.new(title: "foo")
+    assert_equal("foo", second_model_object.subject)
+  end
+
   test "#alias_attribute with an overridden original method issues a deprecation" do
     message = <<~MESSAGE.gsub("\n", " ")
     AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehavior model aliases `title` and has a method called


### PR DESCRIPTION
`define_proxy_call` uses `namespace` argument to fetch the cache where the generated method will be stored. `alias_attribute` method generation has to be scoped per `old_name` since otherwise same alias names for different attributes will reuse the same method body and only one will be correct.

To elaborate on the problem, consider the following models:

```ruby
class Message < ActiveRecord::Base
  alias_attribute :subject, :header
end

class Topic < ActiveRecord::Base
  alias_attribute :subject, :title
end
```

Since https://github.com/rails/rails/pull/48533 we expect Rails to generate the following getters for aliases:

```ruby
class Message < ActiveRecord::Base
  def subject
     attribute(:header)
  end
end

class Topic < ActiveRecord::Base
  def subject
     attribute(:title)
  end
end
```

Due to Rails using caching mechanism for method generation and the cache key consists of the hardcoded `proxy_alias_attribute` plus the `proxy_target` which is `"attribute"`  only one `subject` getter method will actually be generated and it depends on whichever of the models gets loaded first, the other model will reuse the cached method with a wrong body

In order to fix that we are including the `old_name` in the method definition namespace to make sure that methods are taken from the cache when both `new_name` and `old_name` match the existing definition.
