### PR TITLE
Use `call_args` in the `define_proxy_method` namespace.

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -409,10 +409,11 @@ module ActiveModel
             mangled_name = "__temp__#{name.unpack1("h*")}"
           end
 
-          code_generator.define_cached_method(name, as: mangled_name, namespace: :"#{namespace}_#{proxy_target}") do |batch|
-            call_args.map!(&:inspect)
-            call_args << parameters if parameters
+          call_args.map!(&:inspect)
+          call_args << parameters if parameters
+          namespace = :"#{namespace}_#{proxy_target}_#{call_args.join("_")}}"
 
+          code_generator.define_cached_method(name, as: mangled_name, namespace: namespace) do |batch|
             body = if CALL_COMPILABLE_REGEXP.match?(proxy_target)
               "self.#{proxy_target}(#{call_args.join(", ")})"
             else

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1144,6 +1144,23 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "abcd", model.read_attribute_before_type_cast("new_bank_balance")
   end
 
+  ToBeLoadedFirst = Class.new(ActiveRecord::Base) do
+    self.table_name = "topics"
+    alias_attribute :subject, :author_name
+  end
+
+  ToBeLoadedSecond = Class.new(ActiveRecord::Base) do
+    self.table_name = "topics"
+    alias_attribute :subject, :title
+  end
+
+  test "aliases to the same attribute name do not conflict with each other" do
+    first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
+    assert_equal("author 1", first_model_object.subject)
+    second_model_object = ToBeLoadedSecond.new(title: "foo")
+    assert_equal("foo", second_model_object.subject)
+  end
+
   ClassWithDeprecatedAliasAttributeBehavior = Class.new(ActiveRecord::Base) do
     self.table_name = "topics"
     alias_attribute :subject, :title


### PR DESCRIPTION
Substitutes https://github.com/rails/rails/pull/48843

`define_proxy_call` accepts `call_args` as an argument which impacts method body generation but it doesn't use `call_args` in the `namespace` generation which leads to the same cached method to be reused even if `call_args` differ.

It has never been an issue since `define_proxy_call` was only used to generate Active Record attribute methods and we were always passing the same `call_args` per method name.

However, since https://github.com/rails/rails/pull/48533 we are using `define_proxy_call` to generate alias attribute methods where `call_args` differ for the same method name which leads to the same cached method being reused in wrong places.

This commit fixes the issue by making sure `call_args` are being considered when generating the `namespace` for the method as anything that results in a different body being generated should be accounted when building the cache key

### Problem example
Consider the following models:

```ruby
class Message < ActiveRecord::Base
  alias_attribute :subject, :header
end

class Topic < ActiveRecord::Base
  alias_attribute :subject, :title
end
```

Since https://github.com/rails/rails/pull/48533 we expect Rails to generate the following getters for aliases:

```ruby
class Message < ActiveRecord::Base
  def subject
     attribute(:header)
  end
end

class Topic < ActiveRecord::Base
  def subject
     attribute(:title)
  end
end
```

Due to Rails using caching mechanism for method generation and the cache key consists of the hardcoded `proxy_alias_attribute` plus the `proxy_target` which is `"attribute"`  only one `subject` getter method will actually be generated and it depends on whichever of the models gets loaded first, the other model will reuse the cached method with a wrong body