### PR TITLE
Omit `webdrivers` gem from `Gemfile` template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem "rake", ">= 13"
 
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
-gem "capybara", ">= 3.38"
-gem "selenium-webdriver", ">= 4.0.0"
+gem "capybara", ">= 3.39"
+gem "selenium-webdriver", ">= 4.11.0"
 
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"
@@ -120,10 +120,6 @@ end
 # Action Mailbox
 gem "aws-sdk-sns", require: false
 gem "webmock"
-
-group :ujs do
-  gem "webdrivers"
-end
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,12 @@ gem "rake", ">= 13"
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.39"
-gem "selenium-webdriver", ">= 4.11.0"
+if RUBY_VERSION < "3"
+  gem "selenium-webdriver", "<= 4.9.0"
+  gem "webdrivers"
+else
+  gem "selenium-webdriver", ">= 4.11.0"
+end
 
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     bunny (2.20.2)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
-    capybara (3.38.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -457,7 +457,7 @@ GEM
       fugit (~> 1.1, >= 1.1.6)
     sdoc (2.6.1)
       rdoc (>= 5.0)
-    selenium-webdriver (4.7.1)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -532,10 +532,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -565,7 +561,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.11)
   benchmark-ips
   bootsnap (>= 1.4.4)
-  capybara (>= 3.38)
+  capybara (>= 3.39)
   cgi (>= 0.3.6)
   connection_pool
   cssbundling-rails
@@ -616,7 +612,7 @@ DEPENDENCIES
   rubocop-rails
   rubyzip (~> 2.0)
   sdoc (>= 2.6.0)
-  selenium-webdriver (>= 4.0.0)
+  selenium-webdriver (>= 4.11.0)
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
@@ -632,7 +628,6 @@ DEPENDENCIES
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)
   web-console
-  webdrivers
   webmock
   webrick
   websocket-client-simple!

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -26,7 +26,7 @@ module ActionDispatch
         yield options if block_given? && options
       end
 
-      # driver_path can be configured as a proc. The webdrivers gem uses this
+      # driver_path can be configured as a proc.
       # proc to update web drivers. Running this proc early allows us to only
       # update the webdriver once and avoid race conditions when using
       # parallel tests.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -886,16 +886,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 end
 ```
 
-In such a case, the gem `webdrivers` is no longer required. You could remove it
-completely or add `require:` option in `Gemfile`.
-
-```ruby
-# ...
-group :test do
-  gem "webdrivers", require: !ENV["SELENIUM_REMOTE_URL"] || ENV["SELENIUM_REMOTE_URL"].empty?
-end
-```
-
 Now you should get a connection to remote browser.
 
 ```bash

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Omit `webdrivers` gem dependency from `Gemfile` template
+
+    *Sean Doyle*
+
 *   Support filtering tests by line ranges
 
     The new syntax allows you to filter tests by line ranges. For example, the

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -59,8 +59,7 @@ end
 <%- if depends_on_system_test? -%>
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
-  gem "selenium-webdriver"
-  gem "webdrivers"
+  gem "capybara", ">= 3.39"
+  gem "selenium-webdriver", ">= 4.11.0"
 end
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -59,7 +59,10 @@ end
 <%- if depends_on_system_test? -%>
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara", ">= 3.39"
-  gem "selenium-webdriver", ">= 4.11.0"
+  gem "capybara"
+  gem "selenium-webdriver"
+<%- if RUBY_VERSION < "3.0" -%>
+  gem "webdrivers"
+<% end %>
 end
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -532,7 +532,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "capybara"
     assert_no_gem "selenium-webdriver"
-    assert_no_gem "webdrivers"
 
     assert_no_directory("test")
   end
@@ -559,7 +558,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-system-test"]
     assert_no_gem "capybara"
     assert_no_gem "selenium-webdriver"
-    assert_no_gem "webdrivers"
 
     assert_directory("test")
 


### PR DESCRIPTION
### Motivation / Background

As of Selenium 4.6, [the Selenium Manager is capable of managing Chrome Driver installations and integrations][readme]. As of Selenium 4.11, the
Selenium Manager is capable of [capable of resolving the Chrome for
Testing installation][] path.


### Detail

By omitting the `gem` declaration from the `Gemfile.tt`, newly generated applications and applications updating their `Gemfile` in lockstep with newer Rails versions can shed the dependency and avoid test failures introduced by newly released Chrome versions (like, for example, [titusfortner/webdrivers#247][]).

[readme]: https://github.com/titusfortner/webdrivers/tree/43f8ac436cc4121c903c1c611dfe76088ef6cbab#update-selenium-manager
[titusfortner/webdrivers#247]: https://github.com/titusfortner/webdrivers/issues/247
[capable of resolving the Chrome for Testing installation]: https://github.com/rails/rails/pull/48847#issuecomment-1656756862


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
