### PR TITLE
Update `listen` gem version in guide [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3612,7 +3612,7 @@ evented file system monitor to detect changes when reloading is enabled:
 
 ```ruby
 group :development do
-  gem 'listen', '~> 3.3'
+  gem 'listen', '~> 3.5'
 end
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the documentation specifies 3.3 as the minimum version of the `listen` gem, but according to [this PR](https://github.com/rails/rails/pull/48622), modern `rails` requires the `listen` gem to be version 3.5 or higher.

### Detail

This Pull Request changes the version of `listen` gem described in the document to 3.5

### Additional information

Referred PR: https://github.com/rails/rails/pull/48622

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
