### PR TITLE
Add Rack::Lint to DebugExceptions missing test

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -165,7 +165,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
   test "closes the response body on cascade pass" do
     boomer = Boomer.new(false)
-    @app = ActionDispatch::DebugExceptions.new(boomer)
+    @app = self.class.build_app(boomer)
     assert_raise ActionController::RoutingError do
       get "/pass", headers: { "action_dispatch.show_exceptions" => :all }
     end


### PR DESCRIPTION
### Motivation / Background

#48837 missed adding Rack::Lint spec to one of the tests in DebugExceptionsTest.

### Detail

This PR adds the Rack::Lint spec for one of tests that was missed in #48837 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
