### PR TITLE
Rename `fixture_file_upload` method to `file_fixture_upload`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Rename `fixture_file_upload` method to `file_fixture_upload`
+
+    Declare an alias to preserve the backwards compatibility of `fixture_file_upload`
+
+    *Sean Doyle*
+
 *   `ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper` saves the screenshot path in test metadata on failure.
 
     *Matija Čupić*

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -8,21 +8,22 @@ module ActionDispatch
     module FixtureFile
       # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_fixture_path, path), type)</tt>:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('david.png', 'image/png') }
+      #   post :change_avatar, params: { avatar: file_fixture_upload('david.png', 'image/png') }
       #
       # Default fixture files location is <tt>test/fixtures/files</tt>.
       #
       # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
       # This will not affect other platforms:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('david.png', 'image/png', :binary) }
-      def fixture_file_upload(path, mime_type = nil, binary = false)
+      #   post :change_avatar, params: { avatar: file_fixture_upload('david.png', 'image/png', :binary) }
+      def file_fixture_upload(path, mime_type = nil, binary = false)
         if self.class.file_fixture_path && !File.exist?(path)
           path = file_fixture(path)
         end
 
         Rack::Test::UploadedFile.new(path, mime_type, binary)
       end
+      alias_method :fixture_file_upload, :file_fixture_upload
     end
 
     include FixtureFile

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1083,6 +1083,8 @@ For dealing with the integration test runner, see [`ActionDispatch::Integration:
 
 When performing requests, we will have [`ActionDispatch::Integration::RequestHelpers`](https://api.rubyonrails.org/classes/ActionDispatch/Integration/RequestHelpers.html) available for our use.
 
+If we need to upload files, take a look at [`ActionDispatch::TestProcess::FixtureFile`](https://edgeapi.rubyonrails.org/classes/ActionDispatch/TestProcess/FixtureFile.html) to help.
+
 If we need to modify the session, or state of our integration test, take a look at [`ActionDispatch::Integration::Session`](https://api.rubyonrails.org/classes/ActionDispatch/Integration/Session.html) to help.
 
 ### Implementing an Integration Test

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1083,7 +1083,7 @@ For dealing with the integration test runner, see [`ActionDispatch::Integration:
 
 When performing requests, we will have [`ActionDispatch::Integration::RequestHelpers`](https://api.rubyonrails.org/classes/ActionDispatch/Integration/RequestHelpers.html) available for our use.
 
-If we need to upload files, take a look at [`ActionDispatch::TestProcess::FixtureFile`](https://edgeapi.rubyonrails.org/classes/ActionDispatch/TestProcess/FixtureFile.html) to help.
+If we need to upload files, take a look at [`ActionDispatch::TestProcess::FixtureFile`](https://api.rubyonrails.org/classes/ActionDispatch/TestProcess/FixtureFile.html) to help.
 
 If we need to modify the session, or state of our integration test, take a look at [`ActionDispatch::Integration::Session`](https://api.rubyonrails.org/classes/ActionDispatch/Integration/Session.html) to help.
 


### PR DESCRIPTION
### Motivation / Background

The naming difference between the test harness' [file_fixture][] helper made available through Active Support (along with the `file_fixture_path` configuration value) and the integration test harness' [fixture_file_upload][] is a constant source of confusion and surprise.

### Detail

Since Active Support is more ubiquitous, this commit renames the `fixture_file_upload` method to `file_fixture_upload` to match the order of words in `file_fixture` and `file_fixture_path`.

To preserve backwards compatibility, declare a `fixture_file_upload` alias to be preserved into the future (or removed at a future point in time).

[file_fixture]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Testing/FileFixtures.html#method-i-file_fixture
[fixture_file_upload]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/TestProcess/FixtureFile.html#method-i-fixture_file_upload

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
