### PR TITLE
Fixes #47909 when using order or unscope

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.joins!(association)
-          if @scope.values.size > 1
+          if reflection.options[:class_name]
             self.not(association => { reflection.association_primary_key => nil })
           else
             self.not(reflection.table_name => { reflection.association_primary_key => nil })
@@ -108,7 +108,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
-          if @scope.values.size > 1
+          if reflection.options[:class_name]
             @scope.where!(association => { reflection.association_primary_key => nil })
           else
             @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -48,8 +48,48 @@ module ActiveRecord
       assert_equal Author.find(1).posts.count, Post.where.associated(:author).merge(Author.where(id: 1)).count
     end
 
+    def test_associated_unscoped_merged_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.unscope(:where).where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_associated_unscoped_merged_joined_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).unscope(:where).where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_associated_unscoped_merged_joined_extended_early_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.extending(Post::NamedExtension).joins(:author).unscope(:where).where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_associated_unscoped_merged_joined_extended_late_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).unscope(:where).where.associated(:author).merge(Author.where(id: 1)).extending(Post::NamedExtension).count
+    end
+
+    def test_associated_ordered_merged_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.order(created_at: :desc).where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_associated_ordered_merged_joined_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).order(created_at: :desc).where.associated(:author).merge(Author.where(id: 1)).count
+    end
+
     def test_associated_with_enum
-      assert_equal Author.find(2), Author.where.associated(:reading_listing).first
+      assert_equal Author.find(2), Author.joins(:reading_listing).where.associated(:reading_listing).first
+    end
+
+    def test_associated_with_enum_ordered
+      assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.associated(:reading_listing).first
+    end
+
+    def test_associated_with_enum_unscoped
+      assert_equal Author.find(2), Author.unscope(:where).joins(:reading_listing).where.associated(:reading_listing).first
+    end
+
+    def test_associated_with_enum_extended_early
+      assert_equal Author.find(2), Author.extending(Author::NamedExtension).order(id: :desc).joins(:reading_listing).where.associated(:reading_listing).first
+    end
+
+    def test_associated_with_enum_extended_late
+      assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.associated(:reading_listing).extending(Author::NamedExtension).first
     end
 
     def test_missing_with_association
@@ -83,8 +123,48 @@ module ActiveRecord
       assert_equal Author.find(1).posts.count, Post.where.missing(:author).merge(Author.where(id: 1)).count
     end
 
+    def test_missing_unscoped_merged_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).unscope(:where).where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_unscoped_merged_joined_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.unscope(:where).where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_ordered_merged_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.order(created_at: :desc).where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_ordered_merged_joined_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).order(created_at: :desc).where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_unscoped_merged_joined_extended_early_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.extending(Post::NamedExtension).joins(:author).unscope(:where).where.missing(:author).merge(Author.where(id: 1)).count
+    end
+
+    def test_missing_unscoped_merged_joined_extended_late_with_scope_on_association
+      assert_equal Author.find(1).posts.count, Post.joins(:author).unscope(:where).where.missing(:author).merge(Author.where(id: 1)).extending(Post::NamedExtension).count
+    end
+
     def test_missing_with_enum
       assert_equal Author.find(2), Author.joins(:reading_listing).where.missing(:unread_listing).first
+    end
+
+    def test_missing_with_enum_ordered
+      assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).first
+    end
+
+    def test_missing_with_enum_unscoped
+      assert_equal Author.find(2), Author.unscope(:where).joins(:reading_listing).where.missing(:unread_listing).first
+    end
+
+    def test_missing_with_enum_extended_early
+      assert_equal Author.find(2), Author.extending(Author::NamedExtension).order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).first
+    end
+
+    def test_missing_with_enum_extended_late
+      assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).extending(Author::NamedExtension).first
     end
 
     def test_not_inverts_where_clause

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -239,6 +239,16 @@ class Author < ActiveRecord::Base
   attr_accessor :post_log
   after_initialize :set_post_log
 
+  module NamedExtension
+    def author
+      "lifo"
+    end
+
+    def greeting
+      super + " :)"
+    end
+  end
+
   def set_post_log
     @post_log = []
   end


### PR DESCRIPTION
This fix corrects the logic in both the associated and missing methods. If the reflection.options hash has a key/value pair for :class_name it will use the association. This fixes [48651](https://github.com/rails/rails/issues/48651) which was not returning the correct value when using an enum association and querying for a record that had one key of the enum but was missing another. This also fixes [44964](https://github.com/rails/rails/issues/44964) where ActiveRecord was not properly aliasing self-referencing relations. If the reflection.options doesn’t contain the key/value pair then it will use the reflection.table_name. This fixes  [47909](https://github.com/rails/rails/issues/47909) in which a user was trying to find records that were either missing a relation or were missing a relation that was ordered or unscoped or were missing a relation that was using extends in the query which resulted in an ActiveRecord Exception. It also allows for using extends in any of these capacities.


* [ X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ X] Tests are added or updated if you fix a bug or add a feature.
* [X ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
