### PR TITLE
Save screenshot path on system test failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.17.0)
+    minitest (5.19.0)
     minitest-bisect (1.6.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper` saves the screenshot path in test metadata on failure.
+
+    *Matija Čupić*
+
 *   `ActionDispatch::Assertions#html_document` uses Nokogiri's HTML5 parser if it is available.
 
     The HTML5 parser better represents what the DOM would be in a browser. Previously this test

--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -42,7 +42,10 @@ module ActionDispatch
         #
         # +take_failed_screenshot+ is called during system test teardown.
         def take_failed_screenshot
-          take_screenshot if failed? && supports_screenshot? && Capybara::Session.instance_created?
+          return unless failed? && supports_screenshot? && Capybara::Session.instance_created?
+
+          take_screenshot
+          metadata[:failure_screenshot_path] = absolute_image_path if Minitest::Runnable.method_defined?(:metadata)
         end
 
         private

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -152,6 +152,24 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     assert_match %r|url=artifact://.+?tmp/screenshots/1_x\.png|, display_image_actual
   end
 
+  test "take_failed_screenshot persists the image path in the test metadata" do
+    skip "Older versions of Minitest don't support test metadata." unless Minitest::Runnable.method_defined?(:metadata)
+
+    Rails.stub :root, Pathname.getwd do
+      @new_test.stub :passed?, false do
+        Capybara::Session.stub :instance_created?, true do
+          @new_test.stub :save_image, nil do
+            @new_test.stub :show, -> (_) { } do
+              @new_test.take_failed_screenshot
+
+              assert_equal @new_test.send(:absolute_image_path), @new_test.metadata[:failure_screenshot_path]
+            end
+          end
+        end
+      end
+    end
+  end
+
   test "image path returns the absolute path from root" do
     Rails.stub :root, Pathname.getwd.join("..") do
       assert_equal Rails.root.join("tmp/screenshots/0_x.png").to_s, @new_test.send(:image_path)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Lots of CI tools support showing a failure screenshot somewhere in their UI (e.g. GitLab). I want to persist the screenshot path so these tools can pick up the screenshot and visually display it.

### Detail

This Pull Request changes `ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper` to save the screenshot path in the test metadata on failure.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Bumping `minitest` to `5.19.0` is required because the metadata changes were added in then.

https://github.com/minitest/minitest/blob/master/History.rdoc#5190--2023-07-26-

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
