### PR TITLE
Don't check `defined?` on `@connection_specification_name`

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -258,7 +258,7 @@ module ActiveRecord
 
     # Return the connection specification name from the current class or its parent.
     def connection_specification_name
-      if !defined?(@connection_specification_name) || @connection_specification_name.nil?
+      if @connection_specification_name.nil?
         return self == Base ? Base.name : superclass.connection_specification_name
       end
       @connection_specification_name
@@ -301,7 +301,7 @@ module ActiveRecord
         MSG
       end
 
-      name ||= @connection_specification_name if defined?(@connection_specification_name)
+      name ||= @connection_specification_name
       # if removing a connection that has a pool, we reset the
       # connection_specification_name so it will use the parent
       # pool.


### PR DESCRIPTION
I've removed these checks for a couple reasons:

1) If an instance variable is undefined, it will return nil, so `@connection_specification_name.nil?` is equivalent to `!defined?(@connection_specification_name)`.
2) It's possible to have a `nil` value for `name` and `@connection_specification_name`. Checking
`defined(@connection_specification_name)` in `remove_connection` doesn't prevent us from trying to remove a `nil` pool. So either way we end up with `nil`. `remove_connection_pool` silently does nothing if there's no pool found.

So neither of the `defined?` checks do anything for us and can be removed.