### PR TITLE
Fix `Cache::NullStore` with local caching for repeated reads

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -124,7 +124,7 @@ module ActiveSupport
 
             local_entries = local_cache.read_multi_entries(keys)
             local_entries.transform_values! do |payload|
-              deserialize_entry(payload).value
+              deserialize_entry(payload)&.value
             end
             missed_keys = keys - local_entries.keys
 

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -56,4 +56,14 @@ class NullStoreTest < ActiveSupport::TestCase
     end
     assert_nil @cache.read("name")
   end
+
+  def test_local_store_repeated_reads
+    @cache.with_local_cache do
+      @cache.read("foo")
+      assert_nil @cache.read("foo")
+
+      @cache.read_multi("foo", "bar")
+      assert_equal({ "foo" => nil, "bar" => nil }, @cache.read_multi("foo", "bar"))
+    end
+  end
 end


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails/pull/45728 into `7-0-stable`.
Fixes #48867.