### PR TITLE
[7-0-stable] Fix AM::Error.full_message to remove ":base"

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Error.full_message should strip ":base" from the message
+
+    *zzak*
+
 ## Rails 7.0.6 (June 29, 2023) ##
 
 *   No changes.

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -49,6 +49,10 @@ module ActiveModel
       defaults << :"errors.format"
       defaults << "%{attribute} %{message}"
 
+      parts = attribute.split(".")
+      parts.delete("base")
+      attribute = parts.join(".")
+
       attr_name = attribute.tr(".", "_").humanize
       attr_name = base_class.human_attribute_name(attribute, {
         default: attr_name,

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -217,6 +217,11 @@ class ErrorTest < ActiveModel::TestCase
     assert error != person
   end
 
+  test "full_message returns the given message when the attribute contains base" do
+    error = ActiveModel::Error.new(Person.new, :"foo.base", "press the button")
+    assert_equal "foo press the button", error.full_message
+  end
+
   # details
 
   test "details which ignores callback and message options" do

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Revert "Fix autosave associations with validations added on `:base` of the associated objects."
+
+    This change intended to remove the :base attribute from the message,
+    but broke many assumptions which key these errors were stored.
+
+    *zzak*
+
 *   Revert breaking changes to `has_one` relationship deleting the old record before the new one is validated.
 
     *zzak*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -354,15 +354,11 @@ module ActiveRecord
       end
 
       def normalize_reflection_attribute(indexed_attribute, reflection, index, attribute)
-        normalized_attribute =
-          if indexed_attribute
-            "#{reflection.name}[#{index}]"
-          else
-            reflection.name
-          end
-
-        normalized_attribute = "#{normalized_attribute}.#{attribute}" if attribute != :base
-        normalized_attribute
+        if indexed_attribute
+          "#{reflection.name}[#{index}].#{attribute}"
+        else
+          "#{reflection.name}.#{attribute}"
+        end
       end
 
       # Is used as an around_save callback to check while saving a collection

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -560,36 +560,6 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal [], guitar.errors.details[:"tuning_pegs.pitch"]
   end
 
-  def test_errors_details_with_error_on_base_should_be_indexed_when_passed_as_array
-    reference = Class.new(ActiveRecord::Base) do
-      self.table_name = "references"
-      def self.name; "Reference"; end
-
-      validate :should_be_favorite
-
-      private
-        def should_be_favorite
-          errors.add(:base, "should be favorite") unless favorite?
-        end
-    end
-
-    person = Class.new(ActiveRecord::Base) do
-      self.table_name = "people"
-      has_many :references, autosave: true, index_errors: true, anonymous_class: reference
-      def self.name; "Person"; end
-    end
-
-    p = person.new
-    reference_valid = reference.new(favorite: true)
-    reference_invalid = reference.new(favorite: false)
-    p.references = [reference_valid, reference_invalid]
-
-    assert_predicate reference_valid, :valid?
-    assert_not_predicate reference_invalid, :valid?
-    assert_not_predicate p, :valid?
-    assert_equal [{ error: "should be favorite" }], p.errors.details[:"references[1]"]
-  end
-
   def test_errors_details_should_be_indexed_when_global_flag_is_set
     old_attribute_config = ActiveRecord.index_nested_attribute_errors
     ActiveRecord.index_nested_attribute_errors = true

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -560,6 +560,37 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal [], guitar.errors.details[:"tuning_pegs.pitch"]
   end
 
+  def test_errors_details_with_error_on_base_should_be_indexed_when_passed_as_array
+    reference = Class.new(ActiveRecord::Base) do
+      self.table_name = "references"
+      def self.name; "Reference"; end
+
+      validate :should_be_favorite
+
+      private
+        def should_be_favorite
+          errors.add(:base, "should be favorite") unless favorite?
+        end
+    end
+
+    person = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+      has_many :references, autosave: true, index_errors: true, anonymous_class: reference
+      def self.name; "Person"; end
+    end
+
+    p = person.new
+    reference_valid = reference.new(favorite: true)
+    reference_invalid = reference.new(favorite: false)
+    p.references = [reference_valid, reference_invalid]
+
+    assert_predicate reference_valid, :valid?
+    assert_not_predicate reference_invalid, :valid?
+    assert_not_predicate p, :valid?
+    assert_equal [{ error: "should be favorite" }], p.errors.details[:"references[1].base"]
+    assert_equal "should be favorite", p.errors[:"references[1].base"].first
+  end
+
   def test_errors_details_should_be_indexed_when_global_flag_is_set
     old_attribute_config = ActiveRecord.index_nested_attribute_errors
     ActiveRecord.index_nested_attribute_errors = true


### PR DESCRIPTION
This PR reverts the changes to autosave from #48413, and fixes #48408, without having to change which key errors are stored.


There is an equivalent PR for `main` branch in #48871