### PR TITLE
Fix AM::Error.full_message to remove ":base"

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,13 +1,14 @@
-*   Add a load hook for `ActiveModel::Model` (named `active_model`) to match the load hook for `ActiveRecord::Base` and
-    allow for overriding aspects of the `ActiveModel::Model` class.
-
-    *Lewis Buckley*
-
-*   Error.full_message should strip ":base" from the message
+*   Error.full_message now strips ":base" from the message.
 
     *zzak*
 
-*   Improve password length validation in ActiveModel::SecurePassword to consider byte size for BCrypt compatibility.
+*   Add a load hook for `ActiveModel::Model` (named `active_model`) to match the load hook for
+    `ActiveRecord::Base` and allow for overriding aspects of the `ActiveModel::Model` class.
+
+    *Lewis Buckley*
+
+*   Improve password length validation in ActiveModel::SecurePassword to consider byte size for BCrypt
+    compatibility.
 
     The previous password length validation only considered the character count, which may not
     accurately reflect the 72-byte size limit imposed by BCrypt. This change updates the validation

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -3,6 +3,10 @@
 
     *Lewis Buckley*
 
+*   Error.full_message should strip ":base" from the message
+
+    *zzak*
+
 *   Improve password length validation in ActiveModel::SecurePassword to consider byte size for BCrypt compatibility.
 
     The previous password length validation only considered the character count, which may not

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -49,9 +49,7 @@ module ActiveModel
       defaults << :"errors.format"
       defaults << "%{attribute} %{message}"
 
-      parts = attribute.split(".")
-      parts.delete("base")
-      attribute = parts.join(".")
+      attribute = attribute.remove(/\.base\z/)
 
       attr_name = attribute.tr(".", "_").humanize
       attr_name = base_class.human_attribute_name(attribute, {

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -49,6 +49,10 @@ module ActiveModel
       defaults << :"errors.format"
       defaults << "%{attribute} %{message}"
 
+      parts = attribute.split(".")
+      parts.delete("base")
+      attribute = parts.join(".")
+
       attr_name = attribute.tr(".", "_").humanize
       attr_name = base_class.human_attribute_name(attribute, {
         default: attr_name,

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -217,6 +217,11 @@ class ErrorTest < ActiveModel::TestCase
     assert_not_equal error, person
   end
 
+  test "full_message returns the given message when the attribute contains base" do
+    error = ActiveModel::Error.new(Person.new, :"foo.base", "press the button")
+    assert_equal "foo press the button", error.full_message
+  end
+
   # details
 
   test "details which ignores callback and message options" do

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -359,15 +359,11 @@ module ActiveRecord
       end
 
       def normalize_reflection_attribute(indexed_attribute, reflection, index, attribute)
-        normalized_attribute =
-          if indexed_attribute
-            "#{reflection.name}[#{index}]"
-          else
-            reflection.name
-          end
-
-        normalized_attribute = "#{normalized_attribute}.#{attribute}" if attribute != :base
-        normalized_attribute
+        if indexed_attribute
+          "#{reflection.name}[#{index}].#{attribute}"
+        else
+          "#{reflection.name}.#{attribute}"
+        end
       end
 
       # Is used as an around_save callback to check while saving a collection

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -570,6 +570,37 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal [], guitar.errors.details[:"tuning_pegs.pitch"]
   end
 
+  def test_errors_details_with_error_on_base_should_be_indexed_when_passed_as_array
+    reference = Class.new(ActiveRecord::Base) do
+      self.table_name = "references"
+      def self.name; "Reference"; end
+
+      validate :should_be_favorite
+
+      private
+        def should_be_favorite
+          errors.add(:base, "should be favorite") unless favorite?
+        end
+    end
+
+    person = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+      has_many :references, autosave: true, index_errors: true, anonymous_class: reference
+      def self.name; "Person"; end
+    end
+
+    p = person.new
+    reference_valid = reference.new(favorite: true)
+    reference_invalid = reference.new(favorite: false)
+    p.references = [reference_valid, reference_invalid]
+
+    assert_predicate reference_valid, :valid?
+    assert_not_predicate reference_invalid, :valid?
+    assert_not_predicate p, :valid?
+    assert_equal [{ error: "should be favorite" }], p.errors.details[:"references[1].base"]
+    assert_equal "should be favorite", p.errors[:"references[1].base"].first
+  end
+
   def test_errors_details_should_be_indexed_when_global_flag_is_set
     old_attribute_config = ActiveRecord.index_nested_attribute_errors
     ActiveRecord.index_nested_attribute_errors = true

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -570,36 +570,6 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal [], guitar.errors.details[:"tuning_pegs.pitch"]
   end
 
-  def test_errors_details_with_error_on_base_should_be_indexed_when_passed_as_array
-    reference = Class.new(ActiveRecord::Base) do
-      self.table_name = "references"
-      def self.name; "Reference"; end
-
-      validate :should_be_favorite
-
-      private
-        def should_be_favorite
-          errors.add(:base, "should be favorite") unless favorite?
-        end
-    end
-
-    person = Class.new(ActiveRecord::Base) do
-      self.table_name = "people"
-      has_many :references, autosave: true, index_errors: true, anonymous_class: reference
-      def self.name; "Person"; end
-    end
-
-    p = person.new
-    reference_valid = reference.new(favorite: true)
-    reference_invalid = reference.new(favorite: false)
-    p.references = [reference_valid, reference_invalid]
-
-    assert_predicate reference_valid, :valid?
-    assert_not_predicate reference_invalid, :valid?
-    assert_not_predicate p, :valid?
-    assert_equal [{ error: "should be favorite" }], p.errors.details[:"references[1]"]
-  end
-
   def test_errors_details_should_be_indexed_when_global_flag_is_set
     old_attribute_config = ActiveRecord.index_nested_attribute_errors
     ActiveRecord.index_nested_attribute_errors = true

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -601,6 +601,54 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal "should be favorite", p.errors[:"references[1].base"].first
   end
 
+  def test_indexed_errors_should_be_properly_translated
+    old_i18n_customize_full_message = ActiveModel::Error.i18n_customize_full_message
+    ActiveModel::Error.i18n_customize_full_message = true
+    I18n.backend.store_translations(
+      :en,
+      activerecord: {
+        errors: {
+          models: {
+            "person/references": {
+              format: "%{message}"
+            }
+          }
+        }
+      }
+    )
+    reference = Class.new(ActiveRecord::Base) do
+      self.table_name = "references"
+      def self.name; "Reference"; end
+
+      validate :should_be_favorite
+      validates_presence_of :job_id
+
+      private
+        def should_be_favorite
+          errors.add(:base, "should be favorite") unless favorite?
+        end
+    end
+
+    person = Class.new(ActiveRecord::Base) do
+      self.table_name = "people"
+      has_many :references, autosave: true, index_errors: true, anonymous_class: reference
+      def self.name; "Person"; end
+    end
+
+    p = person.new
+    reference_valid = reference.new(favorite: true, job_id: 1)
+    reference_invalid = reference.new(favorite: false)
+    p.references = [reference_valid, reference_invalid]
+
+    assert_predicate reference_valid, :valid?
+    assert_not_predicate reference_invalid, :valid?
+    assert_not_predicate p, :valid?
+    assert_equal ["should be favorite", "can’t be blank"], p.errors.full_messages
+  ensure
+    ActiveModel::Error.i18n_customize_full_message = old_i18n_customize_full_message
+    I18n.backend = I18n::Backend::Simple.new
+  end
+
   def test_errors_details_should_be_indexed_when_global_flag_is_set
     old_attribute_config = ActiveRecord.index_nested_attribute_errors
     ActiveRecord.index_nested_attribute_errors = true


### PR DESCRIPTION
This PR reverts the changes to autosave from #48413, and fixes #48408, without having to change which key errors are stored.

There is an equivalent PR for `7-0-stable` branch in #48870.

/cc @fatkodima @rafaelfranca @Edouard-chin @kamil-gwozdz