### PR TITLE
Simplify the sanity check in ARTest.connect

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -28,8 +28,7 @@ module ARTest
 
     arunit_adapter = ActiveRecord::Base.connection.pool.db_config.adapter
 
-    if connection_name != arunit_adapter
-      return if connection_name == "sqlite3_mem" && arunit_adapter == "sqlite3"
+    unless connection_name.include?(arunit_adapter)
       raise ArgumentError, "The connection name did not match the adapter name. Connection name is '#{connection_name}' and the adapter name is '#{arunit_adapter}'."
     end
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to allow [Active Record SQL Server Adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) tests to run against the Rails `main` branch.

### Detail

In PR [Fix trilogy builds](https://github.com/rails/rails/pull/48015), a check was included to prevent the tests running against the wrong adapter. The fix handled the special case of SQLite which uses different connection (`sqlite3_mem`) and adapter (`sqlite3`) names. 

This Pull Request extends that check to also handle the SQL Server adapter. The adapter's name is `sqlserver` but the connection's name is `dblib`. I can't find an alternative method in the adapter's codebase of fixing this issue.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
