### PR TITLE
Adds Arel::FactoryMethods#cast(node, type)

### DIFF
--- a/activerecord/lib/arel/factory_methods.rb
+++ b/activerecord/lib/arel/factory_methods.rb
@@ -45,5 +45,9 @@ module Arel # :nodoc: all
     def coalesce(*exprs)
       Nodes::NamedFunction.new "COALESCE", exprs
     end
+
+    def cast(name, type)
+      Nodes::NamedFunction.new "CAST", [name.as(type)]
+    end
   end
 end

--- a/activerecord/test/cases/arel/factory_methods_test.rb
+++ b/activerecord/test/cases/arel/factory_methods_test.rb
@@ -48,7 +48,10 @@ module Arel
         cast = @factory.cast field_node, "boolean"
         assert_instance_of Nodes::NamedFunction, cast
         assert_equal "CAST", cast.name
-        assert_equal %(CAST("users"."active" AS boolean)), cast.to_sql
+        as_node = cast.expressions.first
+        assert_instance_of Nodes::As, as_node
+        assert_equal field_node, as_node.left
+        assert_equal "boolean", as_node.right
       end
     end
   end

--- a/activerecord/test/cases/arel/factory_methods_test.rb
+++ b/activerecord/test/cases/arel/factory_methods_test.rb
@@ -41,6 +41,15 @@ module Arel
         assert_equal "LOWER", lower.name
         assert_equal [:one], lower.expressions.map(&:expr)
       end
+
+      def test_cast
+        relation = Table.new(:users)
+        field_node = relation[:active]
+        cast = @factory.cast field_node, "boolean"
+        assert_instance_of Nodes::NamedFunction, cast
+        assert_equal "CAST", cast.name
+        assert_equal %(CAST("users"."active" AS boolean)), cast.to_sql
+      end
     end
   end
 end


### PR DESCRIPTION
For example:

```
  product_table = Product.arel_table
  product_table.cast(product_table[:position], "integer")
```

Produces SQL:

```
  CAST("products"."position" as integer)
```

### Motivation / Background

`CAST(field as type)` is a widely supported SQL function. This PR adds native arel support for this named function with a `cast(field, type)` helper.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
