### PR TITLE
Fix typo in ActiveRecord Query guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1382,7 +1382,7 @@ Author.joins(books: [{ reviews: { customer: :orders } }, :supplier])
 This produces:
 
 ```sql
-SELECT * FROM authors
+SELECT authors.* FROM authors
   INNER JOIN books ON books.author_id = authors.id
   INNER JOIN reviews ON reviews.book_id = books.id
   INNER JOIN customers ON customers.id = reviews.customer_id


### PR DESCRIPTION
The SQL generated by this query (at 13.1.3.2 of the ActiveRecord Query guide):

```ruby
Author.joins(books: [{ reviews: { customer: :orders } }, :supplier] )
```

Is stated to generate SQL whose select list is comprised of `*`; it should be `authors.*`