### PR TITLE
Remove overflow:hidden from welcome logo

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -51,7 +51,6 @@
       display: flex;
       transition: background 0.25s cubic-bezier(0.33, 1, 0.68, 1);
       filter: drop-shadow(0 20px 13px rgb(0 0 0 / 0.03)) drop-shadow(0 8px 5px rgb(0 0 0 / 0.08));
-      overflow: hidden;
     }
 
     nav a:hover {


### PR DESCRIPTION
This was originally added in #47781:

> ...rails logo hover on welcome page is being triggered on square instead of round image.

However, on Safari the border is being cut-off.

I'm not sure there is another workaround, but I am willing to accept a larger (square) clickable area to have a consistent drop shadow.

Before

<img width="303" alt="Screenshot 2023-08-04 at 18 47 43" src="https://github.com/rails/rails/assets/277819/aa05ff53-5781-4a45-8dc5-a037125e8be1">

After

<img width="303" alt="Screenshot 2023-08-04 at 18 47 48" src="https://github.com/rails/rails/assets/277819/de4413bd-dc08-49f0-9dab-826be4a2b9bd">


/cc @brenda-daroz 