### PR TITLE
Fix `ActiveRecord::QueryMethods#in_order_of` to work with nils

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `ActiveRecord::QueryMethods#in_order_of` to include `nil`s, to match the
+    behavior of `Enumerable#in_order_of`.
+
+    For example, `Post.in_order_of(:title, [nil, "foo"])` will now include posts
+    with `nil` titles, the same as `Post.all.to_a.in_order_of(:title, [nil, "foo"])`.
+
+    *fatkodima*
+
 *   Revert "Fix autosave associations with validations added on `:base` of the associated objects."
 
     This change intended to remove the :base attribute from the message,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -657,15 +657,6 @@ module ActiveRecord
         migration_context.current_version
       end
 
-      def field_ordered_value(column, values) # :nodoc:
-        node = Arel::Nodes::Case.new(column)
-        values.each.with_index(1) do |value, order|
-          node.when(value).then(order)
-        end
-
-        Arel::Nodes::Ascending.new(node.else(values.length + 1))
-      end
-
       class << self
         private
           def initialize_type_map(m)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -138,11 +138,6 @@ module ActiveRecord
         true
       end
 
-      def field_ordered_value(column, values) # :nodoc:
-        field = Arel::Nodes::NamedFunction.new("FIELD", [column, values.reverse.map { |value| Arel::Nodes.build_quoted(value) }])
-        Arel::Nodes::Descending.new(field)
-      end
-
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -69,4 +69,16 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     assert_equal(order, posts.map(&:id))
   end
+
+  def test_in_order_of_with_nil
+    Book.destroy_all
+    Book.create!(format: "paperback")
+    Book.create!(format: "ebook")
+    Book.create!(format: nil)
+
+    order = ["ebook", nil, "paperback"]
+    books = Book.in_order_of(:format, order)
+
+    assert_equal(order, books.map(&:format))
+  end
 end


### PR DESCRIPTION
This a backport of https://github.com/rails/rails/pull/45670 into `7-0-stable` (including a few follow-up PRs which were made after, https://github.com/rails/rails/pull/46031, https://github.com/rails/rails/pull/46471 and https://github.com/rails/rails/commit/18f8c6ac9ba).