### PR TITLE
Fix NoMethodError when request Content-Type is blank.

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -163,7 +163,7 @@ module Mime
 
       def lookup(string)
         # fallback to the media-type without parameters if it was not found
-        LOOKUP[string] || LOOKUP[string.split(";", 2)[0].rstrip] || Type.new(string)
+        LOOKUP[string] || LOOKUP[string.split(";", 2)[0]&.rstrip] || Type.new(string)
       end
 
       def lookup_by_extension(extension)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -607,6 +607,13 @@ class TestCaseTest < ActionController::TestCase
     assert_equal "application/json", parsed_env["CONTENT_TYPE"]
   end
 
+  test "blank Content-Type header" do
+    @request.headers["Content-Type"] = ""
+    assert_raises(ActionDispatch::Http::MimeNegotiation::InvalidType) do
+      get :test_headers
+    end
+  end
+
   def test_using_as_json_sets_request_content_type_to_json
     post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because since [this change](https://github.com/rails/rails/commit/1071a39020564e1f7ebfb618e3e855b52450e015) we started receiving a `NoMethodError` "undefined method \`rstrip' for nil:NilClass" from [line 166](https://github.com/rails/rails/blob/1071a39020564e1f7ebfb618e3e855b52450e015/actionpack/lib/action_dispatch/http/mime_type.rb#L166) of `actionpack/lib/action_dispatch/http/mime_type.rb` when a client makes a request with a blank `Content-Type` header. I believe this client is not adhering to the spec, but prior to the commit they would raise an `ActionDispatch::Http::MimeNegotiation::InvalidType` error and receive a "406 Not Acceptable" response instead of a "500 Server Error" response.

The `NoMethodError`s also clog our error tracking system, whereas we are able to ignore the more specific invalid mime type errors.

### Detail

This Pull Request changes the mime type lookup to use the safe nagivation operator on the call to `rstrip` to handle the case when a client makes a request with a blank `Content-Type` header.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
The following code snippet contains a working recreation of the issue with the current `main` branch.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "rack", "~> 2.0"
end

require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/" => "test#index"
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: "Home"
  end
end

require "minitest/autorun"
require "rack/test"

class BugTest < Minitest::Test
  include Rack::Test::Methods

  def test_returns_success
    get "/", {}, 'CONTENT_TYPE' => ''

    assert last_response.server_error?
    assert (last_response.status == 500)
  end

  private
    def app
      Rails.application
    end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
