### PR TITLE
Action Mailer Preview empty states

### DIFF
--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -15,7 +15,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
   def index
     @previews = ActionMailer::Preview.all
-    @page_title = "Mailer Previews"
+    @page_title = "Action Mailer Previews"
   end
 
   def download
@@ -30,7 +30,7 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
 
   def preview
     if params[:path] == @preview.preview_name
-      @page_title = "Mailer Previews for #{@preview.preview_name}"
+      @page_title = "Action Mailer Previews for #{@preview.preview_name}"
       render action: "mailer"
     else
       @email_action = File.basename(params[:path])

--- a/railties/lib/rails/templates/rails/mailers/index.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/index.html.erb
@@ -1,8 +1,15 @@
-<% @previews.each do |preview| %>
-<h3><%= link_to preview.preview_name.titleize, url_for(controller: "rails/mailers", action: "preview", path: preview.preview_name) %></h3>
-<ul>
-<% preview.emails.each do |email| %>
-<li><%= link_to email, url_for(controller: "rails/mailers", action: "preview", path: "#{preview.preview_name}/#{email}") %></li>
-<% end %>
-</ul>
+<h1><%= @page_title %></h1>
+
+<% if @previews.any? %>
+  <% @previews.each do |preview| %>
+  <h3><%= link_to preview.preview_name.titleize, url_for(controller: "rails/mailers", action: "preview", path: preview.preview_name) %></h3>
+  <ul>
+  <% preview.emails.each do |email| %>
+  <li><%= link_to email, url_for(controller: "rails/mailers", action: "preview", path: "#{preview.preview_name}/#{email}") %></li>
+  <% end %>
+  </ul>
+  <% end %>
+<% else %>
+  <p>You have not defined any Action Mailer Previews.</p>
+  <p>Read <%= link_to "Action Mailer Basics", "https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails" %> to learn how to define your first.</p>
 <% end %>

--- a/railties/lib/rails/templates/rails/mailers/mailer.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/mailer.html.erb
@@ -1,6 +1,12 @@
-<h3><%= @preview.preview_name.titleize %></h3>
-<ul>
-<% @preview.emails.each do |email| %>
-<li><%= link_to email, url_for(controller: "rails/mailers", action: "preview", path: "#{@preview.preview_name}/#{email}") %></li>
+<h1><%= @page_title %></h1>
+
+<% if @preview.emails.any? %>
+  <ul>
+  <% @preview.emails.each do |email| %>
+  <li><%= link_to email, url_for(controller: "rails/mailers", action: "preview", path: "#{@preview.preview_name}/#{email}") %></li>
+  <% end %>
+  </ul>
+<% else %>
+  <p>You have not defined any actions for <%= @preview %>.</p>
+  <p>Read <%= link_to "Action Mailer Basics", "https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails" %> to learn how to define your first.</p>
 <% end %>
-</ul>


### PR DESCRIPTION


### Motivation / Background

When an application defines mailers without any corresponding previews, requests to `GET /rails/mailers` return a page with a blank `<body>` element.

This entirely empty page can be confusing, since it's difficult to distinguish the "success" state with an empty list and a "failure" state with swallowed errors.

Similarly, when an `ActionMailer::Preview` subclass is defined, but doesn't declare any actions, the response contains a mostly empty page.

### Detail



This commit renders empty-state messaging for both scenarios, and links to the [Action Mailer Basics][] guides.

To effectively cover that behavior, this commit also expands the Mailer Preview test coverage to utilize [rails-dom-testing][] assertions.

[Action Mailer Basics]: https://guides.rubyonrails.org/action_mailer_basics.html#previewing-emails
[rails-dom-testing]: http://github.com/rails/rails-dom-testing

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
