### PR TITLE
Add length validation for minium typo, raise error to notify user

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -29,7 +29,7 @@ module ActiveModel
       def check_validity!
         keys = CHECKS.keys & options.keys
 
-        if keys.empty?
+        if keys.empty? || options.key?(:minium)
           raise ArgumentError, "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option."
         end
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,8 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+
+  def test_validates_length_of_using_minium_with_maximum_raise_error
+    assert_raise(ArgumentError) { Topic.validates_length_of :title, minium: 3, maximum: 5 }
+  end
 end


### PR DESCRIPTION
### Motivation / Background

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

post = Post.new(title: "a")
puts post.valid? # true
```
The above code will pass validation because we don't have an equivalent for typos when `minium & maximum` present both.

The PR is more of a workaround at the moment, but I think the `CHECKS.keys & options.keys` code needs to be fixed.

so that `keys.empty?` works correctly.

https://discuss.rubyonrails.org/t/proposal-add-min-and-max-alias-to-lengthvalidator/82771

### Detail

1. Add a comparison to check if there are `minium` in there
2. Add test to make sure it works and would not break other test

### Additional information

Perhaps we can also include the keys that will be used in RESERVED_OPTIONS, so that we don't need to use such a workaround, and the code will be more elegant.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
