### PR TITLE
Support min & max for length validation

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support min & max for length validation
+
+    Provides a simple way for users to set length
+
+    *RobertChang*
+
 *   Error.full_message now strips ":base" from the message.
 
     *zzak*

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -7,8 +7,8 @@ module ActiveModel
     class LengthValidator < EachValidator # :nodoc:
       include ResolveValue
 
-      MESSAGES  = { is: :wrong_length, minimum: :too_short, maximum: :too_long }.freeze
-      CHECKS    = { is: :==, minimum: :>=, maximum: :<= }.freeze
+      MESSAGES  = { is: :wrong_length, minimum: :too_short, maximum: :too_long, min: :too_short, max: :too_long }.freeze
+      CHECKS    = { is: :==, minimum: :>=, maximum: :<=, min: :>=, max: :<= }.freeze
 
       RESERVED_OPTIONS = [:minimum, :maximum, :within, :is, :too_short, :too_long]
 
@@ -30,7 +30,7 @@ module ActiveModel
         keys = CHECKS.keys & options.keys
 
         if keys.empty?
-          raise ArgumentError, "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option."
+          raise ArgumentError, "Range unspecified. Specify the :in, :within, :maximum, :minimum, :min, :max or :is option."
         end
 
         keys.each do |key|

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,45 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+
+  def test_validates_length_of_support_min
+    Topic.validates_length_of :title, min: 3
+
+    t = Topic.new(title: "a")
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:title]
+
+    t = Topic.new(title: "aaa")
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_length_of_support_max
+    Topic.validates_length_of :title, max: 5
+
+    t = Topic.new(title: "aaaaaa")
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too long (maximum is 5 characters)"], t.errors[:title]
+
+    t = Topic.new(title: "aaaaa")
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_length_of_support_min_and_max_both
+    Topic.validates_length_of :title, min: 3, max: 5
+
+    t = Topic.new(title: "a")
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too short (minimum is 3 characters)"], t.errors[:title]
+
+    t = Topic.new(title: "aaaaaa")
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too long (maximum is 5 characters)"], t.errors[:title]
+
+    t = Topic.new(title: "aaaa")
+    assert_predicate t, :valid?
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Provides a simple way for users to set length

This reduces the need for users to make typos like minium and avoid validation.

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

post = Post.new(title: "Invalid")
puts post.valid? # true
```

so If user can use `min` & `max` then it can prevent the wrong situation happened.

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { min: 10, max: 20 }
end

post = Post.new(title: "Invalid")
puts post.valid? # false
```

https://discuss.rubyonrails.org/t/proposal-add-min-and-max-alias-to-lengthvalidator/82771

### Detail

1. add the `min` & `max` to the `CHECKS` and `MESSAGE` like alias the `minimum` and `maximum`
2. add test to make sure everything works good

### Additional information

Other way likes to validate the typo like `minium`.

Add possible keys into the `RESERVED_OPTIONS`

and like:

```ruby
unless options.keys.all? { |k| RESERVED_OPTIONS.include?(k) }
  raise ArgumentError ...
end

keys = CEHCKS.keys & options.keys
```

I try the code above, that's not a good idea, because add possible keys into `RESERVED_OPTIONS` would break the rules now.

like `:message` would be excepted below, so error message would be breaked

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
