### PR TITLE
Change the devcontainer configuration to use docker compose instead of collocated services

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-        mariadb-server libmariadb-dev \
+        mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
         redis-server memcached \
         ffmpeg mupdf mupdf-tools libvips poppler-utils

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
-        memcached \
         ffmpeg mupdf mupdf-tools libvips poppler-utils
 
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,18 +1,18 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
-ARG VARIANT="3.0"
-FROM mcr.microsoft.com/devcontainers/ruby:0-${VARIANT}
+ARG VARIANT="3"
+FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="lts/*"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-server libmariadb-dev \
-        postgresql postgresql-client postgresql-contrib libpq-dev \
+        postgresql-client postgresql-contrib libpq-dev \
         redis-server memcached \
         ffmpeg mupdf mupdf-tools libvips poppler-utils
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
-        redis-server memcached \
+        memcached \
         ffmpeg mupdf mupdf-tools libvips poppler-utils
 
 

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -3,8 +3,6 @@ yarn install
 
 sudo chown -R vscode:vscode /usr/local/bundle
 
-sudo service memcached start
-
 cd activerecord
 
 # Create PostgreSQL databases

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -3,7 +3,6 @@ yarn install
 
 sudo chown -R vscode:vscode /usr/local/bundle
 
-sudo service mariadb start
 sudo service redis-server start
 sudo service memcached start
 

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -3,16 +3,14 @@ yarn install
 
 sudo chown -R vscode:vscode /usr/local/bundle
 
-sudo service postgresql start
 sudo service mariadb start
 sudo service redis-server start
 sudo service memcached start
 
-# Create PostgreSQL users and databases
-sudo su postgres -c "createuser --superuser vscode"
-sudo su postgres -c "createdb -O vscode -E UTF8 -T template0 activerecord_unittest"
-sudo su postgres -c "createdb -O vscode -E UTF8 -T template0 activerecord_unittest2"
-
-# Create MySQL database and databases
 cd activerecord
-MYSQL_CODESPACES=1 bundle exec rake db:mysql:build
+
+# Create PostgreSQL databases
+bundle exec rake db:postgresql:rebuild
+
+# Create MySQL databases
+MYSQL_CODESPACES=1 bundle exec rake db:mysql:rebuild

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -3,7 +3,6 @@ yarn install
 
 sudo chown -R vscode:vscode /usr/local/bundle
 
-sudo service redis-server start
 sudo service memcached start
 
 cd activerecord

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
 		"PGHOST": "postgres",
 		"PGUSER": "postgres",
 		"PGPASSWORD": "postgres",
-		"MYSQL_HOST": "mariadb"
+		"MYSQL_HOST": "mariadb",
+		"REDIS_URL": "redis://redis/0"
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
 	"containerEnv": {
 		"PGHOST": "postgres",
 		"PGUSER": "postgres",
-		"PGPASSWORD": "postgres"
+		"PGPASSWORD": "postgres",
+		"MYSQL_HOST": "mariadb"
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
 		"PGUSER": "postgres",
 		"PGPASSWORD": "postgres",
 		"MYSQL_HOST": "mariadb",
-		"REDIS_URL": "redis://redis/0"
+		"REDIS_URL": "redis://redis/0",
+		"MEMCACHE_SERVERS": "memcached:11211"
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,29 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby
+// For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Ruby",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": {
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
-			"VARIANT": "3",
-			// Options
-			"NODE_VERSION": "lts/*"
-		}
-	},
+	"name": "Rails project development",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "rails",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {
 			"version": "latest"
 		}
 	},
+
+	"containerEnv": {
+		"PGHOST": "postgres",
+		"PGUSER": "postgres",
+		"PGPASSWORD": "postgres"
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	// "forwardPorts": [3000, 5432],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/boot.sh",
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -29,16 +35,6 @@
 		}
 	},
 
-	"containerEnv": {
-		"MYSQL_SOCK": "/run/mysqld/mysqld.sock"
-	},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": ".devcontainer/boot.sh",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - postgres
       - mariadb
       - redis
+      - memcached
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -53,6 +54,13 @@ services:
       - default
     volumes:
       - redis-data:/data
+
+  memcached:
+    image: memcached:latest
+    restart: unless-stopped
+    command: ["-m", "1024"]
+    networks:
+      - default
 
 networks:
   default:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,12 @@ services:
     command: sleep infinity
 
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:postgres
+    networks:
+      - default
+
+    depends_on:
+      - postgres
+      - mariadb
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -21,15 +26,28 @@ services:
   postgres:
     image: postgres:latest
     restart: unless-stopped
+    networks:
+      - default
     volumes:
-      - rails-postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  mariadb:
+    image: mariadb:latest
+    restart: unless-stopped
+    networks:
+      - default
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+
+networks:
+  default:
 
 volumes:
-  rails-postgres-data:
+  postgres-data:
+  mariadb-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+  rails:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:postgres
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  postgres:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - rails-postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  rails-postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     depends_on:
       - postgres
       - mariadb
+      - redis
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -45,9 +46,18 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: root
 
+  redis:
+    image: redis:latest
+    restart: unless-stopped
+    networks:
+      - default
+    volumes:
+      - redis-data:/data
+
 networks:
   default:
 
 volumes:
   postgres-data:
   mariadb-data:
+  redis-data:

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -226,21 +226,17 @@ namespace :db do
     desc "Create the MySQL Rails User"
     task :build_user do
       if ENV["MYSQL_CODESPACES"]
-        if ENV["MYSQL_SOCK"]
-          mysql_command = "sudo mysql -uroot -S #{ENV["MYSQL_SOCK"]} -e"
-        else
-          mysql_command = "sudo mysql -uroot -proot -e"
-        end
+        mysql_command = "mysql -uroot -proot -e"
       else
         mysql_command = "mysql -uroot -e"
       end
 
       mysql_configs.each do |config|
-        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit"]["username"]}'@'localhost';" )
-        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit2"]["username"]}'@'localhost';" )
-        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit"]["database"]}.* to '#{config["arunit"]["username"]}'@'localhost'" )
-        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit2"]["database"]}.* to '#{config["arunit2"]["username"]}'@'localhost'" )
-        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to '#{config["arunit"]["username"]}'@'localhost';" )
+        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit"]["username"]}'@'%';" )
+        %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit2"]["username"]}'@'%';" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit"]["database"]}.* to '#{config["arunit"]["username"]}'@'%'" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit2"]["database"]}.* to '#{config["arunit2"]["username"]}'@'%'" )
+        %x( #{mysql_command} "GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to '#{config["arunit"]["username"]}'@'%';" )
       end
     end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -253,7 +253,7 @@ namespace :db do
     end
 
     desc "Drop the MySQL test databases"
-    task :drop do
+    task drop: ["db:mysql:build_user"] do
       %x( mysql #{mysql2_connection_arguments["arunit"]} -e "drop database IF EXISTS #{mysql2_config["arunit"]["database"]}" )
       %x( mysql #{mysql2_connection_arguments["arunit2"]} -e "drop database IF EXISTS #{mysql2_config["arunit2"]["database"]}" )
 


### PR DESCRIPTION
This will not only match most of the CI configuration but will provide better experience for users of those containers.

Before after the first time the container was created, if it was restarted you needed to run the boot.sh script manually to start those services. Now, docker compose will make sure the services are running and there is no need to run. `boot.sh` again.