### PR TITLE
Draft | Investigate implicit recall usage in url helpers

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -56,7 +56,7 @@ module ActionDispatch
         end
       end
 
-      def generate(name, options, path_parameters = {})
+      def generate(name, options, path_parameters)
         original_options = options.dup
         path_params = options.delete(:path_params) || {}
         options = path_params.merge(options)

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -56,7 +56,7 @@ module ActionDispatch
         end
       end
 
-      def generate(name, options, path_parameters)
+      def generate(name, options, path_parameters = {})
         original_options = options.dup
         path_params = options.delete(:path_params) || {}
         options = path_params.merge(options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -771,7 +771,7 @@ module ActionDispatch
         # Generates a path from routes, returns a RouteWithParams or MissingRoute.
         # MissingRoute will raise ActionController::UrlGenerationError.
         def generate
-          @set.formatter.generate(named_route, options)
+          @set.formatter.generate(named_route, options, recall.except(:id))
         end
 
         def different_controller?

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -261,6 +261,7 @@ module ActionDispatch
 
           def call(t, method_name, args, inner_options, url_strategy)
             controller_options = t.url_options
+            controller_options[:_recall]&.delete(:id)
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
                                           inner_options || {},
@@ -771,7 +772,7 @@ module ActionDispatch
         # Generates a path from routes, returns a RouteWithParams or MissingRoute.
         # MissingRoute will raise ActionController::UrlGenerationError.
         def generate
-          @set.formatter.generate(named_route, options, recall.except(:id))
+          @set.formatter.generate(named_route, options, recall)
         end
 
         def different_controller?

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -771,7 +771,7 @@ module ActionDispatch
         # Generates a path from routes, returns a RouteWithParams or MissingRoute.
         # MissingRoute will raise ActionController::UrlGenerationError.
         def generate
-          @set.formatter.generate(named_route, options, recall)
+          @set.formatter.generate(named_route, options)
         end
 
         def different_controller?

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1351,3 +1351,28 @@ class PolymorphicSessionsControllerTest < ActionController::TestCase
     assert_equal %{/workshops/1/sessions/1.json\n<a href="/workshops/1/sessions/1.json">Session</a>}, @response.body
   end
 end
+
+class MissingKeyUrlController < ActionController::Base
+  ROUTES = test_routes do
+    resources :missing_keys, except: [:edit], controller: "missing_key_url"
+  end
+
+  def show
+    render plain: "#{missing_key_url}"
+  end
+end
+
+class MissingKeyUrlTest < ActionController::TestCase
+  def setup
+    super
+    @routes = MissingKeyUrlController::ROUTES
+  end
+
+  def test_new_nested_resource
+    @controller = MissingKeyUrlController.new
+
+    assert_raises ActionController::UrlGenerationError do
+      get :show, params: { id: 1 }
+    end
+  end
+end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1352,24 +1352,24 @@ class PolymorphicSessionsControllerTest < ActionController::TestCase
   end
 end
 
-class MissingKeyUrlController < ActionController::Base
+class MissingUrlKeyController < ActionController::Base
   ROUTES = test_routes do
-    resources :missing_keys, except: [:edit], controller: "missing_key_url"
+    resources :tasks, controller: "missing_url_key"
   end
 
   def show
-    render plain: "#{missing_key_url}"
+    render plain: "#{task_url}"
   end
 end
 
-class MissingKeyUrlTest < ActionController::TestCase
+class MissingUrlKeyTest < ActionController::TestCase
   def setup
     super
-    @routes = MissingKeyUrlController::ROUTES
+    @routes = MissingUrlKeyController::ROUTES
   end
 
-  def test_new_nested_resource
-    @controller = MissingKeyUrlController.new
+  def test_url_without_key
+    @controller = MissingUrlKeyController.new
 
     assert_raises ActionController::UrlGenerationError do
       get :show, params: { id: 1 }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to investigate https://github.com/rails/rails/issues/15097.

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I noticed that options are also extracted from the recall here:
https://github.com/rails/rails/blob/d73daaca479ac50ef2983d3f0af3ae16af738cf0/actionpack/lib/action_dispatch/routing/route_set.rb#L738-L747

But the `id` is never extracted (in the case of my test) since the `controller` doesn't get extracted in the first place as `segment_keys.include?(key)` returns `false` here:
https://github.com/rails/rails/blob/d73daaca479ac50ef2983d3f0af3ae16af738cf0/actionpack/lib/action_dispatch/routing/route_set.rb#L712

I'm unsure of the usecase for using the recall like this, just thought I'd point it out since it's relevant.

**Edit:** I'm guessing this is utilised in mailers going off of the documentation added here: https://github.com/rails/rails/pull/20631?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
