### PR TITLE
Added String#extract_numbers for extracting numbers from string

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `String#extract_numbers` added to extract all numeric values from a given string.
+
+    The extract_numbers method has been added to the String class in ActiveSupport.
+    This method allows extracting all numeric values from a given string and returns
+    them as an array.
+
+    ```ruby
+    "The numbers are 1, 2, and 3".extract_numbers # Returns [1, 2, 3]
+    "NoNumbersHere".extract_numbers # Returns []
+    "Temperature: -10°C".extract_numbers # Returns [-10]
+    ```
+
+    *Akhil G Krishnan*
+
 *   When using cache format version >= 7.1 or a custom serializer, expired and
     version-mismatched cache entries can now be detected without deserializing
     their values.

--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -148,4 +148,20 @@ class String
       dup
     end
   end
+
+  # Returns an array containing all the numbers found within the string.
+  #
+  # This method scans the string for sequences of digits and extracts them as integers.
+  # It then returns an array containing all the extracted numbers.
+  #
+  # Examples:
+  #   "abc123xyz456".extract_numbers  # => [123, 456]
+  #   "42 is the answer".extract_numbers  # => [42]
+  #   "The year is 2023".extract_numbers  # => [2023]
+  #
+  # Returns:
+  #   An array of integers representing the numbers found in the string.
+  def extract_numbers
+    scan(/-?\d*\.?\d+/).map(&:to_f)
+  end
 end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -441,6 +441,19 @@ class StringInflectionsTest < ActiveSupport::TestCase
   def test_safe_constantize
     run_safe_constantize_tests_on(&:safe_constantize)
   end
+
+  def test_extract_numbers
+    assert_equal [], "".extract_numbers
+    assert_equal [42], "The answer is 42".extract_numbers
+    assert_equal [1, 2, 3], "The numbers are 1, 2, and 3".extract_numbers
+    assert_equal [123, 456, 789], "123abc456def789".extract_numbers
+    assert_equal [3.14159], "Pi is approximately 3.14159".extract_numbers
+    assert_equal [-10], "Temperature: -10°C".extract_numbers
+    assert_equal [123], "  123  ".extract_numbers
+    assert_equal [], "NoNumbersHere".extract_numbers
+    assert_equal [123, 456], "123 456".extract_numbers
+    assert_equal [1000000, 2000, 10], "1000000 2000 10".extract_numbers
+  end
 end
 
 class StringAccessTest < ActiveSupport::TestCase

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1280,6 +1280,17 @@ NOTE: Defined in `active_support/core_ext/string/filters.rb`.
 
 [String#truncate_words]: https://api.rubyonrails.org/classes/String.html#method-i-truncate_words
 
+
+### `extract_numbers`
+
+The method [`extract_numbers`][String#extract_numbers] returns an array of numbers found in the string:
+
+```ruby
+  "abc123def456ghi789zero0".extract_numbers # => [123, 456, 789, 0]
+```
+
+NOTE: Defined in `active_support/core_ext/string/filters.rb`.
+
 ### `inquiry`
 
 The [`inquiry`][String#inquiry] method converts a string into a `StringInquirer` object making equality checks prettier.


### PR DESCRIPTION
### Motivation / Background

This Pull Request aims to add a new method, extract_numbers, to the String class in Rails. The extract_numbers method allows users to extract numeric values from a given string.

### Detail

The extract_numbers method has been added to the String class, allowing users to extract numeric values from a given string. Here's an example of how it works:

```ruby
text = "The temperature outside is -10.5°C and it will rise to 25.7°C in the afternoon."
numbers = text.extract_numbers

puts numbers
# Output: [-10.5, 25.7]
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
