### PR TITLE
Document and test `nil` cache coder

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -303,6 +303,13 @@ module ActiveSupport
       #   serializer or compressor, you should specify the +:serializer+ or
       #   +:compressor+ options instead.
       #
+      #   If the store can handle cache entries directly, you may also specify
+      #   <tt>coder: nil</tt> to omit the serializer, compressor, and coder. For
+      #   example, if you are using ActiveSupport::Cache::MemoryStore and can
+      #   guarantee that cache values will not be mutated, you can specify
+      #   <tt>coder: nil</tt> to avoid the overhead of safeguarding against
+      #   mutation.
+      #
       #   The +:coder+ option is mutally exclusive with the +:serializer+ and
       #   +:compressor+ options. Specifying them together will raise an
       #   +ArgumentError+.

--- a/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
@@ -77,4 +77,10 @@ module CacheStoreCoderBehavior
     @store.read("foo")
     assert_equal 0, coder.loaded_entries.size
   end
+
+  def test_nil_coder_bypasses_serialization
+    @store = lookup_store(coder: nil)
+    entry = ActiveSupport::Cache::Entry.new("value")
+    assert_same entry, @store.send(:serialize_entry, entry)
+  end
 end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -53,6 +53,14 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
+  def test_nil_coder_bypasses_mutation_safeguard
+    @cache = lookup_store(coder: nil)
+    value = {}
+    @cache.write("key", value)
+
+    assert_same value, @cache.read("key")
+  end
+
   private
     def compression_always_disabled_by_default?
       true


### PR DESCRIPTION
Since Rails 6.1 (via c4845aa7791839fcdf723dc77e3df258e7274496), it has been possible to specify `coder: nil` to allow the store to handle cache entries directly.

This commit adds documentation and regression tests for the behavior.

---

Per https://github.com/rails/rails/pull/48451#discussion_r1282090075.