### PR TITLE
Add validation to LengthValidator to prevent typo

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -11,6 +11,7 @@ module ActiveModel
       CHECKS    = { is: :==, minimum: :>=, maximum: :<= }.freeze
 
       RESERVED_OPTIONS = [:minimum, :maximum, :within, :is, :too_short, :too_long]
+      TYPO_OPTIONS = [:minium]
 
       def initialize(options)
         if range = (options.delete(:in) || options.delete(:within))
@@ -29,7 +30,7 @@ module ActiveModel
       def check_validity!
         keys = CHECKS.keys & options.keys
 
-        if keys.empty?
+        if keys.empty? || options.keys.any? { |k| TYPO_OPTIONS.include?(k) }
           raise ArgumentError, "Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option."
         end
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,8 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+
+  def test_validates_length_of_wrong_spelling_of_minium_and_maximum_at_same_time
+    assert_raise(ArgumentError) { Topic.validates_length_of :title, minium: 5, maximum: 10 }
+  end
 end


### PR DESCRIPTION
### Motivation / Background

The current situation, when the user set `minium` & `maximum` together, the validator would ignores the typo.

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

post = Post.new(title: "Invalid")
puts post.valid? # true
```

Just add a typo checker to make it would not happened again.

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

raise ArgumentError...
```

### Detail

1. Add `TYPO_OPTIONS`
2. Make sure no options in there, if yes, raise errror

### Additional information

https://discuss.rubyonrails.org/t/proposal-add-min-and-max-alias-to-lengthvalidator/82771

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
