### PR TITLE
Add `drb`, `mutex_m` and `base64` that are bundled gem candidates for Ruby 3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,10 +82,13 @@ PATH
       activesupport (= 7.1.0.alpha)
       marcel (~> 1.0)
     activesupport (7.1.0.alpha)
+      base64
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     rails (7.1.0.alpha)
       actioncable (= 7.1.0.alpha)
@@ -148,6 +151,7 @@ GEM
       beaneater (~> 1.0)
       concurrent-ruby (~> 1.0, >= 1.0.1)
       dante (> 0.1.5)
+    base64 (0.1.1)
     bcrypt (3.1.18)
     beaneater (1.1.3)
     benchmark-ips (2.10.0)
@@ -193,6 +197,8 @@ GEM
       delayed_job (>= 3.0, < 5)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
+    drb (2.1.1)
+      ruby2_keywords
     error_highlight (0.5.1)
     erubi (1.12.0)
     et-orbi (1.2.7)
@@ -332,6 +338,7 @@ GEM
     msgpack (1.7.0)
     multi_json (1.15.0)
     multipart-post (2.2.3)
+    mutex_m (0.1.2)
     mysql2 (0.5.4)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `drb`, `mutex_m` and `base64` that are bundled gem candidates for Ruby 3.4
+
+    *Yasuo Honda*
+
 *   When using cache format version >= 7.1 or a custom serializer, expired and
     version-mismatched cache entries can now be detected without deserializing
     their values.

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -39,4 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
   s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "base64"
+  s.add_dependency "drb"
+  s.add_dependency "mutex_m"
 end


### PR DESCRIPTION
### Motivation / Background

This commit adds `drb`, `mutex_m` and `base64` to `activesupport/activesupport.gemspec` because 3.3.0dev shows warnings if bundled gem candidates are required like `mutex_m will be not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.`

### Detail

#### Example
```ruby
$ ruby -v ; ruby generic_main.rb
ruby 3.3.0dev (2023-08-07T23:09:02Z master 0e5da05a32) [x86_64-linux]
Fetching https://github.com/rails/rails.git
Resolving dependencies...
Fetching gem metadata from https://rubygems.org/.......
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.3.0+0/bundler/gems/rails-2942958827f1/activesupport/lib/active_support/notifications/fanout.rb:3: warning: mutex_m will be not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.3.0+0/bundler/gems/rails-2942958827f1/activesupport/lib/active_support/message_encryptor.rb:4: warning: base64 will be not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.
generic_main.rb:16: warning: drb will be not part of the default gems since Ruby 3.4.0. Add it to your inline Gemfile.
$
```

#### generic_main.rb
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
end

require "active_support"
require "minitest/autorun"
# These gems will be bundled gems in Ruby 3.4
require "drb"
require "base64"
require "mutex_m"
```

These gems are chosen as follows.
#### Bundled gems candidates for Ruby 3.4

```ruby
$ ruby -v ; ruby -e 'pp Gem::BUNDLED_GEMS::SINCE.select { |k,v| v == "3.4.0" }'
ruby 3.3.0dev (2023-08-07T23:09:02Z master 0e5da05a32) [x86_64-linux]
{"abbrev"=>"3.4.0",
 "observer"=>"3.4.0",
 "getoptlong"=>"3.4.0",
 "resolv-replace"=>"3.4.0",
 "rinda"=>"3.4.0",
 "nkf"=>"3.4.0",
 "syslog"=>"3.4.0",
 "drb"=>"3.4.0",
 "mutex_m"=>"3.4.0",
 "csv"=>"3.4.0",
 "base64"=>"3.4.0"}
$
```

#### `drb`, `mutex_m` and `base64` are required by Rails

- "drb"
```ruby
$ git grep 'require "drb"'
activesupport/lib/active_support/testing/parallelization.rb:require "drb"
activesupport/lib/active_support/testing/parallelization/server.rb:require "drb"
```

- "mutex_m"

```ruby
$ git grep 'require "mutex_m"'
actionpack/lib/action_controller/metal/params_wrapper.rb:    require "mutex_m"
activerecord/lib/active_record/attribute_methods.rb:require "mutex_m"
activerecord/lib/active_record/relation/delegation.rb:require "mutex_m"
activesupport/lib/active_support/notifications/fanout.rb:require "mutex_m"
```

- "base64" usage

```ruby
$ git grep 'require "base64"'
actioncable/Rakefile:require "base64"
actionmailer/lib/action_mailer/inline_preview_interceptor.rb:require "base64"
actionpack/lib/action_controller/metal/http_authentication.rb:require "base64"
actionview/Rakefile:require "base64"
activerecord/lib/active_record/encryption/message_serializer.rb:require "base64"
activerecord/lib/active_record/fixture_set/render_context.rb:require "base64"
activerecord/test/cases/encryption/message_serializer_test.rb:require "base64"
activesupport/lib/active_support/message_encryptor.rb:require "base64"
activesupport/lib/active_support/message_verifier.rb:require "base64"
activesupport/lib/active_support/xml_mini.rb:require "base64"
railties/test/application/mailer_previews_test.rb:require "base64"
```

#### Dependency between Rails related modules

- "drb" is only required by Active Support

- "mutex_m" is required by Action Pack, Active Record and Active Support Action Pack and Active Record depend on Active Support. Therefore, adding dependency to Active Support is fine.

https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actionpack/actionpack.gemspec#L36 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/activerecord/activerecord.gemspec#L38

- "base64" is required by Action Cable, Action Mailer, Action Pack, Action View, Active Record, Active Support and Raillties. Action Cable, Action Mailer, Action Pack, Action View and Active Record and Railties depend on Active Support. Therefore, adding dependency to Active Support is fine.

https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actioncable/actioncable.gemspec#L35 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actionmailer/actionmailer.gemspec#L36 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actionpack/actionpack.gemspec#L36 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actionview/actionview.gemspec#L36 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/actionpack/actionpack.gemspec#L36 https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/railties/railties.gemspec#L40

### Additional information

Refer to:
https://bugs.ruby-lang.org/issues/19776
https://github.com/ruby/ruby/pull/8126
https://github.com/rubygems/rubygems/pull/6840

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
