### PR TITLE
Ensure schema_cache_dump settings are propagated to SchemaReflection class

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -132,8 +132,14 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.use_schema_cache_dump" do
+      ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump = config.active_record.use_schema_cache_dump
+    end
+
     initializer "active_record.check_schema_cache_dump" do
       check_schema_cache_dump_version = config.active_record.check_schema_cache_dump_version
+
+      ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version = check_schema_cache_dump_version
 
       if config.active_record.use_schema_cache_dump && !config.active_record.lazily_load_schema_cache
         config.after_initialize do |app|

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -524,7 +524,7 @@ module ApplicationTests
 
       app "development"
 
-      refute ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version
+      assert_not ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version
     end
 
     test "propagates use_schema_cache_dump=true to ActiveRecord::ConnectionAdapters::SchemaReflection" do
@@ -544,7 +544,7 @@ module ApplicationTests
 
       app "development"
 
-      refute ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump
+      assert_not ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump
     end
 
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -406,7 +406,7 @@ module ApplicationTests
       assert_not_includes Post.instance_methods, :title
     end
 
-    test "does not eager load attribute methods in production when the schema cache is empty and and check_schema_cache_dump_version=false" do
+    test "does not eager load attribute methods in production when the schema cache is empty and check_schema_cache_dump_version=false" do
       app_file "app/models/post.rb", <<-RUBY
         class Post < ActiveRecord::Base
         end
@@ -506,6 +506,47 @@ module ApplicationTests
         app "development"
       end
     end
+
+    test "propagates check_schema_cache_dump_version=true to ActiveRecord::ConnectionAdapters::SchemaReflection" do
+      add_to_config <<-RUBY
+        config.active_record.check_schema_cache_dump_version = true
+      RUBY
+
+      app "development"
+
+      assert ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version
+    end
+
+    test "propagates check_schema_cache_dump_version=false to ActiveRecord::ConnectionAdapters::SchemaReflection" do
+      add_to_config <<-RUBY
+        config.active_record.check_schema_cache_dump_version = false
+      RUBY
+
+      app "development"
+
+      refute ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version
+    end
+
+    test "propagates use_schema_cache_dump=true to ActiveRecord::ConnectionAdapters::SchemaReflection" do
+      add_to_config <<-RUBY
+        config.active_record.use_schema_cache_dump = true
+      RUBY
+
+      app "development"
+
+      assert ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump
+    end
+
+    test "propagates use_schema_cache_dump=false to ActiveRecord::ConnectionAdapters::SchemaReflection" do
+      add_to_config <<-RUBY
+        config.active_record.use_schema_cache_dump = false
+      RUBY
+
+      app "development"
+
+      refute ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump
+    end
+
 
     test "filter_parameters should be able to set via config.filter_parameters" do
       add_to_config <<-RUBY


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because after [the latest schema cache changes](https://github.com/rails/rails/pull/48716) at GitHub we started to see this warning in our development and test environments:

```
Ignoring db/schema/db.dump because it has expired. The current schema version is abc, but the one in the schema cache file is efg.
```

We decided to set the configuration setting that controls this check:

```ruby
config.active_record.check_schema_cache_dump_version = false
```

But we kept seeing the same warning. After some digging we found out that the configuration setting is used only at the ActiveRecord's Railtie level, but it is not propagated internally down to the `ActiveRecord::ConnectionAdapters::SchemaReflection` class, which is the one that does the schema cache dump loading and check.

### Detail

This Pull Request changes ActiveRecord's Railtie so it sets the configuration settings `check_schema_cache_dump_version` and `use_schema_cache_dump` in the `ActiveRecord::ConnectionAdapters::SchemaReflection` class directly. That way the behavior of setting the app configuration settings is preserved across all the app.

I've added tests in the main `railties/test/application/configuration_test.rb` file since it's the only place I saw tests around configuration settings applied at the app level, but I'm not sure that's the right place. I'm happy to move them if someone has a better idea.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
I think another approach could be to add these settings at the `ActiveRecord` module level, like `lazily_load_schema_cache`, and then change `SchemaReflection` so it uses them, but this seemed like a bigger change.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
