### PR TITLE
Stop generating parent-defined alias methods in child classes

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -203,6 +203,7 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
+        local_attribute_aliases[new_name.to_s] = old_name.to_s
         eagerly_generate_alias_attribute_methods(new_name, old_name)
       end
 
@@ -359,6 +360,10 @@ module ActiveModel
           undef_method(*instance_methods)
         end
         attribute_method_patterns_cache.clear
+      end
+
+      def local_attribute_aliases # :nodoc:
+        @local_attribute_aliases ||= {}
       end
 
       private

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -65,12 +65,13 @@ module ActiveRecord
       end
 
       def generate_alias_attributes # :nodoc:
+        superclass.generate_alias_attributes unless base_class?
         return if @alias_attributes_mass_generated
 
         generated_attribute_methods.synchronize do
           return if @alias_attributes_mass_generated
           ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
-            attribute_aliases.each do |new_name, old_name|
+            local_attribute_aliases.each do |new_name, old_name|
               generate_alias_attribute_methods(code_generator, new_name, old_name)
             end
           end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1225,9 +1225,21 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  class ChildWithDeprecatedBehaviorResolved < ClassWithDeprecatedAliasAttributeBehaviorResolved
+  end
+
   test "#alias_attribute with an overridden original method along with an overridden alias method doesn't issue a deprecation" do
     obj = assert_not_deprecated(ActiveRecord.deprecator) do
       ClassWithDeprecatedAliasAttributeBehaviorResolved.new
+    end
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+    assert_equal("overridden_subject_was", obj.subject_was)
+  end
+
+  test "#alias_attribute with an overridden original method along with an overridden alias method in a parent class doesn't issue a deprecation" do
+    obj = assert_not_deprecated(ActiveRecord.deprecator) do
+      ChildWithDeprecatedBehaviorResolved.new
     end
     obj.title = "hey"
     assert_equal("hey", obj.subject)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We currently issue a deprecation warning when an attribute method is overwritten to let people know that they'll need to manually define the alias override as well. If the override is also defined on the parent class, then we shouldn't need to issue a deprecation warning. 

Before, the following was raising a deprecation warning for because `subject_was` is not implemented directly on the child class.

```ruby
class Topic < ActiveRecord::Base
  alias_attribute :subject, :title
  
  def title_was
    "override_title"
  end
  alias_method :subject_was, :title_was
end

class SubTopic < Topic
end
```

Following this change, the behavior works correctly without a deprecation warning.

### Detail

Because we're using a class_attribute to track all of the attribute_aliases, each subclass was regenerating the parent class methods. When a child was generating methods for the parent, it was only looking to see if the manual override method was defined within. 

Instead, we can use a class instance variable to track the attributes aliased locally in that particular subclass. We then walk up the chain and re-define the attribute methods if they haven't been defined yet.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
