### PR TITLE
reflect_on_all_associations to support multiple macros

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Allow `reflect_on_all_associations` to support multiple macros.
+
+    Previously, `reflect_on_all_association` would only allow a single macro to be passed in.
+    To return multiple associations, we would need to use custom select logic.
+
+    Before:
+
+    ```ruby
+    Model.reflect_on_all_associations(:has_many)
+    # Returns an array of all has_many associations
+
+    # To get array of more than one macro associations
+    Model.reflect_on_all_associations.select do |reflection|
+      %i[has_many has_one].include?(reflection.macro)
+    end
+    ```
+
+    After:
+
+    ```ruby
+    Model.reflect_on_all_associations(:has_many, :has_one)
+    # Returns an array of all has_many and has_one associations
+    ```
+
+    *Keshav Biswa*
+
 *   Fully support `NULLS [NOT] DISTINCT` for PostgreSQL 15+ indexes.
 
     Previous work was done to allow the index to be created in a migration, but it was not

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -102,10 +102,11 @@ module ActiveRecord
       #
       #   Account.reflect_on_all_associations             # returns an array of all associations
       #   Account.reflect_on_all_associations(:has_many)  # returns an array of all has_many associations
+      #   Account.reflect_on_all_associations(:has_many, :has_one)  # returns an array of all has_many and has_one associations
       #
-      def reflect_on_all_associations(macro = nil)
+      def reflect_on_all_associations(*macros)
         association_reflections = reflections.values
-        association_reflections.select! { |reflection| reflection.macro == macro } if macro
+        association_reflections.select! { |reflection| macros.include?(reflection.macro) } if macros.any?
         association_reflections
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -573,6 +573,16 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_reflect_on_multiple_associations
+    all_associations = Book.reflect_on_all_associations
+    has_many_and_has_one = Book.reflect_on_all_associations(:has_many, :has_one)
+
+    assert has_many_and_has_one.all? { |reflection| [:has_many, :has_one].include?(reflection.macro) }
+
+    # This assumes there are other associations such as belongs_to in the test model
+    assert has_many_and_has_one.count < all_associations.count
+  end
+
   def test_reflect_on_association_accepts_strings
     assert_nothing_raised do
       assert_equal Hotel.reflect_on_association("departments").name, :departments


### PR DESCRIPTION
### Motivation / Background
I needed a way to get all the associations for a model, for that I was using `reflect_on_all_associations`. But `reflect_on_all_associations` only allows one macro to be passed. For example

```ruby
User.reflect_on_all_associations(:has_many) # This works
User.reflect_on_all_associations(:has_many, :has_one) # This doesn't
```
### Detail

Added ability to add multiple macro in `reflect_on_all_associations` method in `Reflection.rb`.

Previously, `reflect_on_all_association` would only allow a single macro to be passed in.
To return multiple associations, we would need to use custom select logic.

Before:
```ruby
Model.reflect_on_all_associations(:has_many)
# Returns an array of all has_many associations

# To get array of more than one macro associations
Model.reflect_on_all_associations.select do |reflection|
  %i[has_many has_one].include?(reflection.macro)
end
```

After:

```ruby
Model.reflect_on_all_associations(:has_many, :has_one)
# Returns an array of all has_many and has_one associations
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
