### PR TITLE
Use Pathnames for comparisons in the engine rake tasks

### DIFF
--- a/railties/lib/rails/tasks/engine.rake
+++ b/railties/lib/rails/tasks/engine.rake
@@ -18,7 +18,7 @@ task "load_app" do
   task environment: "app:environment"
 
   if !defined?(ENGINE_ROOT) || !ENGINE_ROOT
-    ENGINE_ROOT = find_engine_path(APP_RAKEFILE)
+    ENGINE_ROOT = find_engine_path(Pathname.new(APP_RAKEFILE))
   end
 end
 
@@ -73,12 +73,12 @@ namespace :db do
 end
 
 def find_engine_path(path)
-  return File.expand_path(Dir.pwd) if path == "/"
+  return File.expand_path(Dir.pwd) if path.root?
 
   if Rails::Engine.find(path)
-    path
+    path.to_s
   else
-    find_engine_path(File.expand_path("..", path))
+    find_engine_path(path.join(".."))
   end
 end
 

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -245,5 +245,26 @@ module RailtiesTest
 
       assert_match(/undefined method `abc' for.*RailtiesTest::RailtieTest::Foo/, error.original_message)
     end
+
+    test "rake environment can be called in the ralitie" do
+      $ran_block = false
+
+      class MyTie < Rails::Railtie
+        rake_tasks do
+          $ran_block = true
+        end
+      end
+
+      ::APP_RAKEFILE = "#{app_path}/Rakefile"
+      require "#{app_path}/config/environment"
+
+      assert_not $ran_block
+      require "rake"
+      require "rake/testtask"
+      require "rdoc/task"
+      load "rails/tasks/engine.rake"
+
+      assert $ran_block
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

When loading engine tasks for a railtie on Windows, I noticed we ended up doing endless recursion and throwing a stack error. The reason this happens is:
1. When working on a railtie only (no engine), we try to find the `ENGINE_ROOT`
2. That invokes `find_engine_path`, which is a recursive method that can only stop in two scenarios: if an engine is found (won't ever happen in the railtie case) or if we hit the root of the folder structure `/`

That works on Linux/Mac but will fail on Windows (and possibly other operating systems?) since `/` doesn't exist. In that case, we just never exit recursion and get the stack error.

### Detail

To make sure we're always doing the right thing on different operating systems, I changed the implementation to rely on `Pathname`. This allows us to invoke `root?` to check if we reached the end of the folder structure.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
