### PR TITLE
Use `ActiveRecord.deprecator` for the alias attribute deprecation

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -93,7 +93,7 @@ module ActiveRecord
           aliased_method_redefined_as_well = method_defined_within?(method_name, self)
           return if aliased_method_redefined_as_well
 
-          ActiveModel.deprecator.warn(
+          ActiveRecord.deprecator.warn(
             "#{self} model aliases `#{old_name}` and has a method called `#{target_name}` defined. " \
             "Starting in Rails 7.2 `#{method_name}` will not be calling `#{target_name}` anymore. " \
             "You may want to additionally define `#{method_name}` to preserve the current behavior."

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1177,7 +1177,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 
-    obj = assert_deprecated(message, ActiveModel.deprecator) do
+    obj = assert_deprecated(message, ActiveRecord.deprecator) do
       ClassWithDeprecatedAliasAttributeBehavior.new
     end
     obj.title = "hey"
@@ -1204,7 +1204,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 
-    obj = assert_deprecated(message, ActiveModel.deprecator) do
+    obj = assert_deprecated(message, ActiveRecord.deprecator) do
       ClassWithDeprecatedAliasAttributeBehaviorFromModule.new
     end
     obj.title = "hey"
@@ -1226,7 +1226,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   end
 
   test "#alias_attribute with an overridden original method along with an overridden alias method doesn't issue a deprecation" do
-    obj = assert_not_deprecated(ActiveModel.deprecator) do
+    obj = assert_not_deprecated(ActiveRecord.deprecator) do
       ClassWithDeprecatedAliasAttributeBehaviorResolved.new
     end
     obj.title = "hey"


### PR DESCRIPTION
We are using wrong deprecator to issue the alias attribute deprecation. The deprecation used to live in Active Model during the initial implementation but eventually got moved to Active Record and now Active Model is not affected by it so we need to use a correct deprecator 