### PR TITLE
feat: Add ActiveModel::Model.filter_attributes

### DIFF
--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -19,7 +19,21 @@ class ModelTest < ActiveModel::TestCase
   class BasicModel
     include DefaultValue
     include ActiveModel::Model
+    self.filter_attributes = %w[
+      filtered_attr
+    ]
     attr_accessor :attr
+    attr_accessor :filtered_attr
+  end
+
+  class BasicModelAttributes
+    include DefaultValue
+    include ActiveModel::Model
+    self.filter_attributes = %w[
+      filtered_attr
+    ]
+    attribute :attr, :string
+    attribute :filtered_attr, :string
   end
 
   class BasicModelWithReversedMixins
@@ -74,6 +88,18 @@ class ModelTest < ActiveModel::TestCase
   def test_mixin_initializer_when_args_dont_exist
     assert_raises(ActiveModel::UnknownAttributeError) do
       SimpleModel.new(hello: "world")
+    end
+  end
+
+  def test_filtered_attributes_are_masked
+    [
+      BasicModel,
+      BasicModelAttributes,
+    ].each do |klass|
+      object = klass.new(attr: "value", filtered_attr: "filtered value")
+      assert_equal "value", object.attr
+      assert_equal "filtered value", object.filtered_attr
+      assert_equal %(<#{klass.name} attr="value", filtered_attr="[FILTERED]">), object.inspect
     end
   end
 


### PR DESCRIPTION
If this looks good, I'll fill in the gaps in documentation and respond
to feedback in a timely manner.

Is a simpler version of what's in
https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/core.rb#L373-L396

I'm using this in our application and thought I'd share back.

### Motivation / Background

We using ActiveModel::Model to build plain-old-ruby
objects for things like API clients.  When I use
the Attributes API to define secrets like `attribute :api_key, :string`
I don't want the `api_key` to show up anywhere.

This Pull Request has been created because ActiveModel::Model
is missing the `filter_attributes` behavior present in
ActiveRecord::Core.

### Detail

This Pull Request changes adds `filter_attributes` to ActiveModel::API

I added it to ActiveModel::API so that it does not interfere with
ActiveRecord.


### Additional information

We're using this in our app.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.