### PR TITLE
[Fix #48922] Honour encrypted attribute context in encrypted_attribute?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `encrypted_attribute?` to take into account context properties passed to `encrypts`.
+
+    *Maxime Réty*
+
 *   The object returned by `explain` now responds to `pluck`, `first`,
     `last`, `average`, `count`, `maximum`, `minimum`, and `sum`. Those
     new methods run `EXPLAIN` on the corresponding queries:

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -144,7 +144,13 @@ module ActiveRecord
 
       # Returns whether a given attribute is encrypted or not.
       def encrypted_attribute?(attribute_name)
-        ActiveRecord::Encryption.encryptor.encrypted? read_attribute_before_type_cast(attribute_name)
+        name = attribute_name.to_s
+        name = self.class.attribute_aliases[name] || name
+
+        return false unless self.class.encrypted_attributes&.include? name.to_sym
+
+        type = type_for_attribute(name)
+        type.encrypted? read_attribute_before_type_cast(name)
       end
 
       # Returns the ciphertext for +attribute_name+.

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -44,6 +44,10 @@ module ActiveRecord
         end
       end
 
+      def encrypted?(value)
+        with_context { encryptor.encrypted? value }
+      end
+
       def changed_in_place?(raw_old_value, new_value)
         old_value = raw_old_value.nil? ? nil : deserialize(raw_old_value)
         old_value != new_value

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -9,6 +9,7 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
 
     author = create_author_with_name_encrypted_with_previous_scheme
     assert_equal "dhh", author.reload.name
+    assert author.encrypted_attribute? :name
   end
 
   test "when defining previous encryption schemes, you still get Decryption errors when using invalid clear values" do
@@ -24,6 +25,7 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
   test "use a custom encryptor" do
     author = EncryptedAuthor1.create name: "1"
     assert_equal "1", author.name
+    assert author.encrypted_attribute? :name
   end
 
   test "support previous contexts" do
@@ -32,10 +34,12 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
     author = EncryptedAuthor2.create name: "2"
     assert_equal "2", author.name
     assert_equal author, EncryptedAuthor2.find_by_name("2")
+    assert author.encrypted_attribute? :name
 
     Author.find(author.id).update! name: "1"
     assert_equal "1", author.reload.name
     assert_equal author, EncryptedAuthor2.find_by_name("1")
+    assert_not author.encrypted_attribute? :name
   end
 
   test "use global previous schemes to decrypt data encrypted with previous schemes" do
@@ -191,7 +195,9 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       end
 
       def encrypted?(text)
-        text == encrypted_text
+        decrypt(text)
+      rescue ActiveRecord::Encryption::Errors::Decryption
+        false
       end
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created to fix https://github.com/rails/rails/issues/48922.

### Detail

The helper `encrypted_attribute?` currently delegates the check to the global default encryptor configured, cf

https://github.com/rails/rails/blob/e0a55b038f7f2f50d1467876558be183be6cedaa/activerecord/lib/active_record/encryption/encryptable_record.rb#L145-L148

This Pull Request delegates the check to the EncryptedAttributeType instance defined for the attribute instead. This attribute type properly applies context properties defined initially with `encrypts`, such as a custom encryptor or message serializer.

This fixes an issue where the `encrypted_attribute?` helper would return erroneous results.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
