### PR TITLE
This removes the writer method for table_alias from Arel::Table.

### DIFF
--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -8,7 +8,8 @@ module Arel # :nodoc: all
     @engine = nil
     class << self; attr_accessor :engine; end
 
-    attr_accessor :name, :table_alias
+    attr_accessor :name
+    attr_reader :table_alias
 
     def initialize(name, as: nil, klass: nil, type_caster: klass&.type_caster)
       @name =

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -189,19 +189,15 @@ module Arel
 
     describe "equality" do
       it "is equal with equal ivars" do
-        relation1 = Table.new(:users)
-        relation1.table_alias = "zomg"
-        relation2 = Table.new(:users)
-        relation2.table_alias = "zomg"
+        relation1 = Table.new(:users, as: "zomg")
+        relation2 = Table.new(:users, as: "zomg")
         array = [relation1, relation2]
         assert_equal 1, array.uniq.size
       end
 
       it "is not equal with different ivars" do
-        relation1 = Table.new(:users)
-        relation1.table_alias = "zomg"
-        relation2 = Table.new(:users)
-        relation2.table_alias = "zomg2"
+        relation1 = Table.new(:users, as: "zomg")
+        relation2 = Table.new(:users, as: "zomg2")
         array = [relation1, relation2]
         assert_equal 2, array.uniq.size
       end


### PR DESCRIPTION
This removes the writer method for table_alias from `Arel::Table`.  Since arel_table is a private API of the framework, no one should be modifying it. It addresses #48775

### Checklist

Before submitting the PR make sure the following are checked:

* [ X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ X] Tests are added or updated if you fix a bug or add a feature.
* [ X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.