### PR TITLE
Refine the alias_attribute warning message to be more specific

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -136,6 +136,7 @@ module ActiveRecord
       autoload :Read
       autoload :Serialization
       autoload :TimeZoneConversion
+      autoload :Validation
       autoload :Write
     end
   end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -19,6 +19,7 @@ module ActiveRecord
       include TimeZoneConversion
       include Dirty
       include Serialization
+      include Validation
     end
 
     RESTRICTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
@@ -260,78 +261,6 @@ module ActiveRecord
           child_class.class_eval do
             @alias_attributes_mass_generated = false
             @attribute_names = nil
-          end
-        end
-
-        def aliased_method_redefined?(method_name)
-          method_defined_within?(method_name, self)
-        end
-
-        # Given an attribute and a pattern, identify any manually defined methods in the
-        # aliased chain.
-        # Returns the far attribute, target definition name, the already defined method (if it exists) and a boolean of whether all targets are attribute methods.
-        def find_attribute_targets(old_name, pattern)
-          all_targets_are_attribute_methods = true
-
-          far_name = next_name = old_name
-          while next_name
-            far_name = next_name
-
-            far_target = pattern.method_name(far_name).to_s
-            far_method = (instance_method(far_target) if method_defined?(far_target) || private_method_defined?(far_target))
-            if far_method
-              unless far_method.owner == generated_attribute_methods || far_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
-                all_targets_are_attribute_methods = false
-                break
-              end
-            elsif attribute_aliases.key?(far_name)
-              # walk past a missing method in the alias chain: it might not be defined yet
-            else
-              all_targets_are_attribute_methods = false
-              break
-            end
-
-            next_name = attribute_aliases[far_name]
-          end
-
-          [all_targets_are_attribute_methods, far_name, far_method, far_target]
-        end
-
-        def add_alias_attribute_deprecation_warning(far_name, far_method, far_target, new_name, old_name, method_name)
-          # TODO: We should warn about this too. Either it's a typo, or
-          # it indicates a possible backwards compatibility issue we
-          # haven't directly addressed, like a target that's being provided
-          # by method_missing.
-          return unless far_method
-
-          alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
-          intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
-
-          # It's an attribute, this is just an overridden method
-          if has_attribute?(far_name)
-            where = far_method.owner == self ? "" : " in #{far_method.owner}"
-
-            ActiveRecord.deprecator.warn(
-              "#{intro}, and also overrides the `#{far_target}` method#{where}. " \
-              "In Rails 7.2, `#{method_name}` will directly access the `#{far_name}` attribute value instead of calling the method; " \
-              "explicitly forward or alias `#{method_name}` to `#{far_target}` to preserve the current behavior."
-            )
-
-          # Common anti-pattern: using alias_attribute to alias an association
-          elsif reflect_on_association(far_name)
-            ActiveRecord.deprecator.warn(
-              "#{intro}, but `#{far_name}` is an association. " \
-              "In Rails 7.2, alias_attribute will no longer work with associations; " \
-              "use `alias_association :#{new_name}, :#{far_name}` instead."
-            )
-
-          # Also anti-pattern: using alias_attribute to alias a plain method
-          else
-            ActiveRecord.deprecator.warn(
-              "#{intro}, but `#{far_name}` is not an attribute. " \
-              "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
-              "define `#{method_name}` or use `alias_method :#{method_name}, :#{far_target}` instead."
-            )
           end
         end
     end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -108,7 +108,7 @@ module ActiveRecord
         # our responsibility, we need a deprecation warning. For that,
         # we want to check for a few specific patterns so we can give
         # the most helpful warning possible.
-        deprecation_type = check_for_deprecations(target_method, far_name)
+        deprecation_type = check_for_deprecations(target_method, far_name, pattern)
         if deprecation_type
           add_alias_attribute_deprecation_warning(new_name, old_name, method_name, target_method_name, target_method, far_name, deprecation_type)
           super

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -100,45 +100,12 @@ module ActiveRecord
         # we want to check for a few specific patterns so we can give
         # the most helpful warning possible.
 
-        aliased_method_redefined = method_defined_within?(method_name, self)
+        # TODO: While not necessary for backwards compatibility, we
+        # should probably still define the method to ensure perfect
+        # forward compatibility when we stop checking this in 7.2.
+        return if aliased_method_redefined?(method_name)
 
-        if aliased_method_redefined
-          # Not much for us to do here? The user has already (re)defined
-          # the method we were going to create.
-
-          # TODO: While not necessary for backwards compatibility, we
-          # should probably still define the method to ensure perfect
-          # forward compatibility when we stop checking this in 7.2.
-
-          return
-        end
-
-        # If the target method (including any further aliases) hasn't
-        # been redefined by the user, we can go with define_proxy_call.
-        # To establish that, we need to walk the chain of aliases.
-
-        all_targets_are_attribute_methods = true
-
-        far_name = next_name = old_name
-        while next_name
-          far_name = next_name
-
-          far_target = pattern.method_name(far_name).to_s
-          far_method = (instance_method(far_target) if method_defined?(far_target) || private_method_defined?(far_target))
-          if far_method
-            unless far_method.owner == generated_attribute_methods || far_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
-              all_targets_are_attribute_methods = false
-              break
-            end
-          elsif attribute_aliases.key?(far_name)
-            # walk past a missing method in the alias chain: it might not be defined yet
-          else
-            all_targets_are_attribute_methods = false
-            break
-          end
-
-          next_name = attribute_aliases[far_name]
-        end
+        all_targets_are_attribute_methods, far_name, far_method, far_target = find_attribute_targets(old_name, pattern)
 
         if all_targets_are_attribute_methods && has_attribute?(far_name)
           define_proxy_call(code_generator, method_name, pattern.proxy_target, pattern.parameters, far_name,
@@ -147,52 +114,7 @@ module ActiveRecord
           return
         end
 
-        # We hit a non-attribute method, so we need a warning.
-
-        if far_method
-          # We found a method that doesn't belong to us
-
-          alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
-          intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
-
-          if has_attribute?(far_name)
-            # It's an attribute, this is just an overridden method
-
-            where = far_method.owner == self ? "" : " in #{far_method.owner}"
-
-            ActiveRecord.deprecator.warn(
-              "#{intro}, and also overrides the `#{far_target}` method#{where}. " \
-              "In Rails 7.2, `#{method_name}` will directly access the `#{far_name}` attribute value instead of calling the method; " \
-              "explicitly forward or alias `#{method_name}` to `#{far_target}` to preserve the current behavior."
-            )
-
-          elsif reflect_on_association(far_name)
-            # Common anti-pattern: using alias_attribute to alias an association
-
-            ActiveRecord.deprecator.warn(
-              "#{intro}, but `#{far_name}` is an association. " \
-              "In Rails 7.2, alias_attribute will no longer work with associations; " \
-              "use `alias_association :#{new_name}, :#{far_name}` instead."
-            )
-
-          else
-            # Also anti-pattern: using alias_attribute to alias a plain method
-
-            ActiveRecord.deprecator.warn(
-              "#{intro}, but `#{far_name}` is not an attribute. " \
-              "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
-              "define `#{method_name}` or use `alias_method :#{method_name}, :#{far_target}` instead."
-            )
-          end
-        else
-          # We didn't find a method at all
-
-          # TODO: We should warn about this too. Either it's a typo, or
-          # it indicates a possible backwards compatibility issue we
-          # haven't directly addressed, like a target that's being provided
-          # by method_missing.
-        end
-
+        add_alias_attribute_deprecation_warning(far_name, far_method, far_target, new_name, old_name, method_name)
         super
       end
 
@@ -338,6 +260,78 @@ module ActiveRecord
           child_class.class_eval do
             @alias_attributes_mass_generated = false
             @attribute_names = nil
+          end
+        end
+
+        def aliased_method_redefined?(method_name)
+          method_defined_within?(method_name, self)
+        end
+
+        # Given an attribute and a pattern, identify any manually defined methods in the
+        # aliased chain.
+        # Returns the far attribute, target definition name, the already defined method (if it exists) and a boolean of whether all targets are attribute methods.
+        def find_attribute_targets(old_name, pattern)
+          all_targets_are_attribute_methods = true
+
+          far_name = next_name = old_name
+          while next_name
+            far_name = next_name
+
+            far_target = pattern.method_name(far_name).to_s
+            far_method = (instance_method(far_target) if method_defined?(far_target) || private_method_defined?(far_target))
+            if far_method
+              unless far_method.owner == generated_attribute_methods || far_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
+                all_targets_are_attribute_methods = false
+                break
+              end
+            elsif attribute_aliases.key?(far_name)
+              # walk past a missing method in the alias chain: it might not be defined yet
+            else
+              all_targets_are_attribute_methods = false
+              break
+            end
+
+            next_name = attribute_aliases[far_name]
+          end
+
+          [all_targets_are_attribute_methods, far_name, far_method, far_target]
+        end
+
+        def add_alias_attribute_deprecation_warning(far_name, far_method, far_target, new_name, old_name, method_name)
+          # TODO: We should warn about this too. Either it's a typo, or
+          # it indicates a possible backwards compatibility issue we
+          # haven't directly addressed, like a target that's being provided
+          # by method_missing.
+          return unless far_method
+
+          alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
+          intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
+
+          # It's an attribute, this is just an overridden method
+          if has_attribute?(far_name)
+            where = far_method.owner == self ? "" : " in #{far_method.owner}"
+
+            ActiveRecord.deprecator.warn(
+              "#{intro}, and also overrides the `#{far_target}` method#{where}. " \
+              "In Rails 7.2, `#{method_name}` will directly access the `#{far_name}` attribute value instead of calling the method; " \
+              "explicitly forward or alias `#{method_name}` to `#{far_target}` to preserve the current behavior."
+            )
+
+          # Common anti-pattern: using alias_attribute to alias an association
+          elsif reflect_on_association(far_name)
+            ActiveRecord.deprecator.warn(
+              "#{intro}, but `#{far_name}` is an association. " \
+              "In Rails 7.2, alias_attribute will no longer work with associations; " \
+              "use `alias_association :#{new_name}, :#{far_name}` instead."
+            )
+
+          # Also anti-pattern: using alias_attribute to alias a plain method
+          else
+            ActiveRecord.deprecator.warn(
+              "#{intro}, but `#{far_name}` is not an attribute. " \
+              "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
+              "define `#{method_name}` or use `alias_method :#{method_name}, :#{far_target}` instead."
+            )
           end
         end
     end

--- a/activerecord/lib/active_record/attribute_methods/validation.rb
+++ b/activerecord/lib/active_record/attribute_methods/validation.rb
@@ -7,79 +7,63 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       module ClassMethods
-         def aliased_method_redefined?(method_name)
+        def aliased_method_redefined?(method_name)
           method_defined_within?(method_name, self)
         end
 
-        # Given an attribute and a pattern, identify any manually defined methods in the
-        # aliased chain.
-        # Returns the far attribute, target definition name, the already defined method (if it exists) and a boolean of whether all targets are attribute methods.
-        def find_attribute_targets(old_name, pattern)
-          all_targets_are_attribute_methods = true
-
-          far_name = next_name = old_name
-          while next_name
-            far_name = next_name
-
-            far_target = pattern.method_name(far_name).to_s
-            far_method = (instance_method(far_target) if method_defined?(far_target) || private_method_defined?(far_target))
-            if far_method
-              unless far_method.owner == generated_attribute_methods || far_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
-                all_targets_are_attribute_methods = false
-                break
-              end
-            elsif attribute_aliases.key?(far_name)
-              # walk past a missing method in the alias chain: it might not be defined yet
-            else
-              all_targets_are_attribute_methods = false
-              break
-            end
-
-            next_name = attribute_aliases[far_name]
-          end
-
-          [all_targets_are_attribute_methods, far_name, far_method, far_target]
-        end
-
-        def add_alias_attribute_deprecation_warning(far_name, far_method, far_target, new_name, old_name, method_name)
+        def add_alias_attribute_deprecation_warning(new_name, old_name, method_name, target_method_name, target_method, far_name)
           # TODO: We should warn about this too. Either it's a typo, or
           # it indicates a possible backwards compatibility issue we
           # haven't directly addressed, like a target that's being provided
           # by method_missing.
-          return unless far_method
-
+          return false unless target_method
+          is_attribute_method = target_method.owner == generated_attribute_methods || target_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
           alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
           intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
 
           # It's an attribute, this is just an overridden method
-          if has_attribute?(far_name)
-            where = far_method.owner == self ? "" : " in #{far_method.owner}"
+          if has_attribute?(far_name) && !is_attribute_method
+            where = target_method.owner == self ? "" : " in #{target_method.owner}"
 
             ActiveRecord.deprecator.warn(
-              "#{intro}, and also overrides the `#{far_target}` method#{where}. " \
-              "In Rails 7.2, `#{method_name}` will directly access the `#{far_name}` attribute value instead of calling the method; " \
-              "explicitly forward or alias `#{method_name}` to `#{far_target}` to preserve the current behavior."
+              "#{intro}, and also overrides the `#{target_method_name}` method#{where}. " \
+              "In Rails 7.2, `#{method_name}` will directly access the `#{old_name}` attribute value instead of calling the method; " \
+              "explicitly forward or alias `#{method_name}` to `#{target_method_name}` to preserve the current behavior."
             )
+            return true
+          end
 
           # Common anti-pattern: using alias_attribute to alias an association
-          elsif reflect_on_association(far_name)
+          if reflect_on_association(far_name)
             ActiveRecord.deprecator.warn(
               "#{intro}, but `#{far_name}` is an association. " \
               "In Rails 7.2, alias_attribute will no longer work with associations; " \
               "use `alias_association :#{new_name}, :#{far_name}` instead."
             )
+            return true
+          end
 
           # Also anti-pattern: using alias_attribute to alias a plain method
-          else
+          if !has_attribute?(far_name)
             ActiveRecord.deprecator.warn(
               "#{intro}, but `#{far_name}` is not an attribute. " \
               "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
-              "define `#{method_name}` or use `alias_method :#{method_name}, :#{far_target}` instead."
+              "define `#{method_name}` or use `alias_method :#{method_name}, :#{old_name}` instead."
             )
+            return true
           end
+          false
         end
-       
-      end  
+
+        def find_attribute_far_name(old_name)
+          far_name = next_name = old_name
+          while next_name
+            next_name = attribute_aliases[next_name]
+            far_name = next_name if next_name
+          end
+          far_name
+        end
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/attribute_methods/validation.rb
+++ b/activerecord/lib/active_record/attribute_methods/validation.rb
@@ -11,18 +11,37 @@ module ActiveRecord
           method_defined_within?(method_name, self)
         end
 
-        def add_alias_attribute_deprecation_warning(new_name, old_name, method_name, target_method_name, target_method, far_name)
+        def check_for_deprecations(target_method, target_association_name)
           # TODO: We should warn about this too. Either it's a typo, or
           # it indicates a possible backwards compatibility issue we
           # haven't directly addressed, like a target that's being provided
-          # by method_missing.
-          return false unless target_method
+          # by method_missing
+          return unless target_method
           is_attribute_method = target_method.owner == generated_attribute_methods || target_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
+
+          # It's an attribute, this is just an overridden method
+          if has_attribute?(target_association_name) && !is_attribute_method
+            return :missing_forward_for_manually_defined_method
+          end
+
+          # Common anti-pattern: using alias_attribute to alias an association
+          if reflect_on_association(target_association_name)
+            return :target_is_association
+          end
+
+          # Also anti-pattern: using alias_attribute to alias a plain method
+          if !has_attribute?(target_association_name)
+            :not_an_attribute
+          end
+        end
+
+        def add_alias_attribute_deprecation_warning(new_name, old_name, method_name, target_method_name, target_method, far_name, deprecation_type)
+          return unless deprecation_type
           alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
           intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
 
-          # It's an attribute, this is just an overridden method
-          if has_attribute?(far_name) && !is_attribute_method
+          case deprecation_type
+          when :missing_forward_for_manually_defined_method
             where = target_method.owner == self ? "" : " in #{target_method.owner}"
 
             ActiveRecord.deprecator.warn(
@@ -30,29 +49,19 @@ module ActiveRecord
               "In Rails 7.2, `#{method_name}` will directly access the `#{old_name}` attribute value instead of calling the method; " \
               "explicitly forward or alias `#{method_name}` to `#{target_method_name}` to preserve the current behavior."
             )
-            return true
-          end
-
-          # Common anti-pattern: using alias_attribute to alias an association
-          if reflect_on_association(far_name)
+          when :target_is_association
             ActiveRecord.deprecator.warn(
               "#{intro}, but `#{far_name}` is an association. " \
               "In Rails 7.2, alias_attribute will no longer work with associations; " \
               "use `alias_association :#{new_name}, :#{far_name}` instead."
             )
-            return true
-          end
-
-          # Also anti-pattern: using alias_attribute to alias a plain method
-          if !has_attribute?(far_name)
+          when :not_an_attribute
             ActiveRecord.deprecator.warn(
               "#{intro}, but `#{far_name}` is not an attribute. " \
               "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
               "define `#{method_name}` or use `alias_method :#{method_name}, :#{old_name}` instead."
             )
-            return true
           end
-          false
         end
 
         def find_attribute_far_name(old_name)

--- a/activerecord/lib/active_record/attribute_methods/validation.rb
+++ b/activerecord/lib/active_record/attribute_methods/validation.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module AttributeMethods
+    # = Active Record Attribute Methods \Validation
+    module Validation
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+         def aliased_method_redefined?(method_name)
+          method_defined_within?(method_name, self)
+        end
+
+        # Given an attribute and a pattern, identify any manually defined methods in the
+        # aliased chain.
+        # Returns the far attribute, target definition name, the already defined method (if it exists) and a boolean of whether all targets are attribute methods.
+        def find_attribute_targets(old_name, pattern)
+          all_targets_are_attribute_methods = true
+
+          far_name = next_name = old_name
+          while next_name
+            far_name = next_name
+
+            far_target = pattern.method_name(far_name).to_s
+            far_method = (instance_method(far_target) if method_defined?(far_target) || private_method_defined?(far_target))
+            if far_method
+              unless far_method.owner == generated_attribute_methods || far_method.owner == ActiveRecord::AttributeMethods::PrimaryKey
+                all_targets_are_attribute_methods = false
+                break
+              end
+            elsif attribute_aliases.key?(far_name)
+              # walk past a missing method in the alias chain: it might not be defined yet
+            else
+              all_targets_are_attribute_methods = false
+              break
+            end
+
+            next_name = attribute_aliases[far_name]
+          end
+
+          [all_targets_are_attribute_methods, far_name, far_method, far_target]
+        end
+
+        def add_alias_attribute_deprecation_warning(far_name, far_method, far_target, new_name, old_name, method_name)
+          # TODO: We should warn about this too. Either it's a typo, or
+          # it indicates a possible backwards compatibility issue we
+          # haven't directly addressed, like a target that's being provided
+          # by method_missing.
+          return unless far_method
+
+          alias_chain = far_name == old_name ? "" : ", which in turn aliases to `#{far_name}`"
+          intro = "#{self} uses `alias_attribute :#{new_name}, :#{old_name}`#{alias_chain}"
+
+          # It's an attribute, this is just an overridden method
+          if has_attribute?(far_name)
+            where = far_method.owner == self ? "" : " in #{far_method.owner}"
+
+            ActiveRecord.deprecator.warn(
+              "#{intro}, and also overrides the `#{far_target}` method#{where}. " \
+              "In Rails 7.2, `#{method_name}` will directly access the `#{far_name}` attribute value instead of calling the method; " \
+              "explicitly forward or alias `#{method_name}` to `#{far_target}` to preserve the current behavior."
+            )
+
+          # Common anti-pattern: using alias_attribute to alias an association
+          elsif reflect_on_association(far_name)
+            ActiveRecord.deprecator.warn(
+              "#{intro}, but `#{far_name}` is an association. " \
+              "In Rails 7.2, alias_attribute will no longer work with associations; " \
+              "use `alias_association :#{new_name}, :#{far_name}` instead."
+            )
+
+          # Also anti-pattern: using alias_attribute to alias a plain method
+          else
+            ActiveRecord.deprecator.warn(
+              "#{intro}, but `#{far_name}` is not an attribute. " \
+              "In Rails 7.2, alias_attribute will no longer work with non-attributes; " \
+              "define `#{method_name}` or use `alias_method :#{method_name}, :#{far_target}` instead."
+            )
+          end
+        end
+       
+      end  
+    end
+  end
+end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1331,6 +1331,21 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "A river runs through it", obj.heading
   end
 
+  class SubTopicWithTypo < Topic
+    alias_attribute :heading, :title_oops
+  end
+
+  test "#alias_attribute creates a new attribute" do
+    message = <<~MESSAGE.gsub("\n", " ")
+    AttributeMethodsTest::SubTopicWithTypo uses `alias_attribute :heading, :title_oops`, but `title_oops`
+    is not an attribute or a method. In Rails 7.2, alias_attribute will only work on attributes; use `attribute
+    :title_oops` first.
+    MESSAGE
+    obj = assert_deprecated(message, ActiveRecord.deprecator) do
+      SubTopicWithTypo.new
+    end
+  end
+
   private
     def new_topic_like_ar_class(&block)
       klass = Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We want to be clear that alias_attribute is not meant to be used for non-attributes, and provide a clear deprecation warning if it's used for associations or otherwise non-attribute methods. This adds specific deprecation warnings for overriding an attribute method that won't forward in the future, aliasing an association (a common anti-pattern), and aliasing a non-attribute method.

In addition, we add tests for some of these common cases to ensure that we get the expected deprecation warning.

- If the user has manually defined an attribute method, we need to warn them that we won't forward to that method call in the future.
- If the user is using `alias_attribute` to alias an association (a common anti-pattern), we need to warn them of that specifically. 
- Finally, we can warn if `alias_attribute` is being used with a non-attribute target. 

### Detail

We add a check to walk up the alias chain to ensure that the target hasn't been redefined by the user. If the targets are all attribute methods and the class has the attribute, we can use `define_proxy_call`. Otherwise, we determine a deprecation warning to issue. 

### Additional information

Opened separately from https://github.com/rails/rails/pull/48913 to try to keep the changes easier to reason about, but let me know if there are any conflicts I may have missed. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
