### PR TITLE
Use `alias_attribute` to provide `id_value` alias for `id` attribute

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveRecord::Base#id_value` alias to access the raw value of a record's id column.
+
+    This alias is only provided for models that declare an `:id` column.
+
+    *Adrianna Chang*
+
 *   Fix previous change tracking for `ActiveRecord::Store` when using a column with JSON structured database type
 
     Before, the methods to access the changes made during the last save `#saved_change_to_key?`, `#saved_change_to_key`, and `#key_before_last_save` did not work if the store was defined as a `store_accessor` on a column with a JSON structured database type

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -618,6 +618,7 @@ module ActiveRecord
               default: column.default,
               user_provided_default: false
             )
+            alias_attribute :id_value, :id if name == "id"
           end
 
           super

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -44,6 +44,26 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal(123_456, order.id_value)
   end
 
+  test "#id_value alias returns the value in the id column, when id column exists" do
+    topic = Topic.new
+    assert_nil topic.id_value
+
+    topic = Topic.find(1)
+    assert_equal 1, topic.id_value
+  end
+
+  test "#id_value alias is not defined if id column doesn't exist" do
+    keyboard = Keyboard.create!
+
+    assert_empty keyboard.attribute_aliases
+  end
+
+  test "#id_value alias returns id column only for composite primary key models" do
+    order = ::Cpk::Order.create(id: [1, 2])
+
+    assert_equal 2, order.id_value
+  end
+
   test "attribute_for_inspect with a string" do
     t = topics(:first)
     t.title = "The First Topic Now Has A Title With\nNewlines And More Than 50 Characters"


### PR DESCRIPTION
### Motivation / Background

Extends on https://github.com/rails/rails/pull/48533.

This allows access to the raw `id` column value on records for which an id column exists but is not the primary key. This is common amongst models with composite primary keys.

### Detail

Use `alias_attribute` to provide a `uid` alias for the `id` attribute. That was one of the primary use cases described in the above pull request; as such, we've decided to provide it out of the box in Rails.

### Additional information

Is there a better way to provide documentation for `#uid` than via a comment inserted above the `alias_attribute` call?

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @nvasilevski @rafaelfranca 
