### PR TITLE
Fix a regression preventing vendorizing gems outside of the vendor folder

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -620,7 +620,7 @@ module Rails
       next if is_a?(Rails::Application)
 
       fixtures = config.root.join("test", "fixtures")
-      if fixtures_in_root_and_not_in_vendor?(fixtures)
+      if fixtures_in_root_and_not_in_gem_path?(fixtures)
         ActiveSupport.on_load(:active_record_fixtures) { self.fixture_paths |= ["#{fixtures}/"] }
       end
     end
@@ -728,9 +728,9 @@ module Rails
         end
       end
 
-      def fixtures_in_root_and_not_in_vendor?(fixtures)
+      def fixtures_in_root_and_not_in_gem_path?(fixtures)
         fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s) &&
-          !fixtures.to_s.start_with?(Rails.root.join("vendor").to_s)
+          !Gem.path.any? { |gem_path| fixtures.to_s.start_with?(gem_path) }
       end
 
       def build_request(env)


### PR DESCRIPTION
#48287 introduced auto loading fixtures in engines. All engines present in the root folder of the rails app would have their fixtures auto loaded. This caused tests to fail when gems were vendorized, because fixtures from the internal rails test suite would be loaded.

#48323 Added a check to exclude the vendor folder.

This PR extends the check introduced in #48323 to prevent loading fixtures from gem paths instead of just the vendor folder.

Some tools like devenv install gems in the root of the app, but outside of the vendor folder (`.devenv/state`).

This change prevents automatically loading fixtures from gems instead of the vendor folder.

### Motivation / Background

I run rails using devenv and after updating rails, my test suite started to complain about fixtures from rails internal tests.
The current check doesn't fix the issue for all situations. This new check *should*.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
