### PR TITLE
Handle non-string partial body in ActionView::CollectionCaching (7.0 backport)

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `render collection: @records, cache: true` inside `jbuilder` templates
+
+    The previous fix that shipped in `7.0.7` assumed template fragments are always strings,
+    this isn't true with `jbuilder`.
+
+    *Jean Boussier*
+
 ## Rails 7.0.7 (August 09, 2023) ##
 
 *   Fix `render collection: @records, cache: true` to cache fragments as bare strings

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -95,9 +95,16 @@ module ActionView
             build_rendered_template(content, template)
           else
             rendered_partial = yield
-            if fragment = rendered_partial.body&.to_str
-              entries_to_write[cache_key] = fragment
+            body = rendered_partial.body
+
+            # We want to cache buffers as raw strings. This both improve performance and
+            # avoid creating forward compatibility issues with the internal representation
+            # of these two types.
+            if body.is_a?(ActiveSupport::SafeBuffer)
+              body = body.to_str
             end
+
+            entries_to_write[cache_key] = body
             rendered_partial
           end
         end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/48645

Some template engines such as `jbuilder` use these Action View primitives with types other than strings, which breaks a bunch of assumptions.

I wish I could add a test for this, but this is deep in private methods I don't see a way to cover this.

FYI @edariedl