### PR TITLE
Ignore all environment files in the gitignore template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -7,6 +7,13 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore all environment files.
+/.env*
+!/.env*.erb
+!/.env*.example
+!/.env*.sample
+!/.env*.template
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*


### PR DESCRIPTION
### Motivation / Background

I've been playing a bit with MRSK on a new Rails 7.1alpha project (using `main`) and something that is both mentioned in the video and the [Readme](https://github.com/mrsked/mrsk#using-a-generated-env-file) is the ability to set a `.env.erb` template and then run `mrsk envify` to generate the final `.env`.

Given that MRSK might become more popular to deploy Rails applications, it feels like a good default to automatically remove any `.env` from the Git repository that are not templates or examples.

### Detail

This adds a few new lines to the `.gitignore` template to ignore all env files that are not ending by `.erb` or `.example`

### Additional information

This is similar to what the `.dockerignore` is [currently doing](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/dockerignore.tt#L13), with the exception of allowing template files and any specialized env files (eg. `.env.staging.erb` / `.env.staging.example`)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
