### PR TITLE
Add support for Playwright as a driver for system tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for Playwright as a driver for system tests.
+
+    *Yuki Nishijima*
+
 *   Rename `fixture_file_upload` method to `file_fixture_upload`
 
     Declare an alias to preserve the backwards compatibility of `fixture_file_upload`

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -30,7 +30,7 @@ module ActionDispatch
 
       private
         def registerable?
-          [:selenium, :cuprite, :rack_test].include?(@driver_type)
+          [:selenium, :cuprite, :rack_test, :playwright].include?(@driver_type)
         end
 
         def register
@@ -41,6 +41,7 @@ module ActionDispatch
             when :selenium then register_selenium(app)
             when :cuprite then register_cuprite(app)
             when :rack_test then register_rack_test(app)
+            when :playwright then register_playwright(app)
             end
           end
         end
@@ -61,6 +62,17 @@ module ActionDispatch
 
         def register_rack_test(app)
           Capybara::RackTest::Driver.new(app, respect_data_method: true, **@options)
+        end
+
+        def register_playwright(app)
+          screen = { width: @screen_size[0], height: @screen_size[1] } if @screen_size
+          options = {
+            screen: screen,
+            viewport: screen,
+            **@options
+          }.compact
+
+          Capybara::Playwright::Driver.new(app, **options)
         end
 
         def setup

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -60,6 +60,14 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ js_errors: false }), driver.instance_variable_get(:@options)
   end
 
+  test "initializing the driver with Playwright" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:playwright, screen_size: [1400, 1400], options: { headless: true })
+
+    assert_equal :playwright, driver.instance_variable_get(:@driver_type)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ headless: true }), driver.instance_variable_get(:@options)
+  end
+
   test "define extra capabilities using chrome" do
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome) do |option|
       option.add_argument("start-maximized")


### PR DESCRIPTION
### Motivation / Background

[Playwright](https://playwright.dev/) is getting popularity as a new browser automation tool. There is a community-maintained Ruby client ([client](https://github.com/YusukeIwaki/playwright-ruby-client) and [capybara driver](https://github.com/YusukeIwaki/capybara-playwright-driver)) as well. I have been using it for a while now and it works great, and it would be great if we could add support for it to Rails.

### Detail

This PR adds support for the Playwright driver to Rails.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
