### PR TITLE
Bump bundler requirement to >= 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ PATH
       activerecord (= 7.1.0.alpha)
       activestorage (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
-      bundler (>= 1.15.0)
+      bundler (>= 2.2.0)
       railties (= 7.1.0.alpha)
     railties (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.0.0"
 end

--- a/guides/bug_report_templates/action_controller_main.rb
+++ b/guides/bug_report_templates/action_controller_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "rack", "~> 2.0"
 end

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.0.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "rack", "~> 2.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activejob", "~> 7.0.0"
 end

--- a/guides/bug_report_templates/active_job_main.rb
+++ b/guides/bug_report_templates/active_job_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
 end
 

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.0.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_main.rb
+++ b/guides/bug_report_templates/active_record_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "sqlite3"
 end

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.0.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_migrations_main.rb
+++ b/guides/bug_report_templates/active_record_migrations_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "sqlite3"
 end

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.0.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_storage_main.rb
+++ b/guides/bug_report_templates/active_storage_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "rack", "~> 2.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
   gem "benchmark-ips"
 end

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activesupport", "~> 7.0.0"
 end

--- a/guides/bug_report_templates/generic_main.rb
+++ b/guides/bug_report_templates/generic_main.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails", github: "rails/rails", branch: "main"
 end
 

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "actiontext",    version
   s.add_dependency "railties",      version
 
-  s.add_dependency "bundler", ">= 1.15.0"
+  s.add_dependency "bundler", ">= 2.2.0"
 end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Require `bundler` version >= 2.2.0
+
+    *zzak*
+
+*   Remove `git_source` from `Gemfile` for plugin generator.
+
+    *zzak*
+
 *   Omit `webdrivers` gem dependency from `Gemfile` template
 
     *Sean Doyle*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -633,7 +633,6 @@ module Rails
         if !File.exist?(File.expand_path("Gemfile", destination_root))
           create_file("Gemfile", <<~GEMFILE)
             source "https://rubygems.org"
-            git_source(:github) { |repo| "https://github.com/\#{repo}.git" }
             #{rails_gemfile_entry}
           GEMFILE
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 <% unless options[:skip_gemspec] -%>
 
 # Specify your gem's dependencies in <%= name %>.gemspec.

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -141,11 +141,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/integration/navigation_test.rb", /ActionDispatch::IntegrationTest/
   end
 
-  def test_inclusion_of_git_source
-    run_generator [destination_root]
-    assert_file "Gemfile", /git_source/
-  end
-
   def test_inclusion_of_a_debugger
     run_generator [destination_root, "--full"]
     if defined?(JRUBY_VERSION)


### PR DESCRIPTION
My main motivation was to remove `git_source` from the `bug_report_templates`, which is possible by rubygems/rubygems@c2e81f8ff6

In general, I'm curious what is preventing us from upgrading `bundler` and probably the `required_rubygems_version` should be increased at some point?

Seems like `git_source` was removed from the generated `Gemfile` (but not templates) in #48396.