### PR TITLE
Fix CacheStore#write_multi with Redis::Distributed+ConnectionPool

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix CacheStore#write_multi when using a distributed Redis cache with a connection pool.
+
+    Fixes [#48938](https://github.com/rails/rails/issues/48938).
+
+    *Jonathan del Strother*
+
+
 ## Rails 7.0.7 (August 09, 2023) ##
 
 *   Fix `Cache::NullStore` with local caching for repeated reads.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -313,13 +313,15 @@ module ActiveSupport
 
       private
         def set_redis_capabilities
-          case redis
-          when Redis::Distributed
-            @mget_capable = true
-            @mset_capable = false
-          else
-            @mget_capable = true
-            @mset_capable = true
+          redis.with do |c|
+            case c
+            when Redis::Distributed
+              @mget_capable = true
+              @mset_capable = false
+            else
+              @mget_capable = true
+              @mset_capable = true
+            end
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

When RedisCacheStore uses a connection pool, `RedisCacheStore#mset_capable?` would always return true due to the class-check here: https://github.com/rails/rails/blame/a844773245e96de8a47d24df76747cdc9e4aa01f/activesupport/lib/active_support/cache/redis_cache_store.rb#L315

In Rails 7.0.7, collection caching [started using write_multi](https://github.com/rails/rails/pull/48645). If you're using Redis::Distributed with a connection pool, it'll then raise `MAPPED_MSET cannot be used in Redis::Distributed because the keys involved need to be on the same server or because we cannot guarantee that the operation will be atomic.`.



### Detail

This Pull Request changes the class-check to handle connection pools, so that mget/mset_capable are set appropriately based on the underling class.
I've also added another subclass of RedisCacheStoreCommonBehaviorTest, this one using distributed-redis + a connection pool, to try & get some more coverage there.

( ~I also wanted to point out that I've [disabled a test there](https://github.com/rails/rails/pull/48952/commits/afa6a6ba3bd68a32bdb4b9a506a5819a15437ae4#diff-6cbd9119d9ff9196372e53699cb973838036a376995cf32e4c0c5d6584520d6aR277) because `delete_multi` returns the incorrect number of deletions when using Redis::Distributed.~  Can no longer reproduce the failure, think I must have been confused)

### Additional information

I'd originally looked at [fixing this upstream in redis-rb](https://github.com/redis/redis-rb/pull/1215) to add mset support to Redis::Distributed, and then started looking at replacing RedisCacheStore's use of Redis::Distributed with a new wrapper-class that could handle the sharding itself. I think this fix might be a better option in the short-term though, as a small fix to 7-0-stable.

I don't believe the same fix is needed on main because that no-longer uses mset_capable (https://github.com/rails/rails/commit/f9fce850da754daca5274f402b7b6dc77c7489b9). It might be worth adding the extra test coverage from the new RedisCacheStoreWithDistributedRedisTest though - any preferences how that's done?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
