### PR TITLE
Fix served_url printed when using Puma & Rack 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.8)
+    nio4r (2.5.9)
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -373,7 +373,7 @@ GEM
     psych (5.1.0)
       stringio
     public_suffix (5.0.1)
-    puma (6.0.2)
+    puma (6.3.0)
       nio4r (~> 2.0)
     queue_classic (4.0.0)
       pg (>= 1.1, < 2.0)

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -86,7 +86,7 @@ module Rails
       end
 
       def use_puma?
-        server.to_s == "Rack::Handler::Puma"
+        server.to_s.end_with?("Handler::Puma")
       end
   end
 
@@ -96,7 +96,7 @@ module Rails
 
       RACK_HANDLER_GEMS = %w(cgi webrick scgi thin puma unicorn falcon)
       # Hard-coding a bunch of handlers here as we don't have a public way of
-      # querying them from the Rack::Handler registry.
+      # querying them from the Rackup::Handler registry.
       RACK_HANDLERS = RACK_HANDLER_GEMS + %w(fastcgi lsws)
       RECOMMENDED_SERVER = "puma"
 

--- a/railties/test/commands/server_test.rb
+++ b/railties/test/commands/server_test.rb
@@ -306,6 +306,12 @@ class Rails::Command::ServerTest < ActiveSupport::TestCase
     assert_equal "http://127.0.0.1:4567", server.served_url
   end
 
+  def test_served_url_when_server_prints_it
+    args = %w(-u puma -b 127.0.0.1 -p 4567)
+    server = Rails::Server.new(parse_arguments(args))
+    assert_nil server.served_url
+  end
+
   private
     def run_command(*args)
       build_app


### PR DESCRIPTION
### Motivation / Background

This `#use_puma?` check was [introduced][1] because Rails could potentially display the wrong server URL in development if another host or port is configured in `config/puma.rb`.

However, in Rack 3 the the name of the server class changed from `Rack::Handler::Puma` to `Rackup::Handler::Puma`, which means that the served_url is being logged again.

### Detail

This commit fixes the check to accept either version of the class. Additionally, puma was updated in Gemfile.lock because Puma 6.0.x prints a deprecation warning about Rack::Handler that's fixed in 6.1.0.

[1]: https://github.com/rails/rails/commit/29648ff60e66c674b3cc49151df15dc100ffb4f4

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
