### PR TITLE
Add test coverage for ShowExceptions failsafe

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -54,7 +54,7 @@ module ActionDispatch
       rescue Exception => failsafe_error
         $stderr.puts "Error during failsafe response: #{failsafe_error}\n  #{failsafe_error.backtrace * "\n  "}"
 
-        [500, { "Content-Type" => "text/plain; charset=utf-8" },
+        [500, { Rack::CONTENT_TYPE => "text/plain; charset=utf-8" },
           ["500 Internal Server Error\n" \
           "If you are the administrator of this website, then please read this web " \
           "application's log file and/or the web server's log file to find out what " \

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -135,6 +135,18 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal("{\"status\":400,\"error\":\"Bad Request\"}", body)
   end
 
+  test "failsafe prevents raising if exceptions_app raises" do
+    old_stderr, $stderr = $stderr, StringIO.new
+    @app = build_app(->(_) { raise })
+
+    get "/"
+
+    assert_response 500
+    assert_match(/500 Internal Server Error/, body)
+  ensure
+    $stderr = old_stderr
+  end
+
   private
     def build_app(exceptions_app = nil)
       exceptions_app ||= ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")


### PR DESCRIPTION
### Motivation / Background

Ref #48874 

This adds additional test coverage to ShowExceptions, since one of the possible responses it creates was not previously tested.

### Detail

Because of the previous [addition][1] of Rack::Lint, this also demonstrates that the Content-Type header needed to be fixed.

[1]: https://github.com/rails/rails/commit/339dda4a82356d173b62dab144870790618e40c6

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
