### PR TITLE
Better handle SyntaxError in Action View

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -242,7 +242,7 @@ module ActionDispatch
         end
 
         def spot(exc)
-          if RubyVM::AbstractSyntaxTree.respond_to?(:node_id_for_backtrace_location)
+          if RubyVM::AbstractSyntaxTree.respond_to?(:node_id_for_backtrace_location) && __getobj__.is_a?(Thread::Backtrace::Location)
             location = @template.spot(__getobj__)
           else
             location = super
@@ -267,7 +267,12 @@ module ActionDispatch
 
         (@exception.backtrace_locations || []).map do |loc|
           if built_methods.key?(loc.label.to_s)
-            SourceMapLocation.new(loc, built_methods[loc.label.to_s])
+            thread_backtrace_location = if loc.respond_to?(:__getobj__)
+              loc.__getobj__
+            else
+              loc
+            end
+            SourceMapLocation.new(thread_backtrace_location, built_methods[loc.label.to_s])
           else
             loc
           end

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -43,7 +43,26 @@ module ActiveSupport
 
     private
       def parse_message_for_trace
-        __getobj__.to_s.split("\n")
+        if source_location_eval?
+          # If the exception is coming from a call to eval, we need to keep
+          # the path of the file in which eval was called to ensure we can
+          # return the right source fragment to show the location of the
+          # error
+          location = __getobj__.backtrace_locations[0]
+          ["#{location.path}:#{location.lineno}: #{__getobj__}"]
+        else
+          __getobj__.to_s.split("\n")
+        end
+      end
+
+      if SyntaxError.method_defined?(:path) # Ruby 3.3+
+        def source_location_eval?
+          __getobj__.path.start_with?("(eval")
+        end
+      else # 3.2 and older versions of Ruby
+        def source_location_eval?
+          __getobj__.to_s.start_with?("(eval")
+        end
       end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #48326

This Pull Request has been created to fix an issue where syntax errors generated inside an eval method cause an Internal Server Error due to a TypeError.

### Detail

In order to display the extraced source of a syntax error, we try to locate the node id for the backtrace location. The call to RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location is expecting a Thread::Backtrace::Location object, but we are passing a SourceMapLocation instead.

Once this is fixed, another issue then appears. The first location of the backtrace for an eval error does not include the filename of where eval is called, so we can't extract the source. This means that the development view fails to show the extracted source because it is hard-coded to show the source extracted for the first location.

This commit does two things:
1) it addresses the issue by making sure that we are always passing a Thread::Backtrace::Location instead
2) it allows the development view to show the extracted source fragment by ensuring the first location of the backtrace for a syntax error coming from eval includes the name of the file where eval is called


### Additional information

I have tried to keep the changes consistent with the approach introduced in https://github.com/rails/rails/pull/46171.