### PR TITLE
Remove uneeded requires of core_ext/string/filters

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/filters"
-
 module ActionDispatch
   # The routing module provides URL rewriting in native Ruby. It's a way to
   # redirect incoming requests to controllers and actions. This replaces

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/filters"
 require "active_support/log_subscriber"
 
 module ActiveJob

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -3,7 +3,6 @@
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/deep_dup"
-require "active_support/core_ext/string/filters"
 require "active_model/error"
 require "active_model/nested_error"
 require "forwardable"

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -2,7 +2,6 @@
 
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"
-require "active_support/core_ext/string/filters"
 require "active_support/parameter_filter"
 require "concurrent/map"
 

--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/filters"
 require "active_support/inflector"
 
 class Module

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -3,7 +3,6 @@
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/acts_like"
-require "active_support/core_ext/string/filters"
 
 module ActiveSupport
   # = Active Support \Duration

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -5,7 +5,6 @@ require "erb"
 
 require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/module/delegation"
-require "active_support/core_ext/string/filters"
 require "active_support/core_ext/string/inflections"
 
 require "rails/command/actions"

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -3,7 +3,6 @@
 require "fileutils"
 require "action_dispatch"
 require "rails"
-require "active_support/core_ext/string/filters"
 require "rails/dev_caching"
 require "rails/command/environment_argument"
 require "rails/rackup/server"


### PR DESCRIPTION
`actionpack/lib/action_dispatch/routing.rb`
- added: 013745151be062aa4d0fc1f2a008a7303fdb6e04
- removed: 93034ad7fea7e00562103a7cd0acfab19bbfadf9

`activejob/lib/active_job/log_subscriber.rb`
- added: b314ab555e0d85e6efb41be94fb5f3a157bb12fe
- removed: 5ab2034730feacfc2caee418f8c0b55191d27427

`activemodel/lib/active_model/errors.rb`
- added: cf7fac7e29bb2816412c949fdaed3d61a923eb23
- removed: 9de6457ab0767ebab7f2c8bc583420fda072e2bd

`activerecord/lib/active_record/core.rb`
- added: b3bfa361c503e107aff4dee5edf79bd7fd3d3725
- removed: e1066f450d1a99c9a0b4d786b202e2ca82a4c3b3

`activesupport/lib/active_support/core_ext/module/introspection.rb`
- added: 358ac36edf1695fcbec0aa21f126a3d8b83d4b5a
- removed: 167b4153cac0069a21e0bb9689cb16f34f6abbaa

`activesupport/lib/active_support/duration.rb`
- added: 75924c4517c8f87712d3f59c11f10152ed57b9d8
- removed: a91ea1d51048342d13fc73f9b09ce4cfd086bb34

`railties/lib/rails/commands/server/server_command.rb`
- added: f2173648938b418d120f5a68d8f3862d8ae9dace
- removed: 553b86fc751c751db504bcbe2d033eb2bb5b6a0b

`railties/lib/rails/command/base.rb`
- added: 6813edc7d926965e5644cd8befaf229a35b9d8ca
- removed: b617a561d865a65cfc140caa0e3c4af4350bfcef
