### PR TITLE
Add Rack::Lint to ActionCable::Server health tests

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -235,7 +235,7 @@ module ActionCable
 
           logger.error invalid_request_message
           logger.info finished_request_message
-          [ 404, { "Content-Type" => "text/plain; charset=utf-8" }, [ "Page not found" ] ]
+          [ 404, { Rack::CONTENT_TYPE => "text/plain; charset=utf-8" }, [ "Page not found" ] ]
         end
 
         # Tags are declared in the server but computed in the connection. This allows us per-connection tailored tags.

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rack"
+
 module ActionCable
   module Server
     # = Action Cable \Server \Configuration
@@ -25,7 +27,7 @@ module ActionCable
         @filter_parameters = []
 
         @health_check_application = ->(env) {
-          [204, { "Content-Type" => "text/html", "date" => Time.now.httpdate }, []]
+          [200, { Rack::CONTENT_TYPE => "text/html", "date" => Time.now.httpdate }, []]
         }
       end
 


### PR DESCRIPTION
### Motivation / Background

Ref #48874

This adds additional coverage to ActionCable::Server to validate that its output follow the Rack SPEC.

### Detail

In addition to using Rack::CONTENT_TYPE for the Content-Type header, there was another change required: the Content-Type header cannot be specified when the Response status is 204, so the default health check status was updated to 200

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
