### PR TITLE
Revert "Bundler should use platform :windows instead of :mingw, etc."

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,7 +147,7 @@ group :test do
   gem "benchmark-ips"
 end
 
-platforms :ruby, :windows do
+platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
 
   # Needed for compiling the ActionDispatch::Journey parser.
@@ -187,8 +187,8 @@ if ENV["ORACLE_ENHANCED"]
   gem "activerecord-oracle_enhanced-adapter", github: "rsim/oracle-enhanced", branch: "master"
 end
 
-gem "tzinfo-data", platforms: [:windows, :jruby]
-gem "wdm", ">= 0.1.0", platforms: [:windows]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
 
 # The error_highlight gem only works on CRuby 3.1 or later.
 # Also, Rails depends on a new API available since error_highlight 0.4.0.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,4 +641,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.3.22
+   2.3.17

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -615,10 +615,6 @@ module Rails
         !(options[:skip_bundle] || options[:pretend])
       end
 
-      def bundler_windows_platforms
-        Gem.rubygems_version >= Gem::Version.new("3.3.22") ? "windows" : "mswin mswin64 mingw x64_mingw"
-      end
-
       def depends_on_system_test?
         !(options[:skip_system_test] || options[:skip_test] || options[:api])
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -15,7 +15,7 @@ ruby <%= "\"#{gem_ruby_version}\"" -%>
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
@@ -35,7 +35,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
+  gem "debug", platforms: %i[ mri mingw x64_mingw ]
 end
 <% end -%>
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -13,7 +13,7 @@ gemspec
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 <% end -%>
-<% if RUBY_PLATFORM.match?(/mingw|mswin|java/) -%>
+<% if RUBY_PLATFORM.match?(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
-gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 <% end -%>

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -93,7 +93,6 @@ module GeneratorsTestHelper
         depends_on_system_test: false,
         options: ActiveSupport::OrderedOptions.new,
         skip_sprockets: false,
-        bundler_windows_platforms: "windows",
       }
     end
 end


### PR DESCRIPTION
Reverts rails/rails#46009

This change breaks building Rails source on Ruby 3.0.

In #48951, we found that `gem install rails` and `rails new` must work on the currently supported Ruby versions default available rubygems&bundler.

The reason this feature passed CI was because we always update to the latest rubygems and bundler in our build images, including Ruby 2.7 and up.

Through experimenting on rails/buildkite-config#65, I realized that the two are mutually exclusive, and there are things in the test suite that we may want to make exceptions for in order to keep builds green -- if that means a developer who wants to contribute to rails/rails also has to update to the latest version.

All of that said, this feature breaks that guarantee that we will support the default available rubygems and bundler for each version of Ruby we support.