### PR TITLE
Add test coverage for RedisCacheStore with Redis::Distributed / ConnectionPool

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -10,6 +10,7 @@ rescue LoadError
 end
 
 require "connection_pool"
+require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/numeric/time"
 require "active_support/digest"
@@ -455,8 +456,8 @@ module ActiveSupport
         def supports_expire_nx?
           return @supports_expire_nx if defined?(@supports_expire_nx)
 
-          redis_version = redis.then { |c| c.info("server").fetch("redis_version") }
-          @supports_expire_nx = Gem::Version.new(redis_version) >= Gem::Version.new("7.0.0")
+          redis_versions = redis.then { |c| Array.wrap(c.info("server")).pluck("redis_version") }
+          @supports_expire_nx = redis_versions.all? { |v| Gem::Version.new(v) >= Gem::Version.new("7.0.0") }
         end
 
         def failsafe(method, returning: nil)


### PR DESCRIPTION

### Motivation / Background

The [Rails guides](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore) suggest using connection pooling & multiple cache-urls in production, but there's very little test coverage for that situation.

### Detail

This 'forward-ports' some tests which were added against 7-0-stable here: #48952

Also fixes a bug in `supports_expire_nx?` when using distributed-redis.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


cc @byroot 