### PR TITLE
Fix 6.1 change_column setting datetime precision

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix change_column setting datetime precision for 6.1 Migrations
+
+    *Hartley McGuire*
+
 *   Add `ActiveRecord::Base#id_value` alias to access the raw value of a record's id column.
 
     This alias is only provided for models that declare an `:id` column.

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -178,6 +178,15 @@ module ActiveRecord
           super
         end
 
+        def change_column(table_name, column_name, type, **options)
+          if type == :datetime
+            options[:precision] ||= nil
+          end
+
+          type = PostgreSQLCompat.compatible_timestamp_type(type, connection)
+          super
+        end
+
         def create_table(table_name, **options)
           if block_given?
             super { |t| yield compatible_table_definition(t) }

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -520,6 +520,28 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :published_at, **precision_implicit_default)
       end
 
+      def test_datetime_doesnt_set_precision_on_change_column_6_1
+        create_migration = Class.new(ActiveRecord::Migration[6.1]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.date :published_at
+            end
+          end
+        }.new(nil, 0)
+
+        change_migration = Class.new(ActiveRecord::Migration[6.1]) {
+          def migrate(x)
+            change_column :more_testings, :published_at, :datetime
+          end
+        }.new(nil, 1)
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration, @internal_metadata).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
       def test_change_table_allows_if_exists_option_on_7_0
         migration = Class.new(ActiveRecord::Migration[7.0]) {
           def migrate(x)


### PR DESCRIPTION
### Motivation / Background

Fix #48965 

This is already the case for add_column and create_table, but change_column was missed

### Additional Information

This needs to be backported to 7.0, but the test change won't backport cleanly because the Migrator signature in the test changed. I'll make a PR for 7-0-stable as well if that would be easier

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
