### PR TITLE
Fix list item numbering on API docs main page [ci-skip]

### DIFF
--- a/railties/RDOC_MAIN.md
+++ b/railties/RDOC_MAIN.md
@@ -56,27 +56,29 @@ In addition to that, \Rails also comes with:
 
 ## Getting Started
 
-1. Install \Rails at the command prompt if you haven't yet:
+1.  Install \Rails at the command prompt if you haven't yet:
 
         $ gem install rails
 
-2. At the command prompt, create a new \Rails application:
+2.  At the command prompt, create a new \Rails application:
 
         $ rails new myapp
 
-   where "myapp" is the application name.
+    where "myapp" is the application name.
 
-3. Change directory to `myapp` and start the web server:
+3.  Change directory to `myapp` and start the web server:
 
         $ cd myapp
         $ bin/rails server
 
-   Run with `--help` or `-h` for options.
+    Run with `--help` or `-h` for options.
 
-4. Go to `http://localhost:3000` and you'll see the \Rails bootscreen with your \Rails and Ruby versions.
+4.  Go to `http://localhost:3000` and you'll see the \Rails bootscreen with your
+    \Rails and Ruby versions.
 
-5. Follow the guidelines to start developing your application. You may find
-   the following resources handy:
+5.  Follow the guidelines to start developing your application. You may find the
+    following resources handy:
+
     * [Getting Started with Rails](https://guides.rubyonrails.org/getting_started.html)
     * [Ruby on Rails Guides](https://guides.rubyonrails.org)
     * [The API Documentation](https://api.rubyonrails.org)


### PR DESCRIPTION
Follow-up to #47178.

RDoc's Markdown parser requires multi-line list items to use a hanging indent of at least four spaces.  Otherwise, trailing lines will be rendered as an independent paragraph, and the next list item will start a new list.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/rails/assets/771968/d0c2b486-7a8c-492f-bfad-8982dbc18af4) | ![after](https://github.com/rails/rails/assets/771968/7e0efc66-11c9-4677-8d9a-d49011e1057f) |

(The unordered list being rendered as an ordered list is actually a CSS issue, not a Markdown issue, and will be fixed in an upcoming version of SDoc.)
