### PR TITLE
Add method for accessing only query constraints

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -489,6 +489,11 @@ module ActiveRecord
         raise ArgumentError, "You must specify at least one column to be used in querying" if columns_list.empty?
 
         @query_constraints_list = columns_list.map(&:to_s)
+        @has_query_constraints = @query_constraints_list
+      end
+
+      def has_query_constraints? # :nodoc:
+        @has_query_constraints
       end
 
       def query_constraints_list # :nodoc:

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -523,7 +523,7 @@ module ActiveRecord
           else
             custom_primary_key.to_s.freeze
           end
-        elsif options[:query_constraints]
+        elsif active_record.has_query_constraints? || options[:query_constraints]
           active_record.query_constraints_list
         else
           primary_key(active_record).freeze
@@ -807,7 +807,7 @@ module ActiveRecord
 
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
-        if options[:query_constraints]
+        if !polymorphic? && ((klass || self.klass).has_query_constraints? || options[:query_constraints])
           (klass || self.klass).composite_query_constraints_list
         elsif primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s


### PR DESCRIPTION
I'm working on an enhancement to query constraints that will require me to know when we have query constraints but not a composite key. Currently if you have a composite key it will be included in the query constraints list. There's not a way to differentiate between the two which means that we're forced into setting the query constraints on the associations for the primary key.

This change adds a `has_query_constraints?` method so we can check the class for query constraints. The options still work as well but we can be sure we're always picking up the query constraints when they're present.

cc/ @nvasilevski 