### PR TITLE
Ensure target is an attribute for `alias_attribute`

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -203,7 +203,7 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
-        local_attribute_aliases[new_name.to_s] = old_name.to_s
+        self.local_attribute_aliases = local_attribute_aliases.merge(new_name.to_s => old_name.to_s)
         eagerly_generate_alias_attribute_methods(new_name, old_name)
       end
 
@@ -370,6 +370,8 @@ module ActiveModel
       end
 
       private
+        attr_writer :local_attribute_aliases # :nodoc:
+
         def inherited(base) # :nodoc:
           super
           base.class_eval do


### PR DESCRIPTION
### Motivation / Background

We ran into a few cases at GitHub where we were using `alias_attribute` incorrectly to target non-attribute methods. Previously, this "worked", because `alias_attribute` just forwarded the method call, but this is no longer the case.

In most cases, this raised a deprecation warning, although the message was a bit unclear. The original deprecation warning was intended to look for manually defined alias methods that won't be forwarded in the future. 

If the target happens to be a generated attribute method, no deprecation is raised. For example, assuming a model has a `title` attribute, `alias_attribute :saved_title, :title_in_database` was using the new behavior, because we only raise the deprecation if the target method is not an attribute method. 

### Detail

This Pull Request adds a check to `alias_attribute_method_definition` to ensure that you actually are targeting an attribute, and raises a deprecation warning if not. In the future, I think we should raise if you try to use `alias_attribute` with a non-attribute method. 

Note that the following code will still behave correctly, because `has_attribute?` will forward the aliases to the far target automatically.

```ruby
class Topic
  alias_attribute :heading, :title
  alias_attribute :subject, :heading
end
```

This correctly issues a deprecation warning for generated attribute methods, and also makes the warning for any non-attribute methods more clear.

### Additional information
We originally tried to make this warning even more specific in #48929, but the logic got kind of complicated. Issuing one warning for this case felt like a good compromise.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
