### PR TITLE
Alias scope merge fix

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -492,8 +492,6 @@ module ActiveRecord
       end
 
       def has_query_constraints? # :nodoc:
-
-        
           @has_query_constraints
       end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -487,13 +487,16 @@ module ActiveRecord
       #   # SELECT "developers".* FROM "developers" WHERE "developers"."company_id" = 1 AND "developers"."id" = 1 LIMIT 1
       def query_constraints(*columns_list)
         raise ArgumentError, "You must specify at least one column to be used in querying" if columns_list.empty?
-
         @query_constraints_list = columns_list.map(&:to_s)
         @has_query_constraints = @query_constraints_list
       end
 
       def has_query_constraints? # :nodoc:
-        @has_query_constraints
+        if @has_query_constraints
+          @has_query_constraints
+        else
+          @has_query_constraints = nil
+        end
       end
 
       def query_constraints_list # :nodoc:

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -492,11 +492,9 @@ module ActiveRecord
       end
 
       def has_query_constraints? # :nodoc:
-        if @has_query_constraints
+
+        
           @has_query_constraints
-        else
-          @has_query_constraints = nil
-        end
       end
 
       def query_constraints_list # :nodoc:

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -618,9 +618,7 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_Or(o, collector)
-          if o.inspect.include?("TableAlias")
-            o.right.instance_values["left"].relation = Nodes::TableAlias.new(o.right.instance_values["left"].relation, o.left.instance_values["left"].relation.right)
-          end
+        
           stack = [o.right, o.left]
 
           while o = stack.pop

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -618,7 +618,9 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_Or(o, collector)
-        
+          if o.inspect.include?("TableAlias")
+            o.right.instance_values["left"].relation = Nodes::TableAlias.new(o.right.instance_values["left"].relation, o.left.instance_values["left"].relation.right)
+          end
           stack = [o.right, o.left]
 
           while o = stack.pop

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -618,6 +618,9 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_Or(o, collector)
+          if o.inspect.include?("TableAlias")
+            o.right.instance_values["left"].relation = Nodes::TableAlias.new(o.right.instance_values["left"].relation, o.left.instance_values["left"].relation.right)
+          end
           stack = [o.right, o.left]
 
           while o = stack.pop


### PR DESCRIPTION
### Motivation / Background

This branch allows a user to set "self.table_alias" in the model to custom set a table alias.  It then accounts for the SQL needed for this in the AST.  

### Detail

Since Arel ends up combining two different Queries in this specific use case, it seemed to make the most sense to reuse the Alias in the WHERE condition.  I think for most use cases we still want to use the `association` if the `reflection.options` hash includes `:class_name`.  This fix ensures the continued use of that behavior.

### Additional information

WIP. Open to suggestions.

### Checklist

Before submitting the PR make sure the following are checked:

* [ X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X ] Tests are added or updated if you fix a bug or add a feature.
* [ X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
