### PR TITLE
Alias scope merge or fix

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -45,6 +45,10 @@ module ActiveRecord
         if left.empty? || right.empty?
           common
         else
+          if left.predicates[0].methods.include?(:left) && left.predicates[0].left.relation.class == Arel::Nodes::TableAlias
+            right.predicates[0].left.relation = Arel::Nodes::TableAlias.new(right.predicates[0].left.relation, left.predicates[0].left.relation.name)
+          end
+
           left = left.ast
           left = left.expr if left.is_a?(Arel::Nodes::Grouping)
 

--- a/activerecord/test/assets/schema_dump_5_1.yml
+++ b/activerecord/test/assets/schema_dump_5_1.yml
@@ -342,4 +342,6 @@ data_sources:
   test_with_keyword_column_name: true
   fk_test_has_pk: true
   fk_test_has_fk: true
+  goals: true
+  goal_states: true
 version: 0

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -8,6 +8,8 @@ require "models/essay"
 require "models/comment"
 require "models/categorization"
 require "models/book"
+require "models/goal"
+require "models/goal_state"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
@@ -165,6 +167,11 @@ module ActiveRecord
 
     def test_missing_with_enum_extended_late
       assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).extending(Author::NamedExtension).first
+    end
+
+    def test_missing_merge_or
+      Goal.create!
+      assert_equal Goal.find(1), Goal.no_state.first
     end
 
     def test_not_inverts_where_clause

--- a/activerecord/test/models/goal.rb
+++ b/activerecord/test/models/goal.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Goal < ActiveRecord::Base
+  has_one :state, class_name: "GoalState", dependent: :destroy
+
+  scope :no_state, -> { where.missing(:state).or(left_joins(:state).merge(GoalState.not_set)) }
+end

--- a/activerecord/test/models/goal_state.rb
+++ b/activerecord/test/models/goal_state.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GoalState < ActiveRecord::Base
+  belongs_to :goal
+
+  scope :set, -> { where.not(state: nil) }
+  scope :not_set, -> { where(state: nil) }
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1448,6 +1448,14 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
+
+  create_table :goals, force: true do |t|
+  end
+
+  create_table :goal_states, force: true do |t|
+    t.integer :goal_id
+    t.string :state
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
This branch addresses the issues raised in #48945. When a User has already aliased a table, and then joins upon it again with a merger of a separate model's table, this makes sure that both conditions in the WHERE clause use the aliased table.

### Detail

This checks in the `visit_Arel_Nodes_Or` method whether there is a TableAlias node inside.  If so, it creates a TableAlias node on the right as well. This way we can continue to use an alias if the `reflection.options[:class]` key has a value.  I believe approaching it this way will allow all of these edge cases to function well together.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
