### PR TITLE
Fix regression blocking creation of some strict association

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -81,9 +81,9 @@ module ActiveRecord
         # to try to properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.belongs_to?
-            Array(through_reflection.foreign_key).map do |foreign_key_column|
+            Array(through_reflection.foreign_key).filter_map do |foreign_key_column|
               owner[foreign_key_column] && owner[foreign_key_column].to_s
-            end
+            end.presence
           end
         end
 

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -284,6 +284,20 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_with_has_one_through_does_not_prevent_creation_of_association
+    firm = Firm.new(name: "SuperFirm").tap(&:strict_loading!)
+    computer = Computer.new(extendedWarranty: 1).tap(&:strict_loading!)
+
+    computer.firm = firm
+    computer.developer.name = "Joe"
+    firm.lead_developer = computer.developer
+
+    assert_nothing_raised do
+      computer.save!
+    end
+  end
+
+
   def test_preload_audit_logs_are_strict_loading_because_parent_is_strict_loading
     developer = Developer.first
 

--- a/activerecord/test/models/computer.rb
+++ b/activerecord/test/models/computer.rb
@@ -2,4 +2,5 @@
 
 class Computer < ActiveRecord::Base
   belongs_to :developer, foreign_key: "developer"
+  has_one :firm, through: :developer
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -38,6 +38,7 @@ class Developer < ActiveRecord::Base
   accepts_nested_attributes_for :projects
 
   has_and_belongs_to_many :shared_computers, class_name: "Computer"
+  has_many :computers, foreign_key: :developer
 
   has_and_belongs_to_many :projects_extended_by_name,
       -> { extending(ProjectsAssociationExtension) },


### PR DESCRIPTION
#48606 introduced a regression preventing the creation of a chain of models using a has_one through association when strict_loading is activated.



### Detail

The association [relies on the initial @stale_state being `nil` to skip loading the target](https://github.com/gmcgibbon/rails/blob/755c13f167af4fddc6960ed3768ed7e178a2395a/activerecord/lib/active_record/associations/association.rb#L175).


#48606 initializes the [@stale_state to `[nil]`](https://github.com/rails/rails/pull/48606/files#diff-39c3da3c5f3fbff01b0a32d3b7ec613fda6bc6225fdbe2629134d91babe37786R84-R86)


This change converts the `[nil]` state back to `nil` while keeping composite primary key support


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG N/A