### PR TITLE
Add an option to start rails console in sandbox mode by default

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -311,6 +311,10 @@ Sets the format used in responses when errors occur in the development environme
 
 Controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to `false`.
 
+#### `config.sandbox_by_default`
+
+When `true`, rails console starts in sandbox mode. To start rails console in non-sandbox mode, `--no-sandbox` must be specified. This is helpful to avoid accidental writing to the production database. Defaults to `false`.
+
 #### `config.dom_testing_default_html_version`
 
 Controls whether an HTML4 parser or an HTML5 parser is used by default by the test helpers in Action View, Action Dispatch, and `rails-dom-testing`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add an option to start rails console in sandbox mode by default
+
+    `sandbox_by_default` option is added to start rails console in sandbox
+    mode by default. With this option turned on, `--no-sandbox` must be
+    specified to start rails in non-sandbox mode.
+
+    Note that this option is ignored when rails environment is development
+    or test.
+
+    *Shouichi Kamiya*
+
 *   Omit `webdrivers` gem dependency from `Gemfile` template
 
     *Sean Doyle*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,8 +21,9 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
-                    :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :rake_eager_load, :server_timing, :log_file_size, :dom_testing_default_html_version
+                    :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
+                    :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
+                    :dom_testing_default_html_version
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -76,6 +77,7 @@ module Rails
         @loaded_config_version                   = nil
         @credentials                             = ActiveSupport::InheritableOptions.new(credentials_defaults)
         @disable_sandbox                         = false
+        @sandbox_by_default                      = false
         @add_autoload_paths_to_load_path         = true
         @permissions_policy                      = nil
         @rake_eager_load                         = false

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -46,7 +46,11 @@ module Rails
     end
 
     def sandbox?
-      options[:sandbox]
+      return options[:sandbox] if !options[:sandbox].nil?
+
+      return false if Rails.env.local?
+
+      app.config.sandbox_by_default
     end
 
     def environment
@@ -79,7 +83,7 @@ module Rails
     class ConsoleCommand < Base # :nodoc:
       include EnvironmentArgument
 
-      class_option :sandbox, aliases: "-s", type: :boolean, default: false,
+      class_option :sandbox, aliases: "-s", type: :boolean, default: nil,
         desc: "Rollback database modifications on exit."
 
       def initialize(args = [], local_options = {}, config = {})

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -165,6 +165,42 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     assert_equal 1, $?.exitstatus
   end
 
+  def test_sandbox_by_default
+    add_to_config <<-RUBY
+      config.sandbox_by_default = true
+    RUBY
+
+    options = "-e production -- --verbose --nocolorize"
+    spawn_console(options)
+
+    write_prompt "puts Rails.application.sandbox", "puts Rails.application.sandbox\r\ntrue"
+    @primary.puts "quit"
+  end
+
+  def test_sandbox_by_default_with_no_sandbox
+    add_to_config <<-RUBY
+      config.sandbox_by_default = true
+    RUBY
+
+    options = "-e production --no-sandbox -- --verbose --nocolorize"
+    spawn_console(options)
+
+    write_prompt "puts Rails.application.sandbox", "puts Rails.application.sandbox\r\nfalse"
+    @primary.puts "quit"
+  end
+
+  def test_sandbox_by_default_with_development_environment
+    add_to_config <<-RUBY
+      config.sandbox_by_default = true
+    RUBY
+
+    options = "-- --verbose --nocolorize"
+    spawn_console(options)
+
+    write_prompt "puts Rails.application.sandbox", "puts Rails.application.sandbox\r\nfalse"
+    @primary.puts "quit"
+  end
+
   def test_environment_option_and_irb_option
     options = "-e test -- --verbose --nocolorize"
     spawn_console(options)

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -169,7 +169,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     def build_app(console)
       mocked_console = Class.new do
         attr_accessor :sandbox
-        attr_reader :console, :disable_sandbox
+        attr_reader :console, :disable_sandbox, :sandbox_by_default
 
         def initialize(console)
           @console = console


### PR DESCRIPTION
To avoid accidental writing to the production database, I always start rails console in sandbox mode. I only start rails console in non-sandbox mode when I'm sure I want to write to the production database.

`sandbox_by_default` option is added to start rails console in sandbox mode by default. With this option turned on, `--no-sandbox` must be specified to start rails in non-sandbox mode.

Note that this option is ignored when rails environment is development or test.