### PR TITLE
[Fix #46509] Run autosave validations regardless of changes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Ensure autosave validations are run regardless of changes.
+
+    Before, autosave validations were only run if the record had changes to save. This was inconsistent with how
+    validations are run when saving a record directly, which also resulted in inconsistent behaviour when using
+    `#accepts_nested_attributes_for`.
+    Now, autosave validations are always run, regardless of whether the record has changes to save, while still
+    taking into account association options like `:validate` and custom validation context.
+
+    *Joshua Young*
+
 *   Allow batching methods to use already loaded relation if available
 
     Calling batch methods on already loaded relations will use the records previously loaded instead of retrieving


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix https://github.com/rails/rails/issues/46509.

### Detail

This Pull Request changes association autosave logic to decouple validation and save conditions, so that validations are always run (still taking into consideration options like `:validate`) regardless of whether or not the record is changing. This makes autosave validations consistent with direct persistence methods like `save`, as shown in https://github.com/rails/rails/issues/46509#issuecomment-1322641993 and the test I've added in this PR.

This approach was inspired by the comments in https://github.com/rails/rails/pull/47088, which was an alternate approach to fixing the linked issue.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Failing one edge case test, see https://github.com/rails/rails/pull/48986#issuecomment-1685203599.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
