### PR TITLE
Adds a specific ArgumentError when passing nil to dom_id.

### DIFF
--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -91,6 +91,8 @@ module ActionView
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post, :custom)        # => "custom_post"
     def dom_id(record_or_class, prefix = nil)
+      raise ArgumentError, "dom_id must be passed a record_or_class as the first argument, you passed #{record_or_class.inspect}" unless record_or_class
+
       record_id = record_key_for_dom_id(record_or_class) unless record_or_class.is_a?(Class)
       if record_id
         "#{dom_class(record_or_class, prefix)}#{JOIN}#{record_id}"

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -83,6 +83,12 @@ class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
     assert_equal "edit_airplane_1", dom_id(@record, :edit)
   end
 
+  def test_dom_id_raises_useful_error_when_passed_nil
+    assert_raises ArgumentError do
+      ActionView::RecordIdentifier.dom_id(nil)
+    end
+  end
+
   def test_dom_class
     assert_equal "airplane", dom_class(@record)
   end


### PR DESCRIPTION
### Motivation / Background

I created this PR to make invalid arguments passed to `dom_id` raise a specific error when it receives an invalid argument.

For example with the following

`dom_id(@something_non_existent)`

Before this commit it would raise the following: `NoMethodError: undefined method 'to_key' for nil:NilClass`
After it raises `ArumentError: dom_id must be passed a record_or_class as the first parameter, you passed 'nil'`

### Detail

This PR updates `dom_id` to validate it's argument and raise an ArgumentError whenever it is passed nil.  
The current `NoMethodError: undefined method 'to_key' for nil:NilClass` error is relatively difficult to identify what is going on because it occurs when the record is cast to a key

The NoMethod error is raised when the argument that is passed to `dom_id` is sent to `record_key_for_dom_id`

```
def dom_id(record_or_class, prefix = nil)
  # nil is passed down the the private method  
  record_id = record_key_for_dom_id(record_or_class) unless record_or_class.is_a?(Class)
   ...
end

# this will raise the error which is harder to identify
def record_key_for_dom_id(record) # :doc:
  key = convert_to_model(record).to_key
  key ? key.join(JOIN) : key
end
```

Passing a nil argument can happen in many scenarios, but a specific example is misspelling an instance variable 

```
# Set somewhere in your code path
@ivar = 'foo'

# somewhere else, like a view, the @ivar is misspelled
dom_id(@viar)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
