### PR TITLE
Sort mailers on mailer preview page alphabetically

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Mailers are listed in alphabetical order on the mailer preview page now.
+
+    *Martin Spickermann*
+
 *   Deprecate passing params to `assert_enqueued_email_with` via the `:args`
     kwarg. `assert_enqueued_email_with` now supports a `:params` kwarg, so use
     that to pass params:

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -103,7 +103,7 @@ module ActionMailer
       # Returns all mailer preview classes.
       def all
         load_previews if descendants.empty?
-        descendants
+        descendants.sort_by { |mailer| mailer.name.titleize }
       end
 
       # Returns the mail object for the given email name. The registered preview

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -1131,6 +1131,24 @@ class BasePreviewInterceptorsTest < ActiveSupport::TestCase
   end
 end
 
+class PreviewTest < ActiveSupport::TestCase
+  class A < ActionMailer::Preview; end
+
+  module B
+    class A < ActionMailer::Preview; end
+    class C < ActionMailer::Preview; end
+  end
+
+  class C < ActionMailer::Preview; end
+
+  test "all() returns mailers in alphabetical order" do
+    ActionMailer::Preview.stub(:descendants, [C, A, B::C, B::A]) do
+      mailers = ActionMailer::Preview.all
+      assert_equal [A, B::A, B::C, C], mailers
+    end
+  end
+end
+
 class BasePreviewTest < ActiveSupport::TestCase
   class BaseMailerPreview < ActionMailer::Preview
     def welcome


### PR DESCRIPTION
### Motivation / Background

Mailers on the mailer preview page are listed in the order in which they were found in the `descendants` array. Which might or might not be in alphabetical order. The more mailers are defined in an application, the harder it gets to find a specific mailer on the preview page because of this non-intuitive order.

This PR ensures that the list of mailers on the mailer preview page are always returned in alphabetical order (by their titleized name) to make it easier to scan the list and find a specific mailer.

Please note that if a mailer has multiple methods, those methods are already returned sorted by the [`emails` method](https://github.com/rails/rails/blob/5e2d79b5cc71ceedd6b3821cf868583256629211/actionmailer/lib/action_mailer/preview.rb#L121).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
