### PR TITLE
Fix defect where aliased attribute methods on abstract classes were not being defined

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -65,7 +65,7 @@ module ActiveRecord
       end
 
       def generate_alias_attributes # :nodoc:
-        superclass.generate_alias_attributes unless base_class?
+        superclass.generate_alias_attributes unless superclass == Base
         return if @alias_attributes_mass_generated
 
         generated_attribute_methods.synchronize do

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1246,6 +1246,18 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal("overridden_subject_was", obj.subject_was)
   end
 
+  test "#alias_attribute method on an abstract class is available on subclasses" do
+    superclass = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+      alias_attribute :id_value, :id
+    end
+    subclass = Class.new(superclass) { self.table_name = "topics" }
+
+    object = subclass.build(id: 123_456)
+
+    assert_equal 123_456, object.id_value
+  end
+
   private
     def new_topic_like_ar_class(&block)
       klass = Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because of a defect where no methods for alias attributes defined on an abstract class are being generated.

### Detail

rails/rails@a88f47d fixed an issue where subclasses were regenerating aliased attribute methods defined on parent classes. Part of the solution was to call `#generate_alias_attributes` recursively on a class's superclass to generate all the alias attributes in the inheritance hierarchy. However, the implementation relies on `#base_class` to determine if we should call `#generate_alias_attributes` on the superclass. [Since all models that inherit from abstract classes are base classes](https://github.com/rails/rails/blob/2d1ec4bf09381af24a336f0e1923369eb050864a/activerecord/lib/active_record/inheritance.rb#L266), this means that `#generate_alias_attributes` will never be called on abstract classes, meaning no method will be generated for any alias attributes defined on them.

To fix this issue, we should always call `#generate_alias_attributes` on the superclass unless the superclass is `ActiveRecord::Base`.

### Additional information

The docs about how `base_class` work are somewhat unclear. I plan to open a separate PR to try to improve them.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
