### PR TITLE
Make `has_secure_password` pluginable/extendable with different password hashing algorithms

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,37 @@
+*   `has_secure_password` can support different password hashing algorithms (if defined) using the `:algorithm` option:
+
+    ```ruby
+    module ActiveModel
+      module SecurePassword
+        class MyAlgo < Base
+          def self.algorithm_name
+            :my_algo
+          end
+
+          def hash_password(unencrypted_password, options = {})
+            SomeHashingLib.create_password_hash(unencrypted_password)
+          end
+
+          def verify_password(password, digest)
+            SomeHashingLib.verify_password_against_hash(password, digest)
+          end
+
+          def password_salt(digest)
+            SomeHashingLib.get_salt_from_hash(digest)
+          end
+        end
+      end
+    end
+    ```
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_secure_password :algorithm: :my_algo
+    end
+    ```
+
+    *Justin Bull*
+
 *   Error.full_message now strips ":base" from the message.
 
     *zzak*

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -26,7 +26,7 @@
 
     ```ruby
     class User < ActiveRecord::Base
-      has_secure_password :algorithm: :my_algo
+      has_secure_password algorithm: :my_algo
     end
     ```
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -111,10 +111,7 @@ module ActiveModel
       #
       def has_secure_password(attribute = :password, validations: true, algorithm: :bcrypt)
         password_hasher_klass = ActiveModel::SecurePassword.available_password_algorithms[algorithm]
-        if password_hasher_klass.nil?
-          warn "Unsupported password hashing algorithm '#{algorithm}'."
-          raise
-        end
+        raise NotImplementedError, "Unsupported password hashing algorithm '#{algorithm}'." if password_hasher_klass.nil?
 
         password_hasher = password_hasher_klass.new
         include InstanceMethodsOnActivation.new(attribute, password_hasher)

--- a/activemodel/lib/active_model/secure_password/base.rb
+++ b/activemodel/lib/active_model/secure_password/base.rb
@@ -12,7 +12,7 @@ module ActiveModel
       end
 
       def validate(record)
-        raise NotImplementedError
+        nil
       end
 
       def hash_password(unencrypted_password, options = {})

--- a/activemodel/lib/active_model/secure_password/base.rb
+++ b/activemodel/lib/active_model/secure_password/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module SecurePassword
+    class Base
+      def self.algorithm_name
+        raise NotImplementedError
+      end
+
+      def algorithm_name
+        self.class.algorithm_name
+      end
+
+      def validate(record)
+        raise NotImplementedError
+      end
+
+      def hash_password(unencrypted_password, options = {})
+        raise NotImplementedError
+      end
+
+      def verify_password(password, digest)
+        raise NotImplementedError
+      end
+
+      def password_salt(digest)
+        raise NotImplementedError
+      end
+    end
+  end
+end
+
+require "active_model/secure_password/bcrypt"

--- a/activemodel/lib/active_model/secure_password/bcrypt.rb
+++ b/activemodel/lib/active_model/secure_password/bcrypt.rb
@@ -1,0 +1,44 @@
+module ActiveModel
+  module SecurePassword
+    class BCrypt < Base
+      # BCrypt hash function can handle maximum 72 bytes, and if we pass
+      # password of length more than 72 bytes it ignores extra characters.
+      # Hence need to put a restriction on password length.
+      MAX_PASSWORD_LENGTH_ALLOWED = 72
+
+      # Load bcrypt gem only when has_secure_password is used.
+      # This is to avoid ActiveModel (and by extension the entire framework)
+      # being dependent on a binary library.
+      def initialize
+        require "bcrypt"
+      rescue LoadError
+        warn "You don't have bcrypt installed in your application. Please add it to your Gemfile and run bundle install."
+        raise
+      end
+
+      def self.algorithm_name
+        :bcrypt
+      end
+
+      def validate(record, attribute)
+        password_value = record.public_send(attribute)
+        if password_value.present?
+          record.errors.add(attribute, :password_too_long) if password_value.bytesize > MAX_PASSWORD_LENGTH_ALLOWED
+        end
+      end
+
+      def hash_password(unencrypted_password, options = {})
+        cost = options[:min_cost] ? ::BCrypt::Engine::MIN_COST : ::BCrypt::Engine.cost
+        ::BCrypt::Password.create(unencrypted_password, cost: cost)
+      end
+
+      def verify_password(password, digest)
+        ::BCrypt::Password.new(digest).is_password?(password)
+      end
+
+      def password_salt(digest)
+        ::BCrypt::Password.new(digest).salt
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/secure_password/bcrypt.rb
+++ b/activemodel/lib/active_model/secure_password/bcrypt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveModel
   module SecurePassword
     class BCrypt < Base

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -360,7 +360,7 @@ class SecurePasswordTest < ActiveModel::TestCase
 
   test "Specifying unknown algorithm name raises NotImplementedError" do
     assert_raise NotImplementedError do
-      user_with_unknown_algo = Class.new(User) do
+      Class.new(User) do
         has_secure_password algorithm: :some_hashing_name
       end.new
     end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -290,6 +290,10 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_nil @user.password_salt
   end
 
+  test "password_algorithm" do
+    assert_equal @user.password_algorithm, :bcrypt
+  end
+
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 


### PR DESCRIPTION
### Motivation / Background

Based on an idea by @rafaelfranca in https://github.com/rails/rails/issues/41420#issuecomment-1686745412.

While BCrypt may be the desirable default password hashing algorithm in Rails for the foreseeable future, making the mechanism for hashing and verifying passwords in `has_secure_password` extendable/modular is valuable.

Developers may opt for different hashing algorithms and can now extend or plug in their own alongside BCrypt in a clean and maintainable way. From the referenced thread, there is discourse amongst people on what should be the _de facto_ password algorithm and disagreement on whether Argon2 should be it. Rails should make it easier for the community to progress on best password hashing practices.

This also unlocks Rails shipping with more than BCrypt as an available hashing algorithm.

I _could_ see a world where Rails offers PBKDF2 (for those wanting FIPS 140 compliance), BCrypt (the safe default), and Argon2 (since OWASP recommends it).

### Detail

This PR takes BCrypt-specific code in `ActiveModel::SecurePassword` and extracts it out into an object `ActiveModel::SecurePassword::BCrypt`. The object adheres to a simple interface (`ActiveModel::SecurePassword::Base`) so developers can supplement with different algorithms (or different libraries of the same underlying algo). 

A user of the Rails framework uses the newly added `:algorithm` option in `has_secure_password` to declare what password hashing algo should be used on a given attribute.

Developers can write libraries or even initializers to add different password hashing algorithm support following a very clean interface.

Below is an example of someone opting to use Argon2 using `ruby-argon2`:

```ruby
# config/initializers/add_argon2_to_activemodel_securepassword.rb

require "active_model/secure_password/base"

module ActiveModel
  module SecurePassword
    class Argon2id < Base
      def initialize
        require "argon2"
      rescue LoadError
        warn "You don't have argon2 installed in your application. Please add it to your Gemfile and run bundle install."
        raise
      end

      def self.algorithm_name
        :argon2id
      end

      def hash_password(unencrypted_password, options = {})
        if options[:min_cost]
          hasher = Argon2::Password.new(t_cost: 1, m_cost: 3, p_cost: 1)
        else
          hasher = Argon2::Password.new(t_cost: 2, m_cost: 19, p_cost: 1)  # Latest OWASP recommended values
        end
        hasher.create(unencrypted_password)
      end

      def verify_password(password, digest)
        Argon2::Password.verify_password(password, digest)
      end

      def password_salt(digest)
        Argon2::HashFormat.new(digest).salt
      end
    end
  end
end
```

```ruby
# app/models/user.rb

class User < ActiveRecord::Base
  has_secure_password :password, algorithm: :argon2
end
```

### Additional information

I'm a bit of a novice when it comes to making Rails aware of different files and how to "register" a series of subclasses (some of which could be defined in libraries or the initializers folder) to a part of Rails. Open to whatever pattern is the most appropriate.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

