### PR TITLE
Allow parent being the owner of an alias attribute method

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -87,7 +87,8 @@ module ActiveRecord
         old_name = old_name.to_s
 
         method_defined = method_defined?(target_name) || private_method_defined?(target_name)
-        manually_defined = method_defined && self.instance_method(target_name).owner != generated_attribute_methods
+        manually_defined = method_defined &&
+          !self.instance_method(target_name).owner.is_a?(GeneratedAttributeMethods)
         reserved_method_name = ::ActiveRecord::AttributeMethods.dangerous_attribute_methods.include?(target_name)
 
         if manually_defined && !reserved_method_name


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/48994

When an abstract class inherited from an Active Record model defines an alias attribute Rails should expect the original methods of the aliased attribute to be defined in the parent class and avoid raising deprecation warning.


In the reproduction test context the owner of the method is: `ParentWithAlias::GeneratedAttributeMethods` and `generated_attribute_methods.class` is `ActiveRecord::AttributeMethods::GeneratedAttributeMethods`

So `ParentWithAlias::GeneratedAttributeMethods.is_a?(ActiveRecord::AttributeMethods::GeneratedAttributeMethods)` returns `true` meaning that the method was defined by Rails itself regardless whether it lives in `self.generated_attribute_methods` or parent's module

