### PR TITLE
ActiveJob::LogSubscriber avoid triggering Time#to_s deprecation

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Avoid triggering `Time#to_s` deprecation in ActiveJob::LogSubscriber
+
+    *Jean Boussier*
+
 ## Rails 7.0.7 (August 09, 2023) ##
 
 *   No changes.

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -38,7 +38,7 @@ module ActiveJob
         end
       else
         info do
-          "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)} at #{scheduled_at(event)}" + args_info(job)
+          "Enqueued #{job.class.name} (Job ID: #{job.job_id}) to #{queue_name(event)} at #{scheduled_at(event).to_fs}" + args_info(job)
         end
       end
     end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48995
