### PR TITLE
Support composite identifiers in `to_key`

### DIFF
--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -217,3 +217,13 @@ class Plane
     @to_key = [1]
   end
 end
+
+class CompositePrimaryKeyRecord
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -30,6 +30,11 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     assert_equal "#{@singular}_1", dom_id(@record)
   end
 
+  def test_dom_id_with_composite_primary_key_record
+    record = CompositePrimaryKeyRecord.new([1, 123])
+    assert_equal("composite_primary_key_record_1_123", dom_id(record))
+  end
+
   def test_dom_id_with_prefix
     @record.save
     assert_equal "edit_#{@singular}_1", dom_id(@record, :edit)

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -58,7 +58,7 @@ module ActiveModel
     #   person.to_key # => [1]
     def to_key
       key = respond_to?(:id) && id
-      key ? [key] : nil
+      key ? Array(key) : nil
     end
 
     # Returns a +string+ representing the object's key suitable for use in URLs,

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -18,6 +18,10 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal [1], Contact.new(id: 1).to_key
   end
 
+  test "to_key doesn't double-wrap composite `id`s" do
+    assert_equal ["abc", "xyz"], Contact.new(id: ["abc", "xyz"]).to_key
+  end
+
   test "to_param default implementation returns nil for new records" do
     assert_nil Contact.new.to_param
   end

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       # available.
       def to_key
         key = id
-        [key] if key
+        Array(key) if key
       end
 
       # Returns the primary key column's value.

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -29,6 +29,13 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal keyboard.to_key, [keyboard.id]
   end
 
+  def test_to_key_with_composite_primary_key
+    order = Cpk::Order.new
+    assert_equal [nil, nil], order.to_key
+    order.id = [1, 2]
+    assert_equal [1, 2], order.to_key
+  end
+
   def test_read_attribute_with_custom_primary_key
     keyboard = Keyboard.create!
     assert_equal keyboard.key_number, keyboard.read_attribute(:id)


### PR DESCRIPTION
This commit adds support for composite identifiers in `to_key`. Rails 7.1 adds support for composite primary key which means that composite primary key models' `#id` method returns an `Array` and `to_key` needs to avoid double-wrapping the value so it can be correctly used in `dom_id`

This is a non-breaking change since `Array(id)` is the same as `[id]` for non composite primary key models
