### PR TITLE
Fix NoMethodError in ActiveStorage::TransformJob for untracked variants.

### DIFF
--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -7,6 +7,6 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
 
   def perform(blob, transformations)
-    blob.variant(transformations).process
+    blob.variant(transformations).processed
   end
 end

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -15,4 +15,19 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
       end
     end
   end
+
+  test "creates variant when untracked" do
+    @was_tracking, ActiveStorage.track_variants = ActiveStorage.track_variants, false
+    transformations = { resize_to_limit: [100, 100] }
+
+    begin
+      assert_changes -> { @blob.variant(transformations).send(:processed?) }, from: false, to: true do
+        perform_enqueued_jobs do
+          ActiveStorage::TransformJob.perform_later @blob, transformations
+        end
+      end
+    ensure
+      ActiveStorage.track_variants = @was_tracking
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
This Pull Request has been created because a ``NoMethodError: private method `process' called for #<ActiveStorage::Variant`` error is raised in `ActiveStorage::TransformJob` when variant tracking is disabled. This prevents the ability to use preprocessed variants when variant tracking is disabled.

### Detail

This Pull Request changes the call to `process` in `ActiveStorage::TransformJob` to the `processed` method which is publicly available in both the `ActiveStorage::VariantWithRecord` and `ActiveStorage::Variant` classes.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
The following code snipped contains a working recreation of the issue with the current `main` branch.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "rack", "~> 2.0"
  gem "sqlite3"
  gem 'image_processing', '~> 1.2'
end

require "active_record/railtie"
require "active_storage/engine"
require "tmpdir"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.eager_load = false
  config.session_store :cookie_store, key: "cookie_store_key"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  config.active_storage.service = :local
  config.active_storage.service_configurations = {
    local: {
      root: Dir.tmpdir,
      service: "Disk"
    }
  }

  config.active_storage.track_variants = false
end

ENV["DATABASE_URL"] = "sqlite3::memory:"

Rails.application.initialize!

require ActiveStorage::Engine.root.join("db/migrate/20170806125915_create_active_storage_tables.rb").to_s

ActiveRecord::Schema.define do
  CreateActiveStorageTables.new.change

  create_table :users, force: true
end

class User < ActiveRecord::Base
  has_one_attached :profile do |attachable|
    attachable.variant :test, resize_to_limit: [100, 100], preprocessed: true
  end
end

require "minitest/autorun"

class BugTest < Minitest::Test
  def test_upload_and_download
    user = User.create!(
      profile: {
        content_type: "image/jpeg",
        filename: "racecar.jpg",
        io: Pathname.new("activestorage/test/fixtures/files/racecar.jpg").open,
      }
    )

    assert_equal false, user.profile.variant(:test).send(:processed?)

    user.profile.attachment.send(:named_variants).each do |_name, named_variant|
      assert_raises(NoMethodError) do
        ActiveStorage::TransformJob.perform_now(user.profile, named_variant.transformations)
      end
    end
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
