### PR TITLE
Document `response.parsed_body` in 7.1 release notes

### DIFF
--- a/guides/.rubocop.yml
+++ b/guides/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from:
   - '../.rubocop.yml'
 
+AllCops:
+  TargetRubyVersion: 3.0
+
 Style/StringLiterals:
   Enabled: false
 


### PR DESCRIPTION
### Motivation / Background

Add notes for [#47144][] to the 7.1 Release Notes.

### Detail

Additionally, in the time since that was merged, both Nokogiri and Minitest have merged the PRs mentioned to integrate support for Ruby's Pattern matching (https://github.com/sparklemotion/nokogiri/pull/2523 and https://github.com/minitest/minitest/pull/936, respectively).

This commit adds coverage for those new assertions, and incorporates guidance into the release notes.

[#47144]: https://github.com/rails/rails/pull/47144

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
