### PR TITLE
Replace repeated list literals in Getting Started guide w/ a constant

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1917,12 +1917,12 @@ Our blog has <%= Article.public_count %> articles and counting!
 <%= link_to "New Article", new_article_path %>
 ```
 
-To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also specify the default status as `public`. In `app/views/articles/_form.html.erb`, we can add:
+To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. Rather than repeat the literal list of statuses, we can make the code even DRYer and more expressive, by referencing `Visible::VALID_STATUSES`. We can also specify the default status as `public`. In `app/views/articles/_form.html.erb`, we can add:
 
 ```html+erb
 <div>
   <%= form.label :status %><br>
-  <%= form.select :status, ['public', 'private', 'archived'], selected: 'public' %>
+  <%= form.select :status, Visible::VALID_STATUSES, selected: 'public' %>
 </div>
 ```
 
@@ -1931,7 +1931,7 @@ and in `app/views/comments/_form.html.erb`:
 ```html+erb
 <p>
   <%= form.label :status %><br>
-  <%= form.select :status, ['public', 'private', 'archived'], selected: 'public' %>
+  <%= form.select :status, Visible::VALID_STATUSES, selected: 'public' %>
 </p>
 ```
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1917,7 +1917,7 @@ Our blog has <%= Article.public_count %> articles and counting!
 <%= link_to "New Article", new_article_path %>
 ```
 
-To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. Rather than repeat the literal list of statuses, we can make the code even DRYer and more expressive, by referencing `Visible::VALID_STATUSES`. We can also specify the default status as `public`. In `app/views/articles/_form.html.erb`, we can add:
+To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also specify the default status as `public`. In `app/views/articles/_form.html.erb`, we can add:
 
 ```html+erb
 <div>


### PR DESCRIPTION
### Motivation / Background

In Getting Started guide, in the article and comment status dropdowns, it repeats the literal list of valid statuses estabished in the Visible module.  In fact, it does so twice!  It would make the code DRYer, briefer, and more expressive, to use Visible::VALID_STATUSES instead.  This PR does so, and also adds a sentence explaining why, in the preceding text.

This Pull Request has been created because it just bugged me to see it so horribly un-DRY, in something that (were it anything approaching a "real" app), would be very subject to change, such as by adding a "deleted" status.  This tiny change will help get/reinforce the idea of DRY in Rails-beginners' minds, without clubbing them over the head with it, nor (IMHO) taking it too far.  (After all, the constant was already there, convenient to use.)

### Checklist

Before submitting the PR make sure the following are checked:

* [Yes] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [Yes] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [N/A] Tests are added or updated if you fix a bug or add a feature.
* [N/A] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.