### PR TITLE
Use zzak/action-discord@v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,8 +48,9 @@ jobs:
     - run: bin/check-changelogs ./rails
     - run: bin/check-config-docs ./rails
 
-    - uses: zzak/action-discord@v4
+    - uses: zzak/action-discord@v8
       continue-on-error: true
-      if: always() && github.ref_name == 'main'
+      if: failure() && github.ref_name == 'main'
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -34,8 +34,9 @@ jobs:
     - name: Test container
       run: ruby -r ./.github/workflows/scripts/test-container.rb
 
-    - uses: zzak/action-discord@v4
+    - uses: zzak/action-discord@v8
       continue-on-error: true
-      if: always() && github.ref_name == 'main'
+      if: failure() && github.ref_name == 'main'
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -23,8 +23,11 @@ jobs:
     - name: Run RuboCop
       run: bundle exec rubocop --parallel
 
-    - uses: zzak/action-discord@v4
+    - uses: zzak/action-discord@v8
+      env:
+        BUNDLE_ONLY: ""
       continue-on-error: true
-      if: always() && github.ref_name == 'main'
+      if: failure() && github.ref_name == 'main'
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
Fixes notifications from #48919

* Removed 'fixed/still failing' modes
* Only runs when failure() step
* Include GITHUB_TOKEN to prevent rate-limits
  * (zzak/action-discord#5)
* Need to reset BUNDLE_ONLY on rubocop job

---

* 🔴 [Example rubocop failure](https://github.com/rails/rails/actions/runs/5934495668/job/16091478529#step:5:123)
* 🔴 [Example inline failure](https://github.com/rails/rails/actions/runs/5934495673/job/16091478518#step:8:143)

There is some more context if necessary in zzak/action-discord#7 and [zzak/action-discord@v8](https://github.com/zzak/action-discord/releases/tag/v8).

Basically, I tried to "hide" the `BUNDLE_ONLY` part of rubocop inside of the action, but failed to do so without spending a ton of time trying to hack it.

Lastly, because we are only using this action as a step to notify when a job fails, it could be greatly simplified and just make that the only use-case for this action. It wasn't worth trying to support multiple modes for me.
