### PR TITLE
select existing article status if any, in Getting Started Guide -- Fixes #45028 (mostly)

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1917,7 +1917,7 @@ Our blog has <%= Article.public_count %> articles and counting!
 <%= link_to "New Article", new_article_path %>
 ```
 
-To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also specify the default status as `public`. One problem with simply selecting a default status, though, is that some articles may have already been created with a different status, or none at all (`nil`). Those will show up as `public` in the `edit` form. To solve this, in the article version, we can select the existing status, but if there is none yet, _then_ we select `public`, though this will only become true if the form is submitted. In `app/views/articles/_form.html.erb`, we can add:
+To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also select the status of the object, or a default of `public` if it hasn't been set yet. In `app/views/articles/_form.html.erb`, we can add:
 
 ```html+erb
 <div>

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1917,12 +1917,12 @@ Our blog has <%= Article.public_count %> articles and counting!
 <%= link_to "New Article", new_article_path %>
 ```
 
-To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also specify the default status as `public`. In `app/views/articles/_form.html.erb`, we can add:
+To finish up, we will add a select box to the forms, and let the user select the status when they create a new article or post a new comment. We can also specify the default status as `public`. One problem with simply selecting a default status, though, is that some articles may have already been created with a different status, or none at all (`nil`). Those will show up as `public` in the `edit` form. To solve this, in the article version, we can select the existing status, but if there is none yet, _then_ we select `public`, though this will only become true if the form is submitted. In `app/views/articles/_form.html.erb`, we can add:
 
 ```html+erb
 <div>
   <%= form.label :status %><br>
-  <%= form.select :status, ['public', 'private', 'archived'], selected: 'public' %>
+  <%= form.select :status, ['public', 'private', 'archived'], selected: article.status || 'public' %>
 </div>
 ```
 


### PR DESCRIPTION
### Motivation / Background

In the Getting Started guide, in the dropdown for an article or comment's status, there is a bug.  Pre-selecting `public` will make _all_ articles seem `public,` even if their status is really something else -- even `nil`.  The `nil` case was reported in issue #45028, but it also applies to articles with other statuses.

Selecting `article.status || 'public'` instead will fix this, in _most_ cases.  Pre-existing articles with `nil` status will still show up as `public`, but if the form is submitted, they will indeed become `public`.

This commit makes that change, and adds text to explain why it is done.

Fixes #45028 (mostly)

This Pull Request has been created because I stumbled across the issue (while looking to see whether my other PR was redundant), verified the problem, and thought of a quick and easy solution for the majority of cases.  :-)  (And yes, verified that the fix works, at least On My Machine  ;-) )

### Checklist

* [Yes ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [Yes] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ N/A] Tests are added or updated if you fix a bug or add a feature.
* [ N/A] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.