### PR TITLE
Ensure all migration versions use TableDefinition

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -559,6 +559,38 @@ module ActiveRecord
 
     # This must be defined before the inherited hook, below
     class Current < Migration # :nodoc:
+      def create_table(table_name, **options)
+        if block_given?
+          super { |t| yield compatible_table_definition(t) }
+        else
+          super
+        end
+      end
+
+      def change_table(table_name, **options)
+        if block_given?
+          super { |t| yield compatible_table_definition(t) }
+        else
+          super
+        end
+      end
+
+      def create_join_table(table_1, table_2, **options)
+        if block_given?
+          super { |t| yield compatible_table_definition(t) }
+        else
+          super
+        end
+      end
+
+      def drop_table(table_name, **options)
+        if block_given?
+          super { |t| yield compatible_table_definition(t) }
+        else
+          super
+        end
+      end
+
       def compatible_table_definition(t)
         t
       end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -99,19 +99,7 @@ module ActiveRecord
           options[:_uses_legacy_table_name] = true
           options[:_skip_validate_options] = true
 
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def change_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
+          super
         end
 
         def rename_table(table_name, new_name, **options)
@@ -187,22 +175,6 @@ module ActiveRecord
           super
         end
 
-        def create_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def change_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
         module TableDefinition
           def new_column_definition(name, type, **options)
             type = PostgreSQLCompat.compatible_timestamp_type(type, @conn)
@@ -257,30 +229,6 @@ module ActiveRecord
             end
         end
 
-        def create_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def change_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def create_join_table(table_1, table_2, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
         def add_reference(table_name, ref_name, **options)
           if connection.adapter_name == "SQLite"
             options[:type] = :integer
@@ -331,30 +279,6 @@ module ActiveRecord
 
           def invert_change_table_comment(args)
             [:change_table_comment, args]
-          end
-        end
-
-        def create_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def change_table(table_name, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
-          end
-        end
-
-        def create_join_table(table_1, table_2, **options)
-          if block_given?
-            super { |t| yield compatible_table_definition(t) }
-          else
-            super
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

Ref #49011

This is similar to a [previous commit][1] which ensures that versioned migrations always call `super` in `compatible_table_definition`. In this case, these methods are being pulled up to `Current` so that all subclasses will use a `TableDefinition` class and future developers do not have to remember to add all of these methods to new versioned classes when a new one is created.

[1]: https://github.com/rails/rails/commit/16f8bd79444a512dfebf2d77bd2fd3075041475b

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
