### PR TITLE
Add new behavior of `undefine_attribute_methods` to CHANGELOG

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `undefine_attribute_methods` undefines alias attribute methods along with attribute methods.
+
+    *Nikita Vasilevsky*
+
 *   Error.full_message now strips ":base" from the message.
 
     *zzak*

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -215,6 +215,30 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_raises(NoMethodError) { ModelWithAttributes.new.foo }
   end
 
+  test "#undefine_attribute_methods undefines alias attribute methods" do
+    topic_class = Class.new do
+      include ActiveModel::AttributeMethods
+      define_attribute_methods :title
+      alias_attribute :subject_to_be_undefined, :title
+
+      def attributes
+        { title: "Active Model Topic" }
+      end
+
+      private
+        def attribute(name)
+          attributes[name.to_sym]
+        end
+    end
+
+    assert_equal("Active Model Topic", topic_class.new.subject_to_be_undefined)
+    topic_class.undefine_attribute_methods
+
+    assert_raises(NoMethodError, match: /undefined method `subject_to_be_undefined'/) do
+      topic_class.new.subject_to_be_undefined
+    end
+  end
+
   test "accessing a suffixed attribute" do
     m = ModelWithAttributes2.new
     m.attributes = { "foo" => "bar" }

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1022,6 +1022,22 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert subklass.method_defined?(:id), "subklass is missing id method"
   end
 
+  test "#undefine_attribute_methods undefines alias attribute methods" do
+    topic_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+
+      alias_attribute :subject_to_be_undefined, :title
+    end
+
+    topic = topic_class.new(title: "New topic")
+    assert_equal("New topic", topic.subject_to_be_undefined)
+    topic_class.undefine_attribute_methods
+
+    assert_raises(NoMethodError, match: /undefined method `subject_to_be_undefined'/) do
+      topic.subject_to_be_undefined
+    end
+  end
+
   test "define_attribute_method works with both symbol and string" do
     klass = Class.new(ActiveRecord::Base)
     klass.table_name = "foo"


### PR DESCRIPTION
In https://github.com/rails/rails/pull/48533 Rails changed the target
where alias attribute methods are defined. It lead to
`undefine_attribute_methods` to clean alias attribute methods along with
the attribute methods. It was an intended behavior change but it wasn't
properly documented and tested. This commit clarifies the new behavior
in the Active Model changelog along with covering the behavior with tests.