### PR TITLE
Deprecate `read_attribute(:id)` returning the primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `read_attribute(:id)` returning the primary key if the primary key is not `:id`.
+
+    Starting in Rails 7.2, `read_attribute(:id)` will return the value of the id column, regardless of the model's
+    primary key. To retrieve the value of the primary key, use `#id` instead. `read_attribute(:id)` for composite
+    primary key models will now return the value of the id column.
+
+    *Adrianna Chang*
+
 *   Fix `change_table` setting datetime precision for 6.1 Migrations
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -333,11 +333,7 @@ module ActiveRecord
             if mem_record = memory.delete(record)
 
               ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save - mem_record.class._attr_readonly).each do |name|
-                if name == "id" && mem_record.class.composite_primary_key?
-                  mem_record.class.primary_key.zip(record[name]) { |attr, value| mem_record._write_attribute(attr, value) }
-                else
-                  mem_record._write_attribute(name, record[name])
-                end
+                mem_record._write_attribute(name, record[name])
               end
 
               mem_record

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -33,8 +33,14 @@ module ActiveRecord
         return @attributes.fetch_value(name, &block) unless name == "id" && @primary_key
 
         if self.class.composite_primary_key?
-          @primary_key.map { |col| @attributes.fetch_value(col, &block) }
+          @attributes.fetch_value("id", &block)
         else
+          if @primary_key != "id"
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Using read_attribute(:id) to read the primary key value is deprecated.
+              Use #id instead.
+            MSG
+          end
           @attributes.fetch_value(@primary_key, &block)
         end
       end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -36,22 +36,32 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal [1, 2], order.to_key
   end
 
+  def test_read_attribute_id
+    topic = Topic.find(1)
+    id = assert_not_deprecated(ActiveRecord.deprecator) do
+      topic.read_attribute(:id)
+    end
+
+    assert_equal 1, id
+  end
+
   def test_read_attribute_with_custom_primary_key
     keyboard = Keyboard.create!
-    assert_equal keyboard.key_number, keyboard.read_attribute(:id)
+    msg = "Using read_attribute(:id) to read the primary key value is deprecated. Use #id instead."
+    id = assert_deprecated(msg, ActiveRecord.deprecator) do
+      keyboard.read_attribute(:id)
+    end
+
+    assert_equal keyboard.key_number, id
   end
 
   def test_read_attribute_with_composite_primary_key
     book = Cpk::Book.new(id: [1, 2])
-    assert_equal [1, 2], book.read_attribute(:id)
-  end
+    id = assert_not_deprecated(ActiveRecord.deprecator) do
+      book.read_attribute(:id)
+    end
 
-  def test_read_attribute_with_composite_primary_key_and_column_named_id
-    order = Cpk::Order.new
-    order.id = [1, 2]
-
-    assert_equal [1, 2], order.read_attribute(:id)
-    assert_equal 2, order.attributes["id"]
+    assert_equal 2, id
   end
 
   def test_to_key_with_primary_key_after_destroy


### PR DESCRIPTION
### Motivation / Background

This PR deprecates `read_attribute(:id)` returning the primary key if the model's primary key is not the id column. Starting in Rails 7.2, `read_attribute(:id)` should return the value of the id column.

This commit also changes `read_attribute(:id)` for composite primary key models to return the value of the id column, not the composite primary key.

`read_attribute` should not translate "id" to mean "primary key" -- this method ought to return the raw attribute value, so that applications have an easy way to access the `id` attribute on a model, regardless of whether that is the model's primary key.

### Detail

This pull request changes `read_attribute` to raise a deprecation warning if we are reading `:id`, but `id` is not the primary key. Additionally, it changes the behaviour for composite primary key models to start returning the id column value. Note that this will also result in `cpk_record["id"]` returning the id column, rather than the composite primary key.

I'm recommending `#id` be used instead. There have been other discussions about deprecating `#id` returning the primary key ([example](https://github.com/rails/rails/pull/48930#issuecomment-1679080904)), but that would require introducing a new getter method for retrieving the PK value. As it stands, those changes are a long ways off 😄 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
