### PR TITLE
[Feature Request] Fixture scenarios for complex associations

### DIFF
--- a/activerecord/lib/active_record/fixture_set/config.rb
+++ b/activerecord/lib/active_record/fixture_set/config.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "active_support/configuration_file"
+
+module ActiveRecord
+  class FixtureSet
+    Config = Struct.new(:table_name, :ignored_fixtures, :model_class, :rows, keyword_init: true) do # :nodoc:
+      def self.read_fixture_file(file)
+        data = ActiveSupport::ConfigurationFile.parse(file,
+          context: ActiveRecord::FixtureSet::RenderContext.create_subclass.new.get_binding)
+
+        # Validate our unmarshalled data.
+        data ? validate_data_format(file, data).to_a : nil
+      end
+
+      def self.validate_data_format(file, data)
+        unless Hash === data || YAML::Omap === data
+          raise Fixture::FormatError, "fixture is not a hash: #{file}"
+        end
+
+        invalid = data.reject { |_, row| Hash === row }
+        if invalid.any?
+          raise Fixture::FormatError, "fixture key is not a hash: #{file}, keys: #{invalid.keys.inspect}"
+        end
+        data
+      end
+
+      def self.validate_config_row(file, data)
+        unless Hash === data
+          raise Fixture::FormatError, "Invalid `_fixture` section: `_fixture` must be a hash: #{file}"
+        end
+
+        begin
+          data.assert_valid_keys("model_class", "ignore")
+        rescue ArgumentError => error
+          raise Fixture::FormatError, "Invalid `_fixture` section: #{error.message}: #{file}"
+        end
+        data
+      end
+
+      def +(other_config)
+        self.rows ||= {}
+        self.class.new(
+          table_name: table_name || other_config.table_name,
+          model_class: model_class || other_config.model_class,
+          ignored_fixtures: ignored_fixtures || other_config.ignored_fixtures,
+          rows: rows.merge(other_config.rows),
+        )
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/configuration_file"
-
 module ActiveRecord
   class FixtureSet
     class File # :nodoc:
@@ -32,6 +30,14 @@ module ActiveRecord
         config_row["ignore"]
       end
 
+      def fixtures_config
+        Config.new(
+          model_class: model_class,
+          ignored_fixtures: ignored_fixtures,
+          rows: to_h
+        )
+      end
+
       private
         def rows
           @rows ||= raw_rows.reject { |fixture_name, _| fixture_name == "_fixture" }
@@ -41,7 +47,7 @@ module ActiveRecord
           @config_row ||= begin
             row = raw_rows.find { |fixture_name, _| fixture_name == "_fixture" }
             if row
-              validate_config_row(row.last)
+              Config.validate_config_row(@file, row.last)
             else
               { 'model_class': nil, 'ignore': nil }
             end
@@ -50,39 +56,10 @@ module ActiveRecord
 
         def raw_rows
           @raw_rows ||= begin
-            data = ActiveSupport::ConfigurationFile.parse(@file, context:
-              ActiveRecord::FixtureSet::RenderContext.create_subclass.new.get_binding)
-            data ? validate(data).to_a : []
+            Config.read_fixture_file(@file) || []
           rescue RuntimeError => error
             raise Fixture::FormatError, error.message
           end
-        end
-
-        def validate_config_row(data)
-          unless Hash === data
-            raise Fixture::FormatError, "Invalid `_fixture` section: `_fixture` must be a hash: #{@file}"
-          end
-
-          begin
-            data.assert_valid_keys("model_class", "ignore")
-          rescue ArgumentError => error
-            raise Fixture::FormatError, "Invalid `_fixture` section: #{error.message}: #{@file}"
-          end
-
-          data
-        end
-
-        # Validate our unmarshalled data.
-        def validate(data)
-          unless Hash === data || YAML::Omap === data
-            raise Fixture::FormatError, "fixture is not a hash: #{@file}"
-          end
-
-          invalid = data.reject { |_, row| Hash === row }
-          if invalid.any?
-            raise Fixture::FormatError, "fixture key is not a hash: #{@file}, keys: #{invalid.keys.inspect}"
-          end
-          data
         end
     end
   end

--- a/activerecord/lib/active_record/fixture_set/scenario.rb
+++ b/activerecord/lib/active_record/fixture_set/scenario.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class FixtureSet
+    class Scenario # :nodoc:
+      include Enumerable
+
+      def self.open(file)
+        x = new file
+        block_given? ? yield(x) : x
+      end
+
+      def initialize(file, loaded_fixture_ids = nil)
+        @file = file
+        @loaded_fixture_ids = loaded_fixture_ids || {}
+      end
+
+      def each(&block)
+        sets.each(&block)
+      end
+
+      def [](table_name)
+        sets[table_name]
+      end
+
+      private
+        def sets
+          @sets ||= raw_rows.each_with_object({}) do |(table_name, rows), result|
+            config_row = Config.validate_config_row(@file, rows.fetch("_fixture", {}))
+            validate_fixture_identifiers(table_name, rows.keys)
+
+            result[table_name] = Config.new(
+              table_name: table_name,
+              model_class: config_row["model_class"],
+              ignored_fixtures: config_row["ignore"],
+              rows: rows.reject { |k, v| k == "_fixture" }
+            )
+          end
+        end
+
+        def raw_rows
+          @raw_rows ||= begin
+            Config.read_fixture_file(@file) || []
+          rescue RuntimeError => error
+            raise Fixture::FormatError, error.message
+          end
+        end
+
+        def validate_fixture_identifiers(fs_table_name, fs_names)
+          return unless @loaded_fixture_ids[fs_table_name]
+
+          if (existing_identifiers = @loaded_fixture_ids[fs_table_name] & fs_names).any?
+            raise Fixture::FixtureError, "Fixture scenarios cannot override already existing fixtures: #{existing_identifiers.to_sentence}"
+          end
+        end
+    end
+  end
+end

--- a/activerecord/test/cases/fixture_set/config_test.rb
+++ b/activerecord/test/cases/fixture_set/config_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "tempfile"
+
+module ActiveRecord
+  class FixtureSet
+    class ConfigRowTest < ActiveRecord::TestCase
+      def test_validate_config_row_with_valid_keys
+        assert Config.validate_config_row("filename.yml", { "model_class" => "Foo", "ignore" => ["Bar"] })
+      end
+
+      def test_validate_config_row_with_unknown_key
+        error = assert_raises(ActiveRecord::Fixture::FormatError) do
+          Config.validate_config_row("filename.yml", { "class_name" => "Foo" })
+        end
+        assert_equal "Invalid `_fixture` section: Unknown key: \"class_name\". Valid keys are: \"model_class\", \"ignore\": filename.yml", error.message
+      end
+
+      def test_validate_config_row_with_invalid_data_foramt
+        error = assert_raises(ActiveRecord::Fixture::FormatError) do
+          Config.validate_config_row("filename.yml", [{ "model_class" => "Foo", "ignore" => ["Bar"] }])
+        end
+        assert_equal "Invalid `_fixture` section: `_fixture` must be a hash: filename.yml", error.message
+      end
+    end
+
+    class ConfigReadFixtureFileTest < ActiveRecord::TestCase
+      def test_erb_processing
+        result = Config.read_fixture_file(::File.join(FIXTURES_ROOT, "developers.yml"))
+
+        devs = Array.new(8) { |i| "dev_#{i + 3}" }
+
+        assert_equal [], devs - result.map(&:first)
+      end
+
+      def test_empty_file
+        tmp_yaml ["empty", "yml"], "" do |t|
+          assert_equal [], Config.read_fixture_file(t.path)
+        end
+      end
+
+      # A valid YAML file is not necessarily a value Fixture file. Make sure
+      # an exception is raised if the format is not valid Fixture format.
+      def test_wrong_fixture_format_string
+        tmp_yaml ["empty", "yml"], "qwerty" do |t|
+          assert_raises(ActiveRecord::Fixture::FormatError) do
+            Config.read_fixture_file(t.path)
+          end
+        end
+      end
+
+      def test_wrong_fixture_format_nested
+        tmp_yaml ["empty", "yml"], "one: two" do |t|
+          assert_raises(ActiveRecord::Fixture::FormatError) do
+            Config.read_fixture_file(t.path)
+          end
+        end
+      end
+
+      def test_render_context_helper
+        ActiveRecord::FixtureSet.context_class.class_eval do
+          def fixture_helper
+            "Fixture helper"
+          end
+        end
+        yaml = "one:\n  name: <%= fixture_helper %>\n"
+        tmp_yaml ["curious", "yml"], yaml do |t|
+          golden = [["one", { "name" => "Fixture helper" }]]
+          assert_equal golden, Config.read_fixture_file(t.path)
+        end
+        ActiveRecord::FixtureSet.context_class.class_eval do
+          remove_method :fixture_helper
+        end
+      end
+
+      def test_render_context_lookup_scope
+        yaml = <<END
+one:
+  ActiveRecord: <%= defined? ActiveRecord %>
+  ActiveRecord_FixtureSet: <%= defined? ActiveRecord::FixtureSet %>
+  FixtureSet: <%= defined? FixtureSet %>
+  ActiveRecord_FixtureSet_File: <%= defined? ActiveRecord::FixtureSet::File %>
+  File: <%= File.name %>
+END
+
+        golden = [["one", {
+          "ActiveRecord" => "constant",
+          "ActiveRecord_FixtureSet" => "constant",
+          "FixtureSet" => nil,
+          "ActiveRecord_FixtureSet_File" => "constant",
+          "File" => "File"
+        }]]
+
+        tmp_yaml ["curious", "yml"], yaml do |t|
+          assert_equal golden, Config.read_fixture_file(t.path)
+        end
+      end
+
+      # Make sure that each fixture gets its own rendering context so that
+      # fixtures are independent.
+      def test_independent_render_contexts
+        yaml1 = "<% def leaked_method; 'leak'; end %>\n"
+        yaml2 = "one:\n  name: <%= leaked_method %>\n"
+        tmp_yaml ["leaky", "yml"], yaml1 do |t1|
+          tmp_yaml ["curious", "yml"], yaml2 do |t2|
+            Config.read_fixture_file(t1.path)
+            assert_raises(NameError) do
+              Config.read_fixture_file(t2.path)
+            end
+          end
+        end
+      end
+
+    private
+      def tmp_yaml(name, contents)
+        t = Tempfile.new name
+        t.binmode
+        t.write contents
+        t.close
+        yield t
+      ensure
+        t.close true
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/fixture_set/scenario_test.rb
+++ b/activerecord/test/cases/fixture_set/scenario_test.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "tempfile"
+
+module ActiveRecord
+  class FixtureSet
+    class ScenarioTest < ActiveRecord::TestCase
+      def setup
+        @path = ::File.join(SCENARIOS_ROOT, "/organisation_with_author_and_posts.yml")
+        @scenario = Scenario.new(@path)
+      end
+
+      def test_sets
+        scenario = <<~YAML
+          organizations:
+            _fixture:
+              model_class: Organization
+              ignore:
+                - BASE
+                - ARCHIVED
+
+            ARCHIVED:
+              name: archived
+
+            BASE:
+              name: base name
+
+            code_monkeys:
+              name: The code monkeys
+
+          posts:
+            <% 1.upto(3) do |i| %>
+            alex_post<%= i %>:
+              author: alex
+              title: Alex post <%= i %>
+              body: Such a lovely day
+              type: Post
+            <% end %>
+
+          authors:
+            _fixture:
+              model_class: Author
+              ignore: BASE
+
+            BASE:
+              name: Person's name
+
+            alex:
+              name: Alex
+              author_address_id: 100
+              organization: code_monkeys
+
+          author_addresses:
+            alex_address:
+              id: 100
+        YAML
+
+        expected = {
+          "organizations" => Config.new(
+            table_name: "organizations",
+            ignored_fixtures: ["BASE", "ARCHIVED"],
+            model_class: "Organization",
+            rows: {
+              "code_monkeys" => { "name" => "The code monkeys" },
+              "ARCHIVED" => { "name" => "archived" },
+              "BASE" => { "name" => "base name" }
+            }
+          ),
+          "authors" => Config.new(
+            table_name: "authors",
+            ignored_fixtures: "BASE",
+            model_class: "Author",
+            rows: {
+              "alex" => {
+                "name" => "Alex",
+                "author_address_id" => 100,
+                "organization" => "code_monkeys"
+              },
+              "BASE" => {
+                "name" => "Person's name"
+              }
+            }
+          ),
+          "author_addresses" => Config.new(
+            table_name: "author_addresses",
+            ignored_fixtures: nil,
+            model_class: nil,
+            rows: { "alex_address" => { "id" => 100 } }
+          ),
+          "posts" => Config.new(
+            table_name: "posts",
+            ignored_fixtures: nil,
+            model_class: nil,
+            rows: {
+              "alex_post1" => {
+                "author" => "alex",
+                "title" => "Alex post 1",
+                "body" => "Such a lovely day",
+                "type" => "Post"
+              },
+              "alex_post2" => {
+                "author" => "alex",
+                "title" => "Alex post 2",
+                "body" => "Such a lovely day",
+                "type" => "Post"
+              },
+              "alex_post3" => {
+                "author" => "alex",
+                "title" => "Alex post 3",
+                "body" => "Such a lovely day",
+                "type" => "Post"
+              }
+            }
+          )
+        }
+
+        tmp_yaml ["full", "scenario", "yml"], scenario do |t|
+          Scenario.open(t.path) do |fh|
+            assert_equal expected, fh.to_h
+          end
+        end
+      end
+
+      def test_removes_fixture_config_row
+        Scenario.open(@path) do |fh|
+          assert fh.none? { |table_name, set| set.rows.include?("_fixture") }
+        end
+      end
+
+      def test_extracts_model_class_from_config_row
+        Scenario.open(@path) do |fh|
+          assert_equal "Organization", fh["organizations"].model_class
+        end
+      end
+
+      def test_extracts_ignored_fixtures_class_from_config_row
+        yaml = <<~YAML
+          organizations:
+            _fixture:
+              model_class: Organization
+              ignore:
+                - BASE
+                - ARCHIVED_ORGANISATION
+        YAML
+
+        tmp_yaml ["config", "yml"], yaml do |t|
+          Scenario.open(t.path) do |fh|
+            assert_equal ["BASE", "ARCHIVED_ORGANISATION"], fh["organizations"].ignored_fixtures
+          end
+        end
+      end
+
+      def test_empty_file
+        tmp_yaml ["empty", "yml"], "" do |t|
+          assert_equal [], Scenario.open(t.path) { |fh| fh.to_a }
+        end
+      end
+
+      # A valid YAML file is not necessarily a value Fixture file. Make sure
+      # an exception is raised if the format is not valid Fixture format.
+      def test_wrong_fixture_format_string
+        tmp_yaml ["empty", "yml"], "qwerty" do |t|
+          assert_raises(ActiveRecord::Fixture::FormatError) do
+            Scenario.open(t.path) { |fh| fh.to_a }
+          end
+        end
+      end
+
+      def test_wrong_fixture_format_nested
+        tmp_yaml ["empty", "yml"], "one: two" do |t|
+          assert_raises(ActiveRecord::Fixture::FormatError) do
+            Scenario.open(t.path) { |fh| fh.to_a }
+          end
+        end
+      end
+
+      def test_wrong_config_row
+        tmp_yaml ["empty", "yml"], { "organizations" => { "_fixture" => { "class_name" => "Foo" } } }.to_yaml do |t|
+          error = assert_raises(ActiveRecord::Fixture::FormatError) do
+            Scenario.open(t.path) { |fh| fh.to_a }
+          end
+          assert_includes error.message, "Invalid `_fixture` section"
+        end
+      end
+
+      def test_render_context_helper
+        ActiveRecord::FixtureSet.context_class.class_eval do
+          def fixture_helper
+            "Fixture helper"
+          end
+        end
+
+        yaml = <<~YAML
+          organizations:
+            one:
+              name: <%= fixture_helper %>
+        YAML
+
+        tmp_yaml ["curious", "yml"], yaml do |t|
+          golden = [["one", { "name" => "Fixture helper" }]]
+          assert_equal golden, Scenario.open(t.path) { |fh| fh["organizations"].rows.to_a }
+        end
+
+        ActiveRecord::FixtureSet.context_class.class_eval do
+          remove_method :fixture_helper
+        end
+      end
+
+      def test_render_context_lookup_scope
+        yaml = <<END
+organizations:
+  one:
+    ActiveRecord: <%= defined? ActiveRecord %>
+    ActiveRecord_FixtureSet: <%= defined? ActiveRecord::FixtureSet %>
+    FixtureSet: <%= defined? FixtureSet %>
+    ActiveRecord_FixtureSet_File: <%= defined? ActiveRecord::FixtureSet::File %>
+    File: <%= File.name %>
+END
+
+        golden = [["one", {
+          "ActiveRecord" => "constant",
+          "ActiveRecord_FixtureSet" => "constant",
+          "FixtureSet" => nil,
+          "ActiveRecord_FixtureSet_File" => "constant",
+          "File" => "File"
+        }]]
+
+        tmp_yaml ["curious", "yml"], yaml do |t|
+          assert_equal golden, Scenario.open(t.path) { |fh| fh["organizations"].rows.to_a }
+        end
+      end
+
+      # Make sure that each fixture gets its own rendering context so that
+      # fixtures are independent.
+      def test_independent_render_contexts
+        yaml1 = "<% def leaked_method; 'leak'; end %>\n"
+        yaml2 = "one:\n  name: <%= leaked_method %>\n"
+        tmp_yaml ["leaky", "yml"], yaml1 do |t1|
+          tmp_yaml ["curious", "yml"], yaml2 do |t2|
+            Scenario.open(t1.path) { |fh| fh.to_a }
+            assert_raises(NameError) do
+              Scenario.open(t2.path) { |fh| fh.to_a }
+            end
+          end
+        end
+      end
+
+      private
+        def tmp_yaml(name, contents)
+          t = Tempfile.new name
+          t.binmode
+          t.write contents
+          t.close
+          yield t
+        ensure
+          t.close true
+        end
+    end
+  end
+end

--- a/activerecord/test/config.rb
+++ b/activerecord/test/config.rb
@@ -3,6 +3,7 @@
 TEST_ROOT       = __dir__
 ASSETS_ROOT     = TEST_ROOT + "/assets"
 FIXTURES_ROOT   = TEST_ROOT + "/fixtures"
+SCENARIOS_ROOT  = TEST_ROOT + "/scenarios"
 MODELS_ROOT     = TEST_ROOT + "/models"
 MIGRATIONS_ROOT = TEST_ROOT + "/migrations"
 SCHEMA_ROOT     = TEST_ROOT + "/schema"

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -195,6 +195,7 @@ class Author < ActiveRecord::Base
   belongs_to :owned_essay, primary_key: :name, class_name: "Essay"
   has_one :owned_essay_category, through: :owned_essay, source: :category
 
+  belongs_to :organization
   belongs_to :author_address,       dependent: :destroy
   belongs_to :author_address_extra, dependent: :delete, class_name: "AuthorAddress"
 

--- a/activerecord/test/scenarios/organisation_with_author_and_posts.yml
+++ b/activerecord/test/scenarios/organisation_with_author_and_posts.yml
@@ -1,0 +1,31 @@
+organizations:
+  _fixture:
+    model_class: Organization
+
+  code_monkeys:
+    name: The code monkeys
+
+posts:
+  <% 1.upto(5) do |i| %>
+  alex_post<%= i %>:
+    author: alex
+    title: Alex post <%= i %>
+    body: Such a lovely day
+    type: Post
+  <% end %>
+
+authors:
+  alex:
+    name: Alex
+    author_address_id: 100
+    organization: code_monkeys
+
+  nsa_author:
+    name: NSA Author
+    author_address_id: 100
+    organization: nsa
+
+author_addresses:
+  alex_address:
+    id: 100
+

--- a/activerecord/test/scenarios/posts_referencing_an_external_scenario_author.yml
+++ b/activerecord/test/scenarios/posts_referencing_an_external_scenario_author.yml
@@ -1,0 +1,6 @@
+posts:
+  other_alex_post:
+    author: alex
+    title: Other Alex's post
+    body: Such a lovely day
+    type: Post

--- a/activerecord/test/scenarios/scenario_overriding_fixture.yml
+++ b/activerecord/test/scenarios/scenario_overriding_fixture.yml
@@ -1,0 +1,3 @@
+organizations:
+  nsa:
+    name: No Such Agency (override)

--- a/activerecord/test/scenarios/scenario_overriding_scenario_fixture.yml
+++ b/activerecord/test/scenarios/scenario_overriding_scenario_fixture.yml
@@ -1,0 +1,3 @@
+organizations:
+  code_monkeys:
+    name: The code monkeys (override)

--- a/activerecord/test/scenarios/ships_and_pirates.yml
+++ b/activerecord/test/scenarios/ships_and_pirates.yml
@@ -1,0 +1,14 @@
+ships:
+  whispering_shadow:
+    name: "Whispering Shadow"
+    pirate: scarlet
+  golden_horizon:
+    name: "Golden Horizon"
+    pirate: morgan
+
+pirates:
+  scarlet:
+    catchphrase: "Avast, ye scallywags!"
+
+  morgan:
+    catchphrase: "Sailin' the high seas, we be!"


### PR DESCRIPTION
# Introducing fixture scenarios

This pull request proposes a new feature: Fixture Scenarios via a new TestCase method, `#load_scenario`. This concept aims to improve test data management by introducing situational fixtures known as "scenarios." The primary goal is to enable the creation of manageable sets of fixtures with complex associations within a single file.

Your feedback on this proposal would be highly appreciated! :) 

## Problem Statement

The current approach to managing throwaway scenarios with fixtures has limitations. Fixtures accumulate in various files, often leading to confusion about their original intent. On-the-fly records or using FactoryBot can result in unnecessary records creation and does not adequately manage associations between records.

## Solution Overview

By grouping fixtures per scenario or purpose instead of types, fixture scenarios offer an alternative to loading sets of records for each test. They provide the following benefits:

- Utilize familiar features like ERB, `_fixture` configuration, associations, and table access.
- Manage all records' relationships within a single file, which is particularly useful for testing scenarios with complex associations.
- Load scenarios only when explicitly specified, ensuring the flexibility to use permanent fixtures when needed.

This can be useful to snapshot a set of records when reproducing a bug or a complex state without bloating the test setup with method calls that are irrelevant to the thing tested. A dev could build records manually once and snapshot their state in a scenario instead of building that state every time the test runs on a pipeline.

## Scenario Example

Here's an example of how a scenario could look:

```yml
# test/scenarios/organisation_with_author_and_posts.yml
organizations:
  _fixture:
    model_class: Organization

  code_monkeys:
    name: The code monkeys

posts:
  <% 1.upto(5) do |i| %>
  alex_post<%= i %>:
    author: alex
    title: Alex post <%= i %>
    body: Such a lovely day
    type: Post
  <% end %>

authors:
  alex:
    name: Alex
    author_address_id: 100
    organization: code_monkeys

  nsa_author:
    name: NSA Author
    author_address_id: 100
    organization: nsa

author_addresses:
  alex_address:
    id: 100

```

### Usage

```ruby
require "test_helper"

class TestLoadScenario < ActiveRecord::TestCase
  def test_create_scenario
    load_scenario(SCENARIOS_ROOT + "/organisation_with_author_and_posts.yml")

    author = authors(:alex)

    assert author.author_address
    assert_equal "The Code Monkeys", author.organization.name
    assert_equal 5, author.posts.count
  end
end
```

## Implemented Rules

This PR is a POC with the following rules governing scenario fixtures:

* They are not loaded by default.
* They do not delete existing fixtures.
* They can reference existing fixtures.
* They can reference other existing scenario fixtures.
* They cannot override existing fixtures.
* They cannot override existing scenario fixtures.
* They allow ERB for dynamic data generation.
* They allow \_fixture configuration.
* They are accessible through table access.

## Caveats

One of the caveats is that managing records of the same type across multiple files can become challenging with schema changes unless shared defaults are established. This caveat likely applies to normal fixtures as well.

