### PR TITLE
Configure `config.active_support.cache_format_version = 7.1` for `RailtieTest`

### DIFF
--- a/activemodel/test/cases/railtie_test.rb
+++ b/activemodel/test/cases/railtie_test.rb
@@ -15,6 +15,7 @@ class RailtieTest < ActiveModel::TestCase
     @app ||= Class.new(::Rails::Application) do
       config.eager_load = false
       config.logger = fake_logger
+      config.active_support.cache_format_version = 7.1
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This commit suppresses the `DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.` warning at `RailtieTest`

### Detail

This commit sets `config.active_support.cache_format_version = 7.1` explicitly for `RailtieTest` because https://github.com/rails/rails/pull/48598 deprecates `active_support.cache_format_version = 6.1` and still the default format_version is 6.1, I think this is intended.

https://github.com/rails/rails/blob/4ac237de74a1ff383a44f6dc04c0e8894633722b/activesupport/lib/active_support/cache.rb#L55

#### Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd rails/activemodel
bundle
bin/test test/cases/railtie_test.rb:21
```

#### Without this commit
```ruby
$ bin/test test/cases/railtie_test.rb:21
Run options: --seed 36872

# Running:

DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from block (3 levels) in run at /home/yahonda/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
.

Finished in 0.321429s, 3.1111 runs/s, 3.1111 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
$
```

#### With this commit
```ruby
$ bin/test test/cases/railtie_test.rb:21
Run options: --seed 65282

# Running:

Finished in 0.006108s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
$
```

### Additional information
Related to https://github.com/rails/rails/pull/48598
https://github.com/rails/rails/pull/48586
https://github.com/rails/rails/pull/48604

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
