### PR TITLE
Fix test leak

### DIFF
--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -121,7 +121,7 @@ class IntegrationTest < ActiveRecord::TestCase
     assert_equal("1;123", Cpk::Book.new(id: [1, 123]).to_param)
   ensure
     Cpk::Order.param_delimiter = old_order_delimiter
-    Cpk::Order.param_delimiter = old_book_delimiter
+    Cpk::Book.param_delimiter = old_book_delimiter
   end
 
   def test_cache_key_for_existing_record_is_not_timezone_dependent

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -103,25 +103,18 @@ class IntegrationTest < ActiveRecord::TestCase
   end
 
   def test_param_delimiter_changes_delimiter_used_in_to_param
-    old_delimiter = Cpk::Order.param_delimiter
-    Cpk::Order.param_delimiter = ","
-    assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
-  ensure
-    Cpk::Order.param_delimiter = old_delimiter
+    Cpk::Order.with(param_delimiter: ",") do
+      assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
+    end
   end
 
   def test_param_delimiter_is_defined_per_class
-    old_order_delimiter = Cpk::Order.param_delimiter
-    old_book_delimiter = Cpk::Book.param_delimiter
-
-    Cpk::Order.param_delimiter = ","
-    Cpk::Book.param_delimiter = ";"
-
-    assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
-    assert_equal("1;123", Cpk::Book.new(id: [1, 123]).to_param)
-  ensure
-    Cpk::Order.param_delimiter = old_order_delimiter
-    Cpk::Book.param_delimiter = old_book_delimiter
+    Cpk::Order.with(param_delimiter: ",") do
+      Cpk::Book.with(param_delimiter: ";") do
+        assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
+        assert_equal("1;123", Cpk::Book.new(id: [1, 123]).to_param)
+      end
+    end
   end
 
   def test_cache_key_for_existing_record_is_not_timezone_dependent


### PR DESCRIPTION
### Motivation / Background

I was looking at https://github.com/rails/rails/pull/49020 and saw that one of the configuration values wasn't properly restored (looks like wrong copy/paste):
https://github.com/rails/rails/blob/153eae8995c2de3d1bafc0fb13ae5a3250703a3d/activerecord/test/cases/integration_test.rb#L124

### Detail

First commit is strictly the fix, we can leave it at that if you'd like, but I felt like using `Object#with` would have avoided the issue in the first place, so I've done it in the second commit. They should be squashed if you're ok with this.
