### PR TITLE
Fix TimeWithZone#to_s being overriden with ENV set

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `TimeWithZone` still using deprecated `#to_s` when `ENV` or `config` to
+    disable it are set.
+
+    *Hartley McGuire*
+
 *   Fix CacheStore#write_multi when using a distributed Redis cache with a connection pool.
 
     Fixes [#48938](https://github.com/rails/rails/issues/48938).

--- a/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
@@ -34,3 +34,40 @@ class Time
     end
   end
 end
+
+module ActiveSupport
+  class TimeWithZone
+    NOT_SET = Object.new # :nodoc:
+
+    def to_s(format = NOT_SET) # :nodoc:
+      if format == :db
+        ActiveSupport::Deprecation.warn(
+          "TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead."
+        )
+        utc.to_fs(format)
+      elsif formatter = ::Time::DATE_FORMATS[format]
+        ActiveSupport::Deprecation.warn(
+          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
+        )
+        formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+      elsif format == NOT_SET
+        if formatter = ::Time::DATE_FORMATS[:default]
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Using a :default format for TimeWithZone#to_s is deprecated. Please use TimeWithZone#to_fs instead.
+            If you fixed all places inside your application that you see this deprecation, you can set
+            `ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION']` to `"true"` in the `config/application.rb` file before
+            the `Bundler.require` call to fix all the callers outside of your application.
+          MSG
+          formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
+        else
+          "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
+        end
+      else
+        ActiveSupport::Deprecation.warn(
+          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
+        )
+        "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
+      end
+    end
+  end
+end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -206,38 +206,9 @@ module ActiveSupport
     end
     alias_method :rfc822, :rfc2822
 
-    NOT_SET = Object.new # :nodoc:
-
     # Returns a string of the object's date and time.
-    def to_s(format = NOT_SET)
-      if format == :db
-        ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead."
-        )
-        utc.to_fs(format)
-      elsif formatter = ::Time::DATE_FORMATS[format]
-        ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
-        )
-        formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
-      elsif format == NOT_SET
-        if formatter = ::Time::DATE_FORMATS[:default]
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using a :default format for TimeWithZone#to_s is deprecated. Please use TimeWithZone#to_fs instead.
-            If you fixed all places inside your application that you see this deprecation, you can set
-            `ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION']` to `"true"` in the `config/application.rb` file before
-            the `Bundler.require` call to fix all the callers outside of your application.
-          MSG
-          formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
-        else
-          "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
-        end
-      else
-        ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
-        )
-        "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
-      end
+    def to_s
+      "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
     end
 
     # Returns a string of the object's date and time.


### PR DESCRIPTION
### Motivation / Background

Fixes #49033

`#to_s` with a format was previously [deprecated][1], and the warning was later [improved][2] for calling `#to_s` without a format. However, an oversight in the deprecation is that neither the `ENV` or the config to disable the deprecation would work because `TimeWithZone#to_s` is defined on the `TimeWithZone` class and not in a `core_ext`.

### Detail

This commit fixes the issue by moving the deprecated `#to_s` definition to `core_ext/time/deprecated_conversions`. Since there are currently no `core_ext` for `TimeWithZone` this seems like the best place to put it (especially since the file will not be added to `main`).

[1]: https://github.com/rails/rails/commit/f9fbfe0ab3cfc31f72663b9f06286ab32224b886
[2]: https://github.com/rails/rails/commit/7e9ffc2e137b649c6fd2ca1c580cdfffc9845b55

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
