### PR TITLE
Add bigdecimal to runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ PATH
       marcel (~> 1.0)
     activesupport (7.1.0.alpha)
       base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb
@@ -155,6 +156,7 @@ GEM
     bcrypt (3.1.18)
     beaneater (1.1.3)
     benchmark-ips (2.10.0)
+    bigdecimal (3.1.4)
     bindex (0.8.1)
     bootsnap (1.15.0)
       msgpack (~> 1.2)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "mutex_m"
+  s.add_dependency "bigdecimal"
 end


### PR DESCRIPTION
### Motivation / Background

Follow up https://github.com/ruby/ruby/commit/1c93288f8bbf667cb95eb7137b2fe64213894b77.

This PR adds bigdecimal to runtime dependency of Active Support to suppress the following Ruby 3.3.0dev's warning.

> /Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/bundler/gems/rails-a8871e6829e5/activesupport/lib/
> active_support/core_ext/object/json.rb:5: warning: bigdecimal will be not part of the default gems since Ruby 3.4.0.
> Add bigdecimal to your Gemfile. Also contact author of  to add bigdecimal into its gemspec.

The grep yields the following results:

```console
$ git grep 'require.*bigdecimal'
activejob/lib/active_job/arguments.rb:3:require "bigdecimal"
activejob/lib/active_job/serializers/big_decimal_serializer.rb:3:require "bigdecimal"
activejob/test/cases/argument_serialization_test.rb:3:require "bigdecimal"
activemodel/lib/active_model/type/decimal.rb:3:require "bigdecimal/util"
activemodel/lib/active_model/validations/numericality.rb:5:require "bigdecimal/util"
activemodel/test/cases/validations/numericality_validation_test.rb:8:require "bigdecimal"
activerecord/test/cases/adapters/sqlite3/quoting_test.rb:4:require "bigdecimal"
activerecord/test/cases/arel/visitors/to_sql_test.rb:4:require "bigdecimal"
activerecord/test/cases/migration_test.rb:5:require "bigdecimal/util"
activesupport/lib/active_support/core_ext/big_decimal/conversions.rb:3:require "bigdecimal"
activesupport/lib/active_support/core_ext/big_decimal/conversions.rb:4:require "bigdecimal/util"
activesupport/lib/active_support/core_ext/object/json.rb:5:require "bigdecimal"
activesupport/lib/active_support/message_pack/extensions.rb:3:require "bigdecimal"
activesupport/lib/active_support/xml_mini.rb:5:require "bigdecimal"
activesupport/lib/active_support/xml_mini.rb:6:require "bigdecimal/util"
activesupport/test/core_ext/hash_ext_test.rb:4:require "bigdecimal"
activesupport/test/core_ext/object/duplicable_test.rb:4:require "bigdecimal"
activesupport/test/hash_with_indifferent_access_test.rb:4:require "bigdecimal"
activesupport/test/json/encoding_test_cases.rb:3:require "bigdecimal"
```

By adding only to Active Support as a dependency, it should resolve the issue due to the dependency.

### Detail

The warning is confirmed in the following step:

```ruby
$ cat generic_main.rb
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
end

require 'active_support'
require 'minitest/autorun'
# These gems will be bundled gems in Ruby 3.4
require 'bigdecimal'
```

Run generic_main.rb with Ruby 3.3.0dev below.

```console
$ ruby -v
ruby 3.3.0dev (2023-08-25T17:47:04Z master 7d32011399) [x86_64-darwin22]

$ ruby generic_main.rb
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/bundler/gems/rails-a8871e6829e5/activesupport/lib/
active_support/core_ext/object/json.rb:5: warning: bigdecimal will be not part of the default gems since Ruby 3.4.0.
Add bigdecimal to your Gemfile. Also contact author of  to add bigdecimal into its gemspec.
Run options: --seed 39015

# Running:

Finished in 0.001313s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

### Additional information

It is essentially the same as https://github.com/rails/rails/pull/48907.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
