### PR TITLE
Improve #select with Hash argument to be more consistent with #where

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2002,6 +2002,10 @@ module ActiveRecord
           case columns_aliases
           when Hash
             columns_aliases.map do |column, column_alias|
+              if values[:joins]&.include?(key)
+                references = PredicateBuilder.references({ key.to_s => fields[key] })
+                self.references_values |= references unless references.empty?
+              end
               arel_column("#{key}.#{column}") do
                 predicate_builder.resolve_arel_attribute(key.to_s, column)
               end.as(column_alias.to_s)

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -45,6 +45,21 @@ module ActiveRecord
       end
     end
 
+    def test_select_with_hash_and_table_alias
+      post = Post.joins(:comments, :comments_with_extend)
+        .select(
+          :title,
+          posts: { title: :post_title },
+          comments: { body: :comment_body },
+          comments_with_extend: { body: :comment_body_2 }
+        )
+        .take
+
+      assert_equal post.title, post.post_title
+      assert_not_nil post.comment_body
+      assert_not_nil post.comment_body_2
+    end
+
     def test_select_with_invalid_nested_field
       assert_raises(ActiveRecord::StatementInvalid) do
         Post.select(posts: { "UPPER(title)" => :post_title }).take


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/48862

### Motivation / Background

I created this to fix the issues raised in [48862](https://github.com/rails/rails/issues/48862).   The problem the User was facing was trying to use an alias within select using a hash.  Due to extra aliasing taking place the queries were unsuccessful.

### Detail

I add a check into the `Hash` block of the `case` statement to check if the `Relation` object includes the current `key` in it's `:joins` array.  If so, I then create a reference to it and store it in the `Relation` `references_values` attribute.  This then allows the query to be aware of the table alias as it goes to `make_constraints`.  Once available in this method it will then use the table alias as an alias in `aliased_table_for` instead of the reflection's table name.  This allows for a successful use of the User's table alias instead of Rails creating one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
