### PR TITLE
Add `extract_value` method to `ActionController::Parameters`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActionController::Parameters#extract_value` method to allow extracting serialized values from params
+
+    ```ruby
+    params = ActionController::Parameters.new(id: "1_123", tags: "ruby,rails")
+    params.extract_value(:id) # => ["1", "123"]
+    params.extract_value(:tags, delimiter: ",") # => ["ruby", "rails"]
+    ```
+
+    *Nikita Vasilevsky*
+
 *   Parse JSON `response.parsed_body` with `ActiveSupport::HashWithIndifferentAccess`
 
     Integrate with Minitest's new `assert_pattern` by parsing the JSON contents

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -926,6 +926,15 @@ module ActionController
       end
     end
 
+    # Returns parameter value for the given +key+ separated by +delimiter+.
+    #
+    #   params = ActionController::Parameters.new(id: "1_123", tags: "ruby,rails")
+    #   params.extract_value(:id) # => ["1", "123"]
+    #   params.extract_value(:tags, delimiter: ",") # => ["ruby", "rails"]
+    def extract_value(key, delimiter: "_")
+      @parameters[key].split(delimiter)
+    end
+
     protected
       attr_reader :parameters
 

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -421,4 +421,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     @params.dig(:person, :addresses)[0] = { city: "Boston", state: "Massachusetts" }
     assert_equal "Boston", @params.dig(:person, :addresses, 0, :city)
   end
+
+  test "#extract_value splits param by delimiter" do
+    params = ActionController::Parameters.new(
+      id: "1_123",
+      tags: "ruby,rails,web"
+    )
+
+    assert_equal(["1", "123"], params.extract_value(:id))
+    assert_equal(["ruby", "rails", "web"], params.extract_value(:tags, delimiter: ","))
+  end
 end


### PR DESCRIPTION
This commit adds `extract_value` method to `ActionController::Parameters` as a primary way to extract composite `id` values serialized from `ActiveRecord::Base#to_param` called on a model with a composite primary key.


After extending `to_param` method to support composite identifiers https://github.com/rails/rails/pull/49020 actionview helpers like `form_for(cpk_record)` will build resource url with composite key joined by `"_"` (by default): `/travel_routes/Ottawa_Paris`
This leads to the need for the controller to turn the joined value back into a composite primary key value and `extract_value` is the helper method to achieve this:
```ruby
def show
  identifier = params.extract_value(:id, delimiter: TravelRoute.param_delimiter)
  @travel_route = TravelRoute.find(identifier)
   ...
end
```

### Potential concerns

- The implementation is way too simple to justify adding a whole new method
- `extract_value` name is similar to existing `extract!` method but has a different API