### PR TITLE
Fix column typecasting with duplicate column names for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -562,7 +562,7 @@ module ActiveRecord
               klass.attribute_types.fetch(name = result.columns[i]) do
                 join_dependencies ||= build_join_dependencies
                 lookup_cast_type_from_join_dependencies(name, join_dependencies) ||
-                  result.column_types[name] || Type.default_value
+                  result.column_type(name, i, {}) || Type.default_value
               end
           end
         end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -130,6 +130,14 @@ module ActiveRecord
       end
     end
 
+    def column_type(name, index, type_overrides)
+      type_overrides.fetch(name) do
+        column_types.fetch(index) do
+          column_types.fetch(name, Type.default_value)
+        end
+      end
+    end
+
     def initialize_copy(other)
       @columns      = columns.dup
       @rows         = rows.dup
@@ -143,14 +151,6 @@ module ActiveRecord
     end
 
     private
-      def column_type(name, index, type_overrides)
-        type_overrides.fetch(name) do
-          column_types.fetch(index) do
-            column_types.fetch(name, Type.default_value)
-          end
-        end
-      end
-
       def hash_rows
         @hash_rows ||=
           begin


### PR DESCRIPTION
Fixes incorrect typecasting that occurred when there were duplicate column names returned from PostgreSQL which is always the case when calculations/aggregates are use multiple times when no aliases are used. The `column_type` method was moved from private to public, and the typecasting logic was updated.

Fixes #48946.

### Additional information

There are several other places where the `ActiveRecord::Result#column_type` is used directly, but I'm not sure if accessing the column_type via index would be correct/possible there. To me it seems these places are even incorrect since https://github.com/rails/rails/pull/45783 because the the `types`/`column_types` potentially not only contains columns by name but also by index.
- https://github.com/rails/rails/blob/f6b987d521b9ad3f9938b40f039fbdda78058a06/activerecord/lib/active_record/querying.rb#L66-L66
- https://github.com/rails/rails/blob/f6b987d521b9ad3f9938b40f039fbdda78058a06/activerecord/lib/active_record/associations/join_dependency.rb#L127-L127
- https://github.com/rails/rails/blob/f6b987d521b9ad3f9938b40f039fbdda78058a06/activerecord/lib/active_record/relation/calculations.rb#L508-L508


<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
