### PR TITLE
This allows Users to merge the actual model to an already aliased/scoped model when using the missing or associated methods. Fixes #48945. 

### DIFF
--- a/activerecord/test/assets/schema_dump_5_1.yml
+++ b/activerecord/test/assets/schema_dump_5_1.yml
@@ -342,4 +342,6 @@ data_sources:
   test_with_keyword_column_name: true
   fk_test_has_pk: true
   fk_test_has_fk: true
+  goals: true
+  goal_states: true
 version: 0

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -8,7 +8,8 @@ require "models/essay"
 require "models/comment"
 require "models/categorization"
 require "models/book"
-
+require "models/goal"
+require "models/goal_state"
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
     fixtures :posts, :comments, :authors, :humans, :essays, :author_addresses, :books
@@ -92,6 +93,18 @@ module ActiveRecord
       assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.associated(:reading_listing).extending(Author::NamedExtension).first
     end
 
+    def test_associated_merge_or
+      goal = Goal.create!
+      GoalState.create!(goal_id: goal.id)
+      assert_equal goal, Goal.associated_state.first
+    end
+
+    def test_associated_simple_or
+      goal = Goal.create!
+      GoalState.create!(goal_id: goal.id)
+      assert_equal goal, Goal.associated_state_simple_or.first
+    end
+
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
@@ -165,6 +178,16 @@ module ActiveRecord
 
     def test_missing_with_enum_extended_late
       assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).extending(Author::NamedExtension).first
+    end
+
+    def test_missing_merge_or
+      goal = Goal.create!
+      assert_equal goal, Goal.no_state.first
+    end
+
+    def test_missing_simple_or
+      goal = Goal.create!
+      assert_equal goal, Goal.no_state_simple_or.first
     end
 
     def test_not_inverts_where_clause

--- a/activerecord/test/models/goal.rb
+++ b/activerecord/test/models/goal.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Goal < ActiveRecord::Base
+  has_one :state, class_name: "GoalState", dependent: :destroy
+
+  scope :no_state, -> { where.missing(:state).or(left_joins(:state).merge(GoalState.not_set)) }
+  scope :no_state_simple_or, -> { where.missing(:state).or(GoalState.not_set) }
+  scope :associated_state, -> { where.associated(:state).or(joins(:state).merge(GoalState.not_set)) }
+  scope :associated_state_simple_or, -> { where.associated(:state).or(GoalState.not_set) }
+end

--- a/activerecord/test/models/goal_state.rb
+++ b/activerecord/test/models/goal_state.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GoalState < ActiveRecord::Base
+  belongs_to :goal
+
+  scope :set, -> { where.not(state: nil) }
+  scope :not_set, -> { where(state: nil) }
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1448,6 +1448,14 @@ ActiveRecord::Schema.define do
     t.bigint :toooooooo_long_a_id, null: false
     t.bigint :toooooooo_long_b_id, null: false
   end
+
+  create_table :goals, force: true do |t|
+  end
+
+  create_table :goal_states, force: true do |t|
+    t.integer :goal_id
+    t.string :state
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
Since `aliased_table_for` is called later on in the stack as to make the `missing` and `associated` methods have no awareness of aliasing taking place, I decided to make a similar data structure available within both.  By adding `@scope.table_name`, and  any `joins` `table_names` to an array, I am offering up a similar object that the `alias_tracker.aliases` hash would contain.  I used an array instead of a hash because in this case we don't need to check the values of the keys like `aliased_table_for` does.  By building this array it gives these methods an awareness of what aliasing might take place further on in the stack so that it can take the correct course of action when building the where clause.  

This adds an `alias_prediction` method which implements the behavior noted above:
```Ruby
        def alias_prediction
          alias_table_names = []
          alias_table_names.push(@scope.table_name)
          if @scope.values[:joins]
            @scope.values[:joins].each do |join|
              current_join = scope_association_reflection(join)
              alias_table_names.push(current_join.table_name)
            end
          end
          alias_table_names
        end
```

Note: The initial `reflection.options[:class_name]` check is still necessary to avoid false positives.

### Motivation / Background

This Pull Request has been created because a bug report was raised. Fixes #[48945](https://github.com/rails/rails/issues/48945).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
