### PR TITLE
Try to build with sqlite3 1.6.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", "< 1.6.4"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,10 +503,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.2)
+    sqlite3 (1.6.3)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.6.2-x86_64-darwin)
-    sqlite3 (1.6.2-x86_64-linux)
+    sqlite3 (1.6.3-x86_64-darwin)
+    sqlite3 (1.6.3-x86_64-linux)
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -626,7 +626,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.4)
+  sqlite3 (< 1.6.4)
   stackprof
   stimulus-rails
   sucker_punch


### PR DESCRIPTION
CI started failing:

* https://buildkite.com/rails/rails/builds/99131
* https://buildkite.com/rails/rails-ci/builds/96

4 hours ago, sqlite3-ruby v1.6.4 was released:
https://github.com/sparklemotion/sqlite3-ruby/releases/tag/v1.6.4

~Are they related?~ this fixed CI, so I think so