### PR TITLE
fixes issue where rails console filters lines that match 'APP_DIRS_PATTERN' because they are prefixed with 'from'

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -10,10 +10,17 @@ module Rails
 
     def initialize
       super
-      @root = "#{Rails.root}/"
+
+      from_prefix = "\tfrom "
       add_filter do |line|
-        line.start_with?(@root) ? line.from(@root.size) : line
+        line.start_with?(from_prefix) ? line.from(from_prefix.size) : line
       end
+
+      root = "#{Rails.root}/"
+      add_filter do |line|
+        line.start_with?(root) ? line.from(root.size) : line
+      end
+
       add_filter do |line|
         if RENDER_TEMPLATE_PATTERN.match?(line)
           line.sub(RENDER_TEMPLATE_PATTERN, "")
@@ -21,6 +28,7 @@ module Rails
           line
         end
       end
+
       add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end
   end

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -8,6 +8,13 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     @cleaner = Rails::BacktraceCleaner.new
   end
 
+  test "should filter '\tfrom' before processing" do
+    backtrace = ["\tfrom /Path/to/railsapp/app/models/user.rb:22:in `bar'"]
+    result = @cleaner.clean(backtrace, :all)
+    assert_equal "/Path/to/railsapp/app/models/user.rb:22:in `bar'", result[0]
+    assert_equal 1, result.length
+  end
+
   test "#clean should consider traces from irb lines as User code" do
     backtrace = [ "(irb):1",
                   "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",


### PR DESCRIPTION
### Motivation / Background
I noticed and confirmed with others that rails console was omitting expected backtrace lines as seen here:
```
$ cat app/models/user.rb
class User < ApplicationRecord

  def foo
    bar
  end

  def bar
    baz
  end

  def baz
    raise
  end
end

$  rc
Loading development environment (Rails 7.0.7)
3.1.4 :001 > User.new.foo
/Users/jsharpe/railsapp/app/models/user.rb:12:in `baz': unhandled exception
(irb):1:in `<main>
```

I believe this is caused by irb itself prefixing backtrace lines with the string: `\tfrom ` as seen here:
```
√ (9:21:40 PM) ~ irb
3.0.4 :001 > class Foo
3.0.4 :002 > def foo
3.0.4 :003 > bar
3.0.4 :004 > end
3.0.4 :005 > def bar
3.0.4 :006 > baz
3.0.4 :007 > end
3.0.4 :008 > def baz
3.0.4 :009 > raise
3.0.4 :010 > end
3.0.4 :011 > end
 => :baz
3.0.4 :012 >
3.0.4 :013 > Foo.new.foo
(irb):9:in `baz': unhandled exception
	from (irb):6:in `bar'
	from (irb):3:in `foo'
	from (irb):13:in `<main>'
	from /Users/jsharpe/.rvm/gems/ruby-3.0.4/gems/irb-1.7.4/exe/irb:9:in `<top (required)>'
	from /Users/jsharpe/.rvm/gems/ruby-3.0.4/bin/irb:25:in `load'
	from /Users/jsharpe/.rvm/gems/ruby-3.0.4/bin/irb:25:in `<main>'
	from /Users/jsharpe/.rvm/gems/ruby-3.0.4/bin/ruby_executable_hooks:22:in `eval'
	from /Users/jsharpe/.rvm/gems/ruby-3.0.4/bin/ruby_executable_hooks:22:in `<main>'
```


This causes rails console to mistakenly filter lines that would otherwise match `Rails::BacktraceCleaner::APP_DIRS_PATTERN` because that regex hasn't anticipated the prefix.  
This patch filters `\tfrom ` if it exists which then allows the filter using `APP_DIRS_PATTERN` below to work correctly:

```
$ rc
Loading development environment (Rails 7.0.7)
3.1.4 :001 > User.new.foo
/Users/jsharpe/railsapp/app/models/user.rb:12:in `baz': unhandled exception
app/models/user.rb:8:in `bar'
app/models/user.rb:4:in `foo'
(irb):1:in `<main>'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
