### PR TITLE
[Fix #48535]: fix behavior of `proc_for_binds` in `Arel::Nodes::HomogenousIn`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `where(field: values)` queries when `field` is a serialized attribute
+    (for example, when `field` uses `ActiveRecord::Base.serialize` or is a JSON
+    column).
+
+    *João Alves*
+
 *   Make the output of `ActiveRecord::Core#inspect` configurable.
 
     By default, calling `inspect` on a record will yield a formatted string including just the `id`.

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -28,7 +28,6 @@ module ActiveRecord
         ActiveRecord::Relation.prepend(RelationQueries)
         ActiveRecord::Base.include(CoreQueries)
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
-        Arel::Nodes::HomogeneousIn.prepend(InWithAdditionalValues)
       end
 
       # When modifying this file run performance tests in
@@ -150,20 +149,6 @@ module ActiveRecord
             data.value
           else
             super
-          end
-        end
-      end
-
-      module InWithAdditionalValues
-        def proc_for_binds
-          -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, encryption_aware_type_caster) }
-        end
-
-        def encryption_aware_type_caster
-          if attribute.type_caster.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
-            attribute.type_caster.cast_type
-          else
-            attribute.type_caster
           end
         end
       end

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -48,7 +48,7 @@ module Arel # :nodoc: all
       end
 
       def proc_for_binds
-        -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, attribute.type_caster) }
+        -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, ActiveModel::Type.default_value) }
       end
 
       def fetch_attribute(&block)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -245,7 +245,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     settings = { "color" => "green" }
     Topic.serialize(:content, type: Hash)
     topic = Topic.create!(content: settings)
-    assert_equal topic, Topic.where(content: [settings]).take
+    assert_equal topic, Topic.where(content: [settings, { "herring" => "red" }]).take
   end
 
   def test_serialized_default_class


### PR DESCRIPTION
### Motivation / Background
This PR addresses the issues #48535 and #48072.

With the introduction of PR #41068, an unintended behavior surfaced, causing the `proc_for_binds` to apply casting to attributes that were already casted. Consequently, this led to the malfunctioning of queries, as noted in the referenced issues.

This commit fixes the issue by replacing the type with `ActiveModel::Type.default_value` so that the 2nd serialization is effectively a no-op. This correction has obviated the need for changes such as "Fix deterministic queries that were broken after #41068," as detailed in [this commit](https://github.com/wbotelhos/rails/commit/37361bfb4222c5d210f11e48ecee46b05ea7d50e). These changes had inadvertently caused the tests initially intended for `proc_for_binds` within `HomogeneousIn` to erroneously evaluate the `proc_for_binds` within `InWithAdditionalValues`. This resulted in false positives whenever adjustments were made to the `proc_for_binds` within `HomogeneousIn`.

Fixes #48072.
Fixes #48535.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
