### PR TITLE
Fix no _method input in form_for namespaced model

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `form_for` missing the hidden `_method` input for models with a
+    namespaced route.
+
+    *Hartley McGuire*
+
 *   Fix `render collection: @records, cache: true` inside `jbuilder` templates
 
     The previous fix that shipped in `7.0.7` assumed template fragments are always strings,

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -465,12 +465,13 @@ module ActionView
 
         as = options[:as]
         namespace = options[:namespace]
-        action = object.respond_to?(:persisted?) && object.persisted? ? :edit : :new
+        action, method = object.respond_to?(:persisted?) && object.persisted? ? [:edit, :patch] : [:new, :post]
         options[:html] ||= {}
         options[:html].reverse_merge!(
           class:  as ? "#{action}_#{as}" : dom_class(object, action),
           id:     (as ? [namespace, action, as] : [namespace, dom_id(object, action)]).compact.join("_").presence,
         )
+        options[:method] ||= method
       end
       private :apply_form_for_options!
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2148,6 +2148,26 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_form_for_with_nested_persisted_to_model
+    post_form = RecordForm.new(to_model: @post)
+
+    form_for([:admin, post_form]) { }
+
+    expected = whole_form("/admin/posts/123", "edit_post_123", "edit_post", method: :patch) { "" }
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_for_with_nested_new_record_to_model
+    post_form = RecordForm.new(to_model: Post.new)
+
+    form_for([:admin, post_form]) { }
+
+    expected = whole_form("/admin/posts", "new_post", "new_post", method: :post) { "" }
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_form_for_with_file_field_generate_multipart
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.file_field(:file)


### PR DESCRIPTION
### Motivation / Background

Fixes #48789

This was originally [added][1] before Rails 7.0.0, but was [broken][2] before the official 7.0.0 release. Additionally, it was backported to 6-1-stable and so it first appeared in 6.1.5. It was also [resolved][3] later on main but in a backwards incompatible way.

### Detail

This fixes the issue without any backwards compatibility changes so it can safely be applied to 7-0-stable and the behavior is consistent between 6-1-stable, 7-0-stable, and main.

[1]: http://github.com/rails/rails/commit/58127ec6d5bdfc21787c6978b70f1e51f6cbb0a0
[2]: http://github.com/rails/rails/commit/269f6722c3228ec92756a62bb0ffcc3d43817337
[3]: http://github.com/rails/rails/commit/3404606378dd93344007d954ab326cc1e973c22a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
