### PR TITLE
[Fix #49055] Raise an `ArgumentError` when `#accepts_nested_attributes_for` is redeclared for an association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise an `ArgumentError` when `#accepts_nested_attributes_for` is declared more than once for an association in
+    the same class. Previously, the last declaration would silently override the previous one. Overriding in a subclass
+    is still allowed.
+
+    *Joshua Young*
+
 *   Deprecate `rewhere` argument on `#merge`.
 
     The `rewhere` argument on `#merge`is deprecated without replacement and

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -355,11 +355,16 @@ module ActiveRecord
         options.update(attr_names.extract_options!)
         options.assert_valid_keys(:allow_destroy, :reject_if, :limit, :update_only)
         options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
+        options[:class] = self
 
         attr_names.each do |association_name|
           if reflection = _reflect_on_association(association_name)
             reflection.autosave = true
             define_autosave_validation_callbacks(reflection)
+
+            if nested_attributes_options.dig(association_name.to_sym, :class) == self
+              raise ArgumentError, "Already declared #{association_name} as an accepts_nested_attributes association for this class."
+            end
 
             nested_attributes_options = self.nested_attributes_options.dup
             nested_attributes_options[association_name.to_sym] = options

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -18,6 +18,7 @@ require "active_support/hash_with_indifferent_access"
 
 class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   teardown do
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, allow_destroy: true, reject_if: proc(&:empty?)
   end
 
@@ -74,6 +75,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_should_disable_allow_destroy_by_default
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship
 
     pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -92,6 +94,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_method_without_arguments
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, reject_if: :new_record?
 
     pirate = Pirate.new(catchphrase: "Stop wastin' me time")
@@ -100,6 +103,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_method_with_arguments
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, reject_if: :reject_empty_ships_on_create
 
     pirate = Pirate.new(catchphrase: "Stop wastin' me time")
@@ -113,6 +117,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_with_indifferent_keys
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| attributes[:name].blank? }
 
     pirate = Pirate.new(catchphrase: "Stop wastin' me time")
@@ -121,6 +126,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_one
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| true }
     pirate = Pirate.create(catchphrase: "Stop wastin' me time")
     ship = pirate.create_ship(name: "s1")
@@ -143,6 +149,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_with_a_proc_which_returns_true_always_for_has_many
+    Human.nested_attributes_options.delete :interests
     Human.accepts_nested_attributes_for :interests, reject_if: proc { |attributes| true }
     human = Human.create(name: "John")
     interest = human.interests.create(topic: "photography")
@@ -151,6 +158,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_destroy_works_independent_of_reject_if
+    Human.nested_attributes_options.delete :interests
     Human.accepts_nested_attributes_for :interests, reject_if: proc { |attributes| true }, allow_destroy: true
     human = Human.create(name: "Jon")
     interest = human.interests.create(topic: "the ladies")
@@ -159,6 +167,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_is_not_short_circuited_if_allow_destroy_is_false
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, reject_if: ->(a) { a[:name] == "The Golden Hind" }, allow_destroy: false
 
     pirate = Pirate.create!(catchphrase: "Stop wastin' me time", ship_attributes: { name: "White Pearl", _destroy: "1" })
@@ -172,6 +181,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_has_many_association_updating_a_single_record
+    Human.nested_attributes_options.delete(:interests)
     Human.accepts_nested_attributes_for(:interests)
     human = Human.create(name: "John")
     interest = human.interests.create(topic: "photography")
@@ -180,6 +190,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_reject_if_with_blank_nested_attributes_id
+    Pirate.nested_attributes_options.delete :ship
     # When using a select list to choose an existing 'ship' id, with include_blank: true
     Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| attributes[:id].blank? }
 
@@ -189,6 +200,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_first_and_array_index_zero_methods_return_the_same_value_when_nested_attributes_are_set_to_update_existing_record
+    Human.nested_attributes_options.delete(:interests)
     Human.accepts_nested_attributes_for(:interests)
     human = Human.create(name: "John")
     interest = human.interests.create topic: "gardening"
@@ -198,6 +210,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_allows_class_to_override_setter_and_call_super
+    Pirate.nested_attributes_options.delete :parrot
     mean_pirate_class = Class.new(Pirate) do
       accepts_nested_attributes_for :parrot
       def parrot_attributes=(attrs)
@@ -222,6 +235,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
   end
 
   def test_should_not_create_duplicates_with_create_with
+    Human.nested_attributes_options.delete(:interests)
     Human.accepts_nested_attributes_for(:interests)
 
     assert_difference("Interest.count", 1) do
@@ -338,12 +352,14 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, allow_destroy: false, reject_if: proc(&:empty?)
 
     @pirate.update(ship_attributes: { id: @pirate.ship.id, _destroy: "1" })
 
     assert_equal @ship, @pirate.reload.ship
 
+    Pirate.nested_attributes_options.delete :ship
     Pirate.accepts_nested_attributes_for :ship, allow_destroy: true, reject_if: proc(&:empty?)
   end
 
@@ -411,6 +427,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_destroy_existing_when_update_only_is_true_and_id_is_given_and_is_marked_for_destruction
+    Pirate.nested_attributes_options.delete :update_only_ship
     Pirate.accepts_nested_attributes_for :update_only_ship, update_only: true, allow_destroy: true
     @ship.delete
     @ship = @pirate.create_update_only_ship(name: "Nights Dirty Lightning")
@@ -420,6 +437,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     assert_nil @pirate.reload.ship
     assert_raise(ActiveRecord::RecordNotFound) { Ship.find(@ship.id) }
 
+    Pirate.nested_attributes_options.delete :update_only_ship
     Pirate.accepts_nested_attributes_for :update_only_ship, update_only: true, allow_destroy: false
   end
 end
@@ -532,11 +550,13 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_destroy_an_existing_record_if_allow_destroy_is_false
+    Ship.nested_attributes_options.delete :pirate
     Ship.accepts_nested_attributes_for :pirate, allow_destroy: false, reject_if: proc(&:empty?)
 
     @ship.update(pirate_attributes: { id: @ship.pirate.id, _destroy: "1" })
     assert_nothing_raised { @ship.pirate.reload }
   ensure
+    Ship.nested_attributes_options.delete :pirate
     Ship.accepts_nested_attributes_for :pirate, allow_destroy: true, reject_if: proc(&:empty?)
   end
 
@@ -588,6 +608,7 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_destroy_existing_when_update_only_is_true_and_id_is_given_and_is_marked_for_destruction
+    Ship.nested_attributes_options.delete :update_only_pirate
     Ship.accepts_nested_attributes_for :update_only_pirate, update_only: true, allow_destroy: true
     @pirate.delete
     @pirate = @ship.create_update_only_pirate(catchphrase: "Aye")
@@ -596,6 +617,7 @@ class TestNestedAttributesOnABelongsToAssociation < ActiveRecord::TestCase
 
     assert_raise(ActiveRecord::RecordNotFound) { @pirate.reload }
 
+    Ship.nested_attributes_options.delete :update_only_pirate
     Ship.accepts_nested_attributes_for :update_only_pirate, update_only: true, allow_destroy: false
   end
 end
@@ -820,6 +842,7 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_validate_presence_of_parent_works_with_inverse_of
+    Human.nested_attributes_options.delete(:interests)
     Human.accepts_nested_attributes_for(:interests)
     assert_equal :human, Human.reflect_on_association(:interests).options[:inverse_of]
     assert_equal :interests, Interest.reflect_on_association(:human).options[:inverse_of]
@@ -842,6 +865,7 @@ module NestedAttributesOnACollectionAssociationTests
   end
 
   def test_numeric_column_changes_from_zero_to_no_empty_string
+    Human.nested_attributes_options.delete(:interests)
     Human.accepts_nested_attributes_for(:interests)
 
     repair_validations(Interest) do
@@ -909,6 +933,7 @@ end
 
 module NestedAttributesLimitTests
   def teardown
+    Pirate.nested_attributes_options.delete :parrots
     Pirate.accepts_nested_attributes_for :parrots, allow_destroy: true, reject_if: proc(&:empty?)
   end
 
@@ -933,6 +958,7 @@ end
 
 class TestNestedAttributesLimitNumeric < ActiveRecord::TestCase
   def setup
+    Pirate.nested_attributes_options.delete :parrots
     Pirate.accepts_nested_attributes_for :parrots, limit: 2
 
     @pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -943,6 +969,7 @@ end
 
 class TestNestedAttributesLimitSymbol < ActiveRecord::TestCase
   def setup
+    Pirate.nested_attributes_options.delete :parrots
     Pirate.accepts_nested_attributes_for :parrots, limit: :parrots_limit
 
     @pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?", parrots_limit: 2)
@@ -953,6 +980,7 @@ end
 
 class TestNestedAttributesLimitProc < ActiveRecord::TestCase
   def setup
+    Pirate.nested_attributes_options.delete :parrots
     Pirate.accepts_nested_attributes_for :parrots, limit: proc { 2 }
 
     @pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
@@ -965,6 +993,7 @@ class TestNestedAttributesWithNonStandardPrimaryKeys < ActiveRecord::TestCase
   fixtures :owners, :pets
 
   def setup
+    Owner.nested_attributes_options.delete :pets
     Owner.accepts_nested_attributes_for :pets, allow_destroy: true
 
     @owner = owners(:ashley)
@@ -1130,5 +1159,24 @@ class TestNestedAttributesForDelegatedType < ActiveRecord::TestCase
   def test_should_build_a_new_record_based_on_the_delegated_type
     assert_not_predicate @entry.entryable, :persisted?
     assert_equal "Hello world!", @entry.entryable.subject
+  end
+end
+
+class TestPreDeclaredNestedAttributesAssociation < ActiveRecord::TestCase
+  setup do
+    assert @current_options = Developer.nested_attributes_options[:projects]
+  end
+
+  def test_should_raise_an_argument_error_with_similar_options
+    assert_raises ArgumentError do
+      Developer.accepts_nested_attributes_for :projects, **@current_options
+    end
+  end
+
+  def test_should_raise_an_argument_error_with_varying_options
+    assert_equal false, @current_options[:update_only]
+    assert_raises ArgumentError do
+      Developer.accepts_nested_attributes_for :projects, **@current_options.merge(update_only: true)
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix https://github.com/rails/rails/issues/49055.

### Detail

This Pull Request changes `ActiveRecord::NestedAttributes#accepts_nested_attributes_for` to raise an `ArgumentError` when it has already been declared for an association **in the same class**. There is a use case for overriding this in subclasses, that functionality is unchanged.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
