### PR TITLE
upsert should accept update_only parameter like upsert_all does

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -249,8 +249,8 @@ module ActiveRecord
       # go through Active Record's type casting and serialization.
       #
       # See #upsert_all for documentation.
-      def upsert(attributes, on_duplicate: :update, returning: nil, unique_by: nil, record_timestamps: nil)
-        upsert_all([ attributes ], on_duplicate: on_duplicate, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
+      def upsert(attributes, **kwargs)
+        upsert_all([ attributes ], **kwargs)
       end
 
       # Updates or inserts (upserts) multiple records into the database in a


### PR DESCRIPTION
### Motivation / Background

`upsert` is just a proxy method to `upsert_all`, but when the `update_only` parameter was introduced to `upsert_all`, it wasn't added to `upsert` as well. I think the two methods should accept the same parameters.

### Additional information

Does this warrant a changelog entry?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
