### PR TITLE
Fix ActiveModel::Conversion._to_partial_path not using a model's model_name.

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -108,7 +108,9 @@ module ActiveModel
       # Provide a class level cache for #to_partial_path. This is an
       # internal method and should not be accessed directly.
       def _to_partial_path # :nodoc:
-        @_to_partial_path ||= begin
+        @_to_partial_path ||= if respond_to?(:model_name)
+          "#{model_name.collection}/#{model_name.element}"
+        else
           element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))
           collection = ActiveSupport::Inflector.tableize(name)
           "#{collection}/#{element}"

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -54,6 +54,10 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "helicopter/comanches/comanche", Helicopter::Comanche.new.to_partial_path
   end
 
+  test "to_partial_path handles non-standard model_name" do
+    assert_equal "attack_helicopters/ah-64", Helicopter::Apache.new.to_partial_path
+  end
+
   test "#to_param_delimiter allows redefining the delimiter used in #to_param" do
     old_delimiter = Contact.param_delimiter
     Contact.param_delimiter = "_"

--- a/activemodel/test/models/helicopter.rb
+++ b/activemodel/test/models/helicopter.rb
@@ -7,3 +7,16 @@ end
 class Helicopter::Comanche
   include ActiveModel::Conversion
 end
+
+class Helicopter::Apache
+  include ActiveModel::Conversion
+
+  class << self
+    def model_name
+      @model_name ||= ActiveModel::Name.new(self).tap do |model_name|
+        model_name.collection = "attack_helicopters"
+        model_name.element = "ah-64"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveModel::Conversion._to_partial_path` ignores the information provided by a model's `model_name`.

The partial path currently is composed of two bits, `collection` and `element` which are also fields provided by `ActiveModel::Name`. `_to_partial_path` derives these fields the same way as `ActiveModel::Name#initialize`.

This works for all standard cases, but not (necessarily) for models that provide a non-standard `model_name`. While users can define `MyModel#to_partial_path` to fix this on their end, I feel like this is something Rails should handle implicitly.

### Detail

This Pull Request changes `ActiveModel::Conversion._to_partial_path` to use the information provided by `model_name` if `self` responds to `model_name`. If not, it falls back to the existing implementation.

### Additional information

To conform with the existing helicopter test case, this change tests if `self` responds to `model_name`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
