### PR TITLE
Use SecureRandom.alphanumeric for SecureRandom.base36/base58

### DIFF
--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -16,12 +16,18 @@ module SecureRandom
   #
   #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
   #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
-  def self.base58(n = 16)
-    SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(58) if idx >= 58
-      BASE58_ALPHABET[idx]
-    end.join
+  if RUBY_VERSION >= "3.3"
+    def self.base58(n = 16)
+      SecureRandom.alphanumeric(n, chars: BASE58_ALPHABET)
+    end
+  else
+    def self.base58(n = 16)
+      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
+        idx = byte % 64
+        idx = SecureRandom.random_number(58) if idx >= 58
+        BASE58_ALPHABET[idx]
+      end.join
+    end
   end
 
   # SecureRandom.base36 generates a random base36 string in lowercase.
@@ -35,11 +41,17 @@ module SecureRandom
   #
   #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
   #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
-  def self.base36(n = 16)
-    SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(36) if idx >= 36
-      BASE36_ALPHABET[idx]
-    end.join
+  if RUBY_VERSION >= "3.3"
+    def self.base36(n = 16)
+      SecureRandom.alphanumeric(n, chars: BASE36_ALPHABET)
+    end
+  else
+    def self.base36(n = 16)
+      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
+        idx = byte % 64
+        idx = SecureRandom.random_number(36) if idx >= 36
+        BASE36_ALPHABET[idx]
+      end.join
+    end
   end
 end

--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -28,6 +28,18 @@ class SecureRandomTest < ActiveSupport::TestCase
     assert_match(/^[^0OIl]+$/, s2)
   end
 
+  def test_base58_with_nil
+    s1 = SecureRandom.base58(nil)
+    s2 = SecureRandom.base58(nil)
+
+    assert_not_equal s1, s2
+    assert_equal 16, s1.length
+    assert_match(/^[a-zA-Z0-9]+$/, s1)
+    assert_match(/^[a-zA-Z0-9]+$/, s2)
+    assert_match(/^[^0OIl]+$/, s1)
+    assert_match(/^[^0OIl]+$/, s2)
+  end
+
   def test_base36
     s1 = SecureRandom.base36
     s2 = SecureRandom.base36
@@ -44,6 +56,16 @@ class SecureRandomTest < ActiveSupport::TestCase
 
     assert_not_equal s1, s2
     assert_equal 24, s1.length
+    assert_match(/^[a-z0-9]+$/, s1)
+    assert_match(/^[a-z0-9]+$/, s2)
+  end
+
+  def test_base36_with_nil
+    s1 = SecureRandom.base36(nil)
+    s2 = SecureRandom.base36(nil)
+
+    assert_not_equal s1, s2
+    assert_equal 16, s1.length
     assert_match(/^[a-z0-9]+$/, s1)
     assert_match(/^[a-z0-9]+$/, s2)
   end


### PR DESCRIPTION
### Motivation / Background

Ruby 3.3 [allows passing](https://github.com/ruby/ruby/pull/8312) a list of characters to
`SecureRandom.alphanumeric`. For `SecureRandom.base36` using `choose` is
faster than the current implementation. For `SecureRandom.base58` it is
a bit slower.

I've also added a test to make sure passing nil as the length defaults it to 16.

### Detail

__Benchmark__

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "benchmark-ips"
end

require "active_support"
require "active_support/core_ext/securerandom"

module SecureRandom
  def self.fast_base36(n)
    n = n ? n.to_int : 16
    choose(BASE36_ALPHABET, n)
  end
end

[10, 100, 1000, 10000].each do |length|
  puts
  puts " #{length} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("base36")      { SecureRandom.base36(length) }
    x.report("fast_base36") { SecureRandom.fast_base36(length) }
    x.compare!
  end
end
```

 __Results for base36__

      ====================================== 10 ======================================

      Warming up --------------------------------------
                    base36    20.513k i/100ms
               fast_base36    24.843k i/100ms
      Calculating -------------------------------------
                    base36    200.940k (±13.8%) i/s -    984.624k in   5.060203s
               fast_base36    235.531k (± 5.7%) i/s -      1.192M in   5.080574s

      Comparison:
               fast_base36:   235530.9 i/s
                    base36:   200939.9 i/s - same-ish: difference falls within error

      ===================================== 100 ======================================

      Warming up --------------------------------------
                    base36     2.746k i/100ms
               fast_base36     2.995k i/100ms
      Calculating -------------------------------------
                    base36     25.559k (± 8.5%) i/s -    129.062k in   5.087961s
               fast_base36     30.265k (± 6.6%) i/s -    152.745k in   5.070263s

      Comparison:
               fast_base36:    30264.7 i/s
                    base36:    25558.8 i/s - 1.18x  slower

      ===================================== 1000 =====================================

      Warming up --------------------------------------
                    base36   278.000  i/100ms
               fast_base36   308.000  i/100ms
      Calculating -------------------------------------
                    base36      2.595k (±11.6%) i/s -     12.788k in   5.007921s
               fast_base36      3.133k (± 6.1%) i/s -     15.708k in   5.033310s

      Comparison:
               fast_base36:     3132.6 i/s
                    base36:     2594.9 i/s - 1.21x  slower

      ==================================== 10000 =====================================

      Warming up --------------------------------------
                    base36    24.000  i/100ms
               fast_base36    34.000  i/100ms
      Calculating -------------------------------------
                    base36    256.601  (± 8.6%) i/s -      1.296k in   5.089604s
               fast_base36    322.119  (± 6.5%) i/s -      1.632k in   5.089614s

      Comparison:
               fast_base36:      322.1 i/s
                    base36:      256.6 i/s - 1.26x  slower

 __Results for base58__

      ====================================== 10 ======================================

      Warming up --------------------------------------
                    base58    33.181k i/100ms
               fast_base58    24.859k i/100ms
      Calculating -------------------------------------
                    base58    333.202k (± 6.7%) i/s -      1.659M in   5.002939s
               fast_base58    243.700k (±10.2%) i/s -      1.218M in   5.058493s

      Comparison:
                    base58:   333201.6 i/s
               fast_base58:   243700.5 i/s - 1.37x  slower

      ===================================== 100 ======================================

      Warming up --------------------------------------
                    base58     4.703k i/100ms
               fast_base58     2.957k i/100ms
      Calculating -------------------------------------
                    base58     45.411k (±11.3%) i/s -    225.744k in   5.046111s
               fast_base58     27.600k (± 8.6%) i/s -    138.979k in   5.077366s

      Comparison:
                    base58:    45410.8 i/s
               fast_base58:    27599.7 i/s - 1.65x  slower

      ===================================== 1000 =====================================

      Warming up --------------------------------------
                    base58   571.000  i/100ms
               fast_base58   295.000  i/100ms
      Calculating -------------------------------------
                    base58      5.268k (± 9.5%) i/s -     26.266k in   5.036386s
               fast_base58      2.854k (± 8.7%) i/s -     14.160k in   5.000566s

      Comparison:
                    base58:     5267.5 i/s
               fast_base58:     2854.4 i/s - 1.85x  slower

      ==================================== 10000 =====================================

      Warming up --------------------------------------
                    base58    52.000  i/100ms
               fast_base58    31.000  i/100ms
      Calculating -------------------------------------
                    base58    521.886  (±10.2%) i/s -      2.600k in   5.045054s
               fast_base58    294.473  (± 9.8%) i/s -      1.457k in   5.002835s

      Comparison:
                    base58:      521.9 i/s
               fast_base58:      294.5 i/s - 1.77x  slower

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
