### PR TITLE
Fix form_for id generation for new CPK models

### DIFF
--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -112,7 +112,7 @@ module ActionView
     # make sure yourself that your dom ids are valid, in case you override this method.
     def record_key_for_dom_id(record) # :doc:
       key = convert_to_model(record).to_key
-      key ? key.join(JOIN) : key
+      key && key.all? ? key.join(JOIN) : nil
     end
   end
 end

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -218,12 +218,27 @@ class Plane
   end
 end
 
-class CompositePrimaryKeyRecord
-  extend ActiveModel::Naming
-  include ActiveModel::Conversion
-  attr_reader :id
+module Cpk
+  class Book < Struct.new(:author_id, :id, :title)
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
 
-  def initialize(id)
-    @id = id
+    def initialize(author_id: nil, id: nil, title: nil)
+      self.author_id = author_id
+      self.title = title
+      self.id = id
+    end
+
+    def persisted?
+      id.all?
+    end
+
+    def id
+      [@author_id, @id]
+    end
+
+    def id=(id)
+      @author_id, @id = Array(id)
+    end
   end
 end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -156,6 +156,10 @@ class FormHelperTest < ActionView::TestCase
       end
     end
 
+    namespace(:cpk) do
+      resources(:books)
+    end
+
     get "/foo", to: "controller#action"
     root to: "main#index"
   end
@@ -4111,6 +4115,20 @@ class FormHelperTest < ActionView::TestCase
 
     form_for(@post, builder: builder_class) { }
     assert_equal 1, initialization_count, "form builder instantiated more than once"
+  end
+
+  def test_form_for_with_new_cpk_model
+    form_for(Cpk::Book.new) { }
+
+    expected = whole_form("/cpk/books", "new_cpk_book", "new_cpk_book", method: "post")
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_form_for_with_persisted_cpk_model
+    form_for(Cpk::Book.new(id: [1, 2], title: "Some book")) { }
+
+    expected = whole_form("/cpk/books/1-2", "edit_cpk_book_1_2", "edit_cpk_book", method: "patch")
+    assert_dom_equal expected, @rendered
   end
 
   private

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -31,8 +31,8 @@ class RecordIdentifierTest < ActiveSupport::TestCase
   end
 
   def test_dom_id_with_composite_primary_key_record
-    record = CompositePrimaryKeyRecord.new([1, 123])
-    assert_equal("composite_primary_key_record_1_123", dom_id(record))
+    record = Cpk::Book.new(id: [1, 123])
+    assert_equal("cpk_book_1_123", dom_id(record))
   end
 
   def test_dom_id_with_prefix


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because dom ID generation for CPK models is subtly broken.

### Detail

This Pull Request changes Action View by adding tests for form_for when using composite primary key models and fixes `dom_id` output for new CPK models.

### Additional information

Every record key casting is either going to be nil or an array, so the code should be safe.

Also, I removed the original `CompositePrimaryKeyRecord` because it didn't follow the existing pattern of using example-based models in tests. As a result, I updated the test using it to use the new fake CPK model.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
