### PR TITLE
Encryption: support `support_unencrypted_data` at a per-attribute level

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Encryption now supports `support_unencrypted_data` being set per-attribute.
+
+    You can now opt out of `support_unencrypted_data` on a specific encrypted attribute.
+    This only has an effect if `ActiveRecord::Encryption.config.support_unencrypted_data == true`.
+
+    ```ruby
+    class User < ActiveRecord::Base
+      encrypts :name, deterministic: true, support_unencrypted_data: false
+      encrypts :email, deterministic: true
+    end
+    ```
+
+    *Alex Ghiculescu*
+
 *   Add instrumentation for Active Record transactions
 
     Allows subscribing to transaction events for tracking/instrumentation. The event payload contains the connection, as well as timing details.

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -54,6 +54,10 @@ module ActiveRecord
         @previous_types[support_unencrypted_data?] ||= build_previous_types_for(previous_schemes_including_clean_text)
       end
 
+      def support_unencrypted_data?
+        ActiveRecord::Encryption.config.support_unencrypted_data && scheme.support_unencrypted_data? && !previous_type?
+      end
+
       private
         def previous_schemes_including_clean_text
           previous_schemes.including((clean_text_scheme if support_unencrypted_data?)).compact
@@ -129,10 +133,6 @@ module ActiveRecord
 
         def encryptor
           ActiveRecord::Encryption.encryptor
-        end
-
-        def support_unencrypted_data?
-          ActiveRecord::Encryption.config.support_unencrypted_data && !previous_type?
         end
 
         def encryption_options

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -19,24 +19,25 @@ module ActiveRecord
     # * ActiveRecord::Base - Used in <tt>Contact.find_by_email_address(...)</tt>
     # * ActiveRecord::Relation - Used in <tt>Contact.internal.find_by_email_address(...)</tt>
     #
-    # ActiveRecord::Base relies on ActiveRecord::Relation (ActiveRecord::QueryMethods) but it does
-    # some prepared statements caching. That's why we need to intercept +ActiveRecord::Base+ as soon
-    # as it's invoked (so that the proper prepared statement is cached).
-    #
-    # When modifying this file run performance tests in +test/performance/extended_deterministic_queries_performance_test.rb+ to
-    #   make sure performance overhead is acceptable.
-    #
-    # We will extend this to support previous "encryption context" versions in future iterations
-    #
-    # @TODO Experimental. Support for every kind of query is pending
-    # @TODO It should not patch anything if not needed (no previous schemes or no support for previous encryption schemes)
+    # This module is included if `config.active_record.encryption.extend_queries` is `true`.
     module ExtendedDeterministicQueries
       def self.install_support
+        # ActiveRecord::Base relies on ActiveRecord::Relation (ActiveRecord::QueryMethods) but it does
+        # some prepared statements caching. That's why we need to intercept +ActiveRecord::Base+ as soon
+        # as it's invoked (so that the proper prepared statement is cached).
         ActiveRecord::Relation.prepend(RelationQueries)
         ActiveRecord::Base.include(CoreQueries)
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
         Arel::Nodes::HomogeneousIn.prepend(InWithAdditionalValues)
       end
+
+      # When modifying this file run performance tests in
+      # +activerecord/test/cases/encryption/performance/extended_deterministic_queries_performance_test.rb+
+      # to make sure performance overhead is acceptable.
+      #
+      # @TODO We will extend this to support previous "encryption context" versions in future iterations
+      # @TODO Experimental. Support for every kind of query is pending
+      # @TODO It should not patch anything if not needed (no previous schemes or no support for previous encryption schemes)
 
       module EncryptedQuery # :nodoc:
         class << self

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     class Scheme
       attr_accessor :previous_schemes
 
-      def initialize(key_provider: nil, key: nil, deterministic: nil, downcase: nil, ignore_case: nil,
+      def initialize(key_provider: nil, key: nil, deterministic: nil, support_unencrypted_data: nil, downcase: nil, ignore_case: nil,
                      previous_schemes: nil, **context_properties)
         # Initializing all attributes to +nil+ as we want to allow a "not set" semantics so that we
         # can merge schemes without overriding values with defaults. See +#merge+
@@ -18,6 +18,7 @@ module ActiveRecord
         @key_provider_param = key_provider
         @key = key
         @deterministic = deterministic
+        @support_unencrypted_data = support_unencrypted_data
         @downcase = downcase || ignore_case
         @ignore_case = ignore_case
         @previous_schemes_param = previous_schemes
@@ -37,6 +38,10 @@ module ActiveRecord
 
       def deterministic?
         !!@deterministic
+      end
+
+      def support_unencrypted_data?
+        @support_unencrypted_data.nil? ? ActiveRecord::Encryption.config.support_unencrypted_data : @support_unencrypted_data
       end
 
       def fixed?

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -9,19 +9,19 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
   end
 
   test "Finds records when data is unencrypted" do
-    ActiveRecord::Encryption.without_encryption { UnencryptedBook.create! name: "Dune" }
+    UnencryptedBook.create!(name: "Dune")
     assert EncryptedBook.find_by(name: "Dune") # core
     assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end
 
   test "Finds records when data is encrypted" do
-    UnencryptedBook.create! name: "Dune"
+    EncryptedBook.create!(name: "Dune")
     assert EncryptedBook.find_by(name: "Dune") # core
     assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end
 
   test "Works well with downcased attributes" do
-    ActiveRecord::Encryption.without_encryption { EncryptedBookWithDowncaseName.create! name: "Dune" }
+    EncryptedBookWithDowncaseName.create! name: "Dune"
     assert EncryptedBookWithDowncaseName.find_by(name: "DUNE")
   end
 
@@ -44,7 +44,31 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
   end
 
   test "exists?(...) works" do
-    ActiveRecord::Encryption.without_encryption { EncryptedBook.create! name: "Dune" }
+    EncryptedBook.create! name: "Dune"
     assert EncryptedBook.exists?(name: "Dune")
+  end
+
+  test "If support_unencrypted_data is opted out at the attribute level, cannot find unencrypted data" do
+    UnencryptedBook.create! name: "Dune"
+    assert_nil EncryptedBookWithUnencryptedDataOptedOut.find_by(name: "Dune") # core
+    assert_nil EncryptedBookWithUnencryptedDataOptedOut.where("id > 0").find_by(name: "Dune") # relation
+  end
+
+  test "If support_unencrypted_data is opted out at the attribute level, can find encrypted data" do
+    EncryptedBook.create! name: "Dune"
+    assert EncryptedBookWithUnencryptedDataOptedOut.find_by(name: "Dune") # core
+    assert EncryptedBookWithUnencryptedDataOptedOut.where("id > 0").find_by(name: "Dune") # relation
+  end
+
+  test "If support_unencrypted_data is opted in at the attribute level, can find unencrypted data" do
+    UnencryptedBook.create! name: "Dune"
+    assert EncryptedBookWithUnencryptedDataOptedIn.find_by(name: "Dune") # core
+    assert EncryptedBookWithUnencryptedDataOptedIn.where("id > 0").find_by(name: "Dune") # relation
+  end
+
+  test "If support_unencrypted_data is opted in at the attribute level, can find encrypted data" do
+    EncryptedBook.create! name: "Dune"
+    assert EncryptedBookWithUnencryptedDataOptedIn.find_by(name: "Dune") # core
+    assert EncryptedBookWithUnencryptedDataOptedIn.where("id > 0").find_by(name: "Dune") # relation
   end
 end

--- a/activerecord/test/cases/encryption/uniqueness_validations_test.rb
+++ b/activerecord/test/cases/encryption/uniqueness_validations_test.rb
@@ -15,10 +15,27 @@ class ActiveRecord::Encryption::UniquenessValidationsTest < ActiveRecord::Encryp
   test "uniqueness validations work when mixing encrypted an unencrypted data" do
     ActiveRecord::Encryption.config.support_unencrypted_data = true
 
-    ActiveRecord::Encryption.without_encryption { EncryptedBookWithDowncaseName.create! name: "dune" }
-
+    UnencryptedBook.create! name: "dune"
     assert_raises ActiveRecord::RecordInvalid do
-      EncryptedBookWithDowncaseName.create!(name: "dune")
+      EncryptedBookWithDowncaseName.create!(name: "DUNE")
+    end
+  end
+
+  test "uniqueness validations do not work when mixing encrypted an unencrypted data and unencrypted data is opted out per-attribute" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+
+    UnencryptedBook.create! name: "dune"
+    assert_nothing_raised do
+      EncryptedBookWithUnencryptedDataOptedOut.create!(name: "dune")
+    end
+  end
+
+  test "uniqueness validations work when mixing encrypted an unencrypted data and unencrypted data is opted in per-attribute" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+
+    UnencryptedBook.create! name: "dune"
+    assert_raises ActiveRecord::RecordInvalid do
+      EncryptedBookWithUnencryptedDataOptedIn.create!(name: "dune")
     end
   end
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -70,5 +70,7 @@ ActiveRecord::Encryption.configure \
   deterministic_key: "test deterministic key",
   key_derivation_salt: "testing key derivation salt"
 
+# Simulate https://github.com/rails/rails/blob/735cba5bed7a54c7397dfeec1bed16033ae286f8/activerecord/lib/active_record/railtie.rb#L392
+ActiveRecord::Encryption.config.extend_queries = true
 ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
 ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -22,3 +22,17 @@ class EncryptedBookThatIgnoresCase < ActiveRecord::Base
 
   encrypts :name, deterministic: true, ignore_case: true
 end
+
+class EncryptedBookWithUnencryptedDataOptedOut < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  validates :name, uniqueness: true
+  encrypts :name, deterministic: true, support_unencrypted_data: false
+end
+
+class EncryptedBookWithUnencryptedDataOptedIn < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  validates :name, uniqueness: true
+  encrypts :name, deterministic: true, support_unencrypted_data: true
+end


### PR DESCRIPTION
If `ActiveRecord::Encryption.config.support_unencrypted_data == true`, this allows you to do:

```ruby
class User < ActiveRecord::Base
  encrypts :name, deterministic: true, support_unencrypted_data: false
  encrypts :email, deterministic: true
end
```

Now only the `email` column will allow unencrypted data (and if `extend_queries` is true, only `email` queries will get extended). [Here](https://github.com/rails/rails/pull/49072#issuecomment-1697170252) is some back story on why you might want this.