### PR TITLE
[skip ci] Railties, ActionPack notable changes and deprecations added to 7.1 release note

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -215,11 +215,15 @@ Please refer to the [Changelog][railties] for detailed changes.
 
 *   Remove deprecated `bin/rails secrets:setup` command.
 
+*   Remove default `X-Download-Options` header since it is used only by Internet Explorer.
+
 ### Deprecations
 
 *   Deprecated usage of `Rails.application.secrets`.
 
 *   Deprecated `secrets:show` and `secrets:edit` commands in favor of `credentials`.
+
+*   Deprecated `Rails::Generators::Testing::Behaviour` in favor of `Rails::Generators::Testing::Behavior`.
 
 ### Notable changes
 
@@ -268,7 +272,17 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Deprecate `ActionDispatch::IllegalStateError`.
 
+*   Deprecate `speaker`, `vibrate`, and `vr` permissions policy directives.
+
 ### Notable changes
+
+*   Add `exclude?` method to `ActionController::Parameters`. It is the inverse of `include?` method.
+
+*   Add `ActionController::Parameters#extract_value` method to allow extracting serialized values from params.
+
+*   Add the ability to use custom logic for storing and retrieving CSRF tokens.
+
+*   Add `html` and `screenshot` kwargs for system test screenshot helper.
 
 Action View
 -----------


### PR DESCRIPTION
### Detail

This Pull Request updated,
 - Updated `ActionPack` notable changes, and deprecations
 -  UIpdated `Railties`  removal and deprecations
in  Rails 7.1 release note.
### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
