### PR TITLE
Makes sure values have the correct type in _update_record. Fixes #49009.

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -593,7 +593,7 @@ module ActiveRecord
 
       def _update_record(values, constraints) # :nodoc:
         constraints = constraints.map { |name, value| predicate_builder[name, value] }
-
+        values = values.transform_values { |value| value.with_type(arel_table.type_for_attribute(value.name)) }
         default_constraint = build_default_constraint
         constraints << default_constraint if default_constraint
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -24,6 +24,8 @@ require "models/admin/user"
 require "models/cpk"
 require "models/chat_message"
 require "models/default"
+require "models/book"
+require "models/book_encrypted"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses,
@@ -1571,5 +1573,15 @@ class QueryConstraintsTest < ActiveRecord::TestCase
 
   def test_child_class_with_query_constraints_overrides_parents
     assert_equal(["clothing_type", "color", "size"], ClothingItem::Sized.query_constraints_list)
+  end
+
+  def test_update_after_becomes
+    book = Book.create!(name: "adf")
+    converted_book = book.becomes(EncryptedBookCustomType)
+    converted_book.name = "Testing"
+    converted_book.save
+
+    name = Book.find(converted_book.id).name
+    assert_includes ["1", "t"], name
   end
 end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -36,3 +36,9 @@ class EncryptedBookWithUnencryptedDataOptedIn < ActiveRecord::Base
   validates :name, uniqueness: true
   encrypts :name, deterministic: true, support_unencrypted_data: true
 end
+
+class EncryptedBookCustomType < ActiveRecord::Base
+  self.table_name = "books"
+
+  attribute :name, :boolean
+end


### PR DESCRIPTION
By transforming the values hash and adding in the type from the table it's being added to it ensures that the correct Type is used for the table.  This enables a user to make sure the specified type is used if one is set in the model. 

Fixes #49009.
### Checklist

Before submitting the PR make sure the following are checked:

* [ X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ X] Tests are added or updated if you fix a bug or add a feature.
* [ X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
