### PR TITLE
Fix to_param id generation for partial composite keys

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1302,7 +1302,7 @@ class PolymorphicControllerTest < ActionController::TestCase
     @routes = WorkshopsController::ROUTES
   end
 
-  def test_new_resource
+  def test_index_resource
     @controller = WorkshopsController.new
 
     get :index
@@ -1314,6 +1314,13 @@ class PolymorphicControllerTest < ActionController::TestCase
 
     get :show, params: { id: 1 }
     assert_equal %{/workshops/1\n<a href="/workshops/1">Workshop</a>}, @response.body
+  end
+
+  def test_existing_cpk_resource
+    @controller = WorkshopsController.new
+
+    get :show, params: { id: "1-27" }
+    assert_equal %{/workshops/1-27\n<a href="/workshops/1-27">Workshop</a>}, @response.body
   end
 
   def test_current_page_when_options_does_not_respond_to_to_hash

--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -88,7 +88,7 @@ module ActiveModel
     #   person = Person.new(1)
     #   person.to_param # => "1"
     def to_param
-      (persisted? && key = to_key) ? key.join(self.class.param_delimiter) : nil
+      (persisted? && (key = to_key) && key.all?) ? key.join(self.class.param_delimiter) : nil
     end
 
     # Returns a +string+ identifying the path associated with the object.

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -34,6 +34,10 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "abc-xyz", Contact.new(id: ["abc", "xyz"]).to_param
   end
 
+  test "to_param returns nil if composite id is incomplete" do
+    assert_nil Contact.new(id: [1, nil]).to_param
+  end
+
   test "to_param returns nil if to_key is nil" do
     klass = Class.new(Contact) do
       def persisted?


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because parameter generation for CPK models is subtly broken.

### Detail

This Pull Request changes Action View and Active Model by adding tests for url_for when using composite primary key models and fixes to_param output for CPK models with partially complete IDs (eg. one column has a value but the other doesn't).

### Additional information

Somewhat similar to https://github.com/rails/rails/pull/49069, which made me think that `to_key` might actually be the source of both bugs. However, after reviewing the documentation, it seems like the current behaviour is correct: https://github.com/rails/rails/blob/9d8ac620afc44d5f2b872b0710177852933c82d3/activemodel/lib/active_model/conversion.rb#L53-L54
Note _any_ attribute being set, so partial CPK IDs are expected. I assume we don't want parameters with incomplete CPK IDs, so I fixed it in `to_param` instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
