### PR TITLE
Remove outdated libxml-ruby version spec in XmlMini doc comment

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   # = \XmlMini
   #
   # To use the much faster libxml parser:
-  #   gem 'libxml-ruby', '=0.9.7'
+  #   gem 'libxml-ruby'
   #   XmlMini.backend = 'LibXML'
   module XmlMini
     extend self


### PR DESCRIPTION
### Motivation / Background

XmlMini is currently being tested against libxml-ruby 4.0.0[^1], but the doc comment for XmlMini says:

```
To use the much faster libxml parser:
gem 'libxml-ruby', '=0.9.7'
```

This comment seems to be very much out of date and could mislead users.

### Detail

This PR fixes the comment by removing the version specifier so that the documentation simply recommends:

```
To use the much faster libxml parser:
gem 'libxml-ruby'
XmlMini.backend = 'LibXML'
```

[^1]: https://github.com/rails/rails/blob/621bc6854819847686133a7adb775cf718153fc6/Gemfile.lock#L310
