### PR TITLE
Log delivery errors in ActionMailer::LogSubscriber

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -11,8 +11,9 @@ module ActionMailer
     # An email was delivered.
     def deliver(event)
       info do
-        perform_deliveries = event.payload[:perform_deliveries]
-        if perform_deliveries
+        if exception = event.payload[:exception_object]
+          "Failed delivery of mail #{event.payload[:message_id]} error_class=#{exception.class} error_message=#{exception.message.inspect}"
+        elsif event.payload[:perform_deliveries]
           "Delivered mail #{event.payload[:message_id]} (#{event.duration.round(1)}ms)"
         else
           "Skipped delivery of mail #{event.payload[:message_id]} as `perform_deliveries` is false"

--- a/actionmailer/test/log_subscriber_test.rb
+++ b/actionmailer/test/log_subscriber_test.rb
@@ -13,12 +13,6 @@ class AMLogSubscriberTest < ActionMailer::TestCase
     ActionMailer::LogSubscriber.attach_to :action_mailer
   end
 
-  class TestMailer < ActionMailer::Base
-    def receive(mail)
-      # Do nothing
-    end
-  end
-
   class BogusDelivery
     def initialize(*)
     end


### PR DESCRIPTION
In case of mail delivery errors, the old ActionMailer::LogSubscriber erroneously logged a "Delivered mail ..." line.
With this change it checks the passed exception object and logs a "Failed delivery of mail" line instead.

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
