### PR TITLE
Allow Active Record to derive the association query constraints

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -532,6 +532,8 @@ module ActiveRecord
           primary_key_options
         elsif reflection.options[:query_constraints] && (query_constraints = record.class.query_constraints_list)
           query_constraints
+        elsif record.class.has_query_constraints? && !reflection.options[:foreign_key]
+          record.class.query_constraints_list
         else
           record.class.primary_key
         end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -6,10 +6,10 @@ module Sharded
     query_constraints :blog_id, :id
 
     belongs_to :blog
-    has_many :comments, query_constraints: [:blog_id, :blog_post_id]
-    has_many :delete_comments, class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id], dependent: :delete_all
+    has_many :comments
+    has_many :delete_comments, class_name: "Sharded::Comment", dependent: :delete_all
 
-    has_many :blog_post_tags, query_constraints: [:blog_id, :blog_post_id]
+    has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
   end
 end

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -3,8 +3,9 @@
 module Sharded
   class BlogPostTag < ActiveRecord::Base
     self.table_name = :sharded_blog_posts_tags
+    query_constraints :blog_id, :id
 
-    belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
-    belongs_to :tag, query_constraints: [:blog_id, :tag_id]
+    belongs_to :blog_post
+    belongs_to :tag
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_comments
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post, query_constraints: [:blog_id, :blog_post_id]
+    belongs_to :blog_post
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id
     belongs_to :blog
   end

--- a/activerecord/test/models/sharded/tag.rb
+++ b/activerecord/test/models/sharded/tag.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_tags
     query_constraints :blog_id, :id
 
-    has_many :blog_post_tags, query_constraints: [:blog_id, :tag_id]
+    has_many :blog_post_tags
     has_many :blog_posts, through: :blog_post_tags
   end
 end


### PR DESCRIPTION
Active Record already has the ability to guess the foreign key. With query constraints we can use the information from the owner class and that foreign key to infer what the query constraints should be for an association. This change improves the ergonomics of the query constraints feature by making it so that you only have to define the query constraints on the top level model and skip defining it on the association. There are a few caveats to this as of this PR:

- If the query constraints on the parent are greater than 2, Rails can't derive the association constraints
- If the query constraints on the parent don't include the primary key, Rails can't derive the association constraints.
- I have not implemented support for CPK yet as it's more complex and maybe not possible since we don't know which key to split on and use for the foreign association.

Prior to this change you would need to do the following to use query constraints:

```ruby
class Post
  query_constraints :blog_id, :id

  has_many :comments, query_constraints: [:blog_id, :blog_post_id]
end

class Comment
  query_constraints :blog_id, :id

  belongs_to :blog, query_constraints: [:blog_id, :blog_post_id]
end
```

After this change, the associations don't require you to set the query constraints, Active Record will generate `[:blog_id, :blog_post_id]` foreign key itself.

```ruby
class Post
  query_constraints :blog_id, :id

  has_many :comments
end

class Comment
  query_constraints :blog_id, :id

  belongs_to :blog
end
```