### PR TITLE
Prevent `NoMethodError` in extract_value when specifying non-existent keys

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -931,8 +931,9 @@ module ActionController
     #   params = ActionController::Parameters.new(id: "1_123", tags: "ruby,rails")
     #   params.extract_value(:id) # => ["1", "123"]
     #   params.extract_value(:tags, delimiter: ",") # => ["ruby", "rails"]
+    #   params.extract_value(:non_existent_key) # => nil
     def extract_value(key, delimiter: "_")
-      @parameters[key].split(delimiter)
+      @parameters[key]&.split(delimiter)
     end
 
     protected

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -430,5 +430,6 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
     assert_equal(["1", "123"], params.extract_value(:id))
     assert_equal(["ruby", "rails", "web"], params.extract_value(:tags, delimiter: ","))
+    assert_nil(params.extract_value(:non_existent_key))
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Introduced in https://github.com/rails/rails/pull/49042, the method `ActionController::Parameters#extract_value` promises to replace utility methods that were previously defined as private methods in controllers.
However, it currently throws a `NoMethodError` when passed a non-existent key.

`params` is dependent on client requests and is thus beyond the application's control.
Rather than throwing a `NoMethodError`, it would be more convenient for the method to return `nil`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
