### PR TITLE
Fix alias_attribute deprecation warning and message

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -96,9 +96,9 @@ module ActiveRecord
           should_warn = target_name == old_name
           if should_warn
             ActiveRecord.deprecator.warn(
-              "#{self} model aliases `#{old_name}`, but #{old_name} is not an attribute. " \
-              "Starting in Rails 7.2 `, alias_attribute with non-attribute targets will raise. " \
-              "Use `alias_method :#{new_name}`, :#{old_name} or define the method manually."
+              "#{self} model aliases `#{old_name}`, but `#{old_name}` is not an attribute. " \
+              "Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. " \
+              "Use `alias_method :#{new_name}, :#{old_name}` or define the method manually."
             )
           end
           super

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -444,44 +444,51 @@ module ActiveRecord
       end
 
       class Barcode < ActiveRecord::Base
+      end
+
+      class BarcodeCustomPk < ActiveRecord::Base
         self.primary_key = "code"
       end
 
       def test_copy_table_with_existing_records_have_custom_primary_key
-        connection = Barcode.connection
-        connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true) do |t|
+        connection = BarcodeCustomPk.connection
+        connection.create_table(:barcode_custom_pks, primary_key: "code", id: :string, limit: 42, force: true) do |t|
           t.text :other_attr
         end
         code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
-        Barcode.create!(code: code, other_attr: "xxx")
+        BarcodeCustomPk.create!(code: code, other_attr: "xxx")
 
-        connection.remove_column("barcodes", "other_attr")
+        connection.remove_column("barcode_custom_pks", "other_attr")
 
-        assert_equal code, Barcode.first.id
+        assert_equal code, BarcodeCustomPk.first.id
       ensure
-        Barcode.reset_column_information
+        BarcodeCustomPk.reset_column_information
+      end
+
+      class BarcodeCpk < ActiveRecord::Base
+        self.primary_key = ["region", "code"]
       end
 
       def test_copy_table_with_composite_primary_keys
-        connection = Barcode.connection
-        connection.create_table(:barcodes, primary_key: ["region", "code"], force: true) do |t|
+        connection = BarcodeCpk.connection
+        connection.create_table(:barcode_cpks, primary_key: ["region", "code"], force: true) do |t|
           t.string :region
           t.string :code
           t.text :other_attr
         end
         region = "US"
         code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
-        Barcode.create!(region: region, code: code, other_attr: "xxx")
+        BarcodeCpk.create!(region: region, code: code, other_attr: "xxx")
 
-        connection.remove_column("barcodes", "other_attr")
+        connection.remove_column("barcode_cpks", "other_attr")
 
-        assert_equal ["region", "code"], connection.primary_keys("barcodes")
+        assert_equal ["region", "code"], connection.primary_keys("barcode_cpks")
 
-        barcode = Barcode.first
+        barcode = BarcodeCpk.first
         assert_equal region, barcode.region
         assert_equal code, barcode.code
       ensure
-        Barcode.reset_column_information
+        BarcodeCpk.reset_column_information
       end
 
       def test_custom_primary_key_in_create_table

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1209,9 +1209,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with an overridden original method issues a deprecation" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehavior model aliases `title` and has a method called
-    `title_was` defined. Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
-    You may want to additionally define `subject_was` to preserve the current behavior.
+      AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehavior model aliases
+      `title` and has a method called `title_was` defined.
+      Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
+      You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 
     obj = assert_deprecated(message, ActiveRecord.deprecator) do
@@ -1236,9 +1237,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with an overridden original method from a module issues a deprecation" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehaviorFromModule model aliases `title` and has a method
-    called `title_was` defined. Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
-    You may want to additionally define `subject_was` to preserve the current behavior.
+      AttributeMethodsTest::ClassWithDeprecatedAliasAttributeBehaviorFromModule model aliases
+      `title` and has a method called `title_was` defined.
+      Starting in Rails 7.2 `subject_was` will not be calling `title_was` anymore.
+      You may want to additionally define `subject_was` to preserve the current behavior.
     MESSAGE
 
     obj = assert_deprecated(message, ActiveRecord.deprecator) do
@@ -1324,8 +1326,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with an _in_database method issues a deprecation warning" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithGeneratedAttributeMethodTarget model aliases `title_in_database`, but title_in_database is not an attribute.
-    Starting in Rails 7.2 `, alias_attribute with non-attribute targets will raise. Use `alias_method :saved_title`, :title_in_database or define the method manually.
+      AttributeMethodsTest::ClassWithGeneratedAttributeMethodTarget model aliases
+      `title_in_database`, but `title_in_database` is not an attribute.
+      Starting in Rails 7.2, alias_attribute with non-attribute targets will raise.
+      Use `alias_method :saved_title, :title_in_database` or define the method manually.
     MESSAGE
 
     obj = assert_deprecated(message, ActiveRecord.deprecator) do
@@ -1350,9 +1354,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with enum method issues a deprecation warning" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithEnumMethodTarget model aliases `pending?`, but pending? is not an attribute.
-    Starting in Rails 7.2 `, alias_attribute with non-attribute targets will raise.
-    Use `alias_method :is_pending?`, :pending? or define the method manually.
+    AttributeMethodsTest::ClassWithEnumMethodTarget model aliases `pending?`, but `pending?` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :is_pending?, :pending?` or define the method manually.
     MESSAGE
 
     obj = assert_deprecated(message, ActiveRecord.deprecator) do
@@ -1372,9 +1374,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with an association method issues a deprecation warning" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithAssociationTarget model aliases `author`, but author is not an attribute.
-    Starting in Rails 7.2 `, alias_attribute with non-attribute targets will raise.
-    Use `alias_method :written_by`, :author or define the method manually.
+    AttributeMethodsTest::ClassWithAssociationTarget model aliases `author`, but `author` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :written_by, :author` or define the method manually.
     MESSAGE
 
     obj = assert_deprecated(message, ActiveRecord.deprecator) do
@@ -1395,9 +1395,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "#alias_attribute with a manually defined method issues a deprecation warning" do
     message = <<~MESSAGE.gsub("\n", " ")
-    AttributeMethodsTest::ClassWithAliasedManuallyDefinedMethod model aliases `publish`, but publish is not an attribute.
-    Starting in Rails 7.2 `, alias_attribute with non-attribute targets will raise.
-    Use `alias_method :print`, :publish or define the method manually.
+      AttributeMethodsTest::ClassWithAliasedManuallyDefinedMethod model aliases `publish`,
+      but `publish` is not an attribute.
+      Starting in Rails 7.2, alias_attribute with non-attribute targets will raise.
+      Use `alias_method :print, :publish` or define the method manually.
     MESSAGE
 
     assert_deprecated(message, ActiveRecord.deprecator) do


### PR DESCRIPTION
I noticed this test was throwing a warning for `alias_attribute :id_value, :id` defined by Rails. Since this test messes with primary keys I decided to fix it by making custom classes for each of the tests that need to change the PK.

While debugging these tests I noticed the deprecation wasn't formatted correctly so I fixed that while in there.
