### PR TITLE
Make enums validatable without raising error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,6 +9,26 @@
 
     *Nikita Vasilevsky*
 
+*   Add validation option for `enum`
+
+    ```ruby
+    class Contract < ApplicationRecord
+      enum :status, %w[in_progress completed], validate: true
+    end
+    Contract.new(status: "unknown").valid? # => false
+    Contract.new(status: nil).valid? # => false
+    Contract.new(status: "completed").valid? # => true
+
+    class Contract < ApplicationRecord
+      enum :status, %w[in_progress completed], validate: { allow_nil: true }
+    end
+    Contract.new(status: "unknown").valid? # => false
+    Contract.new(status: nil).valid? # => true
+    Contract.new(status: "completed").valid? # => true
+    ```
+
+    *Edem Topuzov*
+
 *   Allow batching methods to use already loaded relation if available
 
     Calling batch methods on already loaded relations will use the records previously loaded instead of retrieving

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -313,6 +313,44 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "'unknown' is not a valid status", e.message
   end
 
+  test "validation with 'validate: true' option" do
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "Book"; end
+      enum :status, [:proposed, :written], validate: true
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+  end
+
+  test "validation with 'validate: hash' option" do
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "Book"; end
+      enum :status, [:proposed, :written], validate: { allow_nil: true }
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: nil)
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+  end
+
   test "NULL values from database should be casted to nil" do
     Book.where(id: @book.id).update_all("status = NULL")
     assert_nil @book.reload.status


### PR DESCRIPTION
### Motivation / Background

There is a pretty old issue #13971
@dhh offered to make such contributions in [2017](https://github.com/rails/rails/issues/13971#issuecomment-282989242)
But opened MR #41730 was not maintained since 2021
I tried to take into account the comments in that code review

### Detail

This Pull Request adds `:validate` option for enums

If you want the enum value to be validated before saving, use the option `:validate`:

```ruby
class Conversation < ApplicationRecord
  enum :status, %i[active archived], validate: true
end

conversation = Conversation.new

conversation.status = :unknown
conversation.valid? # => false

conversation.status = nil
conversation.valid? # => false

conversation.status = :active
conversation.valid? # => true
```

It is also possible to pass additional validation options:

```ruby
class Conversation < ApplicationRecord
  enum :status, %i[active archived], validate: { allow_nil: true }
end

conversation = Conversation.new

conversation.status = :unknown
conversation.valid? # => false

conversation.status = nil
conversation.valid? # => true

conversation.status = :active
conversation.valid? # => true
```

Otherwise `ArgumentError` will raise (standard current behavior):

```ruby
class Conversation < ApplicationRecord
  enum :status, %i[active archived]
end

conversation = Conversation.new

conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
```

### Additional information

This was intended as non-breaking change

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.