### PR TITLE
Document `where` support for AR `normalizes`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -856,6 +856,7 @@
       ```ruby
       class User < ActiveRecord::Base
         normalizes :email, with: -> email { email.strip.downcase }
+        normalizes :phone, with: -> phone { phone.delete("^0-9").delete_prefix("1") }
       end
 
       user = User.create(email: " CRUISE-CONTROL@EXAMPLE.COM\n")
@@ -865,8 +866,12 @@
       user.email                  # => "cruise-control@example.com"
       user.email_before_type_cast # => "cruise-control@example.com"
 
+      User.where(email: "\tCRUISE-CONTROL@EXAMPLE.COM ").count # => 1
+
       User.exists?(email: "\tCRUISE-CONTROL@EXAMPLE.COM ")         # => true
       User.exists?(["email = ?", "\tCRUISE-CONTROL@EXAMPLE.COM "]) # => false
+
+      User.normalize_value_for(:phone, "+1 (555) 867-5309") # => "5558675309"
       ```
 
     *Jonathan Hefner*

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -69,6 +69,8 @@ module ActiveRecord # :nodoc:
       #   user.email                  # => "cruise-control@example.com"
       #   user.email_before_type_cast # => "cruise-control@example.com"
       #
+      #   User.where(email: "\tCRUISE-CONTROL@EXAMPLE.COM ").count # => 1
+      #
       #   User.exists?(email: "\tCRUISE-CONTROL@EXAMPLE.COM ")         # => true
       #   User.exists?(["email = ?", "\tCRUISE-CONTROL@EXAMPLE.COM "]) # => false
       #

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -83,6 +83,16 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     assert_equal @aircraft, NormalizedAircraft.find_by(manufactured_at: @time.to_s)
   end
 
+  test "searches a record by normalized value" do
+    from_database = NormalizedAircraft.where(name: "fly HIGH")
+    assert_equal [@aircraft], from_database
+  end
+
+  test "searches a record by normalized values" do
+    from_database = NormalizedAircraft.where(name: ["fly LOW", "fly HIGH"])
+    assert_equal [@aircraft], from_database
+  end
+
   test "can stack normalizations" do
     titlecase_then_reverse = Class.new(NormalizedAircraft) do
       normalizes :name, with: -> name { name.reverse }

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -78,10 +78,12 @@ user = User.find_by(email: "\tCRUISE-CONTROL@EXAMPLE.COM ")
 user.email                  # => "cruise-control@example.com"
 user.email_before_type_cast # => "cruise-control@example.com"
 
+User.where(email: "\tCRUISE-CONTROL@EXAMPLE.COM ").count # => 1
+
 User.exists?(email: "\tCRUISE-CONTROL@EXAMPLE.COM ")         # => true
 User.exists?(["email = ?", "\tCRUISE-CONTROL@EXAMPLE.COM "]) # => false
 
-User.normalize(:phone, "+1 (555) 867-5309") # => "5558675309"
+User.normalize_value_for(:phone, "+1 (555) 867-5309") # => "5558675309"
 ```
 
 ### Add `ActiveRecord::Base.generates_token_for`


### PR DESCRIPTION
### Motivation / Background

Reading through the changelog for `normalized` made me wonder if it also works with `where`.  It says it works  with finder methods, but I don't think `where` is one of those. It works regardless, so I added it to the changelog and made some tests for it.

I also noticed some inconsistencies in the changelog, fixed those up too. I hope that's ok to put in one PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
