### PR TITLE
Fix `ActiveRecord.disconnect_all!` to not disable reconnect on pools

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         end
 
         def disconnect_all!
-          INSTANCES.each_key(&:disconnect!)
+          INSTANCES.each_key { |c| c.disconnect!(automatic_reconnect: true) }
         end
       end
 
@@ -44,7 +44,7 @@ module ActiveRecord
         end
       end
 
-      def disconnect!
+      def disconnect!(automatic_reconnect: false)
         ActiveSupport::ForkTracker.check!
 
         return unless @pool
@@ -52,7 +52,7 @@ module ActiveRecord
         synchronize do
           return unless @pool
 
-          @pool.automatic_reconnect = false
+          @pool.automatic_reconnect = automatic_reconnect
           @pool.disconnect!
         end
 

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "rack"
+
+class ActiveRecordTest < ActiveRecord::TestCase
+  unless in_memory_db?
+    test ".disconnect_all! closes all connections" do
+      ActiveRecord::Base.connection.active?
+      assert_predicate ActiveRecord::Base, :connected?
+
+      ActiveRecord.disconnect_all!
+      assert_not_predicate ActiveRecord::Base, :connected?
+
+      ActiveRecord::Base.connection.active?
+      assert_predicate ActiveRecord::Base, :connected?
+    end
+  end
+end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/47856

I'd would also like to add some `connect_all!` of some sort, as establishing the connection can take a bit of time, which tend to cause latency spikes post deploy. But I'm not too sure how to handle it for multi-threaded apps. We could pre-connect the whole pool, but in many case the pool size is much higher than how much connection are actually used. So this needs a bit more thoughts.