### PR TITLE
Remove useless include in DescendantsTracker

### DIFF
--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -66,8 +66,6 @@ module ActiveSupport
       end
     end
 
-    include ReloadedClassesFiltering
-
     class << self
       def disable_clear! # :nodoc:
         unless @clear_disabled


### PR DESCRIPTION
Either we are on a modern Ruby with `Class#subclass`, in which case `DescendantsTracker#subclass` isn't defined, so we don't need the filtering module.

Or we're on an old Ruby, and `DescendantsTracker.subclass` already does the filtering.
