### PR TITLE
Add CHANGELOG entries for `ActiveModel::Conversion#to_key` changes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support composite identifiers in `to_key`
+
+    `to_key` avoids wrapping `#id` value into an `Array` if `#id` already an array
+
+    *Nikita Vasilevsky*
+
 *   Add `ActiveModel::Conversion.param_delimiter` to configure delimiter being used in `to_param`
 
     *Nikita Vasilevsky*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support composite identifiers in `to_key`
+
+    `to_key` avoids wrapping `#id` value into an `Array` if `#id` already an array
+
+    *Nikita Vasilevsky*
+
 *   Allow batching methods to use already loaded relation if available
 
     Calling batch methods on already loaded relations will use the records previously loaded instead of retrieving


### PR DESCRIPTION
https://github.com/rails/rails/pull/48998 made changes to `to_key` in order to support composite identifiers. This commit adds CHANGELOG entries for those.

