### PR TITLE
Fix DescendantsTrackerTest when ran in isolation

### DIFF
--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -107,7 +107,7 @@ module ActiveSupport
       end
 
       def descendants
-        subclasses = self.subclasses
+        subclasses = DescendantsTracker.reject!(self.subclasses)
         subclasses.concat(subclasses.flat_map(&:descendants))
       end
     else


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/49108

DescendantsTracker need to work whether the `Class#descendants` core ext is loaded or not. I missed that in the previous PR.

cc @skipkayhil 