### PR TITLE
Infer `primary_key: :id` on associations with composite primary key models

### DIFF
--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1784,7 +1784,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenBook#order primary key ["shop_id", "id"]
+      Association Cpk::BrokenBook#order primary key ["shop_id", "status"]
       doesn't match with foreign key order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3199,7 +3199,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenOrder#books primary key ["shop_id", "id"]
+      Association Cpk::BrokenOrder#books primary key ["shop_id", "status"]
       doesn't match with foreign key broken_order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
@@ -3211,7 +3211,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-    Association Cpk::BrokenOrderWithNonCpkBooks#books primary key [\"shop_id\", \"id\"]
+    Association Cpk::BrokenOrderWithNonCpkBooks#books primary key [\"shop_id\", \"status\"]
     doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -922,7 +922,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenOrder#book primary key ["shop_id", "id"]
+      Association Cpk::BrokenOrder#book primary key ["shop_id", "status"]
       doesn't match with foreign key broken_order_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
@@ -934,7 +934,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenOrderWithNonCpkBooks#book primary key [\"shop_id\", \"id\"]
+      Association Cpk::BrokenOrderWithNonCpkBooks#book primary key [\"shop_id\", \"status\"]
       doesn't match with foreign key broken_order_with_non_cpk_books_id. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -13,7 +13,7 @@ module Cpk
   end
 
   class BrokenBook < Book
-    belongs_to :order
+    belongs_to :order, class_name: "Cpk::OrderWithSpecialPrimaryKey"
   end
 
   class BrokenBookWithNonCpkOrder < Book

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -9,17 +9,28 @@ module Cpk
 
     alias_attribute :id_value, :id
 
-    has_many :order_agreements, primary_key: :id
+    has_many :order_agreements
     has_many :books, query_constraints: [:shop_id, :order_id]
     has_one :book, query_constraints: [:shop_id, :order_id]
   end
 
   class BrokenOrder < Order
+    self.primary_key = [:shop_id, :status]
+
     has_many :books
     has_one :book
   end
 
+  class OrderWithSpecialPrimaryKey < Order
+    self.primary_key = [:shop_id, :status]
+
+    has_many :books, query_constraints: [:shop_id, :status]
+    has_one :book, query_constraints: [:shop_id, :status]
+  end
+
   class BrokenOrderWithNonCpkBooks < Order
+    self.primary_key = [:shop_id, :status]
+
     has_many :books, class_name: "Cpk::NonCpkBook"
     has_one :book, class_name: "Cpk::NonCpkBook"
   end
@@ -29,7 +40,7 @@ module Cpk
   end
 
   class OrderWithPrimaryKeyAssociatedBook < Order
-    has_one :book, primary_key: :id, foreign_key: :order_id
+    has_one :book, foreign_key: :order_id
   end
 
   class OrderWithNullifiedBook < Order

--- a/activerecord/test/models/cpk/order_agreement.rb
+++ b/activerecord/test/models/cpk/order_agreement.rb
@@ -5,6 +5,6 @@ module Cpk
   class OrderAgreement < ActiveRecord::Base
     self.table_name = :cpk_order_agreements
 
-    belongs_to :order, primary_key: :id # foreign key is derived as `order_id`
+    belongs_to :order
   end
 end

--- a/activerecord/test/models/cpk/order_tag.rb
+++ b/activerecord/test/models/cpk/order_tag.rb
@@ -5,6 +5,6 @@ module Cpk
     self.table_name = :cpk_order_tags
 
     belongs_to :tag
-    belongs_to :order, primary_key: :id
+    belongs_to :order
   end
 end


### PR DESCRIPTION
### Motivation / Background

Previously, a composite primary key model would need to specify either a `primary_key` or `query_constraints` option on its associations. Without it, a `CompositePrimaryKeyMismatchError` would be raised.

Most of the time, the composite primary key includes the `:id` column, and associations already expect that `:id` is being used as the primary key for the association (and the associated model is inferring a foreign key of `<cpk_model>_id`).

Rather than requiring users to define `primary_key: :id` throughout an application with composite primary key associations, we can infer that the `:id` column should be used. Users can still override this behaviour by specifying `primary_key:` or `query_constraints:` on the association.

Note that, if the composite primary key for a model does _not_ include `:id`, Rails **won't** infer the primary key for any related associations, and users must still specify `query_constraints` or `primary_key`.

Prior to this change, you'd need to do the following to set up associations for composite primary key models:

```ruby
class Order
  self.primary_key = [:shop_id, :id]

  has_many :order_agreements, primary_key: :id
end

class OrderAgreement
  belongs_to :order, primary_key: :id
end
```

After this change, the `primary_key` option no longer needs to be specified:

```ruby
class Order
  self.primary_key = [:shop_id, :id]

  has_many :order_agreements
end

class OrderAgreement
  belongs_to :order
end
```
### Detail

Most of the changes in this PR involve inferring the `primary_key` for an association, when a) the owner in the association is a composite primary key model, and b) the composite primary key includes `:id`.

I ended up refactoring `#save_has_one_association` to use `#compute_primary_key` so it could share this PK-inference logic with `#save_belongs_to_association`.

I also needed to change some of the models that were testing logic related to `CompositePrimaryKeyMismatchError`, since these associations are no longer malformed (as Active Record can now infer the primary_key on those associations properly). I opted to change the primary key on those "broken" models to exclude the `id` column, since that prevents Rails from inferring the PK on the association, and causes the expected `CompositePrimaryKeyMismatchError` to be raised.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
