### PR TITLE
Add option validation to HABTM, closes #48939

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 module ActiveRecord::Associations::Builder # :nodoc:
-  class HasAndBelongsToMany # :nodoc:
+  class HasAndBelongsToMany < CollectionAssociation # :nodoc:
     attr_reader :lhs_model, :association_name, :options
+
+    def self.valid_options(options)
+      super + %i[join_table association_foreign_key] - %i[primary_key query_constraints inverse_of dependent]
+    end
+
+    private_class_method :valid_options
 
     def initialize(association_name, lhs_model, options)
       @association_name = association_name
       @lhs_model = lhs_model
       @options = options
+      validate_options
     end
 
     def through_model
@@ -68,6 +75,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     private
+      def validate_options
+        self.class.send(:validate_options, @options)
+      end
+
       def middle_options(join_model)
         middle_options = {}
         middle_options[:class_name] = "#{lhs_model.name}::#{join_model.name}"

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -1009,4 +1009,14 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     sink = Sink.create! kitchen: Kitchen.new, sources: [Source.new]
     assert_equal 1, sink.sources.count
   end
+
+  def test_unknown_options
+    error = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        has_and_belongs_to_many :books, dependent: :destroy
+      end
+    end
+
+    assert_match(/Unknown key: :dependent/, error.message)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it's annoying that HABTM doesn't alert you when you supply the wrong options.

### Detail

This Pull Request changes HABTM so it works like the other associations and raises `ArgumentError` when you supply options that it doesn't handle.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Fixes #48939
