### PR TITLE
[skip ci] ActiveSupport deprecate changes added to 7.1 release note

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -575,6 +575,14 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 *   Deprecate `config.active_support.use_rfc4122_namespaced_uuids`.
 
+*   Deprecate `SafeBuffer#clone_empty`.
+
+*   Deprecate usage of the singleton `ActiveSupport::Deprecation`.
+
+*   Deprecated initializing a `ActiveSupport::Cache::MemCacheStore` with an instance of `Dalli::Client`.
+
+*   Deprecate `Notification::Event`'s `#children` and `#parent_of?` methods.
+
 ### Notable changes
 
 Active Job

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -579,7 +579,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 *   Deprecate usage of the singleton `ActiveSupport::Deprecation`.
 
-*   Deprecated initializing a `ActiveSupport::Cache::MemCacheStore` with an instance of `Dalli::Client`.
+*   Deprecate initializing a `ActiveSupport::Cache::MemCacheStore` with an instance of `Dalli::Client`.
 
 *   Deprecate `Notification::Event`'s `#children` and `#parent_of?` methods.
 


### PR DESCRIPTION
This PR updated the deprecate changes of ActiveSupport in the rails 7.1 release note.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
