### PR TITLE
Fix: simple_format with blank wrapper_tag option returns plain html tag.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Fix `simple_format` with blank `wrapper_tag` option returns plain html tag
+
+    By default `simple_format` method returns the text wrapped with `<p>`. But if we explicitly specify
+    the `wrapper_tag: nil` in the options, it returns the text wrapped with `<></>` tag.
+
+    Before:
+
+    ```ruby
+    simple_format("Hello World", {},  { wrapper_tag: nil })
+    # <>Hello World</>
+    ```
+
+    After:
+
+    ```ruby
+    simple_format("Hello World", {},  { wrapper_tag: nil })
+    # <p>Hello World</p>
+    ```
+
+    *Akhil G Krishnan*, *Junichi Ito*
+
 *   Don't double-encode nested `field_id` and `field_name` index values
 
     Pass `index: @options` as a default keyword argument to `field_id` and

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -320,7 +320,7 @@ module ActionView
       #   simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>", {}, { sanitize_options: { attributes: %w[target href] } })
       #   # => "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>"
       def simple_format(text, html_options = {}, options = {})
-        wrapper_tag = options.fetch(:wrapper_tag, :p)
+        wrapper_tag = options[:wrapper_tag] || "p"
 
         text = sanitize(text, options.fetch(:sanitize_options, {})) if options.fetch(:sanitize, true)
         paragraphs = split_paragraphs(text)

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -68,6 +68,7 @@ class TextHelperTest < ActionView::TestCase
 
   def test_simple_format_with_custom_wrapper
     assert_equal "<div></div>", simple_format(nil, {}, { wrapper_tag: "div" })
+    assert_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: nil })
   end
 
   def test_simple_format_with_custom_wrapper_and_multi_line_breaks


### PR DESCRIPTION
Partially Fixes #44948

By default `simple_format` method returns the text wrapped with `<p>`. But if we explicitly specify the `wrapper_tag: nil` in the options, it returns the text wrapped with `<></>` tag.

```ruby
simple_format("Hello World")
# <p>Hello World</p>

simple_format("Hello World", {},  {wrapper_tag: "div"})
# <div>Hello World</div>

simple_format("Hello World", {},  {wrapper_tag: nil})
# <>Hello World</>
```

### Detail

In this PR, it updates the behavior of the `simple_format` helper, If the user passes `nil` or an empty string as a value for `wrapper_tag` it defaults to use the `<p>` tag for wrapping.

```ruby
simple_format("Hello World", {},  {wrapper_tag: "div"})
# <div>Hello World</div>

simple_format("Hello World", {},  {wrapper_tag: nil})
# <p>Hello World</p>
```

 Co-authored-by: @JunichiIto 
 
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
