### PR TITLE
Fix change_column not setting precision for sqlite [7-0-stable]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `change_column` not setting `precision: 6` on `datetime` columns when
+    using 7.0+ Migrations and SQLite.
+
+    *Hartley McGuire*
+
 *   Fix unscope is not working in specific case
 
     Before:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
@@ -4,6 +4,12 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        def change_column(column_name, type, **options)
+          name = column_name.to_s
+          @columns_hash[name] = nil
+          column(name, type, **options)
+        end
+
         def references(*args, **options)
           super(*args, type: :integer, **options)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -287,10 +287,7 @@ module ActiveRecord
 
       def change_column(table_name, column_name, type, **options) # :nodoc:
         alter_table(table_name) do |definition|
-          definition[column_name].instance_eval do
-            self.type = aliased_types(type.to_s, type)
-            self.options.merge!(options)
-          end
+          definition.change_column(column_name, type, **options)
         end
       end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -314,22 +314,6 @@ module ActiveRecord
         end
       end
 
-      def test_datetime_doesnt_set_precision_on_create_table
-        migration = Class.new(ActiveRecord::Migration[6.1]) {
-          def migrate(x)
-            create_table :more_testings do |t|
-              t.datetime :published_at
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
-      ensure
-        connection.drop_table :more_testings rescue nil
-      end
-
       def test_datetime_doesnt_set_precision_on_add_column_5_0
         migration = Class.new(ActiveRecord::Migration[5.0]) {
           def migrate(x)
@@ -352,28 +336,6 @@ module ActiveRecord
         ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.column_exists?(:testings, :published_at, **precision_implicit_default)
-      end
-
-      def test_datetime_doesnt_set_precision_on_change_column_6_1
-        create_migration = Class.new(ActiveRecord::Migration[6.1]) {
-          def migrate(x)
-            create_table :more_testings do |t|
-              t.date :published_at
-            end
-          end
-        }.new(nil, 0)
-
-        change_migration = Class.new(ActiveRecord::Migration[6.1]) {
-          def migrate(x)
-            change_column :more_testings, :published_at, :datetime
-          end
-        }.new(nil, 1)
-
-        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
-
-        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
-      ensure
-        connection.drop_table :more_testings rescue nil
       end
 
       if current_adapter?(:SQLite3Adapter)
@@ -457,6 +419,44 @@ module DefaultPrecisionImplicitTestCases
     connection.drop_table :more_testings rescue nil
   end
 
+  def test_datetime_doesnt_set_precision_on_create_table
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.datetime :published_at
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_datetime_doesnt_set_precision_on_change_column
+    create_migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.date :published_at
+        end
+      end
+    }.new(nil, 0)
+
+    change_migration = Class.new(migration_class) {
+      def migrate(x)
+        change_column :more_testings, :published_at, :datetime
+      end
+    }.new(nil, 1)
+
+    ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+    assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
   private
     def precision_implicit_default
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
@@ -484,6 +484,44 @@ module DefaultPrecisionSixTestCases
         end
       end
     }.new(nil, 2)
+
+    ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+    assert connection.column_exists?(:more_testings, :published_at, precision: 6)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_datetime_sets_precision_6_on_create_table
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.datetime :published_at
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.column_exists?(:more_testings, :published_at, precision: 6)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_datetime_sets_precision_6_on_change_column
+    create_migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.date :published_at
+        end
+      end
+    }.new(nil, 0)
+
+    change_migration = Class.new(migration_class) {
+      def migrate(x)
+        change_column :more_testings, :published_at, :datetime
+      end
+    }.new(nil, 1)
 
     ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
 


### PR DESCRIPTION
### Motivation / Background

There were a few 6.1 migration compatibility fixes in [previous][1] [commits][2]. Most importantly, those commits reorganized some of the compatibility tests to ensure that the tests would run against every Migration version. To continue the effort of improving test coverage for Migration compatibility, this commit converts tests for create_table and change_column setting the correct precision on datetime columns.

### Detail

While the create_table tests all pass, the change_column test did not pass for 7.0 versioned Migrations on sqlite. This was due to the sqlite adapter not using new_column_definition to set the options on the new column (new_column_definition is where precision: 6 gets set if no precision is specified). This happens because columns can't be modified in place in sqlite and instead the whole table must be recreated and the data copied. Before this commit, change_column would use the options of the existing column as a base and merge in the exact options (and type) passed to change_column.

This commit changes the change_column method to replace the existing column without using the existing options. This ensures that precision: 6 is set consistently across adapters when change_column is used to create a datetime column.

### Additional information

Ref #49090

(manually backported to 7-0-stable because it did not apply cleanly)

[1]: https://github.com/rails/rails/commit/c2f838e80c76c9a3407e1e7af1ecbd738511fd72
[2]: https://github.com/rails/rails/commit/9b07b2d6ca2ee9854cd986da0bf914b9ace9d547

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
