### PR TITLE
Fix Compatibility tests using `@internal_metadata`

### DIFF
--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -270,7 +270,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         assert connection.table_exists?(:tests)
       ensure
@@ -287,7 +287,7 @@ module ActiveRecord
           end
         }.new
 
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
         column = connection.columns(:tests).find { |column| column.name == "some_id" }
         assert_equal :string, column.type
@@ -369,7 +369,7 @@ module ActiveRecord
           end
         }.new(nil, 1)
 
-        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration, @internal_metadata).migrate
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
 
         assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
       ensure


### PR DESCRIPTION
### Motivation / Background

These came from backports from `main`, where the signature of Migrator has changed.

```
def initialize(direction, migrations, schema_migration, target_version = nil)
```

```
def initialize(direction, migrations, schema_migration, internal_metadata, target_version = nil)
```

So passing a `nil` value here usually isn't a problem, but it is definitely incorrect.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
