### PR TITLE
Remove $global mistakenly left in test

### DIFF
--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -783,8 +783,6 @@ module DefaultPrecisionSixTestCases
       end
     }.new(nil, 0)
 
-    $global = true
-
     change_migration = Class.new(migration_class) {
       def migrate(x)
         change_column :more_testings, :published_at, :datetime


### PR DESCRIPTION
Ref #49090

This was accidentally left in when this change was [submitted][1] to main. This was already addressed in the backport commit but this addresses it for main.

[1]: https://github.com/rails/rails/commit/57a9e25f8e96eb28f4f3704db4be55bdb88c22f0

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
