### PR TITLE
Simplify explanation by removing docs for classic mode

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -238,28 +238,6 @@ NOTE: The `ApplicationController` class inside an engine is named just like a
 Rails application in order to make it easier for you to convert your
 applications into engines.
 
-NOTE: If the parent application runs in `classic` mode, you may run into a
-situation where your engine controller is inheriting from the main application
-controller and not your engine's application controller. The best way to prevent
-this is to switch to `zeitwerk` mode in the parent application. Otherwise, use
-`require_dependency` to ensure that the engine's application controller is
-loaded. For example:
-
-```ruby
-# ONLY NEEDED IN `classic` MODE.
-require_dependency "blorgh/application_controller"
-
-module Blorgh
-  class ArticlesController < ApplicationController
-    # ...
-  end
-end
-```
-
-WARNING: Don't use `require` because it will break the automatic reloading of
-classes in the development environment - using `require_dependency` ensures that
-classes are loaded and unloaded in the correct manner.
-
 Just like for `app/controllers`, you will find a `blorgh` subdirectory under
 the `app/helpers`, `app/jobs`, `app/mailers` and `app/models` directories
 containing the associated `application_*.rb` file for gathering common


### PR DESCRIPTION
### Motivation / Background

Rails 7.0 and higher does no more support classic mode, which allows us to remove differences in classic and zeitwerk modes from [Engines docs](https://edgeguides.rubyonrails.org/engines.html#app-directory).

This Pull Request has been created because this makes it simple app directory section in [Engines](https://edgeguides.rubyonrails.org/engines.html).

### Detail

This Pull Request changes paragraphs explaining `classic` (and `zeitwerk`) mode in the **Engines** guide.

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
