### PR TITLE
Lock globalid gem version to address broken CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem "json", ">= 2.0.0"
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 
+# Workaround until globalid gem is fixed
+gem "globalid", "< 1.2.0", require: false
+
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     fugit (1.8.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
-    globalid (1.0.0)
+    globalid (1.1.0)
       activesupport (>= 5.0)
     google-apis-core (0.9.4)
       addressable (~> 2.5, >= 2.5.1)
@@ -582,6 +582,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   error_highlight (>= 0.4.0)
+  globalid (< 1.2.0)
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails


### PR DESCRIPTION
Broken CI is due to https://github.com/rails/globalid/pull/163 in globalid 1.2.0.

https://buildkite.com/rails/rails/builds/99329#018a5f01-a966-4424-9596-0a7f1deeb1ff/1178-1190
