### PR TITLE
Expose ActionDispatch::Request::Session changed state

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `changed?` to `ActionDispatch::Request::Session` to allow commit session only if it changed
+
+    *ardevelop*
+
 *   Add `ActionController::Parameters#extract_value` method to allow extracting serialized values from params
 
     ```ruby

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -77,6 +77,7 @@ module ActionDispatch
         @delegate = {}
         @loaded   = false
         @exists   = nil # We haven't checked yet.
+        @changed  = false
         @enabled  = enabled
         @id_was = nil
         @id_was_initialized = false
@@ -88,6 +89,10 @@ module ActionDispatch
 
       def enabled?
         @enabled
+      end
+
+      def changed?
+        @changed
       end
 
       def options
@@ -256,6 +261,7 @@ module ActionDispatch
         def load_for_write!
           if enabled?
             load! unless loaded?
+            @changed = true
           else
             raise DisabledSessionError, "Your application has sessions disabled. To write to the session you must first configure a session store"
           end

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -93,6 +93,14 @@ module ActionDispatch
         assert_equal("awesome", s["rails"])
       end
 
+      def test_changed?
+        s = Session.create(store, req, {})
+
+        assert_equal(false, s.changed?)
+        s["rails"] = "ftw"
+        assert_equal(true, s.changed?)
+      end
+
       def test_delete
         s = Session.create(store, req, {})
         s["rails"] = "ftw"


### PR DESCRIPTION
### Motivation / Background

Currently `rack-session` commits the session every time it gets loaded, so when concurrent requests are made from the browser to the server, all of them load the session to get the information about the current user, and one of the requests stores some data in the session. Due to racing, there is a chance that a response that reads from the session will overwrite the session value set by a response that writes to the session.

These changes are not going to solve the issue of the overwritten session but are going to make them less frequent. Also will reduce actions done in runtime like cookie encrypting and signing.

The issue was reported:
- https://stackoverflow.com/questions/42044076/why-is-rails-constantly-sending-back-a-set-cookie-header

### Additional information

Related to:
- https://github.com/rack/rack-session/pull/24

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
