### PR TITLE
Fix `has_secure_token on: :initialize` when column is not selected

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -52,7 +52,7 @@ module ActiveRecord
         require "active_support/core_ext/securerandom"
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(length: length) }
         set_callback on, on == :initialize ? :after : :before do
-          send("#{attribute}=", self.class.generate_unique_secure_token(length: length)) unless send("#{attribute}?")
+          send("#{attribute}=", self.class.generate_unique_secure_token(length: length)) if has_attribute?(attribute) && !send("#{attribute}?")
         end
       end
 

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -25,6 +25,18 @@ class SecureTokenTest < ActiveRecord::TestCase
     assert_equal token, User.find(@user.id).token
   end
 
+  def test_generating_token_on_initialize_is_skipped_if_column_was_not_selected
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "users"
+      has_secure_token on: :initialize
+    end
+
+    model.create!
+    assert_nothing_raised do
+      model.select(:id).last
+    end
+  end
+
   def test_regenerating_the_secure_token
     @user.save
     old_token = @user.token


### PR DESCRIPTION
Fixes #49130.