### PR TITLE
Fix `assert_deprecated` related warnings in ActiveRecord tests

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -45,12 +45,12 @@ module ActiveRecord
 
       if options.key?(:rewhere)
         if options[:rewhere]
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             Specifying `Relation#merge(rewhere: true)` is deprecated, as that has now been
             the default since Rails 7.0. Setting the rewhere option will error in Rails 7.2
           MSG
         else
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
             `Relation#merge(rewhere: false)` is deprecated without replacement,
             and will be removed in Rails 7.2
           MSG

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -24,30 +24,30 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     assert_equal [mary], david_and_mary.merge(Author.where(id: mary))
     assert_equal [mary], david_and_mary.merge(Author.rewhere(id: mary))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary], david_and_mary.merge(Author.where(id: mary), rewhere: true)
     end
 
     assert_equal [bob],  david_and_mary.merge(Author.where(id: bob))
     assert_equal [bob],  david_and_mary.merge(Author.rewhere(id: bob))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [bob],  david_and_mary.merge(Author.where(id: bob), rewhere: true)
     end
 
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
     end
 
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
     assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
@@ -56,7 +56,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
     end
     assert_equal [david], david_and_mary.and(david_and_bob)
@@ -74,30 +74,30 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     assert_equal [mary], david_and_mary.merge(Author.where(id: mary))
     assert_equal [mary], david_and_mary.merge(Author.rewhere(id: mary))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary], david_and_mary.merge(Author.where(id: mary), rewhere: true)
     end
 
     assert_equal [bob], david_and_mary.merge(Author.where(id: bob))
     assert_equal [bob],  david_and_mary.merge(Author.rewhere(id: bob))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [bob],  david_and_mary.merge(Author.where(id: bob), rewhere: true)
     end
 
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
     end
 
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
     assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
@@ -106,7 +106,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
     end
     assert_equal [david], david_and_mary.and(david_and_bob)
@@ -124,31 +124,31 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     assert_equal [mary], david_and_mary.merge(Author.where(id: mary))
     assert_equal [mary], david_and_mary.merge(Author.rewhere(id: mary))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary], david_and_mary.merge(Author.where(id: mary), rewhere: true)
     end
 
     assert_equal [bob], david_and_mary.merge(Author.where(id: bob))
     assert_equal [bob],  david_and_mary.merge(Author.rewhere(id: bob))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [bob],  david_and_mary.merge(Author.where(id: bob), rewhere: true)
     end
 
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]))
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
     end
 
 
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
     assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
     end
     assert_equal [mary], david_and_mary.and(mary_and_bob)
@@ -157,7 +157,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
     end
     assert_equal [david], david_and_mary.and(david_and_bob)
@@ -172,12 +172,12 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [david], non_mary_and_bob
 
     assert_equal [david], Author.where(id: david).merge(non_mary_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david], Author.where(id: david).merge(non_mary_and_bob, rewhere: true)
     end
 
     assert_equal [david], Author.where(id: mary).merge(non_mary_and_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david], Author.where(id: mary).merge(non_mary_and_bob, rewhere: true)
     end
   end
@@ -190,12 +190,12 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [david, mary], less_than_bob
 
     assert_equal [david, mary], Author.where(id: david).merge(less_than_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, mary], Author.where(id: david).merge(less_than_bob, rewhere: true)
     end
 
     assert_equal [david, mary], Author.where(id: mary).merge(less_than_bob)
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       assert_equal [david, mary], Author.where(id: mary).merge(less_than_bob, rewhere: true)
     end
   end
@@ -218,7 +218,7 @@ class RelationMergingTest < ActiveRecord::TestCase
       end
 
       assert_sql(/WHERE \(#{Regexp.escape(author_id)} IN \('1'\)\)\z/) do
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_equal [david], only_david.merge(only_david, rewhere: true)
         end
       end
@@ -228,7 +228,7 @@ class RelationMergingTest < ActiveRecord::TestCase
       end
 
       assert_sql(/WHERE \(#{Regexp.escape(author_id)} IN \(1\)\)\z/) do
-        assert_deprecated do
+        assert_deprecated(ActiveRecord.deprecator) do
           assert_equal [david], only_david.merge(only_david, rewhere: true)
         end
       end
@@ -255,7 +255,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     devs = Developer.where(salary_attr.eq(80000)).merge(Developer.where(salary_attr.eq(9000)))
     assert_equal [developers(:poor_jamis)], devs.to_a
 
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       devs = Developer.where(salary_attr.eq(80000)).merge(Developer.where(salary_attr.eq(9000)), rewhere: true)
     end
     assert_equal [developers(:poor_jamis)], devs.to_a
@@ -271,7 +271,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     devs = Developer.where(abs_salary.eq(80000)).merge(Developer.where(abs_salary.eq(9000)))
     assert_equal [developers(:poor_jamis)], devs.to_a
 
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       devs = Developer.where(abs_salary.eq(80000)).merge(Developer.where(abs_salary.eq(9000)), rewhere: true)
     end
     assert_equal [developers(:poor_jamis)], devs.to_a
@@ -404,7 +404,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     message = <<-MSG.squish
       Specifying `Relation#merge(rewhere: true)` is deprecated
     MSG
-    assert_deprecated(message) do
+    assert_deprecated(message, ActiveRecord.deprecator) do
       Author.where(id: 1).merge(Author.where(id: 2), rewhere: true)
     end
   end
@@ -413,7 +413,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     message = <<-MSG.squish
       Relation#merge(rewhere: false)` is deprecated without replacement
     MSG
-    assert_deprecated(message) do
+    assert_deprecated(message, ActiveRecord.deprecator) do
       Author.where(id: 1).merge(Author.where(id: 2), rewhere: false)
     end
   end


### PR DESCRIPTION
This PR fixes warnings, currently produced by ActiveRecord tests:
```
$ SEED=29905 rake test:sqlite3
```

```
..............................................................................................................................................................................................................SSSSSSS...S...................................................................................................DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
.DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block (3 levels) in run at /Users/fatkodima/.asdf/installs/ruby/3.2.1/lib/ruby/gems/3.2.0/gems/minitest-5.19.0/lib/minitest/test.rb:94)
```