### PR TITLE
Fix in-place modification of shared `_counter_cache_columns` class attribute

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -37,7 +37,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       }
 
       klass = reflection.class_name.safe_constantize
-      klass._counter_cache_columns << cache_column if klass && klass.respond_to?(:_counter_cache_columns)
+      klass._counter_cache_columns |= [cache_column] if klass && klass.respond_to?(:_counter_cache_columns)
     end
 
     def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/topic"
 require "models/bulb"
+require "models/person"
 require "models/car"
 require "models/aircraft"
 require "models/wheel"
@@ -12,7 +13,6 @@ require "models/category"
 require "models/categorization"
 require "models/dog"
 require "models/dog_lover"
-require "models/person"
 require "models/friendship"
 require "models/subscriber"
 require "models/subscription"
@@ -395,6 +395,11 @@ class CounterCacheTest < ActiveRecord::TestCase
     assert_touching @topic, :updated_at, :written_on do
       Topic.decrement_counter(:replies_count, @topic.id, touch: %i( updated_at written_on ))
     end
+  end
+
+  test "counter_cache_column?" do
+    assert Person.counter_cache_column?("cars_count")
+    assert_not Car.counter_cache_column?("cars_count")
   end
 
   private


### PR DESCRIPTION
Fixes #49132.

`_counter_cache_columns` class attribute is defined on `ActiveRecord::Base` class and all models share its value. We should not modify it in place, but reassign to it.