### PR TITLE
Include ActiveModel::Attributes to ActiveModel::Model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include `ActiveModel::Attributes` in `ActiveModel::Model`
+
+    *Niklas Häusele*
+
 *   Support composite identifiers in `to_key`
 
     `to_key` avoids wrapping `#id` value into an `Array` if `#id` already an array

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -43,6 +43,7 @@ module ActiveModel
     extend ActiveSupport::Concern
     include ActiveModel::API
     include ActiveModel::Access
+    include ActiveModel::Attributes
 
     ##
     # :method: slice

--- a/activemodel/test/cases/model_test.rb
+++ b/activemodel/test/cases/model_test.rb
@@ -33,6 +33,11 @@ class ModelTest < ActiveModel::TestCase
     attr_accessor :attr
   end
 
+  class AttributeModel
+    include ActiveModel::Model
+    attribute :attr, :string
+  end
+
   def setup
     @model = BasicModel.new
   end
@@ -75,6 +80,11 @@ class ModelTest < ActiveModel::TestCase
     assert_raises(ActiveModel::UnknownAttributeError) do
       SimpleModel.new(hello: "world")
     end
+  end
+
+  def test_attributes_work
+    object = AttributeModel.new(attr: "world")
+    assert_equal "world", object.attr
   end
 
   def test_load_hook_is_called


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of the comment [here](https://github.com/rails/rails/pull/48921#issuecomment-1674978552). If there are other things that need to happen before this change, please let me know and I'll try to come up with a solution.

### Detail

It includes `ActiveModel::Attributes` to `ActiveModel::Model`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
