### PR TITLE
Deprecate require_dependency

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `require_dependency`.
+
+    This method is obsolete. The semantics of the autoloader match Ruby's and
+    you do not need to be defensive with load order anymore. Just refer to
+    classes and modules normally.
+
+    *Petrik de Heus*
+
 *   Add `drb`, `mutex_m` and `base64` that are bundled gem candidates for Ruby 3.4
 
     *Yasuo Honda*

--- a/activesupport/lib/active_support/dependencies/require_dependency.rb
+++ b/activesupport/lib/active_support/dependencies/require_dependency.rb
@@ -9,6 +9,12 @@ module ActiveSupport::Dependencies::RequireDependency
   # should call +require_dependency+ where needed in case the runtime mode is
   # +:classic+.
   def require_dependency(filename)
+    ActiveSupport.deprecator.warn(<<-MSG.squish)
+      `require_dependency` is deprecated and will be removed in Rails 7.2.
+      This method is obsolete. The semantics of the autoloader match Ruby's and
+      you do not need to be defensive with load order anymore. Just refer to
+      classes and modules normally.
+    MSG
     filename = filename.to_path if filename.respond_to?(:to_path)
 
     unless filename.is_a?(String)

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -24,6 +24,7 @@ class RequireDependencyTest < ActiveSupport::TestCase
     @root_dir = Dir.mktmpdir
     File.write("#{@root_dir}/x.rb", "X = :X")
     ActiveSupport::Dependencies.autoload_paths << @root_dir
+    ActiveSupport.deprecator.begin_silence
   end
 
   teardown do
@@ -32,6 +33,7 @@ class RequireDependencyTest < ActiveSupport::TestCase
 
     FileUtils.rm_rf(@root_dir)
     Object.send(:remove_const, :X) if Object.const_defined?(:X)
+    ActiveSupport.deprecator.end_silence
   end
 
   test "require_dependency looks autoload paths up" do


### PR DESCRIPTION
As Rails no longer supports classic autoloading this method is obsolete. The semantics of the autoloader match Ruby's and you do not need to be defensive with load order anymore. Just refer to classes and modules normally.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
