### PR TITLE
Remove internal usage of require_dependency

### DIFF
--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -144,7 +144,7 @@ module ActionMailer
       private
         def load_previews
           preview_paths.each do |preview_path|
-            Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| require_dependency file }
+            Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| require file }
           end
         end
 


### PR DESCRIPTION
`require_dependency` is [obsolete](https://github.com/rails/rails/blob/6633671e3a118048d000c6d82066cd7230448718/activesupport/lib/active_support/dependencies/require_dependency.rb#L4-L6) since Rails stopped supporting classic mode.
It is only used by engines that need to support classic mode as well.

We can safely remove internal usage of `require_dependency`.
It was only used in the ActionMailer::Preview which ends up using just `require` anyway.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
