### PR TITLE
Fix more bugs in declarative specs filter

### DIFF
--- a/railties/lib/rails/test_unit/line_filtering.rb
+++ b/railties/lib/rails/test_unit/line_filtering.rb
@@ -5,7 +5,7 @@ require "rails/test_unit/runner"
 module Rails
   module LineFiltering # :nodoc:
     def run(reporter, options = {})
-      options[:filter] = Rails::TestUnit::Runner.compose_filter(self, options[:filter])
+      options = options.merge(filter: Rails::TestUnit::Runner.compose_filter(self, options[:filter]))
 
       super
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -693,7 +693,7 @@ module ApplicationTests
         end
       RUBY
 
-      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  . bar/'").tap do |output|
+      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  .\\ bar/'").tap do |output|
         assert_match "hello foo", output
         assert_match "hello again foo", output
         assert_match "hello bar", output
@@ -703,9 +703,12 @@ module ApplicationTests
 
     def test_declarative_style_regexp_filter_with_minitest_spec
       app_file "test/models/post_test.rb", <<~RUBY
+        require "test_helper"
         require "minitest/spec"
 
-        class PostTest < Minitest::Spec
+        class PostTest < ActiveSupport::TestCase
+          extend Minitest::Spec::DSL
+
           it "greets foo" do
             puts "hello foo"
             assert true
@@ -727,7 +730,7 @@ module ApplicationTests
         end
       RUBY
 
-      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  . bar/'").tap do |output|
+      run_test_command("test/models/post_test.rb -n '/greets foo|greets .  .\\ bar/'").tap do |output|
         assert_match "hello foo", output
         assert_match "hello again foo", output
         assert_match "hello bar", output


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/47942

This PR fixes some things that were missed in first PR.

1) `Minitest::Spec` doesn't extend `Rails::LineFiltering`, so `compose_filter` (and thus `escape_declarative_test_filter`) were not being called in the tests we added. This PR adds a new test case with `Rails::LineFiltering` included to confirm behaviour is the same either way.
2) The filter in `escape_declarative_test_filter` didn't work on regexes that had passed through `Regexp#escape`. Now it supports that too.