### PR TITLE
Do not generate configuration for sprockets if propshaft is used

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/assets.rb.tt
@@ -5,8 +5,10 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+<% if options[:asset_pipeline] == "sprockets" -%>
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+<% end -%>


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because currently, when a new rails project is initialized using `propshaft`, configuration for `sprockets` is generated in the file `config/initializers/assets.rb`.

```
# Precompile additional assets.
# application.js, application.css, and all non-JS/CSS in the app/assets
# folder are already added.
# Rails.application.config.assets.precompile += %w( admin.js admin.css )
```

Although this part of the code is generated with comments, it can mislead especially people who are less experts in the framework.

### Detail

This Pull Request includes the necessary changes so that that part is not generated in the configuration file.

