### PR TITLE
Rails Guides: describe composite primary keys (CPK) for migrations and querying

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -370,8 +370,9 @@ end
 This method creates a `products` table with a column called `name`.
 
 By default, `create_table` will implicitly create a primary key called `id` for
-you. You can change the name of the column with the `:primary_key` option  or,
-if you don't want a primary key at all, you can pass the option `id: false`.
+you. You can change the name of the column with the `:primary_key` option, or
+pass an array to `:primary_key` for a composite primary key. If you don't want
+a primary key at all, you can pass the option `id: false`.
 
 If you need to pass database specific options you can place an SQL fragment in
 the `:options` option. For example:

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -199,6 +199,8 @@ SELECT * FROM customers WHERE (customers.id IN (1,10))
 
 WARNING: The `find` method will raise an `ActiveRecord::RecordNotFound` exception unless a matching record is found for **all** of the supplied primary keys.
 
+If your table uses a composite primary key, you'll need to pass an array to find a single item. You can also pass an array of arrays to find multiple records.
+
 #### `take`
 
 The [`take`][] method retrieves a record without any implicit ordering. For example:


### PR DESCRIPTION
In the active_record_migrations guide, mention that a composite primary key can be specified using an array.

In the active_record_querying guide, mention that `find` takes an array or array of arrays for composite primary keys.

Both of these are recent API changes, not yet mentioned in the Rails guides.