### PR TITLE
Just check the BigDecimal 3.1+ behavior at `NumericalityValidationTest`

### DIFF
--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -112,14 +112,9 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     subject = model_class.new(virtual_decimal_number: 123.455)
 
-    if 123.455.to_d(5) == BigDecimal("123.46")
-      # BigDecimal's to_d behavior changed in BigDecimal 3.0.1, see https://github.com/ruby/bigdecimal/issues/70
-      # TODO: replace this with a check against BigDecimal::VERSION, currently
-      # we just check the behavior because both versions of BigDecimal report "3.0.0"
-      assert_not_predicate subject, :valid?
-    else
-      assert_predicate subject, :valid?
-    end
+    # BigDecimal's to_d behavior changed in BigDecimal 3.1.0, see https://github.com/ruby/bigdecimal/issues/70
+    # Since BigDecimal 3.1.4 or higher is installed as an Active Support dependency, we just check the behavior of BigDecimal 3.1.0+.
+    assert_not_predicate subject, :valid?
   end
 
   def test_virtual_attribute_with_precision_round_up


### PR DESCRIPTION
### Motivation / Background

To prepare Ruby 3.4 will ship `bigdecimal` as bundled gem, `bigdecimal` has been added to Active Support runtime dependency via https://github.com/rails/rails/pull/49039

It will install BigDecimal version 3.1.4 or higher, so we just check the BigDecimal 3.1+ behavior at `NumericalityValidationTest`.

### Detail
None

### Additional information

Refer to
https://github.com/rails/rails/pull/49039
https://github.com/ruby/bigdecimal/pull/180
https://github.com/ruby/bigdecimal/issues/70

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
