### PR TITLE
Add composite primary key examples to fixture docs

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -456,6 +456,41 @@ module ActiveRecord
   # In the above example, 'base' will be ignored when creating fixtures.
   # This can be used for common attributes inheriting.
   #
+  # == Composite Primary Key Fixtures
+  #
+  # Fixtures for composite primary key tables are fairly similar to normal tables.
+  # When using an id column, the column may be omitted as usual:
+  #
+  #   # app/models/book.rb
+  #   class Book < ApplicationRecord
+  #     self.primary_key = [:author_id, :id]
+  #     belongs_to :author
+  #   end
+  #
+  #   # books.yml
+  #   alices_adventure_in_wonderland:
+  #     author_id: <%= ActiveRecord::FixtureSet.identify(:lewis_carroll) %>
+  #     title: "Alice's Adventures in Wonderland"
+  #
+  # However, in order to support composite primary key relationships,
+  # you must use the `composite_identify` method:
+  #
+  #   # app/models/book_orders.rb
+  #   class BookOrder < ApplicationRecord
+  #     self.primary_key = [:shop_id, :id]
+  #     belongs_to :order, query_constraints: [:shop_id, :order_id]
+  #     belongs_to :book, query_constraints: [:author_id, :book_id]
+  #   end
+  #
+  #   # book_orders.yml
+  #   alices_adventure_in_wonderland_in_books:
+  #     author: lewis_carroll
+  #     book_id: <%= ActiveRecord::FixtureSet.composite_identify(
+  #                  :alices_adventure_in_wonderland, Book.primary_key)[:id] %>
+  #     shop: book_store
+  #     order_id: <%= ActiveRecord::FixtureSet.composite_identify(
+  #                  :books, Order.primary_key)[:id] %>
+  #
   # == Configure the fixture model class
   #
   # It's possible to set the fixture's model class directly in the YAML file.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because fixture docs should mention composite primary key fixture generation.

### Detail

This Pull Request changes Active Record to add CPK examples to `ActiveRecord::FixtureSet`.

### Additional information

Composite keys don't change fixtures much, but we should mention them in ActiveRecord::FixtureSet' documentation. Let me know if I should add anything.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
