### PR TITLE
Load ambient fixtures for `ActiveRecordMessagePackTest`

### DIFF
--- a/activerecord/test/cases/message_pack_test.rb
+++ b/activerecord/test/cases/message_pack_test.rb
@@ -9,6 +9,8 @@ require "active_support/message_pack"
 require "active_record/message_pack"
 
 class ActiveRecordMessagePackTest < ActiveRecord::TestCase
+  fixtures :posts, :comments, :authors
+
   test "enshrines type IDs" do
     expected = {
       119 => ActiveModel::Type::Binary::Data,


### PR DESCRIPTION
`ActiveRecordMessagePackTest` does not use any fixtures, but fixtures that were previously loaded without preserving referential integrity can affect query results.  For example, if previous tests load `:comments` fixtures but not `:posts` fixtures, there will be `Comment` records in the database with `post_id = 1` but no corresponding `Post` record. Then, when a `Post` is created in `ActiveRecordMessagePackTest`, its `comments` association will accidentally include those prior `Comment` records.

This commit loads ambient fixtures for the relevant models in `ActiveRecordMessagePackTest` to prevent such accidental results.

Fixes #49143.
