### PR TITLE
Add an error when saving a record that was previously destroyed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add configuration and logic to add an error when saving a destroyed object
+
+    Before:
+    ```ruby
+    post = Post.find(1)
+    post.destroy
+    post.save
+    # => false
+    post.errors.inspect
+    # => #<ActiveModel::Errors []>
+    ```
+    After:
+    ```ruby
+    post = Post.find(1)
+    post.destroy
+    post.save
+    # => false
+    post.errors.inspect
+    # => #<ActiveModel::Errors [#<ActiveModel::Error attribute=base, type=The record was previously destroyed., options={}>]>
+    ```
+    This can be configured with the new `active_record.error_saving_destroyed` setting.
+
+    *Ariel Juodziukynas*
+
 *   Raise an `ArgumentError` when `#accepts_nested_attributes_for` is declared more than once for an association in
     the same class. Previously, the last declaration would silently override the previous one. Overriding in a subclass
     is still allowed.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -454,6 +454,13 @@ module ActiveRecord
   singleton_class.attr_accessor :generate_secure_token_on
   self.generate_secure_token_on = :create
 
+  ##
+  # :singleton-method:
+  # Controls if an error should be added when saving an already destroyed
+  # object declarations. Defaults to <tt>:false</tt>.
+  singleton_class.attr_accessor :error_saving_destroyed
+  self.error_saving_destroyed = false
+
   def self.marshalling_format_version
     Marshalling.format_version
   end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1216,7 +1216,10 @@ module ActiveRecord
 
     def create_or_update(**, &block)
       _raise_readonly_record_error if readonly?
-      return false if destroyed?
+      if destroyed?
+        errors.add(:base, "The record was previously destroyed.") if ActiveRecord.error_saving_destroyed
+        return false
+      end
       result = new_record? ? _create_record(&block) : _update_record(&block)
       result != false
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -73,6 +73,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.default_column_serializer`](#config-active-record-default-column-serializer): `nil`
 - [`config.active_record.encryption.hash_digest_class`](#config-active-record-encryption-hash-digest-class): `OpenSSL::Digest::SHA256`
 - [`config.active_record.encryption.support_sha1_for_non_deterministic_encryption`](#config-active-record-encryption-support-sha1-for-non-deterministic-encryption): `false`
+- [`config.active_record.error_saving_destroyed`](#config-active-record-error-saving-destroyed): `true`
 - [`config.active_record.generate_secure_token_on`](#config-active-record-generate-secure-token-on): `:initialize`
 - [`config.active_record.marshalling_format_version`](#config-active-record-marshalling-format-version): `7.1`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
@@ -1551,6 +1552,15 @@ record.token # => "fwZcXX6SkJBJRogzMdciS7wf"
 | --------------------- | -------------------- |
 | (original)            | `:create`            |
 | 7.1                   | `:initialize`        |
+
+#### `config.active_record.error_saving_destroyed`
+
+Configures whether to add or not add an error when attempting to save an object that was previously destroyed.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
 
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` and `ActiveRecord::ConnectionAdapters::TrilogyAdapter.emulate_booleans`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -292,6 +292,7 @@ module Rails
             active_record.marshalling_format_version = 7.1
             active_record.run_after_transaction_callbacks_in_order_defined = true
             active_record.generate_secure_token_on = :initialize
+            active_record.error_saving_destroyed = true
           end
 
           if respond_to?(:action_dispatch)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -221,3 +221,12 @@
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #
 # Rails.application.config.dom_testing_default_html_version = :html5
+
+# Configure whether to add or not add an error for Active Record objects
+# if a save is performed after the object was already destroyed.
+#
+# In previous versions of Rails, saving an object that was destroyed fails but
+# no information about the reason is present in the errors. Turn this to `true`
+# to use the new behavior (an error message is added to the `:base` errors).
+#
+# Rails.application.config.active_record.error_saving_destroyed = true


### PR DESCRIPTION
### Motivation / Background

Currently, if we call `save` or `save!` in an object that was already destroyed, `save` returns `false` and `save!` raises an exception, but there's no information about why the save failed.

I ran into this issue with a legacy app that, because of a complicated set of callbacks, was destroying an object at some point and then calling `save!` somewhere else. This produced an exception, but there was no information about the reason.

After a lot of research I realized that the issue was the record was destroyed (so `.destroyed?` was `true`), but I think it will help a lot to have an error added to avoid having to find this out.

### Detail

This PR updates the `create_or_update` method to add a `:base` error message for this specific scenario.

I added a configuration for this to keep the old behavior if needed and during upgrades, since I imagine some apps may rely on the errors hash being empty.

### Additional information

No additional information.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
