### PR TITLE
Remove unused fixtures in `*ConnectionTest`

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -6,8 +6,6 @@ require "support/connection_helper"
 class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   include ConnectionHelper
 
-  fixtures :comments
-
   def setup
     super
     @subscriber = SQLSubscriber.new

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -10,8 +10,6 @@ module ActiveRecord
     class NonExistentTable < ActiveRecord::Base
     end
 
-    fixtures :comments
-
     def setup
       super
       @subscriber = SQLSubscriber.new


### PR DESCRIPTION
These fixtures were added in 9a4e183fe9f81365f7815c391512b3d46622d8c8 to test the behavior of `connection.truncate`, but then the relevant tests were extracted to `AdapterTestWithoutTransaction` in fdac932707fb16b7d074b1d0bc7c255157d72675.
