### PR TITLE
Require deprecator in core_exts that use it

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/deprecator"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/to_param"

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "date"
+
+require "active_support/deprecator"
 require "active_support/inflector/methods"
 require "active_support/core_ext/date/zones"
 require "active_support/core_ext/module/redefine_method"

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "date"
+
+require "active_support/deprecator"
 require "active_support/inflector/methods"
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/date_time/calculations"

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "time"
+
+require "active_support/deprecator"
 require "active_support/inflector/methods"
 require "active_support/values/time_zone"
 

--- a/activesupport/lib/active_support/deprecator.rb
+++ b/activesupport/lib/active_support/deprecator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module ActiveSupport
   def self.deprecator # :nodoc:
     ActiveSupport::Deprecation._instance


### PR DESCRIPTION
### Motivation / Background

Currently, requiring a railtie file that defines configuration options would cause error:

```rb
require "rails/railtie"

class Foo < Rails::Railtie
  config.foo = ActiveSupport::OrderedOptions.new
  config.foo.greetings = "hello"
end
```

```
/PATH_TO_BUNDLER/gems/rails-f9e4fb9bedec/activesupport/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)

deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
Did you mean?  deprecate_constant
```

Essentially, the problem is that `active_support/deprecator` is not required in the core_ext files that use it.

And consider core ext files are usually required individually, I think it's better to require `active_support/deprecator` in the core_ext files instead of in `rails/railtie`.

And given that `active_support/deprecator` would not work without `active_support/deprecation`, I think it's better to require `active_support/deprecation` in it.

### Detail

1. Require `active_support/deprecation` in `active_support/deprecator`
2. Require `active_support/deprecator` in several core extension files that use `ActiveSupport.deprecator` at the top-level like

```
  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
```
 
### Additional information

1. I'm ok to only add the require to `array/conversion` as that's the root cause of the error I'm seeing.
2. I'm not sure if there's an easy way to test this change as in [`railtie_test.rb`](https://github.com/rails/rails/blob/main/railties/test/railties/railtie_test.rb) the deprecator is already required.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
