### PR TITLE
dump PostgreSQL schemas as part of the schema dump

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Dump PostgreSQL schemas as part of the schema dump.
+
+    *Lachlan Sylvester*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Encryption now supports `support_unencrypted_data` being set per-attribute.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -28,6 +28,17 @@ module ActiveRecord
             end
           end
 
+          def schemas(stream)
+            schema_names = @connection.schema_names - ["public"]
+
+            if schema_names.any?
+              schema_names.sort.each do |name|
+                stream.puts "  create_schema #{name.inspect}"
+              end
+              stream.puts
+            end
+          end
+
           def exclusion_constraints_in_create(table, stream)
             if (exclusion_constraints = @connection.exclusion_constraints(table)).any?
               add_exclusion_constraint_statements = exclusion_constraints.map do |exclusion_constraint|

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -57,6 +57,7 @@ module ActiveRecord
 
     def dump(stream)
       header(stream)
+      schemas(stream)
       extensions(stream)
       types(stream)
       tables(stream)
@@ -117,6 +118,10 @@ module ActiveRecord
 
       # (enum) types are only supported by PostgreSQL
       def types(stream)
+      end
+
+      # schemas are only supported by PostgreSQL
+      def schemas(stream)
       end
 
       def tables(stream)

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -17,6 +17,7 @@ end
 
 class SchemaTest < ActiveRecord::PostgreSQLTestCase
   include PGSchemaHelper
+  include SchemaDumpingHelper
   self.use_transactional_tests = false
 
   SCHEMA_NAME = "test_schema"
@@ -485,6 +486,14 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.rename_index("#{SCHEMA_NAME}.#{TABLE_NAME}", old_name, new_name)
     assert_not @connection.index_name_exists?("#{SCHEMA_NAME}.#{TABLE_NAME}", old_name)
     assert @connection.index_name_exists?("#{SCHEMA_NAME}.#{TABLE_NAME}", new_name)
+  end
+
+  def test_dumping_schemas
+    output = dump_all_table_schema(/./)
+
+    assert_no_match %r{create_schema "public"}, output
+    assert_match %r{create_schema "test_schema"}, output
+    assert_match %r{create_schema "test_schema2"}, output
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

As part of Active Record migrations, there are methods to create and drop PostgreSQL schemas.

However, when you dump the schema for a database that uses the PostgreSQL schemas into the schema.rb file, there are not methods to create the schemas, so when you try to load this schema into a new database, a `ActiveRecord::StatementInvalid: PG::InvalidSchemaName` can be raised.

This PR adds `create_schema` statements to the schema.rb file so that is can load schemas that use PostgreSQL schemas.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x]  Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
