### PR TITLE
ensure identical md5 sums for gzip schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -471,6 +471,7 @@ module ActiveRecord
           File.atomic_write(filename) do |file|
             if File.extname(filename) == ".gz"
               zipper = Zlib::GzipWriter.new file
+              zipper.mtime = 0
               yield zipper
               zipper.flush
               zipper.close

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -334,6 +334,27 @@ module ActiveRecord
         tempfile.unlink
       end
 
+      def test_gzip_dumps_identical
+        # Create an empty cache.
+        cache = new_bound_reflection
+
+        tempfile_a = Tempfile.new(["schema_cache-", ".dump.gz"])
+        # Dump it. It should get populated before dumping.
+        cache.dump_to(tempfile_a.path)
+        digest_a = Digest::MD5.file(tempfile_a).hexdigest
+        sleep(1)
+        tempfile_b = Tempfile.new(["schema_cache-", ".dump.gz"])
+        # Dump it. It should get populated before dumping.
+        cache.dump_to(tempfile_b.path)
+        digest_b = Digest::MD5.file(tempfile_b).hexdigest
+
+
+        assert_equal digest_a, digest_b
+      ensure
+        tempfile_a.unlink
+        tempfile_b.unlink
+      end
+
       def test_data_source_exist
         assert @cache.data_source_exists?("courses")
         assert_not @cache.data_source_exists?("foo")

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -342,7 +342,7 @@ module ActiveRecord
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_a.path)
         digest_a = Digest::MD5.file(tempfile_a).hexdigest
-        sleep(1)
+        sleep(1) # ensure timestamp changes
         tempfile_b = Tempfile.new(["schema_cache-", ".dump.gz"])
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_b.path)


### PR DESCRIPTION
### Motivation / Background

This PR ensures that .gz versions of identical schema caches have identical md5 sums, avoiding spurious change notifications in git

### Detail

Due to gzip's default inclusion of modification time in the file header, the following sequence results in a changed `db/schema_cache.yml.gz`:

```
rails db:schema:cache:dump
rails db:rollback
rails db:migrate
rails db:schema:cache:dump
```

Since migrations may need to be rolled back and forth in development, and the .gz file is opaque, this causes confusion.

To mitigate this we set `zipper.mtime = 0` before writing cache.
### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
