### PR TITLE
Record ping on every actioncable message

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -236,6 +236,7 @@
         return;
       }
       const {identifier: identifier, message: message, reason: reason, reconnect: reconnect, type: type} = JSON.parse(event.data);
+      this.monitor.recordPing();
       switch (type) {
        case message_types.welcome:
         if (this.triedToReconnect()) {

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -128,6 +128,7 @@ Connection.prototype.events = {
   message(event) {
     if (!this.isProtocolSupported()) { return }
     const {identifier, message, reason, reconnect, type} = JSON.parse(event.data)
+    this.monitor.recordPing()
     switch (type) {
       case message_types.welcome:
         if (this.triedToReconnect()) {


### PR DESCRIPTION
### Motivation / Background

This PR is a fix for this issue described and closed due to inactivity here https://github.com/rails/rails/issues/42336
It still happens in apps with rails 7.0.7.2, ruby 3.2.2 and @rails/actioncable 7.0.4: when large number of events is sent via actioncable (in our case they are turbo broadcast messages) it prevents ping messages from coming in time (currently ping threshold is 6 seconds), so actioncable assumes connection as stale and creates a new one. However, during a downtime between closing/opening connections events could (and are) miss(ed).

In this PR pings are also recorded on every normal message coming to the client.

### Expected behavior

Connection does not become stale and does not get reconnected when ping messages are delayed due to large number of normal messages.

### Actual behavior

The client is disconnected if it doesn't receive ping events within the staleThreshold even though it's receiving other events.