### PR TITLE
Define alias attribute methods in `define_attribute_methods`

### DIFF
--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -119,6 +119,34 @@ class AttributeMethodsTest < ActiveModel::TestCase
     ModelWithAttributes.undefine_attribute_methods
   end
 
+  test "#define_attribute_methods defines alias attribute methods after undefining" do
+    topic_class = Class.new do
+      include ActiveModel::AttributeMethods
+      define_attribute_methods :title
+      alias_attribute :aliased_title_to_be_redefined, :title
+
+      def attributes
+        { title: "Active Model Topic" }
+      end
+
+      private
+        def attribute(name)
+          attributes[name.to_sym]
+        end
+    end
+
+    topic = topic_class.new
+    assert_equal("Active Model Topic", topic.aliased_title_to_be_redefined)
+    topic_class.undefine_attribute_methods
+
+    assert_not_respond_to topic, :aliased_title_to_be_redefined
+
+    topic_class.define_attribute_methods :title
+
+    assert_respond_to topic, :aliased_title_to_be_redefined
+    assert_equal "Active Model Topic", topic.aliased_title_to_be_redefined
+  end
+
   test "#define_attribute_method does not generate attribute method if already defined in attribute module" do
     klass = Class.new(ModelWithAttributes)
     klass.send(:generated_attribute_methods).module_eval do

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -71,8 +71,10 @@ module ActiveRecord
         generated_attribute_methods.synchronize do
           return if @alias_attributes_mass_generated
           ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|
-            local_attribute_aliases.each do |new_name, old_name|
-              generate_alias_attribute_methods(code_generator, new_name, old_name)
+            aliases_by_attribute_name.each do |old_name, new_names|
+              new_names.each do |new_name|
+                generate_alias_attribute_methods(code_generator, new_name, old_name)
+              end
             end
           end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1039,6 +1039,25 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  test "#define_attribute_methods brings back undefined aliases" do
+    topic_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+
+      alias_attribute :title_alias_to_be_undefined, :title
+    end
+
+    topic = topic_class.new(title: "New topic")
+    assert_equal("New topic", topic.title_alias_to_be_undefined)
+    topic_class.undefine_attribute_methods
+
+    assert_not_respond_to topic, :title_alias_to_be_undefined
+
+    topic_class.define_attribute_methods
+
+    assert_respond_to topic, :title_alias_to_be_undefined
+    assert_equal "New topic", topic.title_alias_to_be_undefined
+  end
+
   test "define_attribute_method works with both symbol and string" do
     klass = Class.new(ActiveRecord::Base)
     klass.table_name = "foo"

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -5,7 +5,6 @@ require "models/numeric_data"
 
 class NumericalityValidationTest < ActiveRecord::TestCase
   def setup
-    NumericData.generate_alias_attributes
     @model_class = NumericData.dup
   end
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/48931

`undefine_attribute_methods` now removes alias attribute methods along with attribute methods. This commit changes `define_attribute_methods` to redefine methods back if any alias attributes were declared which provides applications and libraries an option to bring the alias methods back after using `undefine_attribute_methods`.

### Implementation details

In addition to existing `alias_attribute` internal lists we will populate one more - `aliases_by_attribute_name` which will keep a list of alias attributes per attribute name. We will use this list in the  `define_attribute_methods` to restore aliases any time the method is being redefined. Basically it makes `define_attribute_methods` responsible for defining both alias attribute methods and actual attribute methods for most cases apart from when a non-attribute thing is being aliased.