### PR TITLE
HTML tag validation added for tag names

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,23 @@
+*   Added validation for HTML tag names in the `tag` and `content_tag` helper method. The `tag` and
+    `content_tag` method now checks that the provided tag name adheres to the HTML specification. If
+    an invalid HTML tag name is provided, the method raises an `ArgumentError` with an appropriate error
+    message.
 
+    Examples:
+
+    ```ruby
+    # Raises ArgumentError: Invalid HTML5 tag name: 12p
+    content_tag("12p") # Starting with a number
+
+    # Raises ArgumentError: Invalid HTML5 tag name: ""
+    content_tag("") # Empty tag name
+
+    # Raises ArgumentError: Invalid HTML5 tag name: div/
+    tag("div/") # Contains a solidus
+
+    # Raises ArgumentError: Invalid HTML5 tag name: "image file"
+    tag("image file") # Contains a space
+    ```
+
+    *Akhil G Krishnan*
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -79,11 +79,10 @@ module ActionView
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
 
+          TagHelper.ensure_valid_html5_tag_name(name)
           if escape
-            name = ERB::Util.xml_name_escape(name)
             content = ERB::Util.unwrapped_html_escape(content)
           end
-
           "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name]}#{content}</#{name}>".html_safe
         end
 
@@ -310,7 +309,7 @@ module ActionView
         if name.nil?
           tag_builder
         else
-          name = ERB::Util.xml_name_escape(name) if escape
+          ensure_valid_html5_tag_name(name)
           "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open ? ">" : " />"}".html_safe
         end
       end
@@ -400,6 +399,11 @@ module ActionView
       end
 
       private
+        def ensure_valid_html5_tag_name(name)
+          raise ArgumentError, "Invalid HTML5 tag name: #{name.inspect}" unless /\A[a-zA-Z][^\s\/>]*\z/.match?(name)
+        end
+        module_function :ensure_valid_html5_tag_name
+
         def build_tag_values(*args)
           tag_values = []
 


### PR DESCRIPTION
Follow-up #49120, Also fixes the  empty string `""` case of https://github.com/rails/rails/issues/44948

### Motivation / Background

As per the discussion in https://github.com/rails/rails/pull/49120#discussion_r1315644911, finally decided to have validation for invalid HTML characters in `tag`, `content_tag` helper methods.

### Detail

Added validation for HTML tag names in the  `tag` and  `content_tag` method. The `content_tag` method now checks that the provided tag name adheres to the HTML specification. If an invalid HTML tag name is provided, the method raises an `ArgumentError` with an appropriate error message.

Examples:
Before: 
```ruby
content_tag("12p") 
#  "<12p></12p>"

content_tag("") 
# "<></>"

tag("image file")
#  "<image_file></image_file>"
```

After: 
```ruby
# Raises ArgumentError: Invalid HTML5 tag name: 12p
content_tag("12p") # Starting with a number

# Raises ArgumentError: Invalid HTML5 tag name:  
content_tag("") # Empty tag name

# Raises ArgumentError: Invalid HTML5 tag name: "image file"
tag("image file") # Contains a space
```

cc\ @byroot
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
