### PR TITLE
Update mysql2 gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.2.3)
     mutex_m (0.1.2)
-    mysql2 (0.5.4)
+    mysql2 (0.5.5)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     net-imap (0.3.6)


### PR DESCRIPTION
So that it can find the mysql libraries with homebrew on arm64


### Motivation / Background

I get an error trying to run `bundle install` on an M1 Mac with the homebrew `mysql-client` package installed. Presumably because it can't find the necessary dependencies.

### Additional information

The mysql2 [changelog](https://github.com/brianmario/mysql2/releases/tag/0.5.5) specifically mentions adding additional search paths for homebrew.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
