### PR TITLE
Adds support for `if_not_exists` when adding a check constraint.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Adds support for `if_not_exists` when adding a check constraint.
+
+    ```ruby
+    add_check_constraint :posts, "post_type IN ('blog', 'comment', 'share')", if_not_exists: true
+    ```
+
+    *Cody Cutrer*
+
 *   Raise an `ArgumentError` when `#accepts_nested_attributes_for` is declared more than once for an association in
     the same class. Previously, the last declaration would silently override the previous one. Overriding in a subclass
     is still allowed.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1225,12 +1225,16 @@ module ActiveRecord
       # The +options+ hash can include the following keys:
       # [<tt>:name</tt>]
       #   The constraint name. Defaults to <tt>chk_rails_<identifier></tt>.
+      # [<tt>:if_not_exists</tt>]
+      #   Silently ignore if the constraint already exists, rather than raise an error.
       # [<tt>:validate</tt>]
       #   (PostgreSQL only) Specify whether or not the constraint should be validated. Defaults to +true+.
-      def add_check_constraint(table_name, expression, **options)
+      def add_check_constraint(table_name, expression, if_not_exists: false, **options)
         return unless supports_check_constraints?
 
         options = check_constraint_options(table_name, expression, options)
+        return if if_not_exists && check_constraint_exists?(table_name, **options)
+
         at = create_alter_table(table_name)
         at.add_check_constraint(expression, options)
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -308,12 +308,19 @@ module ActiveRecord
         end
 
         def invert_add_check_constraint(args)
-          args.last.delete(:validate) if args.last.is_a?(Hash)
+          if (options = args.last).is_a?(Hash)
+            options.delete(:validate)
+            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
+          end
           super
         end
 
         def invert_remove_check_constraint(args)
           raise ActiveRecord::IrreversibleMigration, "remove_check_constraint is only reversible if given an expression." if args.size < 2
+
+          if (options = args.last).is_a?(Hash)
+            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
+          end
           super
         end
 

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -123,6 +123,14 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           end
         end
 
+        def test_add_check_constraint_with_if_not_exists_options
+          @connection.add_check_constraint :trades, "quantity > 0"
+
+          assert_nothing_raised do
+            @connection.add_check_constraint :trades, "quantity > 0", if_not_exists: true
+          end
+        end
+
         if supports_non_unique_constraint_name?
           def test_add_constraint_with_same_name_to_different_table
             @connection.add_check_constraint :trades, "quantity > 0", name: "greater_than_zero"

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -460,6 +460,16 @@ module ActiveRecord
         end
       end
 
+      def test_invert_add_check_constraint
+        enable = @recorder.inverse_of :add_check_constraint, [:dogs, "speed > 0", name: "speed_check"]
+        assert_equal [:remove_check_constraint, [:dogs, "speed > 0", name: "speed_check"], nil], enable
+      end
+
+      def test_invert_add_check_constraint_if_not_exists
+        enable = @recorder.inverse_of :add_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_not_exists: true]
+        assert_equal [:remove_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_exists: true], nil], enable
+      end
+
       def test_invert_remove_check_constraint
         enable = @recorder.inverse_of :remove_check_constraint, [:dogs, "speed > 0", name: "speed_check"]
         assert_equal [:add_check_constraint, [:dogs, "speed > 0", name: "speed_check"], nil], enable
@@ -469,6 +479,11 @@ module ActiveRecord
         assert_raises(ActiveRecord::IrreversibleMigration) do
           @recorder.inverse_of :remove_check_constraint, [:dogs]
         end
+      end
+
+      def test_invert_remove_check_constraint_if_exists
+        enable = @recorder.inverse_of :remove_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_exists: true]
+        assert_equal [:add_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_not_exists: true], nil], enable
       end
 
       def test_invert_add_unique_key_constraint_with_using_index


### PR DESCRIPTION
The `add_check_constraint` method now accepts an `if_not_exists` option. If set to true an error won't be raised if the check constraint already exists. In addition, `if_exists` and `if_not_exists` options are transposed if set when reversing `remove_check_constraint` and `add_check_constraint`. This enables simple creation of idempotent, non-transactional migrations.

### Motivation / Background

We often write migrations like this:

```ruby
class MyMigration < ActiveRecord::Migration[7.0]
  disable_ddl_transaction!

  def change
    add_check_constraint(:table, "expression", name: "mychk", validate: false)
    validate_constraint(:table, "mychk")
  end
end
```

But we also want to be able to easily re-run the migration, in case the validation fails. So it needs to be idempotent, because it's non-transactional. So we need an `if_not_exists` option for `add_check_constraint`. Also, because it's in a non-transactional migration, in order to properly revert it, the reversion that calls `remove_check_constraint` should set `if_exists: true`, in case the reversion was disconnected from the database between the check constraint being removed, and the migration being recorded as complete (this is slightly contrived, but could be far more common if you happen to be adding then removing a check constraint in the same migration).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
