### PR TITLE
Expose Active Storage service names

### DIFF
--- a/activestorage/lib/active_storage/service/registry.rb
+++ b/activestorage/lib/active_storage/service/registry.rb
@@ -22,6 +22,10 @@ module ActiveStorage
       end
     end
 
+    def names
+      configurations.keys
+    end
+
     private
       attr_reader :configurations, :services
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1370,7 +1370,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # ...
   def after_teardown
     super
-    FileUtils.rm_rf(ActiveStorage::Blob.service.root)
+    directories = ActiveStorage::Blob.services.names.map do |service_name|
+      ActiveStorage::Blob.services.fetch(service_name).root
+    end
+    FileUtils.rm_rf(directories)
   end
   # ...
 end
@@ -1384,7 +1387,10 @@ tests.
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # ...
   parallelize_setup do |i|
-    ActiveStorage::Blob.service.root = "#{ActiveStorage::Blob.service.root}-#{i}"
+    ActiveStorage::Blob.services.names.each do |service_name|
+      service = ActiveStorage::Blob.services.fetch(service_name)
+      service.root = "#{service.root}-#{i}"
+    end
   end
   # ...
 end
@@ -1411,7 +1417,10 @@ automatically cleaned up. If you want to clear the files, you can do it in an
 class ActionDispatch::IntegrationTest
   def after_teardown
     super
-    FileUtils.rm_rf(ActiveStorage::Blob.service.root)
+    directories = ActiveStorage::Blob.services.names.map do |service_name|
+      ActiveStorage::Blob.services.fetch(service_name).root
+    end
+    FileUtils.rm_rf(directories)
   end
 end
 ```
@@ -1423,7 +1432,10 @@ tests.
 ```ruby
 class ActionDispatch::IntegrationTest
   parallelize_setup do |i|
-    ActiveStorage::Blob.service.root = "#{ActiveStorage::Blob.service.root}-#{i}"
+    ActiveStorage::Blob.services.names.each do |service_name|
+      service = ActiveStorage::Blob.services.fetch(service_name)
+      service.root = "#{service.root}-#{i}"
+    end
   end
 end
 ```


### PR DESCRIPTION
This is useful to configure multiple disk services for parallel testing without having to resort to something like `ActiveStorage::Blob.services.send(:configurations).keys` to get this information.
