### PR TITLE
Instrument Active Record transactions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add instrumentation for Active Record transactions
+
+    Allows subscribing to transaction events for tracking/instrumentation. The event payload contains the connection, as well as timing details.
+
+    ```ruby
+    ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      puts "Transaction event occurred!"
+      connection = event.payload[:connection]
+      puts "Connection: #{connection.inspect}"
+    end
+    ```
+
+    *Daniel Colson*, *Ian Candy*
+
 *   Support composite foreign keys via migration helpers.
 
     ```ruby

--- a/activerecord/test/cases/transaction_instrumentation_test.rb
+++ b/activerecord/test/cases/transaction_instrumentation_test.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+
+class TransactionInstrumentationTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+  fixtures :topics
+
+  def test_transaction_instrumentation_on_commit
+    topic = topics(:fifth)
+
+    notified = false
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      assert event.payload[:connection]
+      notified = true
+    end
+
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Ruby on Rails")
+    end
+
+    assert notified
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_on_rollback
+    topic = topics(:fifth)
+
+    notified = false
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      assert event.payload[:connection]
+      notified = true
+    end
+
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Ruby on Rails")
+      raise ActiveRecord::Rollback
+    end
+
+    assert notified
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_with_savepoints
+    topic = topics(:fifth)
+
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      events << event
+    end
+
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Sinatra")
+      ActiveRecord::Base.transaction(requires_new: true) do
+        topic.update(title: "Ruby on Rails")
+      end
+    end
+
+    assert_equal 2, events.count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_with_restart_parent_transaction_on_commit
+    topic = topics(:fifth)
+
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      events << event
+    end
+
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        topic.update(title: "Ruby on Rails")
+      end
+    end
+
+    assert_equal 1, events.count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_with_restart_parent_transaction_on_rollback
+    topic = topics(:fifth)
+
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      events << event
+    end
+
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        topic.update(title: "Ruby on Rails")
+        raise ActiveRecord::Rollback
+      end
+      raise ActiveRecord::Rollback
+    end
+
+    assert_equal 2, events.count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_with_unmaterialized_restart_parent_transactions
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      events << event
+    end
+
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    assert_equal 0, events.count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_with_restart_savepoint_parent_transactions
+    topic = topics(:fifth)
+
+    events = []
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      events << event
+    end
+
+    ActiveRecord::Base.transaction do
+      topic.update(title: "Sinatry")
+      ActiveRecord::Base.transaction(requires_new: true) do
+        ActiveRecord::Base.transaction(requires_new: true) do
+          topic.update(title: "Ruby on Rails")
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    assert_equal 3, events.count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_only_fires_if_materialized
+    notified = false
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      notified = true
+    end
+
+    ActiveRecord::Base.transaction do
+    end
+
+    assert_not notified
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_fires_before_after_commit_callbacks
+    notified = false
+    after_commit_triggered = false
+
+    topic_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+
+      after_commit do
+        after_commit_triggered = true
+      end
+    end
+
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      assert_not after_commit_triggered, "Transaction notification fired after the after_commit callback"
+      notified = true
+    end
+
+    topic_model.create!
+
+    assert notified
+    assert after_commit_triggered
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_fires_before_after_rollback_callbacks
+    notified = false
+    after_rollback_triggered = false
+
+    topic_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+
+      after_rollback do
+        after_rollback_triggered = true
+      end
+    end
+
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      assert_not after_rollback_triggered, "Transaction notification fired after the after_rollback callback"
+      notified = true
+    end
+
+    topic_model.transaction do
+      topic_model.create!
+      raise ActiveRecord::Rollback
+    end
+
+    assert notified
+    assert after_rollback_triggered
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  def test_transaction_instrumentation_on_failed_commit
+    topic = topics(:fifth)
+
+    notified = false
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      notified = true
+    end
+
+    error = Class.new(StandardError)
+    assert_raises error do
+      ActiveRecord::Base.connection.stub(:commit_db_transaction, -> (*) { raise error }) do
+        ActiveRecord::Base.transaction do
+          topic.update(title: "Ruby on Rails")
+        end
+      end
+    end
+
+    assert notified
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
+  unless in_memory_db?
+    def test_transaction_instrumentation_on_failed_rollback
+      topic = topics(:fifth)
+
+      notified = false
+      subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+        notified = true
+      end
+
+      error = Class.new(StandardError)
+      assert_raises error do
+        ActiveRecord::Base.connection.stub(:rollback_db_transaction, -> (*) { raise error }) do
+          ActiveRecord::Base.transaction do
+            topic.update(title: "Ruby on Rails")
+            raise ActiveRecord::Rollback
+          end
+        end
+      end
+
+      assert notified
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+
+  def test_transaction_instrumentation_on_broken_subscription
+    topic = topics(:fifth)
+
+    error = Class.new(StandardError)
+    subscriber = ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|
+      raise error
+    end
+
+    assert_raises(error) do
+      ActiveRecord::Base.transaction do
+        topic.update(title: "Ruby on Rails")
+      end
+    end
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request adds events to track when Active Record-managed transactions occur. Tracking Active Record-managed transactions seems to be a common need, but there's currently not a great way to do it. Here's a few examples we've seen:

* GitHub has custom transaction tracking that monkey patches the Active Record `TransactionManager` and `RealTransaction`. We use the tracking to prevent opening a transaction to one database cluster inside a transaction to a different database cluster, and to report slow transactions (we get slow transaction data directly from MySQL as well, but it's still helpful to report from the application with backtraces to help track them down).
* https://github.com/palkan/isolator tracks transactions to prevent non-atomic interactions like external network calls inside a transaction. The gem works by subscribing to `sql.active_record`, then piecing together the transactions by looking for `BEGIN`, `COMMIT`, `SAVEPOINT`, etc., but this is unreliable: - https://github.com/palkan/isolator/issues/65 - https://github.com/palkan/isolator/issues/64
* It looks like GitLab patches `TransactionManager` and `RealTransaction` to track nested savepoints. See https://github.com/palkan/isolator/issues/46

### Detail

This PR adds a new `transaction.active_record` event that should provide a more reliable solution for these various use cases. It includes the connection in the payload (useful, for example, in differentiating transactions to different databases),

### Additional information

- This instrumentation needs to start and finish at fairly specific times:
  - start on materialize
  - finish after committing or rolling back, but before the after_commit or after_rollback callbacks
  - finish and start again when the transaction restarts (at least for real transactions—we've done it for savepoints as well but I'm not certain we should)
  - ensure it finishes if commit and rollback fail (e.g. if the connection goes away) To make all that work, this commit uses the lower-level `#build-handle` API instead of `#instrument`.
- If this change gets merged we're also planning to add details about what type of transaction it is (savepoint or real) and what the outcome is (commit, rollback, restarted, errored).
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
