### PR TITLE
Keep VariantWithRecord API consistent with Variant

### DIFF
--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -7,6 +7,7 @@
 class ActiveStorage::VariantWithRecord
   attr_reader :blob, :variation
   delegate :service, to: :blob
+  delegate :content_type, to: :variation
 
   def initialize(blob, variation)
     @blob, @variation = blob, ActiveStorage::Variation.wrap(variation)
@@ -19,6 +20,10 @@ class ActiveStorage::VariantWithRecord
 
   def image
     record&.image
+  end
+
+  def filename
+    ActiveStorage::Filename.new "#{blob.filename.base}.#{variation.format.downcase}"
   end
 
   # Destroys record and deletes file from service.

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -23,6 +23,8 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     end
 
     assert_match(/racecar\.jpg/, variant.url)
+    assert_equal "racecar.jpg", variant.filename.to_s
+    assert_equal "image/jpeg", variant.content_type
 
     image = read_image(variant.image)
     assert_equal 100, image.width


### PR DESCRIPTION
Similar to c18bcd582819212c0d8d5523f7918cd4c1c4d53f
Adds the content_type and filename methods to VariantWithRecord as defined in Variant:

https://github.com/rails/rails/blob/44bd6e7acaa91dd59c260beea6863a49b84f6039/activestorage/app/models/active_storage/variant.rb#L58

https://github.com/rails/rails/blob/44bd6e7acaa91dd59c260beea6863a49b84f6039/activestorage/app/models/active_storage/variant.rb#L90-L92

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
