### PR TITLE
Remove unused methods on ActiveStorage::Variant

### DIFF
--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -91,12 +91,6 @@ class ActiveStorage::Variant
     ActiveStorage::Filename.new "#{blob.filename.base}.#{variation.format.downcase}"
   end
 
-  alias_method :content_type_for_serving, :content_type
-
-  def forced_disposition_for_serving # :nodoc:
-    nil
-  end
-
   # Returns the receiving variant. Allows ActiveStorage::Variant and ActiveStorage::Preview instances to be used interchangeably.
   def image
     self


### PR DESCRIPTION
These methods were added in b221a4dc43368a1b6f00476f7c5f6047c5c7eea4 But they don't seem to be used by Rails internally or have any tests, so I assume they were added by accident?
As they both seem to be marked as :nodoc: on ActiveStorage::Blob, we can remove them without a deprecation warning.

If we decide to keep these methods, they should be added to ActiveStorage::VariantWithRecord as well.
No one complaining about there methods missing on ActiveStorage::VariantWithRecord is another reason these methods aren't used.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
