### PR TITLE
Support custom content type matchers on ActiveStorage::Blob

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,17 @@
+*   Support custom content type matchers on ActiveStorage::Blob
+
+    ActiveStorage::Blob has predefined methods for checking if it's an image,
+    video, audio or text.
+
+    `Rails.application.config.active_storage.content_type_matchers` allows defining custom
+    matchers or overriding the default matchers.
+
+    ```ruby
+    Rails.application.config.active_storage.content_type_matchers[:pdf] = -> (c) { c == "application/pdf" }
+    blob = ActiveStorage::Blob.last
+    blob.pdf? # => true
+    ```
+
+    *Petrik de Heus*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -17,6 +17,8 @@
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveStorage::Record
+  class UnknownContentTypeMatcher < StandardError; end
+
   include Analyzable
   include Identifiable
   include Representable
@@ -188,22 +190,22 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   # Returns true if the content_type of this blob is in the image range, like image/png.
   def image?
-    content_type.start_with?("image")
+    content_type_match_for?(:image)
   end
 
   # Returns true if the content_type of this blob is in the audio range, like audio/mpeg.
   def audio?
-    content_type.start_with?("audio")
+    content_type_match_for?(:audio)
   end
 
   # Returns true if the content_type of this blob is in the video range, like video/mp4.
   def video?
-    content_type.start_with?("video")
+    content_type_match_for?(:video)
   end
 
   # Returns true if the content_type of this blob is in the text range, like text/plain.
   def text?
-    content_type.start_with?("text")
+    content_type_match_for?(:text)
   end
 
   # Returns the URL of the blob on the service. This returns a permanent URL for public files, and returns a
@@ -384,6 +386,30 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
     def update_service_metadata
       service.update_metadata key, **service_metadata if service_metadata.any?
+    end
+
+    def method_missing(method, *args)
+      if method.end_with?("?")
+        matcher_name = method[0..-2]
+        content_type_match_for?(matcher_name)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      if method.end_with?("?")
+        matcher_name = method[0..-2]
+        ActiveStorage.content_type_matchers.has_key?(matcher_name.to_sym)
+      else
+        super
+      end
+    end
+
+    def content_type_match_for?(name)
+      matcher = ActiveStorage.content_type_matchers[name.to_sym]
+      raise UnknownContentTypeMatcher, "Unknown content type matcher '#{name}'" unless matcher
+      matcher.call(content_type)
     end
 end
 

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -61,6 +61,7 @@ module ActiveStorage
   mattr_accessor :binary_content_type,              default: "application/octet-stream"
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline,     default: []
+  mattr_accessor :content_type_matchers,            default: {}
 
   mattr_accessor :supported_image_processing_methods, default: [
     "adaptive_blur",

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -75,6 +75,13 @@ module ActiveStorage
       application/pdf
     )
 
+    config.active_storage.content_type_matchers = {
+      image: -> (content_type) { content_type.start_with?("image") },
+      audio: -> (content_type) { content_type.start_with?("audio") },
+      video: -> (content_type) { content_type.start_with?("video") },
+      text:  -> (content_type) { content_type.start_with?("text") }
+    }
+
     config.eager_load_namespaces << ActiveStorage
 
     initializer "active_storage.deprecator", before: :load_environment_config do |app|
@@ -115,6 +122,7 @@ module ActiveStorage
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
+        ActiveStorage.content_type_matchers = app.config.active_storage.content_type_matchers
 
         unless app.config.active_storage.silence_invalid_content_types_warning.nil?
           ActiveStorage.silence_invalid_content_types_warning = app.config.active_storage.silence_invalid_content_types_warning

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2792,6 +2792,20 @@ By default, this is defined as:
 config.active_storage.content_types_allowed_inline` = %w(image/png image/gif image/jpeg image/tiff image/vnd.adobe.photoshop image/vnd.microsoft.icon application/pdf)
 ```
 
+#### `config.active_storage.content_type_matchers`
+
+Accepts a hash of with procs to match the content type.
+By default, this is defined as:
+
+```ruby
+config.active_storage.content_type_matchers = {
+  image: -> (content_type) { content_type.start_with?("image") },
+  audio: -> (content_type) { content_type.start_with?("audio") },
+  video: -> (content_type) { content_type.start_with?("video") },
+  text:  -> (content_type) { content_type.start_with?("text") }
+}
+```
+
 #### `config.active_storage.queues.analysis`
 
 Accepts a symbol indicating the Active Job queue to use for analysis jobs. When this option is `nil`, analysis jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).


### PR DESCRIPTION
ActiveStorage::Blob has methods for checking if it's an image, video, etc. In some case we might want to override the matchers or define our own matchers, for example to check if it's a PDF.

Instead of adding new methods for every possible content type, we should make this configurable with
`Rails.application.config.active_storage.content_type_matchers`.

```ruby
Rails.application.config.active_storage.content_type_matchers[:pdf] = -> (c) { c == "application/pdf" }
blob = ActiveStorage::Blob.last
blob.pdf? # => true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
