### PR TITLE
[ci skip] Guides guidelines: note that guide text should wrap at 80 columns

### DIFF
--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -92,6 +92,10 @@ https://api.rubyonrails.org/v5.1.0/classes/ActionDispatch/Response.html
 
 Please don't link to `edgeapi.rubyonrails.org` manually.
 
+Column Wrapping
+---------------
+
+Do not reformat old guides just to wrap columns. But new sections and guides should wrap at 80 columns.
 
 API Documentation Guidelines
 ----------------------------


### PR DESCRIPTION
@eileencodes you mentioned that we want to wrap new text at 80 cols, but I couldn't find that in the guides guidelines or the API doc guidelines. Added a section to say so.