### PR TITLE
Drop `id` column from `cpk_order_tags` table

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -452,6 +452,21 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_empty(tag.orders.reload)
   end
 
+  def test_composite_primary_key_join_table
+    order = Cpk::Order.create(shop_id: 1, status: "open")
+    tag = cpk_tags(:cpk_tag_loyal_customer)
+
+    order_tag = Cpk::OrderTag.create(order_id: order.id_value, tag_id: tag.id, attached_by: "Nikita")
+
+    assert_equal(order, order_tag.order)
+    assert_equal(tag, order_tag.tag)
+    order_tag.update(attached_reason: "This is our loyal customer")
+
+    order_tag = order.order_tags.find { |order_tag| order_tag.tag_id == tag.id }
+
+    assert_equal("This is our loyal customer", order_tag.attached_reason)
+  end
+
   def test_destroy_all_on_association_clears_scope
     post = Post.create!(title: "Rails 6", body: "")
     people = post.people

--- a/activerecord/test/models/cpk/order.rb
+++ b/activerecord/test/models/cpk/order.rb
@@ -12,6 +12,8 @@ module Cpk
     has_many :order_agreements
     has_many :books, query_constraints: [:shop_id, :order_id]
     has_one :book, query_constraints: [:shop_id, :order_id]
+    has_many :order_tags
+    has_many :tags, through: :order_tags
   end
 
   class BrokenOrder < Order

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -275,9 +275,11 @@ ActiveRecord::Schema.define do
     t.string :status
   end
 
-  create_table :cpk_order_tags, force: true do |t|
+  create_table :cpk_order_tags, primary_key: [:order_id, :tag_id], force: true do |t|
     t.integer :order_id
     t.integer :tag_id
+    t.string :attached_by
+    t.string :attached_reason
   end
 
   create_table :cpk_tags, force: true do |t|


### PR DESCRIPTION
We are preparing to extend Rails guides with a recommendation to use composite primary key on join tables that are backed by a model
Before writing the guide we'd like to demonstrate the approach using one of the tests. We already have a suitable setup where `cpk_order_tags` is being used as a join table with `id` column present but being completely unused

This PR drops `id` column primary key from `cpk_order_tags` in favor of `:order_id, :tag_id` composite primary key and adds a test showing some basic use-case of using a join table backed by a model which also stores a bit of context about the association - `attached_by` and `attached_reason` 