### PR TITLE
Remove X-Download-Options default config

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -32,7 +32,6 @@ module ActionDispatch
       "X-Frame-Options" => "SAMEORIGIN",
       "X-XSS-Protection" => "1; mode=block",
       "X-Content-Type-Options" => "nosniff",
-      "X-Download-Options" => "noopen",
       "X-Permitted-Cross-Domain-Policies" => "none",
       "Referrer-Policy" => "strict-origin-when-cross-origin"
     }

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -406,7 +406,6 @@ You can also use the `p` or `pp` command to evaluate Ruby expressions, which is 
 {"X-Frame-Options"=>"SAMEORIGIN",
  "X-XSS-Protection"=>"1; mode=block",
  "X-Content-Type-Options"=>"nosniff",
- "X-Download-Options"=>"noopen",
  "X-Permitted-Cross-Domain-Policies"=>"none",
  "Referrer-Policy"=>"strict-origin-when-cross-origin"}
 (rdbg)


### PR DESCRIPTION
Follow-up: #43968

### Detail

This Pull Request removes s`X-Download-Options` from `config.action_dispatch.default_headers`.

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
