### PR TITLE
Deprecate calling `render` with no arguments in API controllers

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate calling `render` with no arguments in API controllers
+
+    Calling `render` without any arguments in API controllers was returning a
+    200 OK with a body of " ". In Rails 7.2, this will raise an error.
+
+    *Nick Holden*
+
 *   `AbstractController::Translation.raise_on_missing_translations` removed
 
     This was a private API, and has been removed in favour of a more broadly applicable

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -155,7 +155,15 @@ module ActionController
     end
 
     def render_to_body(options = {}) # :nodoc:
-      super || _render_in_priorities(options) || " "
+      result = super || _render_in_priorities(options)
+      return result if result
+
+      ActionController.deprecator.warn <<~MSG
+        ActionController found no valid render format for #{self.class.name}\##{action_name}
+        In Rails 7.2, this will raise an error instead of returning " ".
+      MSG
+
+      " "
     end
 
     private

--- a/actionpack/test/controller/api/renderers_test.rb
+++ b/actionpack/test/controller/api/renderers_test.rb
@@ -25,6 +25,10 @@ class RenderersApiController < ActionController::API
   def plain
     render plain: "Hi from plain", status: 500
   end
+
+  def no_arguments
+    render
+  end
 end
 
 class RenderersApiTest < ActionController::TestCase
@@ -46,5 +50,14 @@ class RenderersApiTest < ActionController::TestCase
     get :plain
     assert_response :internal_server_error
     assert_equal("Hi from plain", @response.body)
+  end
+
+  def test_render_no_arguments
+    assert_deprecated(ActionController.deprecator) do
+      get :no_arguments
+    end
+
+    assert_response :success
+    assert_equal " ", @response.body
   end
 end

--- a/actionpack/test/controller/metal/renderers_test.rb
+++ b/actionpack/test/controller/metal/renderers_test.rb
@@ -42,7 +42,10 @@ class RenderersMetalTest < ActionController::TestCase
   end
 
   def test_render_xml
-    get :two
+    assert_deprecated(ActionController.deprecator) do
+      get :two
+    end
+
     assert_response :success
     assert_equal(" ", @response.body)
     assert_equal "text/plain", @response.media_type

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -134,7 +134,7 @@ module ActionView
           @format = format
         end
 
-        def body; nil; end
+        def body; " "; end
       end
     end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -411,12 +411,12 @@ module RenderTestCases
     assert_equal "local-variable\nlocal-variable", @controller_view.render([a, b])
   end
 
-  def test_render_partial_with_empty_collection_should_return_nil
-    assert_nil @view.render(partial: "test/customer", collection: [])
+  def test_render_partial_with_empty_collection
+    assert_equal " ", @view.render(partial: "test/customer", collection: [])
   end
 
-  def test_render_partial_with_nil_collection_should_return_nil
-    assert_nil @view.render(partial: "test/customer", collection: nil)
+  def test_render_partial_with_nil_collection
+    assert_equal " ", @view.render(partial: "test/customer", collection: nil)
   end
 
   def test_render_partial_collection_for_non_array
@@ -465,8 +465,8 @@ module RenderTestCases
       @view.render(partial: "test/customer", layout: "test/b_layout_for_partial_with_object", object: Customer.new("Amazon"))
   end
 
-  def test_render_partial_with_empty_array_should_return_nil
-    assert_nil @view.render(partial: [])
+  def test_render_partial_with_empty_array
+    assert_equal " ", @view.render(partial: [])
   end
 
   def test_render_partial_using_string
@@ -975,7 +975,7 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
   test "collection caching with empty collection and logger with level debug" do
     ActionView::PartialRenderer.collection_cache.logger = Logger.new(nil, level: :debug)
 
-    assert_nil @view.render(partial: "test/cached_customer", collection: [], cached: true)
+    assert_equal " ", @view.render(partial: "test/cached_customer", collection: [], cached: true)
   end
 
   test "collection caching with repeated collection" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when I called `render_to_string(partial: 'foo')` in an API controller, I got back `" "` whether or not the partial existed.

It turns out that in API controllers, the `partial` option on `render` does nothing, so it's equivalent to calling `render` with no arguments. I learned that in API controllers, calling `render` with no arguments has the surprising response of 200 OK with a body of `" "`.

### Detail

This change deprecates that surprising behavior and proposes that in the future, calling `render` with no arguments in API controllers will raise an error.

### Additional information

I'm open to other approaches here! Just trying to help other developers avoid this head-scratching behavior. 😅 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
