### PR TITLE
Remove AbstractController::Translation.raise_on_missing_translations added to release note [skip ci]

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -441,6 +441,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing.
 
+*   Remove `AbstractController::Translation.raise_on_missing_translations` in favor of `config.i18n.raise_on_missing_translations`.
+
 ### Deprecations
 
 *   Deprecate `config.action_dispatch.return_only_request_media_type_on_content_type`.


### PR DESCRIPTION
This PR adds a removal change for `AbstractController::Translation.raise_on_missing_translations` #47115 in 7.1 release note

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
