### PR TITLE
Remove Enumerable#sum from guide [skip ci]

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2197,47 +2197,6 @@ BigDecimal(5.00, 6).to_s("e")  # => "0.5E1"
 Extensions to `Enumerable`
 --------------------------
 
-### `sum`
-
-The method [`sum`][Enumerable#sum] adds the elements of an enumerable:
-
-```ruby
-[1, 2, 3].sum # => 6
-(1..100).sum  # => 5050
-```
-
-Addition only assumes the elements respond to `+`:
-
-```ruby
-[[1, 2], [2, 3], [3, 4]].sum    # => [1, 2, 2, 3, 3, 4]
-%w(foo bar baz).sum             # => "foobarbaz"
-{ a: 1, b: 2, c: 3 }.sum          # => [:a, 1, :b, 2, :c, 3]
-```
-
-The sum of an empty collection is zero by default, but this is customizable:
-
-```ruby
-[].sum    # => 0
-[].sum(1) # => 1
-```
-
-If a block is given, `sum` becomes an iterator that yields the elements of the collection and sums the returned values:
-
-```ruby
-(1..5).sum { |n| n * 2 } # => 30
-[2, 4, 6, 8, 10].sum    # => 30
-```
-
-The sum of an empty receiver can be customized in this form as well:
-
-```ruby
-[].sum(1) { |n| n**3 } # => 1
-```
-
-NOTE: Defined in `active_support/core_ext/enumerable.rb`.
-
-[Enumerable#sum]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-sum
-
 ### `index_by`
 
 The method [`index_by`][Enumerable#index_by] generates a hash with the elements of an enumerable indexed by some key.


### PR DESCRIPTION
### Detail

This Pull Request removes the `Enumerable#sum` documentation from the guide, as it was removed in https://github.com/rails/rails/commit/3ec629784cac7a8b518feb402475153465cd8e96


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
