### PR TITLE
Update description for `require_master_key` setting

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -18,8 +18,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
   <%- end -%>
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
+  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
   # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).


### PR DESCRIPTION
### Motivation / Background

While looking into an issue relating to credentials, I found the description for the `require_master_key` setting was incomplete, due to Rails 6 adding support for multi-environment credentials:

https://blog.saeloun.com/2019/10/10/rails-6-adds-support-for-multi-environment-credentials/

In the situation where `RAILS_MASTER_KEY` is not set, and `config/master.key` does not exist, the `require_master_key` check will still pass if an environment key is available.

This Pull Request has been created to expand the description.

### Detail

This Pull Request updates the template comment for the `require_master_key` setting in the template to mention that credentials may be loaded from a specific environment key.

The implemention of `require_master_key` can be seen here:
https://github.com/rails/rails/blob/b1ac22fe7edffaf47051c207d2c43d8971b98a25/activesupport/lib/active_support/railtie.rb#L110

It calls, `Rails::Application#credentials`, which already correctly mentions the possibilty of an environment key:

https://github.com/rails/rails/blob/b1ac22fe7edffaf47051c207d2c43d8971b98a25/railties/lib/rails/application.rb#L494-L501

### Additional information

It could be argued that the `requires_master_key` setting name was already no longer accurate – perhaps it should be `requires_key` or `requires_credentials_key`?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
