### PR TITLE
Add `ActiveStorage::Blob#pdf?`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveStorage::Blob#pdf?`
+
+    Returns true if the content type is "application/pdf".
+
+    *Petrik de Heus*
+
 *   Disables the session in `ActiveStorage::Blobs::ProxyController`
     and `ActiveStorage::Representations::ProxyController`
     in order to allow caching by default in some CDNs as CloudFlare

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -206,6 +206,11 @@ class ActiveStorage::Blob < ActiveStorage::Record
     content_type.start_with?("text")
   end
 
+  # Returns true if the content_type of this blob is application/pdf.
+  def pdf?
+    content_type == "application/pdf"
+  end
+
   # Returns the URL of the blob on the service. This returns a permanent URL for public files, and returns a
   # short-lived URL for private files. Private files are signed, and not for public use. Instead,
   # the URL should only be exposed as a redirect from a stable, possibly authenticated URL. Hiding the

--- a/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
@@ -4,7 +4,7 @@ module ActiveStorage
   class Previewer::MuPDFPreviewer < Previewer
     class << self
       def accept?(blob)
-        blob.content_type == "application/pdf" && mutool_exists?
+        blob.pdf? && mutool_exists?
       end
 
       def mutool_path

--- a/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
@@ -4,7 +4,7 @@ module ActiveStorage
   class Previewer::PopplerPDFPreviewer < Previewer
     class << self
       def accept?(blob)
-        blob.content_type == "application/pdf" && pdftoppm_exists?
+        blob.pdf? && pdftoppm_exists?
       end
 
       def pdftoppm_path

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -143,6 +143,12 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_not_predicate blob, :audio?
   end
 
+  test "pdf?" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    assert_predicate blob, :pdf?
+    assert_not_predicate blob, :audio?
+  end
+
   test "download yields chunks" do
     blob   = create_blob data: "a" * 5.0625.megabytes
     chunks = []


### PR DESCRIPTION
It returns true if the content type is "application/pdf".
Similar to the existing `audio?`, `image?`, `video?` and `text?`
methods.

We probably don't want to add methods for every content type,
but pdf is pretty common and it's also used internally by Rails for
the Previewers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
