### PR TITLE
[ci skip] Suggest using composite primary key on join tables in `:through` associations

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -482,6 +482,8 @@ The simplest rule of thumb is that you should set up a `has_many :through` relat
 
 You should use `has_many :through` if you need validations, callbacks, or extra attributes on the join model.
 
+While `has_and_belongs_to_many` suggests creating join table with no primary key - `id: false`, consider using composite primary key for the join table in the `has_many :through` relationship. For example its recommended to use `create_table :manifests, primary_key: []:assembly_id, :part_id]` for the example above.
+
 ### Polymorphic Associations
 
 A slightly more advanced twist on associations is the _polymorphic association_. With polymorphic associations, a model can belong to more than one other model, on a single association. For example, you might have a picture model that belongs to either an employee model or a product model. Here's how this could be declared:


### PR DESCRIPTION
Currently Rails suggests to create tables with no primary key to be used as a join table for a `has_and_belongs_to_many` association which makes sense since there is no model backing the table

However for a join table with a backing model it may make more sense to choose a composite primary key on both `foreign_key_1, foreign_key_2` column instead of unnecessarily keeping the `id` column .

This PR adds a suggestion to consider composite primary key for join tables that are represented by a whole model

We are utilizing this suggestion ourselves in the Rails test suite - https://github.com/rails/rails/pull/49206