### PR TITLE
Rails supports but does not recommend non-PK `id` column

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -212,7 +212,11 @@ class Product < ApplicationRecord
 end
 ```
 
-NOTE: **Active Record does not support using non-primary key columns named `id`.**
+NOTE: **Active Record does not recommend using non-primary key columns named `id`.**
+Using a column named `id` which is not a single-column primary key complicates the access to the column value.
+The application will have to use the [`id_value`][] alias attribute to access the value of the non-PK `id` column.
+
+[`id_value`]: https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema.html#method-i-id_value
 
 NOTE: If you try to create a column named `id` which is not the primary key,
 Rails will throw an error during migrations such as:


### PR DESCRIPTION
`NOTE: Active Record does not support using non-primary key columns named id.` is a little bit misleading. 
It is possible to have a model backed by a db table with `id` column which is not being used a sole primary key. The model can either use a different column as a PK or use a composite primary key. However it will lead to an additional complexity related to inability to keep accessing `id` column value using `PrimaryKey#id` method since the method returns the value of the primary key. 

### Question for reviewers

I'm not 100% confident about changing the current note. At one hand this note is false as Active Record won't stop working for a model with a non-PK `id` column. At the same time Rails should discourage schema designs like this due to unnecessary complexities associated with `id` attribute access. 
So maybe we should actually keep the stronger wording even though it may be a little falsey 