### PR TITLE
Remove AbstractController::Translation.raise_on_missing_translations from changelog [skip ci]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,10 +1,3 @@
-*   `AbstractController::Translation.raise_on_missing_translations` removed
-
-    This was a private API, and has been removed in favour of a more broadly applicable
-    `config.i18n.raise_on_missing_translations`. See the upgrading guide for more information.
-
-    *Alex Ghiculescu*
-
 *   Add `ActionController::Parameters#extract_value` method to allow extracting serialized values from params
 
     ```ruby


### PR DESCRIPTION
`AbstractController::Translation.raise_on_missing_translations`  is not part of public API, so we don't really need to add that in the changelog. ref: https://github.com/rails/rails/pull/49213#issuecomment-1714144365

### Detail

This Pull Request removes the changelog entry for `AbstractController::Translation.raise_on_missing_translations` removal.

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
