### PR TITLE
Add +when+ to ActiveRecord query methods.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add `when` to query methods.
+
+    ```ruby
+    # before
+    users = User
+      .where(active: true)
+      .order(created_at: :desc)
+
+    if params[:name].present?
+      users = User.where(name: params[:name])
+    end
+
+    # after
+    users = User
+      .where(active: true)
+
+      # if params[:name] is present, then call on our instance
+      .when(params[:name], -> (name) { where(name: name) })
+
+      # or pass a hash directly
+      # .when(params[:name], name: params[:name])
+
+      .order(created_at: :desc)
+    ```
+
+    *Baylor Weathers*
+
 *   Support composite foreign keys via migration helpers.
 
     ```ruby

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
+      :where, :rewhere, :invert_where, :when, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1006,6 +1006,35 @@ module ActiveRecord
       self
     end
 
+    # Allows query methods to be called when an optional value is present.
+    #
+    #   # before
+    #   users = User
+    #     .where(active: true)
+    #     .order(created_at: :desc)
+    #
+    #   if params[:name].present?
+    #     users = User.where(name: params[:name])
+    #   end
+    #
+    #   # after
+    #   users = User
+    #     .where(active: true)
+    #
+    #     # if params[:name] is present, then call on our instance
+    #     .when(params[:name], -> (name) { where(name: name) })
+    #
+    #     # or pass a hash directly
+    #     # .when(params[:name], name: params[:name])
+    #
+    #     .order(created_at: :desc)
+    #
+    def when(value, proc_or_hash)
+      return self if value.blank?
+      return self.instance_exec(value, &proc_or_hash) if proc_or_hash.respond_to?(:call)
+      self.where(proc_or_hash)
+    end
+
     # Checks whether the given relation is structurally compatible with this relation, to determine
     # if it's possible to use the #and and #or methods without raising an error. Structurally
     # compatible is defined as: they must be scoping the same model, and they must differ only by

--- a/activerecord/test/cases/relation/when_test.rb
+++ b/activerecord/test/cases/relation/when_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/car"
+
+module ActiveRecord
+  class WhenTest < ActiveRecord::TestCase
+    fixtures :cars
+
+    def test_passes_the_value_to_a_proc
+      honda = cars(:honda)
+
+      name = "honda"
+      expected = Car.where(id: honda)
+      actual   = Car.when(name, -> (value) { where(name: value) })
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
+    def test_allows_the_value_to_be_directly_used_in_a_hash
+      honda = cars(:honda)
+
+      name = "honda"
+      expected = Car.where(id: honda)
+      actual   = Car.when(name, name: name)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
+    def test_passes_the_relation_through_when_the_value_is_empty_string
+      honda = cars(:honda)
+      zyke = cars(:zyke)
+
+      name = ""
+      expected = Car.where(id: [honda, zyke])
+      actual   = Car.when(name, name: name)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+
+    def test_passes_the_relation_through_when_the_value_is_nil
+      honda = cars(:honda)
+      zyke = cars(:zyke)
+
+      name = nil
+      expected = Car.where(id: [honda, zyke])
+      actual   = Car.when(name, name: name)
+
+      assert_equal expected.to_a, actual.to_a
+    end
+  end
+end


### PR DESCRIPTION
This introduces a method to `ActiveRecord::QueryMethods` that removes the need to create temporary variables or add conditionals with overwriting query assignments.

```ruby
# before
users = User
  .where(active: true)
  .order(created_at: :desc)

if params[:name].present?
  users = User.where(name: params[:name])
end

# after
users = User
  .where(active: true)

  # if params[:name] is present, then call on our instance
  .when(params[:name], -> (name) { where(name: name) })

  # or pass a hash directly
  # .when(params[:name], name: params[:name])

  .order(created_at: :desc)
```

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This was inspired by Laravel's +when+ method which [I saw used by their ORM in a video](https://youtu.be/Lc1pSnRQAMY?t=370). It accomplishes a scenario I regularly face and I liked the simplicity of the implementation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.