### PR TITLE
Make bin/setup work with bun

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   bin/setup uses `bun` instead of `yarn` when generated an app with bun
+
+    Use `bun install` on `bin/setup` when using `bun`.
+
+    *Cadu Ribeiro*
+
 *   `config/application.rb` now includes
 
     ```ruby

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -467,8 +467,14 @@ module Rails
       end
 
       def using_node?
+        return if using_bun?
+
         (options[:javascript] && !%w[importmap].include?(options[:javascript])) ||
           (options[:css] && !%w[tailwind sass].include?(options[:css]))
+      end
+
+      def using_bun?
+        options[:javascript] == "bun"
       end
 
       def node_version
@@ -569,12 +575,12 @@ module Rails
       def css_gemfile_entry
         return unless options[:css]
 
-        if !using_node? && options[:css] == "tailwind"
-          GemfileEntry.floats "tailwindcss-rails", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]"
-        elsif !using_node? && options[:css] == "sass"
-          GemfileEntry.floats "dartsass-rails", "Use Dart SASS [https://github.com/rails/dartsass-rails]"
-        else
+        if using_node? || using_bun?
           GemfileEntry.floats "cssbundling-rails", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]"
+        elsif options[:css] == "tailwind"
+          GemfileEntry.floats "tailwindcss-rails", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]"
+        elsif options[:css] == "sass"
+          GemfileEntry.floats "dartsass-rails", "Use Dart SASS [https://github.com/rails/dartsass-rails]"
         end
       end
 
@@ -684,12 +690,12 @@ module Rails
       def run_css
         return if !options[:css] || !bundle_install?
 
-        if !using_node? && options[:css] == "tailwind"
-          rails_command "tailwindcss:install"
-        elsif !using_node? && options[:css] == "sass"
-          rails_command "dartsass:install"
-        else
+        if using_bun? || using_node?
           rails_command "css:install:#{options[:css]}"
+        elsif options[:css] == "tailwind"
+          rails_command "tailwindcss:install"
+        elsif options[:css] == "sass"
+          rails_command "dartsass:install"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -19,6 +19,10 @@ FileUtils.chdir APP_ROOT do
 
   # Install JavaScript dependencies
   system("yarn check --check-files") || system!("yarn install")
+<% elsif using_bun? %>
+  # Install JavaScript dependencies
+
+  system("bun install")
 <% end -%>
 <% unless options.skip_active_record? -%>
 


### PR DESCRIPTION
### Motivation / Background

Now that rails/jsbundling-rails supports bun https://github.com/rails/jsbundling-rails/pull/167 (thanks @terracatta), we can make `bin/setup` use `bun` instead of `yarn`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
