### PR TITLE
Enable Minitest/LiteralAsActualArgument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -350,6 +350,9 @@ Minitest/AssertRaisesWithRegexpArgument:
 Minitest/AssertWithExpectedArgument:
   Enabled: true
 
+Minitest/LiteralAsActualArgument:
+  Enabled: true
+
 Minitest/SkipEnsure:
   Enabled: true
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -832,8 +832,8 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "proc default values can have arity of 1 where arg is a mailer instance" do
-    assert_equal(ProcMailer.welcome["X-Lambda-Arity-1-arg"].to_s, "complex_value")
-    assert_equal(ProcMailer.welcome["X-Lambda-Arity-1-self"].to_s, "complex_value")
+    assert_equal("complex_value", ProcMailer.welcome["X-Lambda-Arity-1-arg"].to_s)
+    assert_equal("complex_value", ProcMailer.welcome["X-Lambda-Arity-1-self"].to_s)
   end
 
   test "proc default values with fixed arity of 0 can be called" do

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -181,7 +181,7 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
     params.permit!
     params_hash = params.to_h { |key, value| [:"#{key}_modified", value] }
-    assert_equal params_hash.keys, %w(name_modified age_modified location_modified)
+    assert_equal %w(name_modified age_modified location_modified), params_hash.keys
   end
   # rubocop:enable Style/HashTransformKeys
 
@@ -190,7 +190,7 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
     params.permit!
     params_hash = params.to_h { |key, value| [key, value.is_a?(String) ? "#{value}_modified" : value] }
-    assert_equal params_hash.values, %w(Alex_modified 40_modified Beijing_modified)
+    assert_equal %w(Alex_modified 40_modified Beijing_modified), params_hash.values
   end
   # rubocop:enable Style/HashTransformValues
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1694,7 +1694,7 @@ class RouteSetTest < ActiveSupport::TestCase
     end
     assert_equal({ controller: "pages", action: "show", name: "mypage" },
       set.recognize_path("http://subdomain.example.org/page/mypage"))
-    assert_equal(name_param, "mypage")
+    assert_equal("mypage", name_param)
   end
 
   def test_route_requirement_recognize_with_ignore_case

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -259,7 +259,7 @@ class TestCaseTest < ActionController::TestCase
 
     post :test_params, params: { foo: klass.new }
 
-    assert_equal JSON.parse(@response.body)["foo"], "bar"
+    assert_equal "bar", JSON.parse(@response.body)["foo"]
   end
 
   def test_body_stream
@@ -1146,7 +1146,7 @@ module EngineControllerTests
 
     def test_engine_controller_route
       get :index
-      assert_equal @response.body, "bar"
+      assert_equal "bar", @response.body
     end
   end
 
@@ -1159,7 +1159,7 @@ module EngineControllerTests
 
     def test_engine_controller_route
       get :index
-      assert_equal @response.body, "bar"
+      assert_equal "bar", @response.body
     end
   end
 end

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -161,8 +161,8 @@ class MimeTypeTest < ActiveSupport::TestCase
   end
 
   test "type should be equal to symbol" do
-    assert_equal Mime[:html], "application/xhtml+xml"
-    assert_equal Mime[:html], :html
+    assert_operator Mime[:html], :==, "application/xhtml+xml"
+    assert_operator Mime[:html], :==, :html
   end
 
   test "type convenience methods" do

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -402,7 +402,7 @@ class ResponseTest < ActiveSupport::TestCase
   test "[response.to_a].flatten does not recurse infinitely" do
     Timeout.timeout(1) do # use a timeout to prevent it stalling indefinitely
       status, headers, body = [@response.to_a].flatten
-      assert_equal status, 200
+      assert_equal 200, status
       assert_equal headers, @response.headers
       assert_nil body
     end

--- a/actionpack/test/dispatch/test_response_test.rb
+++ b/actionpack/test/dispatch/test_response_test.rb
@@ -37,7 +37,7 @@ class TestResponseTest < ActiveSupport::TestCase
       </html>
     HTML
     assert_kind_of(Nokogiri::XML::Document, response.parsed_body)
-    assert_equal(response.parsed_body.at_xpath("/html/body/div").text, "Content")
+    assert_equal("Content", response.parsed_body.at_xpath("/html/body/div").text)
   end
 
   if RUBY_VERSION >= "3.1"

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1497,7 +1497,7 @@ class RenderTest < ActionController::TestCase
     end
 
     assert_not_includes @response.body, "BEGIN"
-    assert_equal @response.body.split("\n").length, 1
+    assert_equal 1, @response.body.split("\n").length
   end
 
   def test_line_offset_with_annotations_enabled

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -151,7 +151,7 @@ module RenderTestCases
     buffer = ActiveSupport::SafeBuffer.new
     buffer << @view.render(template: "plain_text")
     assert_equal true, buffer.html_safe?
-    assert_equal buffer, "<%= hello_world %>\n"
+    assert_equal "<%= hello_world %>\n", buffer
   end
 
   def test_render_ruby_template_with_handlers

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -107,17 +107,17 @@ class LoggingTest < ActiveSupport::TestCase
   def test_enqueue_job_logging
     events = subscribed { HelloJob.perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue.active_job")
+    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_callback_chain_is_halted
     events = subscribed { AbortBeforeEnqueueJob.perform_later }
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue.active_job")
+    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_error_is_raised_during_callback_chain
@@ -128,9 +128,9 @@ class LoggingTest < ActiveSupport::TestCase
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue.active_job")
+    assert_equal("enqueue.active_job", key)
   end
 
   def test_perform_job_logging
@@ -207,9 +207,9 @@ class LoggingTest < ActiveSupport::TestCase
   def test_enqueue_at_job_logging
     events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue_at.active_job")
+    assert_equal("enqueue_at.active_job", key)
   rescue NotImplementedError
     skip
   end
@@ -217,9 +217,9 @@ class LoggingTest < ActiveSupport::TestCase
   def test_enqueue_at_job_log_error_when_callback_chain_is_halted
     events = subscribed { AbortBeforeEnqueueJob.set(wait: 1.second).perform_later }
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue_at.active_job")
+    assert_equal("enqueue_at.active_job", key)
   end
 
   def test_enqueue_at_job_log_error_when_error_is_raised_during_callback_chain
@@ -230,17 +230,17 @@ class LoggingTest < ActiveSupport::TestCase
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue_at.active_job")
+    assert_equal("enqueue_at.active_job", key)
   end
 
   def test_enqueue_in_job_logging
     events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
     assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-    assert_equal(events.count, 1)
+    assert_equal(1, events.count)
     key, * = events.first
-    assert_equal(key, "enqueue_at.active_job")
+    assert_equal("enqueue_at.active_job", key)
   rescue NotImplementedError
     skip
   end

--- a/activemodel/test/cases/attributes_dirty_test.rb
+++ b/activemodel/test/cases/attributes_dirty_test.rb
@@ -134,7 +134,7 @@ class AttributesDirtyTest < ActiveModel::TestCase
     @model.name = "DudeFella ManGuy"
     @model.name = "Mr. Manfredgensonton"
     assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
-    assert_equal @model.name_was, "Otto"
+    assert_equal "Otto", @model.name_was
   end
 
   test "using attribute_will_change! with a symbol" do

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -55,33 +55,35 @@ class CallbacksTest < ActiveModel::TestCase
   test "complete callback chain" do
     model = ModelCallbacks.new
     model.create
-    assert_equal model.callbacks, [ :before_create, :before_around_create, :create,
-                                    :after_around_create, :after_create, :final_callback]
+    assert_equal \
+      [:before_create, :before_around_create, :create, :after_around_create, :after_create, :final_callback],
+      model.callbacks
   end
 
   test "the callback chain is not halted when around or after callbacks return false" do
     model = ModelCallbacks.new
     model.create
-    assert_equal model.callbacks.last, :final_callback
+    assert_equal :final_callback, model.callbacks.last
   end
 
   test "the callback chain is not halted when a before callback returns false)" do
     model = ModelCallbacks.new(before_create_returns: false)
     model.create
-    assert_equal model.callbacks.last, :final_callback
+    assert_equal :final_callback, model.callbacks.last
   end
 
   test "the callback chain is halted when a callback throws :abort" do
     model = ModelCallbacks.new(before_create_throws: :abort)
     model.create
-    assert_equal model.callbacks, [:before_create]
+    assert_equal [:before_create], model.callbacks
   end
 
   test "after callbacks are not executed if the block returns false" do
     model = ModelCallbacks.new(valid: false)
     model.create
-    assert_equal model.callbacks, [ :before_create, :before_around_create,
-                                    :create, :after_around_create]
+    assert_equal \
+      [:before_create, :before_around_create, :create, :after_around_create],
+      model.callbacks
   end
 
   test "only selects which types of callbacks should be created" do

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -184,7 +184,7 @@ class DirtyTest < ActiveModel::TestCase
     @model.status = "finished"
     assert_equal ["Otto", "Mr. Manfredgensonton"], @model.name_change
     assert_equal ["waiting", "finished"], @model.status_change
-    assert_equal @model.name_was, "Otto"
+    assert_equal "Otto", @model.name_was
   end
 
   test "using attribute_will_change! with a symbol" do

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -241,8 +241,8 @@ class ErrorTest < ActiveModel::TestCase
     )
 
     assert_equal(
-      error.details,
-      { error: :too_short, foo: :bar }
+      { error: :too_short, foo: :bar },
+      error.details
     )
   end
 
@@ -250,6 +250,6 @@ class ErrorTest < ActiveModel::TestCase
     person = Person.new
     error = ActiveModel::Error.new(person, :name, foo: :bar)
 
-    assert_equal(error.details, { error: :invalid, foo: :bar })
+    assert_equal({ error: :invalid, foo: :bar }, error.details)
   end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -200,7 +200,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     got_lock = @connection.get_advisory_lock(lock_name)
     assert got_lock, "get_advisory_lock should have returned true but it didn't"
 
-    assert_equal test_lock_free(lock_name), false,
+    assert_equal false, test_lock_free(lock_name),
       "expected the test advisory lock to be held but it wasn't"
 
     released_lock = @connection.release_advisory_lock(lock_name)
@@ -212,7 +212,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_release_non_existent_advisory_lock
     lock_name = "fake lock'n'name"
     released_non_existent_lock = @connection.release_advisory_lock(lock_name)
-    assert_equal released_non_existent_lock, false,
+    assert_equal false, released_non_existent_lock,
       "expected release_advisory_lock to return false when there was no lock to release"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -150,7 +150,7 @@ module ActiveRecord
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: true }))
         set_true = ActiveRecord::Base.connection.exec_query "SHOW DEBUG_PRINT_PLAN"
-        assert_equal set_true.rows, [["on"]]
+        assert_equal [["on"]], set_true.rows
       end
     end
 
@@ -158,7 +158,7 @@ module ActiveRecord
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: false }))
         set_false = ActiveRecord::Base.connection.exec_query "SHOW DEBUG_PRINT_PLAN"
-        assert_equal set_false.rows, [["off"]]
+        assert_equal [["off"]], set_false.rows
       end
     end
 
@@ -211,7 +211,7 @@ module ActiveRecord
       fake_lock_id = 2940075057017742022
       with_warning_suppression do
         released_non_existent_lock = @connection.release_advisory_lock(fake_lock_id)
-        assert_equal released_non_existent_lock, false,
+        assert_equal false, released_non_existent_lock,
           "expected release_advisory_lock to return false when there was no lock to release"
       end
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1180,7 +1180,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     error = assert_raise ArgumentError do
       Class.new(Author).belongs_to :special_author_address, dependent: :nullify
     end
-    assert_equal error.message, "The :dependent option must be one of [:destroy, :delete, :destroy_async], but is :nullify"
+    assert_equal "The :dependent option must be one of [:destroy, :delete, :destroy_async], but is :nullify", error.message
   end
 
   class EssayDestroy < ActiveRecord::Base
@@ -1225,7 +1225,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   def test_attributes_are_being_set_when_initialized_from_belongs_to_association_with_where_clause
     new_firm = accounts(:signals37).build_firm(name: "Apple")
-    assert_equal new_firm.name, "Apple"
+    assert_equal "Apple", new_firm.name
   end
 
   def test_attributes_are_set_without_error_when_initialized_from_belongs_to_association_with_array_in_where_clause

--- a/activerecord/test/cases/associations/bidirectional_destroy_dependencies_test.rb
+++ b/activerecord/test/cases/associations/bidirectional_destroy_dependencies_test.rb
@@ -38,6 +38,6 @@ class BidirectionalDestroyDependenciesTest < ActiveRecord::TestCase
 
     2.times { content.destroy }
 
-    assert_equal content.destroyed?, true
+    assert_equal true, content.destroyed?
   end
 end

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -167,7 +167,7 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
 
   def test_eager_association_loading_with_missing_first_record
     posts = Post.where(id: 3).preload(author: { comments: :post }).to_a
-    assert_equal posts.size, 1
+    assert_equal 1, posts.size
   end
 
   def test_eager_association_loading_with_recursive_cascading_four_levels_has_many_through

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -299,7 +299,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     second_category = Category.create! name: "Second!", posts: [post]
 
     categories = Category.where(id: [first_category.id, second_category.id]).includes(posts: :special_comments)
-    assert_equal categories.map { |category| category.posts.first.special_comments.loaded? }, [true, true]
+    assert_equal [true, true], categories.map { |category| category.posts.first.special_comments.loaded? }
   end
 
   def test_finding_with_includes_on_has_many_association_with_same_include_includes_only_once

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -840,13 +840,13 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_attributes_are_being_set_when_initialized_from_habtm_association_with_where_clause
     new_developer = projects(:action_controller).developers.where(name: "Marcelo").build
-    assert_equal new_developer.name, "Marcelo"
+    assert_equal "Marcelo", new_developer.name
   end
 
   def test_attributes_are_being_set_when_initialized_from_habtm_association_with_multiple_where_clauses
     new_developer = projects(:action_controller).developers.where(name: "Marcelo").where(salary: 90_000).build
-    assert_equal new_developer.name, "Marcelo"
-    assert_equal new_developer.salary, 90_000
+    assert_equal "Marcelo", new_developer.name
+    assert_equal 90_000, new_developer.salary
   end
 
   def test_include_method_in_has_and_belongs_to_many_association_should_return_true_for_instance_added_with_build

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1338,7 +1338,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate Ship.reflect_on_association(:treasures), :has_cached_counter?
 
     # Count should come from sql count() of treasures rather than treasures_count attribute
-    assert_equal ship.treasures.size, 0
+    assert_equal 0, ship.treasures.size
 
     assert_no_difference lambda { ship.reload.treasures_count }, "treasures_count should not be changed" do
       ship.treasures.create(name: "Gold")
@@ -2545,13 +2545,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_attributes_are_being_set_when_initialized_from_has_many_association_with_where_clause
     new_comment = posts(:welcome).comments.where(body: "Some content").build
-    assert_equal new_comment.body, "Some content"
+    assert_equal "Some content", new_comment.body
   end
 
   def test_attributes_are_being_set_when_initialized_from_has_many_association_with_multiple_where_clauses
     new_comment = posts(:welcome).comments.where(body: "Some content").where(type: "SpecialComment").build
-    assert_equal new_comment.body, "Some content"
-    assert_equal new_comment.type, "SpecialComment"
+    assert_equal "Some content", new_comment.body
+    assert_equal "SpecialComment", new_comment.type
     assert_equal new_comment.post_id, posts(:welcome).id
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1068,13 +1068,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_attributes_are_being_set_when_initialized_from_hm_through_association_with_where_clause
     new_subscriber = books(:awdr).subscribers.where(nick: "marklazz").build
-    assert_equal new_subscriber.nick, "marklazz"
+    assert_equal "marklazz", new_subscriber.nick
   end
 
   def test_attributes_are_being_set_when_initialized_from_hm_through_association_with_multiple_where_clauses
     new_subscriber = books(:awdr).subscribers.where(nick: "marklazz").where(name: "Marcelo Giorgi").build
-    assert_equal new_subscriber.nick, "marklazz"
-    assert_equal new_subscriber.name, "Marcelo Giorgi"
+    assert_equal "marklazz", new_subscriber.nick
+    assert_equal "Marcelo Giorgi", new_subscriber.name
   end
 
   def test_include_method_in_association_through_should_return_true_for_instance_added_with_build
@@ -1345,8 +1345,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     active_persons = Person.joins(:readers).joins(:posts).distinct(true).where("posts.title" => "active")
 
-    assert_equal active_persons.map(&:followers_count).reduce(:+), 10
-    assert_equal active_persons.sum(:followers_count), 10
+    assert_equal 10, active_persons.map(&:followers_count).reduce(:+)
+    assert_equal 10, active_persons.sum(:followers_count)
     assert_equal active_persons.sum(:followers_count), active_persons.map(&:followers_count).reduce(:+)
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -54,8 +54,8 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_with_select
-    assert_equal Firm.find(1).account_with_select.attributes.size, 2
-    assert_equal Firm.all.merge!(includes: :account_with_select).find(1).account_with_select.attributes.size, 2
+    assert_equal 2, Firm.find(1).account_with_select.attributes.size
+    assert_equal 2, Firm.all.merge!(includes: :account_with_select).find(1).account_with_select.attributes.size
   end
 
   def test_finding_using_primary_key
@@ -528,7 +528,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_attributes_are_being_set_when_initialized_from_has_one_association_with_where_clause
     new_account = companies(:first_firm).build_account(firm_name: "Account")
-    assert_equal new_account.firm_name, "Account"
+    assert_equal "Account", new_account.firm_name
   end
 
   def test_create_association_replaces_existing_without_dependent_option

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -631,8 +631,8 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
     exception = assert_raise(ActiveRecord::RecordNotFound) { human.interests.load.find() }
 
-    assert_equal exception.model, "Interest"
-    assert_equal exception.primary_key, "id"
+    assert_equal "Interest", exception.model
+    assert_equal "id", exception.primary_key
   end
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -504,14 +504,14 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
   def test_create_via_association_with_block
     post = authors(:david).posts.create(title: "New on Edge") { |p| p.body = "More cool stuff!" }
-    assert_equal post.title, "New on Edge"
-    assert_equal post.body, "More cool stuff!"
+    assert_equal "New on Edge", post.title
+    assert_equal "More cool stuff!", post.body
   end
 
   def test_create_with_bang_via_association_with_block
     post = authors(:david).posts.create!(title: "New on Edge") { |p| p.body = "More cool stuff!" }
-    assert_equal post.title, "New on Edge"
-    assert_equal post.body, "More cool stuff!"
+    assert_equal "New on Edge", post.title
+    assert_equal "More cool stuff!", post.body
   end
 
   def test_reload_returns_association

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -812,10 +812,10 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_distinct_is_honored_when_used_with_count_operation_after_group
     # Count the number of authors for approved topics
     approved_topics_count = Topic.group(:approved).count(:author_name)[true]
-    assert_equal approved_topics_count, 4
+    assert_equal 4, approved_topics_count
     # Count the number of distinct authors for approved Topics
     distinct_authors_for_approved_count = Topic.group(:approved).distinct.count(:author_name)[true]
-    assert_equal distinct_authors_for_approved_count, 3
+    assert_equal 3, distinct_authors_for_approved_count
   end
 
   def test_pluck

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -122,7 +122,7 @@ if ActiveRecord::Base.connection.supports_comments?
       column = Commented.columns_hash["new_rating"]
 
       assert_equal :string, column.type
-      assert_equal column.comment, "I am running out of imagination"
+      assert_equal "I am running out of imagination", column.comment
     end
 
     def test_schema_dump_with_comments

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -79,7 +79,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
       end
     end
 
-    assert_equal application.config.filter_parameters, []
+    assert_equal [], application.config.filter_parameters
 
     ActiveRecord::Encryption.config.excluded_from_filter_parameters = []
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -149,8 +149,8 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_find_with_ids_with_no_id_passed
     exception = assert_raises(ActiveRecord::RecordNotFound) { Topic.find }
-    assert_equal exception.model, "Topic"
-    assert_equal exception.primary_key, "id"
+    assert_equal "Topic", exception.model
+    assert_equal "id", exception.primary_key
   end
 
   def test_find_with_ids_with_id_out_of_range
@@ -158,8 +158,8 @@ class FinderTest < ActiveRecord::TestCase
       Topic.find("9999999999999999999999999999999")
     end
 
-    assert_equal exception.model, "Topic"
-    assert_equal exception.primary_key, "id"
+    assert_equal "Topic", exception.model
+    assert_equal "id", exception.primary_key
   end
 
   def test_find_passing_active_record_object_is_not_permitted

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -564,12 +564,12 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_yml_file_in_subdirectory
-    assert_equal(categories(:sub_special_1).name, "A special category in a subdir file")
+    assert_equal("A special category in a subdir file", categories(:sub_special_1).name)
     assert_equal(categories(:sub_special_1).class, SpecialCategory)
   end
 
   def test_subsubdir_file_with_arbitrary_name
-    assert_equal(categories(:sub_special_3).name, "A special category in an arbitrarily named subsubdir file")
+    assert_equal("A special category in an arbitrarily named subsubdir file", categories(:sub_special_3).name)
     assert_equal(categories(:sub_special_3).class, SpecialCategory)
   end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -21,14 +21,14 @@ module ActiveRecord
 
       def test_create_table_without_id
         testing_table_with_only_foo_attribute do
-          assert_equal connection.columns(:testings).size, 1
+          assert_equal 1, connection.columns(:testings).size
         end
       end
 
       def test_add_column_with_primary_key_attribute
         testing_table_with_only_foo_attribute do
           connection.add_column :testings, :id, :primary_key
-          assert_equal connection.columns(:testings).size, 2
+          assert_equal 2, connection.columns(:testings).size
         end
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -569,13 +569,13 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_reflect_on_association_accepts_symbols
     assert_nothing_raised do
-      assert_equal Hotel.reflect_on_association(:departments).name, :departments
+      assert_equal :departments, Hotel.reflect_on_association(:departments).name
     end
   end
 
   def test_reflect_on_association_accepts_strings
     assert_nothing_raised do
-      assert_equal Hotel.reflect_on_association("departments").name, :departments
+      assert_equal :departments, Hotel.reflect_on_association("departments").name
     end
   end
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -314,7 +314,7 @@ class RelationMergingTest < ActiveRecord::TestCase
   end
 
   def test_relation_merging_with_skip_query_cache
-    assert_equal Post.all.merge(Post.all.skip_query_cache!).skip_query_cache_value, true
+    assert_equal true, Post.all.merge(Post.all.skip_query_cache!).skip_query_cache_value
   end
 
   def test_relation_merging_with_association

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1561,8 +1561,8 @@ class RelationTest < ActiveRecord::TestCase
       record.color = "blue"
     end
     assert_predicate bird, :persisted?
-    assert_equal bird.name, "bob"
-    assert_equal bird.color, "blue"
+    assert_equal "bob", bird.name
+    assert_equal "blue", bird.color
 
     assert_equal bird, Bird.find_or_create_by(name: "bob", color: "blue")
   end
@@ -1669,8 +1669,8 @@ class RelationTest < ActiveRecord::TestCase
       record.color = "blue"
     end
     assert_predicate bird, :new_record?
-    assert_equal bird.name, "bob"
-    assert_equal bird.color, "blue"
+    assert_equal "bob", bird.name
+    assert_equal "blue", bird.color
     bird.save!
 
     assert_equal bird, Bird.find_or_initialize_by(name: "bob", color: "blue")

--- a/activerecord/test/cases/type/type_map_test.rb
+++ b/activerecord/test/cases/type/type_map_test.rb
@@ -103,8 +103,8 @@ module ActiveRecord
         mapping.register_type(/decimal/i) { |sql_type| sql_type }
         mapping.alias_type(/number/i, "decimal")
 
-        assert_equal mapping.lookup("number(20)"), "decimal(20)"
-        assert_equal mapping.lookup("number"), "decimal"
+        assert_equal "decimal(20)", mapping.lookup("number(20)")
+        assert_equal "decimal", mapping.lookup("number")
       end
 
       def test_fuzzy_lookup

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -137,12 +137,12 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
   def test_validate_uniqueness_when_integer_out_of_range
     entry = BigIntTest.create(engines_count: INT_MAX_VALUE + 1)
-    assert_equal entry.errors[:engines_count], ["is not included in the list"]
+    assert_equal ["is not included in the list"], entry.errors[:engines_count]
   end
 
   def test_validate_uniqueness_when_integer_out_of_range_show_order_does_not_matter
     entry = BigIntReverseTest.create(engines_count: INT_MAX_VALUE + 1)
-    assert_equal entry.errors[:engines_count], ["is not included in the list"]
+    assert_equal ["is not included in the list"], entry.errors[:engines_count]
   end
 
   def test_validates_uniqueness_with_newline_chars

--- a/activestorage/test/fixture_set_test.rb
+++ b/activestorage/test/fixture_set_test.rb
@@ -11,9 +11,9 @@ class ActiveStorage::FixtureSetTest < ActiveSupport::TestCase
 
     avatar = user.avatar
 
-    assert_equal avatar.blob.content_type, "image/jpeg+override"
-    assert_equal avatar.blob.filename.to_s, "racecar.jpg"
-    assert_equal avatar.blob.service.name, :local
+    assert_equal "image/jpeg+override", avatar.blob.content_type
+    assert_equal "racecar.jpg", avatar.blob.filename.to_s
+    assert_equal :local, avatar.blob.service.name
     avatar.blob.open { |file| assert FileUtils.identical?(file, file_fixture("racecar.jpg")) }
   end
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -20,7 +20,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
 
     assert_not_empty @user.highlights_attachments
-    assert_equal @user.highlights_blobs.count, 2
+    assert_equal 2, @user.highlights_blobs.count
   end
 
   test "attaching existing blobs from signed IDs to an existing record" do

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -70,7 +70,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       headers = service.headers_for_direct_upload(key, checksum: checksum, filename: ActiveStorage::Filename.new("test.txt"), disposition: :attachment)
-      assert_equal(headers["Cache-Control"], "public, max-age=1800")
+      assert_equal("public, max-age=1800", headers["Cache-Control"])
 
       headers.each do |k, v|
         request.add_field k, v

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -193,7 +193,7 @@ class ConcernTest < ActiveSupport::TestCase
     @klass.include included
     @klass.prepend prepended
 
-    assert_equal @klass.new.foo, [:included, :class, :prepended]
+    assert_equal [:included, :class, :prepended], @klass.new.foo
   end
 
   def test_prepended_and_included_class_methods
@@ -208,6 +208,6 @@ class ConcernTest < ActiveSupport::TestCase
     @klass.include included
     @klass.prepend prepended
 
-    assert_equal @klass.foo, [:included, :class, :prepended]
+    assert_equal [:included, :class, :prepended], @klass.foo
   end
 end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -101,7 +101,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     with_zone = ActiveSupport::TimeWithZone.new(nil, ActiveSupport::TimeZone["Hawaii"], local)
 
     assert_equal local.nsec, with_zone.nsec
-    assert_equal with_zone.nsec, 999999999
+    assert_equal 999999999, with_zone.nsec
   end
 
   def test_strftime

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -581,7 +581,7 @@ class DeprecationTest < ActiveSupport::TestCase
   end
 
   test "disallowed_warnings is empty by default" do
-    assert_equal @deprecator.disallowed_warnings, []
+    assert_equal [], @deprecator.disallowed_warnings
   end
 
   test "disallowed_warnings can be configured" do

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -53,7 +53,7 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   test "reading comment-only configuration" do
     @credentials.write("# comment")
 
-    assert_equal @credentials.config, {}
+    assert_equal({}, @credentials.config)
   end
 
   test "writing with element assignment and reading with element reference" do

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -93,7 +93,7 @@ class AssertionsTest < ActiveSupport::TestCase
       @object.increment
     end
 
-    assert_equal incremented, 1
+    assert_equal 1, incremented
   end
 
   def test_assert_difference_with_implicit_difference

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3807,16 +3807,16 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal ActiveStorage.video_preview_arguments,
-        "-y -vframes 1 -f image2"
+      assert_equal "-y -vframes 1 -f image2",
+        ActiveStorage.video_preview_arguments
     end
 
     test "ActiveStorage.video_preview_arguments uses the new arguments by default" do
       app "development"
 
-      assert_equal ActiveStorage.video_preview_arguments,
-        "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1'" \
-        " -frames:v 1 -f image2"
+      assert_equal \
+        "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2",
+        ActiveStorage.video_preview_arguments
     end
 
     test "ActiveStorage.variant_processor uses mini_magick without Rails 7 defaults" do

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -96,7 +96,7 @@ module ApplicationTests
 
       boot_app
 
-      assert_equal ActiveRecord::QueryLogs.tags, [ :application, :controller, :action, :job ]
+      assert_equal [ :application, :controller, :action, :job ], ActiveRecord::QueryLogs.tags
     end
 
     test "controller actions have tagging filters enabled by default" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -576,7 +576,7 @@ module ApplicationTests
         assert_match(/"geese"/, tables)
 
         columns = rails("runner", "p ActiveRecord::Base.connection.columns('geese').map(&:name)").strip
-        assert_equal columns, '["gooseid", "name"]'
+        assert_equal '["gooseid", "name"]', columns
       end
 
       test "db:schema:load fails if schema.rb doesn't exist yet" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -940,7 +940,7 @@ module ApplicationTests
         RUBY
 
         output = rails("db:seed")
-        assert_equal output, "storage/development.sqlite3"
+        assert_equal "storage/development.sqlite3", output
       ensure
         ENV["RAILS_ENV"] = @old_rails_env
         ENV["RACK_ENV"] = @old_rack_env

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -798,7 +798,7 @@ module ApplicationTests
       matches = @test_output.match(/(\d+) runs, (\d+) assertions, (\d+) failures/)
 
       assert_match %r{Interrupt}, @error_output
-      assert_equal matches[3].to_i, 1
+      assert_equal 1, matches[3].to_i
       assert matches[1].to_i < 11
     end
 

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -138,7 +138,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   def test_size_option_can_be_passed_to_string_text_and_binary
     %w(text binary).each do |attribute_type|
       generated_attribute = create_generated_attribute("#{attribute_type}{medium}")
-      assert_equal generated_attribute.attr_options[:size], :medium
+      assert_equal :medium, generated_attribute.attr_options[:size]
     end
   end
 
@@ -155,7 +155,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   def test_limit_option_can_be_passed_to_string_text_integer_and_binary
     %w(string text binary integer).each do |attribute_type|
       generated_attribute = create_generated_attribute("#{attribute_type}{65535}")
-      assert_equal generated_attribute.attr_options[:limit], 65535
+      assert_equal 65535, generated_attribute.attr_options[:limit]
     end
   end
 


### PR DESCRIPTION
There are assertions that expected/actual arguments are passed in the
reversed order by mistake. Enabling the LiteralAsActualArgument rule
prevents this mistake from happening.

The existing tests were auto-corrected by rubocop with a bit of
indentation adjustment.