### PR TITLE
Use less strict match on logging message

### DIFF
--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -249,14 +249,14 @@ class LoggingTest < ActiveSupport::TestCase
     EnqueueErrorJob.disable_test_adapter
 
     EnqueueErrorJob.perform_later
-    assert_match(/Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
+    assert_match(/Failed enqueuing EnqueueErrorJob to .*\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
   end
 
   def test_enqueue_at_log_when_enqueue_error_is_set
     EnqueueErrorJob.disable_test_adapter
 
     EnqueueErrorJob.set(wait: 1.hour).perform_later
-    assert_match(/Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
+    assert_match(/Failed enqueuing EnqueueErrorJob to .*\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/, @logger.messages)
   end
 
   def test_for_tagged_logger_support_is_consistent


### PR DESCRIPTION
This results in the following error:

```

Failure:
LoggingTest#test_enqueue_log_when_enqueue_error_is_set [/rails/activejob/test/cases/logging_test.rb:251]:
Expected /Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/ to match "[ActiveJob] Failed enqueuing EnqueueErrorJob to Class(default): ActiveJob::EnqueueError (There was an error enqueuing the job)\n".

rails test rails/activejob/test/cases/logging_test.rb:247

.............F

Failure:
LoggingTest#test_enqueue_at_log_when_enqueue_error_is_set [/rails/activejob/test/cases/logging_test.rb:258]:
Expected /Failed enqueuing EnqueueErrorJob to EnqueueError\(default\): ActiveJob::EnqueueError \(There was an error enqueuing the job\)/ to match "[ActiveJob] Failed enqueuing EnqueueErrorJob to Class(default): ActiveJob::EnqueueError (There was an error enqueuing the job)\n".

rails test rails/activejob/test/cases/logging_test.rb:254
```

[[Example build](https://buildkite.com/rails/rails/builds/99399#018a6685-8061-4ef8-8130-50752b087fcb/1094-1109)]
