### PR TITLE
Fix inferred query constraints

### DIFF
--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -12,6 +12,7 @@ require "models/reply"
 require "models/person"
 require "models/vertex"
 require "models/edge"
+require "models/essay"
 
 class CascadedEagerLoadingTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :mixins, :companies, :posts, :topics, :accounts, :comments,

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -35,6 +35,7 @@ require "models/matey"
 require "models/parrot"
 require "models/sharded"
 require "models/cpk"
+require "models/member_type"
 
 class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
   fixtures :citations

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -38,6 +38,8 @@ require "models/seminar"
 require "models/session"
 require "models/sharded"
 require "models/cpk"
+require "models/mentor"
+require "models/member_type"
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -2,6 +2,8 @@
 
 require "pp"
 require "cases/helper"
+require "models/mentor"
+require "models/member_type"
 require "models/computer"
 require "models/developer"
 require "models/project"
@@ -226,15 +228,27 @@ class AssociationsTest < ActiveRecord::TestCase
   end
 
   def test_query_constraints_over_three_without_defining_explicit_foreign_key_query_constraints_raises
-    Sharded::BlogPostWithRevision.has_many :comments_without_query_constraints, primary_key: [:blog_id, :id], class_name: "Comment"
+    original = Sharded::BlogPost.instance_variable_get(:@query_constraints_list)
+    original_comments = Sharded::Comment.instance_variable_get(:@query_constraints_list)
+    Sharded::BlogPost.query_constraints :blog_id, :revision, :id
+    Sharded::Comment.query_constraints :blog_id, :revision, :id
+    Sharded::BlogPost.has_many :comments_over_three, class_name: "Comment"
     blog_post = sharded_blog_posts(:great_post_blog_one)
-    blog_post = Sharded::BlogPostWithRevision.find(blog_post.id)
 
     error = assert_raises ArgumentError do
-      blog_post.comments_without_query_constraints.to_a
+      blog_post.comments_over_three.to_a
     end
 
-    assert_equal "The query constraints list on the `Sharded::BlogPostWithRevision` model has more than 2 attributes. Active Record is unable to derive the query constraints for the association. You need to explicitly define the query constraints for this association.", error.message
+    assert_equal "The query constraints list on the `Sharded::BlogPost` model has more than 2 attributes. Active Record is unable to derive the query constraints for the association. You need to explicitly define the query constraints for this association.", error.message
+
+    Sharded::BlogPost.has_many :comments_fix_over_three, class_name: "Comment", query_constraints: [:blog_id, :id]
+
+    assert_nothing_raised do
+      blog_post.comments_fix_over_three.to_a
+    end
+  ensure
+    Sharded::BlogPost.instance_variable_set(:@query_constraints_list, original)
+    Sharded::Comment.instance_variable_set(:@query_constraints_list, original_comments)
   end
 
   def test_model_with_composite_query_constraints_has_many_association_sql
@@ -329,17 +343,50 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_query_constraints_that_dont_include_the_primary_key_raise
     original = Sharded::BlogPost.instance_variable_get(:@query_constraints_list)
-    Sharded::BlogPost.query_constraints :title, :revision
-    Sharded::BlogPost.has_many :comments_without_query_constraints, primary_key: [:blog_id, :id], class_name: "Comment"
+    original_comments = Sharded::Comment.instance_variable_get(:@query_constraints_list)
+    Sharded::BlogPost.query_constraints :blog_id, :revision
+    Sharded::Comment.query_constraints :blog_id, :revision
+    Sharded::BlogPost.has_many :comments_no_pk, class_name: "Comment"
     blog_post = sharded_blog_posts(:great_post_blog_one)
 
     error = assert_raises ArgumentError do
-      blog_post.comments_without_query_constraints.to_a
+      blog_post.comments_no_pk.to_a
     end
 
     assert_equal "The query constraints on the `Sharded::BlogPost` model does not include the primary key so Active Record is unable to derive the foreign key constraints for the association. You need to explicitly define the query constraints for this association.", error.message
+
+    Sharded::BlogPost.has_many :comments_fix_qc_no_pk, class_name: "Comment", query_constraints: [:blog_id, :revision]
+
+    assert_nothing_raised do
+      blog_post.comments_fix_qc_no_pk.to_a
+    end
   ensure
     Sharded::BlogPost.instance_variable_set(:@query_constraints_list, original)
+    Sharded::Comment.instance_variable_set(:@query_constraints_list, original_comments)
+  end
+
+  def test_query_constraints_raise_when_they_dont_match
+    original = Sharded::BlogPost.instance_variable_get(:@query_constraints_list)
+    original_comments = Sharded::Comment.instance_variable_get(:@query_constraints_list)
+    Sharded::BlogPost.query_constraints :blog_id, :id
+    Sharded::Comment.query_constraints :blog_id, :body
+    Sharded::BlogPost.has_many :comments_dont_match, class_name: "Comment"
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    error = assert_raises ArgumentError do
+      blog_post.comments_dont_match.to_a
+    end
+
+    assert_equal "The query constraints list on the `Sharded::Comment` model doesn't match the query constraints on the `Sharded::BlogPost` model so Active Record is unable to derive the query constraints for the association. You need to explicitly define the query constraints for this association.", error.message
+
+    Sharded::BlogPost.has_many :comments_fix_qc_no_match, class_name: "Comment", query_constraints: [:blog_id, :body]
+
+    assert_nothing_raised do
+      blog_post.comments_fix_qc_no_match.to_a
+    end
+  ensure
+    Sharded::BlogPost.instance_variable_set(:@query_constraints_list, original)
+    Sharded::Comment.instance_variable_set(:@query_constraints_list, original_comments)
   end
 
   def test_assign_belongs_to_cpk_model_by_id_attribute

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -25,6 +25,8 @@ require "models/too_long_table_name"
 require "support/stubs/strong_parameters"
 require "support/async_helper"
 require "models/cpk"
+require "models/essay"
+require "models/dashboard"
 
 class CalculationsTest < ActiveRecord::TestCase
   include AsyncHelper

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -7,6 +7,7 @@ require "models/computer"
 require "models/owner"
 require "models/pet"
 require "models/cpk"
+require "models/mentor"
 
 class IntegrationTest < ActiveRecord::TestCase
   fixtures :companies, :developers, :owners, :pets

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -233,12 +233,21 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "accounts", Firm.reflect_on_association(:account).table_name
   end
 
+  class Foo < ActiveRecord::Base
+  end
+
+  class Baz < ActiveRecord::Base
+  end
+
+  class Bar < ActiveRecord::Base
+  end
+
   def test_belongs_to_inferred_foreign_key_from_assoc_name
-    Company.belongs_to :foo
+    Company.belongs_to :foo, class_name: "ReflectionTest::Foo"
     assert_equal "foo_id", Company.reflect_on_association(:foo).foreign_key
-    Company.belongs_to :bar, class_name: "Xyzzy"
+    Company.belongs_to :bar, class_name: "ReflectionTest::Bar"
     assert_equal "bar_id", Company.reflect_on_association(:bar).foreign_key
-    Company.belongs_to :baz, class_name: "Xyzzy", foreign_key: "xyzzy_id"
+    Company.belongs_to :baz, class_name: "ReflectionTest::Baz", foreign_key: "xyzzy_id"
     assert_equal "xyzzy_id", Company.reflect_on_association(:baz).foreign_key
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -28,6 +28,9 @@ require "models/categorization"
 require "models/edge"
 require "models/subscriber"
 require "models/cpk"
+require "models/essay"
+require "models/mentor"
+require "models/speedometer"
 
 class RelationTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :topics, :entrants, :developers, :people, :companies, :developers_projects, :accounts, :categories, :categorizations, :categories_posts, :posts, :comments, :tags, :taggings, :cars, :minivans, :cpk_orders

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -4,6 +4,8 @@ require "cases/helper"
 require "models/account"
 require "models/company"
 require "models/toy"
+require "models/owner"
+require "models/pet"
 require "models/matey"
 
 SIGNED_ID_VERIFIER_TEST_SECRET = -> { "This is normally set by the railtie initializer when used with Rails!" }

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -321,6 +321,7 @@ ActiveRecord::Schema.define do
     t.string :body
     t.integer :blog_post_id
     t.integer :blog_id
+    t.integer :revision
   end
 
   create_table :sharded_tags, force: true do |t|


### PR DESCRIPTION
While working on implementing query constraints in our vitess gem, I
noticed that we were applying query constraints even when we didn't have
them on both sides of the association. We only want to infer query
constraints if both the `klass` and `active_record` have them set.


* If both the `klass` and `active_record` on the association don't have query constraints set, use the `foreign_key` and don't infer query constraints.
* Adds an error if the `active_record` and `klass` query constraints don't match.
* Calling `klass` in `derive_fk_query_constraints` revealed that a bunch of our tests are missing requires, without these we'll see test failures that an association can't compute the klass name. Adding the requires fixes those.
