### PR TITLE
dep: bump sqlite3 dependency to v1.6.6 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "< 1.6.4"
+  gem "sqlite3", "~> 1.6", ">= 1.6.6"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,10 +503,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3)
+    sqlite3 (1.6.6)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.6.3-x86_64-darwin)
-    sqlite3 (1.6.3-x86_64-linux)
+    sqlite3 (1.6.6-x86_64-darwin)
+    sqlite3 (1.6.6-x86_64-linux)
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -627,7 +627,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (< 1.6.4)
+  sqlite3 (~> 1.6, >= 1.6.6)
   stackprof
   stimulus-rails
   sucker_punch


### PR DESCRIPTION

### Motivation / Background

sqlite3-ruby v1.6.6 has sqlite 3.43.1 which fixes the AVG() bug described in https://github.com/sparklemotion/sqlite3-ruby/issues/396

See related https://github.com/rails/rails/pull/49048

### Reviewers

Is this too narrow/modern of a version pin? Could also do something like

```
gem "sqlite3", "~>1.4", "!= 1.6.4", "!= 1.6.5"
```

but I prefer what's in the PR.
 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
