### PR TITLE
Standardize use of ENV.fetch for strings / numbers

### DIFF
--- a/actionmailbox/test/dummy/config/cable.yml
+++ b/actionmailbox/test/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/actionmailbox/test/dummy/config/database.yml
+++ b/actionmailbox/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). Use "debug"
   # for everything.
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/actionmailbox/test/dummy/config/puma.rb
+++ b/actionmailbox/test/dummy/config/puma.rb
@@ -7,8 +7,8 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
@@ -22,13 +22,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/actiontext/test/dummy/config/cable.yml
+++ b/actiontext/test/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/actiontext/test/dummy/config/database.yml
+++ b/actiontext/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). Use "debug"
   # for everything.
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/actiontext/test/dummy/config/puma.rb
+++ b/actiontext/test/dummy/config/puma.rb
@@ -7,8 +7,8 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
@@ -22,13 +22,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/activestorage/test/dummy/config/cable.yml
+++ b/activestorage/test/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/activestorage/test/dummy/config/database.yml
+++ b/activestorage/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). Use "debug"
   # for everything.
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/activestorage/test/dummy/config/puma.rb
+++ b/activestorage/test/dummy/config/puma.rb
@@ -7,8 +7,8 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
@@ -22,13 +22,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/activesupport/lib/active_support/message_pack/serializer.rb
+++ b/activesupport/lib/active_support/message_pack/serializer.rb
@@ -51,7 +51,7 @@ module ActiveSupport
               install_unregistered_type_handler
               message_pack_factory.freeze
             end
-            message_pack_factory.pool(ENV.fetch("RAILS_MAX_THREADS") { 5 })
+            message_pack_factory.pool(ENV.fetch("RAILS_MAX_THREADS", 5))
           end
         end
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -108,7 +108,7 @@ default: &default
 
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: <%= app_name %>_production

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
@@ -38,7 +38,7 @@
 
 default: &default
   adapter: jdbc
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: <%= app_name %>
   password:
   driver:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -11,7 +11,7 @@
 #
 default: &default
   adapter: mysql
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
   host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
@@ -6,7 +6,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
 <% if mysql_socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
@@ -18,7 +18,7 @@
 #
 default: &default
   adapter: oracle_enhanced
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: <%= app_name %>
   password:
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: trilogy
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
 <% if mysql_socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -7,8 +7,8 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
@@ -22,13 +22,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
         development:
            database: <%= Rails.application.config.database %>
            adapter: sqlite3
-           pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+           pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
            timeout: 5000
       YAML
 
@@ -44,7 +44,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+          pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
           timeout: 5000
 
         development:


### PR DESCRIPTION
### Motivation / Background

Usage of `ENV.fetch` is inconsistent throughout the repo. Given a slight mem / perf optimization this standardizes to use fetch w/ the `fetch(key, default)` syntax everywhere the default is an integer / string. This also matches the default preferred format in RuboCop per:

https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFetchBlock

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
