### PR TITLE
[7-0-stable] Backport "dep: bump sqlite3 dependency to v1.6.6 or higher"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.4", "< 1.6.4"
+  gem "sqlite3", "~> 1.6", ">= 1.6.6"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,10 +520,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3)
+    sqlite3 (1.6.6)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.6.3-x86_64-darwin)
-    sqlite3 (1.6.3-x86_64-linux)
+    sqlite3 (1.6.6-x86_64-darwin)
+    sqlite3 (1.6.6-x86_64-linux)
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -644,7 +644,7 @@ DEPENDENCIES
   sneakers
   sprockets-export
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.4, < 1.6.4)
+  sqlite3 (~> 1.6, >= 1.6.6)
   stackprof
   stimulus-rails
   sucker_punch


### PR DESCRIPTION
Backport #49243 to `7-0-stable` branch