### PR TITLE
`#unique_keys` returns the renamed column name

### DIFF
--- a/activerecord/test/cases/migration/unique_key_test.rb
+++ b/activerecord/test/cases/migration/unique_key_test.rb
@@ -202,6 +202,18 @@ if ActiveRecord::Base.connection.supports_unique_keys?
             @connection.remove_unique_key :sections, name: "nonexistent"
           end
         end
+
+        def test_renamed_unique_key
+          @connection.add_unique_key :sections, [:position]
+          @connection.rename_column :sections, :position, :new_position
+
+          unique_keys = @connection.unique_keys("sections")
+          assert_equal 1, unique_keys.size
+
+          constraint = unique_keys.first
+          assert_equal "sections", constraint.table_name
+          assert_equal ["new_position"], constraint.column
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

follow-up #46192

Fixed a bug where `unique_keys` returned the old column name after the column 
specified in add_unique_key was renamed.

### Detail

Since `pg_attribute.attname` may return the old column name after renaming a column,
match `attrelid, attnum` in the process of getting the list of column names.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
