### PR TITLE
Don't pass active_record to `derive_fk_query_constraints`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -507,7 +507,7 @@ module ActiveRecord
           derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)
 
           if active_record.has_query_constraints?
-            derived_fk = derive_fk_query_constraints(active_record, derived_fk)
+            derived_fk = derive_fk_query_constraints(derived_fk)
           end
 
           derived_fk
@@ -770,13 +770,13 @@ module ActiveRecord
           end
         end
 
-        def derive_fk_query_constraints(klass, foreign_key)
-          primary_query_constraints = klass.query_constraints_list
-          owner_pk = klass.primary_key
+        def derive_fk_query_constraints(foreign_key)
+          primary_query_constraints = active_record.query_constraints_list
+          owner_pk = active_record.primary_key
 
           if primary_query_constraints.size != 2
             raise ArgumentError, <<~MSG.squish
-              The query constraints list on the `#{klass}` model has more than 2
+              The query constraints list on the `#{active_record}` model has more than 2
               attributes. Active Record is unable to derive the query constraints
               for the association. You need to explicitly define the query constraints
               for this association.
@@ -785,17 +785,11 @@ module ActiveRecord
 
           if !primary_query_constraints.include?(owner_pk)
             raise ArgumentError, <<~MSG.squish
-              The query constraints on the `#{klass}` model does not include the primary
+              The query constraints on the `#{active_record}` model does not include the primary
               key so Active Record is unable to derive the foreign key constraints for
               the association. You need to explicitly define the query constraints for this
               association.
             MSG
-          end
-
-          # The primary key and foreign key are both already in the query constraints
-          # so we don't want to derive the key. In this case we want a single key.
-          if primary_query_constraints.include?(owner_pk) && primary_query_constraints.include?(foreign_key)
-            return foreign_key
           end
 
           first_key, last_key = primary_query_constraints
@@ -807,7 +801,7 @@ module ActiveRecord
           else
             raise ArgumentError, <<~MSG.squish
               Active Record couldn't correctly interpret the query constraints
-              for the `#{klass}` model. The query constraints on `#{klass}` are
+              for the `#{active_record}` model. The query constraints on `#{active_record}` are
               `#{primary_query_constraints}` and the foreign key is `#{foreign_key}`.
               You need to explicitly set the query constraints for this association.
             MSG


### PR DESCRIPTION
We already have access to the `active_record` on the reflection here so there's no point in passing it to `derive_fk_query_constraints`.

In addition the id, fk check wasn't actually doing anything here, it was holdover from debugging I was doing when implementing this functionality.