### PR TITLE
Add outcome to transaction tracking payload

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Add instrumentation for Active Record transactions
 
-    Allows subscribing to transaction events for tracking/instrumentation. The event payload contains the connection, as well as timing details.
+    Allows subscribing to transaction events for tracking/instrumentation. The event payload contains the connection and the outcome (commit, rollback, restart, incomplete), as well as timing details.
 
     ```ruby
     ActiveSupport::Notifications.subscribe("transaction.active_record") do |event|


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Following up on https://github.com/rails/rails/pull/49192, this commit adds the transaction `outcome` to the payload, helpful for collecting stats on how many transactions commit, rollback, restart, or (perhaps most interestingly) are incomplete because of an error. 

### Detail
One quirk here is that we have to modify the payload on finish. It's not the only place this sort of thing happens (instrument mutates the payload with exceptions, for example), but it does mean we need to dup the payload we initialize with to avoid mutating it for other tracking.


### Additional information
See https://github.com/rails/rails/pull/49192 linked above

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
