### PR TITLE
Explicit `primary_key:` option should always take priority in associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -862,10 +862,10 @@ module ActiveRecord
 
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
-        if !polymorphic? && ((klass || self.klass).has_query_constraints? || options[:query_constraints])
-          (klass || self.klass).composite_query_constraints_list
-        elsif primary_key = options[:primary_key]
+        if primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s
+        elsif !polymorphic? && ((klass || self.klass).has_query_constraints? || options[:query_constraints])
+          (klass || self.klass).composite_query_constraints_list
         elsif (klass || self.klass).composite_primary_key?
           # If klass has composite primary key of shape [:<tenant_key>, :id], infer primary_key as :id
           primary_key = (klass || self.klass).primary_key

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -260,6 +260,13 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal(blog_post, comment.blog_post_by_id)
   end
 
+  def test_preloads_model_with_query_constraints_by_explicitly_configured_fk_and_pk
+    comment = sharded_comments(:great_comment_blog_post_one)
+    comments = Sharded::Comment.where(id: comment.id).preload(:blog_post_by_id).to_a
+    comment = comments.first
+    assert_equal(comment.blog_post_by_id, comment.blog_post)
+  end
+
   def test_append_composite_foreign_key_has_many_association
     blog_post = sharded_blog_posts(:great_post_blog_one)
     comment = Sharded::Comment.new(body: "Great post! :clap:")

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -29,6 +29,7 @@ require "models/drink_designer"
 require "models/recipe"
 require "models/user_with_invalid_relation"
 require "models/hardback"
+require "models/sharded/comment"
 
 class ReflectionTest < ActiveRecord::TestCase
   include ActiveRecord::Reflection
@@ -612,6 +613,11 @@ class ReflectionTest < ActiveRecord::TestCase
       assert_no_match "NotAClass", error.message
       assert_no_match "not_a_class", error.message
     end
+  end
+
+  def test_association_primary_key_uses_explicit_primary_key_option_as_first_priority
+    actual = Sharded::Comment.reflect_on_association(:blog_post_by_id).association_primary_key
+    assert_equal "id", actual
   end
 
   private

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -6,7 +6,7 @@ module Sharded
     query_constraints :blog_id, :id
 
     belongs_to :blog_post
-    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id
+    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
     belongs_to :blog
   end
 end


### PR DESCRIPTION
This PR fixes the issue where the `primary_key:` option was ignored if the associated model had a `query_constraints` configured. Now `primary_key:` option always takes priority and only if there is no `primary_key:` option, the `query_constraints` are used to determine the `association_primary_key` value.

Technically now this is a bug in Rails 7.1 beta so I presume we want a changelog entry and the commit to be backported to `7-1-stable` if such exist? Let me know whether it needs a CHANGELOG entry and how to ensure it gets included into the next release as a bugfix