### PR TITLE
Clean up old composite key code

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -64,9 +64,7 @@ module ActiveRecord
         ids.map! { |id| pk_type.cast(id) }
 
         records = if klass.composite_primary_key?
-          query_records = ids.map { |values_set| klass.where(primary_key.zip(values_set).to_h) }.inject(&:or)
-
-          query_records.index_by do |record|
+          klass.where(primary_key => ids).index_by do |record|
             primary_key.map { |primary_key| record._read_attribute(primary_key) }
           end
         else

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -527,12 +527,7 @@ module ActiveRecord
       def find_some(ids)
         return find_some_ordered(ids) unless order_values.present?
 
-        relation = if klass.composite_primary_key?
-          ids.map { |values_set| where(primary_key.zip(values_set).to_h) }.inject(&:or)
-        else
-          where(primary_key => ids)
-        end
-
+        relation = where(primary_key => ids)
         relation = relation.select(table[primary_key]) unless select_values.empty?
         result = relation.to_a
 
@@ -559,11 +554,7 @@ module ActiveRecord
         ids = ids.slice(offset_value || 0, limit_value || ids.size) || []
 
         relation = except(:limit, :offset)
-        relation = if klass.composite_primary_key?
-          ids.map { |values_set| relation.where(primary_key.zip(values_set).to_h) }.inject(&:or)
-        else
-          relation.where(primary_key => ids)
-        end
+        relation = relation.where(primary_key => ids)
         relation = relation.select(table[primary_key]) unless select_values.empty?
         result = relation.records
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there's some old code that can be cleaned up related to composite primary key handling.

### Detail

This Pull Request changes Active Record to lean on tuple query syntax to reduce logical branches in code. Because where now supports tuple querying, we don't need to manually build queries with where and or statements.

### Additional information

This is just cleanup for an unreleased feature, so I think we can lean on existing tests and changelogs for CPK.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
