### PR TITLE
Fix as_json behavior in ActionText::Attachable

### DIFF
--- a/actiontext/lib/action_text/attachable.rb
+++ b/actiontext/lib/action_text/attachable.rb
@@ -98,11 +98,6 @@ module ActionText
       false
     end
 
-    # Returns the attachable as JSON with the +attachable_sgid+ included.
-    def as_json(*)
-      super.merge("attachable_sgid" => persisted? ? attachable_sgid : nil)
-    end
-
     # Returns the path to the partial that is used for rendering the attachable
     # in Trix. Defaults to +to_partial_path+.
     #
@@ -142,5 +137,18 @@ module ActionText
         attrs[:height] = attachable_metadata[:height]
       end.compact
     end
+
+    private
+      def attribute_names_for_serialization
+        super + ["attachable_sgid"]
+      end
+
+      def read_attribute_for_serialization(key)
+        if key == "attachable_sgid"
+          persisted? ? super : nil
+        else
+          super
+        end
+      end
   end
 end

--- a/actiontext/test/unit/attachable_test.rb
+++ b/actiontext/test/unit/attachable_test.rb
@@ -40,4 +40,13 @@ class ActionText::AttachableTest < ActiveSupport::TestCase
 
     assert_equal attributes, attachable.as_json
   end
+
+  test "attachable_sgid is included in as_json when only option is nil or includes attachable_sgid" do
+    attachable = ActiveStorage::Blob.create_after_unfurling!(io: StringIO.new("test"), filename: "test.txt", key: 123)
+
+    assert_equal({ "id" => attachable.id }, attachable.as_json(only: :id))
+    assert_equal({ "id" => attachable.id }, attachable.as_json(only: [:id]))
+    assert_equal(attachable.as_json.except("attachable_sgid"), attachable.as_json(except: :attachable_sgid))
+    assert_equal(attachable.as_json.except("attachable_sgid"), attachable.as_json(except: [:attachable_sgid]))
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The as_json method in `ActiveModel` accepts the only option to restrict the keys that are included in the JSON output. However, when including `ActionText::Attachable`, this behavior is overridden, and an additional `attachable_sgid` key is unconditionally added to the JSON output.

```
class User < ActiveRecord
   include ActionText::Attachable
end

user = User.new(name: "Dave")
user.as_json(only: :name)
#=> { "name" => "Dave", "attachable_sgid" => "..." }
```

I am not sure if applying the only option in ActionText::Attachable's as_json method was the correct approach, but I made that modification.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
