### PR TITLE
Make GeneratedAttribute work without ActiveRecord

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -65,11 +65,13 @@ module Rails
         end
 
         def dangerous_name?(name)
-          ActiveRecord::Base.dangerous_attribute_method?(name)
+          defined?(ActiveRecord::Base) &&
+            ActiveRecord::Base.dangerous_attribute_method?(name)
         end
 
         def valid_type?(type)
           DEFAULT_TYPES.include?(type.to_s) ||
+            !defined?(ActiveRecord::Base) ||
             ActiveRecord::Base.connection.valid_type?(type)
         end
 


### PR DESCRIPTION
If GeneratedAttribute is used in a project that doesn't require ActiveRecord, it should still work.

Fixes the issue mentioned here:
https://github.com/rails/rails/pull/47752#issuecomment-1720256371

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
