### PR TITLE
Update 7_1_release_notes.md

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -484,11 +484,13 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Deprecate `config.action_dispatch.return_only_request_media_type_on_content_type`.
 
-*   Deprecate `AbstractController::Helpers::MissingHelperError`
+*   Deprecate `AbstractController::Helpers::MissingHelperError`.
 
 *   Deprecate `ActionDispatch::IllegalStateError`.
 
 *   Deprecate `speaker`, `vibrate`, and `vr` permissions policy directives.
+
+*   Deprecate `true` and `false` values for `action_dispatch.show_exceptions` in favor of `:all`, `:rescuable`, or `:none`.
 
 ### Notable changes
 

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -490,7 +490,7 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Deprecate `speaker`, `vibrate`, and `vr` permissions policy directives.
 
-*   Deprecate `true` and `false` values for `action_dispatch.show_exceptions` in favor of `:all`, `:rescuable`, or `:none`.
+*   Deprecate `true` and `false` values for `config.action_dispatch.show_exceptions` in favor of `:all`, `:rescuable`, or `:none`.
 
 ### Notable changes
 


### PR DESCRIPTION
For background see https://github.com/rails/rails/pull/45867

Include in release notes the deprecation of `true` and `false` values for `config.action_dispatch.show_exceptions` in favor of `:all`, `:rescuable` and `:none`.