### PR TITLE
Ensure the SQLite3 adapter handles default functions with the `||` concatenation operator

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Ensure the SQLite3 adapter handles default functions with the `||` concatenation operator
+
+    Previously, this default function would produce the static string `"'Ruby ' || 'on ' || 'Rails'"`.
+    Now, the adapter will appropriately receive and use `"Ruby on Rails"`.
+
+    ```ruby
+    change_column_default "test_models", "ruby_on_rails", -> { "('Ruby ' || 'on ' || 'Rails')" }
+    ```
+
+    *Stephen Margheim*
+
 *   Dump PostgreSQL schemas as part of the schema dump.
 
     *Lachlan Sylvester*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -451,10 +451,10 @@ module ActiveRecord
           when /^null$/i
             nil
           # Quoted types
-          when /^'(.*)'$/m
+          when /^'([^|]*)'$/m
             $1.gsub("''", "'")
           # Quoted types
-          when /^"(.*)"$/m
+          when /^"([^|]*)"$/m
             $1.gsub('""', '"')
           # Numeric types
           when /\A-?\d+(\.\d*)?\z/
@@ -474,7 +474,7 @@ module ActiveRecord
         end
 
         def has_default_function?(default_value, default)
-          !default_value && %r{\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
+          !default_value && %r{\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP|\|\|}.match?(default)
         end
 
         # See: https://www.sqlite.org/lang_altertable.html

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -311,6 +311,15 @@ module ActiveRecord
         assert_equal "CURRENT_TIMESTAMP", TestModel.columns_hash["edited_at"].default_function
       end
 
+      def test_change_column_default_supports_default_function_with_concatenation_operator
+        skip unless current_adapter?(:SQLite3Adapter)
+
+        add_column "test_models", "ruby_on_rails", :string
+        connection.change_column_default "test_models", "ruby_on_rails", -> { "('Ruby ' || 'on ' || 'Rails')" }
+        TestModel.reset_column_information
+        assert_equal "'Ruby ' || 'on ' || 'Rails'", TestModel.columns_hash["ruby_on_rails"].default_function
+      end
+
       def test_change_column_null_false
         add_column "test_models", "first_name", :string
         connection.change_column_null "test_models", "first_name", false


### PR DESCRIPTION
Previously, this default function would produce the static string `"'Ruby ' || 'on ' || 'Rails'"`. Now, the adapter will appropriately receive and use `"Ruby on Rails"`.

```ruby
change_column_default "test_models", "ruby_on_rails", -> { "('Ruby ' || 'on ' || 'Rails')" }
```

### Motivation / Background

The wave of using SQLite in production is growing, but the ActiveRecord `SQLite3Adapter` doesn't take full advantage of the power and functionality of the SQLite engine. In order to begin making the `SQLite3Adapter` feature-comparable with the `MySQLAdapter` and `PostgreSQLAdapter`, I am undertaking a multi-step task to level up the `SQLite3Adapter`.

### Detail

I am beginning with the simplest improvement I initially found, in order to "get my feet wet" with the process of upstreaming feature to Rails and ActiveRecord. Instead of using the `CONCAT()` function, SQLite provides the `||` concatenation operator. The adapter does not recognize usage of this operator as a dynamic `default_function`, however.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
