### PR TITLE
Action View: docs use `application/` instead of `shared/`

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -44,9 +44,9 @@ module ActionView # :nodoc:
   # Using sub templates allows you to sidestep tedious replication and extract common display structures in shared templates. The
   # classic example is the use of a header and footer (even though the Action Pack-way would be to use Layouts):
   #
-  #   <%= render "shared/header" %>
+  #   <%= render "application/header" %>
   #   Something really specific and terrific
-  #   <%= render "shared/footer" %>
+  #   <%= render "application/footer" %>
   #
   # As you see, we use the output embeddings for the render methods. The render call itself will just return a string holding the
   # result of the rendering. The output embedding writes it to the current template.
@@ -55,7 +55,7 @@ module ActionView # :nodoc:
   # variables defined using the regular embedding tags. Like this:
   #
   #   <% @page_title = "A Wonderful Hello" %>
-  #   <%= render "shared/header" %>
+  #   <%= render "application/header" %>
   #
   # Now the header can pick up on the <tt>@page_title</tt> variable and use it for outputting a title tag:
   #
@@ -65,9 +65,9 @@ module ActionView # :nodoc:
   #
   # You can pass local variables to sub templates by using a hash with the variable names as keys and the objects as values:
   #
-  #   <%= render "shared/header", { headline: "Welcome", person: person } %>
+  #   <%= render "application/header", { headline: "Welcome", person: person } %>
   #
-  # These can now be accessed in <tt>shared/header</tt> with:
+  # These can now be accessed in <tt>application/header</tt> with:
   #
   #   Headline: <%= headline %>
   #   First name: <%= person.first_name %>

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -9,9 +9,9 @@ module ActionView
   # Layouts reverse the common pattern of including shared headers and footers in many templates to isolate changes in
   # repeated setups. The inclusion pattern has pages that look like this:
   #
-  #   <%= render "shared/header" %>
+  #   <%= render "application/header" %>
   #   Hello World
-  #   <%= render "shared/footer" %>
+  #   <%= render "application/footer" %>
   #
   # This approach is a decent way of keeping common structures isolated from the changing content, but it's verbose
   # and if you ever want to change the structure of these two includes, you'll have to change all the templates.

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -96,7 +96,7 @@ module ActionView
     #
     # Given this sub template rendering:
     #
-    #   <%= render "shared/header", { headline: "Welcome", person: person } %>
+    #   <%= render "application/header", { headline: "Welcome", person: person } %>
     #
     # You can use +local_assigns+ in the sub templates to access the local variables:
     #

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -125,14 +125,14 @@ module SharedTrackerTests
 
   def test_finds_multiple_unrelated_odd_dependencies
     template = FakeTemplate.new("
-      <%= render('shared/header', title: 'Title') %>
+      <%= render('application/header', title: 'Title') %>
       <h2>Section title</h2>
       <%= render@section %>
     ", :erb)
 
     tracker = make_tracker("multiple/_dependencies", template)
 
-    assert_equal ["shared/header", "sections/section"], tracker.dependencies
+    assert_equal ["application/header", "sections/section"], tracker.dependencies
   end
 
   def test_finds_dependencies_for_all_kinds_of_identifiers

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -192,7 +192,7 @@ A method for caching fragments of a view rather than an entire action or page. T
 
 ```erb
 <% cache do %>
-  <%= render "shared/footer" %>
+  <%= render "application/footer" %>
 <% end %>
 ```
 

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -197,17 +197,17 @@ To render a partial as part of a view, you use the `render` method within the vi
 This will render a file named `_menu.html.erb` at that point within the view that is being rendered. Note the leading underscore character: partials are named with a leading underscore to distinguish them from regular views, even though they are referred to without the underscore. This holds true even when you're pulling in a partial from another folder:
 
 ```erb
-<%= render "shared/menu" %>
+<%= render "application/menu" %>
 ```
 
-That code will pull in the partial from `app/views/shared/_menu.html.erb`.
+That code will pull in the partial from `app/views/application/_menu.html.erb`.
 
 ### Using Partials to Simplify Views
 
 One way to use partials is to treat them as the equivalent of subroutines; a way to move details out of a view so that you can grasp what's going on more easily. For example, you might have a view that looks like this:
 
 ```html+erb
-<%= render "shared/ad_banner" %>
+<%= render "application/ad_banner" %>
 
 <h1>Products</h1>
 
@@ -216,7 +216,7 @@ One way to use partials is to treat them as the equivalent of subroutines; a way
   <%= render partial: "product", locals: { product: product } %>
 <% end %>
 
-<%= render "shared/footer" %>
+<%= render "application/footer" %>
 ```
 
 Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain content that is shared among many pages in your application. You don't need to see the details of these sections when you're concentrating on a particular page.

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1099,10 +1099,11 @@ To render a partial as part of a view, you use the [`render`][view.render] metho
 This will render a file named `_menu.html.erb` at that point within the view being rendered. Note the leading underscore character: partials are named with a leading underscore to distinguish them from regular views, even though they are referred to without the underscore. This holds true even when you're pulling in a partial from another folder:
 
 ```html+erb
-<%= render "shared/menu" %>
+<%= render "application/menu" %>
 ```
 
-That code will pull in the partial from `app/views/shared/_menu.html.erb`.
+Since view partials rely on the same [Template Inheritance](#template-inheritance)
+as templates and layouts, that code will pull in the partial from `app/views/application/_menu.html.erb`.
 
 [view.render]: https://api.rubyonrails.org/classes/ActionView/Helpers/RenderingHelper.html#method-i-render
 
@@ -1111,14 +1112,14 @@ That code will pull in the partial from `app/views/shared/_menu.html.erb`.
 One way to use partials is to treat them as the equivalent of subroutines: as a way to move details out of a view so that you can grasp what's going on more easily. For example, you might have a view that looked like this:
 
 ```erb
-<%= render "shared/ad_banner" %>
+<%= render "application/ad_banner" %>
 
 <h1>Products</h1>
 
 <p>Here are a few of our fine products:</p>
-...
+<%# ... %>
 
-<%= render "shared/footer" %>
+<%= render "application/footer" %>
 ```
 
 Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain
@@ -1133,7 +1134,7 @@ definitions for several similar resources:
 * `users/index.html.erb`
 
     ```html+erb
-    <%= render "shared/search_filters", search: @q do |form| %>
+    <%= render "application/search_filters", search: @q do |form| %>
       <p>
         Name contains: <%= form.text_field :name_contains %>
       </p>
@@ -1143,14 +1144,14 @@ definitions for several similar resources:
 * `roles/index.html.erb`
 
     ```html+erb
-    <%= render "shared/search_filters", search: @q do |form| %>
+    <%= render "application/search_filters", search: @q do |form| %>
       <p>
         Title contains: <%= form.text_field :title_contains %>
       </p>
     <% end %>
     ```
 
-* `shared/_search_filters.html.erb`
+* `application/_search_filters.html.erb`
 
     ```html+erb
     <%= form_with model: search do |form| %>

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1371,11 +1371,11 @@ en:
       controller "main", <<-RUBY
         class MainController < ActionController::Base
           def foo
-            render inline: '<%= render partial: "shared/foo" %>'
+            render inline: '<%= render partial: "application/foo" %>'
           end
 
           def bar
-            render inline: '<%= render partial: "shared/bar" %>'
+            render inline: '<%= render partial: "application/bar" %>'
           end
         end
       RUBY
@@ -1387,19 +1387,19 @@ en:
         end
       RUBY
 
-      @plugin.write "app/views/shared/_foo.html.erb", <<-RUBY
+      @plugin.write "app/views/application/_foo.html.erb", <<-RUBY
         Bukkit's foo partial
       RUBY
 
-      app_file "app/views/shared/_foo.html.erb", <<-RUBY
+      app_file "app/views/application/_foo.html.erb", <<-RUBY
         App's foo partial
       RUBY
 
-      @blog.write "app/views/shared/_bar.html.erb", <<-RUBY
+      @blog.write "app/views/application/_bar.html.erb", <<-RUBY
         Blog's bar partial
       RUBY
 
-      app_file "app/views/shared/_bar.html.erb", <<-RUBY
+      app_file "app/views/application/_bar.html.erb", <<-RUBY
         App's bar partial
       RUBY
 
@@ -1471,7 +1471,7 @@ en:
       controller "main", <<-RUBY
         class MainController < ActionController::Base
           def foo
-            render inline: '<%= render partial: "shared/foo" %>'
+            render inline: '<%= render partial: "application/foo" %>'
           end
         end
       RUBY
@@ -1482,11 +1482,11 @@ en:
         end
       RUBY
 
-      @plugin.write "app/views/shared/_foo.html.erb", <<-RUBY
+      @plugin.write "app/views/application/_foo.html.erb", <<-RUBY
         Bukkit's foo partial
       RUBY
 
-      app_file "app/views/shared/_foo.html.erb", <<-RUBY
+      app_file "app/views/application/_foo.html.erb", <<-RUBY
         App's foo partial
       RUBY
 


### PR DESCRIPTION
### Motivation / Background

View partials rely on the same [Template Inheritance][] as their template counterparts, so the guides should encourage end-users to benefit from that inheritance.

> This makes `app/views/application/` a great place for your shared
> partials, which can then be rendered in your ERB as such:
>

```html+erb
<%# app/views/admin/products/index.html.erb %>
<%= render @products || "empty_list" %>

<%# app/views/application/_empty_list.html.erb %>
There are no items in this list <em>yet</em>.
```

### Detail

Change mentions of `app/views/shared` in the guides to be `app/views/application` instead. 

To enforce that template resolution, this commit also replaces references to `shared/` with `application/` in the Rails test suite.

[Template Inheritance]: https://guides.rubyonrails.org/layouts_and_rendering.html#template-inheritance

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
