### PR TITLE
Add SQLite3 support for `supports_insert_returning?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   The SQLite3 adapter now supports `supports_insert_returning?`
+
+    Implementing the full `supports_insert_returning?` contract means the SQLite3 adapter supports auto-populated columns (#48241) as well as custom primary keys.
+
+    *Stephen Margheim*
+
 *   Ensure the SQLite3 adapter handles default functions with the `||` concatenation operator
 
     Previously, this default function would produce the static string `"'Ruby ' || 'on ' || 'Rails'"`.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -75,22 +75,6 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
-        def sql_for_insert(sql, pk, binds, returning) # :nodoc:
-          if pk.nil?
-            # Extract the table from the insert sql. Yuck.
-            table_ref = extract_table_ref_from_insert_sql(sql)
-            pk = primary_key(table_ref) if table_ref
-          end
-
-          returning_columns = returning || Array(pk)
-
-          returning_columns_statement = returning_columns.map { |c| quote_column_name(c) }.join(", ")
-          sql = "#{sql} RETURNING #{returning_columns_statement}" if returning_columns.any?
-
-          super
-        end
-        private :sql_for_insert
-
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           if use_insert_returning? || pk == false
             super

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1089,11 +1089,6 @@ module ActiveRecord
           SQL
         end
 
-        def extract_table_ref_from_insert_sql(sql)
-          sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
-          $1.strip if $1
-        end
-
         def arel_visitor
           Arel::Visitors::PostgreSQL.new(self)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -138,10 +138,6 @@ module ActiveRecord
             end
           end
 
-          def last_inserted_id(result)
-            @raw_connection.last_insert_row_id
-          end
-
           def build_fixture_statements(fixture_set)
             fixture_set.flat_map do |table_name, fixtures|
               next if fixtures.empty?
@@ -151,6 +147,10 @@ module ActiveRecord
 
           def build_truncate_statement(table_name)
             "DELETE FROM #{quote_table_name(table_name)}"
+          end
+
+          def returning_column_values(result)
+            result.rows.first
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -126,6 +126,7 @@ module ActiveRecord
 
         @config[:strict] = ConnectionAdapters::SQLite3Adapter.strict_strings_by_default unless @config.key?(:strict)
         @connection_parameters = @config.merge(database: @config[:database].to_s, results_as_hash: true)
+        @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
 
       def database_exists?
@@ -180,6 +181,10 @@ module ActiveRecord
         database_version >= "3.8.3"
       end
 
+      def supports_insert_returning?
+        database_version >= "3.35.0"
+      end
+
       def supports_insert_on_conflict?
         database_version >= "3.24.0"
       end
@@ -193,6 +198,10 @@ module ActiveRecord
 
       def active?
         @raw_connection && !@raw_connection.closed?
+      end
+
+      def return_value_after_insert?(column) # :nodoc:
+        column.auto_populated?
       end
 
       alias :reset! :reconnect!
@@ -393,11 +402,16 @@ module ActiveRecord
           end
         end
 
+        sql << " RETURNING #{insert.returning}" if insert.returning
         sql
       end
 
       def shared_cache? # :nodoc:
         @config.fetch(:flags, 0).anybits?(::SQLite3::Constants::Open::SHAREDCACHE)
+      end
+
+      def use_insert_returning?
+        @use_insert_returning
       end
 
       def get_database_version # :nodoc:

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -14,7 +14,7 @@ class DefaultTest < ActiveRecord::TestCase
     end
   end
 
-  if current_adapter?(:PostgreSQLAdapter)
+  if current_adapter?(:PostgreSQLAdapter) || current_adapter?(:SQLite3Adapter)
     def test_multiline_default_text
       record = Default.new
       # older postgres versions represent the default with escapes ("\\012" for a newline)
@@ -309,7 +309,7 @@ class Sqlite3DefaultExpressionTest < ActiveRecord::TestCase
       assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-      assert_match %r/t\.integer\s+"random_number",\s+default: -> { "random\(\)" }/, output
+      assert_match %r/t\.integer\s+"random_number",\s+default: -> { "ABS\(RANDOM\(\)\)" }/, output
     end
   end
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -47,14 +47,14 @@ class PersistenceTest < ActiveRecord::TestCase
     record_with_defaults = Default.create
     assert_not_nil record_with_defaults.id
     assert_equal "Ruby on Rails", record_with_defaults.ruby_on_rails
-    assert_not_nil record_with_defaults.virtual_stored_number
-    assert_not_nil record_with_defaults.rand_number
+    assert_not_nil record_with_defaults.virtual_stored_number if current_adapter?(:PostgreSQLAdapter)
+    assert_not_nil record_with_defaults.random_number
     assert_not_nil record_with_defaults.modified_date
     assert_not_nil record_with_defaults.modified_date_function
     assert_not_nil record_with_defaults.modified_time
     assert_not_nil record_with_defaults.modified_time_without_precision
     assert_not_nil record_with_defaults.modified_time_function
-  end if current_adapter?(:PostgreSQLAdapter)
+  end if current_adapter?(:PostgreSQLAdapter) || current_adapter?(:SQLite3Adapter)
 
   def test_update_many
     topic_data = { 1 => { "content" => "1 updated" }, 2 => { "content" => "2 updated" } }

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :defaults, force: true do |t|
-    t.virtual :virtual_stored_number, type: :integer, as: "rand_number * 10", stored: true
-    t.integer :rand_number, default: -> { "random() * 100" }
+    t.virtual :virtual_stored_number, type: :integer, as: "random_number * 10", stored: true
+    t.integer :random_number, default: -> { "random() * 100" }
     t.string :ruby_on_rails, default: -> { "concat('Ruby ', 'on ', 'Rails')" }
     t.date :modified_date, default: -> { "CURRENT_DATE" }
     t.date :modified_date_function, default: -> { "now()" }

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -2,15 +2,21 @@
 
 ActiveRecord::Schema.define do
   create_table :defaults, force: true do |t|
-    t.date :modified_date, default: -> { "CURRENT_DATE" }
-    t.date :fixed_date, default: "2004-01-01"
-    t.datetime :fixed_time, default: "2004-01-01 00:00:00"
-    t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
-    t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
-    t.integer :random_number, default: -> { "random()" }
-    t.column :char1, "char(1)", default: "Y"
-    t.string :char2, limit: 50, default: "a varchar field"
-    t.text :char3, limit: 50, default: "a text field"
-  end
+      t.integer :random_number, default: -> { "ABS(RANDOM())" }
+      t.string :ruby_on_rails, default: -> { "('Ruby ' || 'on ' || 'Rails')" }
+      t.date :modified_date, default: -> { "CURRENT_DATE" }
+      t.date :modified_date_function, default: -> { "DATE('now')" }
+      t.date :fixed_date, default: "2004-01-01"
+      t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :modified_time_function, default: -> { "DATETIME('now')" }
+      t.datetime :fixed_time, default: "2004-01-01 00:00:00.000000-00"
+      t.column :char1, "char(1)", default: "Y"
+      t.string :char2, limit: 50, default: "a varchar field"
+      t.text :char3, default: "a text field"
+      t.text :multiline_default, default: "--- []
+
+"
+    end
 end


### PR DESCRIPTION
Implementing the full `supports_insert_returning?` contract means the SQLite3 adapter supports auto-populated columns (#48241) as well as custom primary keys.

### Motivation / Background

Building on the background of https://github.com/rails/rails/pull/49287, this is my first major PR to begin making the `SQLite3Adapter` feature-comparable with the `MySQLAdapter` and `PostgreSQLAdapter`s.

SQLite is a feature-rich database engine, and production usage is only growing. We need Rails' support to offer developers the range and scope of its features.

### Detail

PR https://github.com/rails/rails/pull/48241 introduced the wonderful feature to have ActiveRecord models auto-populate their attributes with database defaults. Initially, this feature was only implemented for the `PostgreSQLAdapter`. The essential SQL feature foundation for this behavior is use of the `RETURNING` keyword, which SQLite has supported since version 3.35.0 (2021-03-12) (see https://www.sqlite.org/lang_returning.html).

In this PR, I am adding full support for the `SQLite3Adapter` by implementing:

* `ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#sql_for_insert`
* `ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#returning_column_values`
* `ActiveRecord::ConnectionAdapters::SQLite3Adapter#supports_insert_returning?`
* `ActiveRecord::ConnectionAdapters::SQLite3Adapter#return_value_after_insert?`
* `ActiveRecord::ConnectionAdapters::SQLite3Adapter#use_insert_returning?`

along with a couple of tweaks to a few methods.

### Additional information

This builds on the work started in https://github.com/rails/rails/pull/49287

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
