### PR TITLE
Clarify that the default retry strategy uses polynomial backoff instead of exponential backoff

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Clarify the backoff strategy for the recommended `:wait` option when retrying jobs
+
+    `wait: :exponentially_longer` is waiting polynomially longer, so it is now recommended to use `wait: :polynomially_longer` to keep the same behavior.
+
+    *Victor Mours*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Fix Active Job log message to correctly report a job failed to enqueue

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -10,7 +10,7 @@ class FirstRetryableErrorOfTwo < StandardError; end
 class SecondRetryableErrorOfTwo < StandardError; end
 class LongWaitError < StandardError; end
 class ShortWaitTenAttemptsError < StandardError; end
-class ExponentialWaitTenAttemptsError < StandardError; end
+class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
 class CustomCatchError < StandardError; end
 class DiscardableError < StandardError; end
@@ -26,7 +26,7 @@ class RetryJob < ActiveJob::Base
   retry_on FirstRetryableErrorOfTwo, SecondRetryableErrorOfTwo, attempts: 4
   retry_on LongWaitError, wait: 1.hour, attempts: 10
   retry_on ShortWaitTenAttemptsError, wait: 1.second, attempts: 10
-  retry_on ExponentialWaitTenAttemptsError, wait: :exponentially_longer, attempts: 10
+  retry_on PolynomialWaitTenAttemptsError, wait: :polynomially_longer, attempts: 10
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }

--- a/activestorage/app/jobs/active_storage/analyze_job.rb
+++ b/activestorage/app/jobs/active_storage/analyze_job.rb
@@ -5,7 +5,7 @@ class ActiveStorage::AnalyzeJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:analysis] }
 
   discard_on ActiveRecord::RecordNotFound
-  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
+  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob)
     blob.analyze

--- a/activestorage/app/jobs/active_storage/mirror_job.rb
+++ b/activestorage/app/jobs/active_storage/mirror_job.rb
@@ -7,7 +7,7 @@ class ActiveStorage::MirrorJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:mirror] }
 
   discard_on ActiveStorage::FileNotFoundError
-  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
+  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(key, checksum:)
     ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum)

--- a/activestorage/app/jobs/active_storage/purge_job.rb
+++ b/activestorage/app/jobs/active_storage/purge_job.rb
@@ -5,7 +5,7 @@ class ActiveStorage::PurgeJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:purge] }
 
   discard_on ActiveRecord::RecordNotFound
-  retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :exponentially_longer
+  retry_on ActiveRecord::Deadlocked, attempts: 10, wait: :polynomially_longer
 
   def perform(blob)
     blob.purge

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -4,7 +4,7 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:transform] }
 
   discard_on ActiveRecord::RecordNotFound
-  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :exponentially_longer
+  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)
     blob.variant(transformations).processed


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the naming of the `wait: :exponentially_longer` option for retrying jobs is misleading as to how often the job will be retried.

The backoff strategy used by ActiveJob is polynomial backoff (which in this case is sometimes also called quartic backoff) rather than exponential backoof.

Part of the app my team works on (an [appointment management system for French social services](https://github.com/betagouv/rdv-solidarites.fr)) has had a partial outage recently, because of background jobs that would timeout and retry a lot, overflowing our queues.

When doing a post-mortem for this incident, we looked at how quickly our jobs were rescheduled, and we were surprised to see that after the first few tries, it was much faster than expected with an exponential backoff. This is what led us into investigating this.

### Detail

This pull request changes the name of the option to clearly indicate that jobs will be retried with polynomial backoff, and keeps the legacy name working for backwards compatibility.

#### The difference between polynomial backoff and exponential backoff

The delays as implemented in ActiveJob with `retry_count**4`,  increases polynomially, while a classic exponential delay, usually implemented as `2**retry_count` increases exponentially (see for example [this Google Cloud documentation page](https://cloud.google.com/iot/docs/how-tos/exponential-backoff)).

An exponential backoff could also be implemented as `4**retry_count` to better match the initial values of the first few tries (this is what we were expecting to happen).

To put this in perspective, this is how long these strategies wait between retries (not including jitter):
```
retry_count:          1,   2,  3,   4,   5,   6,   7,  8,  9,   10,  11, 12, 13,  14,  15,  16,  17,  18, 19, 20, 
retry_count**4 delay: 1s, 16s, 1m,  4m, 10m, 22m, 40m, 1h, 2h,  3h,  4h, 6h,  8h, 11h, 14h, 18h, 23h, 1d, 2d,  2d, 
4**retry_count delay: 4s, 16s, 1m,  4m, 17m,  1h,  5h,18h, 3d, 12d, 49d, 194d,  
2**retry_count delay: 2s,  4s, 8s, 16s, 32s,  1m,  2m, 4m, 9m, 17m, 34m, 1h,  2h,  5h,  9h, 18h,  2d, 3d, 6d, 12d, 
```


Interestingly, ActionCable’s retry strategy uses true exponential backoff (see `actioncable/app/javascript/action_cable/connection_monitor.js:77` and the corresponding test `actioncable/test/javascript/src/unit/connection_monitor_test.js:17`).

#### Is this just a naming error or is it actually a bug ?

I was a bit unsure as to whether this should be considered a bug or just a naming error. In other words, should this mismatch between expectation and implementation be fixed by changing the code to `2 ** retry_count` (or maybe `4 ** retry_count` ?) or by changing the name of the option?

After a bit of research, I realized that polynomial backoff using `retry_count**4` is the de facto standard in most major Ruby libraries (more about this in the next section if you’re interested).

Moreover, it seems like a genuinely hard problem to decide whether polynomial backoff is better or worse than exponential backoff. I don’t believe there can be a clear cut answer that works for the general case of Rails applications.

However, it does seems reasonable to manage expectations, and make it clear what kind of backoff we're using.

Therefore, in the spirit of “if it ain’t broken, don’t fix it”, it seems to me that the sanest option is to clarify the naming, but keep the same implementation (and keep backwards compatibility).


Maybe ActiveJob should provide a new option for a built-in true exponential backoff strategy, that topic should probably be addressed in a different issue.


### Additional information

The confusion between polynomial and exponential backoff seems very pervasive in the Ruby community. I was surprised to find that many other Ruby libraries use a `retry_count ** 4 backoff`, and call it exponential backoff. For an interesting tidbit of history, I tried to find the origin of this, and found [this commit](https://github.com/tobi/delayed_job/commit/2309a943d87db9707a7d93999cfe6c264197b8bf)  in delayed job where this strategy is first introduced (but not named) back in 2008, and then [this commit](https://github.com/tobi/delayed_job/commit/266fc15c12953a94a6d052281ce10059ddd5ebc1#diff-bf8e9f7f94507fcd199bde7d01cd8413f2a470126c83d64785fbb419f1d212e3R64) in 2009 when it is mistakenly documented as using an “exponential scale”.

A similar implementation later appears in sidekiq, sneaker handler , and resque-retry, before being added to ActiveJob in 2016.

I plan on opening similar pull requests on the various projects where there is this confusion.


Math enthusiasts may also point out that it is a genuinely hard problem to figure out if computations that are solved by algorithms with exponential time complexity can also be solved in polynomial time.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


This is my first contribution to Rails so I'm not sure I got the changelog format right, or if I should break this down into more commits. Of course, I'll happily edit any of this to make it compatible with the codebase, and I'm looking forward to any feedback!

Thanks for reading this lengthy description!
