### PR TITLE
Add instrumentation for ActionController::Live#send_stream

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add instrumentation for ActionController::Live#send_stream
+
+    Allows subscribing to `send_stream` events. The event payload contains the filename, disposition, and type.
+
+    *Hannah Ramadan*
+
 *   Add support for `with_routing` test helper in `ActionDispatch::IntegrationTest`
 
     *Gannon McGibbon*

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -373,6 +373,19 @@ module ActionController
       assert_match "my.csv", @response.headers["Content-Disposition"]
     end
 
+    def test_send_stream_instrumentation
+      payload = nil
+      subscriber = proc { |event| payload = event.payload }
+
+      ActiveSupport::Notifications.subscribed(subscriber, "send_stream.action_controller") do
+        get :send_stream_with_explicit_content_type
+      end
+
+      assert_equal "sample.csv", payload[:filename]
+      assert_equal "attachment", payload[:disposition]
+      assert_equal "text/csv", payload[:type]
+    end
+
     def test_send_stream_with_options
       get :send_stream_with_options
       assert_equal %[{ name: "David", age: 41 }], @response.body

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -196,6 +196,22 @@ Additional keys may be added by the caller.
 | `:keys`       | The unpermitted keys                                                          |
 | `:context`    | Hash with the following keys: `:controller`, `:action`, `:params`, `:request` |
 
+#### `send_stream.action_controller`
+
+| Key            | Value                                    |
+| -------------- | ---------------------------------------- |
+| `:filename`    | The filename                             |
+| `:type`        | HTTP content type                        |
+| `:disposition` | HTTP content disposition                 |
+
+```ruby
+{
+  filename: "subscribers.csv",
+  type: "text/csv",
+  disposition: "attachment"
+}
+```
+
 ### Action Controller — Caching
 
 #### `write_fragment.action_controller`


### PR DESCRIPTION
### Motivation / Background

It was great to see `ActionController::Live#send_stream` introduced in Rails 7.0. We'd like to collect information on `send_stream` events by adding instrumentation for it.

### Detail

Adds instrumentation for `ActionController::Live#send_stream`. The event payload contains the filename, disposition, and type.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
