### PR TITLE
[AR] Fix uniqueness validation on association not using overridden PK

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -43,7 +43,7 @@ module ActiveRecord
     def bind_attribute(name, value) # :nodoc:
       if reflection = klass._reflect_on_association(name)
         name = reflection.foreign_key
-        value = value.read_attribute(reflection.klass.primary_key) unless value.nil?
+        value = value.read_attribute(reflection.association_primary_key) unless value.nil?
       end
 
       attr = table[name]

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -11,6 +11,7 @@ require "models/uuid_item"
 require "models/author"
 require "models/person"
 require "models/essay"
+require "models/keyboard"
 
 class Wizard < ActiveRecord::Base
   self.abstract_class = true
@@ -64,6 +65,14 @@ class TopicWithAfterCreate < Topic
   def set_author
     update!(author_name: "#{title} #{id}")
   end
+end
+
+class LessonWithUniqKeyboard < ActiveRecord::Base
+  self.table_name = "lessons"
+
+  belongs_to :keyboard, primary_key: :name, foreign_key: :name
+
+  validates_uniqueness_of :keyboard
 end
 
 class UniquenessValidationTest < ActiveRecord::TestCase
@@ -616,5 +625,14 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_not_predicate item2, :valid?
 
     assert_equal(["has already been taken"], item2.errors[:id])
+  end
+
+  def test_uniqueness_on_custom_relation_primary_key
+    Keyboard.create!(name: "Keyboard #1")
+    LessonWithUniqKeyboard.create!(name: "Keyboard #1")
+
+    another = LessonWithUniqKeyboard.new(name: "Keyboard #1")
+    assert_not_predicate another, :valid?
+    assert_equal ["has already been taken"], another.errors[:keyboard]
   end
 end


### PR DESCRIPTION
This is a backport of #45790 to `7-0-stable`.

Fixes #49293.

cc @yahonda 