### PR TITLE
[ci skip] clarify the benefits of using ActiveJob's execution wrappers

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -122,7 +122,11 @@ GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
 GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
 ```
 
-That's it!
+NOTE: Jobs are meant to be run with the `perform_later`
+wrapper. Running the job's `perform` method directly is possible but
+removes the benefits of using a queue and skips all the logic provided
+by the Active Job wrappers like callbacks or exception rescuing,
+described later in this guide.
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set


### PR DESCRIPTION
### Motivation / Background

I've been stuck on a failing test about a job that was supposed to be rescued from exceptions, and after an embarrassing amount of time I came to realise that using `perform` shortcuts all of the ActiveJob niceties.

This Pull Request has been created because I don't want other people to confuse the `perform`, `perform_now` or `perform_later` altogether and waste valuable time trying to understand why the first one doesn't behave like the two others.

Feel free to challenge the wording as you please :v:

### Detail

This Pull Request changes the ActiveJob guide.

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
