### PR TITLE
eliminate extra blank lines in dockerfile template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -32,7 +32,6 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
     rm -rf /tmp/node-build-master
 
 <% end -%>
-
 <% if using_bun? -%>
 ENV BUN_INSTALL=/usr/local/bun
 ENV PATH=/usr/local/bun/bin:$PATH
@@ -40,7 +39,6 @@ ARG BUN_VERSION=<%= dockerfile_bun_version %>
 RUN curl -fsSL https://bun.sh/install | bash -s -- "${BUN_VERSION}"
 
 <% end -%>
-
 # Install application gems
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \


### PR DESCRIPTION
The rule should be:
  * one blank line between "stanzas" or groups of lines
  * two blanks lines precede FROM statements