### PR TITLE
Consistency/semantics: BUN_VERSION vs bun-v

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -497,7 +497,7 @@ module Rails
       end
 
       def dockerfile_bun_version
-        using_bun? and "bun-v#{`bun --version`[/\d+\.\d+\.\d+/]}"
+        using_bun? and `bun --version`[/\d+\.\d+\.\d+/]
       rescue
         BUN_VERSION
       end

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -36,7 +36,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 ENV BUN_INSTALL=/usr/local/bun
 ENV PATH=/usr/local/bun/bin:$PATH
 ARG BUN_VERSION=<%= dockerfile_bun_version %>
-RUN curl -fsSL https://bun.sh/install | bash -s -- "${BUN_VERSION}"
+RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
 # Install application gems


### PR DESCRIPTION
All the other VERSION ARGS in the Dockerfile are pure version numbers. Any other additions are handled elsewhere.

Arguably, this is just cosmetic/foolish consistency, but it is a source of subtle bugs.  For example, the fallback if `bun -version` fails is defined here:

https://github.com/rails/rails/blob/af1d77abfb0120fdeee23e36878fd97be7ff388f/railties/lib/rails/generators/app_base.rb#L19

Note the _lack_ of bun_v, which ultimately will cause the docker build to fail.