### PR TITLE
doc: Firebug was replaced by Firefox/Chrome DevTools

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -579,7 +579,7 @@ This is alright for some web applications, but certainly not if the user is not 
 
 Depending on your web application, there will be many more parameters the user can tamper with. As a rule of thumb, _no user input data is secure, until proven otherwise, and every parameter from the user is potentially manipulated_.
 
-Don't be fooled by security by obfuscation and JavaScript security. Developer tools let you review and change every form's hidden fields. _JavaScript can be used to validate user input data, but certainly not to prevent attackers from sending malicious requests with unexpected values_. The Firebug addon for Mozilla Firefox logs every request and may repeat and change them. That is an easy way to bypass any JavaScript validations. And there are even client-side proxies that allow you to intercept any request and response from and to the Internet.
+Don't be fooled by security by obfuscation and JavaScript security. Developer tools let you review and change every form's hidden fields. _JavaScript can be used to validate user input data, but certainly not to prevent attackers from sending malicious requests with unexpected values_. DevTools log every request and may repeat and change them. That is an easy way to bypass any JavaScript validations. And there are even client-side proxies that allow you to intercept any request and response from and to the Internet.
 
 Injection
 ---------


### PR DESCRIPTION
### Motivation / Background

Firebug was sunset in 2017, and was replaced by Firefox (or Chrome) DevTools.

- https://getfirebug.com/index.html
- https://hacks.mozilla.org/2017/10/saying-goodbye-to-firebug/ https://firefox-source-docs.mozilla.org/devtools-user/
- https://developer.chrome.com/docs/devtools/

This sentence was originally introduced in 96d610553e5fdaabc923835ab1f194070ddb4477 (before Rails 2.3).

### Detail

This Pull Request replaces Firebug addon with (Firefox or Chrome) DevTools in [the security doc (edge)](https://edgeguides.rubyonrails.org/security.html#privilege-escalation) (or [v7.0](https://guides.rubyonrails.org/v7.0/security.html#privilege-escalation)).

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [n/a] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
