### PR TITLE
Add normalizes_type to apply common normalizations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,11 @@
+*   Add `normalizes_type` to apply normalizations to multiple attributes of the same type.
+
+    ```ruby
+    class User < ActiveRecord::Base
+      normalizes_type :string, except: :name, with: -> attribute { attribute.strip }
+    end
+    ```
+
+    *Niklas Häusele*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -100,6 +100,29 @@ module ActiveRecord # :nodoc:
       def normalize_value_for(name, value)
         type_for_attribute(name).cast(value)
       end
+
+      # Normalizes all attributes of a given type.
+      #
+      # This is handy to apply common normalizations to multiple attributes at once.
+      #
+      # ==== Examples
+      #
+      #   class User < ActiveRecord::Base
+      #     normalizes_type :string, with: -> attribute { attribute.strip }
+      #   end
+      #
+      #   User.normalized_attributes
+      #   # => #<Set: {:email, :name}>
+      def normalizes_type(type, except: nil, with:, apply_to_nil: false)
+        attribute_types
+          .symbolize_keys
+          .filter { |_, attr_type| attr_type.type == type.to_sym }
+          .except(*Array.wrap(except).map(&:to_sym))
+          .keys
+          .each do |name|
+            normalizes(name, with: with, apply_to_nil: apply_to_nil)
+          end
+      end
     end
 
     private

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/aircraft"
+require "models/bird"
 require "active_support/core_ext/string/inflections"
 
 class NormalizedAttributeTest < ActiveRecord::TestCase
@@ -109,5 +110,25 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     assert_equal "0", aircraft.name
     aircraft.save
     assert_equal "1", aircraft.name
+  end
+end
+
+class NormalizedTypeAttributeTest < ActiveRecord::TestCase
+  class NormalizedTypeBird < Bird
+    normalizes_type :string, except: :color, with: -> attribute { attribute.strip }
+  end
+
+  setup do
+    @bird = NormalizedTypeBird.create!(
+      name: " some name ",
+      age: 42,
+      species: " some species ",
+      color: " some color ")
+  end
+
+  test "normalizes all strings types except color" do
+    assert_equal "some name", @bird.name
+    assert_equal "some species", @bird.species
+    assert_equal " some color ", @bird.color # except
   end
 end

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -115,20 +115,19 @@ end
 
 class NormalizedTypeAttributeTest < ActiveRecord::TestCase
   class NormalizedTypeBird < Bird
-    normalizes_type :string, except: :color, with: -> attribute { attribute.strip }
+    normalizes_type :string, with: -> { _1.strip }
   end
 
   setup do
-    @bird = NormalizedTypeBird.create!(
+    @bird = NormalizedTypeBird.new(
       name: " some name ",
       age: 42,
-      species: " some species ",
-      color: " some color ")
+      species: " some species "
+    )
   end
 
-  test "normalizes all strings types except color" do
+  test "normalizes all strings types" do
     assert_equal "some name", @bird.name
     assert_equal "some species", @bird.species
-    assert_equal " some color ", @bird.color # except
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -117,9 +117,11 @@ ActiveRecord::Schema.define do
   end
 
   create_table :birds, force: true do |t|
-    t.string :name
-    t.string :color
+    t.integer :age
     t.integer :pirate_id
+    t.string :color
+    t.string :name
+    t.string :species
   end
 
   create_table :books, id: :integer, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

Many apps use the https://github.com/rmm5t/strip_attributes gem to strip most string attributes.
The new `normalizes` API is a perfect fit for this. One "downside" in contrast to the strip_attributes gem, is that you have to explicitly list all attributes you want to normalize. It would be nice to have a simple way to e.g. "strip all string attributes in most models".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
