### PR TITLE
Support returning option in insert_all for MariaDB

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support insert returning clause for MariaDB
+
+    INSERT RETURNING [have supported](https://mariadb.com/kb/en/insertreturning/) starting with 10.5.0.
+
+    Now you can use returning with MariaDB the same way as with PostgreSQL
+    in ActiveRecord::Persistence insert methods.
+
+    *Nikolay Kondratyev*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Encryption now supports `support_unencrypted_data` being set per-attribute.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -162,6 +162,10 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_returning?
+        mariadb? && database_version >= "10.5.0"
+      end
+
       def supports_insert_on_duplicate_skip?
         true
       end
@@ -628,12 +632,11 @@ module ActiveRecord
       end
 
       def build_insert_sql(insert) # :nodoc:
-        sql = +"INSERT #{insert.into} #{insert.values_list}"
+        sql = +"INSERT"
+        sql << " IGNORE" if insert.skip_duplicates?
+        sql << " #{insert.into} #{insert.values_list}"
 
-        if insert.skip_duplicates?
-          no_op_column = quote_column_name(insert.keys.first)
-          sql << " ON DUPLICATE KEY UPDATE #{no_op_column}=#{no_op_column}"
-        elsif insert.update_duplicates?
+        if insert.update_duplicates?
           sql << " ON DUPLICATE KEY UPDATE "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
@@ -643,6 +646,7 @@ module ActiveRecord
           end
         end
 
+        sql << " RETURNING #{insert.returning}" if insert.returning
         sql
       end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -115,7 +115,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -205,7 +205,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -271,7 +271,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL


### PR DESCRIPTION
MariaDB have supported [INSERT RETURNING](https://mariadb.com/kb/en/insertreturning/) starting with 10.5.0.

This is very convenient to use in methods such as `ActiveRecord::Persistence.insert_all` to return default or setted by trigger attributes.

Now you can use returning option with MariaDB the same way as with PostgreSQL in ActiveRecord::Persistence [insert](https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-insert_all) methods.

There are tests https://github.com/rails/rails/blob/ebcd7233ea1307448f2d97eaf56a8d303200e5f7/activerecord/test/cases/insert_all_test.rb#L87-L120  that will automatically run in the required version of MariaDB.

We've been using this patch in production for several months.