### PR TITLE
Use Ruby 3.3 `Range#overlap?` if available

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use Ruby 3.3 Range#overlap? if available
+
+    *Yasuo Honda*
+
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
 *   Add `drb`, `mutex_m` and `base64` that are bundled gem candidates for Ruby 3.4

--- a/activesupport/lib/active_support/core_ext/range/overlap.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlap.rb
@@ -4,8 +4,10 @@ class Range
   # Compare two ranges and see if they overlap each other
   #  (1..5).overlap?(4..6) # => true
   #  (1..5).overlap?(7..9) # => false
-  def overlap?(other)
-    other.begin == self.begin || cover?(other.begin) || other.cover?(self.begin)
+  unless Range.method_defined?(:overlap?)
+    def overlap?(other)
+      other.begin == self.begin || cover?(other.begin) || other.cover?(self.begin)
+    end
   end
 
   alias :overlaps? :overlap?


### PR DESCRIPTION
### Motivation / Background

This commit uses Ruby 3.3 `Range#overlap?` that has been added to Ruby via https://github.com/ruby/ruby/pull/8242 . Rails 7.1 renames `Range#overlaps?` to `Range#overlap?` via https://github.com/rails/rails/pull/48565 , This commit is not feasible to backport because there is no `Range#overlap?` in Rails 7.0.z

### Detail

This commit addresses the CI faiilure at https://buildkite.com/rails/rails/builds/99745#018a9ea8-82f0-40a6-90c3-cdaa6dabebab/1092-1095 because without this commit, it shows `warning: method redefined; discarding old overlap?`.

```ruby
$ ruby -v
ruby 3.3.0dev (2023-09-16T05:57:19Z master e9b503f1bb) [x86_64-linux]
$ RAILS_STRICT_WARNING=true bundle exec ruby -w -Itest test/core_ext/range_ext_test.rb
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/range/overlap.rb:7: warning: method redefined; discarding old overlap?
Running 46 tests in a single process (parallelization threshold is 50)
Run options: --seed 583

# Running:

..............................................

Finished in 0.011672s, 3940.9670 runs/s, 4883.3722 assertions/s.
46 runs, 57 assertions, 0 failures, 0 errors, 0 skips
```

### Additional information

None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
