### PR TITLE
Use `assert_dom_equal` more in Action View Tests

### DIFF
--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -16,14 +16,14 @@ class CaptureHelperTest < ActionView::TestCase
       @av.output_buffer << "bar"
     end
     assert_predicate @av.output_buffer, :empty?
-    assert_equal "foobar", string
+    assert_dom_equal "foobar", string
   end
 
   def test_capture_captures_the_value_returned_by_the_block_if_the_temporary_buffer_is_blank
     string = @av.capture("foo", "bar") do |a, b|
       a + b
     end
-    assert_equal "foobar", string
+    assert_dom_equal "foobar", string
   end
 
   def test_capture_returns_nil_if_the_returned_value_is_not_a_string
@@ -32,12 +32,12 @@ class CaptureHelperTest < ActionView::TestCase
 
   def test_capture_escapes_html
     string = @av.capture { "<em>bar</em>" }
-    assert_equal "&lt;em&gt;bar&lt;/em&gt;", string
+    assert_dom_equal "&lt;em&gt;bar&lt;/em&gt;", string
   end
 
   def test_capture_doesnt_escape_twice
     string = @av.capture { raw("&lt;em&gt;bar&lt;/em&gt;") }
-    assert_equal "&lt;em&gt;bar&lt;/em&gt;", string
+    assert_dom_equal "&lt;em&gt;bar&lt;/em&gt;", string
   end
 
   def test_capture_does_not_reassign_buffer
@@ -50,24 +50,24 @@ class CaptureHelperTest < ActionView::TestCase
 
   def test_content_for_used_for_read
     content_for :foo, "foo"
-    assert_equal "foo", content_for(:foo)
+    assert_dom_equal "foo", content_for(:foo)
 
     content_for(:bar) { "bar" }
-    assert_equal "bar", content_for(:bar)
+    assert_dom_equal "bar", content_for(:bar)
   end
 
   def test_content_for_with_multiple_calls
     assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title, :bar
-    assert_equal "foobar", content_for(:title)
+    assert_dom_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_multiple_calls_and_flush
     assert_not content_for?(:title)
     content_for :title, "foo"
     content_for :title, :bar, flush: true
-    assert_equal "bar", content_for(:title)
+    assert_dom_equal "bar", content_for(:title)
   end
 
   def test_content_for_with_block
@@ -77,7 +77,7 @@ class CaptureHelperTest < ActionView::TestCase
       output_buffer << "bar"
       nil
     end
-    assert_equal "foobar", content_for(:title)
+    assert_dom_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_block_and_multiple_calls_with_flush
@@ -88,7 +88,7 @@ class CaptureHelperTest < ActionView::TestCase
     content_for :title, flush: true do
       "bar"
     end
-    assert_equal "bar", content_for(:title)
+    assert_dom_equal "bar", content_for(:title)
   end
 
   def test_content_for_with_block_and_multiple_calls_with_flush_nil_content
@@ -99,7 +99,7 @@ class CaptureHelperTest < ActionView::TestCase
     content_for :title, nil, flush: true do
       "bar"
     end
-    assert_equal "bar", content_for(:title)
+    assert_dom_equal "bar", content_for(:title)
   end
 
   def test_content_for_with_block_and_multiple_calls_without_flush
@@ -110,7 +110,7 @@ class CaptureHelperTest < ActionView::TestCase
     content_for :title, flush: false do
       "bar"
     end
-    assert_equal "foobar", content_for(:title)
+    assert_dom_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_whitespace_block
@@ -121,7 +121,7 @@ class CaptureHelperTest < ActionView::TestCase
       nil
     end
     content_for :title, "bar"
-    assert_equal "foobar", content_for(:title)
+    assert_dom_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_whitespace_block_and_flush
@@ -132,7 +132,7 @@ class CaptureHelperTest < ActionView::TestCase
       nil
     end
     content_for :title, "bar", flush: true
-    assert_equal "bar", content_for(:title)
+    assert_dom_equal "bar", content_for(:title)
   end
 
   def test_content_for_returns_nil_when_writing
@@ -140,11 +140,11 @@ class CaptureHelperTest < ActionView::TestCase
     assert_nil content_for(:title, "foo")
     assert_nil content_for(:title) { output_buffer << "bar"; nil }
     assert_nil content_for(:title) { output_buffer << "  \n  "; nil }
-    assert_equal "foobar", content_for(:title)
+    assert_dom_equal "foobar", content_for(:title)
     assert_nil content_for(:title, "foo", flush: true)
     assert_nil content_for(:title, flush: true) { output_buffer << "bar"; nil }
     assert_nil content_for(:title, flush: true) { output_buffer << "  \n  "; nil }
-    assert_equal "bar", content_for(:title)
+    assert_dom_equal "bar", content_for(:title)
   end
 
   def test_content_for_returns_nil_when_content_missing
@@ -175,14 +175,14 @@ class CaptureHelperTest < ActionView::TestCase
     assert_not content_for?(:title)
     provide :title, "hi"
     assert content_for?(:title)
-    assert_equal "hi", content_for(:title)
+    assert_dom_equal "hi", content_for(:title)
     provide :title, "<p>title</p>"
-    assert_equal "hi&lt;p&gt;title&lt;/p&gt;", content_for(:title)
+    assert_dom_equal "hi&lt;p&gt;title&lt;/p&gt;", content_for(:title)
 
     @view_flow = ActionView::OutputFlow.new
     provide :title, :hi
     provide :title, raw("<p>title</p>")
-    assert_equal "hi<p>title</p>", content_for(:title)
+    assert_dom_equal "hi<p>title</p>", content_for(:title)
   end
 
   def test_with_output_buffer_swaps_the_output_buffer_given_no_argument
@@ -227,7 +227,7 @@ class CaptureHelperTest < ActionView::TestCase
 
   def test_with_output_buffer_does_not_assume_there_is_an_output_buffer
     assert_predicate @av.output_buffer, :empty?
-    assert_equal "", @av.with_output_buffer { }.to_s
+    assert_dom_equal "", @av.with_output_buffer { }.to_s
   end
 
   def alt_encoding(output_buffer)

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -14,11 +14,11 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   end
 
   def test_csp_meta_tag
-    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    assert_dom_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
   end
 
   def test_csp_meta_tag_with_options
-    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+    assert_dom_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
   end
 end
 

--- a/actionview/test/template/erb/tag_helper_test.rb
+++ b/actionview/test/template/erb/tag_helper_test.rb
@@ -3,20 +3,24 @@
 require "abstract_unit"
 require "template/erb/helper"
 
+require "rails-dom-testing"
+
 module ERBTest
   class TagHelperTest < BlockTestCase
+    include Rails::Dom::Testing::Assertions
+
     test "percent equals works for content_tag and does not require parenthesis on method call" do
-      assert_equal "<div>Hello world</div>", render_content("content_tag :div", "Hello world")
+      assert_dom_equal "<div>Hello world</div>", render_content("content_tag :div", "Hello world")
     end
 
     test "percent equals works for javascript_tag" do
       expected_output = "<script>\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
-      assert_equal expected_output, render_content("javascript_tag", "alert('Hello')")
+      assert_dom_equal expected_output, render_content("javascript_tag", "alert('Hello')")
     end
 
     test "percent equals works for javascript_tag with options" do
       expected_output = "<script id=\"the_js_tag\">\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>"
-      assert_equal expected_output, render_content("javascript_tag(:id => 'the_js_tag')", "alert('Hello')")
+      assert_dom_equal expected_output, render_content("javascript_tag(:id => 'the_js_tag')", "alert('Hello')")
     end
 
     test "percent equals works with form tags" do
@@ -26,7 +30,7 @@ module ERBTest
 
     test "percent equals works with fieldset tags" do
       expected_output = "<fieldset><legend>foo</legend>hello</fieldset>"
-      assert_equal expected_output, render_content("field_set_tag('foo')", "<%= 'hello' %>")
+      assert_dom_equal expected_output, render_content("field_set_tag('foo')", "<%= 'hello' %>")
     end
   end
 end

--- a/actionview/test/template/erb_util_test.rb
+++ b/actionview/test/template/erb_util_test.rb
@@ -4,8 +4,11 @@ require "abstract_unit"
 require "active_support/json"
 require "active_support/core_ext/erb/util"
 
+require "rails-dom-testing"
+
 class ErbUtilTest < ActiveSupport::TestCase
   include ERB::Util
+  include Rails::Dom::Testing::Assertions
 
   ERB::Util::HTML_ESCAPE.each do |given, expected|
     define_method "test_html_escape_#{expected.gsub(/\W/, '')}" do
@@ -87,26 +90,26 @@ class ErbUtilTest < ActiveSupport::TestCase
 
   def test_html_escape_is_html_safe
     escaped = h("<p>")
-    assert_equal "&lt;p&gt;", escaped
+    assert_dom_equal "&lt;p&gt;", escaped
     assert_predicate escaped, :html_safe?
   end
 
   def test_html_escape_passes_html_escape_unmodified
     escaped = h("<p>".html_safe)
-    assert_equal "<p>", escaped
+    assert_dom_equal "<p>", escaped
     assert_predicate escaped, :html_safe?
   end
 
   def test_rest_in_ascii
     (0..127).to_a.map(&:chr).each do |chr|
       next if %('"&<>).include?(chr)
-      assert_equal chr, html_escape(chr)
+      assert_dom_equal chr, html_escape(chr)
     end
   end
 
   def test_html_escape_once
-    assert_equal "1 &lt;&gt;&amp;&quot;&#39; 2 &amp; 3", html_escape_once('1 <>&"\' 2 &amp; 3')
-    assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", html_escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
+    assert_dom_equal "1 &lt;&gt;&amp;&quot;&#39; 2 &amp; 3", html_escape_once('1 <>&"\' 2 &amp; 3')
+    assert_dom_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", html_escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
 
   def test_html_escape_once_returns_safe_strings_when_passed_unsafe_strings

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -742,14 +742,14 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice
-    assert_equal(
+    assert_dom_equal(
       %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice_with_hash
-    assert_equal(
+    assert_dom_equal(
       %(<input type="submit" name="commit" value="Save" data-disable-with="Processing..." />),
       submit_tag("Save", data: { disable_with: "Processing..." })
     )

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -22,33 +22,33 @@ class JavaScriptHelperTest < ActionView::TestCase
   end
 
   def test_escape_javascript
-    assert_equal "", escape_javascript(nil)
-    assert_equal "123", escape_javascript(123)
-    assert_equal "en", escape_javascript(:en)
-    assert_equal "false", escape_javascript(false)
-    assert_equal "true", escape_javascript(true)
-    assert_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))
-    assert_equal %(backslash\\\\test), escape_javascript(%(backslash\\test))
-    assert_equal %(don\\'t <\\/close> tags), escape_javascript(%(don't </close> tags))
-    assert_equal %(unicode &#x2028; newline), escape_javascript((+%(unicode \342\200\250 newline)).force_encoding(Encoding::UTF_8).encode!)
-    assert_equal %(unicode &#x2029; newline), escape_javascript((+%(unicode \342\200\251 newline)).force_encoding(Encoding::UTF_8).encode!)
+    assert_dom_equal "", escape_javascript(nil)
+    assert_dom_equal "123", escape_javascript(123)
+    assert_dom_equal "en", escape_javascript(:en)
+    assert_dom_equal "false", escape_javascript(false)
+    assert_dom_equal "true", escape_javascript(true)
+    assert_dom_equal %(This \\"thing\\" is really\\n netos\\'), escape_javascript(%(This "thing" is really\n netos'))
+    assert_dom_equal %(backslash\\\\test), escape_javascript(%(backslash\\test))
+    assert_dom_equal %(don\\'t <\\/close> tags), escape_javascript(%(don't </close> tags))
+    assert_dom_equal %(unicode &#x2028; newline), escape_javascript((+%(unicode \342\200\250 newline)).force_encoding(Encoding::UTF_8).encode!)
+    assert_dom_equal %(unicode &#x2029; newline), escape_javascript((+%(unicode \342\200\251 newline)).force_encoding(Encoding::UTF_8).encode!)
 
-    assert_equal %(don\\'t <\\/close> tags), j(%(don't </close> tags))
+    assert_dom_equal %(don\\'t <\\/close> tags), j(%(don't </close> tags))
   end
 
   def test_escape_backtick
-    assert_equal "\\`", escape_javascript("`")
+    assert_dom_equal "\\`", escape_javascript("`")
   end
 
   def test_escape_dollar_sign
-    assert_equal "\\$", escape_javascript("$")
+    assert_dom_equal "\\$", escape_javascript("$")
   end
 
   def test_escape_javascript_with_safebuffer
     given = %('quoted' "double-quoted" new-line:\n </closed>)
     expect = %(\\'quoted\\' \\"double-quoted\\" new-line:\\n <\\/closed>)
-    assert_equal expect, escape_javascript(given)
-    assert_equal expect, escape_javascript(ActiveSupport::SafeBuffer.new(given))
+    assert_dom_equal expect, escape_javascript(given)
+    assert_dom_equal expect, escape_javascript(ActiveSupport::SafeBuffer.new(given))
     assert_instance_of String, escape_javascript(given)
     assert_instance_of ActiveSupport::SafeBuffer, escape_javascript(ActiveSupport::SafeBuffer.new(given))
   end
@@ -59,7 +59,7 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_dom_equal "<script>\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
       javascript_tag("alert('hello')")
 
-    assert_equal "foo", output_buffer, "javascript_tag without a block should not concat to output_buffer"
+    assert_dom_equal "foo", output_buffer, "javascript_tag without a block should not concat to output_buffer"
   end
 
   # Setting the :extname option will control what extension (if any) is appended to the URL for assets

--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -7,120 +7,120 @@ class NumberHelperTest < ActionView::TestCase
 
   def test_number_to_phone
     assert_nil number_to_phone(nil)
-    assert_equal "555-1234", number_to_phone(5551234)
-    assert_equal "(800) 555-1212 x 123", number_to_phone(8005551212, area_code: true, extension: 123)
-    assert_equal "+18005551212", number_to_phone(8005551212, country_code: 1, delimiter: "")
-    assert_equal "+&lt;script&gt;&lt;/script&gt;8005551212", number_to_phone(8005551212, country_code: "<script></script>", delimiter: "")
-    assert_equal "8005551212 x &lt;script&gt;&lt;/script&gt;", number_to_phone(8005551212, extension: "<script></script>", delimiter: "")
+    assert_dom_equal "555-1234", number_to_phone(5551234)
+    assert_dom_equal "(800) 555-1212 x 123", number_to_phone(8005551212, area_code: true, extension: 123)
+    assert_dom_equal "+18005551212", number_to_phone(8005551212, country_code: 1, delimiter: "")
+    assert_dom_equal "+&lt;script&gt;&lt;/script&gt;8005551212", number_to_phone(8005551212, country_code: "<script></script>", delimiter: "")
+    assert_dom_equal "8005551212 x &lt;script&gt;&lt;/script&gt;", number_to_phone(8005551212, extension: "<script></script>", delimiter: "")
   end
 
   def test_number_to_currency
     assert_nil number_to_currency(nil)
-    assert_equal "$1,234,567,890.50", number_to_currency(1234567890.50)
-    assert_equal "$1,234,567,892", number_to_currency(1234567891.50, precision: 0)
-    assert_equal "1,234,567,890.50 - K&#269;", number_to_currency("-1234567890.50", unit: raw("K&#269;"), format: "%n %u", negative_format: "%n - %u")
-    assert_equal "&amp;pound;1,234,567,890.50", number_to_currency("1234567890.50", unit: "&pound;")
-    assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("1234567890.50", format: "<b>%n</b> %u")
-    assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", negative_format: "<b>%n</b> %u")
-    assert_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", "negative_format" => "<b>%n</b> %u")
-    assert_equal "₹ 12,30,000.00", number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: "₹", format: "%u %n")
+    assert_dom_equal "$1,234,567,890.50", number_to_currency(1234567890.50)
+    assert_dom_equal "$1,234,567,892", number_to_currency(1234567891.50, precision: 0)
+    assert_dom_equal "1,234,567,890.50 - K&#269;", number_to_currency("-1234567890.50", unit: raw("K&#269;"), format: "%n %u", negative_format: "%n - %u")
+    assert_dom_equal "&amp;pound;1,234,567,890.50", number_to_currency("1234567890.50", unit: "&pound;")
+    assert_dom_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("1234567890.50", format: "<b>%n</b> %u")
+    assert_dom_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", negative_format: "<b>%n</b> %u")
+    assert_dom_equal "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $", number_to_currency("-1234567890.50", "negative_format" => "<b>%n</b> %u")
+    assert_dom_equal "₹ 12,30,000.00", number_to_currency(1230000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/, unit: "₹", format: "%u %n")
   end
 
   def test_number_to_percentage
     assert_nil number_to_percentage(nil)
-    assert_equal "100.000%", number_to_percentage(100)
-    assert_equal "100.000 %", number_to_percentage(100, format: "%n %")
-    assert_equal "&lt;b&gt;100.000&lt;/b&gt; %", number_to_percentage(100, format: "<b>%n</b> %")
-    assert_equal "<b>100.000</b> %", number_to_percentage(100, format: raw("<b>%n</b> %"))
-    assert_equal "100%", number_to_percentage(100, precision: 0)
-    assert_equal "123.4%", number_to_percentage(123.400, precision: 3, strip_insignificant_zeros: true)
-    assert_equal "1.000,000%", number_to_percentage(1000, delimiter: ".", separator: ",")
-    assert_equal "98a%", number_to_percentage("98a")
-    assert_equal "NaN%", number_to_percentage(Float::NAN)
-    assert_equal "Inf%", number_to_percentage(Float::INFINITY)
-    assert_equal "NaN%", number_to_percentage(Float::NAN, precision: 0)
-    assert_equal "Inf%", number_to_percentage(Float::INFINITY, precision: 0)
-    assert_equal "NaN%", number_to_percentage(Float::NAN, precision: 1)
-    assert_equal "Inf%", number_to_percentage(Float::INFINITY, precision: 1)
+    assert_dom_equal "100.000%", number_to_percentage(100)
+    assert_dom_equal "100.000 %", number_to_percentage(100, format: "%n %")
+    assert_dom_equal "&lt;b&gt;100.000&lt;/b&gt; %", number_to_percentage(100, format: "<b>%n</b> %")
+    assert_dom_equal "<b>100.000</b> %", number_to_percentage(100, format: raw("<b>%n</b> %"))
+    assert_dom_equal "100%", number_to_percentage(100, precision: 0)
+    assert_dom_equal "123.4%", number_to_percentage(123.400, precision: 3, strip_insignificant_zeros: true)
+    assert_dom_equal "1.000,000%", number_to_percentage(1000, delimiter: ".", separator: ",")
+    assert_dom_equal "98a%", number_to_percentage("98a")
+    assert_dom_equal "NaN%", number_to_percentage(Float::NAN)
+    assert_dom_equal "Inf%", number_to_percentage(Float::INFINITY)
+    assert_dom_equal "NaN%", number_to_percentage(Float::NAN, precision: 0)
+    assert_dom_equal "Inf%", number_to_percentage(Float::INFINITY, precision: 0)
+    assert_dom_equal "NaN%", number_to_percentage(Float::NAN, precision: 1)
+    assert_dom_equal "Inf%", number_to_percentage(Float::INFINITY, precision: 1)
   end
 
   def test_number_with_delimiter
     assert_nil number_with_delimiter(nil)
-    assert_equal "12,345,678", number_with_delimiter(12345678)
-    assert_equal "0", number_with_delimiter(0)
+    assert_dom_equal "12,345,678", number_with_delimiter(12345678)
+    assert_dom_equal "0", number_with_delimiter(0)
   end
 
   def test_number_with_precision
     assert_nil number_with_precision(nil)
-    assert_equal "-111.235", number_with_precision(-111.2346)
-    assert_equal "111.00", number_with_precision(111, precision: 2)
-    assert_equal "0.00100", number_with_precision(0.001, precision: 5)
-    assert_equal "3.33", number_with_precision(Rational(10, 3), precision: 2)
+    assert_dom_equal "-111.235", number_with_precision(-111.2346)
+    assert_dom_equal "111.00", number_with_precision(111, precision: 2)
+    assert_dom_equal "0.00100", number_with_precision(0.001, precision: 5)
+    assert_dom_equal "3.33", number_with_precision(Rational(10, 3), precision: 2)
   end
 
   def test_number_to_human_size
     assert_nil number_to_human_size(nil)
-    assert_equal "3 Bytes", number_to_human_size(3.14159265)
-    assert_equal "1.2 MB", number_to_human_size(1234567, precision: 2)
+    assert_dom_equal "3 Bytes", number_to_human_size(3.14159265)
+    assert_dom_equal "1.2 MB", number_to_human_size(1234567, precision: 2)
   end
 
   def test_number_to_human
     assert_nil number_to_human(nil)
-    assert_equal "0",   number_to_human(0)
-    assert_equal "1.23 Thousand", number_to_human(1234)
-    assert_equal "489.0 Thousand", number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
+    assert_dom_equal "0",   number_to_human(0)
+    assert_dom_equal "1.23 Thousand", number_to_human(1234)
+    assert_dom_equal "489.0 Thousand", number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
   end
 
   def test_number_to_human_escape_units
     volume = { unit: "<b>ml</b>", thousand: "<b>lt</b>", million: "<b>m3</b>", trillion: "<b>km3</b>", quadrillion: "<b>Pl</b>" }
-    assert_equal "123 &lt;b&gt;lt&lt;/b&gt;", number_to_human(123456, units: volume)
-    assert_equal "12 &lt;b&gt;ml&lt;/b&gt;", number_to_human(12, units: volume)
-    assert_equal "1.23 &lt;b&gt;m3&lt;/b&gt;", number_to_human(1234567, units: volume)
-    assert_equal "1.23 &lt;b&gt;km3&lt;/b&gt;", number_to_human(1_234_567_000_000, units: volume)
-    assert_equal "1.23 &lt;b&gt;Pl&lt;/b&gt;", number_to_human(1_234_567_000_000_000, units: volume)
+    assert_dom_equal "123 &lt;b&gt;lt&lt;/b&gt;", number_to_human(123456, units: volume)
+    assert_dom_equal "12 &lt;b&gt;ml&lt;/b&gt;", number_to_human(12, units: volume)
+    assert_dom_equal "1.23 &lt;b&gt;m3&lt;/b&gt;", number_to_human(1234567, units: volume)
+    assert_dom_equal "1.23 &lt;b&gt;km3&lt;/b&gt;", number_to_human(1_234_567_000_000, units: volume)
+    assert_dom_equal "1.23 &lt;b&gt;Pl&lt;/b&gt;", number_to_human(1_234_567_000_000_000, units: volume)
 
     # Including fractionals
     distance = { mili: "<b>mm</b>", centi: "<b>cm</b>", deci: "<b>dm</b>", unit: "<b>m</b>",
                  ten: "<b>dam</b>", hundred: "<b>hm</b>", thousand: "<b>km</b>",
                  micro: "<b>um</b>", nano: "<b>nm</b>", pico: "<b>pm</b>", femto: "<b>fm</b>" }
-    assert_equal "1.23 &lt;b&gt;mm&lt;/b&gt;", number_to_human(0.00123, units: distance)
-    assert_equal "1.23 &lt;b&gt;cm&lt;/b&gt;", number_to_human(0.0123, units: distance)
-    assert_equal "1.23 &lt;b&gt;dm&lt;/b&gt;", number_to_human(0.123, units: distance)
-    assert_equal "1.23 &lt;b&gt;m&lt;/b&gt;", number_to_human(1.23, units: distance)
-    assert_equal "1.23 &lt;b&gt;dam&lt;/b&gt;", number_to_human(12.3, units: distance)
-    assert_equal "1.23 &lt;b&gt;hm&lt;/b&gt;", number_to_human(123, units: distance)
-    assert_equal "1.23 &lt;b&gt;km&lt;/b&gt;", number_to_human(1230, units: distance)
-    assert_equal "1.23 &lt;b&gt;um&lt;/b&gt;", number_to_human(0.00000123, units: distance)
-    assert_equal "1.23 &lt;b&gt;nm&lt;/b&gt;", number_to_human(0.00000000123, units: distance)
-    assert_equal "1.23 &lt;b&gt;pm&lt;/b&gt;", number_to_human(0.00000000000123, units: distance)
-    assert_equal "1.23 &lt;b&gt;fm&lt;/b&gt;", number_to_human(0.00000000000000123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;mm&lt;/b&gt;", number_to_human(0.00123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;cm&lt;/b&gt;", number_to_human(0.0123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;dm&lt;/b&gt;", number_to_human(0.123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;m&lt;/b&gt;", number_to_human(1.23, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;dam&lt;/b&gt;", number_to_human(12.3, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;hm&lt;/b&gt;", number_to_human(123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;km&lt;/b&gt;", number_to_human(1230, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;um&lt;/b&gt;", number_to_human(0.00000123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;nm&lt;/b&gt;", number_to_human(0.00000000123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;pm&lt;/b&gt;", number_to_human(0.00000000000123, units: distance)
+    assert_dom_equal "1.23 &lt;b&gt;fm&lt;/b&gt;", number_to_human(0.00000000000000123, units: distance)
   end
 
   def test_number_helpers_escape_delimiter_and_separator
-    assert_equal "111&lt;script&gt;&lt;/script&gt;111&lt;script&gt;&lt;/script&gt;1111", number_to_phone(1111111111, delimiter: "<script></script>")
+    assert_dom_equal "111&lt;script&gt;&lt;/script&gt;111&lt;script&gt;&lt;/script&gt;1111", number_to_phone(1111111111, delimiter: "<script></script>")
 
-    assert_equal "$1&lt;script&gt;&lt;/script&gt;01", number_to_currency(1.01, separator: "<script></script>")
-    assert_equal "$1&lt;script&gt;&lt;/script&gt;000.00", number_to_currency(1000, delimiter: "<script></script>")
+    assert_dom_equal "$1&lt;script&gt;&lt;/script&gt;01", number_to_currency(1.01, separator: "<script></script>")
+    assert_dom_equal "$1&lt;script&gt;&lt;/script&gt;000.00", number_to_currency(1000, delimiter: "<script></script>")
 
-    assert_equal "1&lt;script&gt;&lt;/script&gt;010%", number_to_percentage(1.01, separator: "<script></script>")
-    assert_equal "1&lt;script&gt;&lt;/script&gt;000.000%", number_to_percentage(1000, delimiter: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;010%", number_to_percentage(1.01, separator: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;000.000%", number_to_percentage(1000, delimiter: "<script></script>")
 
-    assert_equal "1&lt;script&gt;&lt;/script&gt;01", number_with_delimiter(1.01, separator: "<script></script>")
-    assert_equal "1&lt;script&gt;&lt;/script&gt;000", number_with_delimiter(1000, delimiter: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;01", number_with_delimiter(1.01, separator: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;000", number_with_delimiter(1000, delimiter: "<script></script>")
 
-    assert_equal "1&lt;script&gt;&lt;/script&gt;010", number_with_precision(1.01, separator: "<script></script>")
-    assert_equal "1&lt;script&gt;&lt;/script&gt;000.000", number_with_precision(1000, delimiter: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;010", number_with_precision(1.01, separator: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;000.000", number_with_precision(1000, delimiter: "<script></script>")
 
-    assert_equal "9&lt;script&gt;&lt;/script&gt;86 KB", number_to_human_size(10100, separator: "<script></script>")
+    assert_dom_equal "9&lt;script&gt;&lt;/script&gt;86 KB", number_to_human_size(10100, separator: "<script></script>")
 
-    assert_equal "1&lt;script&gt;&lt;/script&gt;01", number_to_human(1.01, separator: "<script></script>")
-    assert_equal "100&lt;script&gt;&lt;/script&gt;000 Quadrillion", number_to_human(10**20, delimiter: "<script></script>")
+    assert_dom_equal "1&lt;script&gt;&lt;/script&gt;01", number_to_human(1.01, separator: "<script></script>")
+    assert_dom_equal "100&lt;script&gt;&lt;/script&gt;000 Quadrillion", number_to_human(10**20, delimiter: "<script></script>")
   end
 
   def test_number_to_human_with_custom_translation_scope
     I18n.backend.store_translations "ts",
       custom_units_for_number_to_human: { mili: "mm", centi: "cm", deci: "dm", unit: "m", ten: "dam", hundred: "hm", thousand: "km" }
-    assert_equal "1.01 cm", number_to_human(0.0101, locale: "ts", units: :custom_units_for_number_to_human)
+    assert_dom_equal "1.01 cm", number_to_human(0.0101, locale: "ts", units: :custom_units_for_number_to_human)
   ensure
     I18n.reload!
   end
@@ -154,7 +154,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_predicate number_to_percentage("1".html_safe), :html_safe?
 
     assert_predicate number_to_phone(1), :html_safe?
-    assert_equal "&lt;script&gt;&lt;/script&gt;", number_to_phone("<script></script>")
+    assert_dom_equal "&lt;script&gt;&lt;/script&gt;", number_to_phone("<script></script>")
     assert_predicate number_to_phone("<script></script>"), :html_safe?
     assert_predicate number_to_phone("asdf".html_safe), :html_safe?
     assert_predicate number_to_phone("1".html_safe), :html_safe?

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -21,18 +21,18 @@ class OutputSafetyHelperTest < ActionView::TestCase
 
   test "safe_join should html_escape any items, including the separator, if they are not html_safe" do
     joined = safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
-    assert_equal "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;", joined
+    assert_dom_equal "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;", joined
 
     joined = safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />"))
-    assert_equal "<p>foo</p><br /><p>bar</p>", joined
+    assert_dom_equal "<p>foo</p><br /><p>bar</p>", joined
   end
 
   test "safe_join should work recursively similarly to Array.join" do
     joined = safe_join(["a", ["b", "c"]], ":")
-    assert_equal "a:b:c", joined
+    assert_dom_equal "a:b:c", joined
 
     joined = safe_join(['"a"', ["<b>", "<c>"]], " <br/> ")
-    assert_equal "&quot;a&quot; &lt;br/&gt; &lt;b&gt; &lt;br/&gt; &lt;c&gt;", joined
+    assert_dom_equal "&quot;a&quot; &lt;br/&gt; &lt;b&gt; &lt;br/&gt; &lt;c&gt;", joined
   end
 
   test "safe_join should return the safe string separated by $, when second argument is not passed" do
@@ -41,13 +41,13 @@ class OutputSafetyHelperTest < ActionView::TestCase
     begin
       $, = nil
       joined = safe_join(["a", "b"])
-      assert_equal "ab", joined
+      assert_dom_equal "ab", joined
 
       silence_warnings do
         $, = "|"
       end
       joined = safe_join(["a", "b"])
-      assert_equal "a|b", joined
+      assert_dom_equal "a|b", joined
     ensure
       $, = default_delimiter
     end
@@ -56,23 +56,23 @@ class OutputSafetyHelperTest < ActionView::TestCase
   test "to_sentence should escape non-html_safe values" do
     actual = to_sentence(%w(< > & ' "))
     assert_predicate actual, :html_safe?
-    assert_equal("&lt;, &gt;, &amp;, &#39;, and &quot;", actual)
+    assert_dom_equal("&lt;, &gt;, &amp;, &#39;, and &quot;", actual)
 
     actual = to_sentence(%w(<script>))
     assert_predicate actual, :html_safe?
-    assert_equal("&lt;script&gt;", actual)
+    assert_dom_equal("&lt;script&gt;", actual)
   end
 
   test "to_sentence does not double escape if single value is html_safe" do
-    assert_equal("&lt;script&gt;", to_sentence([ERB::Util.html_escape("<script>")]))
-    assert_equal("&lt;script&gt;", to_sentence(["&lt;script&gt;".html_safe]))
-    assert_equal("&amp;lt;script&amp;gt;", to_sentence(["&lt;script&gt;"]))
+    assert_dom_equal("&lt;script&gt;", to_sentence([ERB::Util.html_escape("<script>")]))
+    assert_dom_equal("&lt;script&gt;", to_sentence(["&lt;script&gt;".html_safe]))
+    assert_dom_equal("&amp;lt;script&amp;gt;", to_sentence(["&lt;script&gt;"]))
   end
 
   test "to_sentence connector words are checked for HTML safety" do
-    assert_equal "one & two, and three", to_sentence(["one", "two", "three"], words_connector: " & ".html_safe)
-    assert_equal "one & two", to_sentence(["one", "two"], two_words_connector: " & ".html_safe)
-    assert_equal "one, two &lt;script&gt;alert(1)&lt;/script&gt; three", to_sentence(["one", "two", "three"], last_word_connector: " <script>alert(1)</script> ")
+    assert_dom_equal "one & two, and three", to_sentence(["one", "two", "three"], words_connector: " & ".html_safe)
+    assert_dom_equal "one & two", to_sentence(["one", "two"], two_words_connector: " & ".html_safe)
+    assert_dom_equal "one, two &lt;script&gt;alert(1)&lt;/script&gt; three", to_sentence(["one", "two", "three"], last_word_connector: " <script>alert(1)</script> ")
   end
 
   test "to_sentence should not escape html_safe values" do
@@ -83,29 +83,29 @@ class OutputSafetyHelperTest < ActionView::TestCase
     expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
     actual = to_sentence([link_to(url, url), ptag])
     assert_predicate actual, :html_safe?
-    assert_equal(expected, actual)
+    assert_dom_equal(expected, actual)
   end
 
   test "to_sentence handles blank strings" do
     actual = to_sentence(["", "two", "three"])
     assert_predicate actual, :html_safe?
-    assert_equal ", two, and three", actual
+    assert_dom_equal ", two, and three", actual
   end
 
   test "to_sentence handles nil values" do
     actual = to_sentence([nil, "two", "three"])
     assert_predicate actual, :html_safe?
-    assert_equal ", two, and three", actual
+    assert_dom_equal ", two, and three", actual
   end
 
   test "to_sentence still supports ActiveSupports Array#to_sentence arguments" do
-    assert_equal "one two, and three", to_sentence(["one", "two", "three"], words_connector: " ")
-    assert_equal "one & two, and three", to_sentence(["one", "two", "three"], words_connector: " & ".html_safe)
-    assert_equal "onetwo, and three", to_sentence(["one", "two", "three"], words_connector: nil)
-    assert_equal "one, two, and also three", to_sentence(["one", "two", "three"], last_word_connector: ", and also ")
-    assert_equal "one, twothree", to_sentence(["one", "two", "three"], last_word_connector: nil)
-    assert_equal "one, two three", to_sentence(["one", "two", "three"], last_word_connector: " ")
-    assert_equal "one, two and three", to_sentence(["one", "two", "three"], last_word_connector: " and ")
+    assert_dom_equal "one two, and three", to_sentence(["one", "two", "three"], words_connector: " ")
+    assert_dom_equal "one & two, and three", to_sentence(["one", "two", "three"], words_connector: " & ".html_safe)
+    assert_dom_equal "onetwo, and three", to_sentence(["one", "two", "three"], words_connector: nil)
+    assert_dom_equal "one, two, and also three", to_sentence(["one", "two", "three"], last_word_connector: ", and also ")
+    assert_dom_equal "one, twothree", to_sentence(["one", "two", "three"], last_word_connector: nil)
+    assert_dom_equal "one, two three", to_sentence(["one", "two", "three"], last_word_connector: " ")
+    assert_dom_equal "one, two and three", to_sentence(["one", "two", "three"], last_word_connector: " and ")
   end
 
   test "to_sentence is not affected by $," do
@@ -114,8 +114,8 @@ class OutputSafetyHelperTest < ActionView::TestCase
       $, = "|"
     end
     begin
-      assert_equal "one and two", to_sentence(["one", "two"])
-      assert_equal "one, two, and three", to_sentence(["one", "two", "three"])
+      assert_dom_equal "one and two", to_sentence(["one", "two"])
+      assert_dom_equal "one, two, and three", to_sentence(["one", "two", "three"])
     ensure
       $, = separator_was
     end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -5,10 +5,14 @@ require "controller/fake_models"
 require "test_renderable"
 require "active_model/validations"
 
+require "rails-dom-testing"
+
 class TestController < ActionController::Base
 end
 
 module RenderTestCases
+  include Rails::Dom::Testing::Assertions
+
   def setup_view(paths)
     @assigns = { secret: "in the sauce" }
 
@@ -126,17 +130,17 @@ module RenderTestCases
   end
 
   def test_render_template_with_locale
-    assert_equal "<h1>Kein Kommentar</h1>", @view.render(template: "comments/empty", locale: [:de])
-    assert_equal "<h1>Kein Kommentar</h1>", @view.render(template: "comments/empty", locale: :de)
+    assert_dom_equal "<h1>Kein Kommentar</h1>", @view.render(template: "comments/empty", locale: [:de])
+    assert_dom_equal "<h1>Kein Kommentar</h1>", @view.render(template: "comments/empty", locale: :de)
   end
 
   def test_render_template_with_variants
-    assert_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", variants: :grid)
+    assert_dom_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", variants: :grid)
   end
 
   def test_render_template_with_handlers
-    assert_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", handlers: [:builder])
-    assert_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", handlers: :builder)
+    assert_dom_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", handlers: [:builder])
+    assert_dom_equal "<h1>No Comment</h1>\n", @view.render(template: "comments/empty", handlers: :builder)
   end
 
   def test_render_raw_template_with_handlers
@@ -258,7 +262,7 @@ module RenderTestCases
   end
 
   def test_render_partial_with_variants
-    assert_equal "<h1>Partial with variants</h1>\n", @view.render(partial: "test/partial_with_variants", variants: :grid)
+    assert_dom_equal "<h1>Partial with variants</h1>\n", @view.render(partial: "test/partial_with_variants", variants: :grid)
   end
 
   def test_render_partial_with_selected_format
@@ -447,21 +451,21 @@ module RenderTestCases
   end
 
   def test_render_partial_with_layout_using_collection_and_template
-    assert_equal "<b>Hello: Amazon</b><b>Hello: Yahoo</b>", @view.render(partial: "test/customer", layout: "test/b_layout_for_partial", collection: [ Customer.new("Amazon"), Customer.new("Yahoo") ])
+    assert_dom_equal "<b>Hello: Amazon</b><b>Hello: Yahoo</b>", @view.render(partial: "test/customer", layout: "test/b_layout_for_partial", collection: [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
   def test_render_partial_with_layout_using_collection_and_template_makes_current_item_available_in_layout
-    assert_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>',
+    assert_dom_equal '<b class="amazon">Hello: Amazon</b><b class="yahoo">Hello: Yahoo</b>',
       @view.render(partial: "test/customer", layout: "test/b_layout_for_partial_with_object", collection: [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
   def test_render_partial_with_layout_using_collection_and_template_makes_current_item_counter_available_in_layout
-    assert_equal '<b data-counter="0">Hello: Amazon</b><b data-counter="1">Hello: Yahoo</b>',
+    assert_dom_equal '<b data-counter="0">Hello: Amazon</b><b data-counter="1">Hello: Yahoo</b>',
       @view.render(partial: "test/customer", layout: "test/b_layout_for_partial_with_object_counter", collection: [ Customer.new("Amazon"), Customer.new("Yahoo") ])
   end
 
   def test_render_partial_with_layout_using_object_and_template_makes_object_available_in_layout
-    assert_equal '<b class="amazon">Hello: Amazon</b>',
+    assert_dom_equal '<b class="amazon">Hello: Amazon</b>',
       @view.render(partial: "test/customer", layout: "test/b_layout_for_partial_with_object", object: Customer.new("Amazon"))
   end
 
@@ -483,7 +487,7 @@ module RenderTestCases
   end
 
   def test_render_partial_with_object_and_format_uses_render_partial_path
-    assert_equal "<greeting>Hello</greeting><name>lifo</name>",
+    assert_dom_equal "<greeting>Hello</greeting><name>lifo</name>",
       @controller_view.render(partial: Customer.new("lifo"), formats: :xml, locals: { greeting: "Hello" })
   end
 
@@ -608,7 +612,7 @@ module RenderTestCases
   end
 
   def test_render_with_layout
-    assert_equal %(<title></title>\nHello world!\n),
+    assert_dom_equal %(<title></title>\nHello world!\n),
       @view.render(template: "test/hello_world", layout: "layouts/yield")
   end
 
@@ -623,7 +627,7 @@ module RenderTestCases
   end
 
   def test_render_partial_with_html_only_extension
-    assert_equal %(<h1>partial html</h1>\nHello world!\n),
+    assert_dom_equal %(<h1>partial html</h1>\nHello world!\n),
       @view.render(template: "test/hello_world", layout: "layouts/render_partial_html")
   end
 
@@ -731,17 +735,17 @@ module RenderTestCases
   end
 
   def test_render_with_nested_layout
-    assert_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
+    assert_dom_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
       @view.render(template: "test/nested_layout", layout: "layouts/yield")
   end
 
   def test_render_with_file_in_layout
-    assert_equal %(\n<title>title</title>\n\n),
+    assert_dom_equal %(\n<title>title</title>\n\n),
       @view.render(template: "test/layout_render_file")
   end
 
   def test_render_layout_with_object
-    assert_equal %(<title>David</title>),
+    assert_dom_equal %(<title>David</title>),
       @view.render(template: "test/layout_render_object")
   end
 

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -8,6 +8,8 @@
 
 require "abstract_unit"
 
+require "rails-dom-testing"
+
 #
 #  Unit test SanitizeHelper behavior. We use a mock vendor to ensure we're testing behavior that is
 #  independent of sanitizer vendors.
@@ -184,6 +186,8 @@ end
 #  for now we should make sure everything works as expected by testing it.
 #
 module SanitizeHelperVendorTests
+  include Rails::Dom::Testing::Assertions
+
   def setup
     super
     @saved_vendor = ActionView::Helpers::SanitizeHelper.sanitizer_vendor
@@ -294,15 +298,15 @@ module SanitizeHelperVendorTests
   def test_sanitize_with_tags_option
     input = %(<b>bold</b> <i>italic</i> <div>hello</div>)
 
-    assert_equal("<b>bold</b> <i>italic</i> hello", @subject.sanitize(input, tags: %w(b i)))
-    assert_equal("bold italic <div>hello</div>", @subject.sanitize(input, tags: %w(div)))
+    assert_dom_equal("<b>bold</b> <i>italic</i> hello", @subject.sanitize(input, tags: %w(b i)))
+    assert_dom_equal("bold italic <div>hello</div>", @subject.sanitize(input, tags: %w(div)))
   end
 
   def test_sanitize_with_attributes_option
     input = %(<div a="1" b="2" c="3">hello</div>)
 
-    assert_equal(%(<div a="1" b="2">hello</div>), @subject.sanitize(input, attributes: %w(a b)))
-    assert_equal(%(<div b="2" c="3">hello</div>), @subject.sanitize(input, attributes: %w(b c)))
+    assert_dom_equal(%(<div a="1" b="2">hello</div>), @subject.sanitize(input, attributes: %w(a b)))
+    assert_dom_equal(%(<div b="2" c="3">hello</div>), @subject.sanitize(input, attributes: %w(b c)))
   end
 
   def test_sanitize_with_loofah_scrubber_option
@@ -311,7 +315,7 @@ module SanitizeHelperVendorTests
       node.content = "scrubbed"
     end
 
-    assert_equal(%(<div>scrubbed</div>), @subject.sanitize(input, scrubber: scrubber))
+    assert_dom_equal(%(<div>scrubbed</div>), @subject.sanitize(input, scrubber: scrubber))
   end
 
   def test_sanitize_with_custom_scrubber_option
@@ -324,7 +328,7 @@ module SanitizeHelperVendorTests
 
     input = %(<div>hello</div><p>world</p>)
 
-    assert_equal(%(<div>hello</div>world), @subject.sanitize(input, scrubber: scrubber))
+    assert_dom_equal(%(<div>hello</div>world), @subject.sanitize(input, scrubber: scrubber))
   end
 
   def test_sanitize_css
@@ -340,14 +344,14 @@ module SanitizeHelperVendorTests
     input = %(<div><a href="http://www.example.com/">Example</a> of a fragment</div>)
     result = @subject.strip_tags(input)
 
-    assert_equal("Example of a fragment", result)
+    assert_dom_equal("Example of a fragment", result)
   end
 
   def test_strip_links
     input = %(<div><a href="http://www.example.com/">Example</a> of a fragment</div>)
     result = @subject.strip_links(input)
 
-    assert_equal("<div>Example of a fragment</div>", result)
+    assert_dom_equal("<div>Example of a fragment</div>", result)
   end
 
   def test_we_get_the_expected_HTML_parser
@@ -367,7 +371,7 @@ module SanitizeHelperVendorTests
       flunk "Unknown vendor #{vendor}"
     end
 
-    assert_equal(expected, @subject.sanitize(input, scrubber: scrubber))
+    assert_dom_equal(expected, @subject.sanitize(input, scrubber: scrubber))
   end
 end
 

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -2,10 +2,14 @@
 
 require "abstract_unit"
 
+require "rails-dom-testing"
+
 class TestController < ActionController::Base
 end
 
 class SetupFiberedBase < ActiveSupport::TestCase
+  include Rails::Dom::Testing::Assertions
+
   def setup
     ActionView::LookupContext::DetailsKey.clear
 
@@ -39,51 +43,51 @@ class FiberedTest < SetupFiberedBase
       content << piece
     end
 
-    assert_equal "<title>",      content[0]
-    assert_equal "",             content[1]
-    assert_equal "</title>\n",   content[2]
-    assert_equal "Hello world!", content[3]
-    assert_equal "\n",           content[4]
+    assert_dom_equal "<title>",      content[0]
+    assert_dom_equal "",             content[1]
+    assert_dom_equal "</title>\n",   content[2]
+    assert_dom_equal "Hello world!", content[3]
+    assert_dom_equal "\n",           content[4]
   end
 
   def test_render_file
-    assert_equal "Hello world!", buffered_render(file: File.absolute_path("../fixtures/test/hello_world.erb", __dir__))
+    assert_dom_equal "Hello world!", buffered_render(file: File.absolute_path("../fixtures/test/hello_world.erb", __dir__))
   end
 
   def test_render_partial
-    assert_equal "only partial", buffered_render(partial: "test/partial_only")
+    assert_dom_equal "only partial", buffered_render(partial: "test/partial_only")
   end
 
   def test_render_inline
-    assert_equal "Hello, World!", buffered_render(inline: "Hello, World!")
+    assert_dom_equal "Hello, World!", buffered_render(inline: "Hello, World!")
   end
 
   def test_render_without_layout
-    assert_equal "Hello world!", buffered_render(template: "test/hello_world")
+    assert_dom_equal "Hello world!", buffered_render(template: "test/hello_world")
   end
 
   def test_render_with_layout
-    assert_equal %(<title></title>\nHello world!\n),
+    assert_dom_equal %(<title></title>\nHello world!\n),
       buffered_render(template: "test/hello_world", layout: "layouts/yield")
   end
 
   def test_render_with_layout_which_has_render_inline
-    assert_equal %(welcome\nHello world!\n),
+    assert_dom_equal %(welcome\nHello world!\n),
       buffered_render(template: "test/hello_world", layout: "layouts/yield_with_render_inline_inside")
   end
 
   def test_render_with_layout_which_renders_another_partial
-    assert_equal %(partial html\nHello world!\n),
+    assert_dom_equal %(partial html\nHello world!\n),
       buffered_render(template: "test/hello_world", layout: "layouts/yield_with_render_partial_inside")
   end
 
   def test_render_with_nested_layout
-    assert_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
+    assert_dom_equal %(<title>title</title>\n\n<div id="column">column</div>\n<div id="content">content</div>\n),
       buffered_render(template: "test/nested_layout", layout: "layouts/yield")
   end
 
   def test_render_with_file_in_layout
-    assert_equal %(\n<title>title</title>\n\n),
+    assert_dom_equal %(\n<title>title</title>\n\n),
       buffered_render(template: "test/layout_render_file")
   end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -10,32 +10,32 @@ class TagHelperTest < ActionView::TestCase
   COMMON_DANGEROUS_CHARS = "&<>\"' %*+,/;=^|"
 
   def test_tag
-    assert_equal "<br />", tag("br")
-    assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
-    assert_equal "<br>", tag("br", nil, true)
+    assert_dom_equal "<br />", tag("br")
+    assert_dom_equal "<br clear=\"left\" />", tag(:br, clear: "left")
+    assert_dom_equal "<br>", tag("br", nil, true)
   end
 
   def test_tag_builder
-    assert_equal "<span></span>", tag.span
-    assert_equal "<span class=\"bookmark\"></span>", tag.span(class: "bookmark")
+    assert_dom_equal "<span></span>", tag.span
+    assert_dom_equal "<span class=\"bookmark\"></span>", tag.span(class: "bookmark")
   end
 
   def test_tag_builder_void_tag
-    assert_equal "<br>", tag.br
-    assert_equal "<br class=\"some_class\">", tag.br(class: "some_class")
+    assert_dom_equal "<br>", tag.br
+    assert_dom_equal "<br class=\"some_class\">", tag.br(class: "some_class")
   end
 
   def test_tag_builder_void_tag_with_forced_content
-    assert_equal "<br>some content</br>", tag.br("some content")
+    assert_dom_equal "<br>some content</br>", tag.br("some content")
   end
 
   def test_tag_builder_self_closing_tag
-    assert_equal "<svg><use href=\"#cool-icon\" /></svg>", tag.svg { tag.use("href" => "#cool-icon") }
-    assert_equal "<svg><circle cx=\"5\" cy=\"5\" r=\"5\" /></svg>", tag.svg { tag.circle(cx: "5", cy: "5", r: "5") }
+    assert_dom_equal "<svg><use href=\"#cool-icon\" /></svg>", tag.svg { tag.use("href" => "#cool-icon") }
+    assert_dom_equal "<svg><circle cx=\"5\" cy=\"5\" r=\"5\" /></svg>", tag.svg { tag.circle(cx: "5", cy: "5", r: "5") }
   end
 
   def test_tag_builder_self_closing_tag_with_content
-    assert_equal "<svg><circle><desc>A circle</desc></circle></svg>", tag.svg { tag.circle { tag.desc "A circle" } }
+    assert_dom_equal "<svg><circle><desc>A circle</desc></circle></svg>", tag.svg { tag.circle { tag.desc "A circle" } }
   end
 
   def test_tag_builder_is_singleton
@@ -51,7 +51,7 @@ class TagHelperTest < ActionView::TestCase
   def test_tag_options_with_array_of_numeric
     str = tag(:input, value: [123, 456])
 
-    assert_equal("<input value=\"123 456\" />", str)
+    assert_dom_equal("<input value=\"123 456\" />", str)
   end
 
   def test_tag_options_with_array_of_random_objects
@@ -63,39 +63,39 @@ class TagHelperTest < ActionView::TestCase
 
     str = tag(:input, value: [klass.new])
 
-    assert_equal("<input value=\"hello\" />", str)
+    assert_dom_equal("<input value=\"hello\" />", str)
   end
 
   def test_tag_options_rejects_nil_option
-    assert_equal "<p />", tag("p", ignored: nil)
+    assert_dom_equal "<p />", tag("p", ignored: nil)
   end
 
   def test_tag_builder_options_rejects_nil_option
-    assert_equal "<p></p>", tag.p(ignored: nil)
+    assert_dom_equal "<p></p>", tag.p(ignored: nil)
   end
 
   def test_tag_options_accepts_false_option
-    assert_equal "<p value=\"false\" />", tag("p", value: false)
+    assert_dom_equal "<p value=\"false\" />", tag("p", value: false)
   end
 
   def test_tag_builder_options_accepts_false_option
-    assert_equal "<p value=\"false\"></p>", tag.p(value: false)
+    assert_dom_equal "<p value=\"false\"></p>", tag.p(value: false)
   end
 
   def test_tag_options_accepts_blank_option
-    assert_equal "<p included=\"\" />", tag("p", included: "")
+    assert_dom_equal "<p included=\"\" />", tag("p", included: "")
   end
 
   def test_tag_builder_options_accepts_blank_option
-    assert_equal "<p included=\"\"></p>", tag.p(included: "")
+    assert_dom_equal "<p included=\"\"></p>", tag.p(included: "")
   end
 
   def test_tag_options_accepts_symbol_option_when_not_escaping
-    assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+    assert_dom_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
   end
 
   def test_tag_options_accepts_integer_option_when_not_escaping
-    assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+    assert_dom_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
   end
 
   def test_tag_options_converts_boolean_option
@@ -116,113 +116,113 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_builder_do_not_modify_html_safe_options
     html_safe_str = '"'.html_safe
-    assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
-    assert_equal '"', html_safe_str
+    assert_dom_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
+    assert_dom_equal '"', html_safe_str
     assert html_safe_str.html_safe?
   end
 
   def test_tag_with_dangerous_name
-    assert_equal "<#{"_" * COMMON_DANGEROUS_CHARS.size} />",
+    assert_dom_equal "<#{"_" * COMMON_DANGEROUS_CHARS.size} />",
                  tag(COMMON_DANGEROUS_CHARS)
 
-    assert_equal "<#{COMMON_DANGEROUS_CHARS} />",
+    assert_dom_equal "<#{COMMON_DANGEROUS_CHARS} />",
                  tag(COMMON_DANGEROUS_CHARS, nil, false, false)
   end
 
   def test_tag_builder_with_dangerous_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<#{escaped_dangerous_chars}></#{escaped_dangerous_chars}>",
+    assert_dom_equal "<#{escaped_dangerous_chars}></#{escaped_dangerous_chars}>",
                  tag.public_send(COMMON_DANGEROUS_CHARS.to_sym)
 
-    assert_equal "<#{COMMON_DANGEROUS_CHARS}></#{COMMON_DANGEROUS_CHARS}>",
+    assert_dom_equal "<#{COMMON_DANGEROUS_CHARS}></#{COMMON_DANGEROUS_CHARS}>",
                  tag.public_send(COMMON_DANGEROUS_CHARS.to_sym, nil, escape: false)
   end
 
   def test_tag_with_dangerous_aria_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
+    assert_dom_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
                  tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_dom_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
                  tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
   def test_tag_builder_with_dangerous_aria_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
   end
 
   def test_tag_with_dangerous_data_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
+    assert_dom_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
                  tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_dom_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
                  tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
   def test_tag_builder_with_dangerous_data_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", data: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
   end
 
   def test_tag_with_dangerous_unknown_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
+    assert_dom_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
                  tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
 
-    assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_dom_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
                  tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
   end
 
   def test_tag_builder_with_dangerous_unknown_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name #{escaped_dangerous_chars}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", COMMON_DANGEROUS_CHARS => "the value")
 
-    assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
+    assert_dom_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
                  tag.public_send(:"the-name", COMMON_DANGEROUS_CHARS => "the value", escape: false)
   end
 
   def test_content_tag
-    assert_equal "<a href=\"create\">Create</a>", content_tag("a", "Create", "href" => "create")
+    assert_dom_equal "<a href=\"create\">Create</a>", content_tag("a", "Create", "href" => "create")
     assert_predicate content_tag("a", "Create", "href" => "create"), :html_safe?
-    assert_equal content_tag("a", "Create", "href" => "create"),
+    assert_dom_equal content_tag("a", "Create", "href" => "create"),
                  content_tag("a", "Create", href: "create")
-    assert_equal "<p>&lt;script&gt;evil_js&lt;/script&gt;</p>",
+    assert_dom_equal "<p>&lt;script&gt;evil_js&lt;/script&gt;</p>",
                  content_tag(:p, "<script>evil_js</script>")
-    assert_equal "<p><script>evil_js</script></p>",
+    assert_dom_equal "<p><script>evil_js</script></p>",
                  content_tag(:p, "<script>evil_js</script>", nil, false)
-    assert_equal "<div @click=\"triggerNav()\">test</div>",
+    assert_dom_equal "<div @click=\"triggerNav()\">test</div>",
                  content_tag(:div, "test", "@click": "triggerNav()")
   end
 
   def test_tag_builder_with_content
-    assert_equal "<div id=\"post_1\">Content</div>", tag.div("Content", id: "post_1")
+    assert_dom_equal "<div id=\"post_1\">Content</div>", tag.div("Content", id: "post_1")
     assert_predicate tag.div("Content", id: "post_1"), :html_safe?
-    assert_equal tag.div("Content", id: "post_1"),
+    assert_dom_equal tag.div("Content", id: "post_1"),
                  tag.div("Content", "id": "post_1")
-    assert_equal "<p>&lt;script&gt;evil_js&lt;/script&gt;</p>",
+    assert_dom_equal "<p>&lt;script&gt;evil_js&lt;/script&gt;</p>",
                  tag.p("<script>evil_js</script>")
-    assert_equal "<p><script>evil_js</script></p>",
+    assert_dom_equal "<p><script>evil_js</script></p>",
                  tag.p("<script>evil_js</script>", escape: false)
-    assert_equal '<input pattern="\w+">', tag.input(pattern: /\w+/)
+    assert_dom_equal '<input pattern="\w+">', tag.input(pattern: /\w+/)
   end
 
   def test_tag_builder_nested
-    assert_equal "<div>content</div>",
+    assert_dom_equal "<div>content</div>",
                  tag.div { "content" }
-    assert_equal "<div id=\"header\"><span>hello</span></div>",
+    assert_dom_equal "<div id=\"header\"><span>hello</span></div>",
                  tag.div(id: "header") { |tag| tag.span "hello" }
-    assert_equal "<div id=\"header\"><div class=\"world\"><span>hello</span></div></div>",
+    assert_dom_equal "<div id=\"header\"><div class=\"world\"><span>hello</span></div></div>",
                  tag.div(id: "header") { |tag| tag.div(class: "world") { tag.span "hello" } }
   end
 
@@ -265,119 +265,119 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_with_block_and_options_outside_out_of_erb
-    assert_equal content_tag("a", "Create", href: "create"),
+    assert_dom_equal content_tag("a", "Create", href: "create"),
                  content_tag("a", "href" => "create") { "Create" }
   end
 
   def test_tag_builder_with_block_and_options_outside_out_of_erb
-    assert_equal tag.a("Create", href: "create"),
+    assert_dom_equal tag.a("Create", href: "create"),
                  tag.a("href": "create") { "Create" }
   end
 
   def test_content_tag_with_block_and_non_string_outside_out_of_erb
-    assert_equal content_tag("p"),
+    assert_dom_equal content_tag("p"),
                  content_tag("p") { 3.times { "do_something" } }
   end
 
   def test_tag_builder_with_block_and_non_string_outside_out_of_erb
-    assert_equal tag.p,
+    assert_dom_equal tag.p,
                  tag.p { 3.times { "do_something" } }
   end
 
   def test_content_tag_nested_in_content_tag_out_of_erb
-    assert_equal content_tag("p", content_tag("b", "Hello")),
+    assert_dom_equal content_tag("p", content_tag("b", "Hello")),
                  content_tag("p") { content_tag("b", "Hello") },
                  output_buffer
-    assert_equal tag.p(tag.b("Hello")),
+    assert_dom_equal tag.p(tag.b("Hello")),
                  tag.p { tag.b("Hello") },
                  output_buffer
   end
 
   def test_content_tag_nested_in_content_tag_in_erb
-    assert_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/content_tag_nested_in_content_tag")
-    assert_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/builder_tag_nested_in_content_tag")
+    assert_dom_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/content_tag_nested_in_content_tag")
+    assert_dom_equal "<p>\n  <b>Hello</b>\n</p>", view.render("test/builder_tag_nested_in_content_tag")
   end
 
   def test_content_tag_nested_in_content_tag_with_data_attributes_out_of_erb
-    assert_equal "<div data-controller=\"read-more\" data-read-more-more-text-value=\"Read more\" data-read-more-less-text-value=\"Read less\"\>\n  <p class=\"content-class\" data-test-name=\"content\">Content text</p>\n  <button class=\"expand-button\" data-action=\"read-more#toggle\">Read more</button>\n</div>",
+    assert_dom_equal "<div data-controller=\"read-more\" data-read-more-more-text-value=\"Read more\" data-read-more-less-text-value=\"Read less\"\>\n  <p class=\"content-class\" data-test-name=\"content\">Content text</p>\n  <button class=\"expand-button\" data-action=\"read-more#toggle\">Read more</button>\n</div>",
                   view.render("test/content_tag_nested_in_content_tag_with_data_attributes_out_of_erb")
   end
 
   def test_content_tag_with_escaped_array_class
     str = content_tag("p", "limelight", class: ["song", "play>"])
-    assert_equal "<p class=\"song play&gt;\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play&gt;\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: ["song", "play"])
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: ["song", ["play"]])
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
   end
 
   def test_tag_builder_with_escaped_array_class
     str = tag.p "limelight", class: ["song", "play>"]
-    assert_equal "<p class=\"song play&gt;\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play&gt;\">limelight</p>", str
 
     str = tag.p "limelight", class: ["song", "play"]
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
 
     str = tag.p "limelight", class: ["song", ["play"]]
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
   end
 
   def test_content_tag_with_unescaped_array_class
     str = content_tag("p", "limelight", { class: ["song", "play>"] }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
 
     str = content_tag("p", "limelight", { class: ["song", ["play>"]] }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
   end
 
   def test_tag_builder_with_unescaped_array_class
     str = tag.p "limelight", class: ["song", "play>"], escape: false
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
 
     str = tag.p "limelight", class: ["song", ["play>"]], escape: false
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
   end
 
   def test_content_tag_with_empty_array_class
     str = content_tag("p", "limelight", class: [])
-    assert_equal '<p class="">limelight</p>', str
+    assert_dom_equal '<p class="">limelight</p>', str
   end
 
   def test_tag_builder_with_empty_array_class
-    assert_equal '<p class="">limelight</p>', tag.p("limelight", class: [])
+    assert_dom_equal '<p class="">limelight</p>', tag.p("limelight", class: [])
   end
 
   def test_content_tag_with_unescaped_empty_array_class
     str = content_tag("p", "limelight", { class: [] }, false)
-    assert_equal '<p class="">limelight</p>', str
+    assert_dom_equal '<p class="">limelight</p>', str
   end
 
   def test_tag_builder_with_unescaped_empty_array_class
     str = tag.p "limelight", class: [], escape: false
-    assert_equal '<p class="">limelight</p>', str
+    assert_dom_equal '<p class="">limelight</p>', str
   end
 
   def test_content_tag_with_conditional_hash_classes
     str = content_tag("p", "limelight", class: { "song": true, "play": false })
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: [{ "song": true }, { "play": false }])
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: { song: true, play: false })
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: [{ song: true }, nil, false])
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: ["song", { foo: false }])
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: [1, 2, 3])
-    assert_equal "<p class=\"1 2 3\">limelight</p>", str
+    assert_dom_equal "<p class=\"1 2 3\">limelight</p>", str
 
     klass = Class.new do
       def to_s
@@ -386,52 +386,52 @@ class TagHelperTest < ActionView::TestCase
     end
 
     str = content_tag("p", "limelight", class: [klass.new])
-    assert_equal "<p class=\"1\">limelight</p>", str
+    assert_dom_equal "<p class=\"1\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: { "song": true, "play": true })
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
 
     str = content_tag("p", "limelight", class: { "song": false, "play": false })
-    assert_equal '<p class="">limelight</p>', str
+    assert_dom_equal '<p class="">limelight</p>', str
   end
 
   def test_tag_builder_with_conditional_hash_classes
     str = tag.p "limelight", class: { "song": true, "play": false }
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = tag.p "limelight", class: [{ "song": true }, { "play": false }]
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = tag.p "limelight", class: { song: true, play: false }
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = tag.p "limelight", class: [{ song: true }, nil, false]
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = tag.p "limelight", class: ["song", { foo: false }]
-    assert_equal "<p class=\"song\">limelight</p>", str
+    assert_dom_equal "<p class=\"song\">limelight</p>", str
 
     str = tag.p "limelight", class: { "song": true, "play": true }
-    assert_equal "<p class=\"song play\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play\">limelight</p>", str
 
     str = tag.p "limelight", class: { "song": false, "play": false }
-    assert_equal '<p class="">limelight</p>', str
+    assert_dom_equal '<p class="">limelight</p>', str
   end
 
   def test_content_tag_with_unescaped_conditional_hash_classes
     str = content_tag("p", "limelight", { class: { "song": true, "play>": true } }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
 
     str = content_tag("p", "limelight", { class: ["song", { "play>": true }] }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
   end
 
   def test_tag_builder_with_unescaped_conditional_hash_classes
     str = tag.p "limelight", class: { "song": true, "play>": true }, escape: false
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
 
     str = tag.p "limelight", class: ["song", { "play>": true }], escape: false
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    assert_dom_equal "<p class=\"song play>\">limelight</p>", str
   end
 
   def test_token_list_and_class_names
@@ -487,21 +487,21 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_cdata_section
-    assert_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
+    assert_dom_equal "<![CDATA[<hello world>]]>", cdata_section("<hello world>")
   end
 
   def test_cdata_section_with_string_conversion
-    assert_equal "<![CDATA[]]>", cdata_section(nil)
+    assert_dom_equal "<![CDATA[]]>", cdata_section(nil)
   end
 
   def test_cdata_section_splitted
-    assert_equal "<![CDATA[hello]]]]><![CDATA[>world]]>", cdata_section("hello]]>world")
-    assert_equal "<![CDATA[hello]]]]><![CDATA[>world]]]]><![CDATA[>again]]>", cdata_section("hello]]>world]]>again")
+    assert_dom_equal "<![CDATA[hello]]]]><![CDATA[>world]]>", cdata_section("hello]]>world")
+    assert_dom_equal "<![CDATA[hello]]]]><![CDATA[>world]]]]><![CDATA[>again]]>", cdata_section("hello]]>world]]>again")
   end
 
   def test_escape_once
-    assert_equal "1 &lt; 2 &amp; 3", escape_once("1 < 2 &amp; 3")
-    assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
+    assert_dom_equal "1 &lt; 2 &amp; 3", escape_once("1 < 2 &amp; 3")
+    assert_dom_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
 
   def test_tag_attributes_inlines_html_attributes
@@ -509,7 +509,7 @@ class TagHelperTest < ActionView::TestCase
       <input type="text" name="name" aria-hidden="false" aria-label="label" data-input-value="data" required="required">
     HTML
 
-    assert_equal expected_output, render_erb(<<~HTML.strip)
+    assert_dom_equal expected_output, render_erb(<<~HTML.strip)
       <input type="text" <%= tag.attributes value: nil, name: "name", "aria-hidden": false, aria: { label: "label" }, data: { input_value: "data" }, required: true %>>
     HTML
   end
@@ -519,34 +519,34 @@ class TagHelperTest < ActionView::TestCase
       <input type="text" xss="&quot;&gt;&lt;script&gt;alert()&lt;/script&gt;">
     HTML
 
-    assert_equal expected_output, render_erb(<<~HTML.strip)
+    assert_dom_equal expected_output, render_erb(<<~HTML.strip)
       <input type="text" <%= tag.attributes xss: '"><script>alert()</script>' %>>
     HTML
   end
 
   def test_tag_attributes_nil
-    assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes nil %>>))
+    assert_dom_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes nil %>>))
   end
 
   def test_tag_attributes_empty
-    assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes({}) %>>))
+    assert_dom_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes({}) %>>))
   end
 
   def test_tag_honors_html_safe_for_param_values
     ["1&amp;2", "1 &lt; 2", "&#8220;test&#8220;"].each do |escaped|
-      assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)
-      assert_equal %(<a href="#{escaped}"></a>), tag.a(href: escaped.html_safe)
+      assert_dom_equal %(<a title="#{escaped}" />), tag("a", title: escaped.html_safe)
+      assert_dom_equal %(<a title="#{escaped}"></a>), tag.a(title: escaped.html_safe)
     end
   end
 
   def test_tag_honors_html_safe_with_escaped_array_class
-    assert_equal '<p class="song&gt; play>" />', tag("p", class: ["song>", raw("play>")])
-    assert_equal '<p class="song> play&gt;" />', tag("p", class: [raw("song>"), "play>"])
+    assert_dom_equal '<p class="song&gt; play>" />', tag("p", class: ["song>", raw("play>")])
+    assert_dom_equal '<p class="song> play&gt;" />', tag("p", class: [raw("song>"), "play>"])
   end
 
   def test_tag_builder_honors_html_safe_with_escaped_array_class
-    assert_equal '<p class="song&gt; play>"></p>', tag.p(class: ["song>", raw("play>")])
-    assert_equal '<p class="song> play&gt;"></p>', tag.p(class: [raw("song>"), "play>"])
+    assert_dom_equal '<p class="song&gt; play>"></p>', tag.p(class: ["song>", raw("play>")])
+    assert_dom_equal '<p class="song> play&gt;"></p>', tag.p(class: [raw("song>"), "play>"])
   end
 
   def test_tag_does_not_honor_html_safe_double_quotes_as_attributes
@@ -561,21 +561,21 @@ class TagHelperTest < ActionView::TestCase
 
   def test_skip_invalid_escaped_attributes
     ["&1;", "&#1dfa3;", "& #123;"].each do |escaped|
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(href: escaped)
+      assert_dom_equal %(<a title="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", title: escaped)
+      assert_dom_equal %(<a title="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(title: escaped)
     end
   end
 
   def test_disable_escaping
-    assert_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
+    assert_dom_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
   end
 
   def test_tag_builder_disable_escaping
-    assert_equal '<a href="&amp;"></a>', tag.a(href: "&amp;", escape: false)
-    assert_equal '<a href="&amp;">cnt</a>', tag.a(href: "&amp;", escape: false) { "cnt" }
-    assert_equal '<br data-hidden="&amp;">', tag.br("data-hidden": "&amp;", escape: false)
-    assert_equal '<a href="&amp;">content</a>', tag.a("content", href: "&amp;", escape: false)
-    assert_equal '<a href="&amp;">content</a>', tag.a(href: "&amp;", escape: false) { "content" }
+    assert_dom_equal '<a href="&amp;"></a>', tag.a(href: "&amp;", escape: false)
+    assert_dom_equal '<a href="&amp;">cnt</a>', tag.a(href: "&amp;", escape: false) { "cnt" }
+    assert_dom_equal '<br data-hidden="&amp;">', tag.br("data-hidden": "&amp;", escape: false)
+    assert_dom_equal '<a href="&amp;">content</a>', tag.a("content", href: "&amp;", escape: false)
+    assert_dom_equal '<a href="&amp;">content</a>', tag.a(href: "&amp;", escape: false) { "content" }
   end
 
   def test_data_attributes
@@ -610,11 +610,11 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_builder_allow_call_via_method_object
-    assert_equal "<foo></foo>", tag.method(:foo).call
+    assert_dom_equal "<foo></foo>", tag.method(:foo).call
   end
 
   def test_tag_builder_dasherize_names
-    assert_equal "<img-slider></img-slider>", tag.img_slider
+    assert_dom_equal "<img-slider></img-slider>", tag.img_slider
   end
 
   def test_respond_to

--- a/actionview/test/template/test_test.rb
+++ b/actionview/test/template/test_test.rb
@@ -22,7 +22,7 @@ end
 
 class PeopleHelperTest < ActionView::TestCase
   def test_title
-    assert_equal "<h1>Ruby on Rails</h1>", title("Ruby on Rails")
+    assert_dom_equal "<h1>Ruby on Rails</h1>", title("Ruby on Rails")
   end
 
   def test_homepage_path
@@ -53,7 +53,7 @@ class PeopleHelperTest < ActionView::TestCase
           "/people/1"
         }
       }
-      assert_equal '<a href="/people/1">David</a>', link_to_person(person)
+      assert_dom_equal '<a href="/people/1">David</a>', link_to_person(person)
       assert_equal person, the_model
     end
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -28,58 +28,58 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_simple_format
-    assert_equal "<p></p>", simple_format(nil)
+    assert_dom_equal "<p></p>", simple_format(nil)
 
-    assert_equal "<p>ridiculous\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
-    assert_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
-    assert_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
+    assert_dom_equal "<p>ridiculous\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
+    assert_dom_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
+    assert_dom_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
 
     text = "A\nB\nC\nD"
-    assert_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
+    assert_dom_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
 
     text = "A\r\n  \nB\n\n\r\n\t\nC\nD"
-    assert_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
+    assert_dom_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
 
-    assert_equal '<p class="test">This is a classy test</p>', simple_format("This is a classy test", class: "test")
-    assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", class: "test")
+    assert_dom_equal '<p class="test">This is a classy test</p>', simple_format("This is a classy test", class: "test")
+    assert_dom_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", class: "test")
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_not_false
-    assert_equal "<p><b> test with unsafe string </b>code!</p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
+    assert_dom_equal "<p><b> test with unsafe string </b>code!</p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_true
-    assert_equal "<p><b> test with unsafe string </b>code!</p>",
+    assert_dom_equal "<p><b> test with unsafe string </b>code!</p>",
       simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: true })
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_options_is_specified
-    assert_equal "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>",
+    assert_dom_equal "<p><a target=\"_blank\" href=\"http://example.com\">Continue</a></p>",
       simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>", {}, { sanitize_options: { attributes: %w[target href] } })
   end
 
   def test_simple_format_should_sanitize_input_when_sanitize_options_is_not_specified
-    assert_equal "<p><a href=\"http://example.com\">Continue</a></p>", simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>")
+    assert_dom_equal "<p><a href=\"http://example.com\">Continue</a></p>", simple_format("<a target=\"_blank\" href=\"http://example.com\">Continue</a>")
   end
 
   def test_simple_format_should_not_sanitize_input_when_sanitize_option_is_false
-    assert_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: false })
+    assert_dom_equal "<p><b> test with unsafe string </b><script>code!</script></p>", simple_format("<b> test with unsafe string </b><script>code!</script>", {}, { sanitize: false })
   end
 
   def test_simple_format_with_custom_wrapper
-    assert_equal "<div></div>", simple_format(nil, {}, { wrapper_tag: "div" })
-    assert_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: nil })
+    assert_dom_equal "<div></div>", simple_format(nil, {}, { wrapper_tag: "div" })
+    assert_dom_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: nil })
   end
 
   def test_simple_format_with_custom_wrapper_and_multi_line_breaks
-    assert_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, { wrapper_tag: "div" })
+    assert_dom_equal "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>", simple_format("We want to put a wrapper...\n\n...right there.", {}, { wrapper_tag: "div" })
   end
 
   def test_simple_format_should_not_change_the_text_passed
     text = "<b>Ok</b><script>code!</script>"
     text_clone = text.dup
     simple_format(text)
-    assert_equal text_clone, text
+    assert_dom_equal text_clone, text
   end
 
   def test_simple_format_does_not_modify_the_html_options_hash
@@ -128,7 +128,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_with_link_options
-    assert_equal "Here is a long test and ...<a href=\"#\">Continue</a>",
+    assert_dom_equal "Here is a long test and ...<a href=\"#\">Continue</a>",
     truncate("Here is a long test and I need a continue to read link", length: 27) { link_to "Continue", "#" }
   end
 
@@ -137,11 +137,11 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_should_escape_the_input
-    assert_equal "Hello &lt;sc...", truncate("Hello <script>code!</script>World!!", length: 12)
+    assert_dom_equal "Hello &lt;sc...", truncate("Hello <script>code!</script>World!!", length: 12)
   end
 
   def test_truncate_should_not_escape_the_input_with_escape_false
-    assert_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", length: 12, escape: false)
+    assert_dom_equal "Hello <sc...", truncate("Hello <script>code!</script>World!!", length: 12, escape: false)
   end
 
   def test_truncate_with_escape_false_should_be_html_safe
@@ -155,12 +155,12 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_with_block_should_escape_the_input
-    assert_equal "&lt;script&gt;code!&lt;/script&gt;He...<a href=\"#\">Continue</a>",
+    assert_dom_equal "&lt;script&gt;code!&lt;/script&gt;He...<a href=\"#\">Continue</a>",
       truncate("<script>code!</script>Here's a long test and I need a continue to read link", length: 27) { link_to "Continue", "#" }
   end
 
   def test_truncate_with_block_should_not_escape_the_input_with_escape_false
-    assert_equal "<script>code!</script>He...<a href=\"#\">Continue</a>",
+    assert_dom_equal "<script>code!</script>He...<a href=\"#\">Continue</a>",
       truncate("<script>code!</script>Here's a long test and I need a continue to read link", length: 27, escape: false) { link_to "Continue", "#" }
   end
 
@@ -170,7 +170,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_truncate_with_block_should_escape_the_block
-    assert_equal "Here is a long test and ...&lt;script&gt;alert(&#39;foo&#39;);&lt;/script&gt;",
+    assert_dom_equal "Here is a long test and ...&lt;script&gt;alert(&#39;foo&#39;);&lt;/script&gt;",
       truncate("Here is a long test and I need a continue to read link", length: 27) { "<script>alert('foo');</script>" }
   end
 
@@ -179,17 +179,17 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_highlight
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful</mark> morning",
       highlight("This is a beautiful morning", "beautiful")
     )
 
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day",
       highlight("This is a beautiful morning, but also a beautiful day", "beautiful")
     )
 
-    assert_equal(
+    assert_dom_equal(
       "This is a <b>beautiful</b> morning, but also a <b>beautiful</b> day",
       highlight("This is a beautiful morning, but also a beautiful day", "beautiful", highlighter: '<b>\1</b>')
     )
@@ -209,67 +209,67 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_highlight_should_sanitize_input
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful</mark> morningcode!",
       highlight("This is a beautiful morning<script>code!</script>", "beautiful")
     )
   end
 
   def test_highlight_should_not_sanitize_if_sanitize_option_if_false
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful</mark> morning<script>code!</script>",
       highlight("This is a beautiful morning<script>code!</script>", "beautiful", sanitize: false)
     )
   end
 
   def test_highlight_with_regexp
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful!</mark> morning",
       highlight("This is a beautiful! morning", "beautiful!")
     )
 
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful! morning</mark>",
       highlight("This is a beautiful! morning", "beautiful! morning")
     )
 
-    assert_equal(
+    assert_dom_equal(
       "This is a <mark>beautiful? morning</mark>",
       highlight("This is a beautiful? morning", "beautiful? morning")
     )
   end
 
   def test_highlight_accepts_regexp
-    assert_equal("This day was challenging for judge <mark>Allen</mark> and his colleagues.",
+    assert_dom_equal("This day was challenging for judge <mark>Allen</mark> and his colleagues.",
                  highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i))
   end
 
   def test_highlight_with_multiple_phrases_in_one_pass
-    assert_equal %(<em>wow</em> <em>em</em>), highlight("wow em", %w(wow em), highlighter: '<em>\1</em>')
+    assert_dom_equal %(<em>wow</em> <em>em</em>), highlight("wow em", %w(wow em), highlighter: '<em>\1</em>')
   end
 
   def test_highlight_with_html
-    assert_equal(
+    assert_dom_equal(
       "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful")
     )
-    assert_equal(
+    assert_dom_equal(
       "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful")
     )
-    assert_equal(
+    assert_dom_equal(
       "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>",
       highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful")
     )
-    assert_equal(
+    assert_dom_equal(
       "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>",
       highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful")
     )
-    assert_equal(
+    assert_dom_equal(
       "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful#top?what=beautiful%20morning&amp;when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>",
       highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful")
     )
-    assert_equal(
+    assert_dom_equal(
       "<div>abc <b>div</b></div>",
       highlight("<div>abc div</div>", "div", highlighter: '<b>\1</b>')
     )
@@ -283,7 +283,7 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_highlight_with_block
-    assert_equal(
+    assert_dom_equal(
       "<b>one</b> <b>two</b> <b>three</b>",
       highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" }
     )

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -2,6 +2,8 @@
 
 require "abstract_unit"
 
+require "rails-dom-testing"
+
 module I18n
   class CustomExceptionHandler
     def self.call(exception, locale, key, options)
@@ -12,6 +14,7 @@ end
 
 class TranslationHelperTest < ActiveSupport::TestCase
   include ActionView::Helpers::TranslationHelper
+  include Rails::Dom::Testing::Assertions
 
   attr_reader :request, :view
 
@@ -99,22 +102,22 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_returns_missing_translation_message_wrapped_into_span
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
-    assert_equal expected, translate(:"translations.missing")
+    assert_dom_equal expected, translate(:"translations.missing")
     assert_equal true, translate(:"translations.missing").html_safe?
   end
 
   def test_returns_missing_translation_message_with_unescaped_interpolation
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing, name: Kir, year: 2015, vulnerable: &amp;quot; onclick=&amp;quot;alert()&amp;quot;">Missing</span>'
-    assert_equal expected, translate(:"translations.missing", name: "Kir", year: "2015", vulnerable: %{" onclick="alert()"})
+    assert_dom_equal expected, translate(:"translations.missing", name: "Kir", year: "2015", vulnerable: %{" onclick="alert()"})
     assert_predicate translate(:"translations.missing"), :html_safe?
   end
 
   def test_returns_missing_translation_message_does_filters_out_i18n_options
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing, year: 2015">Missing</span>'
-    assert_equal expected, translate(:"translations.missing", year: "2015", default: [])
+    assert_dom_equal expected, translate(:"translations.missing", year: "2015", default: [])
 
     expected = '<span class="translation_missing" title="translation missing: en.scoped.translations.missing, year: 2015">Missing</span>'
-    assert_equal expected, translate(:"translations.missing", year: "2015", scope: %i(scoped))
+    assert_dom_equal expected, translate(:"translations.missing", year: "2015", scope: %i(scoped))
   end
 
   def test_raises_missing_translation_message_with_raise_option
@@ -174,7 +177,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_missing_translation_scoped_by_partial
     expected = '<span class="translation_missing" title="translation missing: en.translations.templates.missing.missing">Missing</span>'
-    assert_equal expected, view.render(template: "translations/templates/missing").strip
+    assert_dom_equal expected, view.render(template: "translations/templates/missing").strip
   end
 
   def test_missing_translation_scoped_by_partial_yield_block
@@ -199,7 +202,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_missing_translation_scoped_by_partial_yield_single_argument_block
     expected = '<span class="translation_missing" title="translation missing: en.translations.templates.missing_yield_single_argument_block.missing">Missing</span>'
-    assert_equal expected, view.render(template: "translations/templates/missing_yield_single_argument_block").strip
+    assert_dom_equal expected, view.render(template: "translations/templates/missing_yield_single_argument_block").strip
   end
 
   def test_missing_translation_with_default_scoped_by_partial_yield_single_argument_block
@@ -221,14 +224,14 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_translate_escapes_interpolations_in_translations_with_a_html_suffix
     word_struct = Struct.new(:to_s)
-    assert_equal "<a>Hello &lt;World&gt;</a>", translate(:'translations.interpolated_html', word: "<World>")
-    assert_equal "<a>Hello &lt;World&gt;</a>", translate(:'translations.interpolated_html', word: word_struct.new("<World>"))
+    assert_dom_equal "<a>Hello &lt;World&gt;</a>", translate(:'translations.interpolated_html', word: "<World>")
+    assert_dom_equal "<a>Hello &lt;World&gt;</a>", translate(:'translations.interpolated_html', word: word_struct.new("<World>"))
   end
 
   def test_translate_with_html_count
-    assert_equal "<a>One 1</a>", translate(:'translations.count_html', count: 1)
-    assert_equal "<a>Other 2</a>", translate(:'translations.count_html', count: 2)
-    assert_equal "<a>Other &lt;One&gt;</a>", translate(:'translations.count_html', count: "<One>")
+    assert_dom_equal "<a>One 1</a>", translate(:'translations.count_html', count: 1)
+    assert_dom_equal "<a>Other 2</a>", translate(:'translations.count_html', count: 2)
+    assert_dom_equal "<a>Other &lt;One&gt;</a>", translate(:'translations.count_html', count: "<One>")
   end
 
   def test_translate_marks_array_of_translations_with_a_html_safe_suffix_as_safe_html
@@ -245,20 +248,20 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_translate_with_default_named_html
     translation = translate(:'translations.missing', default: :'translations.hello_html')
-    assert_equal "<a>Hello World</a>", translation
+    assert_dom_equal "<a>Hello World</a>", translation
     assert_equal true, translation.html_safe?
   end
 
   def test_translate_with_default_named_html_and_raise_false
     translation = translate(:"translations.missing", default: :"translations.hello_html", raise: false)
-    assert_equal "<a>Hello World</a>", translation
+    assert_dom_equal "<a>Hello World</a>", translation
     assert_predicate translation, :html_safe?
   end
 
   def test_translate_with_missing_default
     translation = translate(:"translations.missing", default: :also_missing)
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
-    assert_equal expected, translation
+    assert_dom_equal expected, translation
     assert_equal true, translation.html_safe?
   end
 
@@ -276,13 +279,13 @@ class TranslationHelperTest < ActiveSupport::TestCase
 
   def test_translate_with_two_defaults_named_html
     translation = translate(:'translations.missing', default: [:'translations.missing_html', :'translations.hello_html'])
-    assert_equal "<a>Hello World</a>", translation
+    assert_dom_equal "<a>Hello World</a>", translation
     assert_equal true, translation.html_safe?
   end
 
   def test_translate_with_last_default_named_html
     translation = translate(:'translations.missing', default: [:'translations.missing', :'translations.hello_html'])
-    assert_equal "<a>Hello World</a>", translation
+    assert_dom_equal "<a>Hello World</a>", translation
     assert_equal true, translation.html_safe?
   end
 
@@ -295,7 +298,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_translate_does_not_mark_unsourced_string_default_as_html_safe
     untrusted_string = "<script>alert()</script>"
     translation = translate(:"translations.missing", default: [:"translations.missing_html", untrusted_string])
-    assert_equal untrusted_string, translation
+    assert_dom_equal untrusted_string, translation
     assert_not_predicate translation, :html_safe?
   end
 
@@ -402,8 +405,8 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal "Foo", translate(:"translations.foo")
 
     expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
-    assert_equal expected, translate(:"translations.missing")
-    assert_equal expected, translate(:"translations.missing") # returns cached translation
+    assert_dom_equal expected, translate(:"translations.missing")
+    assert_dom_equal expected, translate(:"translations.missing") # returns cached translation
   ensure
     I18n.backend = previous_backend
     I18n.cache_store = previous_cache_store

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -614,7 +614,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_link_tag_using_block_in_erb
     out = render_erb %{<%= link_to('/') do %>Example site<% end %>}
-    assert_equal '<a href="/">Example site</a>', out
+    assert_dom_equal '<a href="/">Example site</a>', out
   end
 
   def test_link_tag_with_html_safe_string
@@ -652,7 +652,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Listing</a>},
       link_to_unless(false, "Listing", url_hash)
 
-    assert_equal "<strong>Showing</strong>",
+    assert_dom_equal "<strong>Showing</strong>",
       link_to_unless(true, "Showing", url_hash) { |name|
         raw "<strong>#{name}</strong>"
       }
@@ -662,10 +662,10 @@ class UrlHelperTest < ActiveSupport::TestCase
         "test"
       }
 
-    assert_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
-    assert_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
-    assert_equal %{<b>Showing</b>}, link_to_unless(true, raw("<b>Showing</b>"), url_hash)
-    assert_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, raw("<b>Showing</b>"), url_hash)
+    assert_dom_equal %{&lt;b&gt;Showing&lt;/b&gt;}, link_to_unless(true, "<b>Showing</b>", url_hash)
+    assert_dom_equal %{<a href="/">&lt;b&gt;Showing&lt;/b&gt;</a>}, link_to_unless(false, "<b>Showing</b>", url_hash)
+    assert_dom_equal %{<b>Showing</b>}, link_to_unless(true, raw("<b>Showing</b>"), url_hash)
+    assert_dom_equal %{<a href="/"><b>Showing</b></a>}, link_to_unless(false, raw("<b>Showing</b>"), url_hash)
   end
 
   def test_link_to_if
@@ -800,22 +800,22 @@ class UrlHelperTest < ActiveSupport::TestCase
 
     @request = request_for_url("/?order=desc")
 
-    assert_equal %{<a href="/?order=asc">Showing</a>},
+    assert_dom_equal %{<a href="/?order=asc">Showing</a>},
       link_to_unless_current("Showing", hash_for(order: :asc))
-    assert_equal %{<a href="http://www.example.com/?order=asc">Showing</a>},
+    assert_dom_equal %{<a href="http://www.example.com/?order=asc">Showing</a>},
       link_to_unless_current("Showing", "http://www.example.com/?order=asc")
 
     @request = request_for_url("/?order=desc")
-    assert_equal %{<a href="/?order=desc&amp;page=2\">Showing</a>},
+    assert_dom_equal %{<a href="/?order=desc&amp;page=2\">Showing</a>},
       link_to_unless_current("Showing", hash_for(order: "desc", page: 2))
-    assert_equal %{<a href="http://www.example.com/?order=desc&amp;page=2">Showing</a>},
+    assert_dom_equal %{<a href="http://www.example.com/?order=desc&amp;page=2">Showing</a>},
       link_to_unless_current("Showing", "http://www.example.com/?order=desc&page=2")
 
     @request = request_for_url("/show")
 
-    assert_equal %{<a href="/">Listing</a>},
+    assert_dom_equal %{<a href="/">Listing</a>},
       link_to_unless_current("Listing", url_hash)
-    assert_equal %{<a href="http://www.example.com/">Listing</a>},
+    assert_dom_equal %{<a href="http://www.example.com/">Listing</a>},
       link_to_unless_current("Listing", "http://www.example.com/")
   end
 
@@ -831,7 +831,7 @@ class UrlHelperTest < ActiveSupport::TestCase
       %{<a class="admin" href="mailto:david@loudthinking.com">David Heinemeier Hansson</a>},
       mail_to("david@loudthinking.com", "David Heinemeier Hansson", "class" => "admin")
     )
-    assert_equal mail_to("david@loudthinking.com", "David Heinemeier Hansson", "class" => "admin"),
+    assert_dom_equal mail_to("david@loudthinking.com", "David Heinemeier Hansson", "class" => "admin"),
                  mail_to("david@loudthinking.com", "David Heinemeier Hansson", class: "admin")
   end
 
@@ -905,7 +905,7 @@ class UrlHelperTest < ActiveSupport::TestCase
       %{<a class="admin" href="sms:15155555785;">Jim Jones</a>},
       sms_to("15155555785", "Jim Jones", "class" => "admin")
     )
-    assert_equal sms_to("15155555785", "Jim Jones", "class" => "admin"),
+    assert_dom_equal sms_to("15155555785", "Jim Jones", "class" => "admin"),
                  sms_to("15155555785", "Jim Jones", class: "admin")
   end
 
@@ -974,7 +974,7 @@ class UrlHelperTest < ActiveSupport::TestCase
       %{<a class="phoner" href="tel:1234567890">Bob</a>},
       phone_to("1234567890", "Bob", "class" => "phoner")
     )
-    assert_equal phone_to("1234567890", "Bob", "class" => "admin"),
+    assert_dom_equal phone_to("1234567890", "Bob", "class" => "admin"),
                  phone_to("1234567890", "Bob", class: "admin")
   end
 
@@ -1222,7 +1222,7 @@ class LinkToUnlessCurrentWithControllerTest < ActionController::TestCase
 
   def test_link_to_unless_current_shows_link
     get :show, params: { id: 1 }
-    assert_equal %{<a href="/tasks">tasks</a>\n} +
+    assert_dom_equal %{<a href="/tasks">tasks</a>\n} +
       %{<a href="#{@request.protocol}#{@request.host_with_port}/tasks">tasks</a>},
       @response.body
   end
@@ -1306,21 +1306,21 @@ class PolymorphicControllerTest < ActionController::TestCase
     @controller = WorkshopsController.new
 
     get :index
-    assert_equal %{/workshops\n<a href="/workshops">Workshop</a>}, @response.body
+    assert_dom_equal %{/workshops\n<a href="/workshops">Workshop</a>}, @response.body
   end
 
   def test_existing_resource
     @controller = WorkshopsController.new
 
     get :show, params: { id: 1 }
-    assert_equal %{/workshops/1\n<a href="/workshops/1">Workshop</a>}, @response.body
+    assert_dom_equal %{/workshops/1\n<a href="/workshops/1">Workshop</a>}, @response.body
   end
 
   def test_existing_cpk_resource
     @controller = WorkshopsController.new
 
     get :show, params: { id: "1-27" }
-    assert_equal %{/workshops/1-27\n<a href="/workshops/1-27">Workshop</a>}, @response.body
+    assert_dom_equal %{/workshops/1-27\n<a href="/workshops/1-27">Workshop</a>}, @response.body
   end
 
   def test_current_page_when_options_does_not_respond_to_to_hash
@@ -1341,20 +1341,20 @@ class PolymorphicSessionsControllerTest < ActionController::TestCase
     @controller = SessionsController.new
 
     get :index, params: { workshop_id: 1 }
-    assert_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions">Session</a>}, @response.body
+    assert_dom_equal %{/workshops/1/sessions\n<a href="/workshops/1/sessions">Session</a>}, @response.body
   end
 
   def test_existing_nested_resource
     @controller = SessionsController.new
 
     get :show, params: { workshop_id: 1, id: 1 }
-    assert_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1">Session</a>}, @response.body
+    assert_dom_equal %{/workshops/1/sessions/1\n<a href="/workshops/1/sessions/1">Session</a>}, @response.body
   end
 
   def test_existing_nested_resource_with_params
     @controller = SessionsController.new
 
     get :edit, params: { workshop_id: 1, id: 1, format: "json"  }
-    assert_equal %{/workshops/1/sessions/1.json\n<a href="/workshops/1/sessions/1.json">Session</a>}, @response.body
+    assert_dom_equal %{/workshops/1/sessions/1.json\n<a href="/workshops/1/sessions/1.json">Session</a>}, @response.body
   end
 end


### PR DESCRIPTION
### Motivation / Background

To [quote @-flavorjones][comment]

> asserting against string constants is error-prone and brittle, and it
> would be better to have a testing framework that asserted on semantic
> equivalence


### Detail

When appropriate, use [assert_dom_equal][] instead of `assert_equal` for String comparisons of Action View Helper-constructed values.

Some exceptions to that guideline are tests that assert equivalence of:

* instances of Objects
* URLs
* view partial paths
* String values not intended for HTML documents

[comment]: https://github.com/seanpdoyle/rails/pull/1#issuecomment-799656813
[assert_dom_equal]: https://github.com/rails/rails-dom-testing#dom-assertions

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
