### PR TITLE
[Docs][Tests] Add tests for validates_exclusion_of to 7.1.0beta1

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -176,6 +176,10 @@
     validates_inclusion_of :birth_date, in: -> { (..Date.today) }
     ```
 
+    ```ruby
+    validates_exclusion_of :birth_date, in: -> { (..Date.today) }
+    ```
+
     *Bo Jeanes*
 
 *   Make validators accept lambdas without record argument

--- a/activemodel/test/cases/validations/exclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/exclusion_validation_test.rb
@@ -84,6 +84,26 @@ class ExclusionValidationTest < ActiveModel::TestCase
     assert_predicate Topic.new(content: "h"), :valid?
   end
 
+  def test_validates_exclusion_of_beginless_numeric_range
+    range_end = 1000
+    Topic.validates_exclusion_of(:raw_price, in: ..range_end)
+    assert_predicate Topic.new(title: "aaa", price: -100), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: 0), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: 100), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: 2000), :valid?
+    assert_predicate Topic.new(title: "aaa", price: range_end), :invalid?
+  end
+
+  def test_validates_exclusion_of_endless_numeric_range
+    range_begin = 0
+    Topic.validates_exclusion_of(:raw_price, in: range_begin..)
+    assert_predicate Topic.new(title: "aaa", price: -1), :valid?
+    assert_predicate Topic.new(title: "aaa", price: -100), :valid?
+    assert_predicate Topic.new(title: "aaa", price: 100), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: 2000), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: range_begin), :invalid?
+  end
+
   def test_validates_exclusion_of_with_time_range
     Topic.validates_exclusion_of :created_at, in: 6.days.ago..2.days.ago
 

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -661,6 +661,10 @@ Please refer to the [Changelog][active-model] for detailed changes.
     validates_inclusion_of :birth_date, in: -> { (..Date.today) }
     ```
 
+    ```ruby
+    validates_exclusion_of :birth_date, in: -> { (..Date.today) }
+    ```
+
 *   Add support for password challenges to `has_secure_password`. When set, validate that the password
     challenge matches the persisted `password_digest`.
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the tests for exclusion validation is missing in https://github.com/rails/rails/pull/45123 and I had to check the exclusivity of the beginless/endless validations as the change for 7.1.0beta1.

> The PR is a second try of #49298 to reduce irrelevant rebase-commits.

### Detail

This Pull Request adds tests for exclusion validation with beginless/endless range, based on the ones for inclusion validation.
And updates 7_1_release_notes.md and CHANGELOG.md for Active Model for conveniences.

The behavior has not been changed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
