### PR TITLE
Fix uninitialized constant error on Puma boot

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Require `concurrent-ruby` in `config/puma.rb` so that Puma can boot in
+    production when `WEB_CONCURRENCY` is not explicitly specified.
+
+    Fixes #49323.
+
+    *Matt Brictson*
+
 *   Raise error when generating attribute with dangerous name.
 
     The following will now raise an error as `save` and `hash` are already

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -13,6 +13,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
 if ENV["RAILS_ENV"] == "production"
+  require "concurrent-ruby"
   worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
   workers worker_count if worker_count > 1
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix #49323: **Puma fails to boot in production with default config due to missing `Concurrency` constant (Rails 7.1.0.beta1)**

### Detail

Before, using the default `puma/config.rb` generated by `rails new`, Puma would fail to boot in production with this error:

```
./config/puma.rb:16:in `block in _load_from': uninitialized constant Puma::DSL::Concurrent (NameError)
	from ./config/puma.rb:16:in `fetch'
	from ./config/puma.rb:16:in `_load_from'
```

This was because `Concurrent.physical_processor_count` was being referenced before the `Concurrent` constant was initialized.

Fix by requiring `concurrent-ruby` just before the `Concurrent` constant is needed.

Fixes #49323

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~~Tests are added or updated if you fix a bug or add a feature.~~ The [original PR](https://github.com/rails/rails/pull/46838) that introduced `Concurrent.physical_processor_count` did not have any tests
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
