### PR TITLE
Handle update and update! on scopes properly

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Calling `update` or `update!` on an `ActiveRecord::Relation` should keep using the scope.
+
+    *István Karaszi*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current behavior is misleading and could cause potential data loss. If you define a scope and you try to call an `update` or `update!` on the scope then you would expect that the updates will be executed on the scope and not on every record by ignoring the scope completely.

If I wanted to update every record, then I would call the `update` or `update!` on the model directly.

### Detail

This change updates the behavior of the `update` and `update!` methods of the `ActiveRecord::Relation`. If you pass a set of ids then the update will be executed on those records that match the selected ids but also satisfy the scope.

With this change, we also make the `update` and `update!` methods symmetric regardless of whether the first parameter was `:all` or a set of ids.

### Additional information

This might be considered a breaking change, but I do believe this is an actual bugfix since the behavior was misleading and it was asymmetric depending on the first argument.

Consider the following scenario, if you want to update the `Model` record and set all of the `sent_at` attributes to the actual time if the items have been sent, then this would work.

```ruby
Model.unsent.update!(:all, sent_at: Time.zone.now)
```

But if you want to reduce it to just a subset of ids:

```ruby
Model.unsent.update!([1, 2], { sent_at: Time.zone.now }, { sent_at: Time.zone.now })
```

Then this method call would update all the `Model` records with the matching ids in the DB and we would lose the previous `sent_at` values if for example Model with id `1` was sent already.

#### Undocumented and untested behavior

I made my change symmetric to `ActiveRecord::Persistence` so it will also raise an `ActiveRecord::RecordNotFound` error if a record could not be found, it also raises similar `ArgumentError` exceptions when invalid arguments are passed.  This behavior was undocumented and untested, now I added tests to cover the cases.

I was using `respond_to?` to check if we received an `Enumerable` like argument. This code is almost the exact copy of the `ActiveRecord::Persistence#update` or `ActiveRecord::Persistence#update!`, we could merge these three methods into one concern, but I did not want to introduce any bigger changes with this PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
