### PR TITLE
Get rid of ActiveRecord::Core#===

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -344,11 +344,6 @@ module ActiveRecord
         end
       end
 
-      # Override the default class equality method to provide support for decorated models.
-      def ===(object) # :nodoc:
-        object.is_a?(self)
-      end
-
       # Returns an instance of +Arel::Table+ loaded with the current table name.
       def arel_table # :nodoc:
         @arel_table ||= Arel::Table.new(table_name, klass: self)

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -34,19 +34,17 @@ module ActiveRecord
         end
 
         def klass(value)
-          case value
-          when Base
+          if value.is_a?(Base)
             value.class
-          when Relation
+          elsif value.is_a?(Relation)
             value.klass
           end
         end
 
         def convert_to_id(value)
-          case value
-          when Base
+          if value.is_a?(Base)
             value._read_attribute(primary_key(value))
-          when Relation
+          elsif value.is_a?(Relation)
             value.select(primary_key(value))
           else
             value


### PR DESCRIPTION
This was added back in 0.9.5 because at the time single associations (e.g. has_one) didn't directly return the record but a proxy

https://github.com/rails/rails/commit/97849debf33

But toaward 3.1, we got rid of that proxy: https://github.com/rails/rails/commit/1644663ba7f678d178deab2bf1629dc05626f85b and the associated test was deleted.

However the `===` method stayed.

This has been around for so long that removing it may break some rare applications, but I doubt it would be hard to fix, and this isn't a documented behavior.

If an application became reliant on this, it should be easy to restore by defining `===` in `ApplicationRecord`.
