### PR TITLE
Fix MySQL expression index dumping with escaped quotes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -36,7 +36,7 @@ module ActiveRecord
               end
 
               if row[:Expression]
-                expression = row[:Expression]
+                expression = row[:Expression].gsub("\\'", "'")
                 expression = +"(#{expression})" unless expression.start_with?("(")
                 indexes.last[-2] << expression
                 indexes.last[-1][:expressions] ||= {}

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -308,6 +308,15 @@ class SchemaDumperTest < ActiveRecord::TestCase
         assert false
       end
     end
+
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      def test_schema_dump_expression_indices_escaping
+        index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*full_name_index/).first.strip
+        index_definition.sub!(/, name: "full_name_index"\z/, "")
+
+        assert_match %r{concat_ws\(`firm_name`,`name`,_utf8mb4' '\)\)"\z}i, index_definition
+      end
+    end
   end
 
   if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -401,7 +401,12 @@ ActiveRecord::Schema.define do
     t.index [:firm_id, :type], name: "company_partial_index", where: "(rating > 10)"
     t.index [:firm_id], name: "company_nulls_not_distinct", nulls_not_distinct: true
     t.index :name, name: "company_name_index", using: :btree
-    t.index "(CASE WHEN rating > 0 THEN lower(name) END) DESC", name: "company_expression_index" if supports_expression_index?
+    if supports_expression_index?
+      t.index "(CASE WHEN rating > 0 THEN lower(name) END) DESC", name: "company_expression_index"
+      if ActiveRecord::TestCase.current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+        t.index "(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))", name: "full_name_index"
+      end
+    end
   end
 
   create_table :content, force: true do |t|


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49334.
There was a "similar" issue previously https://github.com/rails/rails/pull/40822.