### PR TITLE
[ci skip] Document how to rails new with a specific version

### DIFF
--- a/railties/lib/rails/generators/rails/app/USAGE
+++ b/railties/lib/rails/generators/rails/app/USAGE
@@ -9,10 +9,17 @@ Description:
     Note that the arguments specified in the .railsrc file don't affect the
     default values shown above in this help message.
 
+    You can specify which version to use when creating a new rails application 
+    using `rails _<version>_ new`.
+
 Examples:
     `rails new ~/Code/Ruby/weblog`
 
     This generates a new Rails app in ~/Code/Ruby/weblog.
+
+    `rails _<version>_ new weblog`
+
+    This generates a new Rails app with the provided version in ./weblog.
 
     `rails new weblog --api`
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I never remember how to create a new rails application using a beta or rc release.
`gem install rails --pre `installs the latest prerelease version, currently this is `7.1.0.beta1`.
Then which command should I type to generate a new project using `7.1.0.beta1`, I never remember.
rails --help gives me no clue.

I'd like to avoid googling this next time.

### Detail

This Pull Request adds few lines to the helper text displayed when running `rails --help` describing how to create a new rails application using a prerelease or specific version.
