### PR TITLE
Introduce :production_only flag for ActiveSupport::ErorrReporter#handle

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `:production_only` flag for `ActiveSupport::ErrorReporter#handle` and `#report`.
+
+    When the flag is true, errors will only be reported in production, and will be raised in non-production
+    environments.
+
+    *Andrew Novoselac*
+
 *   Use Ruby 3.3 Range#overlap? if available
 
     *Yasuo Honda*

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -88,7 +88,7 @@ module Rails
     #   end
     #   Rails.error.report(error)
     def error
-      ActiveSupport.error_reporter
+      @_error = ActiveSupport.error_reporter.tap { |reporter| reporter.production = env.production? }
     end
 
     # Returns all \Rails groups for loading based on:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to have the ability to use `ActiveSupport::ErrorReport#handle` to handle errors in production, but still have these errors be raised when encountered in test or development mode. Sometimes for un-expected / rare issues is better to handle it gracefully in production but I would still prefer to raise it in dev / test.

### Detail

This Pull Request introduces a `production_only` flag to the `ActiveSupport::ErrorReporter#handle` and `#report` methods and `production` attribute to `ActiveSupport::ErrorReporter`. When this flag is `true` errors will be raised in non-production environments instead of reported. The flag is `false` by default to preserve existing behaviour.

I added a `production` attribute to `ActiveSupport::ErrorReporter` instances to capture what environment we are in. It is `true` by default. 

In `Rails#error` I `tap` the error handler and set the `production` flag based on the Rails environment.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
