### PR TITLE
Add links to Callbacks, note example definition [ci skip]

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -743,7 +743,7 @@ module ActiveSupport
         #
         # The callback can be specified as a symbol naming an instance method; as a
         # proc, lambda, or block; or as an object that responds to a certain method
-        # determined by the <tt>:scope</tt> argument to +define_callbacks+.
+        # determined by the <tt>:scope</tt> argument to #define_callbacks.
         #
         # If a proc, lambda, or block is given, its body is evaluated in the context
         # of the current object. It can also optionally accept the current object as
@@ -787,9 +787,12 @@ module ActiveSupport
           end
         end
 
-        # Skip a previously set callback. Like +set_callback+, <tt>:if</tt> or
+        # Skip a previously set callback. Like #set_callback, <tt>:if</tt> or
         # <tt>:unless</tt> options may be passed in order to control when the
         # callback is skipped.
+        #
+        # Note: this example uses +PersonRecord+ and +#saving_message+, which you
+        # can see defined here[rdoc-ref:ActiveSupport::Callbacks]
         #
         #   class Writer < PersonRecord
         #     attr_accessor :age
@@ -933,7 +936,7 @@ module ActiveSupport
         # <tt>!</tt>, <tt>?</tt> or <tt>=</tt>.
         #
         # Calling +define_callbacks+ multiple times with the same +names+ will
-        # overwrite previous callbacks registered with +set_callback+.
+        # overwrite previous callbacks registered with #set_callback.
         def define_callbacks(*names)
           options = names.extract_options!
 


### PR DESCRIPTION
Reading this doc left me confused where PersonRecord was defined, this commit is intended to make it easier to find where it is.
