### PR TITLE
Skip unless adapter supports insert on duplicate update

### DIFF
--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -298,6 +298,8 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   end
 
   test "loading records with encrypted attributes defined on columns with default values" do
+    skip unless supports_insert_on_duplicate_update?
+
     EncryptedBook.insert({ format: "ebook" })
     book = EncryptedBook.last
     assert_equal "<untitled>", book.name

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -64,6 +64,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_should_handle_empty_arrays
+    skip unless supports_insert_on_duplicate_update?
+
     assert_empty Book.insert_all([])
     assert_empty Book.insert_all!([])
     assert_empty Book.upsert_all([])
@@ -277,6 +279,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_and_upsert_all_with_aliased_attributes
+    skip unless supports_insert_on_duplicate_update?
+
     if supports_insert_returning?
       assert_difference "Book.count" do
         result = Book.insert_all [{ title: "Remote", author_id: 1 }], returning: :title
@@ -284,18 +288,18 @@ class InsertAllTest < ActiveRecord::TestCase
       end
     end
 
-    if supports_insert_on_duplicate_update?
-      Book.upsert_all [{ id: 101, title: "Perelandra", author_id: 7, isbn: "1974522598" }]
-      Book.upsert_all [{ id: 101, title: "Perelandra 2", author_id: 6, isbn: "111111" }], update_only: %i[ title isbn ]
+    Book.upsert_all [{ id: 101, title: "Perelandra", author_id: 7, isbn: "1974522598" }]
+    Book.upsert_all [{ id: 101, title: "Perelandra 2", author_id: 6, isbn: "111111" }], update_only: %i[ title isbn ]
 
-      book = Book.find(101)
-      assert_equal "Perelandra 2", book.title, "Should have updated the title"
-      assert_equal "111111", book.isbn, "Should have updated the isbn"
-      assert_equal 7, book.author_id, "Should not have updated the author_id"
-    end
+    book = Book.find(101)
+    assert_equal "Perelandra 2", book.title, "Should have updated the title"
+    assert_equal "111111", book.isbn, "Should have updated the isbn"
+    assert_equal 7, book.author_id, "Should not have updated the author_id"
   end
 
   def test_insert_all_and_upsert_all_with_sti
+    skip unless supports_insert_on_duplicate_update?
+
     assert_difference -> { Category.count }, 2 do
       SpecialCategory.insert_all [{ name: "First" }, { name: "Second", type: nil }]
     end
@@ -304,15 +308,13 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "SpecialCategory", first.type
     assert_nil second.type
 
-    if supports_insert_on_duplicate_update?
-      SpecialCategory.upsert_all [{ id: 103, name: "First" }, { id: 104, name: "Second", type: nil }]
+    SpecialCategory.upsert_all [{ id: 103, name: "First" }, { id: 104, name: "Second", type: nil }]
 
-      category3 = Category.find(103)
-      assert_equal "SpecialCategory", category3.type
+    category3 = Category.find(103)
+    assert_equal "SpecialCategory", category3.type
 
-      category4 = Category.find(104)
-      assert_nil category4.type
-    end
+    category4 = Category.find(104)
+    assert_nil category4.type
   end
 
   def test_upsert_logs_message_including_model_name


### PR DESCRIPTION
### Motivation / Background

Added checks to tests that rely on the database adapter supporting `supports_insert_on_duplicate_update?`. The tests involved use the `insert`/`insert_all` ActiveRecord methods, which require the adapter to support `supports_insert_on_duplicate_update?`.

Found the issues as the SQL Server adapter (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) does not support upsert and without the checks we need to coerce the tests.

This PR is very similar to https://github.com/rails/rails/pull/44050

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
