### PR TITLE
Add support for generated columns in SQLite3 adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add support for generated columns in SQLite3 adapter
+
+    Generated columns (both stored and dynamic) are supported since version 3.31.0 of SQLite.
+    This adds support for those to the SQLite3 adapter.
+
+    ```ruby
+    create_table :users do |t|
+      t.string :name
+      t.virtual :name_upper, type: :string, as: 'UPPER(name)'
+      t.virtual :name_lower, type: :string, as: 'LOWER(name)', stored: true
+    end
+    ```
+
+    *Stephen Margheim*
+
 *   TrilogyAdapter: ignore `host` if `socket` parameter is set.
 
     This allows to configure a connection on a UNIX socket via DATABASE_URL:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/column.rb
@@ -6,10 +6,11 @@ module ActiveRecord
       class Column < ConnectionAdapters::Column # :nodoc:
         attr_reader :rowid
 
-        def initialize(*, auto_increment: nil, rowid: false, **)
+        def initialize(*, auto_increment: nil, rowid: false, generated_type: nil, **)
           super
           @auto_increment = auto_increment
           @rowid = rowid
+          @generated_type = generated_type
         end
 
         def auto_increment?
@@ -18,6 +19,18 @@ module ActiveRecord
 
         def auto_incremented_by_db?
           auto_increment? || rowid
+        end
+
+        def virtual?
+          !@generated_type.nil?
+        end
+
+        def virtual_stored?
+          virtual? && @generated_type == :stored
+        end
+
+        def has_default?
+          super && !virtual?
         end
 
         def init_with(coder)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -25,6 +25,16 @@ module ActiveRecord
             if options[:collation]
               sql << " COLLATE \"#{options[:collation]}\""
             end
+
+            if as = options[:as]
+              sql << " GENERATED ALWAYS AS (#{as})"
+
+              if options[:stored]
+                sql << " STORED"
+              else
+                sql << " VIRTUAL"
+              end
+            end
             super
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_definitions.rb
@@ -16,9 +16,22 @@ module ActiveRecord
         end
         alias :belongs_to :references
 
+        def new_column_definition(name, type, **options) # :nodoc:
+          case type
+          when :virtual
+            type = options[:type]
+          end
+
+          super
+        end
+
         private
           def integer_like_primary_key_type(type, options)
             :primary_key
+          end
+
+          def valid_column_definition_options
+            super + [:as, :type, :stored]
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -12,6 +12,22 @@ module ActiveRecord
           def explicit_primary_key_default?(column)
             column.bigint?
           end
+
+          def prepare_column_options(column)
+            spec = super
+
+            if @connection.supports_virtual_columns? && column.virtual?
+              spec[:as] = extract_expression_for_virtual_column(column)
+              spec[:stored] = column.virtual_stored?
+              spec = { type: schema_type(column).inspect }.merge!(spec)
+            end
+
+            spec
+          end
+
+          def extract_expression_for_virtual_column(column)
+            column.default_function.inspect
+          end
       end
     end
   end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -263,7 +263,7 @@ module ActiveRecord
           sql = "INSERT INTO ex (number) VALUES (10)"
           name = "foo"
 
-          pragma_query = ["PRAGMA table_info(\"ex\")", "SCHEMA", []]
+          pragma_query = ["PRAGMA table_xinfo(\"ex\")", "SCHEMA", []]
           schema_query = ["SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type = 'table' AND name = 'ex'", "SCHEMA", []]
           modified_insert_query = [(sql + ' RETURNING "id"'), name, []]
           assert_logged [pragma_query, schema_query, modified_insert_query] do

--- a/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+if ActiveRecord::Base.connection.supports_virtual_columns?
+  class SQLite3VirtualColumnTest < ActiveRecord::SQLite3TestCase
+    include SchemaDumpingHelper
+
+    class VirtualColumn < ActiveRecord::Base
+    end
+
+    def setup
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table :virtual_columns, force: true do |t|
+        t.string  :name
+        t.virtual :upper_name, type: :string, as: "UPPER(name)", stored: true
+        t.virtual :lower_name, type: :string, as: "LOWER(name)", stored: false
+        t.virtual :octet_name, type: :integer, as: "LENGTH(name)"
+        t.integer :column1
+      end
+      VirtualColumn.create(name: "Rails", column1: 10)
+    end
+
+    def teardown
+      @connection.drop_table :virtual_columns, if_exists: true
+      VirtualColumn.reset_column_information
+    end
+
+    def test_virtual_column_with_full_inserts
+      partial_inserts_was = VirtualColumn.partial_inserts
+      VirtualColumn.partial_inserts = false
+      assert_nothing_raised do
+        VirtualColumn.create!(name: "Rails")
+      end
+    ensure
+      VirtualColumn.partial_inserts = partial_inserts_was
+    end
+
+    def test_stored_column
+      column = VirtualColumn.columns_hash["upper_name"]
+      assert_predicate column, :virtual?
+      assert_predicate column, :virtual_stored?
+      assert_equal "RAILS", VirtualColumn.take.upper_name
+    end
+
+    def test_explicit_virtual_column
+      column = VirtualColumn.columns_hash["lower_name"]
+      assert_predicate column, :virtual?
+      assert_not_predicate column, :virtual_stored?
+      assert_equal "rails", VirtualColumn.take.lower_name
+    end
+
+    def test_implicit_virtual_column
+      column = VirtualColumn.columns_hash["octet_name"]
+      assert_predicate column, :virtual?
+      assert_not_predicate column, :virtual_stored?
+      assert_equal 5, VirtualColumn.take.octet_name
+    end
+
+    def test_change_table_with_stored_generated_column
+      @connection.change_table :virtual_columns do |t|
+        t.virtual :decr_column1, type: :integer, as: "column1 - 1", stored: true
+      end
+      VirtualColumn.reset_column_information
+      column = VirtualColumn.columns_hash["decr_column1"]
+      assert_predicate column, :virtual?
+      assert_predicate column, :virtual_stored?
+      assert_equal 9, VirtualColumn.take.decr_column1
+    end
+
+    def test_change_table_with_explicit_virtual_generated_column
+      @connection.change_table :virtual_columns do |t|
+        t.virtual :incr_column1, type: :integer, as: "column1 + 1", stored: false
+      end
+      VirtualColumn.reset_column_information
+      column = VirtualColumn.columns_hash["incr_column1"]
+      assert_predicate column, :virtual?
+      assert_not_predicate column, :virtual_stored?
+      assert_equal 11, VirtualColumn.take.incr_column1
+    end
+
+    def test_change_table_with_implicit_virtual_generated_column
+      @connection.change_table :virtual_columns do |t|
+        t.virtual :sqr_column1, type: :integer, as: "pow(column1, 2)"
+      end
+      VirtualColumn.reset_column_information
+      column = VirtualColumn.columns_hash["sqr_column1"]
+      assert_predicate column, :virtual?
+      assert_not_predicate column, :virtual_stored?
+      assert_equal 100, VirtualColumn.take.sqr_column1
+    end
+
+    def test_schema_dumping
+      output = dump_table_schema("virtual_columns")
+      assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "UPPER\(name\)", stored: true$/i, output)
+    end
+
+    def test_build_fixture_sql
+      ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns)
+    end
+  end
+end

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -14,6 +14,8 @@ module ActiveRecord
           default_keys.concat([":auto_increment", ":charset", ":as", ":size", ":unsigned", ":first", ":after", ":type", ":stored"])
         elsif current_adapter?(:PostgreSQLAdapter)
           default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":enum_type", ":stored"])
+        elsif current_adapter?(:SQLite3Adapter)
+          default_keys.concat([":as", ":type", ":stored"])
         end
 
         "Unknown key: :#{key}. Valid keys are: #{default_keys.join(", ")}"


### PR DESCRIPTION
### Motivation / Background

SQLite is a feature-rich database engine, and production usage is only growing. We need Rails' support to offer developers the range and scope of its features.

Both the MySQL and PostgreSQL adapters support virtual columns, and SQLite itself has support generated columns [since 2020](https://www.sqlite.org/releaselog/3_31_0.html).

### Detail

PR https://github.com/rails/rails/pull/41856 introduced virtual columns to the PostgreSQLAdapter. This is effectively a clone of that feature, with some necessary tweaks.

```ruby
create_table :users do |t|
  t.string :name
  t.virtual :name_upper, type: :string, as: 'UPPER(name)'
  t.virtual :name_lower, type: :string, as: 'LOWER(name)', stored: true
end
```

Firstly, SQLite supported both `STORED` and `VIRTUAL` generated columns, while PostgreSQL only supports `VIRTUAL`. Secondly, SQLite doesn't support `ALTER TABLE` commands with generated columns. 

In this PR, I am adding full support for the SQLite3Adapter by implementing:

`ActiveRecord::ConnectionAdapters::SQLite3::Column#virtual?`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#supports_virtual_columns?`

and altering:

`ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#add_column_options`
`ActiveRecord::ConnectionAdapters::SQLite3::SchemaDefinitions#new_column_definition`
`ActiveRecord::ConnectionAdapters::SQLite3::SchemaDumper#prepare_column_options`
`ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#new_column_from_field`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#table_structure`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#invalid_alter_table_type?`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#table_structure_with_collation`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
