### PR TITLE
Performance tune the SQLite3 adapter connection configuration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Performance tune the SQLite3 adapter connection configuration
+
+    For Rails applications, the Write-Ahead-Log in normal syncing mode with a capped journal size, a healthy shared memory buffer and a shared cache will perform, on average, 2× better.
+
+    *Stephen Margheim*
+
 *   Allow SQLite3 `busy_handler` to be configured with simple max number of `retries`
 
     Retrying busy connections without delay is a preferred practice for performance-sensitive applications. Add support for a `database.yml` `retries` integer, which is used in a simple `busy_handler` function to retry busy connections without exponential backoff up to the max number of `retries`.

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -723,7 +723,29 @@ module ActiveRecord
             end
           end
 
+          # Enforce foreign key constraints
+          # https://www.sqlite.org/pragma.html#pragma_foreign_keys
+          # https://www.sqlite.org/foreignkeys.html
           raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
+          unless @memory_database
+            # Journal mode WAL allows for greater concurrency (many readers + one writer)
+            # https://www.sqlite.org/pragma.html#pragma_journal_mode
+            raw_execute("PRAGMA journal_mode = WAL", "SCHEMA")
+            # Set more relaxed level of database durability
+            # 2 = "FULL" (sync on every write), 1 = "NORMAL" (sync every 1000 written pages) and 0 = "NONE"
+            # https://www.sqlite.org/pragma.html#pragma_synchronous
+            raw_execute("PRAGMA synchronous = NORMAL", "SCHEMA")
+            # Set the global memory map so all processes can share some data
+            # https://www.sqlite.org/pragma.html#pragma_mmap_size
+            # https://www.sqlite.org/mmap.html
+            raw_execute("PRAGMA mmap_size = #{128.megabytes}", "SCHEMA")
+          end
+          # Impose a limit on the WAL file to prevent unlimited growth
+          # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+          raw_execute("PRAGMA journal_size_limit = #{64.megabytes}", "SCHEMA")
+          # Set the local connection cache to 2000 pages
+          # https://www.sqlite.org/pragma.html#pragma_cache_size
+          raw_execute("PRAGMA cache_size = 2000", "SCHEMA")
         end
     end
     ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, SQLite3Adapter)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -136,6 +136,26 @@ module ActiveRecord
         assert_equal "UTF-8", @conn.encoding
       end
 
+      def test_default_pragmas
+        if in_memory_db?
+          assert_equal [{ "foreign_keys" => 1 }], @conn.execute("PRAGMA foreign_keys")
+          assert_equal [{ "journal_mode" => "memory" }], @conn.execute("PRAGMA journal_mode")
+          assert_equal [{ "synchronous" => 2 }], @conn.execute("PRAGMA synchronous")
+          assert_equal [{ "journal_size_limit" => 67108864 }], @conn.execute("PRAGMA journal_size_limit")
+          assert_equal [], @conn.execute("PRAGMA mmap_size")
+          assert_equal [{ "cache_size" => 2000 }], @conn.execute("PRAGMA cache_size")
+        else
+          with_file_connection do |conn|
+            assert_equal [{ "foreign_keys" => 1 }], conn.execute("PRAGMA foreign_keys")
+            assert_equal [{ "journal_mode" => "wal" }], conn.execute("PRAGMA journal_mode")
+            assert_equal [{ "synchronous" => 1 }], conn.execute("PRAGMA synchronous")
+            assert_equal [{ "journal_size_limit" => 67108864 }], conn.execute("PRAGMA journal_size_limit")
+            assert_equal [{ "mmap_size" => 134217728 }], conn.execute("PRAGMA mmap_size")
+            assert_equal [{ "cache_size" => 2000 }], conn.execute("PRAGMA cache_size")
+          end
+        end
+      end
+
       def test_exec_no_binds
         with_example_table "id int, data string" do
           result = @conn.exec_query("SELECT id, data FROM ex")
@@ -814,6 +834,17 @@ module ActiveRecord
           yield
         ensure
           SQLite3Adapter.strict_strings_by_default = false
+        end
+
+        def with_file_connection(options = {})
+          options = options.dup
+          db_config = ActiveRecord::Base.configurations.configurations.find { |config| !config.database.include?(":memory:") }
+          options[:database] ||= db_config.database
+          conn = ActiveRecord::Base.sqlite3_connection(options)
+
+          yield(conn)
+        ensure
+          conn.disconnect! if conn
         end
     end
   end


### PR DESCRIPTION
For Rails applications, the Write-Ahead-Log in normal syncing mode with a capped journal size, a healthy shared memory buffer and a shared cache will perform, on average, 2× better.

### Motivation / Background

Rails applications using SQLite are poorly tuned for the web application context in which the database is being run. Because of its commitment to backwards-compatibility and its original use-case for embedded systems, the default configuration of SQLite today is not well-suited for web applications. Luckily, through its `PRAGMA` statements, SQLite is easy to configure.

As has been detailed in [academic literature](https://www.cs.utexas.edu/~vijay/papers/apsys17-sqlite.pdf), [real-world developer experience](https://phiresky.github.io/blog/2020/sqlite-performance-tuning/), and my own [writing](https://fractaledmind.github.io/2023/09/07/enhancing-rails-sqlite-fine-tuning/), SQLite databases can be easily optimized to achieve at least a [2× performance increase](https://fractaledmind.github.io/2023/09/21/enhancing-rails-sqlite-performance-metrics/).

This pull request updates the default configuration of Rails' SQLite connections to better tune them to the context of modern day Rails applications.

### Detail

The first and most important pragma to understand and tune is the [journal_mode pragma](https://www.sqlite.org/pragma.html#pragma_journal_mode). Since version 3.7.0 (2010-07-21) SQLite has offered a [Write-Ahead log](https://www.sqlite.org/wal.html) to support the atomic transactions. This is the recommended journal mode for web applications, since, as the SQLite docs lay out:

>WAL is significantly faster in most scenarios.
>WAL provides more concurrency as readers do not block writers and a writer does not block readers. Reading and writing can proceed concurrently.

Once an application is using the Write-Ahead log, it also makes sense to relax the synchronization rhythm:

>The `synchronous=NORMAL` setting is a good choice for most applications running in WAL mode.

The `NORMAL` sync mode means that SQLite will flush to disk less often than after every single write. SQLite has its own algorithm for determining the “most critical moments” to write to disk, where it syncs every `wal_autocheckpoint` pages (which defaults to 1000). So, if/when the `wal_autocheckpoint` pragma is changed, `NORMAL` mode syncs would occur after that many pages are written. So, we trade an aggressive approach to durability for speed. However, SQLite does a lot to mitigate the reduction in durability, and it is honestly an extreme edge-case. In fact, SQLite ensures that any potential data loss could only happen with OS or filesystem failure; any process crash won’t affect data durability. So, we are optimizing for the 99% case and not the 1% case, which I think is appropriate for a Rails application.

The [`journal_size_limit` pragma](https://www.sqlite.org/pragma.html#pragma_journal_size_limit) tells SQLite how much of the write-ahead log data (in our case) to keep in the on-disk file. The default of -1 means that there is no limit, so this disk file will grow in size indefinitely. This is not what we want. Anyone who has experienced app downtime because log files filled up your disk space no that unlimited file size is just a massive headache waiting to happen. We need to ensure that the file size is capped at an appropriate size. 

Next up, we have the abbreviated pragma [`mmap_size`](https://www.sqlite.org/pragma.html#pragma_mmap_size). This setting controls the “the maximum number of bytes of the database file that will be accessed using memory-mapped I/O.” This is a mouth-full, but the gist is that when we enable memory-mapped I/O, we are allowing SQLite to share data among multiple processes. The memory map plays a similar role to Postgres’ buffer pool, so instead of disabling it, we should set it to the same safe as the default Postgres buffer pool—128MB.

Finally, the [`cache_size` pragma](https://www.sqlite.org/pragma.html#pragma_cache_size) sets the “maximum number of database disk pages that SQLite will hold in memory at once per open database file.” The default value of -2000 is a negative number, which SQLite interprets as a byte limit. If we use a positive number, SQLite will interpret this as a page limit. The default limit is ~2MB (2,048,000 bytes) and is independent of the number of pages. We want to ensure that we have a large cache and that it doesn’t split across pages, so let’s use a positive number to set the cache limit to a page number. I recommend 2,000 pages as the cache_size, which, with the default page size of 4,096 bytes, means that the cache limit is ~8MB (8,192,000 bytes).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
