### PR TITLE
Update doc for `include_hidden` form form file_field.

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2521,7 +2521,7 @@ module ActionView
       # * Creates standard HTML attributes for the tag.
       # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
       # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
-      # * <tt>:include_hidden</tt> - When <tt>multiple: true</tt> and <tt>include_hidden: true</tt>, the field will be prefixed with an <tt><input type="hidden"></tt> field with an empty value to support submitting an empty collection of files.
+      # * <tt>:include_hidden</tt> - When <tt>multiple: true</tt> and <tt>include_hidden: true</tt>, the field will be prefixed with an <tt><input type="hidden"></tt> field with an empty value to support submitting an empty collection of files. Since <tt>include_hidden</tt> will default to <tt>config.active_storage.multiple_file_field_include_hidden</tt> if you don't specify <tt>include_hidden</tt>, you will need to pass <tt>include_hidden: false</tt> to prevent submitting an empty collection of files when passing <tt>multiple: true</tt>.
       # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
       #
       # ==== Examples


### PR DESCRIPTION
### Motivation / Background
[The documentation](https://api.rubyonrails.org/v7.0.4/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field) says that the hidden input is only output if include_hidden: true is present. However, it is also output even if the include_hidden key is entirely absent. The documentation does not state that if the `include_hidden` key is not present it takes `config.active_storage.multiple_file_field_include_hidden` into account.


- It adds proper documentation to avoid any further confusion as to why the hidden input field is present even if `include_hidden` is absent.

This Pull Request has been created because https://github.com/rails/rails/issues/48006
Fixes https://github.com/rails/rails/issues/48006

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.