### PR TITLE
Allow SQLite3 `busy_handler` to be configured with simple max number of retries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow SQLite3 `busy_handler` to be configured with simple max number of `retries`
+
+    Retrying busy connections without delay is a preferred practice for performance-sensitive applications. Add support for a `database.yml` `retries` integer, which is used in a simple `busy_handler` function to retry busy connections without exponential backoff up to the max number of `retries`.
+
+    *Stephen Margheim*
+
 *   The SQLite3 adapter now supports `supports_insert_returning?`
 
     Implementing the full `supports_insert_returning?` contract means the SQLite3 adapter supports auto-populated columns (#48241) as well as custom primary keys.


### PR DESCRIPTION
### Motivation / Background

SQLite's `busy_timeout` is a specific implementation of the lower-level `busy_handler` function which simply retries busy connections with "exponential backoff" (not truly exponential, the backoff steps are [1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50, 100] ms and then 100 ms each step thereafter) up to the `timeout` number of milliseconds. Exposing access to this function via the `timeout` option in the `database.yml` file is useful, but insufficient.

It is growingly common for production Rails applications to use SQLite as their database engine. A recommended performance optimization is to immediately retry busy connections, instead of waiting for backoffs.

### Detail

This pull request adds support for a new option in the `database.yml` called `retries`, which is used in a simple `busy_handler` function to retry busy connections without exponential backoff up to the max number of `retries` .

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [] Tests are added or updated if you fix a bug or add a feature.
  - no tests added as the `timeout` option isn't tested, and testing either the `busy_timeout` or `busy_handler` function is difficult relative to its value
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
