### PR TITLE
Use `ruby file: ".ruby-version"` for new apps

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `ruby file: ".ruby-version"` in generated Gemfile if supported.
+
+    *Hartley McGuire*
+
 *   `bin/rails test` will no longer load files named `*_test.rb` if they are located in the `fixtures` folder.
 
     *Edouard Chin*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -436,8 +436,20 @@ module Rails
         end
       end
 
+      def gem_ruby_entry
+        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2.4.20") # add file: option to #ruby
+          'ruby file: ".ruby-version"'
+        else
+          "ruby \"#{gem_ruby_version}\""
+        end
+      end
+
       def gem_ruby_version
-        Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION
+        if Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") # patch level removed from Gem.ruby_version
+          Gem.ruby_version
+        else
+          RUBY_VERSION
+        end
       end
 
       def rails_prerelease?

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -42,7 +42,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY .ruby-version Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile<% end %>

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby <%= "\"#{gem_ruby_version}\"" -%>
+<%= gem_ruby_entry %>
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1006,7 +1006,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file "Gemfile" do |content|
-      assert_match(/ruby "#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}"/, content)
+      if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2.4.20") # add file: option to #ruby
+        assert_match('ruby file: ".ruby-version"', content)
+      elsif Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") # patch level removed from Gem.ruby_version
+        assert_match("ruby \"#{Gem.ruby_version}\"", content)
+      else
+        assert_match("ruby \"#{RUBY_VERSION}\"", content)
+      end
     end
     assert_file "Dockerfile" do |content|
       assert_match(/ARG RUBY_VERSION=#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}/, content)

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -100,7 +100,7 @@ module GeneratorsTestHelper
   private
     def gemfile_locals
       {
-        gem_ruby_version: RUBY_VERSION,
+        gem_ruby_entry: "ruby \"#{RUBY_VERSION}\"",
         rails_prerelease: false,
         skip_active_storage: true,
         depend_on_bootsnap: false,


### PR DESCRIPTION
### Motivation / Background

Fixes #51014 
Fixes #51089

Previously, new apps would have a Ruby version set in both the Gemfile and the .ruby-version file. This duplication makes it more difficult to quickly change an application's ruby version as users must remember to update multiple files.

### Detail

This commit updates the app generator's Gemfile to read the Ruby version from the .ruby-version file. Since this feature was introduced in the latest version of Bundler, it will only be enabled if a supported version of Bundler is used.

### Additional information

Alternatively, another solution mentioned on the original PR adding .ruby-version was that the .ruby-version file could be removed once rvm/rbenv support reading the Ruby version from the Gemfile. This has a downside that many other tools like chruby do not have plans to support reading a Ruby version from the Gemfile, and so users of those tools would have a worse experience if the .ruby-version file is removed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
