### PR TITLE
[Docs]Add missing entry for encryption.add_to_filter_paramters

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -71,6 +71,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
 - [`config.active_record.commit_transaction_on_non_local_return`](#config-active-record-commit-transaction-on-non-local-return): `true`
 - [`config.active_record.default_column_serializer`](#config-active-record-default-column-serializer): `nil`
+- [`config.active_record.encryption.add_to_filter_parameters`](#config-active-record-encryption-add-to-filter-parameters): `true`
 - [`config.active_record.encryption.hash_digest_class`](#config-active-record-encryption-hash-digest-class): `OpenSSL::Digest::SHA256`
 - [`config.active_record.encryption.support_sha1_for_non_deterministic_encryption`](#config-active-record-encryption-support-sha1-for-non-deterministic-encryption): `false`
 - [`config.active_record.generate_secure_token_on`](#config-active-record-generate-secure-token-on): `:initialize`
@@ -1603,6 +1604,17 @@ Allows setting a different regular expression that will be used to decide
 whether a foreign key's name should be dumped to db/schema.rb or not. By
 default, foreign key names starting with `fk_rails_` are not exported to the
 database schema dump. Defaults to `/^fk_rails_[0-9a-f]{10}$/`.
+
+#### `config.active_record.encryption.add_to_filter_parameters`
+
+Enables automatic filtering of encrypted attributes on `inspect`.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+|-----------------------|----------------------|
+| (original)            | `true`               |
+| 7.1                   | `false`              |
 
 #### `config.active_record.encryption.hash_digest_class`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1613,8 +1613,8 @@ The default value depends on the `config.load_defaults` target version:
 
 | Starting with version | The default value is |
 |-----------------------|----------------------|
-| (original)            | `true`               |
-| 7.1                   | `false`              |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
 
 #### `config.active_record.encryption.hash_digest_class`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -287,6 +287,7 @@ module Rails
             active_record.belongs_to_required_validates_foreign_key = false
             active_record.before_committed_on_all_records = true
             active_record.default_column_serializer = nil
+            active_record.encryption.add_to_filter_parameters = true
             active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
             active_record.encryption.support_sha1_for_non_deterministic_encryption = false
             active_record.marshalling_format_version = 7.1

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -29,6 +29,10 @@
 # as equal to an equivalent `Hash` by default.
 # Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
+# Active Record now filters out the encrypted attributes when performing `inspect`.
+# If you need to disable the behavior, set false to the following config:
+# Rails.application.config.active_record.encryption.add_to_filter_parameters = true
+
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm. Important: If you have
 # data encrypted with previous Rails versions, there are two scenarios to consider:
 #


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the new config entry for #46453 is missing in configuring.md guide.

### Detail

This Pull Request adds `config.active_record.encryption.add_to_filter_parameters` to configuring.md.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
