### PR TITLE
[ci-skip][Doc]Fix: expires_in -> expires_at

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1375,7 +1375,7 @@
 
     *Adrianna Chang*
 
-*   Add `expires_in` option to `signed_id`.
+*   Add `expires_at` option to `signed_id`.
 
     *Shouichi Kamiya*
 


### PR DESCRIPTION
Fixes the following in AR changelog for https://github.com/rails/rails/commit/364939c2b17b219fc8c158da63a8517e57f892ab

```diff
-*   Add `expires_in` option to `signed_id`.
+*   Add `expires_at` option to `signed_id`.
```