### PR TITLE
Action View: Reduce public API of `tag` helper

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -371,7 +371,7 @@ module ActionView
           html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
           html_attributes[:value] = value
 
-          tag_builder.content_tag_string(:option, text, html_attributes)
+          tag_builder.option(text, **html_attributes)
         end.join("\n").html_safe
       end
 

--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -37,7 +37,7 @@ module ActionView
             if options[:include_blank]
               content = (options[:include_blank] if options[:include_blank].is_a?(String))
               label = (" " unless content)
-              option_tags = tag_builder.content_tag_string("option", content, value: "", label: label) + "\n" + option_tags
+              option_tags = tag_builder.option(content, value: "", label: label) + "\n" + option_tags
             end
 
             if value.blank? && options[:prompt]
@@ -45,7 +45,7 @@ module ActionView
                 prompt_opts[:disabled] = true if options[:disabled] == ""
                 prompt_opts[:selected] = true if options[:selected] == ""
               end
-              option_tags = tag_builder.content_tag_string("option", prompt_text(options[:prompt]), tag_options) + "\n" + option_tags
+              option_tags = tag_builder.option(prompt_text(options[:prompt]), **tag_options) + "\n" + option_tags
             end
 
             option_tags


### PR DESCRIPTION
This diff is best reviewed [ignoring indentation changes](https://github.com/rails/rails/pull/49369/files?w=1)
---

### Motivation / Background

The `TagBuilder` instance returned by the
[ActionView::Helpers::TagHelper#tag][] method has the ability to build various HTML elements through its reliance on `method_missing`. The magic of that instance hinges on the fact that it has a **minimal** public interface, and transforms missing methods names into HTML elements. For example, calling `tag.div` invokes a missing `#div` method, which renders a `<div>` element.

There are two exceptional cases:

* `tag.p` is defined, since the existing [Kernel#p][] definition would prevent the underlying `#method_missing` invocation
* `tag.attributes` is a defined method to transform `Hash` instances and keyword arguments in HTML attribute strings

In addition to those two _intentional_ exceptions, there are also several methods that are incidentally part of the public interface:

* `#tag_string`
* `#content_tag_string`
* `#tag_options`
* `#boolean_tag_option`
* `#tag_option`

Along with those methods, the class also includes [OutputSafetyHelper][] and [CaptureHelper][], which expand surface area of the class's public interface even further.

While it's unlikely that these methods would collide with method invocations intended to construct HTML elements, they still impact that design of the object.

The "public" nature of the `TagBuilder` interface has some subtle nuances. While it **is** marked with `:nodoc:`, instances are returned by a public `tag` method, despite it being considered a private class only meant for internal consumption.

That same is true for the incidentally public methods mentioned above: no consuming applications should be invoking `#tag_string` or `#tag_options`. While that's true, those methods _are_ being invoked **directly** by other Action View classes.

### Detail

This commit removes those invocations, and instead replaces them with public method calls.

In cases where the tag name is statically know ahead of time, they're replaced with calls to that method (for example, `tag(:option)` becomes `tag.option`). When they're dynamic, they're replaced by calls to [public_send][] (for example, `tag(name)` becomes
`tag.public_send(name)`).

The majority of these changes are painless, with one exception. Some calls to the `#tag` helper also pass an `open` positional argument that isn't part of the `TagBuilder` class's public interface. As a result, that becomes slightly more complicated, and requires some String mutation to continue to pass the test suite.

This commit also removes the `OutputSafetyHelper` and `CaptureHelper` modules from the class, and delegates to the methods it depended on to j`@view_context`.

Hopefully, calls to `#tag` with positional arguments are less and less common, since the documentation describes it as a [Legacy Syntax][] marked for deprecation in future versions of Rails.

[Kernel#p]: https://ruby-doc.org/3.2.2/Kernel.html#method-i-p
[ActionView::Helpers::TagHelper#tag]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag
[public_send]: https://ruby-doc.org/3.2.2/Object.html#method-i-public_send
[Legacy Syntax]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Legacy+syntax
[OutputSafetyHelper]: https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html
[CaptureHelper]: https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
