### PR TITLE
Deprecate `tag` with positional arguments

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -231,7 +231,7 @@ module ActionView
             tag_options["media"] = "screen"
           end
 
-          tag(:link, tag_options)
+          ActionView.deprecator.silence { tag(:link, tag_options) }
         }.join("\n").html_safe
 
         if use_preload_links_header
@@ -273,12 +273,11 @@ module ActionView
           raise ArgumentError.new("You should pass :type tag_option key explicitly, because you have passed #{type} type other than :rss, :atom, or :json.")
         end
 
-        tag(
-          "link",
-          "rel"   => tag_options[:rel] || "alternate",
-          "type"  => tag_options[:type] || Template::Types[type].to_s,
-          "title" => tag_options[:title] || type.to_s.upcase,
-          "href"  => url_options.is_a?(Hash) ? url_for(url_options.merge(only_path: false)) : url_options
+        tag.link(
+          rel: tag_options[:rel] || "alternate",
+          type: tag_options[:type] || Template::Types[type].to_s,
+          title: tag_options[:title] || type.to_s.upcase,
+          href: url_options.is_a?(Hash) ? url_for(url_options.merge(only_path: false)) : url_options
         )
       end
 
@@ -310,11 +309,13 @@ module ActionView
       #   favicon_link_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png'
       #   # => <link href="/assets/mb-icon.png" rel="apple-touch-icon" type="image/png" />
       def favicon_link_tag(source = "favicon.ico", options = {})
-        tag("link", {
-          rel: "icon",
-          type: "image/x-icon",
-          href: path_to_image(source, skip_pipeline: options.delete(:skip_pipeline))
-        }.merge!(options.symbolize_keys))
+        ActionView.deprecator.silence do
+          tag("link", {
+            rel: "icon",
+            type: "image/x-icon",
+            href: path_to_image(source, skip_pipeline: options.delete(:skip_pipeline))
+          }.merge!(options.symbolize_keys))
+        end
       end
 
       # Returns a link tag that browsers can use to preload the +source+.
@@ -446,7 +447,7 @@ module ActionView
         options[:loading] ||= image_loading if image_loading
         options[:decoding] ||= image_decoding if image_decoding
 
-        tag("img", options)
+        ActionView.deprecator.silence { tag("img", options) }
       end
 
       # Returns an HTML picture tag for the +sources+. If +sources+ is a string,
@@ -501,9 +502,11 @@ module ActionView
             image_tag(sources.last, image_options)
           else
             source_tags = sources.map do |source|
-              tag("source",
-               srcset: resolve_asset_source("image", source, skip_pipeline),
-               type: Template::Types[File.extname(source)[1..]]&.to_s)
+              ActionView.deprecator.silence do
+                tag("source",
+                  srcset: resolve_asset_source("image", source, skip_pipeline),
+                  type: Template::Types[File.extname(source)[1..]]&.to_s)
+              end
             end
             safe_join(source_tags << image_tag(sources.last, image_options))
           end
@@ -604,7 +607,9 @@ module ActionView
 
           if sources.size > 1
             content_tag(type, options) do
-              safe_join sources.map { |source| tag("source", src: resolve_asset_source(type, source, skip_pipeline)) }
+              ActionView.deprecator.silence do
+                safe_join sources.map { |source| tag("source", src: resolve_asset_source(type, source, skip_pipeline)) }
+              end
             end
           else
             options[:src] = resolve_asset_source(type, sources.first, skip_pipeline)

--- a/actionview/lib/action_view/helpers/csp_helper.rb
+++ b/actionview/lib/action_view/helpers/csp_helper.rb
@@ -18,7 +18,7 @@ module ActionView
         if content_security_policy?
           options[:name] = "csp-nonce"
           options[:content] = content_security_policy_nonce
-          tag("meta", options)
+          ActionView.deprecator.silence { tag("meta", options) }
         end
       end
     end

--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -22,8 +22,8 @@ module ActionView
       def csrf_meta_tags
         if defined?(protect_against_forgery?) && protect_against_forgery?
           [
-            tag("meta", name: "csrf-param", content: request_forgery_protection_token),
-            tag("meta", name: "csrf-token", content: form_authenticity_token)
+            tag.meta(name: "csrf-param", content: request_forgery_protection_token),
+            tag.meta(name: "csrf-token", content: form_authenticity_token)
           ].join("\n").html_safe
         end
       end

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1172,7 +1172,7 @@ module ActionView
           }.merge!(@html_options.slice(:disabled))
           select_options[:disabled] = "disabled" if @options[:disabled]
 
-          tag(:input, select_options) + "\n".html_safe
+          tag.input(**select_options) + "\n".html_safe
         end
 
         # Returns the name attribute for the input tag.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -261,7 +261,9 @@ module ActionView
       #   text_field_tag 'ip', '0.0.0.0', maxlength: 15, size: 20, class: "ip-input"
       #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0" />
       def text_field_tag(name, value = nil, options = {})
-        tag :input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
+        ActionView.deprecator.silence do
+          tag :input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
+        end
       end
 
       # Creates a label element. Accepts a block.
@@ -461,7 +463,7 @@ module ActionView
         value, checked = args.empty? ? ["1", false] : [*args, false]
         html_options = { "type" => "checkbox", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
         html_options["checked"] = "checked" if checked
-        tag :input, html_options
+        tag.input(**html_options)
       end
       alias_method :check_box_tag, :checkbox_tag
 
@@ -498,7 +500,7 @@ module ActionView
         checked = args.empty? ? false : args.first
         html_options = { "type" => "radio", "name" => name, "id" => "#{sanitize_to_id(name)}_#{sanitize_to_id(value)}", "value" => value }.update(options.stringify_keys)
         html_options["checked"] = "checked" if checked
-        tag :input, html_options
+        tag.input(**html_options)
       end
 
       # Creates a submit button with the text <tt>value</tt> as the caption.
@@ -528,7 +530,7 @@ module ActionView
         options = options.deep_stringify_keys
         tag_options = { "type" => "submit", "name" => "commit", "value" => value }.update(options)
         set_default_disable_with value, tag_options
-        tag :input, tag_options
+        ActionView.deprecator.silence { tag :input, tag_options }
       end
 
       # Creates a button element that defines a <tt>submit</tt> button,
@@ -614,7 +616,8 @@ module ActionView
       def image_submit_tag(source, options = {})
         options = options.stringify_keys
         src = path_to_image(source, skip_pipeline: options.delete("skip_pipeline"))
-        tag :input, { "type" => "image", "src" => src }.update(options)
+
+        ActionView.deprecator.silence { tag :input, { "type" => "image", "src" => src }.update(options) }
       end
 
       # Creates a field set for grouping HTML form elements.
@@ -1042,7 +1045,7 @@ module ActionView
 
         def form_tag_html(html_options)
           extra_tags = extra_tags_for_form(html_options)
-          html = tag(:form, html_options, true) + extra_tags
+          html = ActionView.deprecator.silence { tag(:form, html_options, true) } + extra_tags
           prevent_content_exfiltration(html)
         end
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -445,9 +445,9 @@ module ActionView
       #   <button <%= tag.attributes id: "call-to-action", disabled: false, aria: { expanded: false } %> class="primary">Get Started!</button>
       #   # => <button id="call-to-action" aria-expanded="false" class="primary">Get Started!</button>
       #
-      # === Legacy syntax
+      # === Deprecated: Legacy syntax
       #
-      # The following format is for legacy syntax support. It will be deprecated in future versions of \Rails.
+      # The following format is for legacy syntax support. It is deprecated, and will be removed in future versions of \Rails.
       #
       #   tag(name, options = nil, open = false, escape = true)
       #
@@ -497,6 +497,8 @@ module ActionView
           tag_builder
         else
           ensure_valid_html5_tag_name(name)
+
+          ActionView.deprecator.warn("Calling tag(#{name.inspect}) with arguments is deprecated. Use tag.#{name} instead")
           "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open ? ">" : " />"}".html_safe
         end
       end

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -28,7 +28,7 @@ module ActionView
           end
 
           include_hidden = options.delete("include_hidden") { true }
-          checkbox = tag("input", options)
+          checkbox = tag.input(**options)
 
           if include_hidden
             hidden = hidden_field_for_checkbox(options)
@@ -57,7 +57,7 @@ module ActionView
           end
 
           def hidden_field_for_checkbox(options)
-            @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value, "autocomplete" => "off")) : "".html_safe
+            @unchecked_value ? tag.input(**options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value, "autocomplete" => "off")) : "".html_safe
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -18,7 +18,7 @@ module ActionView
 
         private
           def hidden_field_for_multiple_file(options)
-            tag("input", "name" => options["name"], "type" => "hidden", "value" => "", "autocomplete" => "off")
+            tag.input(name: options["name"], type: "hidden", value: "", autocomplete: "off")
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -19,7 +19,7 @@ module ActionView
           options["value"]    = @tag_value
           options["checked"] = "checked" if input_checked?(options)
           add_default_name_and_id_for_value(@tag_value, options)
-          tag("input", options)
+          tag.input(**options)
         end
 
         private

--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -22,7 +22,7 @@ module ActionView
             select = content_tag("select", add_options(option_tags, options, value), html_options)
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)
-              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
+              tag.input(disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
             else
               select
             end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -14,7 +14,8 @@ module ActionView
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
           add_default_name_and_id(options)
-          tag("input", options)
+
+          tag.input(**options)
         end
 
         class << self

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -335,14 +335,14 @@ module ActionView
           content_tag("button", name || url, html_options, &block)
         else
           html_options["value"] = name || url
-          tag("input", html_options)
+          tag.input(**html_options)
         end
 
         inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
         if params
           to_form_params(params).each do |param|
-            inner_tags.safe_concat tag(:input, type: "hidden", name: param[:name], value: param[:value],
-                                       autocomplete: "off")
+            inner_tags.safe_concat tag.input(type: "hidden", name: param[:name], value: param[:value],
+                                      autocomplete: "off")
           end
         end
         html = content_tag("form", inner_tags, form_options)
@@ -751,14 +751,14 @@ module ActionView
               else
                 token
               end
-            tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
+            tag.input(type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
           else
             ""
           end
         end
 
         def method_tag(method)
-          tag("input", type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
+          tag.input(type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
         end
 
         # Returns an array of hashes each containing :name and :value keys

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -811,7 +811,9 @@ class AssetTagHelperTest < ActionView::TestCase
   end
 
   def test_picture_tag
-    PictureLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+    ActionView.deprecator.silence do
+      PictureLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
+    end
   end
 
   def test_video_path

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -660,7 +660,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_boolean_options
     assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
     assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, disabled: false, readonly: nil)
-    assert_dom_equal %(<input type="checkbox" />), tag(:input, type: "checkbox", checked: false)
+    assert_dom_equal %(<input type="checkbox" />), tag.input(type: "checkbox", checked: false)
     assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people" name="people"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: nil)

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -76,14 +76,16 @@ class OutputSafetyHelperTest < ActionView::TestCase
   end
 
   test "to_sentence should not escape html_safe values" do
-    ptag = content_tag("p") do
-      safe_join(["<marquee>shady stuff</marquee>", tag("br")])
+    ActionView.deprecator.silence do
+      ptag = content_tag("p") do
+        safe_join(["<marquee>shady stuff</marquee>", tag("br")])
+      end
+      url = "https://example.com"
+      expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
+      actual = to_sentence([link_to(url, url), ptag])
+      assert_predicate actual, :html_safe?
+      assert_equal(expected, actual)
     end
-    url = "https://example.com"
-    expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
-    actual = to_sentence([link_to(url, url), ptag])
-    assert_predicate actual, :html_safe?
-    assert_equal(expected, actual)
   end
 
   test "to_sentence handles blank strings" do

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -11,9 +11,11 @@ class TagHelperTest < ActionView::TestCase
   INVALID_TAG_CHARS = "> /"
 
   def test_tag
-    assert_equal "<br />", tag("br")
-    assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
-    assert_equal "<br>", tag("br", nil, true)
+    ActionView.deprecator.silence do
+      assert_equal "<br />", tag("br")
+      assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
+      assert_equal "<br>", tag("br", nil, true)
+    end
   end
 
   def test_tag_builder
@@ -64,31 +66,39 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options
-    str = tag("p", "class" => "show", :class => "elsewhere")
-    assert_match(/class="show"/, str)
-    assert_match(/class="elsewhere"/, str)
+    ActionView.deprecator.silence do
+      str = tag("p", "class" => "show", :class => "elsewhere")
+      assert_match(/class="show"/, str)
+      assert_match(/class="elsewhere"/, str)
+    end
   end
 
   def test_tag_options_with_array_of_numeric
-    str = tag(:input, value: [123, 456])
+    ActionView.deprecator.silence do
+      str = tag(:input, value: [123, 456])
 
-    assert_equal("<input value=\"123 456\" />", str)
+      assert_equal("<input value=\"123 456\" />", str)
+    end
   end
 
   def test_tag_options_with_array_of_random_objects
-    klass = Class.new do
-      def to_s
-        "hello"
+    ActionView.deprecator.silence do
+      klass = Class.new do
+        def to_s
+          "hello"
+        end
       end
+
+      str = tag(:input, value: [klass.new])
+
+      assert_equal("<input value=\"hello\" />", str)
     end
-
-    str = tag(:input, value: [klass.new])
-
-    assert_equal("<input value=\"hello\" />", str)
   end
 
   def test_tag_options_rejects_nil_option
-    assert_equal "<p />", tag("p", ignored: nil)
+    ActionView.deprecator.silence do
+      assert_equal "<p />", tag("p", ignored: nil)
+    end
   end
 
   def test_tag_builder_options_rejects_nil_option
@@ -96,7 +106,9 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_false_option
-    assert_equal "<p value=\"false\" />", tag("p", value: false)
+    ActionView.deprecator.silence do
+      assert_equal "<p value=\"false\" />", tag("p", value: false)
+    end
   end
 
   def test_tag_builder_options_accepts_false_option
@@ -104,7 +116,9 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_blank_option
-    assert_equal "<p included=\"\" />", tag("p", included: "")
+    ActionView.deprecator.silence do
+      assert_equal "<p included=\"\" />", tag("p", included: "")
+    end
   end
 
   def test_tag_builder_options_accepts_blank_option
@@ -112,16 +126,22 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_symbol_option_when_not_escaping
-    assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+    ActionView.deprecator.silence do
+      assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+    end
   end
 
   def test_tag_options_accepts_integer_option_when_not_escaping
-    assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+    ActionView.deprecator.silence do
+      assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+    end
   end
 
   def test_tag_options_converts_boolean_option
-    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline" />',
-      tag("p", disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
+    ActionView.deprecator.silence do
+      assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline" />',
+        tag("p", disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
+    end
   end
 
   def test_tag_builder_options_converts_boolean_option
@@ -137,7 +157,9 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_builder_do_not_modify_html_safe_options
     html_safe_str = '"'.html_safe
-    assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
+    ActionView.deprecator.silence do
+      assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
+    end
     assert_equal '"', html_safe_str
     assert_predicate html_safe_str, :html_safe?
   end
@@ -146,7 +168,9 @@ class TagHelperTest < ActionView::TestCase
     INVALID_TAG_CHARS.each_char do |char|
       tag_name = "asdf-#{char}"
       assert_raise(ArgumentError, "expected #{tag_name.inspect} to be invalid") do
-        tag(tag_name)
+        ActionView.deprecator.silence do
+          tag(tag_name)
+        end
       end
     end
   end
@@ -161,30 +185,36 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_with_dangerous_aria_attribute_name
-    escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
+    ActionView.deprecator.silence do
+      escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
+      assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
+                  tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+      assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+                  tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+    end
   end
 
   def test_tag_builder_with_dangerous_aria_attribute_name
-    escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\"></the-name>",
-                 tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
+    ActionView.deprecator.silence do
+      escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
+      assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\"></the-name>",
+                  tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
-                 tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
+      assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
+                  tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
+    end
   end
 
   def test_tag_with_dangerous_data_attribute_name
-    escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
+    ActionView.deprecator.silence do
+      escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
+      assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
+                  tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+      assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+                  tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+    end
   end
 
   def test_tag_builder_with_dangerous_data_attribute_name
@@ -197,12 +227,14 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_with_dangerous_unknown_attribute_name
-    escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
+    ActionView.deprecator.silence do
+      escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
+      assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
+                  tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
 
-    assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
+      assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+                  tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
+    end
   end
 
   def test_tag_builder_with_dangerous_unknown_attribute_name
@@ -441,11 +473,13 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_content_tag_with_unescaped_conditional_hash_classes
-    str = content_tag("p", "limelight", { class: { "song": true, "play>": true } }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+    ActionView.deprecator.silence do
+      str = content_tag("p", "limelight", { class: { "song": true, "play>": true } }, false)
+      assert_equal "<p class=\"song play>\">limelight</p>", str
 
-    str = content_tag("p", "limelight", { class: ["song", { "play>": true }] }, false)
-    assert_equal "<p class=\"song play>\">limelight</p>", str
+      str = content_tag("p", "limelight", { class: ["song", { "play>": true }] }, false)
+      assert_equal "<p class=\"song play>\">limelight</p>", str
+    end
   end
 
   def test_content_tag_with_invalid_html_tag
@@ -574,14 +608,18 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_honors_html_safe_for_param_values
     ["1&amp;2", "1 &lt; 2", "&#8220;test&#8220;"].each do |escaped|
-      assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)
+      ActionView.deprecator.silence do
+        assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)
+      end
       assert_equal %(<a href="#{escaped}"></a>), tag.a(href: escaped.html_safe)
     end
   end
 
   def test_tag_honors_html_safe_with_escaped_array_class
-    assert_equal '<p class="song&gt; play>" />', tag("p", class: ["song>", raw("play>")])
-    assert_equal '<p class="song> play&gt;" />', tag("p", class: [raw("song>"), "play>"])
+    ActionView.deprecator.silence do
+      assert_equal '<p class="song&gt; play>" />', tag("p", class: ["song>", raw("play>")])
+      assert_equal '<p class="song> play&gt;" />', tag("p", class: [raw("song>"), "play>"])
+    end
   end
 
   def test_tag_builder_honors_html_safe_with_escaped_array_class
@@ -601,13 +639,17 @@ class TagHelperTest < ActionView::TestCase
 
   def test_skip_invalid_escaped_attributes
     ["&1;", "&#1dfa3;", "& #123;"].each do |escaped|
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)
+      ActionView.deprecator.silence do
+        assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)
+      end
       assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(href: escaped)
     end
   end
 
   def test_disable_escaping
-    assert_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
+    ActionView.deprecator.silence do
+      assert_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
+    end
   end
 
   def test_tag_builder_disable_escaping
@@ -620,18 +662,22 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ["data", :data].each { |data|
-      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
-        tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+      ActionView.deprecator.silence do
+        assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+          tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
+      end
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
         tag.a(data: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
     }
   end
 
   def test_aria_attributes
-    ["aria", :aria].each { |aria|
-      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-        tag("a", aria => { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
-    }
+    ActionView.deprecator.silence do
+      ["aria", :aria].each { |aria|
+        assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+          tag("a", aria => { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
+      }
+    end
 
     assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
     tag.a(aria: { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })


### PR DESCRIPTION
The bulk of this diff is related to indentation changes, so it's best reviewed [ignoring spacing changes](https://github.com/rails/rails/pull/49371/files?w=1)
---

### Motivation / Background

Modern evolutions of the `ActionView::Helpers::TagHelper#tag` method are intended to be called _on_ the `TagBuilder` instance itself instead of with positional arguments.

For example, `tag("div")` would be called with `tag.div`.

According to the [Legacy Syntax](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Legacy+syntax) heading of the [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag) guides:

> The following format is for legacy syntax support. It will be deprecated in future versions of Rails.

Since deprecations must occur during releases, this commit proposes that 7.2 be the release to start the deprecation process so that a subsequent release can remove "Legacy syntax" support entirely.

### Detail

This commit adds a deprecation warning to encourage callers to invoke the helper in the more modern style.

Internally, Rails utilizes the positional argument syntax in several places. Since deprecations must be part of minor version releases, this commit wraps the internal invocations in `ActionView.deprecator.silence` blocks so that they can remain while the deprecation is made public. This compromise buys the framework time to re-structure those invocations to be compatible with the more modern syntax before the next major release.

There are several calls to `tag` with positional arguments in the test suite. This commit wraps those as well. In the future, some of those tests will be able to remove those blocks, while other tests will be able to be removed entirely once that style of invocation is no longer supported.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
