### PR TITLE
Update requires in LoggerThreadSafeLevel

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
-require "active_support/core_ext/module/attribute_accessors"
-require "concurrent"
-require "fiber"
+require "logger"
 
 module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:


### PR DESCRIPTION
### Motivation / Background

The `concurrent` require was [added][1] previously because a `Concurrent::Map` was added to hold all of the log levels by `Thread` id. However, the `Map` was later [removed][2] by storing the log levels in the `Thread` locals (and later in `IsolatedExecutionState`) instead. The new implementation additionally removed the `cattr_accessor` (removing the need to require the "attribute_accessors" core_ext) and also replaced the [usage][3] of `Fiber` with `Thread` (so the require for `Fiber` is also no longer necessary).

### Detail

Since `Concurrent`, `Fiber`, and `cattr_accessor` are no longer used here, we can remove the requires. Since `Logger` is used here (but was previously required by `concurrent`), a require was added for it.

[1]: https://github.com/rails/rails/commit/629efb605728b31ad9644f6f0acaf3760b641a29
[2]: https://github.com/rails/rails/commit/2379bc5d2a7d9580f270eebfde87d9f94b3da6c9
[3]: https://github.com/rails/rails/commit/56ec504db6c130d448ffc1d68c9fdd95fdfc1130

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
