### PR TITLE
Add notice to documentation for protect_from_forgery's :with option

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -134,6 +134,8 @@ module ActionController # :nodoc:
       # * <tt>:exception</tt> - Raises ActionController::InvalidAuthenticityToken exception.
       # * <tt>:reset_session</tt> - Resets the session.
       # * <tt>:null_session</tt> - Provides an empty session during request but doesn't reset it completely. Used as default if <tt>:with</tt> option is not specified.
+      #   Note if <tt>default_protect_from_forgery</tt> is true, Rails call protect_from_forgery with <tt>with :exception</tt>.
+      #   This might not be intuitive as the method itself treats <tt>:with</tt> as <tt>:null_session</tt> by default.
       #
       # You can also implement custom strategy classes for unverified request handling:
       #

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -129,13 +129,12 @@ module ActionController # :nodoc:
       #
       #   If you need to add verification to the beginning of the callback chain, use <tt>prepend: true</tt>.
       # * <tt>:with</tt> - Set the method to handle unverified request.
+      #   Note if <tt>default_protect_from_forgery</tt> is true, Rails call protect_from_forgery with <tt>with :exception</tt>.
       #
       # Built-in unverified request handling methods are:
       # * <tt>:exception</tt> - Raises ActionController::InvalidAuthenticityToken exception.
       # * <tt>:reset_session</tt> - Resets the session.
       # * <tt>:null_session</tt> - Provides an empty session during request but doesn't reset it completely. Used as default if <tt>:with</tt> option is not specified.
-      #   Note if <tt>default_protect_from_forgery</tt> is true, Rails call protect_from_forgery with <tt>with :exception</tt>.
-      #   This might not be intuitive as the method itself treats <tt>:with</tt> as <tt>:null_session</tt> by default.
       #
       # You can also implement custom strategy classes for unverified request handling:
       #


### PR DESCRIPTION
### Motivation / Background

Thanks to https://github.com/rails/rails/pull/29742, newly created Rails apps after Rails 5.2 don't have to deep dive into CSRF problems, and they don't require direct call of `protect_from_forgery`. However, some projects sill have to consider the case where `protect_from_forgery` should be called.

Calling `protect_from_forgery` without `:with` option treats `:with` as `:null_session` by default, not `:exception`, so I was a bit confused by the inconsistency between `default_protect_from_forgery` and `protect_from_forgery`. Maybe, changing the default `:with` to `:exception` will bring significant breaking changes, so I want to suggest adding a notice to the method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.