### PR TITLE
The SQLite3 adapter now implements the `supports_deferrable_constraints?` contract

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   The SQLite3 adapter now implements the `supports_deferrable_constraints?` contract
+
+    Allows foreign keys to be deferred by adding the `:deferrable` key to the `foreign_key` options.
+
+    ```ruby
+    add_reference :person, :alias, foreign_key: { deferrable: :deferred }
+    add_reference :alias, :person, foreign_key: { deferrable: :deferred }
+    ```
+
+    *Stephen Margheim*
+
 *   Add `set_constraints` helper for PostgreSQL
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -5,6 +5,18 @@ module ActiveRecord
     module SQLite3
       class SchemaCreation < SchemaCreation # :nodoc:
         private
+          def visit_AddForeignKey(o)
+            super.dup.tap do |sql|
+              sql << " DEFERRABLE INITIALLY #{o.options[:deferrable].to_s.upcase}" if o.deferrable
+            end
+          end
+
+          def visit_ForeignKeyDefinition(o)
+            super.dup.tap do |sql|
+              sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable
+            end
+          end
+
           def supports_index_using?
             false
           end

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -63,7 +63,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
         end
 
-        if current_adapter?(:PostgreSQLAdapter)
+        if ActiveRecord::Base.connection.supports_deferrable_constraints?
           test "deferrable: false option can be passed" do
             @connection.create_table :testings do |t|
               t.references :testing_parent, foreign_key: { deferrable: false }


### PR DESCRIPTION
### Motivation / Background

SQLite is a feature-rich database engine, and production usage is only growing. We need Rails' support to offer developers the range and scope of its features.

The PostgreSQL adapter supports deferred foreign keys, and SQLite itself has support [deferred foreign keys](https://www.sqlite.org/foreignkeys.html#fk_deferred) [since at least 2011](https://www.sqlite.org/releaselog/3_7_6.html).

### Detail

Implementing the full `supports_deferrable_constraints?` contract allows foreign keys to be deferred by adding the `:deferrable` key to the `foreign_key` options in the `add_reference` and `add_foreign_key` methods.

```ruby
add_reference :person, :alias, foreign_key: { deferrable: :deferred }
add_reference :alias, :person, foreign_key: { deferrable: :deferred }
```

In this PR, I am adding full support for the SQLite3Adapter by implementing:

`ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#visit_AddForeignKey`
`ActiveRecord::ConnectionAdapters::SQLite3::SchemaCreation#visit_ForeignKeyDefinition`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#supports_deferrable_constraints?`
`ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#assert_valid_deferrable`

and altering:

`ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements#add_foreign_key`
`ActiveRecord::ConnectionAdapters::SQLite3Adapter#foreign_keys`

### Additional Info

In order to get the `ActiveRecord::ConnectionAdapters::SQLite3Adapter#foreign_keys` method working properly, I had to add a query to get the `CREATE TABLE` sql and parse which foreign key constraints are deferrable and which of those are deferred. In order to support this use-case, I extracted a `table_structure_sql` method which now `table_structure_with_collation` relies on. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
