### PR TITLE
Action View: Remove internal calls to `tag` with positional arguments

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -227,7 +227,7 @@ module ActionView
             tag_options["media"] = "screen"
           end
 
-          tag(:link, tag_options)
+          tag.link(**tag_options)
         }.join("\n").html_safe
 
         if use_preload_links_header
@@ -269,12 +269,11 @@ module ActionView
           raise ArgumentError.new("You should pass :type tag_option key explicitly, because you have passed #{type} type other than :rss, :atom, or :json.")
         end
 
-        tag(
-          "link",
-          "rel"   => tag_options[:rel] || "alternate",
-          "type"  => tag_options[:type] || Template::Types[type].to_s,
-          "title" => tag_options[:title] || type.to_s.upcase,
-          "href"  => url_options.is_a?(Hash) ? url_for(url_options.merge(only_path: false)) : url_options
+        tag.link(
+          rel: tag_options[:rel] || "alternate",
+          type: tag_options[:type] || Template::Types[type].to_s,
+          title: tag_options[:title] || type.to_s.upcase,
+          href: url_options.is_a?(Hash) ? url_for(url_options.merge(only_path: false)) : url_options
         )
       end
 
@@ -306,11 +305,12 @@ module ActionView
       #   favicon_link_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png'
       #   # => <link href="/assets/mb-icon.png" rel="apple-touch-icon" type="image/png" />
       def favicon_link_tag(source = "favicon.ico", options = {})
-        tag("link", {
+        tag.link(
           rel: "icon",
           type: "image/x-icon",
-          href: path_to_image(source, skip_pipeline: options.delete(:skip_pipeline))
-        }.merge!(options.symbolize_keys))
+          href: path_to_image(source, skip_pipeline: options.delete(:skip_pipeline)),
+          **options.symbolize_keys
+        )
       end
 
       # Returns a link tag that browsers can use to preload the +source+.
@@ -442,7 +442,7 @@ module ActionView
         options[:loading] ||= image_loading if image_loading
         options[:decoding] ||= image_decoding if image_decoding
 
-        tag("img", options)
+        tag.img(**options)
       end
 
       # Returns an HTML picture tag for the +sources+. If +sources+ is a string,
@@ -497,9 +497,9 @@ module ActionView
             image_tag(sources.last, image_options)
           else
             source_tags = sources.map do |source|
-              tag("source",
-               srcset: resolve_asset_source("image", source, skip_pipeline),
-               type: Template::Types[File.extname(source)[1..]]&.to_s)
+              tag.source(
+                srcset: resolve_asset_source("image", source, skip_pipeline),
+                type: Template::Types[File.extname(source)[1..]]&.to_s)
             end
             safe_join(source_tags << image_tag(sources.last, image_options))
           end
@@ -600,7 +600,7 @@ module ActionView
 
           if sources.size > 1
             content_tag(type, options) do
-              safe_join sources.map { |source| tag("source", src: resolve_asset_source(type, source, skip_pipeline)) }
+              safe_join sources.map { |source| tag.source(src: resolve_asset_source(type, source, skip_pipeline)) }
             end
           else
             options[:src] = resolve_asset_source(type, sources.first, skip_pipeline)

--- a/actionview/lib/action_view/helpers/csp_helper.rb
+++ b/actionview/lib/action_view/helpers/csp_helper.rb
@@ -18,7 +18,7 @@ module ActionView
         if content_security_policy?
           options[:name] = "csp-nonce"
           options[:content] = content_security_policy_nonce
-          tag("meta", options)
+          tag.meta(**options)
         end
       end
     end

--- a/actionview/lib/action_view/helpers/csrf_helper.rb
+++ b/actionview/lib/action_view/helpers/csrf_helper.rb
@@ -22,8 +22,8 @@ module ActionView
       def csrf_meta_tags
         if defined?(protect_against_forgery?) && protect_against_forgery?
           [
-            tag("meta", name: "csrf-param", content: request_forgery_protection_token),
-            tag("meta", name: "csrf-token", content: form_authenticity_token)
+            tag.meta(name: "csrf-param", content: request_forgery_protection_token),
+            tag.meta(name: "csrf-token", content: form_authenticity_token)
           ].join("\n").html_safe
         end
       end

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1172,7 +1172,7 @@ module ActionView
           }.merge!(@html_options.slice(:disabled))
           select_options[:disabled] = "disabled" if @options[:disabled]
 
-          tag(:input, select_options) + "\n".html_safe
+          tag.input(**select_options) + "\n".html_safe
         end
 
         # Returns the name attribute for the input tag.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -261,7 +261,7 @@ module ActionView
       #   text_field_tag 'ip', '0.0.0.0', maxlength: 15, size: 20, class: "ip-input"
       #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0" />
       def text_field_tag(name, value = nil, options = {})
-        tag :input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
+        tag.input(**{ type: "text", name: name, id: sanitize_to_id(name), value: value }.update(options.symbolize_keys))
       end
 
       # Creates a label element. Accepts a block.
@@ -460,7 +460,7 @@ module ActionView
         value, checked = args.empty? ? ["1", false] : [*args, false]
         html_options = { "type" => "checkbox", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
         html_options["checked"] = "checked" if checked
-        tag :input, html_options
+        tag.input(**html_options)
       end
 
       ##
@@ -496,7 +496,7 @@ module ActionView
         checked = args.empty? ? false : args.first
         html_options = { "type" => "radio", "name" => name, "id" => "#{sanitize_to_id(name)}_#{sanitize_to_id(value)}", "value" => value }.update(options.stringify_keys)
         html_options["checked"] = "checked" if checked
-        tag :input, html_options
+        tag.input(**html_options)
       end
 
       # Creates a submit button with the text <tt>value</tt> as the caption.
@@ -526,7 +526,7 @@ module ActionView
         options = options.deep_stringify_keys
         tag_options = { "type" => "submit", "name" => "commit", "value" => value }.update(options)
         set_default_disable_with value, tag_options
-        tag :input, tag_options
+        tag.input(**tag_options)
       end
 
       # Creates a button element that defines a <tt>submit</tt> button,
@@ -612,7 +612,7 @@ module ActionView
       def image_submit_tag(source, options = {})
         options = options.stringify_keys
         src = path_to_image(source, skip_pipeline: options.delete("skip_pipeline"))
-        tag :input, { "type" => "image", "src" => src }.update(options)
+        tag.input(**{ type: "image", src: src }.update(options.symbolize_keys))
       end
 
       # Creates a field set for grouping HTML form elements.
@@ -970,8 +970,8 @@ module ActionView
 
         def form_tag_html(html_options)
           extra_tags = extra_tags_for_form(html_options)
-          html = tag(:form, html_options, true) + extra_tags
-          prevent_content_exfiltration(html)
+          html = content_tag(:form, extra_tags, html_options).then { |html| html.delete_suffix!("</form>") }
+          prevent_content_exfiltration(html.html_safe)
         end
 
         def form_tag_with_body(html_options, content)

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -442,9 +442,9 @@ module ActionView
       #   <button <%= tag.attributes id: "call-to-action", disabled: false, aria: { expanded: false } %> class="primary">Get Started!</button>
       #   # => <button id="call-to-action" aria-expanded="false" class="primary">Get Started!</button>
       #
-      # === Legacy syntax
+      # === Deprecated: Legacy syntax
       #
-      # The following format is for legacy syntax support. It will be deprecated in future versions of \Rails.
+      # The following format is for legacy syntax support. It is deprecated, and will be removed in future versions of \Rails.
       #
       #   tag(name, options = nil, open = false, escape = true)
       #

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -28,7 +28,7 @@ module ActionView
           end
 
           include_hidden = options.delete("include_hidden") { true }
-          checkbox = tag("input", options)
+          checkbox = tag.input(**options)
 
           if include_hidden
             hidden = hidden_field_for_checkbox(options)
@@ -57,7 +57,7 @@ module ActionView
           end
 
           def hidden_field_for_checkbox(options)
-            @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value, "autocomplete" => "off")) : "".html_safe
+            @unchecked_value ? tag.input(**options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value, "autocomplete" => "off")) : "".html_safe
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -18,7 +18,7 @@ module ActionView
 
         private
           def hidden_field_for_multiple_file(options)
-            tag("input", "name" => options["name"], "type" => "hidden", "value" => "", "autocomplete" => "off")
+            tag.input(name: options["name"], type: "hidden", value: "", autocomplete: "off")
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -19,7 +19,7 @@ module ActionView
           options["value"]    = @tag_value
           options["checked"] = "checked" if input_checked?(options)
           add_default_name_and_id_for_value(@tag_value, options)
-          tag("input", options)
+          tag.input(**options)
         end
 
         private

--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -22,7 +22,7 @@ module ActionView
             select = content_tag("select", add_options(option_tags, options, value), html_options)
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)
-              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
+              tag.input(disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
             else
               select
             end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -14,7 +14,7 @@ module ActionView
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
           add_default_name_and_id(options)
-          tag("input", options)
+          tag.input(**options)
         end
 
         class << self

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -335,14 +335,14 @@ module ActionView
           content_tag("button", name || url, html_options, &block)
         else
           html_options["value"] = name || url
-          tag("input", html_options)
+          tag.input(**html_options)
         end
 
         inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
         if params
           to_form_params(params).each do |param|
-            inner_tags.safe_concat tag(:input, type: "hidden", name: param[:name], value: param[:value],
-                                       autocomplete: "off")
+            inner_tags.safe_concat tag.input(type: "hidden", name: param[:name], value: param[:value],
+                                      autocomplete: "off")
           end
         end
         html = content_tag("form", inner_tags, form_options)
@@ -751,14 +751,14 @@ module ActionView
               else
                 token
               end
-            tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
+            tag.input(type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
           else
             ""
           end
         end
 
         def method_tag(method)
-          tag("input", type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
+          tag.input(type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
         end
 
         # Returns an array of hashes each containing :name and :value keys

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -301,12 +301,12 @@ class AssetTagHelperTest < ActionView::TestCase
     %(picture_tag("mouse.png", :image => { :alt => nil })) => %(<picture><img src="/images/mouse.png" /></picture>),
     %(picture_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :image => { :alt => nil })) => %(<picture><img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /></picture>),
     %(picture_tag("")) => %(<picture><img src="" /></picture>),
-    %(picture_tag("picture.webp", "picture.png")) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img src="/images/picture.png" /></picture>),
-    %(picture_tag("picture.webp", "picture.png", :class => "my-class")) => %(<picture class="my-class"><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img src="/images/picture.png" /></picture>),
-    %(picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img alt="Image" src="/images/picture.png" /></picture>),
-    %(picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp", "picture.png")) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp", "picture.png", :class => "my-class")) => %(<picture class="my-class"><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img alt="Image" src="/images/picture.png" /></picture>),
     %(picture_tag(:class => "my-class") { tag(:source, :srcset => image_path("picture.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture class="my-class"><source srcset="/images/picture.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
-    %(picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)" /><source srcset="/images/picture-big.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") } ) => %(<picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)" /><source srcset="/images/picture-big.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
   }
 
   FaviconLinkToTag = {
@@ -381,9 +381,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi"></video>),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov"></video>),
     %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov"></video>),
-    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
+    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>)
   }
 
   AudioPathToTag = {
@@ -419,9 +419,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav"></audio>),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
-    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>)
   }
 
   FontPathToTag = {
@@ -876,11 +876,11 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_image_tag_interpreting_email_cid_correctly
     # An inline image has no need for an alt tag to be automatically generated from the cid:
-    assert_equal '<img src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid")
+    assert_equal '<img src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid")
   end
 
   def test_image_tag_interpreting_email_adding_optional_alt_tag
-    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
+    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
   end
 
   def test_should_not_modify_source_string

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -14,11 +14,11 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   end
 
   def test_csp_meta_tag
-    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag
   end
 
   def test_csp_meta_tag_with_options
-    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag(property: "csp-nonce")
   end
 end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -660,7 +660,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_boolean_options
     assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), check_box_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
     assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), check_box_tag("admin", 1, true, disabled: false, readonly: nil)
-    assert_dom_equal %(<input type="checkbox" />), tag(:input, type: "checkbox", checked: false)
+    assert_dom_equal %(<input type="checkbox" />), tag.input(type: "checkbox", checked: false)
     assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people" name="people"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: nil)
@@ -743,14 +743,14 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_submit_tag_doesnt_have_data_disable_with_twice
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing...">),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice_with_hash
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing...">),
       submit_tag("Save", data: { disable_with: "Processing..." })
     )
   end
@@ -895,12 +895,12 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_number_field_tag
-    expected = %{<input name="quantity" max="9" id="quantity" type="number" min="1" />}
+    expected = %{<input name="quantity" max="9" id="quantity" type="number" min="1">}
     assert_dom_equal(expected, number_field_tag("quantity", nil, in: 1...10))
   end
 
   def test_range_input_tag
-    expected = %{<input name="volume" step="0.1" max="11" id="volume" type="range" min="0" />}
+    expected = %{<input name="volume" step="0.1" max="11" id="volume" type="range" min="0">}
     assert_dom_equal(expected, range_field_tag("volume", nil, in: 0..11, step: 0.1))
   end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -163,28 +163,28 @@ class TagHelperTest < ActionView::TestCase
   def test_tag_with_dangerous_aria_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
     assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
+                tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
     assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+                tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
   def test_tag_builder_with_dangerous_aria_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
     assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\"></the-name>",
-                 tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
+                tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
     assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\"></the-name>",
-                 tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
+                tag.public_send(:"the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" }, escape: false)
   end
 
   def test_tag_with_dangerous_data_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
     assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
+                tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
     assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+                tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
   def test_tag_builder_with_dangerous_data_attribute_name
@@ -199,10 +199,10 @@ class TagHelperTest < ActionView::TestCase
   def test_tag_with_dangerous_unknown_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
     assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
-                 tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
+                tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
 
     assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
-                 tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
+                tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
   end
 
   def test_tag_builder_with_dangerous_unknown_attribute_name

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -77,12 +77,12 @@ module ApplicationTests
         javascript_path:        %r{/javascripts/#{contents}},
         stylesheet_path:        %r{/stylesheets/#{contents}},
         image_tag:              %r{<img src="/images/#{contents}"},
-        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}" />},
-        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css" />},
+        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}">},
+        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css">},
         javascript_include_tag: %r{<script src="/javascripts/#{contents}.js">},
         audio_tag:              %r{<audio src="/audios/#{contents}"></audio>},
         video_tag:              %r{<video src="/videos/#{contents}"></video>},
-        image_submit_tag:       %r{<input type="image" src="/images/#{contents}" />}
+        image_submit_tag:       %r{<input type="image" src="/images/#{contents}">}
       }
 
       class ::PostsController < ActionController::Base

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3294,7 +3294,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["Link"]
     end
 
@@ -3320,7 +3320,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_nil last_response.headers["Link"]
     end
 

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -284,7 +284,7 @@ module ApplicationTests
 
       # test that the Active Storage direct upload URL is added to a file field that explicitly requires it within en engine's view code
       get "/someone/blog/file_field_with_direct_upload_path"
-      assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\" />", last_response.body
+      assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\">", last_response.body
     end
 
     test "route path for controller action when engine is mounted at root" do


### PR DESCRIPTION
### Motivation / Background
    
    
Follow-up to [#49371][]
    
In the wake of the deprecation of `tag(:div)` in favor of `tag.div`, this commit replaces all calls made internally with the more modern syntax.

This change is separate from the deprecation cycle, since there are **slight** behavioral changes, since the HTML output changes from self-closing elements like `<input />` to open void elements like `<input>`.

[#49371]: https://github.com/rails/rails/pull/49371

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
