### PR TITLE
Delay Adapter#check_version to #configure_connection

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -23,7 +23,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     ActiveRecord::Base.establish_connection database_config
 
     begin
-      ActiveRecord::Base.connection
+      ActiveRecord::Base.connection.connect!
     rescue
       @rx_adapter = @tx_adapter = nil
       skip "Couldn't connect to PostgreSQL: #{database_config.inspect}"

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -243,7 +243,7 @@ module ActiveRecord
 
       # Returns true if a connection has already been opened.
       def connected?
-        synchronize { @connections.any? }
+        synchronize { @connections.any?(&:connected?) }
       end
 
       # Returns an array containing the connections currently in the pool.
@@ -682,7 +682,6 @@ module ActiveRecord
         def new_connection
           connection = Base.public_send(db_config.adapter_method, db_config.configuration_hash)
           connection.pool = self
-          connection.check_version
           connection
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(self)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -668,6 +668,13 @@ module ActiveRecord
 
       # CONNECTION MANAGEMENT ====================================
 
+      # Checks whether the connection to the database was established. This doesn't
+      # include checking whether the database is actually capable of responding, i.e.
+      # whether the connection is stale.
+      def connected?
+        !@raw_connection.nil?
+      end
+
       # Checks whether the connection to the database is still active. This includes
       # checking whether the database is actually capable of responding, i.e. whether
       # the connection isn't stale.
@@ -1215,6 +1222,7 @@ module ActiveRecord
         # Implementations may assume this method will only be called while
         # holding @lock (or from #initialize).
         def configure_connection
+          check_version
         end
 
         def default_prepared_statements

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -870,6 +870,7 @@ module ActiveRecord
         end
 
         def configure_connection
+          super
           variables = @config.fetch(:variables, {}).stringify_keys
 
           # Increase timeout so the server doesn't disconnect us.

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -130,6 +130,10 @@ module ActiveRecord
       # CONNECTION MANAGEMENT ====================================
       #++
 
+      def connected?
+        !(@raw_connection.nil? || @raw_connection.closed?)
+      end
+
       def active?
         !!@raw_connection&.ping
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -196,9 +196,11 @@ module ActiveRecord
         !@memory_database
       end
 
-      def active?
-        @raw_connection && !@raw_connection.closed?
+      def connected?
+        !(@raw_connection.nil? || @raw_connection.closed?)
       end
+
+      alias_method :active?, :connected?
 
       def return_value_after_insert?(column) # :nodoc:
         column.auto_populated?
@@ -722,6 +724,8 @@ module ActiveRecord
               count <= retries
             end
           end
+
+          super
 
           # Enforce foreign key constraints
           # https://www.sqlite.org/pragma.html#pragma_foreign_keys

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -131,6 +131,10 @@ module ActiveRecord
         end
       end
 
+      def connected?
+        !(@raw_connection.nil? || @raw_connection.closed?)
+      end
+
       def active?
         connection&.ping || false
       rescue ::Trilogy::Error

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -70,6 +70,7 @@ module ActiveRecord
 
         def establish_connection(config = db_config)
           ActiveRecord::Base.establish_connection(config)
+          connection.connect!
         end
 
         def run_cmd(cmd, args, out)

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -158,6 +158,7 @@ module ActiveRecord
           if connection_name
             begin
               connection = ActiveRecord::Base.connection_handler.retrieve_connection(connection_name, shard: shard)
+              connection.connect! # eagerly validate the connection
             rescue ConnectionNotEstablished
               connection = nil
             end

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -12,7 +12,7 @@ class ActiveRecordTest < ActiveRecord::TestCase
       ActiveRecord.disconnect_all!
       assert_not_predicate ActiveRecord::Base, :connected?
 
-      ActiveRecord::Base.connection.active?
+      ActiveRecord::Base.connection.connect!
       assert_predicate ActiveRecord::Base, :connected?
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -469,6 +469,7 @@ module ActiveRecord
       def test_only_reload_type_map_once_for_every_unrecognized_type
         reset_connection
         connection = ActiveRecord::Base.connection
+        connection.select_all "SELECT 1" # eagerly initialize the connection
 
         silence_warnings do
           assert_queries 2, ignore_none: true do

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -244,11 +244,10 @@ module ActiveRecord
           sql = "INSERT INTO ex (number) VALUES (10)"
           name = "foo"
 
-          sqlite_version_query = ["SELECT sqlite_version(*)", "SCHEMA", []]
           pragma_query = ["PRAGMA table_info(\"ex\")", "SCHEMA", []]
           schema_query = ["SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type = 'table' AND name = 'ex'", "SCHEMA", []]
           modified_insert_query = [(sql + ' RETURNING "id"'), name, []]
-          assert_logged [sqlite_version_query, pragma_query, schema_query, modified_insert_query] do
+          assert_logged [pragma_query, schema_query, modified_insert_query] do
             @conn.insert(sql, name)
           end
         end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -85,7 +85,7 @@ module ActiveRecord
           @handler.establish_connection(:primary, shard: :pool_config_two)
 
           # connect to default
-          @handler.connection_pool_list(:writing).first.checkout
+          @handler.connection_pool_list(:writing).first.checkout.connect!
 
           assert @handler.connected?("primary")
           assert @handler.connected?("primary", shard: :default)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1047,6 +1047,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def transaction_open?; end
       def begin_transaction(*args); end
       def rollback_transaction(*args); end
+      def connect!; end
     end.new
 
     connection.pool = Class.new do
@@ -1068,6 +1069,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def rollback_transaction(*args)
         @rollback_transaction_called = true
       end
+      def connect!; end
     end.new
 
     connection.pool = Class.new do
@@ -1087,6 +1089,7 @@ class TransactionalFixturesOnConnectionNotification < ActiveRecord::TestCase
       def transaction_open?; end
       def begin_transaction(*args); end
       def rollback_transaction(*args); end
+      def connect!; end
     end.new
 
     connection.pool = Class.new do

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -11,7 +11,7 @@ class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
     def setup
       # Can't just use current adapter; sqlite3 will create a database
       # file on the fly.
-      Bird.establish_connection adapter: "mysql2", database: "i_do_not_exist"
+      Bird.establish_connection adapter: ARTest.connection_name, database: "i_do_not_exist", host: "127.0.0.1", port: 12, username: "invalid"
     end
 
     teardown do

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -273,7 +273,7 @@ module ApplicationTests
         end
 
         assert_raises ActiveRecord::ConnectionNotEstablished do
-          ActiveRecord::Base.connection.schema_reflection.columns("posts")
+          ActiveRecord::Base.connection.schema_cache.columns("posts")
         end
       end
     end


### PR DESCRIPTION
Ideally we should be able to checkout an Adapter instance without triggering a connection to the server.

For some adapters like Trilogy that is the case today, but only if you have a schema cache loaded, otherwise `check_version` will trigger a query.

I think this check can be delayed to when we actually use the connection.
