### PR TITLE
Actually upload the files when passed as File or Pathname

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -30,6 +30,18 @@ module ActiveStorage
         )
       when Hash
         blob.upload_without_unfurling(attachable.fetch(:io))
+      when File
+        blob.upload_without_unfurling(attachable)
+      when Pathname
+        blob.upload_without_unfurling(attachable.open)
+      when ActiveStorage::Blob
+      when String
+      else
+        raise(
+          ArgumentError,
+          "Could not upload: expected attachable, " \
+            "got #{attachable.inspect}"
+        )
       end
     end
 
@@ -97,7 +109,11 @@ module ActiveStorage
             service_name: attachment_service_name
           )
         else
-          raise ArgumentError, "Could not find or build blob: expected attachable, got #{attachable.inspect}"
+          raise(
+            ArgumentError,
+            "Could not find or build blob: expected attachable, " \
+              "got #{attachable.inspect}"
+          )
         end
       end
 

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -24,12 +24,22 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_not_nil @user.avatar_blob
   end
 
+  test "uploads the file when passing a File as attachable attribute" do
+    @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif").open)
+    assert_nothing_raised { @user.avatar.download }
+  end
+
   test "creating a record with a Pathname as attachable attribute" do
     @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif"))
 
     assert_equal "image.gif", @user.avatar.filename.to_s
     assert_not_nil @user.avatar_attachment
     assert_not_nil @user.avatar_blob
+  end
+
+  test "uploads the file when passing a Pathname as attachable attribute" do
+    @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif"))
+    assert_nothing_raised { @user.avatar.download }
   end
 
   test "attaching an existing blob to an existing record" do


### PR DESCRIPTION
This is a follow-up to https://github.com/rails/rails/pull/45606

We were storing the file metadata in Blob and Attachment but we were not actually uploading the files (into the file system for instance for disk storage).

It was failing silently so I made it explicit what is accepted and what is unexpected

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @p8 @seanpdoyle @byroot @tenderlove @chaadow 