### PR TITLE
[skip ci] Add 7.1 release notes for SQLite3 adapter improvements

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -616,6 +616,11 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Add `#regroup` query method as a short-hand for `.unscope(:group).group(fields)`.
 
+*   Add support for generated columns, deferred foreign keys, auto-populated columns,
+    and custom primary keys to the `SQLite3` adapter.
+
+*   Add modern, performant defaults for `SQLite3` database connections.
+
 Active Storage
 --------------
 


### PR DESCRIPTION
### Motivation / Background

I have been pushing to get the `SQLite3` adapter in a stronger place in advance of the 7.1 release. All in all, I have opened 3 pull requests to bring larger, existing ActiveRecord features to the `SQLite3Adapter`:

* [support auto-populating columns and custom primary keys](https://github.com/rails/rails/pull/49290)
* [support generated columns](https://github.com/rails/rails/pull/49346)
* [support deferred foreign keys](https://github.com/rails/rails/pull/49376)

In addition, I have also opened 3 additional pull requests to add some new, `SQLite`-specific features:

* [support `||` concatenation in default functions](https://github.com/rails/rails/pull/49287)
* [performance tune default connection configurations](https://github.com/rails/rails/pull/49349)
* [add `retries` option as alternative to `timeout`](https://github.com/rails/rails/pull/49352)

As of today (26-09-2023), 4 are merged (https://github.com/rails/rails/pull/49290, https://github.com/rails/rails/pull/49287, https://github.com/rails/rails/pull/49349, https://github.com/rails/rails/pull/49352) and 2 are still open (https://github.com/rails/rails/pull/49346, https://github.com/rails/rails/pull/49376)

I am presuming, however, the the last open 2 will be merged shortly (reviews are done and good to go).

### Detail

This Pull Request adds a summary of the notable changes to the SQLite3 adapter to the release notes

