### PR TITLE
Postgres: use ANY instead of IN for array inclusion queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,20 @@
+*   Postgres: use ANY instead of IN for array inclusion queries
+
+    Previously, queries like `where(id: [1, 2])` generated the SQL `id IN (1, 2)`.
+    Now `id = ANY ('{1,2}')` is generated instead, and `where.not` generates `id != ALL ('{1,2}')`.
+
+    This brings several advantages:
+
+    * the query can now be a prepared statement
+    * query parsing is faster
+    * duplicate entries in `pg_stat_statements` can be avoided
+    * queries are less likely to be truncated in `pg_stat_activity`
+
+    *Sean Linsley*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*
+
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       # Cast a +value+ to a type that the database understands. For example,
       # SQLite does not understand dates, so this method will convert a Date
       # to a String.
-      def type_cast(value)
+      def type_cast(value, **kwargs)
         case value
         when Symbol, ActiveSupport::Multibyte::Chars, Type::Binary::Data
           value.to_s

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -7,7 +7,11 @@ module ActiveRecord
         class Array < Type::Value # :nodoc:
           include ActiveModel::Type::Helpers::Mutable
 
-          Data = Struct.new(:encoder, :values) # :nodoc:
+          Data = Struct.new(:encoder, :values) do # :nodoc:
+            def hash
+              [encoder.name, encoder.delimiter, values].hash
+            end
+          end
 
           attr_reader :subtype, :delimiter
           delegate :type, :user_input_in_time_zone, :limit, :precision, :scale, to: :subtype

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -28,7 +28,6 @@ module ActiveRecord
         ActiveRecord::Relation.prepend(RelationQueries)
         ActiveRecord::Base.include(CoreQueries)
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
-        Arel::Nodes::HomogeneousIn.prepend(InWithAdditionalValues)
       end
 
       # When modifying this file run performance tests in
@@ -150,20 +149,6 @@ module ActiveRecord
             data.value
           else
             super
-          end
-        end
-      end
-
-      module InWithAdditionalValues
-        def proc_for_binds
-          -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, encryption_aware_type_caster) }
-        end
-
-        def encryption_aware_type_caster
-          if attribute.type_caster.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
-            attribute.type_caster.cast_type
-          else
-            attribute.type_caster
           end
         end
       end

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -48,7 +48,7 @@ module Arel # :nodoc: all
       end
 
       def proc_for_binds
-        -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, attribute.type_caster) }
+        -> value { ActiveModel::Attribute.from_database(attribute.name, value, ActiveModel::Type.default_value) }
       end
 
       def fetch_attribute(&block)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1700,7 +1700,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
     c = Sharded::BlogPost.connection
     quoted_blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
     quoted_blog_post_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_post_id"))
-    assert_match(/WHERE #{quoted_blog_id} IN \(.+\) AND #{quoted_blog_post_id} IN \(.+\)/, sql)
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_match(/WHERE #{quoted_blog_id} = ANY \(\$1\) AND #{quoted_blog_post_id} = ANY \(\$2\)/, sql)
+    else
+      assert_match(/WHERE #{quoted_blog_id} IN \(.+\) AND #{quoted_blog_post_id} IN \(.+\)/, sql)
+    end
   end
 
   test "preloading has_many association associated by a composite query_constraints" do

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -524,7 +524,8 @@ class EachTest < ActiveRecord::TestCase
   def test_in_batches_executes_in_queries_when_unconstrained_and_opted_out_of_ranges
     c = Post.connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
-    assert_sql(/#{quoted_posts_id} IN \(.+\)/i) do
+    regex = current_adapter?(:PostgreSQLAdapter) ? /#{quoted_posts_id} = ANY \(\$1\)/i : /#{quoted_posts_id} IN \(.+\)/i
+    assert_sql(regex) do
       Post.in_batches(of: 2, use_ranges: false) { |relation| assert_kind_of Post, relation.first }
     end
   end
@@ -532,7 +533,8 @@ class EachTest < ActiveRecord::TestCase
   def test_in_batches_executes_in_queries_when_constrained
     c = Post.connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
-    assert_sql(/#{quoted_posts_id} IN \(.+\)/i) do
+    regex = current_adapter?(:PostgreSQLAdapter) ? /#{quoted_posts_id} = ANY \(\$1\)/i : /#{quoted_posts_id} IN \(.+\)/i
+    assert_sql(regex) do
       Post.where("id < ?", 5).in_batches(of: 2) { |relation| assert_kind_of Post, relation.first }
     end
   end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -94,7 +94,11 @@ if ActiveRecord::Base.connection.prepared_statements
 
         topics = Topic.where(id: [1, 3]).order(:id)
         assert_equal [1, 3], topics.map(&:id)
-        assert_not_includes statement_cache, to_sql_key(topics.arel)
+        if current_adapter?(:PostgreSQLAdapter)
+          assert_includes statement_cache, to_sql_key(topics.arel)
+        else
+          assert_not_includes statement_cache, to_sql_key(topics.arel)
+        end
       end
 
       def test_statement_cache_with_sql_string_literal
@@ -162,12 +166,12 @@ if ActiveRecord::Base.connection.prepared_statements
       end
 
       def test_bind_params_to_sql_with_prepared_statements
-        assert_bind_params_to_sql
+        assert_bind_params_to_sql(true)
       end
 
       def test_bind_params_to_sql_with_unprepared_statements
         @connection.unprepared_statement do
-          assert_bind_params_to_sql
+          assert_bind_params_to_sql(false)
         end
       end
 
@@ -198,58 +202,38 @@ if ActiveRecord::Base.connection.prepared_statements
       end
 
       private
-        def assert_bind_params_to_sql
+        def assert_bind_params_to_sql(prepared)
           table = Author.quoted_table_name
           pk = "#{table}.#{Author.quoted_primary_key}"
 
-          # prepared_statements: true
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE (`authors`.`id` IN (?, ?, ?) OR `authors`.`id` IS NULL)
-          #
-          # prepared_statements: false
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE (`authors`.`id` IN (1, 2, 3) OR `authors`.`id` IS NULL)
-          #
-          sql = "SELECT #{table}.* FROM #{table} WHERE (#{pk} IN (#{bind_params(1..3)}) OR #{pk} IS NULL)"
+          condition = if current_adapter?(:PostgreSQLAdapter)
+            prepared ? "= ANY ($1)" : "= ANY ('{1,2,3}')"
+          else
+            prepared ? "IN (?, ?, ?)" : "IN (1, 2, 3)"
+          end
+
+          sql = "SELECT #{table}.* FROM #{table} WHERE (#{pk} #{condition} OR #{pk} IS NULL)"
 
           authors = Author.where(id: [1, 2, 3, nil])
           assert_equal sql, @connection.to_sql(authors.arel)
           assert_sql(sql) { assert_equal 3, authors.length }
 
-          # prepared_statements: true
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (?, ?, ?)
-          #
-          # prepared_statements: false
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (1, 2, 3)
-          #
-          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})"
+          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} #{condition}"
 
           authors = Author.where(id: [1, 2, 3, 9223372036854775808])
           assert_equal sql, @connection.to_sql(authors.arel)
           assert_sql(sql) { assert_equal 3, authors.length }
 
-          # prepared_statements: true
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (?, ?, ?)
-          #
-          # prepared_statements: false
-          #
-          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (1, 2, 3)
-          #
-          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})"
+          condition = if current_adapter?(:PostgreSQLAdapter)
+            prepared ? "IN ($1, $2, $3)" : "IN (1, 2, 3)"
+          else
+            prepared ? "IN (?, ?, ?)" : "IN (1, 2, 3)"
+          end
+          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} #{condition}"
 
           arel_node = Arel.sql("SELECT #{table}.* FROM #{table} WHERE #{pk} IN (?)", [1, 2, 3])
           assert_equal sql, @connection.to_sql(arel_node)
           assert_sql(sql) { assert_equal 3, @connection.select_all(arel_node).length }
-        end
-
-        def bind_params(ids)
-          collector = @connection.send(:collector)
-          bind_params = ids.map { |i| Arel::Nodes::BindParam.new(i) }
-          sql, _ = @connection.visitor.compile(bind_params, collector)
-          sql
         end
 
         def to_sql_key(arel)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -397,6 +397,8 @@ module ActiveRecord
 
     def test_where_with_emoji_for_binary_column
       Binary.create!(data: "🥦")
+      count = Binary.where(data: ["🥦", "🍦"]).count
+      assert_equal 1, count
       assert Binary.where(data: ["🥦", "🍦"]).to_sql.include?("f09fa5a6")
       assert Binary.where(data: ["🥦", "🍦"]).to_sql.include?("f09f8da6")
     end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -38,7 +38,11 @@ ActiveRecord::Schema.define do
     t.string :json_data_empty, null: true, default: "", limit: 1024
     t.text :params
     t.references :account
-    t.json :json_options
+    if ActiveRecord::TestCase.current_adapter?(:PostgreSQLAdapter)
+      t.jsonb :json_options
+    else
+      t.json :json_options
+    end
   end
 
   create_table :admin_user_jsons, force: true do |t|


### PR DESCRIPTION
### Motivation

`ANY` has several advantages over `IN`:
- using a single bind param allows the use of prepared statements
- query parsing is faster
- `pg_stat_statements` churn can be avoided
- queries are less likely to be truncated in `pg_stat_activity` (when using prepared statements)

### Detail

Currently, array inclusion queries like `where(id: [1,2])` generate the SQL `id IN (1, 2)`. This PR replaces that with `id = ANY ('{1,2}')`, or `id = ANY ($1)` when prepared statements are enabled.

`NOT IN` is implemented using `!= ALL` https://stackoverflow.com/a/11730845

See also the forum post: https://discuss.rubyonrails.org/t/83667

### Additional information

This is measurably faster on Postgres 15.4. Here are the min and max iterations per second from several benchmark runs:

- 490 - 600 on the main branch
- 750 - 950 on this branch with `BENCHMARK_PREPARED=1`
- 780 - 1020 on this branch with `BENCHMARK_PREPARED=0`

<details><summary>Here's the benchmark:</summary>

```rb
# Adapted from activerecord/examples/performance.rb

require "active_record"
require "benchmark/ips"

TIME    = (ENV["BENCHMARK_TIME"] || 20).to_i
RECORDS = (ENV["BENCHMARK_RECORDS"] || TIME * 1000).to_i

conn = {
  adapter: "postgresql",
  database: "postgres",
  prepared_statements: ENV["BENCHMARK_PREPARED"] == "1"
}

ActiveRecord::Base.establish_connection(conn)

class User < ActiveRecord::Base
  connection.create_table :users, force: true do |t|
    t.string :name, :email
    t.timestamps
  end
end

def progress_bar(int); print "." if (int % 100).zero? ; end

puts "Generating data..."

module ActiveRecord
  class Faker
    LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse non aliquet diam. Curabitur vel urna metus, quis malesuada elit.
     Integer consequat tincidunt felis. Etiam non erat dolor. Vivamus imperdiet nibh sit amet diam eleifend id posuere diam malesuada. Mauris at accumsan sem.
     Donec id lorem neque. Fusce erat lorem, ornare eu congue vitae, malesuada quis neque. Maecenas vel urna a velit pretium fermentum. Donec tortor enim,
     tempor venenatis egestas a, tempor sed ipsum. Ut arcu justo, faucibus non imperdiet ac, interdum at diam. Pellentesque ipsum enim, venenatis ut iaculis vitae,
     varius vitae sem. Sed rutrum quam ac elit euismod bibendum. Donec ultricies ultricies magna, at lacinia libero mollis aliquam. Sed ac arcu in tortor elementum
     tincidunt vel interdum sem. Curabitur eget erat arcu. Praesent eget eros leo. Nam magna enim, sollicitudin vehicula scelerisque in, vulputate ut libero.
     Praesent varius tincidunt commodo".split

    def self.name
      LOREM.grep(/^\w*$/).sort_by { rand }.first(2).join " "
    end

    def self.email
      LOREM.grep(/^\w*$/).sort_by { rand }.first(2).join("@") + ".com"
    end
  end
end

begin
  puts "Inserting #{RECORDS} users..."
  RECORDS.times do |record|
    user = User.create(
      created_at: Date.today,
      name: ActiveRecord::Faker.name,
      email: ActiveRecord::Faker.email
    )
    progress_bar(record)
  end
  puts "Done!\n"

  Benchmark.ips(TIME) do |x|
    x.report "Model.where(id: [...])" do
      User.where(id: (1..100).to_a).count
    end
  end
ensure
  User.connection.drop_table :users
end
```

</details>