### PR TITLE
Ensure transaction tracking finishes when reconnecting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -82,8 +82,11 @@ module ActiveRecord
         @base_payload = payload
       end
 
+      class InstrumentationNotStartedError < ActiveRecordError; end
+      class InstrumentationAlreadyStartedError < ActiveRecordError; end
+
       def start
-        return if @started
+        raise InstrumentationAlreadyStartedError.new("Called start on an already started transaction") if @started
         @started = true
 
         @payload = @base_payload.dup
@@ -92,7 +95,7 @@ module ActiveRecord
       end
 
       def finish(outcome)
-        return unless @started
+        raise InstrumentationNotStartedError.new("Called finish on a transaction that hasn't started") unless @started
         @started = false
 
         @payload[:outcome] = outcome
@@ -166,7 +169,7 @@ module ActiveRecord
       end
 
       def incomplete!
-        @instrumenter.finish(:incomplete)
+        @instrumenter.finish(:incomplete) if materialized?
       end
 
       def materialize!
@@ -180,6 +183,7 @@ module ActiveRecord
 
       def restore!
         if materialized?
+          incomplete!
           @materialized = false
           materialize!
         end
@@ -348,13 +352,13 @@ module ActiveRecord
           connection.rollback_to_savepoint(savepoint_name) if materialized?
         end
         @state.rollback!
-        @instrumenter.finish(:rollback)
+        @instrumenter.finish(:rollback) if materialized?
       end
 
       def commit
         connection.release_savepoint(savepoint_name) if materialized?
         @state.commit!
-        @instrumenter.finish(:commit)
+        @instrumenter.finish(:commit) if materialized?
       end
 
       def full_rollback?; false; end
@@ -389,13 +393,13 @@ module ActiveRecord
       def rollback
         connection.rollback_db_transaction if materialized?
         @state.full_rollback!
-        @instrumenter.finish(:rollback)
+        @instrumenter.finish(:rollback) if materialized?
       end
 
       def commit
         connection.commit_db_transaction if materialized?
         @state.full_commit!
-        @instrumenter.finish(:commit)
+        @instrumenter.finish(:commit) if materialized?
       end
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We noticed a couple of spots where transaction tracking events were potentially incorrect.

- When the connection reconnects with `restore_transactions: true`, we were keeping the original start time for the transaction. In this case, it makes more sense to treat these as two separate transactions for tracking purposes.
- If you manually call `reconnect!` within a transaction opened via `being_transaction` rather than `transaction do`, we were never marking the event as finished and thus never broadcasting the event. This isn't public API and likely isn't very common, but we did run into one scenario in a test file that was doing this in a setup block. 

### Detail

We added a line to the `reset_transactions` method to mark any open transactions as finished. We went back and forth on the naming for this new method, but eventually settled on `suspend_transactions` since the transactions may potentially be restarted.

### Additional information
This is a followup to #49192  and #49262

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
