### PR TITLE
Remove unneeded stub from adapter test

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -533,11 +533,7 @@ module ActiveRecord
       test "materialized transaction state can be restored after a reconnect" do
         @connection.begin_transaction
         assert_predicate @connection, :transaction_open?
-        # +materialize_transactions+ currently automatically dirties the
-        # connection, which would make it unrestorable
-        @connection.transaction_manager.stub(:dirty_current_transaction, nil) do
-          @connection.materialize_transactions
-        end
+        @connection.materialize_transactions
         assert raw_transaction_open?(@connection)
         @connection.reconnect!(restore_transactions: true)
         assert_predicate @connection, :transaction_open?
@@ -627,12 +623,7 @@ module ActiveRecord
       test "active transaction is restored after remote disconnection" do
         assert_operator Post.count, :>, 0
         Post.transaction do
-          # +materialize_transactions+ currently automatically dirties the
-          # connection, which would make it unrestorable
-          @connection.transaction_manager.stub(:dirty_current_transaction, nil) do
-            @connection.materialize_transactions
-          end
-
+          @connection.materialize_transactions
           remote_disconnect @connection
 
           # Regular queries are not retryable, so the only abstract operation we can


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

We were reviewing this test while doing some work around transaction tracking and noticed that the comment here seemed to no longer be the case. `materialize_transactions` doesn't actually dirty the transaction anymore, so it shouldn't be required to stub this out. Indeed, the tests continue to pass without this method stub.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
