### PR TITLE
fix typo in new_framework_defaults_7_1.rb.tt

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -11,7 +11,7 @@
 
 # No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
 # to manually require files that are managed by the autoloader, which you shouldn't do anyway.
-# This reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
+# This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
 # of the bootsnap cache if you use it.
 # Rails.application.config.add_autoload_paths_to_load_path = false
 


### PR DESCRIPTION
This Pull Request has been created because there is a typo in new_framework_defaults_7_1.rb.tt.

This Pull Request changes some minor wording in new_framework_defaults_7_1.rb.tt


