### PR TITLE
Remove deprecated name argument from remove_connection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,7 @@
+*   Remove deprecated `name` argument on `#remove_connection`.
 
+    The `name` argument has been deprecated on `#remove_connection` since Rails 7.1.
+    This argument has been removed.
+
+    *Akhil G Krishnan*
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -292,16 +292,8 @@ module ActiveRecord
       connection_handler.connected?(connection_specification_name, role: current_role, shard: current_shard)
     end
 
-    def remove_connection(name = nil)
-      if name
-        ActiveRecord.deprecator.warn(<<-MSG.squish)
-          The name argument for `#remove_connection` is deprecated without replacement
-          and will be removed in Rails 7.2. `#remove_connection` should always be called
-          on the connection class directly, which makes the name argument obsolete.
-        MSG
-      end
-
-      name ||= @connection_specification_name if defined?(@connection_specification_name)
+    def remove_connection
+      name = @connection_specification_name if defined?(@connection_specification_name)
       # if removing a connection that has a pool, we reset the
       # connection_specification_name so it will use the parent
       # pool.

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -279,22 +279,6 @@ module ActiveRecord
         assert_same klass2.connection, ActiveRecord::Base.connection
       end
 
-      def test_remove_connection_with_name_argument_is_deprecated
-        klass2 = Class.new(Base) { def self.name; "klass2"; end }
-
-        assert_same klass2.connection, ActiveRecord::Base.connection
-
-        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.db_config.configuration_hash)
-        assert_same klass2.connection, pool.connection
-        assert_not_same klass2.connection, ActiveRecord::Base.connection
-
-        assert_deprecated(ActiveRecord.deprecator) do
-          ActiveRecord::Base.remove_connection("klass2")
-        end
-      ensure
-        ActiveRecord::Base.establish_connection :arunit
-      end
-
       class ApplicationRecord < ActiveRecord::Base
         self.abstract_class = true
       end


### PR DESCRIPTION


### Motivation / Background

In #48681 The `name` argument has been deprecated on `#remove_connection` without any replacement.

### Detail

In this PR removes the deprecated `name` argument from `#remove_connection`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @eileencodes 
