### PR TITLE
[ci-skip][docs]Fix typo on action_cable_overview.md

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -780,7 +780,7 @@ The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parame
 ```yaml
 production:
   adapter: redis
-  url: rediss://10.10.3.153:tls_port
+  url: redis://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params: {
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
Just a small fix:

```diff
- url: rediss://10.10.3.153:tls_port
+ url: redis://10.10.3.153:tls_port
```

ref: https://github.com/yasslab/railsguides.jp/pull/1507