### PR TITLE
Fix the problem of database connections leaking between tests

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -404,7 +404,6 @@ module ActiveRecord
 
         thread.join
       ensure
-        remove_connections(SecondaryBase, roles: [:writing], shards: [:default, :one])
         tf_shard_one.close
         tf_shard_one.unlink
         tf_default.close
@@ -455,7 +454,6 @@ module ActiveRecord
 
         thread.join
       ensure
-        remove_connections(SecondaryBase, roles: [:writing, :secondary], shards: [:default, :one])
         tf_shard_one.close
         tf_shard_one.unlink
         tf_default.close
@@ -530,8 +528,6 @@ module ActiveRecord
 
         thread.join
       ensure
-        remove_connections(SecondaryBase, roles: [:writing, :secondary], shards: [:default, :one])
-        remove_connections(SomeOtherBase, roles: [:writing, :secondary], shards: [:default, :one])
         tf_shard_one.close
         tf_shard_one.unlink
         tf_default.close
@@ -549,23 +545,6 @@ module ActiveRecord
         tf_default_reading2.close
         tf_default_reading2.unlink
       end
-
-      private
-        def remove_connections(klass, roles:, shards:)
-          # TODO: Remove this helper when `remove_connection` for different shards is fixed.
-          # See https://github.com/rails/rails/pull/49382.
-          name = klass.name
-
-          roles.each do |role|
-            shards.each do |shard|
-              ActiveRecord::Base.connection_handler.remove_connection_pool(
-                name,
-                role: role,
-                shard: shard
-              )
-            end
-          end
-        end
     end
   end
 end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -235,7 +235,10 @@ module ActiveRecord
       handler = ActiveRecord::Base.connection_handler
       handler.instance_variable_get(:@connection_name_to_pool_manager).each do |owner, pool_manager|
         pool_manager.role_names.each do |role_name|
-          next if role_name == ActiveRecord::Base.default_role
+          next if role_name == ActiveRecord::Base.default_role &&
+                  # TODO: Remove this helper when `remove_connection` for different shards is fixed.
+                  # See https://github.com/rails/rails/pull/49382.
+                  ["ActiveRecord::Base", "ARUnit2Model", "Contact", "ContactSti"].include?(owner)
           pool_manager.remove_role(role_name)
         end
       end


### PR DESCRIPTION
### Motivation / Background

Fixes #49373 fully

@rafaelfranca's commit to address this issue resolved the problem for the one file that the most recent CI had shown was leaking database connections. Further CI runs revealed other such tests, however.

### Detail

At present, I have 5 test seeds that reproduce the `SQLite3::IOException: disk I/O error`:

* `SEED=58510 bundle exec rake db:postgresql:rebuild postgresql:test`
* `SEED=31616 bundle exec rake db:postgresql:rebuild postgresql:test`
* `SEED=64449 bundle exec rake db:postgresql:rebuild postgresql:test`
* `SEED=61510 bundle exec rake db:mysql:rebuild mysql2:test`
* `SEED=62616 bundle exec rake db:mysql:rebuild mysql2:test`

Investigating the various test runs exposed at least 3 tests that leak database connections:

* `ConnectionHandlersShardingDbTest`
* `ConnectionHandlersMultiDbTest`
* `ConnectionSwappingNestedTest`

All tests shared a call to `clean_up_connection_handler` in their `teardown` hook, so I looked for a tweak to `clean_up_connection_handler` that would consistently clean up the connection handlers.

After investigation and experimentation, I found that there were only 4 ActiveRecord classes that were expected to have connections independent of a particular test. So, I added a simple additional check to the `clean_up_connection_handler`.

This removed the need for the previously added `remove_connections` method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
