### PR TITLE
Enable `Lint/RedundantSafeNavigation` rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -243,6 +243,9 @@ Lint/RequireParentheses:
 Lint/RedundantStringCoercion:
   Enabled: true
 
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
 Lint/UriEscapeUnescape:
   Enabled: true
 

--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -32,7 +32,7 @@ module Mail
 
     private
       def address_list(obj)
-        if obj&.respond_to?(:element)
+        if obj.respond_to?(:element)
           # Mail 2.8+
           obj.element
         else

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -860,7 +860,7 @@ module ActionDispatch
         params = route_with_params.params
 
         if options.key? :params
-          if options[:params]&.respond_to?(:to_hash)
+          if options[:params].respond_to?(:to_hash)
             params.merge! options[:params]
           else
             params[:params] = options[:params]

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -175,7 +175,7 @@ module ActiveJob
     end
 
     def scheduled_at=(value)
-      @_scheduled_at_time = if value&.is_a?(Numeric)
+      @_scheduled_at_time = if value.is_a?(Numeric)
         ActiveJob.deprecator.warn(<<~MSG.squish)
           Assigning a numeric/epoch value to scheduled_at is deprecated. Use a Time object instead.
         MSG

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -159,7 +159,7 @@ class Time
       ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, new_offset)
     elsif utc?
       ::Time.utc(new_year, new_month, new_day, new_hour, new_min, new_sec)
-    elsif zone&.respond_to?(:utc_to_local)
+    elsif zone.respond_to?(:utc_to_local)
       new_time = ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, zone)
 
       # When there are two occurrences of a nominal time due to DST ending,


### PR DESCRIPTION
While looking through the recently merged PRs, I identified a place with a redundant safe navigation operator usage - https://github.com/rails/rails/commit/c919b474a7c0fab1498075fe5cc5e99e3cdc21fa#diff-7976e67c4f0e1e93247f577f797f87cc1d5d140c6f789a427050230209c977fcR178 and so decided it will be good to have a relevant rubocop's cop enabled.