### PR TITLE
Ensure system test scaffold supports `datetime` and `time` attributes

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -63,6 +63,16 @@ module TestUnit # :nodoc:
           attribute = attributes.find { |attr| attr.name == name }
           attribute&.virtual?
         end
+
+        def datetime?(name)
+          attribute = attributes.find { |attr| attr.name == name }
+          attribute&.type == :datetime
+        end
+
+        def time?(name)
+          attribute = attributes.find { |attr| attr.name == name }
+          attribute&.type == :time
+        end
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
@@ -35,6 +35,8 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     <%- attributes_hash.each do |attr, value| -%>
     <%- if boolean?(attr) -%>
     check "<%= attr.humanize %>" if <%= value %>
+    <%- elsif datetime?(attr) || time?(attr) -%>
+    fill_in "<%= attr.humanize %>", with: <%= value %>.to_s
     <%- else -%>
     fill_in "<%= attr.humanize %>", with: <%= value %>
     <%- end -%>


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, system tests generated by a scaffold containing `time` or `datetime` attributes would fail during the update test. The captured screenshot would reveal the following client-side validation errors.

```
Please enter a valid value. The two nearest valid values are 10:45:33 AM
and 10:46:33 AM.
```

![failures_test_should_update_time](https://github.com/rails/rails/assets/5122678/f70399a3-536b-4462-a368-e4d7743f8d27)

```
Please enter a valid value. The two nearest valid values are 09/27/2023,
10:45:33 AM and 09/27/2023, 10:46:33 AM.
```

![failures_test_should_update_datetime](https://github.com/rails/rails/assets/5122678/69955881-f132-4156-b3ad-f50507024cf3)

### Detail

This Pull Request updates the system test scaffold by conditionally converting `time` and `datetime` values to a string to ensures they are entered correctly and that the tests pass.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
