### PR TITLE
Use `id` in favor of `send(primary_key)`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1272,7 +1272,7 @@ module ActiveRecord
     def _raise_record_not_destroyed
       @_association_destroy_exception ||= nil
       key = self.class.primary_key
-      raise @_association_destroy_exception || RecordNotDestroyed.new("Failed to destroy #{self.class} with #{key}=#{send(key)}", self)
+      raise @_association_destroy_exception || RecordNotDestroyed.new("Failed to destroy #{self.class} with #{key}=#{id}", self)
     ensure
       @_association_destroy_exception = nil
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -821,6 +821,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
+  def test_destroy_for_a_failed_to_destroy_cpk_record
+    book = cpk_books(:cpk_great_author_first_book)
+    book.fail_destroy = true
+    assert_raises(ActiveRecord::RecordNotDestroyed, match: /Failed to destroy Cpk::Book with \["author_id", "id"\]=/) do
+      book.destroy!
+    end
+  end
+
   def test_find_raises_record_not_found_exception
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(99999) }
   end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -2,11 +2,20 @@
 
 module Cpk
   class Book < ActiveRecord::Base
+    attr_accessor :fail_destroy
+
     self.table_name = :cpk_books
     belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id]
     belongs_to :author, class_name: "Cpk::Author"
 
     has_many :chapters, query_constraints: [:author_id, :book_id]
+
+    before_destroy :prevent_destroy_if_set
+
+    private
+      def prevent_destroy_if_set
+        throw(:abort) if fail_destroy
+      end
   end
 
   class BestSeller < Book


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49408

There is no reason to send `primary_key` to the record to get the value of the primary key. `id` method does exactly that and it's a better abstraction. By implication it also fixes the problem with composite primary keys.