### PR TITLE
Enable raising when running `rubocop-md` against invalid ruby snippets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ AllCops:
     - 'activestorage/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - 'tools/rail_inspector/test/fixtures/*'
+    - guides/source/debugging_rails_applications.md
+    - guides/source/active_support_instrumentation.md
     - '**/node_modules/**/*'
     - '**/CHANGELOG.md'
     - '**/2_*_release_notes.md'
@@ -365,6 +367,6 @@ Minitest/UnreachableAssertion:
 
 Markdown:
   # Whether to run RuboCop against non-valid snippets
-  WarnInvalid: false
+  WarnInvalid: true
   # Whether to lint codeblocks without code attributes
   Autodetect: false

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -170,7 +170,7 @@ Active Storage, with its included JavaScript library, supports uploading directl
     ```
 2. Annotate file inputs with the direct upload URL.
 
-    ```ruby
+    ```erb
     <%= form.file_field :attachments, multiple: true, direct_upload: true %>
     ```
 3. That's it! Uploads begin upon form submission.

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -249,7 +249,7 @@ class ChatChannel < ApplicationCable::Channel
 
   private
     def deliver_error_message(e)
-      broadcast_to(...)
+      # broadcast_to(...)
     end
 end
 ```
@@ -276,7 +276,7 @@ class ChatChannel < ApplicationCable::Channel
 
   private
     def send_welcome_message
-      broadcast_to(...)
+      # broadcast_to(...)
     end
 
     def track_subscription
@@ -847,7 +847,7 @@ You can change that in `config/database.yml` through the `pool` attribute.
 
 Client-side logging is disabled by default. You can enable this by setting the `ActionCable.logger.enabled` to true.
 
-```ruby
+```js
 import * as ActionCable from '@rails/actioncable'
 
 ActionCable.logger.enabled = true

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -537,7 +537,7 @@ You can use `ActiveRecord::Encryption.with_encryption_context` to set an encrypt
 
 ```ruby
 ActiveRecord::Encryption.with_encryption_context(encryptor: ActiveRecord::Encryption::NullEncryptor.new) do
-  ...
+  # ...
 end
 ```
 
@@ -549,7 +549,7 @@ You can run code without encryption:
 
 ```ruby
 ActiveRecord::Encryption.without_encryption do
-   ...
+  # ...
 end
 ```
 
@@ -561,7 +561,7 @@ You can run code without encryption but prevent overwriting encrypted content:
 
 ```ruby
 ActiveRecord::Encryption.protecting_encrypted_data do
-   ...
+  # ...
 end
 ```
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -317,7 +317,7 @@ parameters it's based on. Let's say you want to use a cookie instead of a sessio
 decide when to swap connections. You can write your own class:
 
 ```ruby
-class MyCookieResolver << ActiveRecord::Middleware::DatabaseSelector::Resolver
+class MyCookieResolver < ActiveRecord::Middleware::DatabaseSelector::Resolver
   def self.call(request)
     new(request.cookies)
   end

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -329,7 +329,7 @@ To add a new value you can use `add_enum_value`:
 ```ruby
 # db/migrate/20150720144913_add_new_state_to_articles.rb
 def up
-  add_enum_value :article_state, "archived", # will be at the end after published
+  add_enum_value :article_state, "archived" # will be at the end after published
   add_enum_value :article_state, "in review", before: "published"
   add_enum_value :article_state, "approved", after: "in review"
 end

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -817,11 +817,12 @@ If a query has a hash condition with non-nil values on a nullable column, the re
 ```ruby
 Customer.create!(nullable_country: nil)
 Customer.where.not(nullable_country: "UK")
-=> []
+# => []
+
 # But
 Customer.create!(nullable_country: "UK")
 Customer.where.not(nullable_country: nil)
-=> [#<Customer id: 2, nullable_country: "UK">]
+# => [#<Customer id: 2, nullable_country: "UK">]
 ```
 
 [`where.not`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-not

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -386,8 +386,8 @@ end
 
 or if you are using Rails 6.0+, you can run a model generator command like this:
 
-```ruby
-bin/rails generate model User avatar:attachment
+```bash
+$ bin/rails generate model User avatar:attachment
 ```
 
 You can create a user with an avatar:
@@ -482,8 +482,8 @@ end
 
 or if you are using Rails 6.0+, you can run a model generator command like this:
 
-```ruby
-bin/rails generate model Message images:attachments
+```bash
+$ bin/rails generate model Message images:attachments
 ```
 
 You can create a message with images:

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -981,7 +981,9 @@ Instance methods are created as well for convenience, they are just proxies to t
 ```ruby
 module ActionView
   class Base
-    cattr_accessor :field_error_proc, default: Proc.new { ... }
+    cattr_accessor :field_error_proc, default: Proc.new {
+      # ...
+    }
   end
 end
 ```

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -241,7 +241,9 @@ Example:
 # config/importmap.rb
 pin "@github/hotkey", to: "https://ga.jspm.io/npm:@github/hotkey@1.4.4/dist/index.js", preload: true
 pin "md5", to: "https://cdn.jsdelivr.net/npm/md5@2.3.0/md5.js"
+```
 
+```erb
 # app/views/layouts/application.html.erb
 <%= javascript_importmap_tags %>
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1750,7 +1750,7 @@ end
 
 Each instance of the `Author` model will have these methods:
 
-```ruby
+```
 books
 books<<(object, ...)
 books.delete(object, ...)
@@ -2321,7 +2321,7 @@ end
 
 Each instance of the `Part` model will have these methods:
 
-```ruby
+```
 assemblies
 assemblies<<(object, ...)
 assemblies.delete(object, ...)

--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -139,7 +139,7 @@ module MyApp
       lib.join("generators")
     )
 
-    ...
+    # ...
   end
 end
 ```
@@ -223,7 +223,7 @@ module MyApp
       lib.join("generators")
     )
 
-    ...
+    # ...
   end
 end
 ```

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -208,11 +208,11 @@ render "comments/comments"
 render 'comments/comments'
 render('comments/comments')
 
-render "header" translates to render("comments/header")
+render "header" # translates to render("comments/header")
 
-render(@topic)         translates to render("topics/topic")
-render(topics)         translates to render("topics/topic")
-render(message.topics) translates to render("topics/topic")
+render(@topic)         # translates to render("topics/topic")
+render(topics)         # translates to render("topics/topic")
+render(message.topics) # translates to render("topics/topic")
 ```
 
 On the other hand, some calls need to be changed to make caching work properly.
@@ -381,13 +381,13 @@ you can have multiple threads performing queries to the cache store at the same 
 If you want to disable connection pooling, set `:pool` option to `false` when configuring the cache store:
 
 ```ruby
-config.cache_store = :mem_cache_store, "cache.example.com", pool: false
+config.cache_store = :mem_cache_store, "cache.example.com", { pool: false }
 ```
 
 You can also override default pool settings by providing individual options to the `:pool` option:
 
 ```ruby
-config.cache_store = :mem_cache_store, "cache.example.com", pool: { size: 32, timeout: 1 }
+config.cache_store = :mem_cache_store, "cache.example.com", { pool: { size: 32, timeout: 1 } }
 ```
 
 * `:size` - This option sets the number of connections per process (defaults to 5).

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1904,40 +1904,23 @@ Configures what exceptions are assigned to an HTTP status. It accepts a hash and
 
 ```ruby
 config.action_dispatch.rescue_responses = {
-  'ActionController::RoutingError'
-    => :not_found,
-  'AbstractController::ActionNotFound'
-    => :not_found,
-  'ActionController::MethodNotAllowed'
-    => :method_not_allowed,
-  'ActionController::UnknownHttpMethod'
-    => :method_not_allowed,
-  'ActionController::NotImplemented'
-    => :not_implemented,
-  'ActionController::UnknownFormat'
-    => :not_acceptable,
-  'ActionController::InvalidAuthenticityToken'
-    => :unprocessable_entity,
-  'ActionController::InvalidCrossOriginRequest'
-    => :unprocessable_entity,
-  'ActionDispatch::Http::Parameters::ParseError'
-    => :bad_request,
-  'ActionController::BadRequest'
-    => :bad_request,
-  'ActionController::ParameterMissing'
-    => :bad_request,
-  'Rack::QueryParser::ParameterTypeError'
-    => :bad_request,
-  'Rack::QueryParser::InvalidParameterError'
-    => :bad_request,
-  'ActiveRecord::RecordNotFound'
-    => :not_found,
-  'ActiveRecord::StaleObjectError'
-    => :conflict,
-  'ActiveRecord::RecordInvalid'
-    => :unprocessable_entity,
-  'ActiveRecord::RecordNotSaved'
-    => :unprocessable_entity
+  'ActionController::RoutingError' => :not_found,
+  'AbstractController::ActionNotFound' => :not_found,
+  'ActionController::MethodNotAllowed' => :method_not_allowed,
+  'ActionController::UnknownHttpMethod'=> :method_not_allowed,
+  'ActionController::NotImplemented' => :not_implemented,
+  'ActionController::UnknownFormat'=> :not_acceptable,
+  'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
+  'ActionController::InvalidCrossOriginRequest'=> :unprocessable_entity,
+  'ActionDispatch::Http::Parameters::ParseError' => :bad_request,
+  'ActionController::BadRequest' => :bad_request,
+  'ActionController::ParameterMissing' => :bad_request,
+  'Rack::QueryParser::ParameterTypeError'=> :bad_request,
+  'Rack::QueryParser::InvalidParameterError' => :bad_request,
+  'ActiveRecord::RecordNotFound' => :not_found,
+  'ActiveRecord::StaleObjectError' => :conflict,
+  'ActiveRecord::RecordInvalid'=> :unprocessable_entity,
+  'ActiveRecord::RecordNotSaved' => :unprocessable_entity
 }
 ```
 
@@ -2260,10 +2243,12 @@ Specifies whether mail will actually be delivered and is `true` by default. It c
 Configures Action Mailer defaults. Use to set options like `from` or `reply_to` for every mailer. These default to:
 
 ```ruby
-mime_version:  "1.0",
-charset:       "UTF-8",
-content_type: "text/plain",
-parts_order:  ["text/plain", "text/enriched", "text/html"]
+{
+  mime_version:  "1.0",
+  charset:       "UTF-8",
+  content_type: "text/plain",
+  parts_order:  ["text/plain", "text/enriched", "text/html"]
+}
 ```
 
 Assign a hash to set additional options:

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -600,11 +600,11 @@ To set the new framework default, set the new value in
 def load_defaults(target_version)
   case target_version.to_s
   when "7.1"
-    ...
+    # ...
     if respond_to?(:active_job)
       active_job.existing_behavior = false
     end
-    ...
+    # ...
   end
 end
 ```

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2038,7 +2038,6 @@ so we write that:
 
 ```ruby
 class ArticlesController < ApplicationController
-
   http_basic_authenticate_with name: "dhh", password: "secret", except: [:index, :show]
 
   def index
@@ -2046,6 +2045,7 @@ class ArticlesController < ApplicationController
   end
 
   # snippet for brevity
+end
 ```
 
 We also want to allow only authenticated users to delete comments, so in the
@@ -2053,7 +2053,6 @@ We also want to allow only authenticated users to delete comments, so in the
 
 ```ruby
 class CommentsController < ApplicationController
-
   http_basic_authenticate_with name: "dhh", password: "secret", only: :destroy
 
   def create
@@ -2062,6 +2061,7 @@ class CommentsController < ApplicationController
   end
 
   # snippet for brevity
+end
 ```
 
 Now if you try to create a new article, you will be greeted with a basic HTTP

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -917,7 +917,7 @@ end
 
 The key for the error message in this case is `:blank`. Active Record will look up this key in the namespaces:
 
-```ruby
+```
 activerecord.errors.models.[model_name].attributes.[attribute_name]
 activerecord.errors.models.[model_name]
 activerecord.errors.messages
@@ -927,7 +927,7 @@ errors.messages
 
 Thus, in our example it will try the following keys in this order and return the first result:
 
-```ruby
+```
 activerecord.errors.models.user.attributes.name.blank
 activerecord.errors.models.user.blank
 activerecord.errors.messages.blank

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -982,7 +982,7 @@ Rails.application.config.hosts << "product.com"
 
 Rails.application.config.host_authorization = {
   # Exclude requests for the /healthcheck/ path from host checking
-  exclude: ->(request) { request.path =~ /healthcheck/ }
+  exclude: ->(request) { request.path.include?("healthcheck") },
   # Add custom Rack application for the response
   response_app: -> env do
     [400, { "Content-Type" => "text/plain" }, ["Bad Request"]]

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -99,6 +99,8 @@ By requiring this file, `test_helper.rb` the default configuration to run our te
 
 ```ruby
 class ArticleTest < ActiveSupport::TestCase
+  # ...
+end
 ```
 
 The `ArticleTest` class defines a _test case_ because it inherits from `ActiveSupport::TestCase`. `ArticleTest` thus has all the methods available from `ActiveSupport::TestCase`. Later in this guide, we'll see some of the methods it gives us.
@@ -893,7 +895,7 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   url = ENV.fetch("SELENIUM_REMOTE_URL", nil)
   options = if url
-    { browser: :remote, url }
+    { browser: :remote, url: url }
   else
     { browser: :chrome }
   end
@@ -1330,9 +1332,9 @@ After a request has been made and processed, you will have 3 Hash objects ready 
 As is the case with normal Hash objects, you can access the values by referencing the keys by string. You can also reference them by symbol name. For example:
 
 ```ruby
-flash["gordon"]               flash[:gordon]
-session["shmession"]          session[:shmession]
-cookies["are_good_for_u"]     cookies[:are_good_for_u]
+flash["gordon"]               # or flash[:gordon]
+session["shmession"]          # or session[:shmession]
+cookies["are_good_for_u"]     # or cookies[:are_good_for_u]
 ```
 
 ### Instance Variables Available
@@ -1752,9 +1754,10 @@ test "renders a link to itself" do
 
   render "articles/article", article: article
   anchor = document_root_element.at("a")
+  url = article_url(article)
 
   assert_pattern do
-    anchor => { content: article.title, attributes: [{ name: "href", value: article_url(article) }] }
+    anchor => { content: "Hello, world", attributes: [{ name: "href", value: url }] }
   end
 end
 ```

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -183,7 +183,7 @@ If you don't want to use connection pooling, set `:pool` option to `false` when
 configuring your cache store:
 
 ```ruby
-config.cache_store = :mem_cache_store, "cache.example.com", pool: false
+config.cache_store = :mem_cache_store, "cache.example.com", { pool: false }
 ```
 
 See the [caching with Rails](https://guides.rubyonrails.org/v7.1/caching_with_rails.html#connection-pool-options) guide for more information.
@@ -605,6 +605,8 @@ The schema file will look like this:
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[6.1].define(version: 2022_01_28_123512) do
+  # ...
+end
 ```
 
 NOTE: The first time you dump the schema with Rails 7.0, you will see many changes to that file, including
@@ -1136,10 +1138,10 @@ class User < ApplicationRecord
   has_many_attached :highlights
 end
 
-user.highlights.attach(filename: "funky.jpg", ...)
+user.highlights.attach(filename: "funky.jpg")
 user.highlights.count # => 1
 
-blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg", ...)
+blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg")
 user.update!(highlights: [ blob ])
 
 user.highlights.count # => 2
@@ -1150,10 +1152,10 @@ user.highlights.second.filename # => "town.jpg"
 With the configuration defaults for Rails 6.0, assigning to a collection of attachments replaces existing files instead of appending to them. This matches Active Record behavior when assigning to a collection association:
 
 ```ruby
-user.highlights.attach(filename: "funky.jpg", ...)
+user.highlights.attach(filename: "funky.jpg")
 user.highlights.count # => 1
 
-blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg", ...)
+blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg")
 user.update!(highlights: [ blob ])
 
 user.highlights.count # => 1
@@ -1163,7 +1165,7 @@ user.highlights.first.filename # => "town.jpg"
 `#attach` can be used to add new attachments without removing the existing ones:
 
 ```ruby
-blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg", ...)
+blob = ActiveStorage::Blob.create_after_upload!(filename: "town.jpg")
 user.highlights.attach(blob)
 
 user.highlights.count # => 2
@@ -1792,15 +1794,15 @@ invocation of the instance methods are deferred until either `deliver_now` or
 
 ```ruby
 class Notifier < ActionMailer::Base
-  def notify(user, ...)
+  def notify(user)
     puts "Called"
-    mail(to: user.email, ...)
+    mail(to: user.email)
   end
 end
 ```
 
 ```ruby
-mail = Notifier.notify(user, ...) # Notifier#notify is not yet called at this point
+mail = Notifier.notify(user) # Notifier#notify is not yet called at this point
 mail = mail.deliver_now           # Prints "Called"
 ```
 
@@ -2418,11 +2420,11 @@ Rails 4.0 no longer supports loading plugins from `vendor/plugins`. You must rep
 * Rails 4.0 has changed to default join table for `has_and_belongs_to_many` relations to strip the common prefix off the second table name. Any existing `has_and_belongs_to_many` relationship between models with a common prefix must be specified with the `join_table` option. For example:
 
     ```ruby
-    CatalogCategory < ActiveRecord::Base
+    class CatalogCategory < ActiveRecord::Base
       has_and_belongs_to_many :catalog_products, join_table: 'catalog_categories_catalog_products'
     end
 
-    CatalogProduct < ActiveRecord::Base
+    class CatalogProduct < ActiveRecord::Base
       has_and_belongs_to_many :catalog_categories, join_table: 'catalog_categories_catalog_products'
     end
     ```


### PR DESCRIPTION
The whole example is correct, except that incorrect inheritance.

I noticed, that `rubocop-md` is disabled for invalid example codes, https://github.com/rails/rails/blob/7c03e4f1b7553084f34318a9efc2793137de36f4/.rubocop.yml#L366-L368

If it will be enabled, this syntax error will be identified earlier and automatically. I locally enabled it, and actually, there are not that many errors and they are easily fixable. Wdyt about fixing those as a follow-up to this PR and enabling that option?