### PR TITLE
Document hierarchy for `retry_on` and `discard_on`

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -21,6 +21,9 @@ module ActiveJob
       # You can also pass a block that'll be invoked if the retry attempts fail for custom logic rather than letting
       # the exception bubble up. This block is yielded with the job instance as the first and the error instance as the second parameter.
       #
+      # `retry_on` and `discard_on` handlers are searched from bottom to top, and up the class hierarchy. The handler of the first class for
+      # which <tt>exception.is_a?(klass)</tt> holds true is the one invoked, if any.
+      #
       # ==== Options
       # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
       #   as a computing proc that takes the number of executions so far as an argument, or as a symbol reference of
@@ -86,6 +89,9 @@ module ActiveJob
       # like an Active Record, is no longer available, and the job is thus no longer relevant.
       #
       # You can also pass a block that'll be invoked. This block is yielded with the job instance as the first and the error instance as the second parameter.
+      #
+      # `retry_on` and `discard_on` handlers are searched from bottom to top, and up the class hierarchy. The handler of the first class for
+      # which <tt>exception.is_a?(klass)</tt> holds true is the one invoked, if any.
       #
       # ==== Example
       #


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49406

I used the same wording as https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html which is what these methods use internally.

