### PR TITLE
Do not skip Action Cable PG tests on CI

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -25,6 +25,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     begin
       ActiveRecord::Base.connection
     rescue
+      raise if ENV["CI"] # We shouldn't skip on error on Rails CI.
       @rx_adapter = @tx_adapter = nil
       skip "Couldn't connect to PostgreSQL: #{database_config.inspect}"
     end


### PR DESCRIPTION
The intent is to skip them if you don't have PG running locally but on CI it's supposed to be running.

If we fail to connect, we should fail CI, not skip these tests.
