### PR TITLE
Move the database version cache from schema cache to pool config

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -22,6 +22,16 @@ module ActiveRecord
       end
       NULL_CONFIG = NullConfig.new # :nodoc:
 
+      def initialize
+        super()
+        @mutex = Mutex.new
+        @server_version = nil
+      end
+
+      def server_version(connection) # :nodoc:
+        @server_version || @mutex.synchronize { @server_version ||= connection.get_database_version }
+      end
+
       def schema_reflection
         SchemaReflection.new(nil)
       end
@@ -111,7 +121,7 @@ module ActiveRecord
       attr_accessor :automatic_reconnect, :checkout_timeout
       attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
 
-      delegate :schema_reflection, :schema_reflection=, to: :pool_config
+      delegate :schema_reflection, :schema_reflection=, :server_version, to: :pool_config
 
       # Creates a new ConnectionPool object. +pool_config+ is a PoolConfig
       # object which describes database connection information (e.g. adapter,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -868,7 +868,7 @@ module ActiveRecord
       end
 
       def database_version # :nodoc:
-        schema_cache.database_version
+        pool.server_version(self)
       end
 
       def check_version # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -174,7 +174,7 @@ module ActiveRecord
         end
 
         def full_version
-          schema_cache.database_version.full_version_string
+          database_version.full_version_string
         end
 
         def get_full_version

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -66,10 +66,6 @@ module ActiveRecord
         cache(connection).indexes(connection, table_name)
       end
 
-      def database_version(connection)
-        cache(connection).database_version(connection)
-      end
-
       def version(connection)
         cache(connection).version(connection)
       end
@@ -196,10 +192,6 @@ module ActiveRecord
         @schema_reflection.indexes(@connection, table_name)
       end
 
-      def database_version
-        @schema_reflection.database_version(@connection)
-      end
-
       def version
         @schema_reflection.version(@connection)
       end
@@ -264,7 +256,6 @@ module ActiveRecord
         @primary_keys = {}
         @data_sources = {}
         @indexes      = {}
-        @database_version = nil
         @version = nil
       end
 
@@ -283,7 +274,6 @@ module ActiveRecord
         coder["data_sources"]     = @data_sources.sort.to_h
         coder["indexes"]          = @indexes.sort.to_h
         coder["version"]          = @version
-        coder["database_version"] = @database_version
       end
 
       def init_with(coder)
@@ -293,7 +283,6 @@ module ActiveRecord
         @data_sources     = coder["data_sources"]
         @indexes          = coder["indexes"] || {}
         @version          = coder["version"]
-        @database_version = coder["database_version"]
 
         unless coder["deduplicated"]
           derive_columns_hash_and_deduplicate_values
@@ -370,10 +359,6 @@ module ActiveRecord
         end
       end
 
-      def database_version(connection) # :nodoc:
-        @database_version ||= connection.get_database_version
-      end
-
       def version(connection)
         @version ||= connection.schema_version
       end
@@ -401,7 +386,6 @@ module ActiveRecord
         end
 
         version(connection)
-        database_version(connection)
       end
 
       def dump_to(filename)
@@ -415,11 +399,11 @@ module ActiveRecord
       end
 
       def marshal_dump # :nodoc:
-        [@version, @columns, {}, @primary_keys, @data_sources, @indexes, @database_version]
+        [@version, @columns, {}, @primary_keys, @data_sources, @indexes]
       end
 
       def marshal_load(array) # :nodoc:
-        @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version = array
+        @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, _database_version = array
         @indexes ||= {}
 
         derive_columns_hash_and_deduplicate_values

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -202,7 +202,7 @@ module ActiveRecord
         end
 
         def full_version
-          schema_cache.database_version.full_version_string
+          database_version.full_version_string
         end
 
         def get_full_version

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -162,10 +162,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
                 warn "Failed to validate the schema cache because of #{error.class}: #{error.message}"
                 nil
               end
-              next if current_version.nil?
 
-              if cache.schema_version != current_version
+              if current_version.nil?
+                connection_pool.schema_reflection.clear!
+                next
+              elsif cache.schema_version != current_version
                 warn "Ignoring #{filename} because it has expired. The current schema version is #{current_version}, but the one in the schema cache file is #{cache.schema_version}."
+                connection_pool.schema_reflection.clear!
                 next
               end
             end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
@@ -38,12 +38,10 @@ class DatetimePrecisionQuotingTest < ActiveRecord::AbstractMysqlTestCase
       assert_match match, @connection.quoted_date(Time.now.change(sec: 55, usec: 123456))
     end
 
-    def stub_version(full_version_string)
-      @connection.stub(:get_full_version, full_version_string) do
-        @connection.schema_cache.clear!
-        yield
-      end
+    def stub_version(full_version_string, &block)
+      @connection.pool.pool_config.server_version = nil
+      @connection.stub(:get_full_version, full_version_string, &block)
     ensure
-      @connection.schema_cache.clear!
+      @connection.pool.pool_config.server_version = nil
     end
 end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/49378

As discussed with @matthewd , we have a bit of a chicken and egg problem with the schema cache and the database version.

The database version is stored in the cache to avoid a query, but the schema cache need to query the schema version in the database to be revalidated.

So `check_version` depends on `schema_cache`, which depends on `Migrator.current_version`, which depends on `configure_connection` which depends on `check_version`.

But ultimately, we think storing the server version in the cache is incorrect, because upgrading a DB server is orthogonal from regenerating the schema cache.

So not persisting the version in cache is better. Instead we store it in the pool config, so that we only check it once per process and per database.
