### PR TITLE
Fix RenderCallExtractor to be compatible with Ruby 3.3

### DIFF
--- a/actionview/lib/action_view/ripper_ast_parser.rb
+++ b/actionview/lib/action_view/ripper_ast_parser.rb
@@ -179,7 +179,7 @@ module ActionView
           end
 
           def on_paren(content)
-            content
+            content.size == 1 ? content.first : content
           end
       end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/49128
Ref: https://github.com/ruby/ruby/commit/45cd011d73

We need to unwrap some nodes.
