### PR TITLE
Fix the BroadcastLogger being initialized too late:

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -67,7 +67,7 @@ module ActiveRecord
       unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
         console = ActiveSupport::Logger.new(STDERR)
         console.level = Rails.logger.level
-        Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
+        Rails.logger.broadcast_to(console)
       end
       ActiveRecord.verbose_query_logs = false
     end

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -202,5 +202,17 @@ module ActiveSupport
       def dispatch(&block)
         @broadcasts.each { |logger| block.call(logger) }
       end
+
+      def method_missing(name, *args)
+        loggers = @broadcasts.select { |logger| logger.respond_to?(name) }
+
+        if loggers.none?
+          super(name, *args)
+        elsif loggers.one?
+          loggers.first.send(name, *args)
+        else
+          loggers.map { |logger| logger.send(name, *args) }
+        end
+      end
   end
 end

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -14,9 +14,16 @@ module ActiveSupport
     #   ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)
     #   # => true
     def self.logger_outputs_to?(logger, *sources)
-      logdev = logger.instance_variable_get(:@logdev)
-      logger_source = logdev.dev if logdev.respond_to?(:dev)
-      sources.any? { |source| source == logger_source }
+      loggers = if logger.is_a?(BroadcastLogger)
+        logger.broadcasts
+      else
+        [logger]
+      end
+
+      logdevs = loggers.map { |logger| logger.instance_variable_get(:@logdev) }
+      logger_sources = logdevs.filter_map { |logdev| logdev.dev if logdev.respond_to?(:dev) }
+
+      (sources & logger_sources).any?
     end
 
     def initialize(*args, **kwargs)

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -244,6 +244,30 @@ module ActiveSupport
       assert_not_predicate(@logger, :fatal?)
     end
 
+    test "calling a method that no logger in the broadcast have implemented" do
+      assert_raises(NoMethodError) do
+        @logger.non_existing
+      end
+    end
+
+    test "calling a method when *one* logger in the broadcast has implemented it" do
+      logger = BroadcastLogger.new(CustomLogger.new)
+
+      assert(logger.foo)
+    end
+
+    test "calling a method when *multiple* loggers in the broadcast have implemented it" do
+      logger = BroadcastLogger.new(CustomLogger.new, CustomLogger.new)
+
+      assert_equal([true, true], logger.foo)
+    end
+
+    test "calling a method when a subset of loggers in the broadcast have implemented" do
+      logger = BroadcastLogger.new(CustomLogger.new, FakeLogger.new)
+
+      assert(logger.foo)
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level
@@ -256,6 +280,10 @@ module ActiveSupport
         @local_level = ::Logger::DEBUG
         @progname    = nil
         @formatter   = nil
+      end
+
+      def foo
+        true
       end
 
       def debug(message, &block)

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -28,6 +28,16 @@ class LoggerTest < ActiveSupport::TestCase
     assert_not Logger.logger_outputs_to?(@logger, STDOUT, STDERR), "Expected logger_outputs_to? to STDOUT or STDERR to return false, but was true"
   end
 
+  def test_log_outputs_to_with_a_broadcast_logger
+    logger = ActiveSupport::BroadcastLogger.new(Logger.new(STDOUT))
+
+    assert(Logger.logger_outputs_to?(logger, STDOUT))
+    assert_not(Logger.logger_outputs_to?(logger, STDERR))
+
+    logger.broadcast_to(Logger.new(STDERR))
+    assert(Logger.logger_outputs_to?(logger, STDERR))
+  end
+
   def test_write_binary_data_to_existing_file
     t = Tempfile.new ["development", "log"]
     t.binmode

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3431,7 +3431,7 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `load_active_support`: Requires `active_support/dependencies` which sets up the basis for Active Support. Optionally requires `active_support/all` if `config.active_support.bare` is un-truthful, which is the default.
 
-* `initialize_logger`: Initializes the logger (an `ActiveSupport::Logger` object) for the application and makes it accessible at `Rails.logger`, provided that no initializer inserted before this point has defined `Rails.logger`.
+* `initialize_logger`: Initializes the logger (an `ActiveSupport::BroadcastLogger` object) for the application and makes it accessible at `Rails.logger`, provided that no initializer inserted before this point has defined `Rails.logger`.
 
 * `initialize_cache`: If `Rails.cache` isn't set yet, initializes the cache by referencing the value in `config.cache_store` and stores the outcome as `Rails.cache`. If this object responds to the `middleware` method, its middleware is inserted before `Rack::Runtime` in the middleware stack.
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -56,6 +56,10 @@ module Rails
         end
         Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
 
+        broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
+        broadcast_logger.formatter = Rails.logger.formatter
+        Rails.logger = broadcast_logger
+
         unless config.consider_all_requests_local
           Rails.error.logger = Rails.logger
         end

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -80,7 +80,7 @@ module Rails
         console.level = Rails.logger.level
 
         unless ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDERR, STDOUT)
-          Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, console)
+          Rails.logger.broadcast_to(console)
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

An oversight of #48615 is that it changes the `Rails.logger` to be a broadcast logger after the app is booted. Anything referencing `Rails.logger` during the boot process will get a simple logger and ultimately resulting in logs not being broadcasted.

For example `ActionController::Base.logger.info("abc")` would just output logs in the `development.log` file, not on STDOUT.

### Detail

The only solution I could think of is to create a BroadcastLogger earlier at boot, and add logger to that broadcast when needed (instead of modiyfing the `Rails.logger` variable).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
