### PR TITLE
No more _klass

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -33,10 +33,10 @@ module ActionCable
 
         return if subscriptions.key?(id_key)
 
-        subscription_klass = id_options[:channel].safe_constantize
+        subscription_class = id_options[:channel].safe_constantize
 
-        if subscription_klass && ActionCable::Channel::Base > subscription_klass
-          subscription = subscription_klass.new(connection, id_key, id_options)
+        if subscription_class && ActionCable::Channel::Base > subscription_class
+          subscription = subscription_class.new(connection, id_key, id_options)
           subscriptions[id_key] = subscription
           subscription.subscribe_to_channel
         else

--- a/actioncable/test/subscription_adapter/channel_prefix.rb
+++ b/actioncable/test/subscription_adapter/channel_prefix.rb
@@ -8,10 +8,10 @@ module ChannelPrefixTest
     server2.config.cable = alt_cable_config.with_indifferent_access
     server2.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 
-    adapter_klass = server2.config.pubsub_adapter
+    adapter_class = server2.config.pubsub_adapter
 
-    rx_adapter2 = adapter_klass.new(server2)
-    tx_adapter2 = adapter_klass.new(server2)
+    rx_adapter2 = adapter_class.new(server2)
+    tx_adapter2 = adapter_class.new(server2)
 
     subscribe_as_queue("channel") do |queue|
       subscribe_as_queue("channel", rx_adapter2) do |queue2|

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -15,10 +15,10 @@ module CommonSubscriptionAdapterTest
     server.config.cable = cable_config.with_indifferent_access
     server.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 
-    adapter_klass = server.config.pubsub_adapter
+    adapter_class = server.config.pubsub_adapter
 
-    @rx_adapter = adapter_klass.new(server)
-    @tx_adapter = adapter_klass.new(server)
+    @rx_adapter = adapter_class.new(server)
+    @tx_adapter = adapter_class.new(server)
   end
 
   def teardown

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -47,13 +47,13 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     server.config.cable = cable_config.with_indifferent_access
     server.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 
-    adapter_klass = Class.new(server.config.pubsub_adapter) do
+    adapter_class = Class.new(server.config.pubsub_adapter) do
       def active?
         !@listener.nil?
       end
     end
 
-    adapter = adapter_klass.new(server)
+    adapter = adapter_class.new(server)
 
     subscribe_as_queue("channel", adapter) do |queue|
       adapter.broadcast("channel", "hello world")

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -169,17 +169,17 @@ module ActionController
           model_name = klass.name.delete_suffix("Controller").classify
 
           begin
-            if model_klass = model_name.safe_constantize
-              model_klass
+            if model_class = model_name.safe_constantize
+              model_class
             else
               namespaces = model_name.split("::")
               namespaces.delete_at(-2)
               break if namespaces.last == model_name
               model_name = namespaces.join("::")
             end
-          end until model_klass
+          end until model_class
 
-          model_klass
+          model_class
         end
     end
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -496,7 +496,7 @@ module ActionController
         @request.delete_header "action_dispatch.cookies"
 
         @request          = TestRequest.new scrub_env!(@request.env), @request.session, @controller.class
-        @response         = build_response @response_klass
+        @response         = build_response @response_class
         @response.request = @request
         @controller.recycle!
 
@@ -536,11 +536,11 @@ module ActionController
       def setup_controller_request_and_response
         @controller = nil unless defined? @controller
 
-        @response_klass = ActionDispatch::TestResponse
+        @response_class = ActionDispatch::TestResponse
 
         if klass = self.class.controller_class
           if klass < ActionController::Live
-            @response_klass = LiveTestResponse
+            @response_class = LiveTestResponse
           end
           unless @controller
             begin
@@ -552,7 +552,7 @@ module ActionController
         end
 
         @request          = TestRequest.create(@controller.class)
-        @response         = build_response @response_klass
+        @response         = build_response @response_class
         @response.request = @request
 
         if @controller

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -23,8 +23,8 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_simple_format_included_in_isolation
-    helper_klass = Class.new { include ActionView::Helpers::TextHelper }
-    assert_predicate helper_klass.new.simple_format("<b> test with HTML tags </b>"), :html_safe?
+    helper_class = Class.new { include ActionView::Helpers::TextHelper }
+    assert_predicate helper_class.new.simple_format("<b> test with HTML tags </b>"), :html_safe?
   end
 
   def test_simple_format

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -31,8 +31,8 @@ module SneakersJobsManager
     @pid = fork do
       queues = %w(integration_tests)
       workers = queues.map do |q|
-        worker_klass = "ActiveJobWorker" + OpenSSL::Digest::MD5.hexdigest(q)
-        Sneakers.const_set(worker_klass, Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
+        worker_class = "ActiveJobWorker" + OpenSSL::Digest::MD5.hexdigest(q)
+        Sneakers.const_set(worker_class, Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
           from_queue q
         end)
       end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -213,7 +213,7 @@ module ActiveRecord
       private
         # Reader and writer methods call this so that consistent errors are presented
         # when the association target class does not exist.
-        def ensure_klass_exists!
+        def ensure_class_exists!
           klass
         end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -30,7 +30,7 @@ module ActiveRecord
     class CollectionAssociation < Association # :nodoc:
       # Implements the reader method, e.g. foo.items for Foo.has_many :items
       def reader
-        ensure_klass_exists!
+        ensure_class_exists!
 
         if stale_target?
           reload

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -74,8 +74,8 @@ module ActiveRecord
         @join_type = join_type
       end
 
-      def base_klass
-        join_root.base_klass
+      def base_class
+        join_root.base_class
       end
 
       def reflections
@@ -136,7 +136,7 @@ module ActiveRecord
 
         payload = {
           record_count: result_set.length,
-          class_name: join_root.base_klass.name
+          class_name: join_root.base_class.name
         }
 
         message_bus.instrument("instantiation.active_record", payload) do
@@ -189,8 +189,8 @@ module ActiveRecord
 
         def make_constraints(parent, child, join_type)
           foreign_table = parent.table
-          foreign_klass = parent.base_klass
-          child.join_constraints(foreign_table, foreign_klass, join_type, alias_tracker) do |reflection|
+          foreign_class = parent.base_class
+          child.join_constraints(foreign_table, foreign_class, join_type, alias_tracker) do |reflection|
             table, terminated = @joined_tables[reflection]
             root = reflection == child.reflection
 
@@ -225,9 +225,9 @@ module ActiveRecord
             raise(ConfigurationError, "Can't join '#{klass.name}' to association named '#{name}'; perhaps you misspelled it?")
         end
 
-        def build(associations, base_klass)
+        def build(associations, base_class)
           associations.map do |name, right|
-            reflection = find_reflection base_klass, name
+            reflection = find_reflection base_class, name
             reflection.check_validity!
             reflection.check_eager_loadable!
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           super && reflection == other.reflection
         end
 
-        def join_constraints(foreign_table, foreign_klass, join_type, alias_tracker)
+        def join_constraints(foreign_table, foreign_class, join_type, alias_tracker)
           joins = []
           chain = []
 
@@ -30,7 +30,7 @@ module ActiveRecord
             @table ||= table
 
             if terminated
-              foreign_table, foreign_klass = table, reflection.klass
+              foreign_table, foreign_class = table, reflection.klass
               break
             end
 
@@ -42,7 +42,7 @@ module ActiveRecord
           chain.reverse_each do |reflection, table|
             klass = reflection.klass
 
-            scope = reflection.join_scope(table, foreign_table, foreign_klass)
+            scope = reflection.join_scope(table, foreign_table, foreign_class)
 
             unless scope.references_values.empty?
               associations = scope.eager_load_values | scope.includes_values
@@ -69,7 +69,7 @@ module ActiveRecord
             end
 
             # The current table in this iteration becomes the foreign table in the next
-            foreign_table, foreign_klass = table, klass
+            foreign_table, foreign_class = table, klass
           end
 
           joins
@@ -78,20 +78,20 @@ module ActiveRecord
         def readonly?
           return @readonly if defined?(@readonly)
 
-          @readonly = reflection.scope && reflection.scope_for(base_klass.unscoped).readonly_value
+          @readonly = reflection.scope && reflection.scope_for(base_class.unscoped).readonly_value
         end
 
         def strict_loading?
           return @strict_loading if defined?(@strict_loading)
 
-          @strict_loading = reflection.scope && reflection.scope_for(base_klass.unscoped).strict_loading_value
+          @strict_loading = reflection.scope && reflection.scope_for(base_class.unscoped).strict_loading_value
         end
 
         private
           def append_constraints(join, constraints)
             if join.is_a?(Arel::Nodes::StringJoin)
               join_string = Arel::Nodes::And.new(constraints.unshift join.left)
-              join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
+              join.left = Arel.sql(base_class.connection.visitor.compile(join_string))
             else
               right = join.right
               right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)

--- a/activerecord/lib/active_record/associations/join_dependency/join_base.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_base.rb
@@ -8,14 +8,14 @@ module ActiveRecord
       class JoinBase < JoinPart # :nodoc:
         attr_reader :table
 
-        def initialize(base_klass, table, children)
-          super(base_klass, children)
+        def initialize(base_class, table, children)
+          super(base_class, children)
           @table = table
         end
 
         def match?(other)
           return true if self == other
-          super && base_klass == other.base_klass
+          super && base_class == other.base_class
         end
       end
     end

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -15,12 +15,12 @@ module ActiveRecord
         # The Active Record class which this join part is associated 'about'; for a JoinBase
         # this is the actual base model, for a JoinAssociation this is the target model of the
         # association.
-        attr_reader :base_klass, :children
+        attr_reader :base_class, :children
 
-        delegate :table_name, :column_names, :primary_key, :attribute_types, to: :base_klass
+        delegate :table_name, :column_names, :primary_key, :attribute_types, to: :base_class
 
-        def initialize(base_klass, children)
-          @base_klass = base_klass
+        def initialize(base_class, children)
+          @base_class = base_class
           @children = children
         end
 
@@ -63,7 +63,7 @@ module ActiveRecord
         end
 
         def instantiate(row, aliases, column_types = {}, &block)
-          base_klass.instantiate(extract_record(row, aliases), column_types, &block)
+          base_class.instantiate(extract_record(row, aliases), column_types, &block)
         end
       end
     end

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -46,8 +46,8 @@ module ActiveRecord
 
         def likely_reflections
           parent_classes = parent.target_classes
-          parent_classes.filter_map do |parent_klass|
-            parent_klass._reflect_on_association(@association)
+          parent_classes.filter_map do |parent_class|
+            parent_class._reflect_on_association(@association)
           end
         end
 
@@ -94,8 +94,8 @@ module ActiveRecord
             end
 
             [klass, reflection_scope]
-          end.map do |(rhs_klass, reflection_scope), rs|
-            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default)
+          end.map do |(rhs_class, reflection_scope), rs|
+            preloader_for(reflection).new(rhs_class, rs, reflection, scope, reflection_scope, associate_by_default)
           end
         end
 

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class SingularAssociation < Association # :nodoc:
       # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
       def reader
-        ensure_klass_exists!
+        ensure_class_exists!
 
         if !loaded? || stale_target?
           reload

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -197,8 +197,6 @@ module ActiveRecord
       def connection_class # :nodoc:
         pool_config.connection_class
       end
-      alias :connection_klass :connection_class
-      deprecate :connection_klass, deprecator: ActiveRecord.deprecator
 
       # Returns true if there is an open connection being used for the current thread.
       #

--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -49,14 +49,24 @@ module ActiveRecord
     # to call <tt>require "active_support/core_ext/integer/time"</tt> to load
     # the core extension in order to use +2.seconds+
     class DatabaseSelector
-      def initialize(app, resolver_klass = nil, context_klass = nil, options = {})
+      def initialize(app, resolver_class = nil, context_class = nil, options = {})
         @app = app
-        @resolver_klass = resolver_klass || Resolver
-        @context_klass = context_klass || Resolver::Session
+        @resolver_class = resolver_class || Resolver
+        @context_class = context_class || Resolver::Session
         @options = options
       end
 
-      attr_reader :resolver_klass, :context_klass, :options
+      attr_reader :resolver_class, :context_class, :options
+
+      def resolver_klass
+        resolver_class
+      end
+      deprecate resolver_klass: :resolver_class, deprecator: ActiveRecord.deprecator
+
+      def context_klass
+        context_class
+      end
+      deprecate context_klass: :context_class, deprecator: ActiveRecord.deprecator
 
       # Middleware that determines which database connection to use in a multiple
       # database application.
@@ -70,8 +80,8 @@ module ActiveRecord
 
       private
         def select_database(request, &blk)
-          context = context_klass.call(request)
-          resolver = resolver_klass.call(context, options)
+          context = context_class.call(request)
+          resolver = resolver_class.call(context, options)
 
           response = if resolver.reading_request?(request)
             resolver.read(&blk)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -190,13 +190,13 @@ module ActiveRecord
         scope ? [scope] : []
       end
 
-      def join_scope(table, foreign_table, foreign_klass)
+      def join_scope(table, foreign_table, foreign_class)
         predicate_builder = predicate_builder(table)
         scope_chain_items = join_scopes(table, predicate_builder)
         klass_scope       = klass_join_scope(table, predicate_builder)
 
         if type
-          klass_scope.where!(type => foreign_klass.polymorphic_name)
+          klass_scope.where!(type => foreign_class.polymorphic_name)
         end
 
         scope_chain_items.inject(klass_scope, &:merge!)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       @values = values
       @loaded = false
       @predicate_builder = predicate_builder
-      @delegate_to_klass = false
+      @delegate_to_class = false
       @future_result = nil
       @records = nil
       @async = false
@@ -454,11 +454,11 @@ module ActiveRecord
     end
 
     def _exec_scope(...) # :nodoc:
-      @delegate_to_klass = true
+      @delegate_to_class = true
       registry = klass.scope_registry
       _scoping(nil, registry) { instance_exec(...) || self }
     ensure
-      @delegate_to_klass = false
+      @delegate_to_class = false
     end
 
     # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
@@ -740,7 +740,7 @@ module ActiveRecord
     def reset
       @future_result&.cancel
       @future_result = nil
-      @delegate_to_klass = false
+      @delegate_to_class = false
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
       @cache_keys = nil
@@ -876,7 +876,7 @@ module ActiveRecord
 
     private
       def already_in_scope?(registry)
-        @delegate_to_klass && registry.current_scope(klass, true)
+        @delegate_to_class && registry.current_scope(klass, true)
       end
 
       def global_scope?(registry)

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -538,7 +538,7 @@ module ActiveRecord
 
       def lookup_cast_type_from_join_dependencies(name, join_dependencies = build_join_dependencies)
         each_join_dependencies(join_dependencies) do |join|
-          type = join.base_klass.attribute_types.fetch(name, nil)
+          type = join.base_class.attribute_types.fetch(name, nil)
           return type if type
         end
         nil

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1524,7 +1524,7 @@ module ActiveRecord
           self.references_values |= references unless references.empty?
 
           parts = predicate_builder.build_from_hash(opts) do |table_name|
-            lookup_table_klass_from_join_dependencies(table_name)
+            lookup_table_class_from_join_dependencies(table_name)
           end
         when Arel::Nodes::Node
           parts = [opts]
@@ -1546,9 +1546,9 @@ module ActiveRecord
         spawn.async!
       end
 
-      def lookup_table_klass_from_join_dependencies(table_name)
+      def lookup_table_class_from_join_dependencies(table_name)
         each_join_dependencies do |join|
-          return join.base_klass if table_name == join.table_name
+          return join.base_class if table_name == join.table_name
         end
         nil
       end
@@ -1674,7 +1674,7 @@ module ActiveRecord
 
         joins = joins_values.dup
         if joins.last.is_a?(ActiveRecord::Associations::JoinDependency)
-          stashed_eager_load = joins.pop if joins.last.base_klass == klass
+          stashed_eager_load = joins.pop if joins.last.base_class == klass
         end
 
         joins.each_with_index do |join, i|
@@ -1798,7 +1798,7 @@ module ActiveRecord
         elsif field.match?(/\A\w+\.\w+\z/)
           table, column = field.split(".")
           predicate_builder.resolve_arel_attribute(table, column) do
-            lookup_table_klass_from_join_dependencies(table)
+            lookup_table_class_from_join_dependencies(table)
           end
         else
           yield field

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -43,15 +43,15 @@ module ActiveRecord
       end
 
       if reflection
-        association_klass = reflection.klass unless reflection.polymorphic?
+        association_class = reflection.klass unless reflection.polymorphic?
       elsif block_given?
-        association_klass = yield table_name
+        association_class = yield table_name
       end
 
-      if association_klass
-        arel_table = association_klass.arel_table
+      if association_class
+        arel_table = association_class.arel_table
         arel_table = arel_table.alias(table_name) if arel_table.name != table_name
-        TableMetadata.new(association_klass, arel_table, reflection)
+        TableMetadata.new(association_class, arel_table, reflection)
       else
         type_caster = TypeCaster::Connection.new(klass, table_name)
         arel_table = Arel::Table.new(table_name, type_caster: type_caster)

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -48,11 +48,11 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_not_compatible_with_serialize_array
-    new_klass = Class.new(PgArray) do
+    new_class = Class.new(PgArray) do
       serialize :tags, type: Array
     end
     assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
-      new_klass.new
+      new_class.new
     end
   end
 
@@ -64,12 +64,12 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_array_with_serialized_attributes
-    new_klass = Class.new(PgArray) do
+    new_class = Class.new(PgArray) do
       serialize :tags, coder: MyTags
     end
 
-    new_klass.create!(tags: MyTags.new(["one", "two"]))
-    record = new_klass.first
+    new_class.create!(tags: MyTags.new(["one", "two"]))
+    record = new_class.first
 
     assert_instance_of MyTags, record.tags
     assert_equal ["one", "two"], record.tags.to_a

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -501,14 +501,14 @@ module ActiveRecord
 
       def test_unparsed_defaults_are_at_least_set_when_saving
         with_example_table "id SERIAL PRIMARY KEY, number INTEGER NOT NULL DEFAULT (4 + 4) * 2 / 4" do
-          number_klass = Class.new(ActiveRecord::Base) do
+          number_class = Class.new(ActiveRecord::Base) do
             self.table_name = "ex"
           end
-          column = number_klass.columns_hash["number"]
+          column = number_class.columns_hash["number"]
           assert_nil column.default
           assert_nil column.default_function
 
-          first_number = number_klass.new
+          first_number = number_class.new
           assert_nil first_number.number
 
           first_number.save!
@@ -520,10 +520,10 @@ module ActiveRecord
         @connection.execute("CREATE DOMAIN example_type AS integer")
 
         with_example_table "id SERIAL PRIMARY KEY, number example_type" do
-          number_klass = Class.new(ActiveRecord::Base) do
+          number_class = Class.new(ActiveRecord::Base) do
             self.table_name = "ex"
           end
-          attribute = number_klass.arel_table[:number]
+          attribute = number_class.arel_table[:number]
           assert_queries :any, ignore_none: true do
             @connection.case_insensitive_comparison(attribute, "foo")
           end

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -28,8 +28,8 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
 
   test "can add listeners that will get invoked when declaring encrypted attributes" do
     @klass, @attribute_name = nil
-    ActiveRecord::Encryption.on_encrypted_attribute_declared do |declared_klass, declared_attribute_name|
-      @klass = declared_klass
+    ActiveRecord::Encryption.on_encrypted_attribute_declared do |declared_class, declared_attribute_name|
+      @klass = declared_class
       @attribute_name = declared_attribute_name
     end
 

--- a/activerecord/test/cases/errors_test.rb
+++ b/activerecord/test/cases/errors_test.rb
@@ -5,12 +5,12 @@ require "cases/helper"
 class ErrorsTest < ActiveRecord::TestCase
   def test_can_be_instantiated_with_no_args
     base = ActiveRecord::ActiveRecordError
-    error_klasses = ObjectSpace.each_object(Class).select { |klass| klass < base }
+    error_classes = ObjectSpace.each_object(Class).select { |klass| klass < base }
 
-    (error_klasses - [ActiveRecord::AmbiguousSourceReflectionForThroughAssociation]).each do |error_klass|
-      error_klass.new.inspect
+    (error_classes - [ActiveRecord::AmbiguousSourceReflectionForThroughAssociation]).each do |error_class|
+      error_class.new.inspect
     rescue ArgumentError
-      raise "Instance of #{error_klass} can't be initialized with no arguments"
+      raise "Instance of #{error_class} can't be initialized with no arguments"
     end
   end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -439,7 +439,7 @@ class FixturesTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = "prefix_"
     ActiveRecord::Base.table_name_suffix = "_suffix"
 
-    other_topic_klass = Class.new(ActiveRecord::Base) do
+    other_topic_class = Class.new(ActiveRecord::Base) do
       def self.name
         "OtherTopic"
       end
@@ -460,8 +460,8 @@ class FixturesTest < ActiveRecord::TestCase
 
     assert_equal :prefix_other_topics_suffix, topics.table_name.to_sym
     # This assertion should preferably be the last in the list, because calling
-    # other_topic_klass.table_name sets a class-level instance variable
-    assert_equal :prefix_other_topics_suffix, other_topic_klass.table_name.to_sym
+    # other_topic_class.table_name sets a class-level instance variable
+    assert_equal :prefix_other_topics_suffix, other_topic_class.table_name.to_sym
 
   ensure
     # Restore prefix/suffix to its previous values

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -219,11 +219,11 @@ module JSONSharedTestCases
   end
 
   def test_not_compatible_with_serialize_json
-    new_klass = Class.new(klass) do
+    new_class = Class.new(klass) do
       serialize :payload, coder: JSON
     end
     assert_raises(ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError) do
-      new_klass.new
+      new_class.new
     end
   end
 
@@ -235,12 +235,12 @@ module JSONSharedTestCases
   end
 
   def test_json_with_serialized_attributes
-    new_klass = Class.new(klass) do
+    new_class = Class.new(klass) do
       serialize :settings, coder: MySettings
     end
 
-    new_klass.create!(settings: MySettings.new("one" => "two"))
-    record = new_klass.first
+    new_class.create!(settings: MySettings.new("one" => "two"))
+    record = new_class.first
 
     assert_instance_of MySettings, record.settings
     assert_equal({ "one" => "two" }, record.settings.to_hash)

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -365,51 +365,51 @@ module ActiveRecord
         connection.create_table :testings do |t|
           t.column :title, :string
         end
-        person_klass = Class.new(ActiveRecord::Base)
-        person_klass.table_name = "testings"
+        person_class = Class.new(ActiveRecord::Base)
+        person_class.table_name = "testings"
 
-        person_klass.connection.add_column "testings", "wealth", :integer, null: false, default: 99
-        person_klass.reset_column_information
-        assert_equal 99, person_klass.column_defaults["wealth"]
-        assert_equal false, person_klass.columns_hash["wealth"].null
+        person_class.connection.add_column "testings", "wealth", :integer, null: false, default: 99
+        person_class.reset_column_information
+        assert_equal 99, person_class.column_defaults["wealth"]
+        assert_equal false, person_class.columns_hash["wealth"].null
         # Oracle needs primary key value from sequence
         if current_adapter?(:OracleAdapter)
-          assert_nothing_raised { person_klass.connection.execute("insert into testings (id, title) values (testings_seq.nextval, 'tester')") }
+          assert_nothing_raised { person_class.connection.execute("insert into testings (id, title) values (testings_seq.nextval, 'tester')") }
         else
-          assert_nothing_raised { person_klass.connection.execute("insert into testings (title) values ('tester')") }
+          assert_nothing_raised { person_class.connection.execute("insert into testings (title) values ('tester')") }
         end
 
         # change column default to see that column doesn't lose its not null definition
-        person_klass.connection.change_column_default "testings", "wealth", 100
-        person_klass.reset_column_information
-        assert_equal 100, person_klass.column_defaults["wealth"]
-        assert_equal false, person_klass.columns_hash["wealth"].null
+        person_class.connection.change_column_default "testings", "wealth", 100
+        person_class.reset_column_information
+        assert_equal 100, person_class.column_defaults["wealth"]
+        assert_equal false, person_class.columns_hash["wealth"].null
 
         # rename column to see that column doesn't lose its not null and/or default definition
-        person_klass.connection.rename_column "testings", "wealth", "money"
-        person_klass.reset_column_information
-        assert_nil person_klass.columns_hash["wealth"]
-        assert_equal 100, person_klass.column_defaults["money"]
-        assert_equal false, person_klass.columns_hash["money"].null
+        person_class.connection.rename_column "testings", "wealth", "money"
+        person_class.reset_column_information
+        assert_nil person_class.columns_hash["wealth"]
+        assert_equal 100, person_class.column_defaults["money"]
+        assert_equal false, person_class.columns_hash["money"].null
 
         # change column
-        person_klass.connection.change_column "testings", "money", :integer, null: false, default: 1000
-        person_klass.reset_column_information
-        assert_equal 1000, person_klass.column_defaults["money"]
-        assert_equal false, person_klass.columns_hash["money"].null
+        person_class.connection.change_column "testings", "money", :integer, null: false, default: 1000
+        person_class.reset_column_information
+        assert_equal 1000, person_class.column_defaults["money"]
+        assert_equal false, person_class.columns_hash["money"].null
 
         # change column, make it nullable and clear default
-        person_klass.connection.change_column "testings", "money", :integer, null: true, default: nil
-        person_klass.reset_column_information
-        assert_nil person_klass.columns_hash["money"].default
-        assert_equal true, person_klass.columns_hash["money"].null
+        person_class.connection.change_column "testings", "money", :integer, null: true, default: nil
+        person_class.reset_column_information
+        assert_nil person_class.columns_hash["money"].default
+        assert_equal true, person_class.columns_hash["money"].null
 
         # change_column_null, make it not nullable and set null values to a default value
-        person_klass.connection.execute("UPDATE testings SET money = NULL")
-        person_klass.connection.change_column_null "testings", "money", false, 2000
-        person_klass.reset_column_information
-        assert_nil person_klass.columns_hash["money"].default
-        assert_equal false, person_klass.columns_hash["money"].null
+        person_class.connection.execute("UPDATE testings SET money = NULL")
+        person_class.connection.change_column_null "testings", "money", false, 2000
+        person_class.reset_column_information
+        assert_nil person_class.columns_hash["money"].default
+        assert_equal false, person_class.columns_hash["money"].null
         assert_equal 2000, connection.select_values("SELECT money FROM testings").first.to_i
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -120,7 +120,7 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal object, type.serialize(object)
   end
 
-  def test_reflection_klass_for_nested_class_name
+  def test_reflection_class_for_nested_class_name
     reflection = ActiveRecord::Reflection.create(
       :has_many,
       nil,
@@ -141,7 +141,7 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "PluralIrregular", reflection.class_name
   end
 
-  def test_reflection_klass_not_found_with_no_class_name_option
+  def test_reflection_class_not_found_with_no_class_name_option
     error = assert_raise(NameError) do
       UserWithInvalidRelation.reflect_on_association(:not_a_class).klass
     end
@@ -153,7 +153,7 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_match ":class_name", error.message
   end
 
-  def test_reflection_klass_not_found_with_pointer_to_non_existent_class_name
+  def test_reflection_class_not_found_with_pointer_to_non_existent_class_name
     error = assert_raise(NameError) do
       UserWithInvalidRelation.reflect_on_association(:class_name_provided_not_a_class).klass
     end
@@ -165,7 +165,7 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_no_match ":class_name", error.message
   end
 
-  def test_reflection_klass_requires_ar_subclass
+  def test_reflection_class_requires_ar_subclass
     [ :account_invalid,          # has_one, without :class_name
       :account_class_name,       # has_one, with :class_name
       :info_invalids,            # has_many through, without :class_name

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -268,7 +268,7 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_klass_level_update_all
+  def test_class_level_update_all
     travel 5.seconds do
       now = Time.now.utc
 
@@ -284,7 +284,7 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_klass_level_touch_all
+  def test_class_level_touch_all
     travel 5.seconds do
       now = Time.now.utc
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       assert_not relation.loaded, "relation is not loaded"
     end
 
-    def test_responds_to_model_and_returns_klass
+    def test_responds_to_model_and_returns_class
       relation = Relation.new(FakeKlass)
       assert_equal FakeKlass, relation.model
     end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -432,12 +432,12 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_unscope_and_scope
-    developer_klass = Class.new(Developer) do
+    developer_class = Class.new(Developer) do
       scope :by_name, -> name { unscope(where: :name).where(name: name) }
     end
 
-    expected = developer_klass.where(name: "Jamis").collect { |dev| [dev.name, dev.id] }
-    received = developer_klass.where(name: "David").by_name("Jamis").collect { |dev| [dev.name, dev.id] }
+    expected = developer_class.where(name: "Jamis").collect { |dev| [dev.name, dev.id] }
+    received = developer_class.where(name: "David").by_name("Jamis").collect { |dev| [dev.name, dev.id] }
     assert_equal expected, received
   end
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -119,7 +119,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal topics.count, stats[:count]
   end
 
-  def test_positional_klass_method
+  def test_positional_class_method
     stats = {}
     topics = Topic.all.klass_stats(stats)
 

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -335,7 +335,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
   end
 
-  def test_scoping_with_klass_method_works_in_the_scope_block
+  def test_scoping_with_class_method_works_in_the_scope_block
     expected = SpecialPostWithDefaultScope.unscoped.to_a
     assert_equal expected, SpecialPostWithDefaultScope.unscoped_all
   end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -402,7 +402,7 @@ class TimestampTest < ActiveRecord::TestCase
       def self.name; "Toy"; end
     end
 
-    wheel_klass = Class.new(ActiveRecord::Base) do
+    wheel_class = Class.new(ActiveRecord::Base) do
       def self.name; "Wheel"; end
       belongs_to :wheelable, polymorphic: true, touch: true
     end
@@ -411,7 +411,7 @@ class TimestampTest < ActiveRecord::TestCase
     time = 3.days.ago
     toy.update_columns(updated_at: time)
 
-    wheel = wheel_klass.new
+    wheel = wheel_class.new
     wheel.wheelable = toy
     wheel.save
     wheel.touch

--- a/activerecord/test/cases/validations/absence_validation_test.rb
+++ b/activerecord/test/cases/validations/absence_validation_test.rb
@@ -8,22 +8,22 @@ require "models/topic"
 
 class AbsenceValidationTest < ActiveRecord::TestCase
   def test_non_association
-    boy_klass = Class.new(Human) do
+    boy_class = Class.new(Human) do
       def self.name; "Boy" end
       validates_absence_of :name
     end
 
-    assert_predicate boy_klass.new, :valid?
-    assert_not_predicate boy_klass.new(name: "Alex"), :valid?
+    assert_predicate boy_class.new, :valid?
+    assert_not_predicate boy_class.new(name: "Alex"), :valid?
   end
 
   def test_has_one_marked_for_destruction
-    boy_klass = Class.new(Human) do
+    boy_class = Class.new(Human) do
       def self.name; "Boy" end
       validates_absence_of :face
     end
 
-    boy = boy_klass.new(face: Face.new)
+    boy = boy_class.new(face: Face.new)
     assert_not boy.valid?, "should not be valid if has_one association is present"
     assert_equal 1, boy.errors[:face].size, "should only add one error"
 
@@ -32,11 +32,11 @@ class AbsenceValidationTest < ActiveRecord::TestCase
   end
 
   def test_has_many_marked_for_destruction
-    boy_klass = Class.new(Human) do
+    boy_class = Class.new(Human) do
       def self.name; "Boy" end
       validates_absence_of :interests
     end
-    boy = boy_klass.new
+    boy = boy_class.new
     boy.interests << [i1 = Interest.new, i2 = Interest.new]
     assert_not boy.valid?, "should not be valid if has_many association is present"
 
@@ -48,7 +48,7 @@ class AbsenceValidationTest < ActiveRecord::TestCase
   end
 
   def test_does_not_call_to_a_on_associations
-    boy_klass = Class.new(Human) do
+    boy_class = Class.new(Human) do
       def self.name; "Boy" end
       validates_absence_of :face
     end
@@ -56,7 +56,7 @@ class AbsenceValidationTest < ActiveRecord::TestCase
     face_with_to_a = Face.new
     def face_with_to_a.to_a; ["(/)", '(\)']; end
 
-    assert_nothing_raised { boy_klass.new(face: face_with_to_a).valid? }
+    assert_nothing_raised { boy_class.new(face: face_with_to_a).valid? }
   end
 
   def test_validates_absence_of_virtual_attribute_on_model

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -229,8 +229,8 @@ module ActiveSupport
           @name = name
           @id = id
           @payload = payload
-          @groups = notifier.groups_for(name).map do |group_klass, grouped_listeners|
-            group_klass.new(grouped_listeners, name, id, payload)
+          @groups = notifier.groups_for(name).map do |group_class, grouped_listeners|
+            group_class.new(grouped_listeners, name, id, payload)
           end
           @state = :initialized
         end

--- a/activesupport/test/descendants_tracker_test.rb
+++ b/activesupport/test/descendants_tracker_test.rb
@@ -57,8 +57,8 @@ class DescendantsTrackerTest < ActiveSupport::TestCase
     # that such references are on a stack that will be entirely garbage
     # collected, effectively working around the problem.
     Thread.new do
-      child_klass = Class.new(Parent)
-      assert_equal_sets [Child1, Grandchild1, Grandchild2, Child2, child_klass], Parent.descendants
+      child_class = Class.new(Parent)
+      assert_equal_sets [Child1, Grandchild1, Grandchild2, Child2, child_class], Parent.descendants
     end.join
 
     # Calling `GC.start` 4 times should trigger a full GC run

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -300,7 +300,7 @@ end
 which is only a marker, its body or return value are irrelevant. Then, client code can query for duck-type-safeness this way:
 
 ```ruby
-some_klass.acts_like?(:string)
+some_class.acts_like?(:string)
 ```
 
 Rails has classes that act like `Date` or `Time` and follow this contract.


### PR DESCRIPTION
We use `klass` because `class` is a reserved word in Ruby.

But, any word ending with the suffix `_class` isn't reserved, so we don't need to use the suffix `_klass` anywhere.