### PR TITLE
Rm unused default_protect_from_forgery accessor

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -90,10 +90,6 @@ module ActionController # :nodoc:
       config_accessor :per_form_csrf_tokens
       self.per_form_csrf_tokens = false
 
-      # Controls whether forgery protection is enabled by default.
-      config_accessor :default_protect_from_forgery
-      self.default_protect_from_forgery = false
-
       # The strategy to use for storing and retrieving CSRF tokens.
       config_accessor :csrf_token_storage_strategy
       self.csrf_token_storage_strategy = SessionStore.new

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -77,6 +77,7 @@ module ActionController
 
         # Configs used in other initializers
         filtered_options = options.except(
+          :default_protect_from_forgery,
           :log_query_tags_around_actions,
           :permit_all_parameters,
           :action_on_unpermitted_parameters,

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1747,7 +1747,6 @@ module ApplicationTests
     test "config.action_controller.default_protect_from_forgery is true by default" do
       app "development"
 
-      assert_equal true, ActionController::Base.default_protect_from_forgery
       assert_includes ActionController::Base.__callbacks[:process_action].map(&:filter), :verify_authenticity_token
     end
 


### PR DESCRIPTION
### Motivation / Background

This was [added][1] when the default configuration was added for Rails 5.2, however the accessor itself has never been documented or used. `protect_from_forgery: :exception` is added based on  whether the configuration is set on `config.action_controller` and not this value.

### Detail

Since the accessor is undocumented and unused, this commit removes it.

[1]: https://github.com/rails/rails/commit/48cb8b3e7097e9a1cb45b2298f59b9179f0dbdee

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
