### PR TITLE
No need to include error_highlight when ruby version >= 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -193,6 +193,6 @@ gem "wdm", ">= 0.1.0", platforms: [:windows]
 # The error_highlight gem only works on CRuby 3.1 or later.
 # Also, Rails depends on a new API available since error_highlight 0.4.0.
 # (Note that Ruby 3.1 bundles error_highlight 0.3.0.)
-if RUBY_VERSION >= "3.1"
+if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2"
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,6 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     drb (2.1.1)
       ruby2_keywords
-    error_highlight (0.5.1)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -584,7 +583,6 @@ DEPENDENCIES
   debug (>= 1.1.0)
   delayed_job
   delayed_job_active_record
-  error_highlight (>= 0.4.0)
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -51,7 +51,7 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 
-<%- if RUBY_VERSION >= "3.1" -%>
+<%- if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" -%>
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 <%- end -%>
 end


### PR DESCRIPTION
### Motivation / Background

`gem "error_highlight", ">= 0.4.0"`  was added as a work around for ruby 3.1 since it included error_highlight v0.3.0 while rails needed at least v0.4.0.

Since ruby 3.2 already include v0.5.1, adding `gem "error_highlight", ">= 0.4.0"` is no longer needed when already using ruby 3.2 or above.

<img width="686" alt="Screenshot 2023-09-29 at 10 14 38" src="https://github.com/rails/rails/assets/3153380/77d38e05-d2d8-4e58-9738-ee39d02e5ec7">


This Pull Request has been created because generating a new rails app with ruby 3.2 and above unnecessarily adds this to gem file which is not needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
