### PR TITLE
rails db:drop now removes -shm and -wal sqlite files

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -23,6 +23,7 @@ module ActiveRecord
         db_path = db_config.database
         file = File.absolute_path?(db_path) ? db_path : File.join(root, db_path)
         FileUtils.rm(file)
+        FileUtils.rm_f(["#{file}-shm", "#{file}-wal"])
       rescue Errno::ENOENT => error
         raise NoDatabaseError.new(error.message)
       end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -99,7 +99,9 @@ module ActiveRecord
 
     def test_removes_file_with_absolute_path
       assert_called_with(FileUtils, :rm, [@database_root]) do
-        ActiveRecord::Tasks::DatabaseTasks.drop @configuration_root, @root
+        assert_called_with(FileUtils, :rm_f, [["#{@database_root}-shm", "#{@database_root}-wal"]]) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration_root, @root
+        end
       end
     end
 
@@ -111,7 +113,9 @@ module ActiveRecord
 
     def test_removes_file_with_relative_path
       assert_called_with(FileUtils, :rm, [@database_root]) do
-        ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
+        assert_called_with(FileUtils, :rm_f, [["#{@database_root}-shm", "#{@database_root}-wal"]]) do
+          ActiveRecord::Tasks::DatabaseTasks.drop @configuration, @root
+        end
       end
     end
 


### PR DESCRIPTION
Dropping SQLite databases now removes the -shm and -wal files as well, if present.

Fixes #49435

@fractaledmind, I did not see you wanted to work on this 🙈 Thank you for your recent SQLite contributions ✌️ 