### PR TITLE
Avoid Action Cable config in dev templates on --skip-action-cable

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -345,6 +345,10 @@ module Rails
         options[:skip_active_storage]
       end
 
+      def skip_action_cable? # :doc:
+        options[:skip_action_cable]
+      end
+
       def skip_action_mailer? # :doc:
         options[:skip_action_mailer]
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -80,9 +80,11 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  <%- unless skip_action_cable? -%>
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  <%- end -%>
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   <%- end -%>
-  <%- unless options[:skip_action_cable] -%>
+  <%- unless skip_action_cable? -%>
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"


### PR DESCRIPTION
`rails new --skip-action-cable` now generates `config/environments/development.rb` without Action Cable configurations.

- Follows up #24169
- cf. #22586

### Motivation / Background

As #24169 was not aligned with styles in #22586, even with `--skip-action-cable` option, `rails new` still generates `config/environments/development.rb` with extra comments for Action Cable configurations.

### Detail

- Not to include `config.action_cable.*` config example in `config/environments/development.rb` on `rails new` with `--skip-action-cable`.
- DRY `options[:skip_action_cable]` in the generator.

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [n/a] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
