### PR TITLE
Add tests for send_file and redirect_to instrumentation

### DIFF
--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -601,6 +601,23 @@ class RedirectTest < ActionController::TestCase
     end
   end
 
+  def test_redirect_to_instrumentation
+    payload = nil
+
+    subscriber = proc do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      payload = event.payload
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, "redirect_to.action_controller") do
+      get :simple_redirect
+    end
+
+    assert_equal request, payload[:request]
+    assert_equal 302, payload[:status]
+    assert_equal "http://test.host/redirect/hello_world", payload[:location]
+  end
+
   private
     def with_raise_on_open_redirects
       old_raise_on_open_redirects = ActionController::Base.raise_on_open_redirects


### PR DESCRIPTION
It seems these weren't tested before.

Caching instrumentation is tested in a similar way:
https://github.com/rails/rails/blob/a5f113f4332b3688d4431a97fa517d1b9517ceb0/actionpack/test/controller/caching_test.rb#L257-L270

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
