### PR TITLE
Support multiple analyzers during `ActiveStorage::Blob#analyze`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Support multiple analyzers during ActiveStorage::Blob#analyze`
+
+    *Sean Doyle*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/test/models/blob/analyzable_test.rb
+++ b/activestorage/test/models/blob/analyzable_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::Blob::AnalyzableTest < ActiveSupport::TestCase
+  class AnalyzerA < ActiveStorage::Analyzer
+    def self.accept?(blob)
+      true
+    end
+
+    def metadata
+      { analyzed_by: { a: true } }
+    end
+  end
+
+  class AnalyzerB < ActiveStorage::Analyzer
+    def self.accept?(blob)
+      true
+    end
+
+    def metadata
+      { analyzed_by: { b: true } }
+    end
+  end
+
+  class AnalyzerC < ActiveStorage::Analyzer
+    def self.accept?(blob)
+      false
+    end
+
+    def metadata
+      { analyzed_by: { c: true } }
+    end
+  end
+
+  test "#analyze supports multiple analyzers for a Blob" do
+    ActiveStorage.with analyzers: [AnalyzerA, AnalyzerB, AnalyzerC] do
+      blob = create_blob(filename: "racecar.jpeg")
+
+      analyzed_by = extract_metadata_from(blob).fetch(:analyzed_by)
+
+      assert_equal true, analyzed_by[:a]
+      assert_equal true, analyzed_by[:b]
+      assert_equal false, analyzed_by.key?(:c)
+    end
+  end
+end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -812,9 +812,32 @@ Analyzing Files
 
 Active Storage analyzes files once they've been uploaded by queuing a job in Active Job. Analyzed files will store additional information in the metadata hash, including `analyzed: true`. You can check whether a blob has been analyzed by calling [`analyzed?`][] on it.
 
-Image analysis provides `width` and `height` attributes. Video analysis provides these, as well as `duration`, `angle`, `display_aspect_ratio`, and `video` and `audio` booleans to indicate the presence of those channels. Audio analysis provides `duration` and `bit_rate` attributes.
+Analysis extracts and stores metadata from the file associated with a blob using relevant analyzers. Active Storage comes with built-in analyzers for images and videos. See [ActiveStorage::Analyzer::ImageAnalyzer][] and [ActiveStorage::Analyzer::VideoAnalyzer][] for information about the specific attributes they extract and the third-party libraries they require.
+
+To choose the analyzer for a blob, Active Storage calls `accept?` on each registered analyzer in order. It uses
+all analyzers for which `accept?` returns true when given the blob. If no registered analyzer accepts the blob, no
+metadata is extracted from it.
+
+In a Rails application, add or remove analyzers by manipulating `Rails.application.config.active_storage.analyzers`
+in an initializer:
+
+```ruby
+# Add a custom analyzer for Microsoft Office documents:
+Rails.application.config.active_storage.analyzers.append DOCXAnalyzer
+
+# Remove the built-in video analyzer:
+Rails.application.config.active_storage.analyzers.delete ActiveStorage::Analyzer::VideoAnalyzer
+```
+
+Outside of a Rails application, manipulate `ActiveStorage.analyzers` instead.
+
+You won't ordinarily need to call `ActiveStorage::Blob#analyze` from a Rails application. New blobs are automatically and asynchronously analyzed via `ActiveStorage::Blob#analyze_later` when they're attached for the first time.
+
+The built-in image analysis provides `width` and `height` attributes. The built-in video analysis provides these, as well as `duration`, `angle`, `display_aspect_ratio`, and `video` and `audio` booleans to indicate the presence of those channels. Audio analysis provides `duration` and `bit_rate` attributes.
 
 [`analyzed?`]: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Analyzable.html#method-i-analyzed-3F
+[ActiveStorage::Analyzer::ImageAnalyzer]: https://api.rubyonrails.org/classes/ActiveStorage/Analyzer/ImageAnalyzer.html
+[ActiveStorage::Analyzer::VideoAnalyzer]: https://api.rubyonrails.org/classes/ActiveStorage/Analyzer/VideoAnalyzer.html
 
 Displaying Images, Videos, and PDFs
 ---------------


### PR DESCRIPTION

### Motivation / Background

Prior to this commit, Blob analysis could only involve a single Analyzer. By default, the metadata typically includes information about dimensions (for image and video).

If applications need to include more involved analysis, they also have to re-implement the dimension analysis on their own (either through composition, inheritance, or copy-pasting).

### Detail

This commit extends analysis to support *multiple* anaylzer classes by replacing [Enumerable#detect][] with [Enumerable#select][], and a [Hash#merge][] with an [Enumerable#reduce][].

[Enumerable#detect]: https://ruby-doc.org/core-3.0.2/Enumerable.html#method-i-detect
[Enumerable#select]: https://ruby-doc.org/core-3.0.2/Enumerable.html#method-i-select
[Hash#merge]: https://ruby-doc.org/3.2.2/Hash.html#method-i-hash
[Enumerable#reduce]: https://ruby-doc.org/core-3.0.2/Enumerable.html#method-i-reduce

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
