### PR TITLE
Fix `AS::MessagePack` with `ENV["RAILS_MAX_THREADS"]`

### DIFF
--- a/activesupport/lib/active_support/message_pack/serializer.rb
+++ b/activesupport/lib/active_support/message_pack/serializer.rb
@@ -51,7 +51,7 @@ module ActiveSupport
               install_unregistered_type_handler
               message_pack_factory.freeze
             end
-            message_pack_factory.pool(ENV.fetch("RAILS_MAX_THREADS") { 5 })
+            message_pack_factory.pool(ENV.fetch("RAILS_MAX_THREADS", 5).to_i)
           end
         end
 

--- a/activesupport/test/message_pack/shared_serializer_tests.rb
+++ b/activesupport/test/message_pack/shared_serializer_tests.rb
@@ -140,6 +140,15 @@ module MessagePackSharedSerializerTests
     test "roundtrips ActiveSupport::HashWithIndifferentAccess" do
       assert_roundtrip ActiveSupport::HashWithIndifferentAccess.new(a: true, b: 2, c: "three")
     end
+
+    test "works with ENV['RAILS_MAX_THREADS']" do
+      original_env = ENV.to_h
+      ENV["RAILS_MAX_THREADS"] = "1"
+
+      assert_roundtrip "value"
+    ensure
+      ENV.replace(original_env)
+    end
   end
 
   private


### PR DESCRIPTION
`ENV` values are strings, so `ENV["RAILS_MAX_THREADS"]` must be parsed as an int.

Unfortunately, `MessagePack::Factory::Pool::MemberPool` does not expose a method to check its member count, so the most we can assert is that roundtripping works as expected.

Fixes #49446.
