### PR TITLE
Ensure PG connection is configured before looking up types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -149,6 +149,7 @@ module ActiveRecord
         end
 
         def lookup_cast_type_from_column(column) # :nodoc:
+          verify! if type_map.nil?
           type_map.lookup(column.oid, column.fmod, column.sql_type)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -716,9 +716,7 @@ module ActiveRecord
       end
 
       private
-        def type_map
-          @type_map ||= Type::HashLookupTypeMap.new
-        end
+        attr_reader :type_map
 
         def initialize_type_map(m = type_map)
           self.class.initialize_type_map(m)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/49439

Because Postgres adapter types are connection dependent, we can't lookup types without first connecting to the database.

Note, this really isn't good, ideally types should be stored in the schema cache so that we don't have to extract types every time.

cc @yahonda @rafaelfranca