### PR TITLE
Get rid of the `jruby_skip` test helper

### DIFF
--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -38,12 +38,6 @@ ActionMailer::Base.delivery_job = ActionMailer::MailDeliveryJob
 
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 require_relative "../../tools/test_common"

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -362,12 +362,6 @@ require "active_support/testing/method_call_assertions"
 
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 module CookieAssertions

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -186,12 +186,6 @@ class ActiveSupport::TestCase
   end
 
   include ActiveSupport::Testing::MethodCallAssertions
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 require_relative "../../tools/test_common"

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -144,9 +144,7 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_distance_in_words_doesnt_use_the_quotient_operator
-    jruby_skip "Date is written in Ruby and relies on Integer#/"
-
-    # Make sure that we avoid Integer#/ (redefined by mathn)
+    # Make sure that we avoid Integer#/ (redefined by mathn gem to return Rational)
     Integer.send :private, :/
 
     from = Time.utc(2004, 6, 6, 21, 45, 0)

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -23,12 +23,6 @@ class ActiveModel::TestCase < ActiveSupport::TestCase
 
     raise AssertionlessTest, "No assertions made." if passed? && assertions.zero?
   end
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 require_relative "../../../tools/test_common"

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -43,12 +43,6 @@ class ActiveSupport::TestCase
 
   include ActiveSupport::Testing::MethodCallAssertions
   include ActiveSupport::Testing::ErrorReporterAssertions
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 require_relative "../../tools/test_common"

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -22,12 +22,6 @@ end
 
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
-
-  private
-    # Skips the current run on JRuby using Minitest::Assertions#skip
-    def jruby_skip(message = "")
-      skip message if defined?(JRUBY_VERSION)
-    end
 end
 
 require_relative "../../tools/test_common"


### PR DESCRIPTION
The last test calling it actually passes on latest JRuby.
