### PR TITLE
Fix `ActionController::Parameters#deep_merge` RDoc [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -145,6 +145,31 @@ module ActionController
     cattr_accessor :action_on_unpermitted_parameters, instance_accessor: false
 
     ##
+    # :method: deep_merge
+    #
+    # :call-seq:
+    #   deep_merge(other_hash, &block)
+    #
+    # Returns a new +ActionController::Parameters+ instance with +self+ and +other_hash+ merged recursively.
+    #
+    # Like with <tt>Hash#merge</tt> in the standard library, a block can be provided
+    # to merge values.
+    #
+    #--
+    # Implemented by ActiveSupport::DeepMergeable#deep_merge.
+
+    ##
+    # :method: deep_merge!
+    #
+    # :call-seq:
+    #   deep_merge!(other_hash, &block)
+    #
+    # Same as +#deep_merge+, but modifies +self+.
+    #
+    #--
+    # Implemented by ActiveSupport::DeepMergeable#deep_merge!.
+
+    ##
     # :method: as_json
     #
     # :call-seq:
@@ -866,28 +891,7 @@ module ActionController
       self
     end
 
-    ##
-    # :method: deep_merge
-    # :call-seq: deep_merge(other_hash, &block)
-    #
-    # Returns a new +ActionController::Parameters+ instance with +self+ and +other_hash+ merged recursively.
-    #
-    # Like with +Hash#merge+ in the standard library, a block can be provided
-    # to merge values.
-    #
-    #--
-    # Implemented by ActiveSupport::DeepMergeable#deep_merge.
-
-    ##
-    # :method: deep_merge!
-    # :call-seq: deep_merge!(other_hash, &block)
-    #
-    # Same as +#deep_merge+, but modifies +self+.
-    #
-    #--
-    # Implemented by ActiveSupport::DeepMergeable#deep_merge!.
-
-    def deep_merge?(other_hash) # :nodoc
+    def deep_merge?(other_hash) # :nodoc:
       other_hash.is_a?(ActiveSupport::DeepMergeable)
     end
 


### PR DESCRIPTION
Follow-up to [#45369][]

### Detail

First, add the final `:` to the `#deep_merge?` method's `:nodoc:` declaration.

Next, move the `:method:` documentation out of the methods and into the section of the class that defines the rest of the dynamic method documentation.

Finally, move the `:call-seq:` methods below the directive, like the rest of the methods.

[#45369]: https://github.com/rails/rails/pull/45369

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
