### PR TITLE
Delegate block in broadcast logger method_missing

### DIFF
--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -203,16 +203,20 @@ module ActiveSupport
         @broadcasts.each { |logger| block.call(logger) }
       end
 
-      def method_missing(name, *args)
+      def method_missing(name, *args, &block)
         loggers = @broadcasts.select { |logger| logger.respond_to?(name) }
 
         if loggers.none?
-          super(name, *args)
+          super(name, *args, &block)
         elsif loggers.one?
-          loggers.first.send(name, *args)
+          loggers.first.send(name, *args, &block)
         else
-          loggers.map { |logger| logger.send(name, *args) }
+          loggers.map { |logger| logger.send(name, *args, &block) }
         end
+      end
+
+      def respond_to_missing?(method, include_all)
+        @broadcasts.any? { |logger| logger.respond_to?(method, include_all) }
       end
   end
 end

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -268,6 +268,16 @@ module ActiveSupport
       assert(logger.foo)
     end
 
+    test "calling a method that accepts a block" do
+      logger = BroadcastLogger.new(CustomLogger.new)
+
+      called = false
+      logger.bar do
+        called = true
+      end
+      assert(called)
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level
@@ -284,6 +294,10 @@ module ActiveSupport
 
       def foo
         true
+      end
+
+      def bar
+        yield
       end
 
       def debug(message, &block)


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/49417.

When a method called on a broadcast logger is passed a block, it should be forwarded to all subscribed loggers. For example, calling `Rails.logger.tagged { }` currently returns a new tagged logger instead of running the given block.