### PR TITLE
Handle case when `config.logger` is already a BroadcastLogger:

### DIFF
--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -56,9 +56,11 @@ module Rails
         end
         Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
 
-        broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
-        broadcast_logger.formatter = Rails.logger.formatter
-        Rails.logger = broadcast_logger
+        unless Rails.logger.is_a?(ActiveSupport::BroadcastLogger)
+          broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
+          broadcast_logger.formatter = Rails.logger.formatter
+          Rails.logger = broadcast_logger
+        end
 
         unless config.consider_all_requests_local
           Rails.error.logger = Rails.logger

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1893,6 +1893,26 @@ module ApplicationTests
       assert_equal Logger::DEBUG, Rails.logger.level
     end
 
+    test "config.logger when logger is already a Broadcast Logger" do
+      logger = ActiveSupport::BroadcastLogger.new
+
+      make_basic_app do |application|
+        application.config.logger = logger
+      end
+      assert_same(logger, Rails.logger)
+    end
+
+    test "config.logger when logger is not a Broadcast Logger" do
+      logger = Logger.new(STDOUT)
+
+      make_basic_app do |application|
+        application.config.logger = logger
+      end
+
+      assert_instance_of(ActiveSupport::BroadcastLogger, Rails.logger)
+      assert_includes(Rails.logger.broadcasts, logger)
+    end
+
     test "respond_to? accepts include_private" do
       make_basic_app
 


### PR DESCRIPTION
Handle case when `config.logger` is already a BroadcastLogger:

- This commit avoids having `Rails.logger` be a two level nested BroadcastLogger. Side note that nesting broadcasted logger works and is supported by the implementation but we shouldn't do it in that case as it's confusing for the user.

Ref https://github.com/rails/rails/pull/49417#discussion_r1342124278

cc/ @st0012 
