### PR TITLE
[ci skip] Change `resourceful` to `resource` for clarity

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -83,7 +83,7 @@ NOTE: The `Rails.application.routes.draw do ... end` block that wraps your route
 Resource Routing: the Rails Default
 -----------------------------------
 
-Resource routing allows you to quickly declare all of the common routes for a given resourceful controller. A single call to [`resources`][] can declare all of the necessary routes for your `index`, `show`, `new`, `edit`, `create`, `update`, and `destroy` actions.
+Resource routing allows you to quickly declare all of the common routes for a given resource controller. A single call to [`resources`][] can declare all of the necessary routes for your `index`, `show`, `new`, `edit`, `create`, `update`, and `destroy` actions.
 
 [`resources`]: https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources
 


### PR DESCRIPTION
### Motivation / Background
Fixes #49327

This Pull Request simply changes the wording around the definition of what are resource routes and, specifically, what's a "resourceful controller", by calling it a "resource controller" instead.

As discussed in the issue, although the previous term was fine given the context of the guide, it was probably an improper term, since the meaning seems to be "the controller for a given resource" rather than a special type of controller that is said to be resourceful. Furthermore, the term itself, as far as I know, I've only ever seen in the rails guides, whereas `resource controller` seems to be of more common use.

### Detail

As stated above, I change here `resourceful controller` to `resource controller`.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
