### PR TITLE
Fix test failing because minitest is required

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -211,6 +211,7 @@ module TestHelpers
         config.session_store :cookie_store, key: "_myapp_session"
         config.active_support.deprecation = :log
         config.action_controller.allow_forgery_protection = false
+        config.turbolinks.auto_include = false
       RUBY
     end
 


### PR DESCRIPTION
### Motivation / Background

It appears this test started failing due to a [change][1] in a recent version of rails-dom-testing. By itself, the change is not a problem since rdt should really only be loaded in the test environment. However, the Turbolinks::Engine contains an initializer that includes Turbolinks::Assertions in ActionDispatch::Assertions (which ends up requiring rdt).

### Detail

To fix this issue, we can disable the auto_include behavior of Turbolinks in the app template, since this behavior isn't tested anywhere in Rails.

[1]: https://github.com/rails/rails-dom-testing/commit/a7157c21ff78932dea7d4d2a10c0cd67e48ad0ab

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
