### PR TITLE
Fix uniqueness validation to correctly work with expression indexes

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -87,7 +87,7 @@ module ActiveRecord
           klass.connection.schema_cache.indexes(klass.table_name).any? do |index|
             index.unique &&
               index.where.nil? &&
-              (index.columns - attributes).empty?
+              (Array(index.columns) - attributes).empty?
           end
         end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -812,6 +812,20 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
       t.valid?
     end
   end
+
+  if current_adapter?(:PostgreSQLAdapter)
+    def test_expression_index
+      Topic.validates_uniqueness_of(:title)
+      @connection.add_index(:topics, "LOWER(title)", unique: true, name: :topics_index)
+
+      t = Topic.create!(title: "abc", author_name: "John")
+      t.content = "hello world"
+
+      assert_queries(1) do
+        t.valid?
+      end
+    end
+  end
 end
 
 class UniquenessWithCompositeKey < ActiveRecord::TestCase


### PR DESCRIPTION
Fixes #49481.

For expression indexes, `IndexDefinition#columns` is returned as a string and thats why we get an error.