### PR TITLE
Run `test_expression_index` if `supports_expression_index?` returns true

### DIFF
--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -813,10 +813,10 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
     end
   end
 
-  if current_adapter?(:PostgreSQLAdapter)
+  if ActiveRecord::Base.connection.supports_expression_index?
     def test_expression_index
       Topic.validates_uniqueness_of(:title)
-      @connection.add_index(:topics, "LOWER(title)", unique: true, name: :topics_index)
+      @connection.add_index(:topics, "(LOWER(title))", unique: true, name: :topics_index)
 
       t = Topic.create!(title: "abc", author_name: "John")
       t.content = "hello world"


### PR DESCRIPTION
### Motivation / Background

This test runs the `test_expression_index` test if `supports_expression_index?` returns true.

### Detail
SQL statement to create unique index for generated column.
- `sqlite3` adapter CREATE UNIQUE INDEX "topics_index" ON "topics" ((LOWER(title)))
- `mysql2` and `trilogy` adapter CREATE UNIQUE INDEX `topics_index` ON `topics` ((LOWER(title)))
- `postgresql` adapter CREATE UNIQUE INDEX "topics_index" ON "topics" ((LOWER(title)))

Follow up #49483

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
