### PR TITLE
Extend `validates_associated` to accept a block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Extend `validates_associated` to accept a block
+
+    ```ruby
+    class Book < ActiveRecord::Base
+      belongs_to :author, class: User
+
+      validates_associated :author do |author|
+        author.validates_presence_of :name
+      end
+    end
+    ```
+
+    *Sean Doyle & Matheus Richard*
+
 *   Consistently raise an `ArgumentError` when passing an invalid argument to a nested attributes association writer.
 
     Previously, this would only raise on collection associations and produce a generic error on singular associations.


### PR DESCRIPTION
### Motivation / Background

Sometimes there are context-specific reasons to validate a particular field on an associated model. While it's possible to opt-into and opt-out of validation with contexts (the `on:` option), this commit proposes an alternative that extends validations declared with `validates_associated` and `validates ..., associated: true`.

For example, consider a `User` model with an optional `name` attribute. In most cases, the `User#name` isn't required, but let's say that a name _is_ required when the `User` is related to a `Book` as its `Author`.

### Detail

With the changes in this commit, the `Book` can` pass a block to declare additional validations on the relationship:

```ruby
class Book < ActiveRecord::Base
  belongs_to :author, class: User

  validates_associated :author do |author|
    author.validates_presence_of :name
  end
end
```

The block's parameter is optional, and can be omitted:

```ruby
validates_associated :author do
  validates_presence_of :name
end
```

When configuring the validation with options, pass a lambda as the +with:+ option:

```ruby
validates_associated :author,
  with: -> { validates_presence_of :name },
  unless: :anonymous?
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
