### PR TITLE
Clarify `login_procedure`'s responsibility during request authentication

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -424,7 +424,9 @@ module ActionController
 
       module ControllerMethods
         # Authenticate using an HTTP Bearer token, or otherwise render an HTTP
-        # header requesting the client to send a Bearer token.
+        # header requesting the client to send a Bearer token. For the authentication
+        # to be considered successful, `login_procedure` should return a non-nil
+        # value. Typically, the authenticated user is returned.
         #
         # See ActionController::HttpAuthentication::Token for example usage.
         def authenticate_or_request_with_http_token(realm = "Application", message = nil, &login_procedure)


### PR DESCRIPTION
### Motivation / Background
This pull request has been created because documentation for [`authenticate_or_request_with_http_token`][0] is missing necessary information.

I spent some time trying to figure out why after a small refactor, authorization began to fail for all my users. I use `authenticate_or_request_with_http_token` (from `ActionController::HttpAuthentication::Token::ControllerMethods`) to handle bearer token-based authorization, and it worked for several months. Turns out the refactor reordered expressions in my block and so nil, instead of non-nil value was returned. Reading the documentation on [`authenticate_or_request_with_http_token`][0]

### Detail
I've updated the documentation to clarify the expectation/responsibility of the `login_procedure` block to return non-nil value if authentication succeeded. I've clued the reader in on returning the authenticated user (as examples in other parts of the doc do) but happy to remove that if it could be wrongly interpreted as a command.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

[0]: https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html