### PR TITLE
Add materialized? to NullTransaction

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -115,6 +115,7 @@ module ActiveRecord
       def dirty!; end
       def invalidated?; false; end
       def invalidate!; end
+      def materialized?; false; end
     end
 
     class Transaction # :nodoc:


### PR DESCRIPTION
### Motivation / Background

Checking if the current transaction is materialized cannot be done directly from the `materialized?` method because `NullTransaction` doesn't implemented `materialized?`

A workaround is to first check if the transaction is open:

```ruby
current_transaction = ActiveRecord::Base.connection.current_transaction
current_transaction.open? && current_transaction.materialized?
```

With this change we can skip the extra check on `open?`

```ruby
current_transaction = ActiveRecord::Base.connection.current_transaction
current_transaction.materialized?
```

### Detail

This PR continues the null object pattern approach for the `NullTransaction` by implementing `materialized?` to always return `false`, the same way it always returns `false` for `open?`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I couldn't find existing tests for this, so wasn't sure whether or not to add some.

@matthewd I was told to ask you about this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
