### PR TITLE
Remove extraneous whitespace from filter parameter template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file. 
-# Use this to limit dissemination of sensitive information. 
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn


### PR DESCRIPTION
Produces a file that doesn't trip rubocop with default configuration.