### PR TITLE
Backport to 7-0-stable: MemoryStore: preserve entry ttl when incrementing (and race condition fix)

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix MemoryStore to preserve entries TTL when incrementing or decrementing
+
+    This is to be more consistent with how MemCachedStore and RedisCacheStore behaves.
+
+    *Jean Boussier*
+
 *   Fix Range#overlaps? not taking empty ranges into account on Ruby < 3.3
 
     *Nobuyoshi Nakada*, *Shouichi Kamiya*, *Hartley McGuire*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix MemoryStore to prevent race conditions when incrementing or decrementing.
+
+    *Pierre Jambet*
+
 *   Fix MemoryStore to preserve entries TTL when incrementing or decrementing
 
     This is to be more consistent with how MemCachedStore and RedisCacheStore behaves.

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -190,12 +190,12 @@ module ActiveSupport
 
         def modify_value(name, amount, options)
           options = merged_options(options)
-          synchronize do
-            if num = read(name, options)
-              num = num.to_i + amount
-              write(name, num, options)
-              num
-            end
+
+          if entry = read_entry(name, **options)
+            num = entry.value.to_i + amount
+            entry = Entry.new(num, expires_at: entry.expires_at, version: entry.version)
+            write_entry(name, entry)
+            num
           end
         end
     end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -191,11 +191,13 @@ module ActiveSupport
         def modify_value(name, amount, options)
           options = merged_options(options)
 
-          if entry = read_entry(name, **options)
-            num = entry.value.to_i + amount
-            entry = Entry.new(num, expires_at: entry.expires_at, version: entry.version)
-            write_entry(name, entry)
-            num
+          synchronize do
+            if entry = read_entry(name, **options)
+              num = entry.value.to_i + amount
+              entry = Entry.new(num, expires_at: entry.expires_at, version: entry.version)
+              write_entry(name, entry)
+              num
+            end
           end
         end
     end


### PR DESCRIPTION
### Motivation / Background

Backports the fix from https://github.com/rails/rails/pull/46305

### Detail

Calling `Rails.cache.increment` drops the existing TTL, which is an issue on the current release of Rails, 7.0.

### Additional information

Some of the changes introduced in [the original
PR](https://github.com/rails/rails/pull/46305) were discarded, such as the `normalize_` methods, as well as the change that originated in [that PR](https://github.com/rails/rails/pull/45068) that sets a value if none exists.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
