### PR TITLE
Ensure `#signed_id` outputs `url_safe` strings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Ensure `#signed_id` outputs `url_safe` strings.
+
+    *Jason Meller*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -76,7 +76,7 @@ module ActiveRecord
           if secret.nil?
             raise ArgumentError, "You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids"
           else
-            ActiveSupport::MessageVerifier.new secret, digest: "SHA256", serializer: JSON
+            ActiveSupport::MessageVerifier.new secret, digest: "SHA256", serializer: JSON, url_safe: true
           end
         end
       end

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -178,6 +178,11 @@ class SignedIdTest < ActiveRecord::TestCase
     ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
   end
 
+  test "always output url_safe" do
+    signed_id = @account.signed_id(purpose: "~~~~~~~~~")
+    assert_not signed_id.include?("+")
+  end
+
   test "use a custom verifier" do
     old_verifier = Account.signed_id_verifier
     Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("sekret")


### PR DESCRIPTION
Fixes #49505

When @dhh introduced [signed_ids ](https://github.com/rails/rails/pull/39313) he likely always intended them to be url safe. 

Since the intent of signed_ids is to be included in things like URL params, we should be passing `url_safe: true` option to `MessageVerifier`.

This PR does exactly that.