### PR TITLE
When running in CI, do not fail if Rails frameworks with tables have not been fully installed

### DIFF
--- a/railties/lib/rails/testing/maintain_test_schema.rb
+++ b/railties/lib/rails/testing/maintain_test_schema.rb
@@ -9,7 +9,11 @@ if defined?(ActiveRecord::Base)
   end
 
   if Rails.configuration.eager_load
+    rails_framework_base_classes = [ActionText::Record, ActiveStorage::Record, ActionMailbox::Record]
+
     ActiveRecord::Base.descendants.each do |model|
+      next if rails_framework_base_classes.any? { |r| model < r } && !model.connection.table_exists?(model.table_name)
+
       model.load_schema unless model.abstract_class?
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49500

The Rails first run experience should not require installing Action Text/Active Storage/Action Mailbox so you can run tests in CI. You should only install these features if you actually use them. It also should not require changing the require of `rails/all`.

This config works in production when eager loaded, so we should support it in test too.

With this PR we keep the first run experience we had before `7.1.0` but you can still customise all these things if you want.
