### PR TITLE
[ci-skip][Docs]Update changelog links to 7-1-stable

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -875,16 +875,16 @@ See the
 for the many people who spent many hours making Rails, the stable and robust
 framework it is. Kudos to all of them.
 
-[railties]:       https://github.com/rails/rails/blob/main/railties/CHANGELOG.md
-[action-pack]:    https://github.com/rails/rails/blob/main/actionpack/CHANGELOG.md
-[action-view]:    https://github.com/rails/rails/blob/main/actionview/CHANGELOG.md
-[action-mailer]:  https://github.com/rails/rails/blob/main/actionmailer/CHANGELOG.md
-[action-cable]:   https://github.com/rails/rails/blob/main/actioncable/CHANGELOG.md
-[active-record]:  https://github.com/rails/rails/blob/main/activerecord/CHANGELOG.md
-[active-storage]: https://github.com/rails/rails/blob/main/activestorage/CHANGELOG.md
-[active-model]:   https://github.com/rails/rails/blob/main/activemodel/CHANGELOG.md
-[active-support]: https://github.com/rails/rails/blob/main/activesupport/CHANGELOG.md
-[active-job]:     https://github.com/rails/rails/blob/main/activejob/CHANGELOG.md
-[action-text]:    https://github.com/rails/rails/blob/main/actiontext/CHANGELOG.md
-[action-mailbox]: https://github.com/rails/rails/blob/main/actionmailbox/CHANGELOG.md
-[guides]:         https://github.com/rails/rails/blob/main/guides/CHANGELOG.md
+[railties]:       https://github.com/rails/rails/blob/7-1-stable/railties/CHANGELOG.md
+[action-pack]:    https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md
+[action-view]:    https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md
+[action-mailer]:  https://github.com/rails/rails/blob/7-1-stable/actionmailer/CHANGELOG.md
+[action-cable]:   https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md
+[active-record]:  https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md
+[active-storage]: https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md
+[active-model]:   https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md
+[active-support]: https://github.com/rails/rails/blob/7-1-stable/activesupport/CHANGELOG.md
+[active-job]:     https://github.com/rails/rails/blob/7-1-stable/activejob/CHANGELOG.md
+[action-text]:    https://github.com/rails/rails/blob/7-1-stable/actiontext/CHANGELOG.md
+[action-mailbox]: https://github.com/rails/rails/blob/7-1-stable/actionmailbox/CHANGELOG.md
+[guides]:         https://github.com/rails/rails/blob/7-1-stable/guides/CHANGELOG.md


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the links to the changelogs in 7_1_release_notes.md have not been updated.

### Detail

The PR updates the links to changelogs to be consistent with the [previous 7.0 release notes](https://github.com/rails/rails/blob/main/guides/source/7_0_release_notes.md?plain=1#L354-L366)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
