### PR TITLE
`Rails::Generators::Actions#gem_group`: Prepend existing gem groups

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Rails::Generators::Actions#gem_group: Prepend existing gem groups
+
+    Prior to this commit, calls to `gem_group` would amend the `Gemfile`
+    even if there was an existing [gem group][], resulting in duplication.
+
+    This commit prepends existing gem groups with the added gem.
+
+    [gem groups]: https://bundler.io/guides/groups.html
+
+    *Steve Polito*
+
 *   Conditionally print `$stdout` when invoking `run_generator`
 
     In an effort to improve the developer experience when debugging

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -161,35 +161,45 @@ class ActionsTest < Rails::Generators::TestCase
   def test_gem_group_should_wrap_gems_in_a_group
     run_generator
 
+    action :gem_group, :custom_group_one, :custom_group_two do
+      gem "rspec-rails"
+    end
+
+    action :gem_group, :custom_group_two do
+      gem "fakeweb"
+    end
+
+    assert_file "Gemfile", /\n\ngroup :custom_group_one, :custom_group_two do\n  gem "rspec-rails"\nend\n\ngroup :custom_group_two do\n  gem "fakeweb"\nend\n\z/
+  end
+
+  def test_gem_group_should_predend_existing_group
+    run_generator
+
     action :gem_group, :development, :test do
       gem "rspec-rails"
     end
 
-    action :gem_group, :test do
-      gem "fakeweb"
-    end
-
-    assert_file "Gemfile", /\n\ngroup :development, :test do\n  gem "rspec-rails"\nend\n\ngroup :test do\n  gem "fakeweb"\nend\n\z/
+    assert_file "Gemfile", /\ngroup :development, :test do{1}\n  gem "rspec-rails"/
   end
 
   def test_gem_group_should_indent_comments
     run_generator
 
-    action :gem_group, :test do
+    action :gem_group, :custom_group do
       gem "fakeweb", comment: "Fake requests"
     end
 
-    assert_file "Gemfile", /\n\ngroup :test do\n  # Fake requests\n  gem "fakeweb"\nend\n\z/
+    assert_file "Gemfile", /\n\ngroup :custom_group do\n  # Fake requests\n  gem "fakeweb"\nend\n\z/
   end
 
   def test_gem_group_should_indent_multiline_comments
     run_generator
 
-    action :gem_group, :test do
+    action :gem_group, :custom_group do
       gem "fakeweb", comment: "Fake requests\nNeeded in tests"
     end
 
-    assert_file "Gemfile", /\n\ngroup :test do\n  # Fake requests\n  # Needed in tests\n  gem "fakeweb"\nend\n\z/
+    assert_file "Gemfile", /\n\ngroup :custom_group do\n  # Fake requests\n  # Needed in tests\n  gem "fakeweb"\nend\n\z/
   end
 
   def test_github_should_create_an_indented_block
@@ -265,11 +275,11 @@ class ActionsTest < Rails::Generators::TestCase
     run_generator
     File.open("Gemfile", "a") { |f| f.write('gem "rspec-rails"') }
 
-    action :gem_group, :test do
+    action :gem_group, :custom_group do
       gem "fakeweb"
     end
 
-    assert_file "Gemfile", /gem "rspec-rails"\n\ngroup :test do\n  gem "fakeweb"\nend\n\z/
+    assert_file "Gemfile", /gem "rspec-rails"\n\ngroup :custom_group do\n  gem "fakeweb"\nend\n\z/
   end
 
   def test_add_source_with_gemfile_without_newline_at_the_end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, calls to `gem_group` would amend the `Gemfile` even if there was an existing [gem group][], resulting in duplication.

This commit prepends existing gem groups with the added gem.

[gem group]: https://bundler.io/guides/groups.html

### Detail

Because `gem_group` invokes `instance_eval(&block)` via `with_indentation`, a call to `gem` is made. This means we needed to do the following:

1. Check if the `Gemfile` contains an existing gem group in `gem_group`.
2. Pass information about that  existing gem group to the `gem` method.

### Additional information

Because the `Gemfile` used in existing tests has a `:test` and `:development, :test` groups, we modify the existing tests to use groups not used in the `Gemfile`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
