### PR TITLE
Document `ActionDispatch::IntegrationTest#register_encoder` [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -632,12 +632,12 @@ module ActionDispatch
   # Calling TestResponse#parsed_body on the response parses the response body
   # based on the last response MIME type.
   #
-  # Out of the box, only `:json` is supported. But for any custom MIME types
+  # Out of the box, only `:html` and `:json` are supported. But for any custom MIME types
   # you've registered, you can add your own encoders with:
   #
-  #     ActionDispatch::IntegrationTest.register_encoder :wibble,
-  #       param_encoder: -> params { params.to_wibble },
-  #       response_parser: -> body { body }
+  #     ActionDispatch::IntegrationTest.register_encoder :csv,
+  #       param_encoder: -> params { params.map(&:to_csv).join("\n") },
+  #       response_parser: -> body { CSV.parse(body) }
   #
   # Where `param_encoder` defines how the params should be encoded and
   # `response_parser` defines how the response body should be parsed through
@@ -684,6 +684,29 @@ module ActionDispatch
           @@app = app
         end
 
+        ##
+        # :method: register_encoder
+        # :call-seq:
+        #     register_encoder(mime_name, param_encoder: nil, response_parser: nil)
+        #
+        # Registers an encoder used to parse the response body returned by
+        # TestResponse#parsed_body. IntegrationTest encodes and parses `:html`
+        # and `:json` requests by default.
+        #
+        # #### Arguments
+        #
+        # *   `mime_name` - The MIME-compatible name
+        #
+        # #### Options
+        #
+        # *   `:param_encoder` - A callable that accepts a Hash and returns an encoded value
+        # *   `:response_parser` - A callable that accepts the body String and returns a parsed value
+        #
+        # #### Example
+        #
+        #   ActionDispatch::IntegrationTest.register_encoder :csv,
+        #     param_encoder: -> params { params.map(&:to_csv).join("\n") },
+        #     response_parser: -> body { CSV.parse(body) }
         def register_encoder(*args, **options)
           RequestEncoder.register_encoder(*args, **options)
         end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1022,6 +1022,52 @@ NOTE: Functional tests do not verify whether the specified request type is
 accepted by the action; instead, they focus on the result. For testing the
 request type, request tests are available, making your tests more purposeful.
 
+### Functional Tests with JSON
+
+When testing a request, Action Dispatch serializes the `:params` argument based
+on an optional `:as` argument that specifies the content type. For example,
+Action Dispatch encodes the `:params` argument into the request body as JSON.
+When asserting the response, the
+[`ActionDispatch::TestResponse#parsed_body`](https://api.rubyonrails.org/classes/ActionDispatch/TestResponse.html#method-i-parsed_body)
+method parses the response body into a
+[`HashWithIndifferentAccess`](https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html):
+
+```ruby
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  test "should create an Article with JSON" do
+    post articles_path, params: { article: { body: "Rails is awesome!", title: "Hello Rails" } }, as: :json
+
+    assert_equal "Rails is awesome!", response.parsed_body[:body]
+    assert_equal "Hello Rails", response.parsed_body[:title]
+  end
+end
+```
+
+Since `response.parsed_body` returns a `HashWithIndifferentAccess` for JSON
+responses, tests can combine Ruby [pattern
+matching](https://docs.ruby-lang.org/en/master/syntax/pattern_matching_rdoc.html)
+with Minitest's
+[`assert_pattern`](https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_pattern)
+assertion:
+
+```ruby
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  test "should create an Article with JSON" do
+    post articles_path, params: { article: { body: "Rails is awesome!", title: "Hello Rails" } }, as: :json
+
+    assert_pattern { response.parsed_body => { body: "Rails is awesome!", title: /hello rails/i } }
+  end
+end
+```
+
+Test request encoding and response parsing is configurable, and can be
+configuring with
+[`ActionDispatch::IntegrationTest.register_encoder`](https://api.rubyonrails.org/classes/ActionDispatch/IntegrationTest/Behavior/ClassMethods.html#method-i-register_encoder).
+The `register_encoder` method accepts a two callable options. The
+`:param_encoder` option controls how the `:params` option is encoded into the
+request, and the `:response_parser` option controls how the body is parsed from
+the response.
+
 ### Testing XHR (AJAX) Requests
 
 An AJAX request (Asynchronous JavaScript and XML) is a technique where content is
@@ -1403,7 +1449,7 @@ include:
   session.
 
 * [`ActionDispatch::Integration::RequestHelpers`](https://api.rubyonrails.org/classes/ActionDispatch/Integration/RequestHelpers.html)
-  for performing requests.
+  for performing requests. Responses are instances of [`ActionDispatch::TestResponse`](https://api.rubyonrails.org/classes/ActionDispatch/TestResponse.html).
 
 * [`ActionDispatch::TestProcess::FixtureFile`](https://api.rubyonrails.org/classes/ActionDispatch/TestProcess/FixtureFile.html)
   for uploading files.


### PR DESCRIPTION
### Motivation / Background

Closes #51607 

As of [#47144][], `response.parsed_body` supports parsing both `format: :json` and `format: :html` responses. This commit updates the documentation to reflect that.

Additionally, it cribs the `ActionDispatch::IntegrationTest` documentation that mentions `register_encoder`, and copies it to the method definition so that the documentation entry for that method has descriptive information.

[#47144]: https://github.com/rails/rails/pull/47144

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
