### PR TITLE
Don't log enqueuing details when the job wasn't enqueued

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -76,7 +76,9 @@ module ActiveJob
     def perform_start(event)
       info do
         job = event.payload[:job]
-        "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} enqueued at #{job.enqueued_at.utc.iso8601(9)}" + args_info(job)
+        enqueue_info = job.enqueued_at.present? ? " enqueued at #{job.enqueued_at.utc.iso8601(9)}" : ""
+
+        "Performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)}" + enqueue_info + args_info(job)
       end
     end
     subscribe_log_level :perform_start, :info

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -144,6 +144,15 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_perform_job_logging_when_job_is_not_enqueued
+    perform_enqueued_jobs do
+      LoggingJob.perform_now "Dummy"
+
+      assert_match(/Performing LoggingJob \(Job ID: .*?\) from .*? with arguments:.*Dummy/, @logger.messages)
+      assert_no_match(/enqueued at /, @logger.messages)
+    end
+  end
+
   def test_perform_job_log_error_when_callback_chain_is_halted
     subscribed { AbortBeforeEnqueueJob.perform_now }
     assert_match(/Error performing AbortBeforeEnqueueJob.* a before_perform callback halted/, @logger.messages)


### PR DESCRIPTION
### Motivation / Background

This Pull Request was created to fix a small bug introduced in https://github.com/rails/rails/pull/48066.

### Detail

This changes the logged message when a job is started. Before, the logged message always attempted to include the `enqueued_at` info. Unfortunately, for jobs that are run with `perform_now`, they are not enqueued and instead executed immediately. This left `enqueued_at` as `nil` which in turn caused a `NoMethodError` to be raised when attempting to call `utc` on the `nil` value. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
