### PR TITLE
Add `ActiveRecord::Base::attributes_of_type`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `ActiveRecord::Base::attributes_of_type`, which returns the names of
+    attributes that are of a specified type.  Using this method in conjunction
+    with `normalizes`, you can write something like:
+
+      ```ruby
+      class Post < ActiveRecord::Base
+        normalizes attributes_of_type(:string), with: -> { _1.strip }
+      end
+      ```
+
+    which will strip all string attributes.
+
+    *Jonathan Hefner*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -466,6 +466,18 @@ module ActiveRecord
         end
       end
 
+      # Returns the names of attributes that are of the specified +type+.
+      #
+      #   Post.attributes_of_type(:string)   # => [:title]
+      #   Post.attributes_of_type(:datetime) # => [:created_at, :updated_at]
+      #   Post.attributes_of_type(:decimal)  # => []
+      #
+      def attributes_of_type(type)
+        attribute_types.filter_map do |attr_name, attr_type|
+          attr_name.to_sym if attr_type.type == type
+        end
+      end
+
       # Returns the column object for the named attribute.
       # Returns an +ActiveRecord::ConnectionAdapters::NullColumn+ if the
       # named attribute does not exist.

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -78,6 +78,8 @@ module ActiveRecord # :nodoc:
       #
       #   User.normalize_value_for(:phone, "+1 (555) 867-5309") # => "5558675309"
       def normalizes(*names, with:, apply_to_nil: false)
+        names.flatten!
+
         names.each do |name|
           attribute(name) do |cast_type|
             NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)

--- a/activerecord/test/cases/model_schema_test.rb
+++ b/activerecord/test/cases/model_schema_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/minimalistic"
+
+class ModelSchemaTest < ActiveRecord::TestCase
+  test "#attributes_of_type returns attribute names for specified type" do
+    model = Class.new(Minimalistic) do
+      attribute :int, :integer
+      attribute :str, :string
+    end
+
+    assert_equal [:id, :int].sort, model.attributes_of_type(:integer).sort
+    assert_equal [:str], model.attributes_of_type(:string)
+    assert_equal [], model.attributes_of_type(:decimal)
+  end
+end

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/string/inflections"
 class NormalizedAttributeTest < ActiveRecord::TestCase
   class NormalizedAircraft < Aircraft
     normalizes :name, with: -> name { name.titlecase }
-    normalizes :manufactured_at, with: -> time { time.noon }
+    normalizes [:manufactured_at], with: -> time { time.noon }
 
     attr_accessor :validated_name
     validate { self.validated_name = name.dup }


### PR DESCRIPTION
`attributes_of_type` returns the names of attributes that are of a specified type.  Using this method in conjunction with `normalizes`, you can write something like:

  ```ruby
  class Post < ActiveRecord::Base
    normalizes attributes_of_type(:string), with: -> { _1.strip }
  end
  ```

which will strip all string attributes.

Closes #49314.
