### PR TITLE
Ensures the Rails generated Dockerfile uses correct ruby version and matches Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=<%= Gem.ruby_version %>
+ARG RUBY_VERSION=<%= gem_ruby_version %>
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 
 # Rails app lives here

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -955,6 +955,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile" do |content|
       assert_match(/ruby "#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}"/, content)
     end
+    assert_file "Dockerfile" do |content|
+      assert_match(/ARG RUBY_VERSION=#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}/, content)
+    end
     assert_file ".ruby-version" do |content|
       if ENV["RBENV_VERSION"]
         assert_match(/#{ENV["RBENV_VERSION"]}/, content)


### PR DESCRIPTION
### Motivation / Background
I was trying out the new Rails 7.1 version and found 
the docker build was failing due to a mismatch in the 
ruby version in the Gemfile and Dockerfile. 

#### Generated Dockerfile
```
# syntax = docker/dockerfile:1

# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
ARG RUBY_VERSION=3.0.4.208
FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
```

#### Generated Gemfile
```
source "https://rubygems.org"

ruby "3.0.4"
```

#### Error Screenshot
<img width="935" alt="image" src="https://github.com/rails/rails/assets/7736232/ef961e07-d64d-4547-91f2-a9110203bacc">

### Details
This Pull Request ensures the ruby version set 
in the Gemfile and Dockerfile are the same. 


