### PR TITLE
Fix reverting `rename_table` for older migrations

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -206,7 +206,10 @@ module ActiveRecord
         end
 
         def invert_rename_table(args)
-          [:rename_table, args.reverse]
+          old_name, new_name, options = args
+          args = [new_name, old_name]
+          args << options if options
+          [:rename_table, args]
         end
 
         def invert_remove_column(args)

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -552,6 +552,26 @@ module ActiveRecord
         connection.drop_table(long_table_name) rescue nil
       end
 
+      def test_invert_rename_table_on_7_0
+        connection.create_table(:more_testings)
+
+        migration = Class.new(ActiveRecord::Migration[7.0]) {
+          def change
+            rename_table :more_testings, :new_more_testings
+          end
+        }.new
+
+        migration.migrate(:up)
+        assert connection.table_exists?(:new_more_testings)
+        assert_not connection.table_exists?(:more_testings)
+
+        migration.migrate(:down)
+        assert_not connection.table_exists?(:new_more_testings)
+        assert connection.table_exists?(:more_testings)
+      ensure
+        connection.drop_table(:more_testings) rescue nil
+      end
+
       def test_change_column_null_with_non_boolean_arguments_raises_in_a_migration
         migration = Class.new(ActiveRecord::Migration[7.1]) do
           def up


### PR DESCRIPTION
Fixes #49523.

Previously, when reversing arguments (`args.reverse`) if we had options (for example, it is set via compatibility migration for 7.0), it will incorrectly become the first argument.