### PR TITLE
Enable remote chrome selenium tests for actiontext

### DIFF
--- a/actiontext/test/application_system_test_case.rb
+++ b/actiontext/test/application_system_test_case.rb
@@ -3,7 +3,13 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
+  options = {
+    browser: ENV["SELENIUM_DRIVER_URL"].blank? ? :chrome : :remote,
+    url: ENV["SELENIUM_DRIVER_URL"].blank? ? nil : ENV["SELENIUM_DRIVER_URL"]
+  }
+  driven_by :selenium, using: :headless_chrome, options: options
 end
 
 Capybara.server = :puma, { Silent: true }
+Capybara.server_host = "0.0.0.0" # bind to all interfaces
+Capybara.app_host = "http://#{IPSocket.getaddress(Socket.gethostname)}" if ENV["SELENIUM_DRIVER_URL"].present?


### PR DESCRIPTION
Blocks: rails/buildkite-config#33

Previous works: #47030, #47127

> This is going to affect users' apps. What is the impact of having this option by default?

RF was concerned this might impact users apps, but I'm not seeing how an actiontext test case would do so, if anyone has any ideas!


cc @hahmed @matthewd @rafaelfranca 
