### PR TITLE
Adds DOCTYPE html to the response from `up` on the HealthController

### DIFF
--- a/railties/lib/rails/health_controller.rb
+++ b/railties/lib/rails/health_controller.rb
@@ -49,7 +49,7 @@ module Rails
       end
 
       def html_status(color:)
-        %(<html><body style="background-color: #{color}"></body></html>).html_safe
+        %(<!DOCTYPE html><html><body style="background-color: #{color}"></body></html>).html_safe
       end
   end
 end


### PR DESCRIPTION
### Motivation / Background

When you 'view source' of the response page of the `up` method, Firefox complains that a start tag was found with a DOCTYPE first. This just adds that in.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
