### PR TITLE
Show deprecation warning when using `:required` on `belongs_to` associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate the `:required` option for `belongs_to` associations.
+
+    The `:required` option for `belongs_to` associations is deprecated and will be removed in Rails 7.3. The `:optional` option should be used instead.
+
+    The global configuration option `config.active_record.belongs_to_required_by_default` and the per model configuration attribute `#belongs_to_required_by_default` have also been deprecated and will be removed in Rails 7.3.
+
+    *Joshua Young*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1847,13 +1847,7 @@ module ActiveRecord
         #   object that is the inverse of this #belongs_to association.
         #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional associations for more detail.
         # [+:optional+]
-        #   When set to +true+, the association will not have its presence validated.
-        # [+:required+]
-        #   When set to +true+, the association will also have its presence validated.
-        #   This will validate the association itself, not the id. You can use
-        #   +:inverse_of+ to avoid an extra query during validation.
-        #   NOTE: <tt>required</tt> is set to <tt>true</tt> by default and is deprecated. If
-        #   you don't want to have association presence validated, use <tt>optional: true</tt>.
+        #   +false+ by default. When set to +true+, the association will not have its presence validated.
         # [+:default+]
         #   Provide a callable (i.e. proc or lambda) to specify that the association should
         #   be initialized with a particular record before validation.

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -111,11 +111,25 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.define_validations(model, reflection)
       if reflection.options.key?(:required)
-        reflection.options[:optional] = !reflection.options.delete(:required)
+        optional = !reflection.options.delete(:required)
+
+        ActiveRecord.deprecator.warn(<<-MSG.squish)
+          The `:required` option on `belongs_to` associations is deprecated and will be removed in Rails 7.3.
+          Use `optional: #{optional}` instead for the association `#{reflection.name}`.
+        MSG
+
+        reflection.options[:optional] = optional
       end
 
       if reflection.options[:optional].nil?
         required = model.belongs_to_required_by_default
+
+        if !required
+          ActiveRecord.deprecator.warn(<<-MSG.squish)
+            `#belongs_to_required_by_default` is deprecated and will be removed in Rails 7.3.
+            `belongs_to` associations will have their presence validated by default going forward.
+          MSG
+        end
       else
         required = !reflection.options[:optional]
       end

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -32,13 +32,13 @@ module ActiveRecord::Associations::Builder # :nodoc:
         end
 
         def self.add_left_association(name, options)
-          belongs_to name, required: false, **options
+          belongs_to name, optional: true, **options
           self.left_reflection = _reflect_on_association(name)
         end
 
         def self.add_right_association(name, options)
           rhs_name = name.to_s.singularize.to_sym
-          belongs_to rhs_name, required: false, **options
+          belongs_to rhs_name, optional: true, **options
           self.right_reflection = _reflect_on_association(rhs_name)
         end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -108,16 +108,19 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_optional_relation_can_be_set_per_model
-    model1 = Class.new(ActiveRecord::Base) do
-      self.table_name = "accounts"
-      self.belongs_to_required_by_default = false
+    klass1 = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "accounts"
+        self.belongs_to_required_by_default = false
 
-      belongs_to :company
+        belongs_to :company
 
-      def self.name
-        "FirstModel"
+        def self.name
+          "FirstModel"
+        end
       end
-    end.new
+    end
+    model1 = klass1.new
 
     model2 = Class.new(ActiveRecord::Base) do
       self.table_name = "accounts"
@@ -1379,7 +1382,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   class WheelPolymorphicName < ActiveRecord::Base
     self.table_name = "wheels"
-    belongs_to :wheelable, polymorphic: true, counter_cache: :wheels_count, touch: :wheels_owned_at
+    belongs_to :wheelable, polymorphic: true, counter_cache: :wheels_count, touch: :wheels_owned_at, optional: true
 
     def self.polymorphic_class_for(name)
       raise "Unexpected name: #{name}" unless name == "polymorphic_car"
@@ -1724,7 +1727,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
 
   class ShipRequired < ActiveRecord::Base
     self.table_name = "ships"
-    belongs_to :developer, required: true
+    belongs_to :developer, optional: false
   end
 
   test "runs parent presence check if parent changed or nil" do
@@ -1763,7 +1766,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     model = Class.new(ActiveRecord::Base) do
       self.table_name = "ships"
       def self.name; "Temp"; end
-      belongs_to :developer, required: true
+      belongs_to :developer, optional: false
     end
 
     david = developers(:david)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -485,7 +485,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   class SpecialBook < ActiveRecord::Base
     self.table_name = "books"
 
-    belongs_to :author
+    belongs_to :author, optional: true
     enum last_read: { unread: 0, reading: 2, read: 3, forgotten: nil }
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -804,7 +804,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   class SpecialBook < ActiveRecord::Base
     self.table_name = "books"
-    belongs_to :author, class_name: "SpecialAuthor"
+    belongs_to :author, class_name: "SpecialAuthor", optional: true
     has_one :subscription, class_name: "SpecialSubscription", foreign_key: "subscriber_id"
 
     enum status: [:proposed, :written, :published]
@@ -842,7 +842,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   class DestroyByParentBook < ActiveRecord::Base
     self.table_name = "books"
-    belongs_to :author, class_name: "DestroyByParentAuthor"
+    belongs_to :author, class_name: "DestroyByParentAuthor", optional: true
     before_destroy :dont, unless: :destroyed_by_association
 
     def dont
@@ -876,7 +876,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   class UndestroyableBook < ActiveRecord::Base
     self.table_name = "books"
-    belongs_to :author, class_name: "DestroyableAuthor"
+    belongs_to :author, class_name: "DestroyableAuthor", optional: true
     before_destroy :dont
 
     def dont

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -26,23 +26,28 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
   test "belongs_to associations can be optional by default" do
     original_value = ActiveRecord::Base.belongs_to_required_by_default
-    ActiveRecord::Base.belongs_to_required_by_default = false
 
-    model = subclass_of(Child) do
-      belongs_to :parent, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
+    assert_deprecated(ActiveRecord.deprecator) do
+      ActiveRecord::Base.belongs_to_required_by_default = false
+
+      model = subclass_of(Child) do
+        belongs_to :parent, inverse_of: false,
+          class_name: "RequiredAssociationsTest::Parent"
+      end
+
+      assert model.new.save
+      assert model.new(parent: Parent.new).save
     end
-
-    assert model.new.save
-    assert model.new(parent: Parent.new).save
   ensure
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
   test "required belongs_to associations have presence validated" do
-    model = subclass_of(Child) do
-      belongs_to :parent, required: true, inverse_of: false,
-        class_name: "RequiredAssociationsTest::Parent"
+    model = assert_deprecated(ActiveRecord.deprecator) do
+      subclass_of(Child) do
+        belongs_to :parent, required: true, inverse_of: false,
+          class_name: "RequiredAssociationsTest::Parent"
+      end
     end
 
     record = model.new
@@ -108,7 +113,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
 
   test "required belongs_to associations have a correct error message" do
     model = subclass_of(Child) do
-      belongs_to :parent, required: true, inverse_of: false,
+      belongs_to :parent, optional: false, inverse_of: false,
       class_name: "RequiredAssociationsTest::Parent"
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -508,7 +508,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_calculate_grouped_association_with_foreign_key_option
-    Account.belongs_to :another_firm, class_name: "Firm", foreign_key: "firm_id"
+    Account.belongs_to :another_firm, class_name: "Firm", foreign_key: "firm_id", optional: true
     c = Account.group(:another_firm).count(:all)
     assert_equal 1, c[companies(:first_firm)]
     assert_equal 2, c[companies(:rails_core)]

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -28,7 +28,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         class Astronaut < ActiveRecord::Base
-          belongs_to :rocket
+          belongs_to :rocket, optional: true
         end
 
         class CreateRocketsMigration < ActiveRecord::Migration::Current

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -257,11 +257,11 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_inferred_foreign_key_from_assoc_name
-    Company.belongs_to :foo
+    Company.belongs_to :foo, optional: true
     assert_equal "foo_id", Company.reflect_on_association(:foo).foreign_key
-    Company.belongs_to :bar, class_name: "Xyzzy"
+    Company.belongs_to :bar, class_name: "Xyzzy", optional: true
     assert_equal "bar_id", Company.reflect_on_association(:bar).foreign_key
-    Company.belongs_to :baz, class_name: "Xyzzy", foreign_key: "xyzzy_id"
+    Company.belongs_to :baz, class_name: "Xyzzy", foreign_key: "xyzzy_id", optional: true
     assert_equal "xyzzy_id", Company.reflect_on_association(:baz).foreign_key
   end
 

--- a/activerecord/test/cases/reserved_word_test.rb
+++ b/activerecord/test/cases/reserved_word_test.rb
@@ -8,7 +8,7 @@ class ReservedWordTest < ActiveRecord::TestCase
 
   class Group < ActiveRecord::Base
     Group.table_name = "group"
-    belongs_to :select
+    belongs_to :select, optional: true
     has_one :values
   end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -31,6 +31,9 @@ module ActiveRecord
     self.use_instantiated_fixtures = false
     self.use_transactional_tests = true
 
+    # simulate this default until the config option is removed
+    ActiveRecord::Base.belongs_to_required_by_default = true
+
     def create_fixtures(*fixture_set_names, &block)
       ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_paths, fixture_set_names, fixture_class_names, &block)
     end

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -506,7 +506,7 @@ class TimestampTest < ActiveRecord::TestCase
   def test_clearing_association_touches_the_old_record
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Toy"; end
-      belongs_to :pet, touch: true
+      belongs_to :pet, touch: true, optional: true
     end
 
     toy = klass.find(1)

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -11,7 +11,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   class ReplyWithCallbacks < ActiveRecord::Base
     self.table_name = :topics
 
-    belongs_to :topic, foreign_key: "parent_id"
+    belongs_to :topic, foreign_key: "parent_id", optional: true
 
     validates_presence_of :content
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -44,7 +44,7 @@ class TopicWithEvent < Topic
 end
 
 class TopicWithUniqEvent < Topic
-  belongs_to :event, foreign_key: :parent_id
+  belongs_to :event, foreign_key: :parent_id, optional: true
   validates :event, uniqueness: true
 end
 

--- a/activerecord/test/models/account.rb
+++ b/activerecord/test/models/account.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Account < ActiveRecord::Base
-  belongs_to :firm, class_name: "Company"
-  belongs_to :unautosaved_firm, foreign_key: "firm_id", class_name: "Firm", autosave: false
+  belongs_to :firm, class_name: "Company", optional: true
+  belongs_to :unautosaved_firm, foreign_key: "firm_id", class_name: "Firm", autosave: false, optional: true
 
   alias_attribute :available_credit, :credit_limit
 

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -15,7 +15,7 @@ class Admin::User < ActiveRecord::Base
     end
   end
 
-  belongs_to :account
+  belongs_to :account, optional: true
   store :params, accessors: [ :token ], coder: YAML
   store :settings, accessors: [ :color, :homepage ]
   store_accessor :settings, :favorite_food

--- a/activerecord/test/models/admin/user_json.rb
+++ b/activerecord/test/models/admin/user_json.rb
@@ -15,7 +15,7 @@ class Admin::UserJSON < ActiveRecord::Base
     end
   end
 
-  belongs_to :account
+  belongs_to :account, optional: true
   store :params, accessors: [ :token ], coder: JSON
   store :settings, accessors: [ :color, :homepage ], coder: Coder.new
   store_accessor :settings, :favorite_food

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -192,11 +192,11 @@ class Author < ActiveRecord::Base
   has_many :essays_2, primary_key: :name, class_name: "Essay", foreign_key: :author_id
   has_many :essay_categories_2, through: :essays_2, source: :category
 
-  belongs_to :owned_essay, primary_key: :name, class_name: "Essay"
+  belongs_to :owned_essay, primary_key: :name, class_name: "Essay", optional: true
   has_one :owned_essay_category, through: :owned_essay, source: :category
 
-  belongs_to :author_address,       dependent: :destroy
-  belongs_to :author_address_extra, dependent: :delete, class_name: "AuthorAddress"
+  belongs_to :author_address,       dependent: :destroy, optional: true
+  belongs_to :author_address_extra, dependent: :delete, class_name: "AuthorAddress", optional: true
 
   has_many :category_post_comments, through: :categories, source: :post_comments
 
@@ -306,8 +306,8 @@ class AuthorAddress < ActiveRecord::Base
 end
 
 class AuthorFavorite < ActiveRecord::Base
-  belongs_to :author
-  belongs_to :favorite_author, class_name: "Author"
+  belongs_to :author, optional: true
+  belongs_to :favorite_author, class_name: "Author", optional: true
 end
 
 class AuthorFavoriteWithScope < ActiveRecord::Base
@@ -315,6 +315,6 @@ class AuthorFavoriteWithScope < ActiveRecord::Base
 
   default_scope { order(id: :asc) }
 
-  belongs_to :author
-  belongs_to :favorite_author, class_name: "Author"
+  belongs_to :author, optional: true
+  belongs_to :favorite_author, class_name: "Author", optional: true
 end

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Bird < ActiveRecord::Base
-  belongs_to :pirate
+  belongs_to :pirate, optional: true
   validates_presence_of :name
 
   accepts_nested_attributes_for :pirate

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Book < ActiveRecord::Base
-  belongs_to :author
-  belongs_to :format_record, polymorphic: true
+  belongs_to :author, optional: true
+  belongs_to :format_record, polymorphic: true, optional: true
 
   has_many :citations, inverse_of: :book
   has_many :references, -> { distinct }, through: :citations, source: :reference_of

--- a/activerecord/test/models/bulb.rb
+++ b/activerecord/test/models/bulb.rb
@@ -2,7 +2,7 @@
 
 class Bulb < ActiveRecord::Base
   default_scope { where(name: "defaulty") }
-  belongs_to :car, touch: true
+  belongs_to :car, touch: true, optional: true
   scope :awesome, -> { where(frickinawesome: true) }
 
   attr_reader :scope_after_initialize, :attributes_after_initialize, :count_after_create

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Car < ActiveRecord::Base
-  belongs_to :person, counter_cache: true
+  belongs_to :person, counter_cache: true, optional: true
   has_many :bulbs
   has_many :all_bulbs, -> { unscope(where: :name) }, class_name: "Bulb"
   has_many :all_bulbs2, -> { unscope(:where) }, class_name: "Bulb"

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Categorization < ActiveRecord::Base
-  belongs_to :post
-  belongs_to :category, counter_cache: true
-  belongs_to :named_category, class_name: "Category", foreign_key: :named_category_name, primary_key: :name
-  belongs_to :author
+  belongs_to :post, optional: true
+  belongs_to :category, counter_cache: true, optional: true
+  belongs_to :named_category, class_name: "Category", foreign_key: :named_category_name, primary_key: :name, optional: true
+  belongs_to :author, optional: true
 
   has_many :post_taggings, through: :author, source: :taggings
 
-  belongs_to :author_using_custom_pk,  class_name: "Author", foreign_key: :author_id, primary_key: :author_address_extra_id
+  belongs_to :author_using_custom_pk,  class_name: "Author", foreign_key: :author_id, primary_key: :author_address_extra_id, optional: true
   has_many   :authors_using_custom_pk, class_name: "Author", foreign_key: :id,        primary_key: :category_id
 end
 
@@ -16,6 +16,6 @@ class SpecialCategorization < ActiveRecord::Base
   self.table_name = "categorizations"
   default_scope { where(special: true) }
 
-  belongs_to :author
-  belongs_to :category
+  belongs_to :author, optional: true
+  belongs_to :category, optional: true
 end

--- a/activerecord/test/models/chef.rb
+++ b/activerecord/test/models/chef.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Chef < ActiveRecord::Base
-  belongs_to :employable, polymorphic: true
+  belongs_to :employable, polymorphic: true, optional: true
   has_many :recipes
 end
 
 class ChefList < Chef
-  belongs_to :employable_list, polymorphic: true
+  belongs_to :employable_list, polymorphic: true, optional: true
 end

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Citation < ActiveRecord::Base
-  belongs_to :book, foreign_key: :book1_id, inverse_of: :citations, touch: true
-  belongs_to :reference_of, class_name: "Book", foreign_key: :book2_id
+  belongs_to :book, foreign_key: :book1_id, inverse_of: :citations, touch: true, optional: true
+  belongs_to :reference_of, class_name: "Book", foreign_key: :book2_id, optional: true
   has_many :citations
 end

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -6,7 +6,7 @@ class Club < ActiveRecord::Base
   has_many :members, through: :memberships
   has_one :sponsor
   has_one :sponsored_member, through: :sponsor, source: :sponsorable, source_type: :Member
-  belongs_to :category
+  belongs_to :category, optional: true
 
   has_many :favorites, -> { where(memberships: { favorite: true }) }, through: :memberships, source: :member
 

--- a/activerecord/test/models/column.rb
+++ b/activerecord/test/models/column.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Column < ActiveRecord::Base
-  belongs_to :record
+  belongs_to :record, optional: true
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -12,21 +12,21 @@ class Comment < ActiveRecord::Base
   scope :created, -> { all }
   scope :ordered_by_post_id, -> { order("comments.post_id DESC") }
 
-  belongs_to :post, counter_cache: true
-  belongs_to :author,   polymorphic: true
-  belongs_to :resource, polymorphic: true
-  belongs_to :origin, polymorphic: true
-  belongs_to :company, foreign_key: "company"
+  belongs_to :post, counter_cache: true, optional: true
+  belongs_to :author,   polymorphic: true, optional: true
+  belongs_to :resource, polymorphic: true, optional: true
+  belongs_to :origin, polymorphic: true, optional: true
+  belongs_to :company, foreign_key: "company", optional: true
 
   has_many :ratings
 
-  belongs_to :first_post, foreign_key: :post_id
-  belongs_to :special_post_with_default_scope, foreign_key: :post_id
+  belongs_to :first_post, foreign_key: :post_id, optional: true
+  belongs_to :special_post_with_default_scope, foreign_key: :post_id, optional: true
 
   has_one :post_with_inverse, ->(comment) { where(id: comment.post_id) }, class_name: "FirstPost", inverse_of: :comment_with_inverse
 
   has_many :children, class_name: "Comment", inverse_of: :parent
-  belongs_to :parent, class_name: "Comment", counter_cache: :children_count, inverse_of: :children
+  belongs_to :parent, class_name: "Comment", counter_cache: :children_count, inverse_of: :children, optional: true
 
   enum label: [:default, :child]
 
@@ -66,7 +66,7 @@ class Comment < ActiveRecord::Base
 end
 
 class SpecialComment < Comment
-  belongs_to :ordinary_post, foreign_key: :post_id, class_name: "Post"
+  belongs_to :ordinary_post, foreign_key: :post_id, class_name: "Post", optional: true
   has_one :author, through: :post
   default_scope { where(deleted_at: nil) }
 
@@ -82,7 +82,7 @@ class VerySpecialComment < Comment
 end
 
 class CommentThatAutomaticallyAltersPostBody < Comment
-  belongs_to :post, class_name: "PostThatLoadsCommentsInAnAfterSaveHook", foreign_key: :post_id
+  belongs_to :post, class_name: "PostThatLoadsCommentsInAnAfterSaveHook", foreign_key: :post_id, optional: true
 
   after_save do |comment|
     comment.post.update(body: "Automatically altered")
@@ -91,7 +91,7 @@ end
 
 class CommentWithDefaultScopeReferencesAssociation < Comment
   default_scope -> { includes(:developer).order("developers.name").references(:developer) }
-  belongs_to :developer
+  belongs_to :developer, optional: true
 end
 
 class CommentWithAfterCreateUpdate < Comment

--- a/activerecord/test/models/comment_overlapping_counter_cache.rb
+++ b/activerecord/test/models/comment_overlapping_counter_cache.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class CommentOverlappingCounterCache < ActiveRecord::Base
-  belongs_to :user_comments_count, counter_cache: :comments_count
-  belongs_to :post_comments_count, class_name: "PostCommentsCount"
-  belongs_to :commentable, polymorphic: true, counter_cache: :comments_count
+  belongs_to :user_comments_count, counter_cache: :comments_count, optional: true
+  belongs_to :post_comments_count, class_name: "PostCommentsCount", optional: true
+  belongs_to :commentable, polymorphic: true, counter_cache: :comments_count, optional: true
 end
 
 class UserCommentsCount < ActiveRecord::Base

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -138,17 +138,17 @@ class Agency < Firm
 end
 
 class Client < Company
-  belongs_to :firm, foreign_key: "client_of", inverse_of: :client
-  belongs_to :firm_with_basic_id, class_name: "Firm", foreign_key: "firm_id"
-  belongs_to :firm_with_select, -> { select("id") }, class_name: "Firm", foreign_key: "firm_id"
-  belongs_to :firm_with_other_name, class_name: "Firm", foreign_key: "client_of"
-  belongs_to :firm_with_condition, -> { where "1 = ?", 1 }, class_name: "Firm", foreign_key: "client_of"
-  belongs_to :firm_with_primary_key, class_name: "Firm", primary_key: "name", foreign_key: "firm_name"
-  belongs_to :firm_with_primary_key_symbols, class_name: "Firm", primary_key: :name, foreign_key: :firm_name
-  belongs_to :readonly_firm, -> { readonly }, class_name: "Firm", foreign_key: "firm_id"
-  belongs_to :bob_firm, -> { where name: "Bob" }, class_name: "Firm", foreign_key: "client_of"
+  belongs_to :firm, foreign_key: "client_of", inverse_of: :client, optional: true
+  belongs_to :firm_with_basic_id, class_name: "Firm", foreign_key: "firm_id", optional: true
+  belongs_to :firm_with_select, -> { select("id") }, class_name: "Firm", foreign_key: "firm_id", optional: true
+  belongs_to :firm_with_other_name, class_name: "Firm", foreign_key: "client_of", optional: true
+  belongs_to :firm_with_condition, -> { where "1 = ?", 1 }, class_name: "Firm", foreign_key: "client_of", optional: true
+  belongs_to :firm_with_primary_key, class_name: "Firm", primary_key: "name", foreign_key: "firm_name", optional: true
+  belongs_to :firm_with_primary_key_symbols, class_name: "Firm", primary_key: :name, foreign_key: :firm_name, optional: true
+  belongs_to :readonly_firm, -> { readonly }, class_name: "Firm", foreign_key: "firm_id", optional: true
+  belongs_to :bob_firm, -> { where name: "Bob" }, class_name: "Firm", foreign_key: "client_of", optional: true
   has_many :accounts, through: :firm, source: :accounts
-  belongs_to :account
+  belongs_to :account, optional: true
 
   validate do
     firm

--- a/activerecord/test/models/company_in_module.rb
+++ b/activerecord/test/models/company_in_module.rb
@@ -16,8 +16,8 @@ module MyApplication
     end
 
     class Client < Company
-      belongs_to :firm, foreign_key: "client_of"
-      belongs_to :firm_with_other_name, class_name: "Firm", foreign_key: "client_of"
+      belongs_to :firm, foreign_key: "client_of", optional: true
+      belongs_to :firm_with_other_name, class_name: "Firm", foreign_key: "client_of", optional: true
 
       class Contact < ActiveRecord::Base; end
     end
@@ -81,11 +81,11 @@ module MyApplication
 
     class Account < ActiveRecord::Base
       with_options(foreign_key: :firm_id) do |i|
-        i.belongs_to :firm, class_name: "MyApplication::Business::Firm"
-        i.belongs_to :qualified_billing_firm, class_name: "MyApplication::Billing::Firm"
-        i.belongs_to :unqualified_billing_firm, class_name: "Firm"
-        i.belongs_to :nested_qualified_billing_firm, class_name: "MyApplication::Billing::Nested::Firm"
-        i.belongs_to :nested_unqualified_billing_firm, class_name: "Nested::Firm"
+        i.belongs_to :firm, class_name: "MyApplication::Business::Firm", optional: true
+        i.belongs_to :qualified_billing_firm, class_name: "MyApplication::Billing::Firm", optional: true
+        i.belongs_to :unqualified_billing_firm, class_name: "Firm", optional: true
+        i.belongs_to :nested_qualified_billing_firm, class_name: "MyApplication::Billing::Nested::Firm", optional: true
+        i.belongs_to :nested_unqualified_billing_firm, class_name: "Nested::Firm", optional: true
       end
 
       validate :check_empty_credit_limit

--- a/activerecord/test/models/content.rb
+++ b/activerecord/test/models/content.rb
@@ -30,7 +30,7 @@ class ContentWhichRequiresTwoDestroyCalls < ActiveRecord::Base
 end
 
 class ContentPosition < ActiveRecord::Base
-  belongs_to :content, dependent: :destroy
+  belongs_to :content, dependent: :destroy, optional: true
 
   def self.destroyed_ids
     @destroyed_ids ||= []

--- a/activerecord/test/models/contract.rb
+++ b/activerecord/test/models/contract.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Contract < ActiveRecord::Base
-  belongs_to :company
-  belongs_to :developer, primary_key: :id
-  belongs_to :firm, foreign_key: "company_id"
+  belongs_to :company, optional: true
+  belongs_to :developer, primary_key: :id, optional: true
+  belongs_to :firm, foreign_key: "company_id", optional: true
 
   attribute :metadata, :json
 
@@ -37,6 +37,6 @@ end
 
 class SpecialContract < ActiveRecord::Base
   self.table_name = "contracts"
-  belongs_to :company
-  belongs_to :special_developer, foreign_key: "developer_id"
+  belongs_to :company, optional: true
+  belongs_to :special_developer, foreign_key: "developer_id", optional: true
 end

--- a/activerecord/test/models/course.rb
+++ b/activerecord/test/models/course.rb
@@ -3,6 +3,6 @@
 require "models/arunit2_model"
 
 class Course < ARUnit2Model
-  belongs_to :college
+  belongs_to :college, optional: true
   has_many :entrants
 end

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -5,8 +5,8 @@ module Cpk
     attr_accessor :fail_destroy
 
     self.table_name = :cpk_books
-    belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id]
-    belongs_to :author, class_name: "Cpk::Author"
+    belongs_to :order, autosave: true, query_constraints: [:shop_id, :order_id], optional: true
+    belongs_to :author, class_name: "Cpk::Author", optional: true
 
     has_many :chapters, query_constraints: [:author_id, :book_id]
 
@@ -22,17 +22,17 @@ module Cpk
   end
 
   class BrokenBook < Book
-    belongs_to :order, class_name: "Cpk::OrderWithSpecialPrimaryKey"
+    belongs_to :order, class_name: "Cpk::OrderWithSpecialPrimaryKey", optional: true
   end
 
   class BrokenBookWithNonCpkOrder < Book
-    belongs_to :order, class_name: "Cpk::NonCpkOrder", query_constraints: [:shop_id, :order_id]
+    belongs_to :order, class_name: "Cpk::NonCpkOrder", query_constraints: [:shop_id, :order_id], optional: true
   end
 
   class NonCpkBook < Book
     self.primary_key = :id
 
-    belongs_to :non_cpk_order, query_constraints: [:order_id]
+    belongs_to :non_cpk_order, query_constraints: [:order_id], optional: true
   end
 
   class NullifiedBook < Book

--- a/activerecord/test/models/cpk/chapter.rb
+++ b/activerecord/test/models/cpk/chapter.rb
@@ -7,6 +7,6 @@ module Cpk
     # to be shared between different databases
     self.primary_key = [:author_id, :id]
 
-    belongs_to :book, query_constraints: [:author_id, :book_id]
+    belongs_to :book, query_constraints: [:author_id, :book_id], optional: true
   end
 end

--- a/activerecord/test/models/cpk/order_agreement.rb
+++ b/activerecord/test/models/cpk/order_agreement.rb
@@ -5,6 +5,6 @@ module Cpk
   class OrderAgreement < ActiveRecord::Base
     self.table_name = :cpk_order_agreements
 
-    belongs_to :order
+    belongs_to :order, optional: true
   end
 end

--- a/activerecord/test/models/cpk/order_tag.rb
+++ b/activerecord/test/models/cpk/order_tag.rb
@@ -4,7 +4,7 @@ module Cpk
   class OrderTag < ActiveRecord::Base
     self.table_name = :cpk_order_tags
 
-    belongs_to :tag
-    belongs_to :order
+    belongs_to :tag, optional: true
+    belongs_to :order, optional: true
   end
 end

--- a/activerecord/test/models/cpk/review.rb
+++ b/activerecord/test/models/cpk/review.rb
@@ -4,6 +4,6 @@ module Cpk
   class Review < ActiveRecord::Base
     self.table_name = :cpk_reviews
 
-    belongs_to :book, class_name: "Cpk::Book", query_constraints: [:author_id, :number]
+    belongs_to :book, class_name: "Cpk::Book", query_constraints: [:author_id, :number], optional: true
   end
 end

--- a/activerecord/test/models/customer_carrier.rb
+++ b/activerecord/test/models/customer_carrier.rb
@@ -3,8 +3,8 @@
 class CustomerCarrier < ActiveRecord::Base
   cattr_accessor :current_customer
 
-  belongs_to :customer
-  belongs_to :carrier
+  belongs_to :customer, optional: true
+  belongs_to :carrier, optional: true
 
   default_scope -> {
     if current_customer

--- a/activerecord/test/models/department.rb
+++ b/activerecord/test/models/department.rb
@@ -2,5 +2,5 @@
 
 class Department < ActiveRecord::Base
   has_many :chefs
-  belongs_to :hotel
+  belongs_to :hotel, optional: true
 end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -31,9 +31,9 @@ class Developer < ActiveRecord::Base
     end
   end
 
-  belongs_to :mentor
-  belongs_to :strict_loading_mentor, strict_loading: true, foreign_key: :mentor_id, class_name: "Mentor"
-  belongs_to :strict_loading_off_mentor, strict_loading: false, foreign_key: :mentor_id, class_name: "Mentor"
+  belongs_to :mentor, optional: true
+  belongs_to :strict_loading_mentor, strict_loading: true, foreign_key: :mentor_id, class_name: "Mentor", optional: true
+  belongs_to :strict_loading_off_mentor, strict_loading: false, foreign_key: :mentor_id, class_name: "Mentor", optional: true
 
   accepts_nested_attributes_for :projects
 
@@ -86,7 +86,7 @@ class Developer < ActiveRecord::Base
   has_one :ship, dependent: :nullify
   has_one :strict_loading_ship, strict_loading: true, class_name: "Ship"
 
-  belongs_to :firm
+  belongs_to :firm, optional: true
   has_many :contracted_projects, class_name: "Project"
 
   scope :jamises, -> { where(name: "Jamis") }
@@ -130,13 +130,13 @@ class SymbolIgnoredDeveloper < ActiveRecord::Base
 end
 
 class AuditLog < ActiveRecord::Base
-  belongs_to :developer, validate: true
-  belongs_to :unvalidated_developer, class_name: "Developer"
+  belongs_to :developer, validate: true, optional: true
+  belongs_to :unvalidated_developer, class_name: "Developer", optional: true
 end
 
 class AuditLogRequired < ActiveRecord::Base
   self.table_name = "audit_logs"
-  belongs_to :developer, required: true
+  belongs_to :developer, optional: false
 end
 
 class DeveloperWithBeforeDestroyRaise < ActiveRecord::Base

--- a/activerecord/test/models/dl_keyed_belongs_to.rb
+++ b/activerecord/test/models/dl_keyed_belongs_to.rb
@@ -6,8 +6,11 @@ class DlKeyedBelongsTo < ActiveRecord::Base
     dependent: :destroy_async,
     foreign_key: :destroy_async_parent_id,
     primary_key: :parent_id,
-    class_name: "DestroyAsyncParent"
+    class_name: "DestroyAsyncParent",
+    optional: true
   belongs_to :destroy_async_parent_soft_delete,
     dependent: :destroy_async,
-    ensuring_owner_was: :deleted?, class_name: "DestroyAsyncParentSoftDelete"
+    ensuring_owner_was: :deleted?,
+    class_name: "DestroyAsyncParentSoftDelete",
+    optional: true
 end

--- a/activerecord/test/models/dl_keyed_belongs_to_soft_delete.rb
+++ b/activerecord/test/models/dl_keyed_belongs_to_soft_delete.rb
@@ -6,7 +6,8 @@ class DlKeyedBelongsToSoftDelete < ActiveRecord::Base
   belongs_to :destroy_async_parent_soft_delete,
     dependent: :destroy_async,
     ensuring_owner_was: :deleted?,
-    class_name: "DestroyAsyncParentSoftDelete"
+    class_name: "DestroyAsyncParentSoftDelete",
+    optional: true
 
   def deleted?
     deleted

--- a/activerecord/test/models/dl_keyed_join.rb
+++ b/activerecord/test/models/dl_keyed_join.rb
@@ -4,7 +4,9 @@
    self.primary_key = "joins_key"
 
    belongs_to :destroy_async_parent,
-     primary_key: :parent_id
+     primary_key: :parent_id,
+     optional: true
    belongs_to :dl_keyed_has_many_through,
-     primary_key: :through_key
+     primary_key: :through_key,
+     optional: true
  end

--- a/activerecord/test/models/dog.rb
+++ b/activerecord/test/models/dog.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Dog < ActiveRecord::Base
-  belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count
-  belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count
-  belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true
+  belongs_to :breeder, class_name: "DogLover", counter_cache: :bred_dogs_count, optional: true
+  belongs_to :trainer, class_name: "DogLover", counter_cache: :trained_dogs_count, optional: true
+  belongs_to :doglover, foreign_key: :dog_lover_id, class_name: "DogLover", counter_cache: true, optional: true
 end

--- a/activerecord/test/models/doubloon.rb
+++ b/activerecord/test/models/doubloon.rb
@@ -4,7 +4,7 @@ class AbstractDoubloon < ActiveRecord::Base
   # This has functionality that might be shared by multiple classes.
 
   self.abstract_class = true
-  belongs_to :pirate
+  belongs_to :pirate, optional: true
 end
 
 class Doubloon < AbstractDoubloon

--- a/activerecord/test/models/electron.rb
+++ b/activerecord/test/models/electron.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Electron < ActiveRecord::Base
-  belongs_to :molecule
+  belongs_to :molecule, optional: true
 
   validates_presence_of :name
 end

--- a/activerecord/test/models/engine.rb
+++ b/activerecord/test/models/engine.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Engine < ActiveRecord::Base
-  belongs_to :my_car, class_name: "Car", foreign_key: "car_id",  counter_cache: :engines_count
+  belongs_to :my_car, class_name: "Car", foreign_key: "car_id",  counter_cache: :engines_count, optional: true
 end

--- a/activerecord/test/models/entry.rb
+++ b/activerecord/test/models/entry.rb
@@ -6,5 +6,5 @@ class Entry < ActiveRecord::Base
 
   # alternate delegation for custom foreign_key/foreign_type
   delegated_type :thing, types: %w[ Post ],
-    foreign_key: :entryable_id, foreign_type: :entryable_type
+    foreign_key: :entryable_id, foreign_type: :entryable_type, optional: true
 end

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Essay < ActiveRecord::Base
-  belongs_to :author, primary_key: :name
-  belongs_to :writer, primary_key: :name, polymorphic: true
-  belongs_to :category, primary_key: :name
+  belongs_to :author, primary_key: :name, optional: true
+  belongs_to :writer, primary_key: :name, polymorphic: true, optional: true
+  belongs_to :category, primary_key: :name, optional: true
   has_one :owner, primary_key: :name
 end
 

--- a/activerecord/test/models/essay_destroy_async.rb
+++ b/activerecord/test/models/essay_destroy_async.rb
@@ -2,7 +2,7 @@
 
 class EssayDestroyAsync < ActiveRecord::Base
   self.table_name = "essays"
-  belongs_to :book, dependent: :destroy_async, class_name: "BookDestroyAsync"
+  belongs_to :book, dependent: :destroy_async, class_name: "BookDestroyAsync", optional: true
 end
 
 class LongEssayDestroyAsync < EssayDestroyAsync

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -35,5 +35,5 @@ class Eye < ActiveRecord::Base
 end
 
 class Iris < ActiveRecord::Base
-  belongs_to :eye
+  belongs_to :eye, optional: true
 end

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class Face < ActiveRecord::Base
-  belongs_to :human, inverse_of: :face
-  belongs_to :autosave_human, class_name: "Human", foreign_key: :human_id, inverse_of: :autosave_face
-  belongs_to :super_human, polymorphic: true
-  belongs_to :polymorphic_human, polymorphic: true, inverse_of: :polymorphic_face
+  belongs_to :human, inverse_of: :face, optional: true
+  belongs_to :autosave_human, class_name: "Human", foreign_key: :human_id, inverse_of: :autosave_face, optional: true
+  belongs_to :super_human, polymorphic: true, optional: true
+  belongs_to :polymorphic_human, polymorphic: true, inverse_of: :polymorphic_face, optional: true
   # Oracle identifier length is limited to 30 bytes or less, `polymorphic` renamed `poly`
-  belongs_to :poly_human_without_inverse, polymorphic: true
+  belongs_to :poly_human_without_inverse, polymorphic: true, optional: true
   # These are "broken" inverse_of associations for the purposes of testing
-  belongs_to :confused_human, class_name: "Human", inverse_of: :cnffused_face
-  belongs_to :puzzled_polymorphic_human, polymorphic: true, inverse_of: :puzzled_polymorphic_face
+  belongs_to :confused_human, class_name: "Human", inverse_of: :cnffused_face, optional: true
+  belongs_to :puzzled_polymorphic_human, polymorphic: true, inverse_of: :puzzled_polymorphic_face, optional: true
 
   validate do
     human

--- a/activerecord/test/models/family_tree.rb
+++ b/activerecord/test/models/family_tree.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class FamilyTree < ActiveRecord::Base
-  belongs_to :member, class_name: "User", foreign_key: "member_id"
-  belongs_to :family
+  belongs_to :member, class_name: "User", foreign_key: "member_id", optional: true
+  belongs_to :family, optional: true
 end

--- a/activerecord/test/models/friendship.rb
+++ b/activerecord/test/models/friendship.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Friendship < ActiveRecord::Base
-  belongs_to :friend, class_name: "Person"
+  belongs_to :friend, class_name: "Person", optional: true
   # friend_too exists to test a bug, and probably shouldn't be used elsewhere
-  belongs_to :friend_too, foreign_key: "friend_id", class_name: "Person", counter_cache: :friends_too_count
-  belongs_to :follower, class_name: "Person"
+  belongs_to :friend_too, foreign_key: "friend_id", class_name: "Person", counter_cache: :friends_too_count, optional: true
+  belongs_to :follower, class_name: "Person", optional: true
 end

--- a/activerecord/test/models/image.rb
+++ b/activerecord/test/models/image.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Image < ActiveRecord::Base
-  belongs_to :imageable, polymorphic: true, foreign_key: :imageable_identifier, foreign_type: :imageable_class
+  belongs_to :imageable, polymorphic: true, foreign_key: :imageable_identifier, foreign_type: :imageable_class, optional: true
 end

--- a/activerecord/test/models/interest.rb
+++ b/activerecord/test/models/interest.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 class Interest < ActiveRecord::Base
-  belongs_to :human, inverse_of: :interests
+  belongs_to :human, inverse_of: :interests, optional: true
   belongs_to :human_with_callbacks,
     class_name: "Human",
     foreign_key: :human_id,
-    inverse_of: :interests_with_callbacks
-  belongs_to :polymorphic_human, polymorphic: true, inverse_of: :polymorphic_interests
+    inverse_of: :interests_with_callbacks,
+    optional: true
+  belongs_to :polymorphic_human, polymorphic: true, inverse_of: :polymorphic_interests, optional: true
   belongs_to :polymorphic_human_with_callbacks,
     foreign_key: :polymorphic_human_id,
     foreign_type: :polymorphic_human_type,
     polymorphic: true,
-    inverse_of: :polymorphic_interests_with_callbacks
-  belongs_to :zine, inverse_of: :interests
+    inverse_of: :polymorphic_interests_with_callbacks,
+    optional: true
+  belongs_to :zine, inverse_of: :interests, optional: true
 end

--- a/activerecord/test/models/job.rb
+++ b/activerecord/test/models/job.rb
@@ -3,7 +3,7 @@
 class Job < ActiveRecord::Base
   has_many :references
   has_many :people, through: :references
-  belongs_to :ideal_reference, class_name: "Reference"
+  belongs_to :ideal_reference, class_name: "Reference", optional: true
 
   has_many :agents, through: :people
 end

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class LineItem < ActiveRecord::Base
-  belongs_to :invoice, touch: true
+  belongs_to :invoice, touch: true, optional: true
   has_many :discount_applications, class_name: "LineItemDiscountApplication"
 end
 
 class LineItemDiscountApplication < ActiveRecord::Base
-  belongs_to :line_item
-  belongs_to :discount
+  belongs_to :line_item, optional: true
+  belongs_to :discount, optional: true
 end

--- a/activerecord/test/models/matey.rb
+++ b/activerecord/test/models/matey.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Matey < ActiveRecord::Base
-  belongs_to :pirate
-  belongs_to :target, class_name: "Pirate"
+  belongs_to :pirate, optional: true
+  belongs_to :target, class_name: "Pirate", optional: true
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -14,7 +14,7 @@ class Member < ActiveRecord::Base
   has_one :member_detail, inverse_of: false
   has_one :organization, through: :member_detail
   has_one :organization_without_joins, through: :member_detail, disable_joins: true, source: :organization
-  belongs_to :member_type
+  belongs_to :member_type, optional: true
 
   has_many :nested_member_types, through: :member_detail, source: :member_type
   has_one :nested_member_type, through: :member_detail, source: :member_type
@@ -37,7 +37,7 @@ class Member < ActiveRecord::Base
 
   has_one :club_through_many, through: :favorite_memberships, source: :club
 
-  belongs_to :admittable, polymorphic: true
+  belongs_to :admittable, polymorphic: true, optional: true
   has_one :premium_club, through: :admittable
 
   scope :unnamed, -> { where(name: nil)  }

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class MemberDetail < ActiveRecord::Base
-  belongs_to :member, inverse_of: false
-  belongs_to :organization
+  belongs_to :member, inverse_of: false, optional: true
+  belongs_to :organization, optional: true
   has_one :member_type, through: :member
   has_one :membership, through: :member
   has_one :admittable, through: :member, source_type: "Member"

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -2,18 +2,18 @@
 
 class Membership < ActiveRecord::Base
   enum type: %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
-  belongs_to :member
-  belongs_to :club
+  belongs_to :member, optional: true
+  belongs_to :club, optional: true
 end
 
 class CurrentMembership < Membership
-  belongs_to :member
-  belongs_to :club, inverse_of: :membership
+  belongs_to :member, optional: true
+  belongs_to :club, inverse_of: :membership, optional: true
 end
 
 class SuperMembership < Membership
-  belongs_to :member, -> { order("members.id DESC") }
-  belongs_to :club
+  belongs_to :member, -> { order("members.id DESC") }, optional: true
+  belongs_to :club, optional: true
 end
 
 class SelectedMembership < Membership
@@ -25,8 +25,8 @@ end
 class TenantMembership < Membership
   cattr_accessor :current_member
 
-  belongs_to :member
-  belongs_to :club
+  belongs_to :member, optional: true
+  belongs_to :club, optional: true
 
   default_scope -> {
     if current_member

--- a/activerecord/test/models/minivan.rb
+++ b/activerecord/test/models/minivan.rb
@@ -3,7 +3,7 @@
 class Minivan < ActiveRecord::Base
   self.primary_key = :minivan_id
 
-  belongs_to :speedometer
+  belongs_to :speedometer, optional: true
   has_one :dashboard, through: :speedometer
 
   attr_readonly :color

--- a/activerecord/test/models/mixed_case_monkey.rb
+++ b/activerecord/test/models/mixed_case_monkey.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class MixedCaseMonkey < ActiveRecord::Base
-  belongs_to :human
+  belongs_to :human, optional: true
 end

--- a/activerecord/test/models/molecule.rb
+++ b/activerecord/test/models/molecule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Molecule < ActiveRecord::Base
-  belongs_to :liquid
+  belongs_to :liquid, optional: true
   has_many :electrons
 
   accepts_nested_attributes_for :electrons

--- a/activerecord/test/models/node.rb
+++ b/activerecord/test/models/node.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Node < ActiveRecord::Base
-  belongs_to :tree, touch: true
+  belongs_to :tree, touch: true, optional: true
   belongs_to :parent,   class_name: "Node", touch: true, optional: true
   has_many   :children, class_name: "Node", foreign_key: :parent_id, dependent: :destroy
 end

--- a/activerecord/test/models/order.rb
+++ b/activerecord/test/models/order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Order < ActiveRecord::Base
-  belongs_to :billing, class_name: "Customer", foreign_key: "billing_customer_id"
-  belongs_to :shipping, class_name: "Customer", foreign_key: "shipping_customer_id"
+  belongs_to :billing, class_name: "Customer", foreign_key: "billing_customer_id", optional: true
+  belongs_to :shipping, class_name: "Customer", foreign_key: "shipping_customer_id", optional: true
 end

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -6,7 +6,7 @@ class Owner < ActiveRecord::Base
   has_many :toys, through: :pets
   has_many :persons, through: :pets
 
-  belongs_to :last_pet, class_name: "Pet"
+  belongs_to :last_pet, class_name: "Pet", optional: true
   scope :including_last_pet, -> {
     select('
       owners.*, (

--- a/activerecord/test/models/paragraph.rb
+++ b/activerecord/test/models/paragraph.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Paragraph < ActiveRecord::Base
-  belongs_to :book
+  belongs_to :book, optional: true
 end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -33,5 +33,5 @@ class LiveParrot < Parrot
 end
 
 class DeadParrot < Parrot
-  belongs_to :killer, class_name: "Pirate", foreign_key: :killer_id
+  belongs_to :killer, class_name: "Pirate", foreign_key: :killer_id, optional: true
 end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -27,10 +27,10 @@ class Person < ActiveRecord::Base
   has_many :jobs_with_dependent_delete_all, source: :job, through: :references, dependent: :delete_all
   has_many :jobs_with_dependent_nullify,    source: :job, through: :references, dependent: :nullify
 
-  belongs_to :primary_contact, class_name: "Person"
+  belongs_to :primary_contact, class_name: "Person", optional: true
   has_many :agents, class_name: "Person", foreign_key: "primary_contact_id"
   has_many :agents_of_agents, through: :agents, source: :agents
-  belongs_to :number1_fan, class_name: "Person"
+  belongs_to :number1_fan, class_name: "Person", optional: true
 
   has_many :personal_legacy_things, dependent: :destroy
 
@@ -74,7 +74,7 @@ class LoosePerson < ActiveRecord::Base
   self.abstract_class = true
 
   has_one    :best_friend,    class_name: "LoosePerson", foreign_key: :best_friend_id
-  belongs_to :best_friend_of, class_name: "LoosePerson", foreign_key: :best_friend_of_id
+  belongs_to :best_friend_of, class_name: "LoosePerson", foreign_key: :best_friend_of_id, optional: true
   has_many   :best_friends,   class_name: "LoosePerson", foreign_key: :best_friend_id
 
   accepts_nested_attributes_for :best_friend, :best_friend_of, :best_friends
@@ -86,7 +86,7 @@ class TightPerson < ActiveRecord::Base
   self.table_name = "people"
 
   has_one    :best_friend,    class_name: "TightPerson", foreign_key: :best_friend_id
-  belongs_to :best_friend_of, class_name: "TightPerson", foreign_key: :best_friend_of_id
+  belongs_to :best_friend_of, class_name: "TightPerson", foreign_key: :best_friend_of_id, optional: true
   has_many   :best_friends,   class_name: "TightPerson", foreign_key: :best_friend_id
 
   accepts_nested_attributes_for :best_friend, :best_friend_of, :best_friends

--- a/activerecord/test/models/personal_legacy_thing.rb
+++ b/activerecord/test/models/personal_legacy_thing.rb
@@ -2,5 +2,5 @@
 
 class PersonalLegacyThing < ActiveRecord::Base
   self.locking_column = :version
-  belongs_to :person, counter_cache: true
+  belongs_to :person, counter_cache: true, optional: true
 end

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -4,7 +4,7 @@ class Pet < ActiveRecord::Base
   attr_accessor :current_user
 
   self.primary_key = :pet_id
-  belongs_to :owner, touch: true
+  belongs_to :owner, touch: true, optional: true
   has_many :toys
   has_many :pet_treasures
   has_many :treasures, through: :pet_treasures

--- a/activerecord/test/models/pet_treasure.rb
+++ b/activerecord/test/models/pet_treasure.rb
@@ -3,6 +3,6 @@
 class PetTreasure < ActiveRecord::Base
   self.table_name = "pets_treasures"
 
-  belongs_to :pet
-  belongs_to :treasure
+  belongs_to :pet, optional: true
+  belongs_to :treasure, optional: true
 end

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Pirate < ActiveRecord::Base
-  belongs_to :parrot, validate: true
-  belongs_to :non_validated_parrot, class_name: "Parrot"
+  belongs_to :parrot, validate: true, optional: true
+  belongs_to :non_validated_parrot, class_name: "Parrot", optional: true
   has_and_belongs_to_many :parrots, -> { order("parrots.id ASC") }, validate: true
   has_and_belongs_to_many :non_validated_parrots, class_name: "Parrot"
   has_and_belongs_to_many :parrots_with_method_callbacks, class_name: "Parrot",
@@ -105,8 +105,8 @@ end
 class SpacePirate < ActiveRecord::Base
   self.table_name = "pirates"
 
-  belongs_to :parrot
-  belongs_to :parrot_with_annotation, -> { annotate("that tells jokes") }, class_name: :Parrot, foreign_key: :parrot_id
+  belongs_to :parrot, optional: true
+  belongs_to :parrot_with_annotation, -> { annotate("that tells jokes") }, class_name: :Parrot, foreign_key: :parrot_id, optional: true
   has_and_belongs_to_many :parrots, foreign_key: :pirate_id
   has_and_belongs_to_many :parrots_with_annotation, -> { annotate("that are very colorful") }, class_name: :Parrot, foreign_key: :pirate_id
   has_one :ship, foreign_key: :pirate_id

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -3,9 +3,9 @@
 class Post < ActiveRecord::Base
   class CategoryPost < ActiveRecord::Base
     self.table_name = "categories_posts"
-    belongs_to :group, foreign_key: :category_id, class_name: "Category"
-    belongs_to :category
-    belongs_to :post
+    belongs_to :group, foreign_key: :category_id, class_name: "Category", optional: true
+    belongs_to :category, optional: true
+    belongs_to :post, optional: true
   end
 
   module NamedExtension
@@ -40,13 +40,13 @@ class Post < ActiveRecord::Base
     .having("count(comments.id) >= #{comments_count}")
   }
 
-  belongs_to :author
-  belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id
+  belongs_to :author, optional: true
+  belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id, optional: true
 
-  belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id
-  belongs_to :author_with_address, -> { includes(:author_address) }, class_name: "Author", foreign_key: :author_id
-  belongs_to :author_with_select, -> { select(:id) }, class_name: "Author", foreign_key: :author_id
-  belongs_to :author_with_the_letter_a, -> { where("name LIKE '%a%'") }, class_name: "Author", foreign_key: :author_id
+  belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id, optional: true
+  belongs_to :author_with_address, -> { includes(:author_address) }, class_name: "Author", foreign_key: :author_id, optional: true
+  belongs_to :author_with_select, -> { select(:id) }, class_name: "Author", foreign_key: :author_id, optional: true
+  belongs_to :author_with_the_letter_a, -> { where("name LIKE '%a%'") }, class_name: "Author", foreign_key: :author_id, optional: true
 
   def first_comment
     super.body
@@ -389,9 +389,9 @@ class FakeKlass
 end
 
 class Postesque < ActiveRecord::Base
-  belongs_to :author, class_name: "Author", foreign_key: :author_name, primary_key: :name
-  belongs_to :author_with_address, class_name: "Author", foreign_key: :author_id
-  belongs_to :author_with_the_letter_a, class_name: "Author", foreign_key: :author_id
+  belongs_to :author, class_name: "Author", foreign_key: :author_name, primary_key: :name, optional: true
+  belongs_to :author_with_address, class_name: "Author", foreign_key: :author_id, optional: true
+  belongs_to :author_with_the_letter_a, class_name: "Author", foreign_key: :author_id, optional: true
 end
 
 class PostRecord < ActiveRecord::Base

--- a/activerecord/test/models/price_estimate.rb
+++ b/activerecord/test/models/price_estimate.rb
@@ -3,8 +3,8 @@
 class PriceEstimate < ActiveRecord::Base
   include ActiveSupport::NumberHelper
 
-  belongs_to :estimate_of, polymorphic: true
-  belongs_to :thing, polymorphic: true
+  belongs_to :estimate_of, polymorphic: true, optional: true
+  belongs_to :thing, polymorphic: true, optional: true
 
   validates_numericality_of :price
 

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Project < ActiveRecord::Base
-  belongs_to :mentor
+  belongs_to :mentor, optional: true
   has_and_belongs_to_many :developers, -> { distinct.order "developers.name desc, developers.id desc" }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, class_name: "Developer"
   has_and_belongs_to_many :non_unique_developers, -> { order "developers.name desc, developers.id desc" }, class_name: "Developer"
@@ -14,7 +14,7 @@ class Project < ActiveRecord::Base
                             before_remove: Proc.new { |o, r| o.developers_log << "before_removing#{r.id}" },
                             after_remove: Proc.new { |o, r| o.developers_log << "after_removing#{r.id}" }
   has_and_belongs_to_many :well_paid_salary_groups, -> { group("developers.salary").having("SUM(salary) > 10000").select("SUM(salary) as salary") }, class_name: "Developer"
-  belongs_to :firm
+  belongs_to :firm, optional: true
   has_one :lead_developer, through: :firm, inverse_of: :contracted_projects
   has_one :lead_developer_disable_joins, through: :firm, inverse_of: :contracted_projects, source: :lead_developer, disable_joins: true
 

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Rating < ActiveRecord::Base
-  belongs_to :comment
+  belongs_to :comment, optional: true
   has_many :taggings, as: :taggable
   has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"

--- a/activerecord/test/models/reader.rb
+++ b/activerecord/test/models/reader.rb
@@ -3,8 +3,8 @@
 class Reader < ActiveRecord::Base
   belongs_to :post
   belongs_to :person, inverse_of: :readers
-  belongs_to :single_person, class_name: "Person", foreign_key: :person_id, inverse_of: :reader
-  belongs_to :first_post, -> { where(id: [2, 3]) }
+  belongs_to :single_person, class_name: "Person", foreign_key: :person_id, inverse_of: :reader, optional: true
+  belongs_to :first_post, -> { where(id: [2, 3]) }, optional: true
 end
 
 class SecureReader < ActiveRecord::Base

--- a/activerecord/test/models/recipe.rb
+++ b/activerecord/test/models/recipe.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Recipe < ActiveRecord::Base
-  belongs_to :chef
+  belongs_to :chef, optional: true
 end

--- a/activerecord/test/models/recipient.rb
+++ b/activerecord/test/models/recipient.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Recipient < ActiveRecord::Base
-  belongs_to :message, touch: true
+  belongs_to :message, touch: true, optional: true
 end

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Reference < ActiveRecord::Base
-  belongs_to :person
-  belongs_to :job
+  belongs_to :person, optional: true
+  belongs_to :job, optional: true
 
   has_many :ideal_jobs, class_name: "Job", foreign_key: :ideal_reference_id
   has_many :agents_posts_authors, through: :person

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -3,8 +3,8 @@
 require "models/topic"
 
 class Reply < Topic
-  belongs_to :topic, foreign_key: "parent_id", counter_cache: true, inverse_of: :replies
-  belongs_to :topic_with_primary_key, class_name: "Topic", primary_key: "title", foreign_key: "parent_title", counter_cache: "replies_count", touch: true
+  belongs_to :topic, foreign_key: "parent_id", counter_cache: true, inverse_of: :replies, optional: true
+  belongs_to :topic_with_primary_key, class_name: "Topic", primary_key: "title", foreign_key: "parent_title", counter_cache: "replies_count", touch: true, optional: true
   has_many :replies, class_name: "SillyReply", dependent: :destroy, foreign_key: "parent_id"
   has_many :silly_unique_replies, dependent: :destroy, foreign_key: "parent_id"
 
@@ -24,11 +24,11 @@ class Reply < Topic
 end
 
 class SillyReply < Topic
-  belongs_to :reply, foreign_key: "parent_id", counter_cache: :replies_count
+  belongs_to :reply, foreign_key: "parent_id", counter_cache: :replies_count, optional: true
 end
 
 class UniqueReply < Reply
-  belongs_to :topic, foreign_key: "parent_id", counter_cache: true
+  belongs_to :topic, foreign_key: "parent_id", counter_cache: true, optional: true
   validates_uniqueness_of :content, scope: "parent_id"
 end
 
@@ -74,6 +74,6 @@ end
 
 module Web
   class Reply < Web::Topic
-    belongs_to :topic, foreign_key: "parent_id", counter_cache: true, class_name: "Web::Topic"
+    belongs_to :topic, foreign_key: "parent_id", counter_cache: true, class_name: "Web::Topic", optional: true
   end
 end

--- a/activerecord/test/models/room.rb
+++ b/activerecord/test/models/room.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Room < ActiveRecord::Base
-  belongs_to :user
-  belongs_to :owner, class_name: "User"
+  belongs_to :user, optional: true
+  belongs_to :owner, class_name: "User", optional: true
 end

--- a/activerecord/test/models/section.rb
+++ b/activerecord/test/models/section.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Section < ActiveRecord::Base
-  belongs_to :session, inverse_of: :sections, autosave: true
-  belongs_to :seminar, inverse_of: :sections, autosave: true
+  belongs_to :session, inverse_of: :sections, autosave: true, optional: true
+  belongs_to :seminar, inverse_of: :sections, autosave: true, optional: true
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_blog_posts
     query_constraints :blog_id, :id
 
-    belongs_to :blog
+    belongs_to :blog, optional: true
     has_many :comments
     has_many :delete_comments, class_name: "Sharded::Comment", dependent: :delete_all
 

--- a/activerecord/test/models/sharded/blog_post_destroy_async.rb
+++ b/activerecord/test/models/sharded/blog_post_destroy_async.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_blog_posts
     query_constraints :blog_id, :id
 
-    belongs_to :blog
+    belongs_to :blog, optional: true
     has_many :comments, dependent: :destroy_async, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::CommentDestroyAsync"
 
     has_many :blog_post_tags, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPostTag"

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_blog_posts_tags
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post
-    belongs_to :tag
+    belongs_to :blog_post, optional: true
+    belongs_to :tag, optional: true
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -5,8 +5,8 @@ module Sharded
     self.table_name = :sharded_comments
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post
-    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
-    belongs_to :blog
+    belongs_to :blog_post, optional: true
+    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id, optional: true
+    belongs_to :blog, optional: true
   end
 end

--- a/activerecord/test/models/sharded/comment_destroy_async.rb
+++ b/activerecord/test/models/sharded/comment_destroy_async.rb
@@ -5,8 +5,8 @@ module Sharded
     self.table_name = :sharded_comments
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post, dependent: :destroy_async, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPostDestroyAsync"
-    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPostDestroyAsync", foreign_key: :blog_post_id
-    belongs_to :blog
+    belongs_to :blog_post, dependent: :destroy_async, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPostDestroyAsync", optional: true
+    belongs_to :blog_post_by_id, class_name: "Sharded::BlogPostDestroyAsync", foreign_key: :blog_post_id, optional: true
+    belongs_to :blog, optional: true
   end
 end

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -3,9 +3,9 @@
 class Ship < ActiveRecord::Base
   self.record_timestamps = false
 
-  belongs_to :pirate
-  belongs_to :update_only_pirate, class_name: "Pirate"
-  belongs_to :developer, dependent: :destroy
+  belongs_to :pirate, optional: true
+  belongs_to :update_only_pirate, class_name: "Pirate", optional: true
+  belongs_to :developer, dependent: :destroy, optional: true
   has_many :parts, class_name: "ShipPart"
   has_many :treasures
 
@@ -32,11 +32,11 @@ class ShipWithoutNestedAttributes < ActiveRecord::Base
 end
 
 class Prisoner < ActiveRecord::Base
-  belongs_to :ship, autosave: true, class_name: "ShipWithoutNestedAttributes", inverse_of: :prisoners
+  belongs_to :ship, autosave: true, class_name: "ShipWithoutNestedAttributes", inverse_of: :prisoners, optional: true
 end
 
 class FamousShip < ActiveRecord::Base
   self.table_name = "ships"
-  belongs_to :famous_pirate, foreign_key: :pirate_id
+  belongs_to :famous_pirate, foreign_key: :pirate_id, optional: true
   validates_presence_of :name, on: :conference
 end

--- a/activerecord/test/models/ship_part.rb
+++ b/activerecord/test/models/ship_part.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ShipPart < ActiveRecord::Base
-  belongs_to :ship
+  belongs_to :ship, optional: true
   has_many :trinkets, class_name: "Treasure", as: :looter
   accepts_nested_attributes_for :trinkets, allow_destroy: true
   accepts_nested_attributes_for :ship

--- a/activerecord/test/models/shipping_line.rb
+++ b/activerecord/test/models/shipping_line.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class ShippingLine < ActiveRecord::Base
-  belongs_to :invoice, touch: true
+  belongs_to :invoice, touch: true, optional: true
   has_many :discount_applications, class_name: "ShippingLineDiscountApplication"
 end
 
 class ShippingLineDiscountApplication < ActiveRecord::Base
-  belongs_to :shipping_line
-  belongs_to :discount
+  belongs_to :shipping_line, optional: true
+  belongs_to :discount, optional: true
 end

--- a/activerecord/test/models/shop.rb
+++ b/activerecord/test/models/shop.rb
@@ -7,7 +7,7 @@ module Shop
 
   class Product < ActiveRecord::Base
     has_many :variants, dependent: :delete_all
-    belongs_to :type
+    belongs_to :type, optional: true
 
     class Type < ActiveRecord::Base
       has_many :products

--- a/activerecord/test/models/shop_account.rb
+++ b/activerecord/test/models/shop_account.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ShopAccount < ActiveRecord::Base
-  belongs_to :customer
-  belongs_to :customer_carrier
+  belongs_to :customer, optional: true
+  belongs_to :customer_carrier, optional: true
 
   has_one :carrier, through: :customer_carrier
 end

--- a/activerecord/test/models/speedometer.rb
+++ b/activerecord/test/models/speedometer.rb
@@ -2,7 +2,7 @@
 
 class Speedometer < ActiveRecord::Base
   self.primary_key = :speedometer_id
-  belongs_to :dashboard
+  belongs_to :dashboard, optional: true
 
   has_many :minivans
 end

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Sponsor < ActiveRecord::Base
-  belongs_to :sponsor_club, class_name: "Club", foreign_key: "club_id"
-  belongs_to :sponsorable, polymorphic: true
-  belongs_to :sponsor, polymorphic: true
-  belongs_to :thing, polymorphic: true, foreign_type: :sponsorable_type, foreign_key: :sponsorable_id
+  belongs_to :sponsor_club, class_name: "Club", foreign_key: "club_id", optional: true
+  belongs_to :sponsorable, polymorphic: true, optional: true
+  belongs_to :sponsor, polymorphic: true, optional: true
+  belongs_to :thing, polymorphic: true, foreign_type: :sponsorable_type, foreign_key: :sponsorable_id, optional: true
   belongs_to :sponsorable_with_conditions, -> { where name: "Ernie" }, polymorphic: true,
-             foreign_type: "sponsorable_type", foreign_key: "sponsorable_id"
+             foreign_type: "sponsorable_type", foreign_key: "sponsorable_id", optional: true
 end

--- a/activerecord/test/models/squeak.rb
+++ b/activerecord/test/models/squeak.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Squeak < ActiveRecord::Base
-  belongs_to :mouse
+  belongs_to :mouse, optional: true
   accepts_nested_attributes_for :mouse
 end

--- a/activerecord/test/models/student.rb
+++ b/activerecord/test/models/student.rb
@@ -2,5 +2,5 @@
 
 class Student < ActiveRecord::Base
   has_and_belongs_to_many :lessons
-  belongs_to :college
+  belongs_to :college, optional: true
 end

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Subscription < ActiveRecord::Base
-  belongs_to :subscriber, counter_cache: :books_count
-  belongs_to :book, -> { author_visibility_visible }
+  belongs_to :subscriber, counter_cache: :books_count, optional: true
+  belongs_to :book, -> { author_visibility_visible }, optional: true
 
   validates_presence_of :subscriber_id, :book_id
 end

--- a/activerecord/test/models/tagging.rb
+++ b/activerecord/test/models/tagging.rb
@@ -5,13 +5,13 @@ module Taggable
 end
 
 class Tagging < ActiveRecord::Base
-  belongs_to :tag, -> { includes(:tagging) }
-  belongs_to :super_tag,   class_name: "Tag", foreign_key: "super_tag_id"
-  belongs_to :invalid_tag, class_name: "Tag", foreign_key: "tag_id"
-  belongs_to :ordered_tag, class_name: "OrderedTag", foreign_key: "tag_id"
-  belongs_to :blue_tag, -> { where tags: { name: "Blue" } }, class_name: "Tag", foreign_key: :tag_id
-  belongs_to :tag_with_primary_key, class_name: "Tag", foreign_key: :tag_id, primary_key: :custom_primary_key
-  belongs_to :taggable, polymorphic: true, counter_cache: :tags_count
+  belongs_to :tag, -> { includes(:tagging) }, optional: true
+  belongs_to :super_tag,   class_name: "Tag", foreign_key: "super_tag_id", optional: true
+  belongs_to :invalid_tag, class_name: "Tag", foreign_key: "tag_id", optional: true
+  belongs_to :ordered_tag, class_name: "OrderedTag", foreign_key: "tag_id", optional: true
+  belongs_to :blue_tag, -> { where tags: { name: "Blue" } }, class_name: "Tag", foreign_key: :tag_id, optional: true
+  belongs_to :tag_with_primary_key, class_name: "Tag", foreign_key: :tag_id, primary_key: :custom_primary_key, optional: true
+  belongs_to :taggable, polymorphic: true, counter_cache: :tags_count, optional: true
   has_many :things, through: :taggable
 end
 

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -2,7 +2,7 @@
 
 class Toy < ActiveRecord::Base
   self.primary_key = :toy_id
-  belongs_to :pet
+  belongs_to :pet, optional: true
 
   has_many :sponsors, as: :sponsorable, inverse_of: :sponsorable
 

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -2,9 +2,9 @@
 
 class Treasure < ActiveRecord::Base
   has_and_belongs_to_many :parrots
-  belongs_to :looter, polymorphic: true
+  belongs_to :looter, polymorphic: true, optional: true
   # No counter_cache option given
-  belongs_to :ship
+  belongs_to :ship, optional: true
 
   has_many :price_estimates, as: :estimate_of
   has_and_belongs_to_many :rich_people, join_table: "peoples_treasures", validate: false

--- a/activerecord/test/models/tuning_peg.rb
+++ b/activerecord/test/models/tuning_peg.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class TuningPeg < ActiveRecord::Base
-  belongs_to :guitar
+  belongs_to :guitar, optional: true
   validates_numericality_of :pitch
 end

--- a/activerecord/test/models/tyre.rb
+++ b/activerecord/test/models/tyre.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Tyre < ActiveRecord::Base
-  belongs_to :car
+  belongs_to :car, optional: true
 
   def self.custom_find(id)
     find(id)

--- a/activerecord/test/models/vegetables.rb
+++ b/activerecord/test/models/vegetables.rb
@@ -21,7 +21,7 @@ class KingCole < GreenCabbage
 end
 
 class RedCabbage < Cabbage
-  belongs_to :seller, class_name: "Company"
+  belongs_to :seller, class_name: "Company", optional: true
 end
 
 class YellingVegetable < Vegetable

--- a/activerecord/test/models/wheel.rb
+++ b/activerecord/test/models/wheel.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Wheel < ActiveRecord::Base
-  belongs_to :wheelable, polymorphic: true, counter_cache: true, touch: :wheels_owned_at
+  belongs_to :wheelable, polymorphic: true, counter_cache: true, touch: :wheels_owned_at, optional: true
 end

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1291,13 +1291,6 @@ object won't be validated. By default, this option is set to `false`.
 
 Passing `true` to the `:polymorphic` option indicates that this is a polymorphic association. Polymorphic associations were discussed in detail <a href="#polymorphic-associations">earlier in this guide</a>.
 
-
-##### `:required`
-
-When set to `true`, the association will also have its presence validated. This will validate the association itself, not the id. You can use `:inverse_of` to avoid an extra query during validation.
-
-NOTE: required is set to `true` by default and is deprecated. If you don’t want to have association presence validated, use `optional: true`.
-
 ##### `:strict_loading`
 
 Enforces strict loading every time the associated record is loaded through this association.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1158,18 +1158,6 @@ if there were multiple copies of the same record enrolled in the transaction.
 | (original)            | `false`              |
 | 7.1                   | `true`               |
 
-#### `config.active_record.belongs_to_required_by_default`
-
-Is a boolean value and controls whether a record fails validation if
-`belongs_to` association is not present.
-
-The default value depends on the `config.load_defaults` target version:
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `nil`                |
-| 5.0                   | `true`               |
-
 #### `config.active_record.belongs_to_required_validates_foreign_key`
 
 Enable validating only parent-related columns for presence when the parent is mandatory.

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -185,7 +185,16 @@ module Rails
       end
 
       def required?
-        reference? && Rails.application.config.active_record.belongs_to_required_by_default
+        required_by_default = Rails.application.config.active_record.belongs_to_required_by_default
+
+        if !required_by_default
+          Rails.deprecator.warn(<<-MSG.squish)
+            `config.active_record.belongs_to_required_by_default` is deprecated and will be removed in Rails 7.3.
+            `belongs_to` associations will have their presence validated by default going forward.
+          MSG
+        end
+
+        reference? && required_by_default
       end
 
       def has_index?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

`:required` for `belongs_to` has been considered to be ['deprecated' since `v5.0`](https://github.com/rails/rails/pull/18937) but has never had a deprecation warning. My guess is that at the time, the framework didn't have a well established pattern / process for deprecating features as it does now, other than including this information in public documentation:
https://github.com/rails/rails/blob/46857fb7f51e084e9b26edc80d152b700ec57c7d/activerecord/lib/active_record/associations.rb#L1855-L1856

Adding one now (probably in the `v7.2` release) will allow us to completely remove this feature in `v7.3` (I'm unsure if this is an actual planned release version).

### Detail

Adds a deprecation warning when:
- using the `:required` option with `belongs_to` associations
- setting the global `config.active_record.belongs_to_required_by_default` configuration to `false`
- setting the per model `#belongs_to_required_by_default` configuration attribute to `false` (this is also set to `false` when the global config is set to false but I think it's fine to show the warning regardless since both use the same naming convention)

Also removes any public documentation encouraging the use of this feature and relevant config.

I left the following documentation untouched as it's been written in the context of `v5.0` where this is still available:
https://github.com/rails/rails/blob/e5124aed3fdcacb05204391e236c4fd60a1e6e74/guides/source/upgrading_ruby_on_rails.md?plain=1#L1569-L1600

https://github.com/rails/rails/blob/e5124aed3fdcacb05204391e236c4fd60a1e6e74/guides/source/configuring.md?plain=1#L156

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I am happy to take ownership of this deprecation and follow up with a PR for the removal :)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
