### PR TITLE
Disallow invalid values for rails new options

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -18,6 +18,10 @@ module Rails
       NODE_LTS_VERSION = "18.15.0"
       BUN_VERSION = "1.0.1"
 
+      JAVASCRIPT_OPTIONS = %w( importmap bun webpack esbuild rollup )
+      CSS_OPTIONS = %w( tailwind bootstrap bulma postcss sass )
+      ASSET_PIPELINE_OPTIONS = %w( sprockets propshaft )
+
       attr_accessor :rails_template
       add_shebang_option!
 
@@ -71,7 +75,7 @@ module Rails
         class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil
 
         class_option :asset_pipeline,      type: :string, aliases: "-a", default: "sprockets",
-                                           desc: "Choose your asset pipeline [options: sprockets (default), propshaft]"
+                                           desc: "Choose your asset pipeline [options: #{ASSET_PIPELINE_OPTIONS.join(", ")}]"
 
         class_option :skip_javascript,     type: :boolean, aliases: ["-J", "--skip-js"], default: (true if name == "plugin"),
                                            desc: "Skip JavaScript files"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -277,8 +277,8 @@ module Rails
       class_option :version, type: :boolean, aliases: "-v", group: :rails, desc: "Show Rails version number and quit"
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
-      class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), bun, webpack, esbuild, rollup]"
-      class_option :css, type: :string, aliases: "-c", desc: "Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass] check https://github.com/rails/cssbundling-rails for more options"
+      class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", desc: "Choose JavaScript approach [options: #{JAVASCRIPT_OPTIONS.join(', ')}]"
+      class_option :css, type: :string, aliases: "-c", desc: "Choose CSS processor [options: #{CSS_OPTIONS.join(', ')}] check https://github.com/rails/cssbundling-rails for more options"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: nil, desc: "Don't run bundle install"
       class_option :skip_decrypted_diffs, type: :boolean, default: nil, desc: "Don't configure git to show decrypted diffs of encrypted credentials"
 
@@ -324,6 +324,19 @@ module Rails
 
         if !options[:skip_active_record] && !DATABASES.include?(options[:database])
           raise Error, "Invalid value for --database option. Supported preconfigurations are: #{DATABASES.join(", ")}."
+        end
+
+        if !options[:skip_javascript] && !JAVASCRIPT_OPTIONS.include?(options[:javascript])
+          raise Error, "Invalid value for --javascript option. Supported options are: #{JAVASCRIPT_OPTIONS.join(", ")}."
+        end
+
+        if options[:css] && !CSS_OPTIONS.include?(options[:css])
+          raise Error, "Invalid value for --css option. Supported options are: #{CSS_OPTIONS.join(", ")}."
+        end
+
+        # A value of "none" is permitted as an alternative to --skip-asset-pipeline
+        if !options[:skip_asset_pipeline] && !(ASSET_PIPELINE_OPTIONS + ["none"]).include?(options[:asset_pipeline])
+          raise Error, "Invalid value for --asset-pipeline option. Supported options are: #{ASSET_PIPELINE_OPTIONS.join(", ")}."
         end
 
         @after_bundle_callbacks = []

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -111,6 +111,21 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("app/assets/stylesheets/application.css")
   end
 
+  def test_invalid_javascript_option_raises_an_error
+    content = capture(:stderr) { run_generator([destination_root, "-j", "unknown"]) }
+    assert_match(/Invalid value for --javascript option/, content)
+  end
+
+  def test_invalid_asset_pipeline_option_raises_an_error
+    content = capture(:stderr) { run_generator([destination_root, "-a", "unknown"]) }
+    assert_match(/Invalid value for --asset-pipeline option/, content)
+  end
+
+  def test_invalid_css_option_raises_an_error
+    content = capture(:stderr) { run_generator([destination_root, "-c", "unknown"]) }
+    assert_match(/Invalid value for --css option/, content)
+  end
+
   def test_application_job_file_present
     run_generator
     assert_file("app/jobs/application_job.rb")


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `--database`, `--asset-pipeline`, `--css`, and `--javascript` flags for `rails new` can all take different options. However, only `--database` has a check to make sure the correct option is given.

If someone where to fat-finger a value, for example `--javascript=esbuiild`, they most likely would be left with either importmaps used or some other undefined behavior.

### Detail

This Pull Request changes adds similar checks as the `--database` flag for the other four options to make sure the user enters the correct value.

### Additional information

I'm open to suggestions regarding the naming and placement of the three new constants listing out the options.

As it stands, this change loses the mentioning of which option is the default in the help text. That said, the database list doesn't list it as well. One option could be to have, by convention, the first element in the array be the default and output the help text accordingly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
