### PR TITLE
Remove require of ActiveSupport::ForkTracker

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -6,7 +6,6 @@ require "listen"
 require "set"
 require "pathname"
 require "concurrent/atomic/atomic_boolean"
-require "active_support/fork_tracker"
 
 module ActiveSupport
   # Allows you to "listen" to changes in a file system.


### PR DESCRIPTION
ForkTracker has beed autoloaded since [before][1] the [require][2] was added.

[1]: https://github.com/rails/rails/commit/78b9580e5f3208c7048659de24f2220693afb23c
[2]: https://github.com/rails/rails/commit/eba1534939fe1cf005746f12446235bdd52014c1
