### PR TITLE
Add download support for SSE-C objects in S3 Service

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
+*   Allow setting object download options in S3 service.
+
+    Object download options are used in `S3Service#download`, `S3Service#download_chunk`, `S3Service#compose` and `S3Service#exist?`.
+
+    ```yml
+    s3:
+      service: S3
+      download:
+        sse_customer_algorithm: ""
+        sse_customer_key: ""
+        sse_customer_key_md5: ""
+    ```
+
+    *Lovro Bikić*
+
 *   Deprecate `ActiveStorage::Service::AzureStorageService`.
 
     *zzak*

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -169,7 +169,7 @@ amazon:
   bucket: your_own_bucket-<%= Rails.env %>
 ```
 
-Optionally provide client and upload options:
+Optionally provide client, upload and download options:
 
 ```yaml
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
@@ -185,6 +185,13 @@ amazon:
   upload:
     server_side_encryption: "" # 'aws:kms' or 'AES256'
     cache_control: "private, max-age=<%= 1.day.to_i %>"
+    sse_customer_algorithm: ""
+    sse_customer_key: ""
+    sse_customer_key_md5: ""
+  download:
+    sse_customer_algorithm: ""
+    sse_customer_key: ""
+    sse_customer_key_md5: ""
 ```
 
 TIP: Set sensible client HTTP timeouts and retry limits for your application. In certain failure scenarios, the default AWS client configuration may cause connections to be held for up to several minutes and lead to request queuing.


### PR DESCRIPTION
### Motivation / Background

Active Storage S3 service currently supports uploading objects with [SSE-C (server-side encryption with customer-provided keys)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html):
```yml
# config/storage.yml
s3:
  service: S3
  upload:
    sse_customer_algorithm: AES256
    sse_customer_key: KEY
    sse_customer_key_md5: KEY_MD5
```

However, when you try to download these objects ([S3Service#download](https://api.rubyonrails.org/classes/ActiveStorage/Service/S3Service.html#method-i-download)), an error is raised:
> Aws::S3::Errors::InvalidRequest: The object was stored using a form of Server Side Encryption.
The correct parameters must be provided to retrieve the object

and similarly when you call [S3Service#exist?](https://api.rubyonrails.org/classes/ActiveStorage/Service/S3Service.html#method-i-exist-3F):
> Caused by Aws::Waiters::Errors::UnexpectedError: stopped waiting due to an unexpected error: Aws::S3::Errors::BadRequest

This happens because when you upload an object with your own keys, you can only download them by passing the same keys again, which Rails currently doesn't pass. From the [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html):
> When you upload an object, Amazon S3 uses the encryption key that you provide to apply AES-256 encryption to your data. Amazon S3 then removes the encryption key from memory. When you retrieve an object, you must provide the same encryption key as part of your request.

### Detail

This PR adds `download` key to S3 service configuration, allowing you to specify options for downloading files which are passed to relevant S3 methods:
```yml
# config/storage.yml
s3:
  service: S3
  upload:
    sse_customer_algorithm: AES256
    sse_customer_key: KEY
    sse_customer_key_md5: KEY_MD5
  download:
    sse_customer_algorithm: AES256
    sse_customer_key: KEY
    sse_customer_key_md5: KEY_MD5
```

With these options, `S3Service#download` (and `S3Service#download_chunk`) and `S3Service#exist?` return expected results for objects uploaded with SSE-C.

### Additional information

`download` options are passed to [`Aws::S3::Object#get`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#get-instance_method), [`Aws::S3::Object#exists?`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#exists%3F-instance_method) and [`Aws::S3::Object#head`](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#head-instance_method) methods, so the options used must be supported by all three methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
