### PR TITLE
MemoryStore: prevent race condition

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix MemoryStore to prevent race conditions when incrementing or decrementing.
+
+    *Pierre Jambet*
+
 *   Implement `HashWithIndifferentAccess#to_proc`.
 
     Previously, calling `#to_proc` on `HashWithIndifferentAccess` object used inherited `#to_proc`

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -238,16 +238,18 @@ module ActiveSupport
           key     = normalize_key(name, options)
           version = normalize_version(name, options)
 
-          entry = read_entry(key, **options)
+          synchronize do
+            entry = read_entry(key, **options)
 
-          if !entry || entry.expired? || entry.mismatched?(version)
-            write(name, Integer(amount), options)
-            amount
-          else
-            num = entry.value.to_i + amount
-            entry = Entry.new(num, expires_at: entry.expires_at, version: entry.version)
-            write_entry(key, entry)
-            num
+            if !entry || entry.expired? || entry.mismatched?(version)
+              write(name, Integer(amount), options)
+              amount
+            else
+              num = entry.value.to_i + amount
+              entry = Entry.new(num, expires_at: entry.expires_at, version: entry.version)
+              write_entry(key, entry)
+              num
+            end
           end
         end
     end


### PR DESCRIPTION
### Motivation / Background

It looks like #46305 accidentally removed the synchronize block that would prevent a race conidition where two threads would read the same value and only a single increment/decrement would take effect as they would both write the same value.

### Detail

This was discussed in [this PR](https://github.com/rails/rails/pull/49503) where the original fix for the expiry was being backported to 7.0

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
Doesn't look like it's easy to deterministically test this. All I could do was to spin multiple threads and sometimes see inconsistencies, but not always

That comment shows how I played with it locally to exacerbates the behavior with `sleep` calls: https://github.com/rails/rails/pull/49503#issuecomment-1752116647

Since 7.1 was just released, do we need a different PR to backport this to 7-1-stable?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
