### PR TITLE
SQLite: add additional quote to table name only when it’s not quoted

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -673,7 +673,7 @@ module ActiveRecord
 
         def extract_table_ref_from_insert_sql(sql)
           if sql =~ /into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
-            $1.strip
+            $1.delete('"').strip
           end
         end
     end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -96,6 +96,19 @@ module ActiveRecord
         end
       end
 
+      def test_exec_insert_with_quote
+        with_example_table do
+          vals = [Relation::QueryAttribute.new("number", 10, Type::Value.new)]
+          @conn.exec_insert("insert into \"ex\" (number) VALUES (?)", "SQL", vals)
+
+          result = @conn.exec_query(
+            "select number from \"ex\" where number = ?", "SQL", vals)
+
+          assert_equal 1, result.rows.length
+          assert_equal 10, result.rows.first.first
+        end
+      end
+
       def test_primary_key_returns_nil_for_no_pk
         with_example_table "id int, data string" do
           assert_nil @conn.primary_key("ex")


### PR DESCRIPTION
### Motivation / Background

In Rails 7.1, when using quoted table name in `exec_insert` for SQLite, the table name is quoted again, which raises error that the table does not exist. This breaks downstream gem like activerecord-import. This PR aims to fix the issue by avoid quoting when the table name is already quoted.

### Detail

I added a test in `activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb` to reproduce the issue. When running the below code without the fix, it will raise the below error

- Code:
 
```ruby
@conn.exec_insert("insert into \"ex\" (number) VALUES (?)", "SQL", vals)
```

- Output

```
ActiveRecord::ConnectionAdapters::SQLite3AdapterTest#test_exec_insert_with_quote:
ActiveRecord::StatementInvalid: Could not find table '"ex"'
    /workspaces/rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:460:in `table_structure'
    /workspaces/rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:270:in `primary_keys'
    /workspaces/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:146:in `primary_key'
    /workspaces/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:641:in `sql_for_insert'
    /workspaces/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:152:in `exec_insert'
    /workspaces/rails/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb:102:in `block in test_exec_insert_with_quote'
    /workspaces/rails/activerecord/test/support/ddl_helper.rb:6:in `with_example_table'
    /workspaces/rails/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb:841:in `with_example_table'
    /workspaces/rails/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb:100:in `test_exec_insert_with_quote'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
