### PR TITLE
"NoMethodError: undefined method `pluralize' for an instance of Symbol" in PrismRenderParser

### DIFF
--- a/actionview/lib/action_view/render_parser/prism_render_parser.rb
+++ b/actionview/lib/action_view/render_parser/prism_render_parser.rb
@@ -112,7 +112,7 @@ module ActionView
                 when :local_variable_read_node
                   node.slice
                 when :call_node
-                  node.name
+                  node.name.to_s
                 else
                   return
                 end


### PR DESCRIPTION
### Detail

Fixes #49464

This patch fixes "NoMethodError: undefined method `pluralize' for an instance of Symbol" in PrismRenderParser on Ruby 3.3.

see: https://buildkite.com/rails/rails/builds/100525#018b10a0-9ed9-4c7b-b6d2-028ed05a0a04
/cc @kddnewton 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.