### PR TITLE
Let controller generator generate double-quoted routes

### DIFF
--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -17,7 +17,7 @@ module Rails
       def add_routes
         return if options[:skip_routes]
         return if actions.empty?
-        routing_code = actions.map { |action| "get '#{file_name}/#{action}'" }.join("\n")
+        routing_code = actions.map { |action| %(get "#{file_name}/#{action}") }.join("\n")
         route routing_code, namespace: regular_class_path
       end
 

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -55,7 +55,7 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_add_routes
     run_generator
-    assert_file "config/routes.rb", /^  get 'account\/foo'/, /^  get 'account\/bar'/
+    assert_file "config/routes.rb", /^  get "account\/foo"/, /^  get "account\/bar"/
   end
 
   def test_skip_routes
@@ -94,14 +94,14 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
   def test_namespaced_routes_are_created_in_routes
     run_generator ["admin/dashboard", "index"]
     assert_file "config/routes.rb" do |route|
-      assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n  end$/, route)
+      assert_match(/^  namespace :admin do\n    get "dashboard\/index"\n  end$/, route)
     end
   end
 
   def test_namespaced_routes_with_multiple_actions_are_created_in_routes
     run_generator ["admin/dashboard", "index", "show"]
     assert_file "config/routes.rb" do |route|
-      assert_match(/^  namespace :admin do\n    get 'dashboard\/index'\n    get 'dashboard\/show'\n  end$/, route)
+      assert_match(/^  namespace :admin do\n    get "dashboard\/index"\n    get "dashboard\/show"\n  end$/, route)
     end
   end
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -62,7 +62,7 @@ class NamespacedControllerGeneratorTest < NamespacedGeneratorTestCase
 
   def test_routes_should_not_be_namespaced
     run_generator
-    assert_file "config/routes.rb", /get 'account\/foo'/, /get 'account\/bar'/
+    assert_file "config/routes.rb", /get "account\/foo"/, /get "account\/bar"/
   end
 
   def test_invokes_default_template_engine_even_with_no_action


### PR DESCRIPTION
### Motivation / Background

`rails g controller` currently adds a route entry with a single-quoted string literal.
For instance, `rails g controller home index` makes this change
```diff
 Rails.application.routes.draw do
+  get 'home/index'
   resources :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
```
to routes.rb.

Since almost all other string literals in the generated app are double-quoted (which is unfortunate), this should better be double-quoted as well for consistency. Otherwise, RuboCop with [the Rails rule](https://github.com/rails/rails/blob/main/.rubocop.yml) (which I hate) would report an offence at this line.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.