### PR TITLE
Check if internal metadata is enabled in `create_table_and_set_flags`method

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -64,6 +64,8 @@ module ActiveRecord
     end
 
     def create_table_and_set_flags(environment, schema_sha1 = nil)
+      return unless enabled?
+
       create_table
       update_or_create_entry(:environment, environment)
       update_or_create_entry(:schema_sha1, schema_sha1) if schema_sha1


### PR DESCRIPTION
### Motivation / Background

I maintain a gem ([pg-aws_rds_iam](https://github.com/haines/pg-aws_rds_iam)) that runs acceptance tests against supported versions of Active Record. When I added 7.1 to the test matrix, my test failed with the following error:

```
ERROR AcceptanceTest#test_active_record_load_schema (1.77s)
Minitest::UnexpectedError: ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR: relation "ar_internal_metadata" does not exist
  LINE 1: SELECT * FROM "ar_internal_metadata" WHERE "ar_internal_meta...
                        ^

  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql_adapter.rb:897:in `exec_params'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql_adapter.rb:897:in `block (2 levels) in exec_no_cache'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract_adapter.rb:1024:in `block in with_raw_connection'
  gems/activesupport-7.1.0/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract_adapter.rb:996:in `with_raw_connection'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql_adapter.rb:896:in `block in exec_no_cache'
  gems/activesupport-7.1.0/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract_adapter.rb:1134:in `log'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql_adapter.rb:895:in `exec_no_cache'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql_adapter.rb:875:in `execute_and_clear'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/postgresql/database_statements.rb:61:in `internal_exec_query'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:628:in `select'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:71:in `select_all'
  gems/activerecord-7.1.0/lib/active_record/connection_adapters/abstract/query_cache.rb:114:in `select_all'
  gems/activerecord-7.1.0/lib/active_record/internal_metadata.rb:145:in `select_entry'
  gems/activerecord-7.1.0/lib/active_record/internal_metadata.rb:97:in `update_or_create_entry'
  gems/activerecord-7.1.0/lib/active_record/internal_metadata.rb:68:in `create_table_and_set_flags'
  gems/activerecord-7.1.0/lib/active_record/tasks/database_tasks.rb:365:in `load_schema'
  test/acceptance/test.rb:39:in `block in test_active_record_load_schema'
```

### Detail

It seems that in 7.1 there is a new method, `ActiveRecord::InternalMetadata#create_table_and_set_flags`, which does not respect the `use_metadata_table: false` setting on the connection.

https://github.com/rails/rails/blob/v7.1.0/activerecord/lib/active_record/internal_metadata.rb#L66-L70

`create_table_and_set_flags` calls `create_table` (which is a no-op if the metadata table is disabled) and then `update_or_create_entry` (which assumes that the metadata table exists).

This PR adds a guard clause to `create_table_and_set_flags` to match the other methods in `InternalMetadata`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~ - I'm not sure where or how to add a test for this fix
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
