### PR TITLE
Make the table name too long error message more explicit for Postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1767,14 +1767,18 @@ module ActiveRecord
 
         def validate_index_length!(table_name, new_name, internal = false)
           if new_name.length > index_name_length
-            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
+            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters."
           end
         end
 
         def validate_table_length!(table_name)
           if table_name.length > table_name_length
-            raise ArgumentError, "Table name '#{table_name}' is too long; the limit is #{table_name_length} characters"
+            raise ArgumentError, table_name_too_long_error_message(table_name)
           end
+        end
+
+        def table_name_too_long_error_message(table_name)
+          "Table name '#{table_name}' is too long; the limit is #{table_name_length} characters"
         end
 
         def extract_new_default_value(default_or_changes)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -608,6 +608,10 @@ module ActiveRecord
         max_identifier_length - "_pkey".length
       end
 
+      def table_name_too_long_error_message(table_name)
+        "Table name '#{table_name}' is too long; PostgreSQL allows a maximum length of #{max_identifier_length} characters, but we also need to allow for the `_pkey` suffix that PostgreSQL adds to table names when creating default indexes, so our effective limit is #{table_name_length} characters."
+      end
+
       # Set the authorized user for this session
       def session_auth=(user)
         clear_cache!

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -200,13 +200,18 @@ class MigrationTest < ActiveRecord::TestCase
   def test_create_table_raises_for_long_table_names
     connection = Person.connection
     name_limit = connection.table_name_length
+    max_identifier_length = connection.max_identifier_length
     long_name = "a" * (name_limit + 1)
     short_name = "a" * name_limit
 
     error = assert_raises(ArgumentError) do
       connection.create_table(long_name)
     end
-    assert_equal "Table name '#{long_name}' is too long; the limit is #{name_limit} characters", error.message
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_equal "Table name '#{long_name}' is too long; PostgreSQL allows a maximum length of #{max_identifier_length} characters, but we also need to allow for the `_pkey` suffix that PostgreSQL adds to table names when creating default indexes, so our effective limit is #{name_limit} characters.", error.message
+    else
+      assert_equal "Table name '#{long_name}' is too long; the limit is #{name_limit} characters", error.message
+    end
 
     connection.create_table(short_name)
     assert connection.table_exists?(short_name)


### PR DESCRIPTION
Fixes #49557

Makes it explicit why the enforced limit for max table name length is less than the default Postgres limit.