### PR TITLE
Updated the image_processing gem version for new rails apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :storage do
   gem "google-cloud-storage", "~> 1.11", require: false
   gem "azure-storage-blob", "~> 2.0", require: false
 
-  gem "image_processing", "~> 1.2"
+  gem "image_processing", "~> 1.12"
 end
 
 # Action Mailbox

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,7 +584,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   google-cloud-storage (~> 1.11)
-  image_processing (~> 1.2)
+  image_processing (~> 1.12)
   importmap-rails
   jbuilder
   jsbundling-rails

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -5,7 +5,7 @@ begin
 rescue LoadError
   raise LoadError, <<~ERROR.squish
     Generating image variants require the image_processing gem.
-    Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
+    Please add `gem 'image_processing', '~> 1.12'` to your Gemfile.
   ERROR
 end
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -44,7 +44,7 @@ will not install, and must be installed separately:
 Image analysis and transformations also require the `image_processing` gem. Uncomment it in your `Gemfile`, or add it if necessary:
 
 ```ruby
-gem "image_processing", ">= 1.2"
+gem "image_processing", ">= 1.12"
 ```
 
 TIP: Compared to libvips, ImageMagick is better known and more widely available. However, libvips can be [up to 10x faster and consume 1/10 the memory](https://github.com/libvips/libvips/wiki/Speed-and-memory-use). For JPEG files, this can be further improved by replacing `libjpeg-dev` with `libjpeg-turbo-dev`, which is [2-7x faster](https://libjpeg-turbo.org/About/Performance).

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -24,7 +24,7 @@ gem "bootsnap", require: false
 <% unless skip_active_storage? -%>
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+# gem "image_processing", "~> 1.12"
 <% end -%>
 <%- if options.api? -%>
 


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/32471 Added `image_processing` gem for Active Storage variants. After that we haven't updated the version.
The latest image_processing version is 1.12.

### Detail

This Pull Request updates the `image_processing` gem version to 1.12 for the rails new applications.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
