### PR TITLE
Fixup `LogSubscriber` for non-Numeric `logger.level`

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -122,7 +122,7 @@ module ActiveSupport
         end
 
         def subscribe_log_level(method, level)
-          self.log_levels = log_levels.merge(method => ::Logger.const_get(level.upcase))
+          self.log_levels = log_levels.merge(method => "#{level}?")
           set_event_levels
         end
     end
@@ -137,7 +137,9 @@ module ActiveSupport
     end
 
     def silenced?(event)
-      logger.nil? || logger.level > @event_levels.fetch(event, Float::INFINITY)
+      return false unless @event_levels.key?(event)
+
+      !logger&.public_send(@event_levels.fetch(event))
     end
 
     def call(event)


### PR DESCRIPTION

### Motivation / Background

Numeric values for `Logger#level` is an implementation detail and other logger implementations (for example `semantic_logger`) have `Symbol`s instead. Current implementation doesn't allow that because it's comparing log level to `Float::Infinity`.

Use proper methods like `#debug?` to check if message should be logged.

Fixes bd19d1baf1cb006f3e9f16afac1c7b4e693f111c
CC @byroot 

No idea if/how it should be tested, please advise. Probably I could add a test with some hand-made logger into `log_subscriber_test.rb`, but not sure if it's worth it.

`rails_semantic_logger` CI run with the failure: https://github.com/ojab/rails_semantic_logger/actions/runs/6461173004/job/17540325867

### Detail

Method name is saved in `#subscribe_log_level` instead of log level, so it could be fetched directly in the runtime. Benchmark from https://github.com/rails/rails/pull/45796#issuecomment-1211791483 says that performance is not affected 
<details>
  <summary>Results</summary>
=== timed ===
Warming up --------------------------------------
            test_run     7.150k i/100ms
Calculating -------------------------------------
            test_run     71.278k (± 3.1%) i/s -    357.500k in   5.020450s

Comparison:
            test_run:    71278.4 i/s
                main:    71042.9 i/s - same-ish: difference falls within error


=== timed_monotonic ===
Warming up --------------------------------------
            test_run     6.999k i/100ms
Calculating -------------------------------------
            test_run     72.491k (± 3.2%) i/s -    363.948k in   5.025969s

Comparison:
                main:    72596.2 i/s
            test_run:    72490.7 i/s - same-ish: difference falls within error


=== event_object ===
Warming up --------------------------------------
            test_run     6.497k i/100ms
Calculating -------------------------------------
            test_run     64.583k (± 2.1%) i/s -    324.850k in   5.032327s

Comparison:
            test_run:    64583.3 i/s
                main:    61634.7 i/s - same-ish: difference falls within error


=== evented ===
Warming up --------------------------------------
            test_run    14.749k i/100ms
Calculating -------------------------------------
            test_run    147.907k (± 3.0%) i/s -    752.199k in   5.090467s

Comparison:
            test_run:   147906.6 i/s
                main:   146826.6 i/s - same-ish: difference falls within error


=== unsubscribed ===
Warming up --------------------------------------
            test_run   235.546k i/100ms
Calculating -------------------------------------
            test_run      2.391M (± 1.8%) i/s -     12.013M in   5.026842s

Comparison:
            test_run:  2390513.9 i/s
                main:  2354867.3 i/s - same-ish: difference falls within error


=== silenced ===
Warming up --------------------------------------
            test_run    55.213k i/100ms
Calculating -------------------------------------
            test_run    552.049k (± 4.7%) i/s -      2.761M in   5.013021s

Comparison:
                main:   575708.8 i/s
            test_run:   552048.6 i/s - same-ish: difference falls within error
</details>

### Additional information

`semantic_logger` could be changed to provide Numeric `#level`, but I don't think it's a proper solution.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
