### PR TITLE
[ci-skip][Docs]Add raise_on_missing_callback_actions to configuring guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1747,8 +1747,11 @@ Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
 
 Raises an `AbstractController::ActionNotFound` when the action specified in callback's `:only` or `:except` options is missing in the controller.
 
-The default value is `false`.
-In newly generated 7.1+ app, the default values in config/environments.development.rb and test.rb will be configured as `true`.
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true` (development and test), `false` (other envs)|
+
 
 #### `config.action_controller.raise_on_open_redirects`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1743,6 +1743,13 @@ Rendered messages/_message.html.erb in 1.2 ms [cache hit]
 Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
 ```
 
+#### `config.action_controller.raise_on_missing_callback_actions`
+
+Raises an `AbstractController::ActionNotFound` when the action specified in callback's `:only` or `:except` options is missing in the controller.
+
+The default value is `false`.
+In newly generated 7.1+ app, the default values in config/environments.development.rb and test.rb will be configured as `true`.
+
 #### `config.action_controller.raise_on_open_redirects`
 
 Raises an `ActionController::Redirecting::UnsafeRedirectError` when an unpermitted open redirect occurs.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found `config.action_controller.raise_on_missing_callback_actions` that has been added by https://github.com/rails/rails/pull/43487 is missing in current configuring guides.

### Detail

This Pull Request adds the entry for `config.action_controller.raise_on_missing_callback_actions`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`