### PR TITLE
Improve docs for `order` (ActiveRecord)

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -567,6 +567,11 @@ module ActiveRecord
     #   User.order(:name, email: :desc)
     #   # SELECT "users".* FROM "users" ORDER BY "users"."name" ASC, "users"."email" DESC
     #
+    # Same can be done by chaining multiple #order calls.
+    #
+    #   User.order(:name).order(email: :desc)
+    #   # SELECT "users".* FROM "users" ORDER BY "users"."name" ASC, "users"."email" DESC
+    #
     # === strings
     #
     # Strings are passed directly to the database, allowing you to specify

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -552,11 +552,16 @@ module ActiveRecord
     #   # SELECT "users".* FROM "users" ORDER BY "users"."name" ASC
     #
     # By default, the order is ascending. If you want descending order, you can
-    # map the column name symbol to +:desc+.
+    # map the column name symbol to +:desc+ (also accepted +"desc"+, +:DESC+, +"DESC"+).
     #
     #   User.order(email: :desc)
     #   # SELECT "users".* FROM "users" ORDER BY "users"."email" DESC
     #
+    # Ascending order can be specified in the map form as +:asc+ (also accepted +"asc"+, +:ASC+, +"ASC"+).
+    # This may be useful in some scenarios where you can't use the plain symbol form.
+    #
+    #   User.order(email: (params[:asc] ? :asc : :desc))
+    #   
     # Multiple columns can be passed this way, and they will be applied in the order specified.
     #
     #   User.order(:name, email: :desc)


### PR DESCRIPTION
When reading documentation I was confused about 2 things:

- What order directions are actually supported? There was no mention of ascending order. While playing with my code I also discovered that it allows a few variations (uppercase and string variants).

- How do you swap columns in this example: `User.order(:name, email: :desc)`. I forgot you can chain multiple `order` calls, not mentioned in the docs.