### PR TITLE
Add support for kwargs when delegating calls to custom loggers

### DIFF
--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -223,15 +223,15 @@ module ActiveSupport
         @broadcasts.each { |logger| block.call(logger) }
       end
 
-      def method_missing(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
         loggers = @broadcasts.select { |logger| logger.respond_to?(name) }
 
         if loggers.none?
-          super(name, *args, &block)
+          super(name, *args, **kwargs, &block)
         elsif loggers.one?
-          loggers.first.send(name, *args, &block)
+          loggers.first.send(name, *args, **kwargs, &block)
         else
-          loggers.map { |logger| logger.send(name, *args, &block) }
+          loggers.map { |logger| logger.send(name, *args, **kwargs, &block) }
         end
       end
 

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -278,6 +278,18 @@ module ActiveSupport
       assert(called)
     end
 
+    test "calling a method that accepts args" do
+      logger = BroadcastLogger.new(CustomLogger.new)
+
+      assert(logger.baz("foo"))
+    end
+
+    test "calling a method that accepts kwargs" do
+      logger = BroadcastLogger.new(CustomLogger.new)
+
+      assert(logger.qux(param: "foo"))
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level
@@ -298,6 +310,14 @@ module ActiveSupport
 
       def bar
         yield
+      end
+
+      def baz(param)
+        true
+      end
+
+      def qux(param:)
+        true
       end
 
       def debug(message, &block)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, when a method is called on `Rails.logger`, the `BroadcastLogger` will call the method on the loggers that will respond to it. However, when the method has keyword arguments, they are passed as regular arguments and will throw an ArgumentError. 

```
class CustomLogger
  def foo(bar:)
    true
  end
end

Rails.logger.foo(bar: "baz")
```

Expected: `true`

Actual: `wrong number of arguments (given 1, expected 0) (ArgumentError)`

### Detail

This PR adds keyword argument support by double splatting hash args.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
