### PR TITLE
`NumberHelper`: handle objects responding `to_d`

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -179,8 +179,10 @@ module ActiveSupport
           case number
           when Float, Rational
             number.to_d(0)
-          else
+          when String
             BigDecimal(number, exception: false)
+          else
+            number.to_d rescue nil
           end
         end
     end

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -15,6 +15,16 @@ module ActiveSupport
         extend ActiveSupport::NumberHelper
       end
 
+      class NumberWithToD
+        def initialize(number)
+          @number = number
+        end
+
+        def to_d
+          @number.to_d
+        end
+      end
+
       def setup
         @instance_with_helpers = TestClassWithInstanceNumberHelpers.new
       end
@@ -95,6 +105,7 @@ module ActiveSupport
           assert_equal("-$,11", number_helper.number_to_currency("-,11"))
           assert_equal("$0.00", number_helper.number_to_currency(-0.0))
           assert_equal("$0.00", number_helper.number_to_currency("-0.0"))
+          assert_equal("$1.23", number_helper.number_to_currency(NumberWithToD.new(1.23)))
         end
       end
 


### PR DESCRIPTION
Fixes #49572.

Similar problem was also reported here - https://github.com/rails/rails/pull/49466/files#r1349249299.

Regression was introduced in https://github.com/rails/rails/pull/49466. Before that PR, numbers were checked via `Float()` method https://github.com/rails/rails/pull/49466/files#diff-f242a68844d34525bd9a0e26473578dfb8490bea375bf0c2cbb1a4e7f40cefadL177, which calls `to_f` on its arguments (see https://ruby-doc.org/core-3.1.1/Kernel.html#method-i-Float). `to_f` is defined on `Money` - https://github.com/RubyMoney/money/blob/ccddfdc9616b3f825578d66a50e718a318221cbc/lib/money/money.rb#L485-L487

But after, `BigDecimal()` is used which does not call any of these. So I left `BigDecimal()` for strings only, as these are not fully converted as needed when using `to_f` (https://ruby-doc.org/stdlib-3.1.1/libdoc/bigdecimal/rdoc/String.html#method-i-to_d), only leading characters. And called `to_d` for everything else. `to_d` is also defined for `Money` https://github.com/RubyMoney/money/blob/ccddfdc9616b3f825578d66a50e718a318221cbc/lib/money/money.rb#L462-L464.