### PR TITLE
Recommend fixed-width fonts for HTML and CSS as well in documentation [ci-skip]

### DIFF
--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -263,6 +263,8 @@ Use fixed-width fonts for:
 * Symbols
 * Method parameters
 * File names
+* HTML tags and attributes
+* CSS selectors, attributes and values
 
 ```ruby
 class Array


### PR DESCRIPTION
In https://github.com/rails/rails/pull/49556 fixed-width fonts were added to the `contenteditable` HTML attribute.
We should probably add HTML and CSS to the list of fixed-width fonts.

cc @jonathanhefner, @zzak 