### PR TITLE
Fix remove connection for shards

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Only reset the `connection_specification_name` in `remove_connection` is there's one connection.
+
+    Previously, `#remove_connection` would always set the `connection_specification_name` to `nil` if it found a matching pool. This caused the connection to fall back to the parent class because it will adopt the `connection_specification_name` of the parent. When an application has multiple roles or shards, Active Record should not set the `connection_specification_name` to `nil` unless it's the only remaining pool. To fix this, Active Record now checks if the pool size for a given connection name is equal to 1. If it is the `connection_specification_name` is set to `nil`, otherwise the name is retained. In both cases the pool for the matching shard and role is removed.
+
+    *Eileen M. Uchitelle*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -117,6 +117,10 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
+      def connection_pool_list_for(connection_name) # :nodoc:
+        get_pool_manager(connection_name)&.pool_configs
+      end
+
       def each_connection_pool(role = nil, &block) # :nodoc:
         role = nil if role == :all
         return enum_for(__method__, role) unless block_given?

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -306,10 +306,14 @@ module ActiveRecord
       # connection_specification_name so it will use the parent
       # pool.
       if connection_handler.retrieve_connection_pool(name, role: current_role, shard: current_shard)
-        self.connection_specification_name = nil
-      end
+        pool_list = connection_handler.connection_pool_list_for(name)
 
-      connection_handler.remove_connection_pool(name, role: current_role, shard: current_shard)
+        if pool_list && pool_list.size == 1
+          self.connection_specification_name = nil
+        end
+
+        connection_handler.remove_connection_pool(name, role: current_role, shard: current_shard)
+      end
     end
 
     def clear_cache! # :nodoc:

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -367,6 +367,46 @@ module ActiveRecord
         assert ShardConnectionTestModel.find_by_shard_key("foo")
       end
 
+      def test_removing_connection_for_multiple_shards
+        tf_default = Tempfile.open "shard_key_default"
+        tf_shard_one = Tempfile.open "shard_key_one"
+
+        SecondaryBase.connects_to shards: {
+          default: { writing: { database: tf_default.path, adapter: "sqlite3" } },
+          one: { writing: { database: tf_shard_one.path, adapter: "sqlite3" } }
+        }
+
+        [:default, :one].each do |shard_name|
+          ActiveRecord::Base.connected_to(role: :writing, shard: shard_name) do
+            ShardConnectionTestModel.connection.execute("CREATE TABLE `shard_connection_test_models` (shard_key VARCHAR (255))")
+            ShardConnectionTestModel.connection.execute("INSERT INTO `shard_connection_test_models` VALUES ('shard_key_#{shard_name}')")
+          end
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :one) do
+          SecondaryBase.remove_connection
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
+          assert_equal "shard_key_default", ShardConnectionTestModel.connection.select_value("SELECT shard_key from shard_connection_test_models")
+          SecondaryBase.remove_connection
+        end
+
+        connection_classes = ActiveRecord::Base.connection_handler.connection_pool_list(:writing).map(&:connection_class)
+        assert_not_includes(connection_classes, SecondaryBase)
+      ensure
+        [:default, :one].each do |shard_name|
+          ActiveRecord::Base.connected_to(role: :writing, shard: shard_name) do
+            SecondaryBase.remove_connection
+          end
+        end
+
+        tf_shard_one.close
+        tf_shard_one.unlink
+        tf_default.close
+        tf_default.unlink
+      end
+
       def test_swapping_shards_globally_in_a_multi_threaded_environment
         tf_default = Tempfile.open "shard_key_default"
         tf_shard_one = Tempfile.open "shard_key_one"

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -316,6 +316,9 @@ module ActiveRecord
 
         assert_equal :not_default, SecondaryBase.default_shard
         assert_equal :default, SomeOtherBase.default_shard
+      ensure
+        name = "ActiveRecord::ConnectionAdapters::ConnectionHandlersShardingDbTest::SecondaryBase"
+        ActiveRecord::Base.connection_handler.remove_connection_pool(name, role: :writing, shard: :not_default)
       end
 
       def test_same_shards_across_clusters

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -235,10 +235,7 @@ module ActiveRecord
       handler = ActiveRecord::Base.connection_handler
       handler.instance_variable_get(:@connection_name_to_pool_manager).each do |owner, pool_manager|
         pool_manager.role_names.each do |role_name|
-          next if role_name == ActiveRecord::Base.default_role &&
-                  # TODO: Remove this helper when `remove_connection` for different shards is fixed.
-                  # See https://github.com/rails/rails/pull/49382.
-                  ["ActiveRecord::Base", "ARUnit2Model", "Contact", "ContactSti"].include?(owner)
+          next if role_name == ActiveRecord::Base.default_role
           pool_manager.remove_role(role_name)
         end
       end


### PR DESCRIPTION
Don't change conn spec name if there are more connections

Previously we were setting `connection_specification_name` to `nil`
which would cause connection calls to fall back to the parent,
`ActiveRecord::Base`. This is fine in a single db app, but in a multi-db
app we should not do this unless it is the last remaining connection on
that class. So now we check the pool list size before setting the name
to `nil`. I move the `remove_connection_pool` call inside
`retrieve_connection` because you literally can't remove a connection
that does not exist, so it doesn't change behavior and is just more
accurate.

This also undoes the changes in https://github.com/rails/rails/pull/49403 that are no longer necessary
which requires us to remove the `not_default` shard connection in
another test since we don't want that one sticking around.

Related: https://github.com/rails/rails/pull/49382, https://github.com/rails/rails/pull/49403
Fixes https://github.com/rails/rails/issues/49373

cc/ @rafaelfranca @fractaledmind 