### PR TITLE
Prevent large error messages when using middleware instrumentation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Change inspected value of `ActionDispatch::MiddlewareStack::InstrumentationProxy` objects to prevent large error messages.
+
+    *Chris Zetter*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -66,6 +66,10 @@ module ActionDispatch
           @middleware.call(env)
         end
       end
+
+      def inspect # :nodoc:
+        "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} @middleware=#{@middleware.inspect}>"
+      end
     end
 
     include Enumerable


### PR DESCRIPTION
### Motivation / Background

When you use `ActiveSupport::Notifications` to instrument `process_middleware.action_dispatch`, certain errors may cause a very large error message to be generated. This can exhaust resources and make the application unresponsive

### Detail

This problem happens if the object that caused the exception has direct or indirect reference back to the application middleware stack and the error's exception message includes a representation of the object that raised. For example, a `NoMethod` error on an instance of `ActionDispatch::Request::Session` causes this as this has a reference to `ActionDispatch::Session::CookieStore` which contains a reference to the middleware stack through `@app`.

The error message grows incredibly large because the instrumenter runs around each middleware and handles an error by saving the error message to the `@payload` instance variable. When the next middleware runs, the it error message will include the string of the previously generated error message. This causes the length of the error to more than double for each middleware in the stack.

This effected a real application that I work on, and caused an error to be generated that was an estimated **61,000,000 characters long**.

This change prevents this problem by stopping the `@payload` instance variable from being inspected. `@payload` contains the `:exception_object` and `:exception` keys that cause the error message to grow and grow. The change makes sure `@middleware` is still inspected to match current behavior as much as possible.

This is reproducible in Rails 6.1.7.6, 7.0.8 and 7.1.0. Note that this is no longer an issue for `NoMethodError` in Ruby 3.3.0 preview 1, [as the exception message no longer includes the printed representation of the object](https://github.com/ruby/ruby/pull/6950). I haven't investigated if other standard library errors trigger this behavior.

I originally reported this to the Rails security team as it could be use to perform denial of service attacks on applications, but we decided that this is unlikely because of the very specific error that needs to be raised to trigger this issue.

### Additional information

Here's a minimal reproduction of the issue:

```ruby
# frozen_string_literal: true
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'rails', '7.0.8'
  gem 'puma'
end

require "rails"
require "action_controller/railtie"
require "action_view/railtie"

class App < Rails::Application
  config.root = __dir__
  config.consider_all_requests_local = true
  config.secret_key_base = 'i_am_a_secret'
  config.eager_load = false

  routes.append do
    root to: 'welcome#index'
  end
end

ActiveSupport::Notifications.subscribe('process_middleware.action_dispatch') do |x|
  # just subscribing is enough to trigger this issue
end

class WelcomeController < ActionController::Base
  def index
    session[:key] = 'initialize-session'
    session.non_existant_method
    render inline: 'never reached'
  end
end

App.initialize!

Rack::Server.start(app: App)

# see error message by visiting / on app
```

Here's the [error the example produces before](https://github.com/rails/rails/files/12871979/example_error_before_patch.txt) and [after](https://github.com/rails/rails/files/12871978/example_error_after_patch.txt) the change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
