### PR TITLE
Advise upgraders to set active_record.encryption.hash_digest_class

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -495,7 +495,7 @@ The digest algorithm used to derive keys. `OpenSSL::Digest::SHA1` by default.
 #### `config.active_record.encryption.support_sha1_for_non_deterministic_encryption`
 
 Supports decrypting data encrypted non-deterministically with a digest class SHA1. Default is false, which
-means it  will only support the digest algorithm configured in `config.active_record.encryption.hash_digest_class`.
+means it will only support the digest algorithm configured in `config.active_record.encryption.hash_digest_class`.
 
 ### Encryption Contexts
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -315,6 +315,27 @@ puts Rails.logger.broadcasts #=> [MyLogger]
 
 [assert_match]: https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_match
 
+
+### Active Record encryption algorithm changes
+
+Active Record Encryption now uses SHA-256 as its hash digest algorithm. If you have data encrypted with previous Rails
+versions, there are two scenarios to consider:
+
+1. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA1 (the default
+   before Rails 7.0), you need to configure SHA-1 for Active Record Encryption too:
+
+  ```ruby
+  config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
+  ```
+
+1. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA256 (the new default
+   in 7.0), then you need to configure SHA-256 for Active Record Encryption:
+
+  ```ruby
+  config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+  ```
+
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 


### PR DESCRIPTION
This is currently documented in new_framework_defaults, but deserves highlighting more explicitly to help anyone upgrading from older versions.


cc @rafaelfranca 


### Motivation / Background


This Pull Request has been created because upgrading to rails 7.1 can result in decryption errors unless you've already explicitly set the hash algorithm 

### Additional information

There’s also lengthy discussion at https://github.com/rails/rails/issues/48204 , though as I understand it the conclusion boils down the the advice I’ve added in this PR

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
