### PR TITLE
Load `author_addresses` fixtures for `ActiveRecordMessagePackTest`

### DIFF
--- a/activerecord/test/cases/message_pack_test.rb
+++ b/activerecord/test/cases/message_pack_test.rb
@@ -9,7 +9,7 @@ require "active_support/message_pack"
 require "active_record/message_pack"
 
 class ActiveRecordMessagePackTest < ActiveRecord::TestCase
-  fixtures :posts, :comments, :authors
+  fixtures :posts, :comments, :authors, :author_addresses
 
   test "enshrines type IDs" do
     expected = {


### PR DESCRIPTION
This PR fixes a flaky test from https://buildkite.com/rails/rails/builds/100641#018b1f83-1783-4108-aec6-2b0404b36ba7.

To reproduce, on ruby 2.7 run
```bash
$ cd activerecord
$ SEED=20774 rake test:sqlite3
```

The problem is the same as in https://github.com/rails/rails/pull/49159.