### PR TITLE
Return back maximum allowed PostgreSQL table name to 63 characters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -605,14 +605,6 @@ module ActiveRecord
         @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i
       end
 
-      # Returns the maximum length of a table name.
-      def table_name_length
-        # PostgreSQL automatically creates an index for PRIMARY KEY with name consisting of
-        # truncated table name and "_pkey" suffix fitting into max_identifier_length number of characters.
-        # We allow smaller table names to be able to correctly rename this index when renaming the table.
-        max_identifier_length - "_pkey".length
-      end
-
       # Set the authorized user for this session
       def session_auth=(user)
         clear_cache!

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -570,6 +570,7 @@ module ActiveRecord
         assert connection.table_exists?(:more_testings)
       ensure
         connection.drop_table(:more_testings) rescue nil
+        connection.drop_table(:new_more_testings) rescue nil
       end
 
       def test_change_column_null_with_non_boolean_arguments_raises_in_a_migration


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49567.

Instead of previously changed enforced maximum table name length from 63 to `63 - "_pkey".size`, I returned it back to 63 and now manually constructing the pkey and sequence names (that PostgreSQL generates when creating a table) when renaming a table.

Haven't added new tests, because it is already covered by tests from https://github.com/rails/rails/pull/45136.

cc @rafaelfranca 