### PR TITLE
Add consistent option description for --database on rails new

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -39,7 +39,7 @@ module Rails
                                            desc: "Path to some #{name} template (can be a filesystem path or URL)"
 
         class_option :database,            type: :string, aliases: "-d", default: "sqlite3",
-                                           desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
+                                           desc: "Preconfigure for selected database [options: #{DATABASES.join(", ")}]"
 
         class_option :skip_git,            type: :boolean, aliases: "-G", default: nil,
                                            desc: "Skip git init, .gitignore and .gitattributes"


### PR DESCRIPTION
### Motivation / Background

To clarify the description for the `--database` option in the Rails new command, we are displaying the available database options separated by a forward slash (/).

```bash
[--database=DATABASE]    # Preconfigure for selected database (options: mysql/trilogy/postgresql/sqlite3/oracle/sqlserver/jdbcmysql/jdbcsqlite3/jdbcpostgresql/jdbc)
```

Certainly, for other options such as `--javascript`, `--css`, and `--asset-pipeline`, the description lists their available options separated by commas.

```bash
[--asset-pipeline=ASSET_PIPELINE]    # Choose your asset pipeline [options: sprockets (default), propshaft]
[--javascript=JAVASCRIPT]    # Choose JavaScript approach [options: importmap (default), bun, webpack, esbuild, rollup]
[--css=CSS]    # Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass] check https://github.com/rails/cssbundling-rails for more options
```

### Detail

This Pull Request updates `--database` options description with a consistent pattern.

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
