### PR TITLE
Don't call `Rails.start()` in automatically when `@rails/ujs` is imported as ESM

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Don't call `Rails.start()` in automatically when `@rails/ujs` is imported as esm.
+
+    This fix is for Rails 7.1 regression.
+
+    ``` js
+    import Rails from "@rails/ujs"
+    Rails.start() // In Rails 7.1, this raises `Uncaught Error: rails-ujs has already been loaded!`
+    ```
+
+    *Ryunosuke Sato*
+
 *   Updated `@rails/ujs` files to ignore certain data-* attributes when element is contenteditable.
 
     This fix was already landed in >= 7.0.4.3, < 7.1.0.

--- a/actionview/app/assets/javascripts/rails-ujs.esm.js
+++ b/actionview/app/assets/javascripts/rails-ujs.esm.js
@@ -683,7 +683,7 @@ if (typeof jQuery !== "undefined" && jQuery && jQuery.ajax) {
   }));
 }
 
-if (typeof exports !== "object" && typeof module === "undefined") {
+if (typeof exports !== "object" && typeof module === "undefined" && typeof this !== "undefined") {
   window.Rails = Rails;
   if (fire(document, "rails:attachBindings")) {
     start();

--- a/actionview/app/assets/javascripts/rails-ujs.js
+++ b/actionview/app/assets/javascripts/rails-ujs.js
@@ -620,7 +620,7 @@ Released under the MIT license
       }
     }));
   }
-  if (typeof exports !== "object" && typeof module === "undefined") {
+  if (typeof exports !== "object" && typeof module === "undefined" && typeof this !== "undefined") {
     window.Rails = Rails;
     if (fire(document, "rails:attachBindings")) {
       start();

--- a/actionview/app/javascript/rails-ujs/index.js
+++ b/actionview/app/javascript/rails-ujs/index.js
@@ -149,7 +149,7 @@ if (typeof jQuery !== "undefined" && jQuery && jQuery.ajax) {
 // difference between what happens in a bundler and what happens using a
 // sprockets compiler. In the sprockets case, Rails.start() is called
 // automatically, but it is not in the ESModule case.
-if (typeof exports !== "object" && typeof module === "undefined") {
+if (typeof exports !== "object" && typeof module === "undefined" && typeof this !== "undefined") {
   // The coffeescript bundle would set this at the very top. The Rollup bundle
   // doesn't set this until the entire bundle has finished running, so we need
   // to make sure its set before firing the rails:attachBindings event for

--- a/actionview/rollup.config.js
+++ b/actionview/rollup.config.js
@@ -34,7 +34,8 @@ export default [
     },
     plugins: [
       terser(terserOptions)
-    ]
+    ],
+    context: "this",
   },
 
   {
@@ -46,6 +47,7 @@ export default [
     },
     plugins: [
       terser(terserOptions)
-    ]
+    ],
+    context: "this",
   }
 ]

--- a/actionview/rollup.config.test.js
+++ b/actionview/rollup.config.test.js
@@ -14,5 +14,7 @@ export default {
   plugins: [
     resolve(),
     commonjs()
-  ]
+  ],
+
+  context: "this",
 }

--- a/actionview/test/ujs/public/test/data-confirm.js
+++ b/actionview/test/ujs/public/test/data-confirm.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import Rails from '../../../../app/javascript/rails-ujs/index'
 
 QUnit.module('data-confirm', {
   beforeEach: function() {

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import Rails from '../../../../app/javascript/rails-ujs/index'
 
 function buildSelect(attrs) {
   attrs = $.extend({

--- a/actionview/test/ujs/public/test/override.js
+++ b/actionview/test/ujs/public/test/override.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import Rails from '../../../../app/javascript/rails-ujs/index'
 
 var realHref
 

--- a/actionview/test/ujs/src/test.js
+++ b/actionview/test/ujs/src/test.js
@@ -1,6 +1,7 @@
 import "./attach-bindings"
 
 import Rails from '../../../app/javascript/rails-ujs/index'
+Rails.start()
 
 import "../public/test/settings"
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because https://github.com/rails/rails/issues/49499 should be fixed in Rails 7.1.2.

### Detail

This Pull Request changes auto start logic for `@rails/ujs` as ESM.
This start logic has been changed since https://github.com/rails/rails/pull/45546 unexpectedly.

### Additional information

In the spec of ECMAScript, `this` should be `undefined`.

> 8.1.1.5 Module Environment Records
> 8.1.1.5.4 `GetThisBinding` ()
> 1. Return `undefined`.

Ref: https://262.ecma-international.org/8.0/#sec-module-environment-records-getthisbinding

Since some of build tools (e.g. esbuild) don't have `exports` nor `module` object, adding `this` checking is required whether this file is imported as esm or not.

Close https://github.com/rails/rails/issues/49499

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
