### PR TITLE
Use Thor's enum for class_options

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Disallow invalid values for rails new options.
+
+    The `--database`, `--asset-pipeline`, `--css`, and `--javascript` flags for
+    `rails new` can all take different options. This change adds checks to
+    options to make sure the user enters the correct value.
+
+    *Tony Drake*, *Akhil G Krishnan*, *Petrik de Heus*
+
 *   Conditionally print `$stdout` when invoking `run_generator`
 
     In an effort to improve the developer experience when debugging

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -20,7 +20,7 @@ module Rails
 
       JAVASCRIPT_OPTIONS = %w( importmap bun webpack esbuild rollup )
       CSS_OPTIONS = %w( tailwind bootstrap bulma postcss sass )
-      ASSET_PIPELINE_OPTIONS = %w( sprockets propshaft )
+      ASSET_PIPELINE_OPTIONS = %w( none sprockets propshaft )
 
       attr_accessor :rails_template
       add_shebang_option!
@@ -39,7 +39,8 @@ module Rails
                                            desc: "Path to some #{name} template (can be a filesystem path or URL)"
 
         class_option :database,            type: :string, aliases: "-d", default: "sqlite3",
-                                           desc: "Preconfigure for selected database [options: #{DATABASES.join(", ")}]"
+                                           enum: DATABASES,
+                                           desc: "Preconfigure for selected database"
 
         class_option :skip_git,            type: :boolean, aliases: "-G", default: nil,
                                            desc: "Skip git init, .gitignore and .gitattributes"
@@ -75,7 +76,8 @@ module Rails
         class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil
 
         class_option :asset_pipeline,      type: :string, aliases: "-a", default: "sprockets",
-                                           desc: "Choose your asset pipeline [options: #{ASSET_PIPELINE_OPTIONS.join(", ")}]"
+                                           enum: ASSET_PIPELINE_OPTIONS,
+                                           desc: "Choose your asset pipeline"
 
         class_option :skip_javascript,     type: :boolean, aliases: ["-J", "--skip-js"], default: (true if name == "plugin"),
                                            desc: "Skip JavaScript files"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -277,8 +277,8 @@ module Rails
       class_option :version, type: :boolean, aliases: "-v", group: :rails, desc: "Show Rails version number and quit"
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
-      class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", desc: "Choose JavaScript approach [options: #{JAVASCRIPT_OPTIONS.join(', ')}]"
-      class_option :css, type: :string, aliases: "-c", desc: "Choose CSS processor [options: #{CSS_OPTIONS.join(', ')}] check https://github.com/rails/cssbundling-rails for more options"
+      class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", enum: JAVASCRIPT_OPTIONS, desc: "Choose JavaScript approach"
+      class_option :css, type: :string, aliases: "-c", enum: CSS_OPTIONS, desc: "Choose CSS processor. Check https://github.com/rails/cssbundling-rails for more options"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: nil, desc: "Don't run bundle install"
       class_option :skip_decrypted_diffs, type: :boolean, default: nil, desc: "Don't configure git to show decrypted diffs of encrypted credentials"
 
@@ -321,23 +321,6 @@ module Rails
         super
 
         imply_options(OPTION_IMPLICATIONS, meta_options: META_OPTIONS)
-
-        if !options[:skip_active_record] && !DATABASES.include?(options[:database])
-          raise Error, "Invalid value for --database option. Supported preconfigurations are: #{DATABASES.join(", ")}."
-        end
-
-        if !options[:skip_javascript] && !JAVASCRIPT_OPTIONS.include?(options[:javascript])
-          raise Error, "Invalid value for --javascript option. Supported options are: #{JAVASCRIPT_OPTIONS.join(", ")}."
-        end
-
-        if options[:css] && !CSS_OPTIONS.include?(options[:css])
-          raise Error, "Invalid value for --css option. Supported options are: #{CSS_OPTIONS.join(", ")}."
-        end
-
-        # A value of "none" is permitted as an alternative to --skip-asset-pipeline
-        if !options[:skip_asset_pipeline] && !(ASSET_PIPELINE_OPTIONS + ["none"]).include?(options[:asset_pipeline])
-          raise Error, "Invalid value for --asset-pipeline option. Supported options are: #{ASSET_PIPELINE_OPTIONS.join(", ")}."
-        end
 
         @after_bundle_callbacks = []
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -113,17 +113,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_invalid_javascript_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-j", "unknown"]) }
-    assert_match(/Invalid value for --javascript option/, content)
+    assert_match(/Expected '--javascript' to be one of/, content)
   end
 
   def test_invalid_asset_pipeline_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-a", "unknown"]) }
-    assert_match(/Invalid value for --asset-pipeline option/, content)
+    assert_match(/Expected '--asset-pipeline' to be one of/, content)
   end
 
   def test_invalid_css_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-c", "unknown"]) }
-    assert_match(/Invalid value for --css option/, content)
+    assert_match(/Expected '--css' to be one of/, content)
   end
 
   def test_application_job_file_present

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -62,7 +62,7 @@ module SharedGeneratorTests
 
   def test_invalid_database_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-d", "unknown"]) }
-    assert_match(/Invalid value for --database option/, content)
+    assert_match(/Expected '--database' to be one of/, content)
   end
 
   def test_test_files_are_skipped_if_required


### PR DESCRIPTION
In 11a6adc4fb6172e9af081e20c5f68ca023e3bd8a custom code was added to restrict values for some `rails new` options.
We don't need to implement this when it's already supported by Thor.

This also adds `none` as an option to the asset_pipeline as used in:
`railties/test/generators/shared_generator_tests.rb:320`.

## Before
```bash
  -j, --js,      [--javascript=JAVASCRIPT]                              # Choose JavaScript approach [options: importmap, bun, webpack, esbuild, rollup]
                                                                        # Default: importmap
  -c,            [--css=CSS]                                            # Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass] check https://github.com/rails/cssbundling-rails for more options
```

## After
```bash
  -j, --js,      [--javascript=JAVASCRIPT]                              # Choose JavaScript approach
                                                                        # Default: importmap
                                                                        # Possible values: importmap, bun, webpack, esbuild, rollup
  -c,            [--css=CSS]                                            # Choose CSS processor. Check https://github.com/rails/cssbundling-rails for more options
                                                                        # Possible values: tailwind, bootstrap, bulma, postcss, sass
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
