### PR TITLE
Fix `capture` view helper for HAML and Slim

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix the `capture` view helper compatibility with HAML and Slim
+
+    When a blank string was captured in HAML or Slim (and possibly other template engines)
+    it would instead return the entire buffer.
+
+    *Jean Boussier*
+
 *   Updated `@rails/ujs` files to ignore certain data-* attributes when element is contenteditable.
 
     This fix was already landed in >= 7.0.4.3, < 7.1.0.

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -49,7 +49,13 @@ module ActionView
         @output_buffer ||= ActionView::OutputBuffer.new
         buffer = @output_buffer.capture { value = yield(*args) }
 
-        case string = buffer.presence || value
+        string = if @output_buffer.equal?(value)
+          buffer
+        else
+          buffer.presence || value
+        end
+
+        case string
         when OutputBuffer
           string.to_s
         when ActiveSupport::SafeBuffer

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -230,6 +230,16 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "", @av.with_output_buffer { }.to_s
   end
 
+  def test_ignore_the_block_return_if_its_the_buffer
+    @av.output_buffer << "something"
+    string = @av.capture do
+      @av.output_buffer << "foo"
+      @av.output_buffer << "bar"
+      @av.output_buffer
+    end
+    assert_equal "foobar", string
+  end
+
   def alt_encoding(output_buffer)
     output_buffer.encoding == Encoding::US_ASCII ? Encoding::UTF_8 : Encoding::US_ASCII
   end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47194#issuecomment-1760334146

They both give the buffer as return value of the capture block which confuses the `capture` helper.

Ideally we wouldn't have to check for that, but it's an acceptable tradeoff for backward compatibility.
