### PR TITLE
Support handling Enumerator for non-buffered responses

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -104,7 +104,9 @@ module ActionDispatch # :nodoc:
       end
 
       def to_ary
-        @buf.to_ary
+        @buf.respond_to?(:to_ary) ?
+          @buf.to_ary :
+          @buf.each
       end
 
       def body

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -617,4 +617,40 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal("text/csv; header=present", @response.media_type)
     assert_equal("utf-16", @response.charset)
   end
+
+  test "response body with enumerator" do
+    @app = lambda { |env|
+      [
+        200,
+        { "Content-Type" => "text/plain" },
+        Enumerator.new { |enumerator| 10.times { |n| enumerator << n.to_s } }
+      ]
+    }
+    get "/"
+    assert_response :success
+
+    assert_equal("text/plain", @response.headers["Content-Type"])
+    assert_equal("text/plain", @response.content_type)
+    assert_equal("text/plain", @response.media_type)
+    assert_equal("utf-8", @response.charset)
+    assert_equal("0123456789", @response.body)
+  end
+
+  test "response body with lazy enumerator" do
+    @app = lambda { |env|
+      [
+        200,
+        { "Content-Type" => "text/plain" },
+        (0..10).lazy
+      ]
+    }
+    get "/"
+    assert_response :success
+
+    assert_equal("text/plain", @response.headers["Content-Type"])
+    assert_equal("text/plain", @response.content_type)
+    assert_equal("text/plain", @response.media_type)
+    assert_equal("utf-8", @response.charset)
+    assert_equal("012345678910", @response.body)
+  end
 end


### PR DESCRIPTION
The downside to this is that we cannot generate ETags for these types of responses, but are assuming that by using an enumerator they don't expect a buffered response to be cacheable. This means you cannot use Enumerator to generate streaming responses.

Fixes #49588

See also: #47092
