### PR TITLE
Use correct tense of `cast` for guides

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -485,7 +485,7 @@ irb> macbook.address
 * [type definition](https://www.postgresql.org/docs/current/static/datatype-geometric.html)
 
 All geometric types, with the exception of `points` are mapped to normal text.
-A point is casted to an array containing `x` and `y` coordinates.
+A point is cast to an array containing `x` and `y` coordinates.
 
 ### Interval
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -547,7 +547,7 @@ value.
 ```
 
 Otherwise, it will try to convert the value to a number using `Float`. `Float`s
-are casted to `BigDecimal` using the column's precision value or a maximum of 15
+are cast to `BigDecimal` using the column's precision value or a maximum of 15
 digits.
 
 ```ruby


### PR DESCRIPTION
Switch to `cast` for describing the past tense actions.

`casted` is a common mistake, but not correct English.

[ci skip]