### PR TITLE
Make SchemaMigration a private constant

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -5,6 +5,7 @@ module ActiveRecord
   # have been applied to a given database. When a migration is run, its schema
   # number is inserted in to the schema migrations table so it doesn't need
   # to be executed the next time.
+  private_constant :SchemaMigration
   class SchemaMigration # :nodoc:
     class NullSchemaMigration
     end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -81,7 +81,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_passing_a_schema_migration_class_to_migration_context_is_deprecated
     migrations_path = MIGRATIONS_ROOT + "/valid"
-    migrator = assert_deprecated(ActiveRecord.deprecator) { ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata) }
+    migrator = assert_deprecated(ActiveRecord.deprecator) { ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord.const_get(:SchemaMigration), ActiveRecord::InternalMetadata) }
     migrator.up
 
     assert_equal 3, migrator.current_version

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -41,7 +41,7 @@ module RailtiesTest
       end
 
       migration_root = File.expand_path(migration_path, app_path)
-      sm = ActiveRecord::SchemaMigration::NullSchemaMigration.new
+      sm = ActiveRecord.const_get(:SchemaMigration)::NullSchemaMigration.new
       im = ActiveRecord::InternalMetadata::NullInternalMetadata.new
       ActiveRecord::MigrationContext.new(migration_root, sm, im).migrations
     end


### PR DESCRIPTION
`SchemaMigration` is a private API but that isn't enforced in anyway, only that it's marked as :nodoc:.
We can use `private_constant` to enforce this. 
In tests we can use `const_get` to still access the constant.

We could apply this change to a lot more of the `:nodoc:` constants.

Related discussion: https://ruby.social/@postmodern/111226920326672799

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
