### PR TITLE
Show warning if the url host option contains the protocol

### DIFF
--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -146,6 +146,11 @@ module ActionDispatch
           def normalize_host(_host, options)
             return _host unless named_host?(_host)
 
+            if %r{\A(https?://)}.match?(options[:host])
+              protocol = options[:host].match(%r{\A(https?://)}).captures.first
+              warn "WARNING: The protocol #{protocol} is hardcoded in the host option. Please pass the protocol parameter instead."
+            end
+
             tld_length = options[:tld_length] || @@tld_length
             subdomain  = options.fetch :subdomain, true
             domain     = options[:domain]


### PR DESCRIPTION
### Motivation / Background

If you specify the protocol (e.g., 'https') within the `host` option in a URL, it may lead to unexpected results. This is because the host option is typically overridden by the default 'http' protocol, causing the URL to be constructed with 'http' instead of the desired 'https' protocol. If we want to get the result with https, we pass that in the protocol option (`protocol: "https"`).

```ruby
# bin/rails c
# Loading development environment (Rails 7.2.0.alpha)

>> app.rails_health_check_url
=> "http://www.example.com/up"

>> app.rails_health_check_url host: "https://github.com"
=> "http://github.com/up"
```

ref: https://github.com/rails/rails/issues/46822#issuecomment-1365401165

### Detail

This Pull Request adds a warning to the url host, it  shows the warning if  the url host options contains the protocol.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

/cc: @ghiculescu, @zzak 