### PR TITLE
Use Rack::BodyProxy instead of RackBody

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -167,10 +167,13 @@ module ActionController
         @ignore_disconnect = false
       end
 
-      # ActionDispatch::Response delegates #to_ary to the internal ActionDispatch::Response::Buffer,
-      # defining #to_ary is an indicator that the response body can be buffered and/or cached by
-      # Rack middlewares, this is not the case for Live responses so we undefine it for this Buffer subclass.
-      undef_method :to_ary
+      def respond_to?(method)
+        if method == :to_ary
+          false
+        else
+          super
+        end
+      end
 
       def write(string)
         unless @response.committed?


### PR DESCRIPTION
There is an inherit complexity with wrapping the Rack body inside Rails which can lead to bugs, like #49588.

While #49616 fixed the bug, it's probably not a good long-term solution.

If we go all the way back to 6a89850d, we can see this was the original behavior. However, we were trying to solve a separate issue with streaming bodies during disconnect.

The `live_stream_test#test_abort_with_full_buffer` test fails in this PR, but I wanted to raise that maybe this could be handled a different way.

Also there are two failures in `response_test` which are questions to me:

* `ResponseTest#test_[response.to_a].flatten_does_not_recurse_infinitely`
* `ResponseTest#test_compatibility_with_Rack::ContentLength`

The first seems it is actually resolved upstream, per this comment: https://github.com/rails/rails/pull/47092#discussion_r1087250243

The second means we broke `Rack::ContentLength` and there is a bit on this in #44953.

FWIW: I'm not proposing this PR exactly, but looking for a path forward and would love some feedback. :bow:

/cc @ioquatix 
