### PR TITLE
[Tests only] Enable `Minitest/AssertPredicate` rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -353,6 +353,9 @@ Performance/RedundantStringChars:
 Performance/StringInclude:
   Enabled: true
 
+Minitest/AssertPredicate:
+  Enabled: true
+
 Minitest/AssertRaisesWithRegexpArgument:
   Enabled: true
 

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -44,7 +44,7 @@ class SubscriptionsTestChannelTest < ActionCable::Channel::TestCase
   def test_subscribe
     subscribe
 
-    assert subscription.confirmed?
+    assert_predicate subscription, :confirmed?
     assert_not subscription.rejected?
     assert_equal 1, connection.transmissions.size
     assert_equal ActionCable::INTERNAL[:message_types][:confirmation],
@@ -77,7 +77,7 @@ class RejectionTestChannelTest < ActionCable::Channel::TestCase
     subscribe
 
     assert_not subscription.confirmed?
-    assert subscription.rejected?
+    assert_predicate subscription, :rejected?
     assert_equal 1, connection.transmissions.size
     assert_equal ActionCable::INTERNAL[:message_types][:rejection],
                  connection.transmissions.last["type"]

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -325,7 +325,7 @@ class ClientTest < ActionCable::TestCase
       assert_equal({ "type" => "disconnect", "reason" => "remote", "reconnect" => true }, c.read_message)
 
       c.wait_for_close
-      assert(c.closed?)
+      assert_predicate(c, :closed?)
     end
   end
 
@@ -342,7 +342,7 @@ class ClientTest < ActionCable::TestCase
       assert_equal({ "type" => "disconnect", "reason" => "remote", "reconnect" => false }, c.read_message)
 
       c.wait_for_close
-      assert(c.closed?)
+      assert_predicate(c, :closed?)
     end
   end
 

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -62,7 +62,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
 
     ActiveRecord::Base.connection_handler.clear_reloadable_connections!
 
-    assert adapter.active?
+    assert_predicate adapter, :active?
   end
 
   def test_default_subscription_connection_identifier

--- a/actionmailbox/test/unit/mailbox/bouncing_test.rb
+++ b/actionmailbox/test/unit/mailbox/bouncing_test.rb
@@ -31,7 +31,7 @@ class ActionMailbox::Base::BouncingTest < ActiveSupport::TestCase
       BouncingWithReplyMailbox.receive @inbound_email
     end
 
-    assert @inbound_email.bounced?
+    assert_predicate @inbound_email, :bounced?
     assert_emails 1
 
     mail = ActionMailer::Base.deliveries.last
@@ -44,7 +44,7 @@ class ActionMailbox::Base::BouncingTest < ActiveSupport::TestCase
       BouncingWithImmediateReplyMailbox.receive @inbound_email
     end
 
-    assert @inbound_email.bounced?
+    assert_predicate @inbound_email, :bounced?
     assert_emails 1
 
     mail = ActionMailer::Base.deliveries.last

--- a/actionmailbox/test/unit/mailbox/callbacks_test.rb
+++ b/actionmailbox/test/unit/mailbox/callbacks_test.rb
@@ -61,7 +61,7 @@ class ActionMailbox::Base::CallbacksTest < ActiveSupport::TestCase
 
   test "bouncing in a callback terminates processing" do
     BouncingCallbackMailbox.receive @inbound_email
-    assert @inbound_email.bounced?
+    assert_predicate @inbound_email, :bounced?
     assert_equal [ "Pre-bounce", "Bounce" ], $before_processing
     assert_not $processed
     assert_not $after_processing
@@ -69,7 +69,7 @@ class ActionMailbox::Base::CallbacksTest < ActiveSupport::TestCase
 
   test "marking the inbound email as delivered in a callback terminates processing" do
     DiscardingCallbackMailbox.receive @inbound_email
-    assert @inbound_email.delivered?
+    assert_predicate @inbound_email, :delivered?
     assert_equal [ "Pre-discard", "Discard" ], $before_processing
     assert_not $processed
     assert_not $after_processing

--- a/actionmailbox/test/unit/mailbox/state_test.rb
+++ b/actionmailbox/test/unit/mailbox/state_test.rb
@@ -33,19 +33,19 @@ class ActionMailbox::Base::StateTest < ActiveSupport::TestCase
 
   test "successful mailbox processing leaves inbound email in delivered state" do
     SuccessfulMailbox.receive @inbound_email
-    assert @inbound_email.delivered?
+    assert_predicate @inbound_email, :delivered?
     assert_equal "I was processed", $processed
   end
 
   test "unsuccessful mailbox processing leaves inbound email in failed state" do
     UnsuccessfulMailbox.receive @inbound_email
-    assert @inbound_email.failed?
+    assert_predicate @inbound_email, :failed?
     assert_equal :failure, $processed
   end
 
   test "bounced inbound emails are not delivered" do
     BouncingMailbox.receive @inbound_email
-    assert @inbound_email.bounced?
+    assert_predicate @inbound_email, :bounced?
     assert_equal :bounced, $processed
   end
 end

--- a/actionmailbox/test/unit/relayer_test.rb
+++ b/actionmailbox/test/unit/relayer_test.rb
@@ -19,7 +19,7 @@ module ActionMailbox
       result = @relayer.relay(file_fixture("welcome.eml").read)
       assert_equal "2.0.0", result.status_code
       assert_equal "Successfully relayed message to ingress", result.message
-      assert result.success?
+      assert_predicate result, :success?
       assert_not result.failure?
 
       assert_requested :post, URL, body: file_fixture("welcome.eml").read,
@@ -34,7 +34,7 @@ module ActionMailbox
       assert_equal "4.7.0", result.status_code
       assert_equal "Invalid credentials for ingress", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to an unspecified server error" do
@@ -44,7 +44,7 @@ module ActionMailbox
       assert_equal "4.0.0", result.status_code
       assert_equal "HTTP 500", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to a gateway timeout" do
@@ -54,7 +54,7 @@ module ActionMailbox
       assert_equal "4.0.0", result.status_code
       assert_equal "HTTP 504", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to ECONNRESET" do
@@ -64,7 +64,7 @@ module ActionMailbox
       assert_equal "4.4.2", result.status_code
       assert_equal "Network error relaying to ingress: Connection reset by peer", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to connection failure" do
@@ -74,7 +74,7 @@ module ActionMailbox
       assert_equal "4.4.2", result.status_code
       assert_equal "Network error relaying to ingress: Failed to open TCP connection to example.com:443", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to client-side timeout" do
@@ -84,7 +84,7 @@ module ActionMailbox
       assert_equal "4.4.2", result.status_code
       assert_equal "Timed out relaying to ingress", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
 
     test "unsuccessfully relaying due to an unhandled exception" do
@@ -94,7 +94,7 @@ module ActionMailbox
       assert_equal "4.0.0", result.status_code
       assert_equal "Error relaying to ingress: Something went wrong", result.message
       assert_not result.success?
-      assert result.failure?
+      assert_predicate result, :failure?
     end
   end
 end

--- a/actionmailbox/test/unit/router_test.rb
+++ b/actionmailbox/test/unit/router_test.rb
@@ -136,7 +136,7 @@ module ActionMailbox
       assert_raises(ActionMailbox::Router::RoutingError) do
         @router.route inbound_email
       end
-      assert inbound_email.bounced?
+      assert_predicate inbound_email, :bounced?
     end
 
     test "invalid address" do

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -324,9 +324,9 @@ module ActionController
     tests TestController
 
     def assert_stream_closed
-      assert response.stream.closed?, "stream should be closed"
-      assert response.committed?,     "response should be committed"
-      assert response.sent?,          "response should be sent"
+      assert_predicate response.stream, :closed?, "stream should be closed"
+      assert_predicate response, :committed?,     "response should be committed"
+      assert_predicate response, :sent?,          "response should be sent"
     end
 
     def capture_log_output

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -47,7 +47,7 @@ module BareMetalTest
       controller.set_response!(BareController.make_response!(controller.request))
       controller.index
 
-      assert controller.performed?
+      assert_predicate controller, :performed?
       assert_equal ["Hello world"], controller.response_body
     end
 
@@ -56,7 +56,7 @@ module BareMetalTest
       controller.set_request!(ActionDispatch::Request.empty)
       controller.assign_response_array
 
-      assert controller.performed?
+      assert_predicate controller, :performed?
       assert_equal true, controller.response_body
       assert_equal 200, controller.response[0]
       assert_equal "text/html", controller.response[1]["content-type"]
@@ -67,7 +67,7 @@ module BareMetalTest
       controller.set_request!(ActionDispatch::Request.empty)
       controller.assign_response_object
 
-      assert controller.performed?
+      assert_predicate controller, :performed?
       assert_equal true, controller.response_body
       assert_equal 200, controller.response.status
       assert_equal "text/html", controller.response.headers["content-type"]
@@ -79,10 +79,10 @@ module BareMetalTest
       controller.set_response!(BareController.make_response!(controller.request))
       controller.assign_response_body_proc
 
-      assert controller.performed?
+      assert_predicate controller, :performed?
       assert controller.response_body.is_a?(Proc)
       assert_equal 200, controller.response.status
-      assert controller.response.headers.empty?
+      assert_predicate controller.response.headers, :empty?
     end
 
     test "connect a request to controller instance without dispatch" do

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -55,7 +55,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each carries permitted status" do
     @params.permit!
-    @params.each { |key, value| assert(value.permitted?) if key == "person" }
+    @params.each { |key, value| assert_predicate(value, :permitted?) if key == "person" }
   end
 
   test "each carries unpermitted status" do
@@ -77,7 +77,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each_pair carries permitted status" do
     @params.permit!
-    @params.each_pair { |key, value| assert(value.permitted?) if key == "person" }
+    @params.each_pair { |key, value| assert_predicate(value, :permitted?) if key == "person" }
   end
 
   test "each_pair carries unpermitted status" do

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -933,7 +933,7 @@ class RequestFormat < BaseRequestTest
       "action_dispatch.logger" => Logger.new(output = StringIO.new)
     )
     assert request.formats
-    assert request.format.html?
+    assert_predicate request.format, :html?
 
     output.rewind && (err = output.read)
     assert_match(/Error occurred while parsing request parameters/, err)

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -20,7 +20,7 @@ module ActionDispatch
       end
 
       test "not being empty when route is added" do
-        assert empty?
+        assert_predicate self, :empty?
 
         draw do
           get "foo", to: SimpleApp.new("foo#index")

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3509,16 +3509,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     end
 
     get "/streams"
-    assert @response.ok?, "route without trailing slash should work"
+    assert_predicate @response, :ok?, "route without trailing slash should work"
 
     get "/streams/"
-    assert @response.ok?, "route with trailing slash should work"
+    assert_predicate @response, :ok?, "route with trailing slash should work"
 
     get "/streams?foobar"
-    assert @response.ok?, "route without trailing slash and with QUERY_STRING should work"
+    assert_predicate @response, :ok?, "route without trailing slash and with QUERY_STRING should work"
 
     get "/streams/?foobar"
-    assert @response.ok?, "route with trailing slash and with QUERY_STRING should work"
+    assert_predicate @response, :ok?, "route with trailing slash and with QUERY_STRING should work"
   end
 
   def test_route_with_dashes_in_path

--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -86,14 +86,14 @@ module ActionDispatch
       tf = Tempfile.new
       uf = Http::UploadedFile.new(tempfile: tf)
       uf.close
-      assert tf.closed?
+      assert_predicate tf, :closed?
     end
 
     def test_close_accepts_parameter
       tf = Tempfile.new
       uf = Http::UploadedFile.new(tempfile: tf)
       uf.close(true)
-      assert tf.closed?
+      assert_predicate tf, :closed?
       assert_nil tf.path
     end
 

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -17,9 +17,9 @@ class ActionText::ModelTest < ActiveSupport::TestCase
 
   test "without content" do
     message = Message.create!(subject: "Greetings")
-    assert message.content.nil?
-    assert message.content.blank?
-    assert message.content.empty?
+    assert_predicate message.content, :nil?
+    assert_predicate message.content, :blank?
+    assert_predicate message.content, :empty?
     assert_not message.content?
     assert_not message.content.present?
   end
@@ -27,8 +27,8 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "with blank content" do
     message = Message.create!(subject: "Greetings", content: "")
     assert_not message.content.nil?
-    assert message.content.blank?
-    assert message.content.empty?
+    assert_predicate message.content, :blank?
+    assert_predicate message.content, :empty?
     assert_not message.content?
     assert_not message.content.present?
   end

--- a/actionview/test/template/partial_iteration_test.rb
+++ b/actionview/test/template/partial_iteration_test.rb
@@ -12,7 +12,7 @@ class PartialIterationTest < ActiveSupport::TestCase
 
   def test_first_is_true_when_current_is_at_the_first_index
     iteration = ActionView::PartialIteration.new 3
-    assert iteration.first?, "first when current is 0"
+    assert_predicate iteration, :first?, "first when current is 0"
   end
 
   def test_first_is_false_unless_current_is_at_the_first_index
@@ -25,7 +25,7 @@ class PartialIterationTest < ActiveSupport::TestCase
     iteration = ActionView::PartialIteration.new 3
     iteration.iterate!
     iteration.iterate!
-    assert iteration.last?, "last when current is 2"
+    assert_predicate iteration, :last?, "last when current is 2"
   end
 
   def test_last_is_false_unless_current_is_at_the_last_index

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -135,7 +135,7 @@ class TagHelperTest < ActionView::TestCase
     html_safe_str = '"'.html_safe
     assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
     assert_equal '"', html_safe_str
-    assert html_safe_str.html_safe?
+    assert_predicate html_safe_str, :html_safe?
   end
 
   def test_tag_with_dangerous_name

--- a/actionview/test/template/template_path_test.rb
+++ b/actionview/test/template/template_path_test.rb
@@ -9,7 +9,7 @@ class TemplatePathTest < ActiveSupport::TestCase
     assert_equal "foo/_bar", path.virtual
     assert_equal "foo", path.prefix
     assert_equal "bar", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 
   def test_virtual
@@ -38,14 +38,14 @@ class TemplatePathTest < ActiveSupport::TestCase
     path = ActionView::TemplatePath.parse("_foo")
     assert_equal "", path.prefix
     assert_equal "foo", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 
   def test_parse_root_partial_with_slash
     path = ActionView::TemplatePath.parse("/_foo")
     assert_equal "", path.prefix
     assert_equal "foo", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 
   def test_parse_template
@@ -59,20 +59,20 @@ class TemplatePathTest < ActiveSupport::TestCase
     path = ActionView::TemplatePath.parse("foo/_bar")
     assert_equal "foo", path.prefix
     assert_equal "bar", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 
   def test_parse_deep_partial
     path = ActionView::TemplatePath.parse("foo/bar/_baz")
     assert_equal "foo/bar", path.prefix
     assert_equal "baz", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 
   def test_parse_deep_partial_with_slash
     path = ActionView::TemplatePath.parse("/foo/bar/_baz")
     assert_equal "foo/bar", path.prefix
     assert_equal "baz", path.name
-    assert path.partial?
+    assert_predicate path, :partial?
   end
 end

--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -281,7 +281,7 @@ module ActiveModel
       changed = attribute.with_value_from_user("foo")
       forgotten = changed.forgetting_assignment
 
-      assert changed.changed? # Check to avoid a false positive
+      assert_predicate changed, :changed? # Check to avoid a false positive
       assert_not_predicate forgotten, :changed?
     end
 

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -160,7 +160,7 @@ module ActiveModel
     test "can't modify attributes if frozen" do
       data = ModelForAttributesTest.new
       data.freeze
-      assert data.frozen?
+      assert_predicate data, :frozen?
       assert_raise(FrozenError) { data.integer_field = 1 }
     end
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -55,7 +55,7 @@ class ErrorsTest < ActiveModel::TestCase
   def test_any?
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name)
-    assert errors.any?, "any? should return true"
+    assert_predicate errors, :any?, "any? should return true"
     assert errors.any? { |_| true }, "any? should return true"
   end
 

--- a/activemodel/test/cases/validations/comparison_validation_test.rb
+++ b/activemodel/test/cases/validations/comparison_validation_test.rb
@@ -314,15 +314,15 @@ class ComparisonValidationTest < ActiveModel::TestCase
   private
     def assert_invalid_values(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|
-        assert topic.invalid?, "#{value.inspect} failed comparison"
-        assert topic.errors[:approved].any?, "FAILED for #{value.inspect}"
+        assert_predicate topic, :invalid?, "#{value.inspect} failed comparison"
+        assert_predicate topic.errors[:approved], :any?, "FAILED for #{value.inspect}"
         assert_equal error, topic.errors[:approved].first if error
       end
     end
 
     def assert_valid_values(values)
       with_each_topic_approved_value(values) do |topic, value|
-        assert topic.valid?, "#{value.inspect} failed comparison with validation error: #{topic.errors[:approved].first}"
+        assert_predicate topic, :valid?, "#{value.inspect} failed comparison with validation error: #{topic.errors[:approved].first}"
       end
     end
 

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -14,7 +14,7 @@ class FormatValidationTest < ActiveModel::TestCase
     Topic.validates_format_of(:title, :content, with: /\AValidation\smacros \w+!\z/, message: "is bad data")
 
     t = Topic.new("title" => "i'm incorrect", "content" => "Validation macros rule!")
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
     assert_equal ["is bad data"], t.errors[:title]
     assert_empty t.errors[:content]
 
@@ -39,22 +39,22 @@ class FormatValidationTest < ActiveModel::TestCase
     Topic.validates_format_of(:title, :content, with: /\A[1-9][0-9]*\z/, message: "is bad data")
 
     t = Topic.new("title" => "72x", "content" => "6789")
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
 
     assert_equal ["is bad data"], t.errors[:title]
     assert_empty t.errors[:content]
 
     t.title = "-11"
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
 
     t.title = "03"
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
 
     t.title = "z44"
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
 
     t.title = "5v7"
-    assert t.invalid?, "Shouldn't be valid"
+    assert_predicate t, :invalid?, "Shouldn't be valid"
 
     t.title = "1"
 

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -195,13 +195,13 @@ class InclusionValidationTest < ActiveModel::TestCase
     p = Person.new
     p.karma = %w(Lifo monkey)
 
-    assert p.invalid?
+    assert_predicate p, :invalid?
     assert_equal ["is not included in the list"], p.errors[:karma]
 
     p = Person.new
     p.karma = %w(abe monkey)
 
-    assert p.valid?
+    assert_predicate p, :valid?
   ensure
     Person.clear_validators!
   end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -351,15 +351,15 @@ class NumericalityValidationTest < ActiveModel::TestCase
   private
     def assert_invalid_values(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|
-        assert topic.invalid?, "#{value.inspect} not rejected as a number"
-        assert topic.errors[:approved].any?, "FAILED for #{value.inspect}"
+        assert_predicate topic, :invalid?, "#{value.inspect} not rejected as a number"
+        assert_predicate topic.errors[:approved], :any?, "FAILED for #{value.inspect}"
         assert_equal error, topic.errors[:approved].first if error
       end
     end
 
     def assert_valid_values(values)
       with_each_topic_approved_value(values) do |topic, value|
-        assert topic.valid?, "#{value.inspect} not accepted as a number with validation error: #{topic.errors[:approved].first}"
+        assert_predicate topic, :valid?, "#{value.inspect} not accepted as a number with validation error: #{topic.errors[:approved].first}"
       end
     end
 

--- a/activemodel/test/cases/validations/validations_context_test.rb
+++ b/activemodel/test/cases/validations/validations_context_test.rb
@@ -27,7 +27,7 @@ class ValidationsContextTest < ActiveModel::TestCase
   test "with a class that adds errors on create and validating a new model with no arguments" do
     Topic.validates_with(ValidatorThatAddsErrors, on: :create)
     topic = Topic.new
-    assert topic.valid?, "Validation doesn't run on valid? if 'on' is set to create"
+    assert_predicate topic, :valid?, "Validation doesn't run on valid? if 'on' is set to create"
   end
 
   test "with a class that adds errors on update and validating a new model" do
@@ -47,7 +47,7 @@ class ValidationsContextTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatAddsErrors, on: [:context1, :context2])
 
     topic = Topic.new
-    assert topic.valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
+    assert_predicate topic, :valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
 
     assert topic.invalid?(:context1), "Validation did not run on context1 when 'on' is set to context1 and context2"
     assert_includes topic.errors[:base], ERROR_MESSAGE
@@ -61,7 +61,7 @@ class ValidationsContextTest < ActiveModel::TestCase
     Topic.validates_with(AnotherValidatorThatAddsErrors, on: :context2)
 
     topic = Topic.new
-    assert topic.valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
+    assert_predicate topic, :valid?, "Validation ran with no context given when 'on' is set to context1 and context2"
 
     assert topic.invalid?([:context1, :context2]), "Validation did not run on context1 when 'on' is set to context1 and context2"
     assert_includes topic.errors[:base], ERROR_MESSAGE

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -59,14 +59,14 @@ class ValidatesWithTest < ActiveModel::TestCase
   test "validation with class that adds errors" do
     Topic.validates_with(ValidatorThatAddsErrors)
     topic = Topic.new
-    assert topic.invalid?, "A class that adds errors causes the record to be invalid"
+    assert_predicate topic, :invalid?, "A class that adds errors causes the record to be invalid"
     assert_includes topic.errors[:base], ERROR_MESSAGE
   end
 
   test "with a class that returns valid" do
     Topic.validates_with(ValidatorThatDoesNotAddErrors)
     topic = Topic.new
-    assert topic.valid?, "A class that does not add errors does not cause the record to be invalid"
+    assert_predicate topic, :valid?, "A class that does not add errors does not cause the record to be invalid"
   end
 
   test "with multiple classes" do
@@ -100,13 +100,13 @@ class ValidatesWithTest < ActiveModel::TestCase
     Topic.validates_with(ValidatorThatClearsOptions, ValidatorThatAddsErrors, on: :specific_context)
     topic = Topic.new
     assert topic.invalid?(:specific_context), "validation should work"
-    assert topic.valid?, "Standard options should be preserved"
+    assert_predicate topic, :valid?, "Standard options should be preserved"
   end
 
   test "validates_with preserves validator options" do
     Topic.validates_with(ValidatorThatClearsOptions, ValidatorThatValidatesOptions, field: :first_name)
     topic = Topic.new
-    assert topic.invalid?, "Validator options should be preserved"
+    assert_predicate topic, :invalid?, "Validator options should be preserved"
   end
 
   test "instance validates_with method preserves validator options" do

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -19,11 +19,11 @@ class ValidationsTest < ActiveModel::TestCase
   def test_single_field_validation
     r = Reply.new
     r.title = "There's no content!"
-    assert r.invalid?, "A reply without content should be invalid"
+    assert_predicate r, :invalid?, "A reply without content should be invalid"
     assert r.after_validation_performed, "after_validation callback should be called"
 
     r.content = "Messa content!"
-    assert r.valid?, "A reply with content should be valid"
+    assert_predicate r, :valid?, "A reply with content should be valid"
     assert r.after_validation_performed, "after_validation callback should be called"
   end
 
@@ -31,7 +31,7 @@ class ValidationsTest < ActiveModel::TestCase
     r = Reply.new
     r.title = "There's no content!"
     assert_predicate r, :invalid?
-    assert r.errors[:content].any?, "A reply without content should mark that attribute as invalid"
+    assert_predicate r.errors[:content], :any?, "A reply without content should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["content"], "A reply without content should contain an error"
     assert_equal 1, r.errors.count
   end
@@ -40,10 +40,10 @@ class ValidationsTest < ActiveModel::TestCase
     r = Reply.new
     assert_predicate r, :invalid?
 
-    assert r.errors[:title].any?, "A reply without title should mark that attribute as invalid"
+    assert_predicate r.errors[:title], :any?, "A reply without title should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["title"], "A reply without title should contain an error"
 
-    assert r.errors[:content].any?, "A reply without content should mark that attribute as invalid"
+    assert_predicate r.errors[:content], :any?, "A reply without content should mark that attribute as invalid"
     assert_equal ["is Empty"], r.errors["content"], "A reply without content should contain an error"
 
     assert_equal 2, r.errors.count

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -398,7 +398,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
 
     belongs.destroy
     perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
-    assert parent.reload.deleted?
+    assert_predicate parent.reload, :deleted?
   ensure
     DlKeyedBelongsToSoftDelete.delete_all
     DestroyAsyncParentSoftDelete.delete_all

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -782,7 +782,7 @@ if ActiveRecord::Base.connection.supports_advisory_locks?
     include ConnectionHelper
 
     def test_advisory_locks_enabled?
-      assert ActiveRecord::Base.connection.advisory_locks_enabled?
+      assert_predicate ActiveRecord::Base.connection, :advisory_locks_enabled?
 
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(
@@ -795,7 +795,7 @@ if ActiveRecord::Base.connection.supports_advisory_locks?
           orig_connection.merge(advisory_locks: true)
         )
 
-        assert ActiveRecord::Base.connection.advisory_locks_enabled?
+        assert_predicate ActiveRecord::Base.connection, :advisory_locks_enabled?
       end
     end
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
@@ -22,18 +22,18 @@ class StoredProcedureTest < ActiveRecord::AbstractMysqlTestCase
     rows = @connection.select_rows("CALL ten();")
     assert_equal 10, rows[0][0].to_i, "ten() did not return 10 as expected: #{rows.inspect}"
 
-    assert @connection.active?, "Bad connection use by '#{@connection.class}.select_rows'"
+    assert_predicate @connection, :active?, "Bad connection use by '#{@connection.class}.select_rows'"
   end
 
   def test_multi_results_from_select_one
     row = @connection.select_one("CALL topics(1);")
     assert_equal "David", row["author_name"]
-    assert @connection.active?, "Bad connection use by '#{@connection.class}.select_one'"
+    assert_predicate @connection, :active?, "Bad connection use by '#{@connection.class}.select_one'"
   end
 
   def test_multi_results_from_find_by_sql
     topics = Topic.find_by_sql "CALL topics(3);"
     assert_equal 3, topics.size
-    assert @connection.active?, "Bad connection use by '#{@connection.class}.select'"
+    assert_predicate @connection, :active?, "Bad connection use by '#{@connection.class}.select'"
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -354,11 +354,11 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
       def self.model_name; ActiveModel::Name.new(PgArray) end
     end
     e1 = klass.create("tags" => ["black", "blue"])
-    assert e1.persisted?, "Saving e1"
+    assert_predicate e1, :persisted?, "Saving e1"
 
     e2 = klass.create("tags" => ["black", "blue"])
     assert_not e2.persisted?, "e2 shouldn't be valid"
-    assert e2.errors[:tags].any?, "Should have errors for tags"
+    assert_predicate e2.errors[:tags], :any?, "Should have errors for tags"
     assert_equal ["has already been taken"], e2.errors[:tags], "Should have uniqueness message for tags"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/date_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/date_test.rb
@@ -6,11 +6,11 @@ require "models/topic"
 class PostgresqlDateTest < ActiveRecord::PostgreSQLTestCase
   def test_load_infinity_and_beyond
     topic = Topic.find_by_sql("SELECT 'infinity'::date AS last_read").first
-    assert topic.last_read.infinite?, "timestamp should be infinite"
+    assert_predicate topic.last_read, :infinite?, "timestamp should be infinite"
     assert_operator topic.last_read, :>, 0
 
     topic = Topic.find_by_sql("SELECT '-infinity'::date AS last_read").first
-    assert topic.last_read.infinite?, "timestamp should be infinite"
+    assert_predicate topic.last_read, :infinite?, "timestamp should be infinite"
     assert_operator topic.last_read, :<, 0
   end
 

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -186,7 +186,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     model.save!
 
     model = PostgresqlEnum.find(model.id)
-    assert model.current_mood_happy?
+    assert_predicate model, :current_mood_happy?
   end
 
   def test_enum_type_scoped_to_schemas

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -156,7 +156,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
 
   def test_changes_with_store_accessors
     x = Hstore.new(language: "de")
-    assert x.language_changed?
+    assert_predicate x, :language_changed?
     assert_nil x.language_was
     assert_equal [nil, "de"], x.language_change
     x.save!
@@ -165,7 +165,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
     x.reload
 
     x.settings = nil
-    assert x.language_changed?
+    assert_predicate x, :language_changed?
     assert_equal "de", x.language_was
     assert_equal ["de", nil], x.language_change
   end

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -33,7 +33,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
     record = PostgresqlInfinity.new(float: "-Infinity")
     assert_equal(-Float::INFINITY, record.float)
     record = PostgresqlInfinity.new(float: "NaN")
-    assert record.float.nan?, "Expected #{record.float} to be NaN"
+    assert_predicate record.float, :nan?, "Expected #{record.float} to be NaN"
   end
 
   test "update_all with infinity on a float column" do

--- a/activerecord/test/cases/adapters/postgresql/numbers_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/numbers_test.rb
@@ -33,7 +33,7 @@ class PostgresqlNumberTest < ActiveRecord::PostgreSQLTestCase
     assert_equal 123456.789, first.double
     assert_equal(-::Float::INFINITY, second.single)
     assert_equal ::Float::INFINITY, second.double
-    assert third.double.nan?, "Expected #{third.double} to be NaN"
+    assert_predicate third.double, :nan?, "Expected #{third.double} to be NaN"
   end
 
   def test_update

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -68,7 +68,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
       end
       assert_equal "Should be re-raised", e.message
     end
-    assert warning.blank?, "expected no warnings but got:\n#{warning}"
+    assert_predicate warning, :blank?, "expected no warnings but got:\n#{warning}"
   end
 
   def test_does_not_break_transactions

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -36,7 +36,7 @@ module ActiveRecord
             }
 
             Process.waitpid pid
-            assert $?.success?, "process should exit successfully"
+            assert_predicate $?, :success?, "process should exit successfully"
           end
         end
 

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -128,11 +128,11 @@ class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase
 
   def test_load_infinity_and_beyond
     d = Developer.find_by_sql("select 'infinity'::timestamp as legacy_updated_at")
-    assert d.first.updated_at.infinite?, "timestamp should be infinite"
+    assert_predicate d.first.updated_at, :infinite?, "timestamp should be infinite"
 
     d = Developer.find_by_sql("select '-infinity'::timestamp as legacy_updated_at")
     time = d.first.updated_at
-    assert time.infinite?, "timestamp should be infinite"
+    assert_predicate time, :infinite?, "timestamp should be infinite"
     assert_operator time, :<, 0
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -202,7 +202,7 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     record = klass.create!(guid: "a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11")
     duplicate = klass.new(guid: record.guid)
 
-    assert record.guid.present? # Ensure we actually are testing a UUID
+    assert_predicate record.guid, :present? # Ensure we actually are testing a UUID
     assert_not_predicate duplicate, :valid?
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -40,7 +40,7 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
         rename: { "name" => "person_name" }) do |from, to, options|
       expected = column_values(from, "name")
       assert_equal expected, column_values(to, "person_name")
-      assert expected.any?, "No values in table: #{expected.inspect}"
+      assert_predicate expected, :any?, "No values in table: #{expected.inspect}"
     end
   end
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -642,7 +642,7 @@ module ActiveRecord
         pk_column = connection.columns("barcodes").find { |col| col.name == "id" }
         sql = connection.exec_query("SELECT sql FROM sqlite_master WHERE tbl_name='barcodes'").rows.first.first
 
-        assert(pk_column.auto_increment?)
+        assert_predicate(pk_column, :auto_increment?)
         assert(sql.match?("PRIMARY KEY AUTOINCREMENT"))
 
         connection.change_column(:barcodes, :code, :integer)
@@ -650,7 +650,7 @@ module ActiveRecord
         pk_column = connection.columns("barcodes").find { |col| col.name == "id" }
         sql = connection.exec_query("SELECT sql FROM sqlite_master WHERE tbl_name='barcodes'").rows.first.first
 
-        assert(pk_column.auto_increment?)
+        assert_predicate(pk_column, :auto_increment?)
         assert(sql.match?("PRIMARY KEY AUTOINCREMENT"))
       end
 

--- a/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/statement_pool_test.rb
@@ -15,7 +15,7 @@ class SQLite3StatementPoolTest < ActiveRecord::SQLite3TestCase
       }
 
       Process.waitpid pid
-      assert $?.success?, "process should exit successfully"
+      assert_predicate $?, :success?, "process should exit successfully"
     end
   end
 end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -49,15 +49,15 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   end
 
   test "#supports_comments? answers true" do
-    assert @conn.supports_comments?
+    assert_predicate @conn, :supports_comments?
   end
 
   test "#supports_comments_in_create? answers true" do
-    assert @conn.supports_comments_in_create?
+    assert_predicate @conn, :supports_comments_in_create?
   end
 
   test "#supports_savepoints? answers true" do
-    assert @conn.supports_savepoints?
+    assert_predicate @conn, :supports_savepoints?
   end
 
   test "#requires_reloading? answers false" do
@@ -93,7 +93,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   end
 
   test "#active? answers true with connection" do
-    assert @conn.active?
+    assert_predicate @conn, :active?
   end
 
   test "#active? answers false with connection and exception" do

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -1142,7 +1142,7 @@ module Arel
           table = Table.new(:foo, type_caster: fake_caster)
           condition = table["id"].eq("1").and(table["other_id"].eq("2"))
 
-          assert table.able_to_type_cast?
+          assert_predicate table, :able_to_type_cast?
           _(condition.to_sql).must_equal %("foo"."id" = 1 AND "foo"."other_id" = '2')
         end
 
@@ -1154,7 +1154,7 @@ module Arel
           table = Table.new(:foo, type_caster: fake_caster)
           condition = table["id"].eq(Arel.sql("(select 1)"))
 
-          assert table.able_to_type_cast?
+          assert_predicate table, :able_to_type_cast?
           _(condition.to_sql).must_equal %("foo"."id" = (select 1))
         end
       end

--- a/activerecord/test/cases/arel/nodes/ascending_test.rb
+++ b/activerecord/test/cases/arel/nodes/ascending_test.rb
@@ -24,7 +24,7 @@ module Arel
 
       def test_ascending?
         ascending = Ascending.new "zomg"
-        assert ascending.ascending?
+        assert_predicate ascending, :ascending?
       end
 
       def test_descending?

--- a/activerecord/test/cases/arel/nodes/descending_test.rb
+++ b/activerecord/test/cases/arel/nodes/descending_test.rb
@@ -29,7 +29,7 @@ module Arel
 
       def test_descending?
         descending = Descending.new "zomg"
-        assert descending.descending?
+        assert_predicate descending, :descending?
       end
 
       def test_equality_with_same_ivars

--- a/activerecord/test/cases/arel/nodes/infix_operation_test.rb
+++ b/activerecord/test/cases/arel/nodes/infix_operation_test.rb
@@ -25,7 +25,7 @@ module Arel
         ordering = operation.desc
         assert_kind_of Descending, ordering
         assert_equal operation, ordering.expr
-        assert ordering.descending?
+        assert_predicate ordering, :descending?
       end
 
       def test_equality_with_same_ivars

--- a/activerecord/test/cases/arel/nodes/unary_operation_test.rb
+++ b/activerecord/test/cases/arel/nodes/unary_operation_test.rb
@@ -24,7 +24,7 @@ module Arel
         ordering = operation.desc
         assert_kind_of Descending, ordering
         assert_equal operation, ordering.expr
-        assert ordering.descending?
+        assert_predicate ordering, :descending?
       end
 
       def test_equality_with_same_ivars

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1631,12 +1631,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not node.parent_previously_changed?
 
     node.parent = nodes(:grandparent)
-    assert node.parent_changed?
+    assert_predicate node, :parent_changed?
     assert_not node.parent_previously_changed?
 
     node.save!
     assert_not node.parent_changed?
-    assert node.parent_previously_changed?
+    assert_predicate node, :parent_previously_changed?
   end
 
   test "tracking change from persisted record to new record" do
@@ -1646,12 +1646,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not node.parent_previously_changed?
 
     node.parent = Node.new(tree: node.tree, parent: nodes(:parent_a), name: "Child three")
-    assert node.parent_changed?
+    assert_predicate node, :parent_changed?
     assert_not node.parent_previously_changed?
 
     node.save!
     assert_not node.parent_changed?
-    assert node.parent_previously_changed?
+    assert_predicate node, :parent_previously_changed?
   end
 
   test "tracking change from persisted record to nil" do
@@ -1661,12 +1661,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not node.parent_previously_changed?
 
     node.parent = nil
-    assert node.parent_changed?
+    assert_predicate node, :parent_changed?
     assert_not node.parent_previously_changed?
 
     node.save!
     assert_not node.parent_changed?
-    assert node.parent_previously_changed?
+    assert_predicate node, :parent_previously_changed?
   end
 
   test "tracking change from nil to persisted record" do
@@ -1676,12 +1676,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not node.parent_previously_changed?
 
     node.parent = Node.create!(tree: node.tree, name: "Great-grandparent")
-    assert node.parent_changed?
+    assert_predicate node, :parent_changed?
     assert_not node.parent_previously_changed?
 
     node.save!
     assert_not node.parent_changed?
-    assert node.parent_previously_changed?
+    assert_predicate node, :parent_previously_changed?
   end
 
   test "tracking change from nil to new record" do
@@ -1691,12 +1691,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not node.parent_previously_changed?
 
     node.parent = Node.new(tree: node.tree, name: "Great-grandparent")
-    assert node.parent_changed?
+    assert_predicate node, :parent_changed?
     assert_not node.parent_previously_changed?
 
     node.save!
     assert_not node.parent_changed?
-    assert node.parent_previously_changed?
+    assert_predicate node, :parent_previously_changed?
   end
 
   test "tracking polymorphic changes" do
@@ -1706,20 +1706,20 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not comment.author_previously_changed?
 
     comment.author = authors(:david)
-    assert comment.author_changed?
+    assert_predicate comment, :author_changed?
 
     comment.save!
     assert_not comment.author_changed?
-    assert comment.author_previously_changed?
+    assert_predicate comment, :author_previously_changed?
 
     assert_equal authors(:david).id, companies(:first_firm).id
 
     comment.author = companies(:first_firm)
-    assert comment.author_changed?
+    assert_predicate comment, :author_changed?
 
     comment.save!
     assert_not comment.author_changed?
-    assert comment.author_previously_changed?
+    assert_predicate comment, :author_previously_changed?
   end
 
   class ShipRequired < ActiveRecord::Base

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1338,7 +1338,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     c = Client.create!(name: "Foo", client_of: Company.maximum(:id) + 1)
 
     client = assert_queries(2) { Client.preload(:accounts).find(c.id) }
-    assert_no_queries { assert client.accounts.empty? }
+    assert_no_queries { assert_predicate client.accounts, :empty? }
   end
 
   def test_preloading_has_many_through_with_distinct

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -731,7 +731,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_cant_save_has_many_readonly_association
     authors(:david).readonly_comments.each { |c| assert_raise(ActiveRecord::ReadOnlyRecord) { c.save! } }
-    authors(:david).readonly_comments.each { |c| assert c.readonly? }
+    authors(:david).readonly_comments.each { |c| assert_predicate c, :readonly? }
   end
 
   def test_finding_default_orders
@@ -1866,8 +1866,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     destroyed = companies(:first_firm).clients_of_firm.destroy_all
     assert_equal clients.sort_by(&:id), destroyed.sort_by(&:id)
     assert destroyed.all?(&:frozen?), "destroyed clients should be frozen"
-    assert companies(:first_firm).clients_of_firm.empty?, "37signals has no clients after destroy all"
-    assert companies(:first_firm).clients_of_firm.reload.empty?, "37signals has no clients after destroy all and refresh"
+    assert_predicate companies(:first_firm).clients_of_firm, :empty?, "37signals has no clients after destroy all"
+    assert_predicate companies(:first_firm).clients_of_firm.reload, :empty?, "37signals has no clients after destroy all and refresh"
   end
 
   def test_destroy_all_on_association_clears_scope
@@ -2358,7 +2358,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_calling_many_on_loaded_association_should_not_use_query
     firm = companies(:first_firm)
     firm.clients.load  # force load
-    assert_no_queries { assert firm.clients.many? }
+    assert_no_queries { assert_predicate firm.clients, :many? }
   end
 
   def test_subsequent_calls_to_many_should_use_query

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1293,7 +1293,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     person = Person.create!(first_name: "Gaga")
     person = Person.where(id: person.id).where("readers.id = 1 or 1=1").references(:readers).includes(:posts).to_a.first
 
-    assert person.posts.loaded?, "person.posts should be loaded"
+    assert_predicate person.posts, :loaded?, "person.posts should be loaded"
     assert_equal [], person.posts
   end
 

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -180,7 +180,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
 
   def test_find_with_conditions_on_reflection
     assert_not_empty posts(:welcome).comments
-    assert Post.joins(:nonexistent_comments).where(id: posts(:welcome).id).empty? # [sic!]
+    assert_predicate Post.joins(:nonexistent_comments).where(id: posts(:welcome).id), :empty? # [sic!]
   end
 
   def test_find_with_conditions_on_through_reflection

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -35,10 +35,10 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     monkey_reflection = MixedCaseMonkey.reflect_on_association(:human)
     human_reflection = Human.reflect_on_association(:mixed_case_monkey)
 
-    assert monkey_reflection.has_inverse?, "The monkey reflection should have an inverse"
+    assert_predicate monkey_reflection, :has_inverse?, "The monkey reflection should have an inverse"
     assert_equal human_reflection, monkey_reflection.inverse_of, "The monkey reflection's inverse should be the human reflection"
 
-    assert human_reflection.has_inverse?, "The human reflection should have an inverse"
+    assert_predicate human_reflection, :has_inverse?, "The human reflection should have an inverse"
     assert_equal monkey_reflection, human_reflection.inverse_of, "The human reflection's inverse should be the monkey reflection"
   end
 
@@ -46,7 +46,7 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     account_reflection = Admin::Account.reflect_on_association(:users)
     user_reflection = Admin::User.reflect_on_association(:account)
 
-    assert account_reflection.has_inverse?, "The Admin::Account reflection should have an inverse"
+    assert_predicate account_reflection, :has_inverse?, "The Admin::Account reflection should have an inverse"
     assert_equal user_reflection, account_reflection.inverse_of, "The Admin::Account reflection's inverse should be the Admin::User reflection"
   end
 
@@ -54,10 +54,10 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     car_reflection = Car.reflect_on_association(:bulb)
     bulb_reflection = Bulb.reflect_on_association(:car)
 
-    assert car_reflection.has_inverse?, "The Car reflection should have an inverse"
+    assert_predicate car_reflection, :has_inverse?, "The Car reflection should have an inverse"
     assert_equal bulb_reflection, car_reflection.inverse_of, "The Car reflection's inverse should be the Bulb reflection"
 
-    assert bulb_reflection.has_inverse?, "The Bulb reflection should have an inverse"
+    assert_predicate bulb_reflection, :has_inverse?, "The Bulb reflection should have an inverse"
     assert_equal car_reflection, bulb_reflection.inverse_of, "The Bulb reflection's inverse should be the Car reflection"
   end
 
@@ -65,7 +65,7 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     comment_reflection = Comment.reflect_on_association(:ratings)
     rating_reflection = Rating.reflect_on_association(:comment)
 
-    assert comment_reflection.has_inverse?, "The Comment reflection should have an inverse"
+    assert_predicate comment_reflection, :has_inverse?, "The Comment reflection should have an inverse"
     assert_equal rating_reflection, comment_reflection.inverse_of, "The Comment reflection's inverse should be the Rating reflection"
   end
 
@@ -83,11 +83,11 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
     post_reflection = Post.reflect_on_association(:author)
 
     assert_respond_to author_reflection, :has_inverse?
-    assert author_reflection.has_inverse?, "The Author reflection should have an inverse"
+    assert_predicate author_reflection, :has_inverse?, "The Author reflection should have an inverse"
     assert_equal post_reflection, author_reflection.inverse_of, "The Author reflection's inverse should be the Post reflection"
 
     assert_respond_to author_child_reflection, :has_inverse?
-    assert author_child_reflection.has_inverse?, "The Author reflection should have an inverse"
+    assert_predicate author_child_reflection, :has_inverse?, "The Author reflection should have an inverse"
     assert_equal post_reflection, author_child_reflection.inverse_of, "The Author reflection's inverse should be the Post reflection"
   end
 
@@ -289,8 +289,8 @@ class InverseAssociationTests < ActiveRecord::TestCase
     Developer.create!(name: "Gorbypuff", firm: firm)
 
     new_project = Project.last
-    assert Project.reflect_on_association(:lead_developer).inverse_of.present?, "Expected inverse of to be present"
-    assert new_project.lead_developer.present?, "Expected lead developer to be present on the project"
+    assert_predicate Project.reflect_on_association(:lead_developer).inverse_of, :present?, "Expected inverse of to be present"
+    assert_predicate new_project.lead_developer, :present?, "Expected lead developer to be present on the project"
   end
 end
 
@@ -609,7 +609,7 @@ class InverseHasManyTests < ActiveRecord::TestCase
     Cpk::Order.new(book: book, status: "paid")
     author.save!
 
-    assert book.association(:order).loaded?
+    assert_predicate book.association(:order), :loaded?
   end
 
   def test_raise_record_not_found_error_when_invalid_ids_are_passed

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -478,7 +478,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     new_tag = Tag.new(name: "new")
 
     saved_post.tags << new_tag
-    assert new_tag.persisted? # consistent with habtm!
+    assert_predicate new_tag, :persisted? # consistent with habtm!
     assert_predicate saved_post, :persisted?
     assert_includes saved_post.tags, new_tag
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -112,13 +112,13 @@ class AssociationsTest < ActiveRecord::TestCase
     firm = Firm.new("name" => "A New Firm, Inc")
     firm.save
     firm.clients.each { } # forcing to load all clients
-    assert firm.clients.empty?, "New firm shouldn't have client objects"
+    assert_predicate firm.clients, :empty?, "New firm shouldn't have client objects"
     assert_equal 0, firm.clients.size, "New firm should have 0 clients"
 
     client = Client.new("name" => "TheClient.com", "firm_id" => firm.id)
     client.save
 
-    assert firm.clients.empty?, "New firm should have cached no client objects"
+    assert_predicate firm.clients, :empty?, "New firm should have cached no client objects"
     assert_equal 0, firm.clients.size, "New firm should have cached 0 clients count"
 
     firm.clients.reload
@@ -1238,7 +1238,7 @@ class PreloaderTest < ActiveRecord::TestCase
     bob = bob_post.author
     mary = authors(:mary)
 
-    assert bob_post.association(:author).loaded?
+    assert_predicate bob_post.association(:author), :loaded?
     assert_not mary_post.association(:author).loaded?
 
     assert_queries(1) do
@@ -1363,7 +1363,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     assert_nothing_raised do
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :author, available_records: [[some_other_record]]).call
-      assert post.association(:author).loaded?
+      assert_predicate post.association(:author), :loaded?
       assert_not_equal some_other_record, post.author
     end
   end
@@ -1374,7 +1374,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     ::ActiveRecord::Associations::Preloader.new(records: blog_posts, associations: [:comments]).call
 
-    assert blog_post.association(:comments).loaded?
+    assert_predicate blog_post.association(:comments), :loaded?
     assert_includes(blog_post.comments.to_a, sharded_comments(:great_comment_blog_post_one))
   end
 
@@ -1384,7 +1384,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     ActiveRecord::Associations::Preloader.new(records: comments, associations: :blog_post).call
 
-    assert comment.association(:blog_post).loaded?
+    assert_predicate comment.association(:blog_post), :loaded?
     assert_equal sharded_blog_posts(:great_post_blog_one), comment.blog_post
   end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -430,9 +430,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "read_attribute when true" do
     topic = topics(:first)
     topic.approved = true
-    assert topic.approved?, "approved should be true"
+    assert_predicate topic, :approved?, "approved should be true"
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert_predicate topic, :approved?, "approved should be true"
   end
 
   test "boolean attributes writing and reading" do
@@ -444,10 +444,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_not topic.approved?, "approved should be false"
 
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert_predicate topic, :approved?, "approved should be true"
 
     topic.approved = "true"
-    assert topic.approved?, "approved should be true"
+    assert_predicate topic, :approved?, "approved should be true"
   end
 
   test "overridden write_attribute" do

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2053,7 +2053,7 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     pirate = FamousPirate.create!(catchphrase: "Avast Ye!")
     pirate.famous_ships.create!
 
-    assert pirate.valid?
+    assert_predicate pirate, :valid?
     assert_not pirate.valid?(:conference)
   end
 end
@@ -2100,7 +2100,7 @@ class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::
   def test_validations_still_fire_on_unchanged_association_with_custom_validation_context
     firm_with_low_credit = Firm.create!(name: "Something", account: Account.new(credit_limit: 50))
 
-    assert firm_with_low_credit.valid?
+    assert_predicate firm_with_low_credit, :valid?
     assert_not firm_with_low_credit.valid?(:bank_loan)
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1085,7 +1085,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_clone_of_new_object_marks_as_dirty_only_changed_attributes
     developer = Developer.new name: "Bjorn"
-    assert developer.name_changed?            # obviously
+    assert_predicate developer, :name_changed?            # obviously
     assert_not developer.salary_changed?         # attribute has non-nil default value, so treated as not changed
 
     cloned_developer = developer.clone
@@ -1099,7 +1099,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_predicate developer, :salary_changed?
 
     cloned_developer = developer.dup
-    assert cloned_developer.name_changed?     # both attributes differ from defaults
+    assert_predicate cloned_developer, :name_changed?     # both attributes differ from defaults
     assert_predicate cloned_developer, :salary_changed?
   end
 
@@ -1109,7 +1109,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_not_predicate developer, :salary_changed?
 
     cloned_developer = developer.dup
-    assert cloned_developer.name_changed?     # ... but on cloned object should be
+    assert_predicate cloned_developer, :name_changed?     # ... but on cloned object should be
     assert_not cloned_developer.salary_changed?  # ... BUT salary has non-nil default which should be treated as not changed on cloned instance
   end
 
@@ -1515,7 +1515,7 @@ class BasicsTest < ActiveRecord::TestCase
     marshalled = Marshal.dump(Post.new)
     post       = Marshal.load(marshalled)
 
-    assert post.new_record?, "should be a new record"
+    assert_predicate post, :new_record?, "should be a new record"
   end
 
   def test_marshalling_with_associations
@@ -1567,7 +1567,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     post = Marshal.load(Marshal.dump(post))
 
-    assert post.new_record?, "should be a new record"
+    assert_predicate post, :new_record?, "should be a new record"
   end
 
   def test_attribute_names
@@ -1860,13 +1860,13 @@ class BasicsTest < ActiveRecord::TestCase
   test "#present? and #blank? on ActiveRecord::Base classes" do
     assert_not_empty Topic.all
     assert_no_queries do
-      assert Topic.present?
+      assert_predicate Topic, :present?
       assert_not Topic.blank?
     end
 
     Topic.delete_all
     assert_no_queries do
-      assert Topic.present?
+      assert_predicate Topic, :present?
       assert_not Topic.blank?
     end
   end

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -10,8 +10,8 @@ module ActiveRecord
     def test_persisted
       topic = Topic.first
       cloned = topic.clone
-      assert topic.persisted?, "topic persisted"
-      assert cloned.persisted?, "topic persisted"
+      assert_predicate topic, :persisted?, "topic persisted"
+      assert_predicate cloned, :persisted?, "topic persisted"
       assert_not cloned.new_record?, "topic is not new"
       assert_not cloned.previously_new_record?, "topic was not previously new"
       assert_not cloned.previously_persisted?, "topic was not previously persisted"
@@ -22,9 +22,9 @@ module ActiveRecord
       topic.freeze
 
       cloned = topic.clone
-      assert cloned.persisted?, "topic persisted"
+      assert_predicate cloned, :persisted?, "topic persisted"
       assert_not cloned.new_record?, "topic is not new"
-      assert cloned.frozen?, "topic should be frozen"
+      assert_predicate cloned, :frozen?, "topic should be frozen"
       assert_raise(FrozenError) { cloned.author_name = "Aaron" }
     end
 

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -183,7 +183,7 @@ if ActiveRecord::Base.connection.supports_comments?
       assert_equal "Edited column comment", column.comment
 
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-        assert column.auto_increment?
+        assert_predicate column, :auto_increment?
       end
     end
 

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       def test_in_use?
         assert_not @adapter.in_use?, "adapter is not in use"
         @adapter.lease
-        assert @adapter.in_use?, "adapter is in use"
+        assert_predicate @adapter, :in_use?, "adapter is in use"
       end
 
       def test_lease_twice
@@ -33,7 +33,7 @@ module ActiveRecord
 
       def test_expire_mutates_in_use
         @adapter.lease
-        assert @adapter.in_use?, "adapter is in use"
+        assert_predicate @adapter, :in_use?, "adapter is in use"
         @adapter.expire
         assert_not @adapter.in_use?, "adapter is in use"
       end

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -37,33 +37,33 @@ class DelegatedTypeTest < ActiveRecord::TestCase
 
   test "delegated type name" do
     assert_equal "message", @entry_with_message.entryable_name
-    assert @entry_with_message.entryable_name.message?
+    assert_predicate @entry_with_message.entryable_name, :message?
 
     assert_equal "comment", @entry_with_comment.entryable_name
-    assert @entry_with_comment.entryable_name.comment?
+    assert_predicate @entry_with_comment.entryable_name, :comment?
   end
 
   test "delegated type predicates" do
-    assert @entry_with_message.message?
+    assert_predicate @entry_with_message, :message?
     assert_not @entry_with_message.comment?
 
-    assert @entry_with_comment.comment?
+    assert_predicate @entry_with_comment, :comment?
     assert_not @entry_with_comment.message?
   end
 
   test "delegated type predicates with custom foreign_type" do
-    assert @entry_with_post.post?
+    assert_predicate @entry_with_post, :post?
     assert_not @entry_with_message.post?
     assert_not @entry_with_comment.post?
   end
 
   test "scope" do
-    assert Entry.messages.first.message?
-    assert Entry.comments.first.comment?
+    assert_predicate Entry.messages.first, :message?
+    assert_predicate Entry.comments.first, :comment?
   end
 
   test "scope with custom foreign_type" do
-    assert Entry.posts.first.post?
+    assert_predicate Entry.posts.first, :post?
   end
 
   test "accessor" do

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -630,7 +630,7 @@ class DirtyTest < ActiveRecord::TestCase
       topic = target.create(written_on: written_on)
       topic.written_on += 0.3
 
-      assert topic.written_on_changed?, "Fractional second update not detected"
+      assert_predicate topic, :written_on_changed?, "Fractional second update not detected"
     end
   end
 

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       topic.readonly!
 
       duped = topic.dup
-      assert duped.readonly?, "should be readonly"
+      assert_predicate duped, :readonly?, "should be readonly"
     end
 
     def test_dup_not_persisted
@@ -34,7 +34,7 @@ module ActiveRecord
       duped = topic.dup
 
       assert_not duped.persisted?, "topic not persisted"
-      assert duped.new_record?, "topic is new"
+      assert_predicate duped, :new_record?, "topic is new"
     end
 
     def test_dup_not_previously_new_record

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -137,7 +137,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   test "can't modify encrypted attributes when frozen_encryption is true" do
     post = posts(:welcome).becomes(EncryptedPost)
     post.title = "Some new title"
-    assert post.valid?
+    assert_predicate post, :valid?
 
     ActiveRecord::Encryption.with_encryption_context frozen_encryption: true do
       assert_not post.valid?
@@ -250,7 +250,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   if author_name_limit = EncryptedAuthor.columns_hash["name"].limit
     # No column limits in SQLite
     test "validate column sizes" do
-      assert EncryptedAuthor.new(name: "jorge").valid?
+      assert_predicate EncryptedAuthor.new(name: "jorge"), :valid?
       assert_not EncryptedAuthor.new(name: "a" * (author_name_limit + 1)).valid?
       author = EncryptedAuthor.create(name: "a" * (author_name_limit + 1))
       assert_not author.valid?
@@ -265,7 +265,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_not book.name_previously_changed?
 
     book.update!(name: "A new title!")
-    assert book.name_previously_changed?
+    assert_predicate book, :name_previously_changed?
   end
 
   test "forces UTF-8 encoding for deterministic attributes by default" do
@@ -346,7 +346,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
       key_derivation_salt: "the salt",
       support_sha1_for_non_deterministic_encryption: true
 
-    assert OtherEncryptedPost.type_for_attribute(:title).scheme.previous_schemes.one?
+    assert_predicate OtherEncryptedPost.type_for_attribute(:title).scheme.previous_schemes, :one?
   end
 
   private

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -785,8 +785,8 @@ class EnumTest < ActiveRecord::TestCase
 
   test "uses default status when no status is provided in fixtures" do
     book = books(:tlg)
-    assert book.proposed?, "expected fixture to default to proposed status"
-    assert book.in_english?, "expected fixture to default to english language"
+    assert_predicate book, :proposed?, "expected fixture to default to proposed status"
+    assert_predicate book, :in_english?, "expected fixture to default to english language"
   end
 
   test "uses default value from database on initialization" do

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -304,17 +304,17 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_with_distinct_and_offset_and_joins
-    assert Post.left_joins(:comments).distinct.offset(10).exists?
+    assert_predicate Post.left_joins(:comments).distinct.offset(10), :exists?
     assert_not Post.left_joins(:comments).distinct.offset(11).exists?
   end
 
   def test_exists_with_distinct_and_offset_and_select
-    assert Post.select(:body).distinct.offset(4).exists?
+    assert_predicate Post.select(:body).distinct.offset(4), :exists?
     assert_not Post.select(:body).distinct.offset(5).exists?
   end
 
   def test_exists_with_distinct_and_offset_and_eagerload_and_order
-    assert Post.eager_load(:comments).distinct.offset(10).merge(Comment.order(post_id: :asc)).exists?
+    assert_predicate Post.eager_load(:comments).distinct.offset(10).merge(Comment.order(post_id: :asc)), :exists?
     assert_not Post.eager_load(:comments).distinct.offset(11).merge(Comment.order(post_id: :asc)).exists?
   end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -599,7 +599,7 @@ class FixturesTest < ActiveRecord::TestCase
 
       result = test_case.new(:test_fixtures).run
 
-      assert result.passed?, "Expected #{result.name} to pass:\n#{result}"
+      assert_predicate result, :passed?, "Expected #{result.name} to pass:\n#{result}"
     end
   ensure
     ENV["DATABASE_URL"] = db_url_tmp

--- a/activerecord/test/cases/hot_compatibility_test.rb
+++ b/activerecord/test/cases/hot_compatibility_test.rb
@@ -66,7 +66,7 @@ class HotCompatibilityTest < ActiveRecord::TestCase
           record.reload
         end
 
-        assert get_prepared_statement_cache(@klass.connection).any?,
+        assert_predicate get_prepared_statement_cache(@klass.connection), :any?,
           "expected prepared statement cache to have something in it"
 
         # add a new column
@@ -92,7 +92,7 @@ class HotCompatibilityTest < ActiveRecord::TestCase
           record.reload
         end
 
-        assert get_prepared_statement_cache(@klass.connection).any?,
+        assert_predicate get_prepared_statement_cache(@klass.connection), :any?,
           "expected prepared statement cache to have something in it"
 
         # add a new column

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -153,8 +153,8 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_company_descends_from_active_record
     assert_not_predicate ActiveRecord::Base, :descends_from_active_record?
-    assert AbstractCompany.descends_from_active_record?, "AbstractCompany should descend from ActiveRecord::Base"
-    assert Company.descends_from_active_record?, "Company should descend from ActiveRecord::Base"
+    assert_predicate AbstractCompany, :descends_from_active_record?, "AbstractCompany should descend from ActiveRecord::Base"
+    assert_predicate Company, :descends_from_active_record?, "Company should descend from ActiveRecord::Base"
     assert_not Class.new(Company).descends_from_active_record?, "Company subclass should not descend from ActiveRecord::Base"
   end
 
@@ -468,12 +468,12 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_eager_load_belongs_to_something_inherited
     account = Account.all.merge!(includes: :firm).find(1)
-    assert account.association(:firm).loaded?, "association was not eager loaded"
+    assert_predicate account.association(:firm), :loaded?, "association was not eager loaded"
   end
 
   def test_alt_eager_loading
     cabbage = RedCabbage.all.merge!(includes: :seller).find(4)
-    assert cabbage.association(:seller).loaded?, "association was not eager loaded"
+    assert_predicate cabbage.association(:seller), :loaded?, "association was not eager loaded"
   end
 
   def test_eager_load_belongs_to_primary_key_quoting

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1481,7 +1481,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
           t.change :id, :bigint, auto_increment: true
         end
 
-        assert column(:id).auto_increment?
+        assert_predicate column(:id), :auto_increment?
 
         with_bulk_change_table do |t|
           t.change :id, :bigint, auto_increment: false

--- a/activerecord/test/cases/nested_attributes_with_callbacks_test.rb
+++ b/activerecord/test/cases/nested_attributes_with_callbacks_test.rb
@@ -138,9 +138,9 @@ class NestedAttributesWithCallbacksTest < ActiveRecord::TestCase
 
   def assert_assignment_affects_records_in_target(association_name)
     association = @pirate.public_send(association_name)
-    assert association.detect { |b| b == bird_to_update }.name_changed?,
+    assert_predicate association.detect { |b| b == bird_to_update }, :name_changed?,
       "Update record not updated"
-    assert association.detect { |b| b == bird_to_destroy }.marked_for_destruction?,
+    assert_predicate association.detect { |b| b == bird_to_destroy }, :marked_for_destruction?,
       "Destroy record not marked for destruction"
   end
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -804,7 +804,7 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_delete
     topic = Topic.find(1)
     assert_equal topic, topic.delete, "topic.delete did not return self"
-    assert topic.frozen?, "topic not frozen after delete"
+    assert_predicate topic, :frozen?, "topic not frozen after delete"
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
@@ -823,14 +823,14 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_destroy
     topic = Topic.find(1)
     assert_equal topic, topic.destroy, "topic.destroy did not return self"
-    assert topic.frozen?, "topic not frozen after destroy"
+    assert_predicate topic, :frozen?, "topic not frozen after destroy"
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
   def test_destroy!
     topic = Topic.find(1)
     assert_equal topic, topic.destroy!, "topic.destroy! did not return self"
-    assert topic.frozen?, "topic not frozen after destroy!"
+    assert_predicate topic, :frozen?, "topic not frozen after destroy!"
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(topic.id) }
   end
 
@@ -1110,8 +1110,8 @@ class PersistenceTest < ActiveRecord::TestCase
     t.update_column(:title, "super_title")
     assert_equal "John", t.author_name
     assert_equal "super_title", t.title
-    assert t.changed?, "topic should have changed"
-    assert t.author_name_changed?, "author_name should have changed"
+    assert_predicate t, :changed?, "topic should have changed"
+    assert_predicate t, :author_name_changed?, "author_name should have changed"
 
     t.reload
     assert_equal author_name, t.author_name
@@ -1209,8 +1209,8 @@ class PersistenceTest < ActiveRecord::TestCase
     t.update_columns(title: "super_title")
     assert_equal "John", t.author_name
     assert_equal "super_title", t.title
-    assert t.changed?, "topic should have changed"
-    assert t.author_name_changed?, "author_name should have changed"
+    assert_predicate t, :changed?, "topic should have changed"
+    assert_predicate t, :author_name_changed?, "author_name should have changed"
 
     t.reload
     assert_equal author_name, t.author_name

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -668,10 +668,10 @@ class QueryCacheTest < ActiveRecord::TestCase
       case state
       when :off
         assert_not connection.query_cache_enabled, "cache should be off"
-        assert connection.query_cache.empty?, "cache should be empty"
+        assert_predicate connection.query_cache, :empty?, "cache should be empty"
       when :clean
         assert connection.query_cache_enabled, "cache should be on"
-        assert connection.query_cache.empty?, "cache should be empty"
+        assert_predicate connection.query_cache, :empty?, "cache should be empty"
       when :dirty
         assert connection.query_cache_enabled, "cache should be on"
         assert_not connection.query_cache.empty?, "cache should be dirty"

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -80,16 +80,16 @@ class ReadOnlyTest < ActiveRecord::TestCase
   def test_find_with_readonly_option
     Developer.all.each { |d| assert_not d.readonly? }
     Developer.readonly(false).each { |d| assert_not d.readonly? }
-    Developer.readonly(true).each { |d| assert d.readonly? }
-    Developer.readonly.each { |d| assert d.readonly? }
+    Developer.readonly(true).each { |d| assert_predicate d, :readonly? }
+    Developer.readonly.each { |d| assert_predicate d, :readonly? }
   end
 
   def test_find_with_joins_option_does_not_imply_readonly
     Developer.joins("  ").each { |d| assert_not d.readonly? }
-    Developer.joins("  ").readonly(true).each { |d| assert d.readonly? }
+    Developer.joins("  ").readonly(true).each { |d| assert_predicate d, :readonly? }
 
     Developer.joins(", projects").each { |d| assert_not d.readonly? }
-    Developer.joins(", projects").readonly(true).each { |d| assert d.readonly? }
+    Developer.joins(", projects").readonly(true).each { |d| assert_predicate d, :readonly? }
   end
 
   def test_has_many_find_readonly

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -143,7 +143,7 @@ module ActiveRecord
           end
 
           Process.waitpid(pid)
-          assert $?.success?
+          assert_predicate $?, :success?
         ensure
           pool.discard!
         end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -93,7 +93,7 @@ module ActiveRecord
     end
 
     def test_missing_with_association
-      assert posts(:authorless).author.blank?
+      assert_predicate posts(:authorless).author, :blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
     end
 
@@ -113,7 +113,7 @@ module ActiveRecord
     end
 
     def test_missing_with_multiple_association
-      assert posts(:authorless).comments.empty?
+      assert_predicate posts(:authorless).comments, :empty?
       assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -599,7 +599,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_with_readonly_option
     Developer.all.each { |d| assert_not d.readonly? }
-    Developer.all.readonly.each { |d| assert d.readonly? }
+    Developer.all.readonly.each { |d| assert_predicate d, :readonly? }
   end
 
   def test_eager_association_loading_of_stis_with_multiple_references
@@ -1183,7 +1183,7 @@ class RelationTest < ActiveRecord::TestCase
     posts = Post.all
 
     assert_queries(3) do
-      assert posts.any? # Uses COUNT()
+      assert_predicate posts, :any? # Uses COUNT()
       assert_not_predicate posts.where(id: nil), :any?
 
       assert posts.any? { |p| p.id > 0 }
@@ -1200,7 +1200,7 @@ class RelationTest < ActiveRecord::TestCase
     posts = Post.all
 
     assert_queries(2) do
-      assert posts.many? # Uses COUNT()
+      assert_predicate posts, :many? # Uses COUNT()
       assert posts.many? { |p| p.id > 0 }
       assert_not posts.many? { |p| p.id < 2 }
     end
@@ -1266,7 +1266,7 @@ class RelationTest < ActiveRecord::TestCase
     posts.where.not(id: Post.first).destroy_all
 
     assert_equal 1, posts.size
-    assert posts.one?
+    assert_predicate posts, :one?
   end
 
   def test_to_a_should_dup_target
@@ -1410,7 +1410,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_first_or_create_with_array
     several_green_birds = Bird.where(color: "green").first_or_create([{ name: "parrot" }, { name: "parakeet" }])
     assert_kind_of Array, several_green_birds
-    several_green_birds.each { |bird| assert bird.persisted? }
+    several_green_birds.each { |bird| assert_predicate bird, :persisted? }
 
     same_parrot = Bird.where(color: "green").first_or_create([{ name: "hummingbird" }, { name: "macaw" }])
     assert_kind_of Bird, same_parrot
@@ -1464,7 +1464,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_first_or_create_bang_with_valid_array
     several_green_birds = Bird.where(color: "green").first_or_create!([{ name: "parrot" }, { name: "parakeet" }])
     assert_kind_of Array, several_green_birds
-    several_green_birds.each { |bird| assert bird.persisted? }
+    several_green_birds.each { |bird| assert_predicate bird, :persisted? }
 
     same_parrot = Bird.where(color: "green").first_or_create!([{ name: "hummingbird" }, { name: "macaw" }])
     assert_kind_of Bird, same_parrot
@@ -1973,11 +1973,11 @@ class RelationTest < ActiveRecord::TestCase
     topics = Topic.all
 
     # the first query is triggered because there are no topics yet.
-    assert_queries(1) { assert topics.present? }
+    assert_queries(1) { assert_predicate topics, :present? }
 
     # checking if there are topics is used before you actually display them,
     # thus it shouldn't invoke an extra count query.
-    assert_no_queries { assert topics.present? }
+    assert_no_queries { assert_predicate topics, :present? }
     assert_no_queries { assert_not topics.blank? }
 
     # shows count of topics and loops after loading the query should not trigger extra queries either.

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -255,7 +255,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_any_should_not_fire_query_if_scope_loaded
     topics = Topic.base
     topics.load # force load
-    assert_no_queries { assert topics.any? }
+    assert_no_queries { assert_predicate topics, :any? }
   end
 
   def test_model_class_should_respond_to_any
@@ -285,7 +285,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_many_should_not_fire_query_if_scope_loaded
     topics = Topic.base
     topics.load # force load
-    assert_no_queries { assert topics.many? }
+    assert_no_queries { assert_predicate topics, :many? }
   end
 
   def test_many_should_return_false_if_none_or_one
@@ -496,12 +496,12 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert_equal 4, Topic.approved.count
 
     assert_queries(5) do
-      Topic.approved.find_each(batch_size: 1) { |t| assert t.approved? }
+      Topic.approved.find_each(batch_size: 1) { |t| assert_predicate t, :approved? }
     end
 
     assert_queries(3) do
       Topic.approved.find_in_batches(batch_size: 2) do |group|
-        group.each { |t| assert t.approved? }
+        group.each { |t| assert_predicate t, :approved? }
       end
     end
   end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -89,7 +89,7 @@ class StoreTest < ActiveRecord::TestCase
 
   test "updating the store will mark accessor as changed" do
     @john.color = "red"
-    assert @john.color_changed?
+    assert_predicate @john, :color_changed?
   end
 
   test "new record and no accessors changes" do
@@ -99,14 +99,14 @@ class StoreTest < ActiveRecord::TestCase
     assert_nil user.color_change
 
     user.color = "red"
-    assert user.color_changed?
+    assert_predicate user, :color_changed?
     assert_nil user.color_was
     assert_equal "red", user.color_change[1]
   end
 
   test "updating the store won't mark accessor as changed if the whole store was updated" do
     @john.settings = { color: @john.color, some: "thing" }
-    assert @john.settings_changed?
+    assert_predicate @john, :settings_changed?
     assert_not @john.color_changed?
   end
 
@@ -133,32 +133,32 @@ class StoreTest < ActiveRecord::TestCase
   test "nullifying the store mark accessor as changed" do
     color = @john.color
     @john.settings = nil
-    assert @john.color_changed?
+    assert_predicate @john, :color_changed?
     assert_equal color, @john.color_was
     assert_equal [color, nil], @john.color_change
   end
 
   test "dirty methods for suffixed accessors" do
     @john.configs[:two_factor_auth] = true
-    assert @john.two_factor_auth_configs_changed?
+    assert_predicate @john, :two_factor_auth_configs_changed?
     assert_nil @john.two_factor_auth_configs_was
     assert_equal [nil, true], @john.two_factor_auth_configs_change
   end
 
   test "dirty methods for prefixed accessors" do
     @john.spouse[:name] = "Lena"
-    assert @john.partner_name_changed?
+    assert_predicate @john, :partner_name_changed?
     assert_equal "Dallas", @john.partner_name_was
     assert_equal ["Dallas", "Lena"], @john.partner_name_change
   end
 
   test "saved changes tracking for accessors" do
     @john.spouse[:name] = "Lena"
-    assert @john.partner_name_changed?
+    assert_predicate @john, :partner_name_changed?
 
     @john.save!
     assert_not @john.partner_name_change
-    assert @john.saved_change_to_partner_name?
+    assert_predicate @john, :saved_change_to_partner_name?
     assert_equal ["Dallas", "Lena"], @john.saved_change_to_partner_name
     assert_equal "Dallas", @john.partner_name_before_last_save
   end
@@ -168,11 +168,11 @@ class StoreTest < ActiveRecord::TestCase
       skip "MariaDB doesn't support JSON store_accessor"
     end
     @john.enable_friend_requests = true
-    assert @john.enable_friend_requests_changed?
+    assert_predicate @john, :enable_friend_requests_changed?
 
     @john.save!
     assert_not @john.enable_friend_requests_change
-    assert @john.saved_change_to_enable_friend_requests?
+    assert_predicate @john, :saved_change_to_enable_friend_requests?
     assert_equal [nil, true], @john.saved_change_to_enable_friend_requests
     # Make a second change to test key_before_last_save
     @john.enable_friend_requests = false

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -36,7 +36,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
 
     assert developer.strict_loading!(mode: :n_plus_one_only)
-    assert developer.strict_loading_n_plus_one_only?
+    assert_predicate developer, :strict_loading_n_plus_one_only?
   end
 
   def test_strict_loading_n_plus_one_only_mode_with_has_many
@@ -88,12 +88,12 @@ class StrictLoadingTest < ActiveRecord::TestCase
 
   def test_strict_loading
     Developer.all.each { |d| assert_not d.strict_loading? }
-    Developer.strict_loading.each { |d| assert d.strict_loading? }
+    Developer.strict_loading.each { |d| assert_predicate d, :strict_loading? }
   end
 
   def test_strict_loading_by_default
     with_strict_loading_by_default(Developer) do
-      Developer.all.each { |d| assert d.strict_loading? }
+      Developer.all.each { |d| assert_predicate d, :strict_loading? }
       Developer.strict_loading(false).each { |d| assert_not d.strict_loading? }
     end
   end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       patterns_to_match.each do |pattern|
         failed_patterns << pattern unless SQLCounter.log_all.any? { |sql| pattern === sql }
       end
-      assert failed_patterns.empty?, "Query pattern(s) #{failed_patterns.map(&:inspect).join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
+      assert_predicate failed_patterns, :empty?, "Query pattern(s) #{failed_patterns.map(&:inspect).join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
     end
 
     def assert_queries(num = 1, options = {}, &block)

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -332,7 +332,7 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
 
-    assert Topic.find(1).approved?, "First should have been approved"
+    assert_predicate Topic.find(1), :approved?, "First should have been approved"
   end
 
   def test_rollback_with_return
@@ -661,7 +661,7 @@ class TransactionTest < ActiveRecord::TestCase
       end
     end
 
-    assert Topic.find(1).approved?, "First should have been approved"
+    assert_predicate Topic.find(1), :approved?, "First should have been approved"
     assert_not Topic.find(2).approved?, "Second should have been unapproved"
   end
 
@@ -745,11 +745,11 @@ class TransactionTest < ActiveRecord::TestCase
       raise ActiveRecord::Rollback
     end
 
-    assert @first.approved?, "First should still be changed in the objects"
+    assert_predicate @first, :approved?, "First should still be changed in the objects"
     assert_not @second.approved?, "Second should still be changed in the objects"
 
     assert_not Topic.find(1).approved?, "First shouldn't have been approved"
-    assert Topic.find(2).approved?, "Second should still be approved"
+    assert_predicate Topic.find(2), :approved?, "Second should still be approved"
   end
 
   def test_invalid_keys_for_transaction
@@ -947,7 +947,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert_match(/frozen/i, e.message)
     assert_not topic.persisted?, "not persisted"
     assert_nil topic.id
-    assert topic.frozen?, "not frozen"
+    assert_predicate topic, :frozen?, "not frozen"
   end
 
   def test_rollback_when_thread_killed
@@ -971,11 +971,11 @@ class TransactionTest < ActiveRecord::TestCase
     thread.kill
     thread.join
 
-    assert @first.approved?, "First should still be changed in the objects"
+    assert_predicate @first, :approved?, "First should still be changed in the objects"
     assert_not @second.approved?, "Second should still be changed in the objects"
 
     assert_not Topic.find(1).approved?, "First shouldn't have been approved"
-    assert Topic.find(2).approved?, "Second should still be approved"
+    assert_predicate Topic.find(2), :approved?, "Second should still be approved"
   end
 
   def test_restore_active_record_state_for_all_records_in_a_transaction
@@ -993,15 +993,15 @@ class TransactionTest < ActiveRecord::TestCase
       assert topic_3.save
       @first.save
       @second.destroy
-      assert topic_1.persisted?, "persisted"
+      assert_predicate topic_1, :persisted?, "persisted"
       assert_not_nil topic_1.id
-      assert topic_2.persisted?, "persisted"
+      assert_predicate topic_2, :persisted?, "persisted"
       assert_not_nil topic_2.id
-      assert topic_3.persisted?, "persisted"
+      assert_predicate topic_3, :persisted?, "persisted"
       assert_not_nil topic_3.id
-      assert @first.persisted?, "persisted"
+      assert_predicate @first, :persisted?, "persisted"
       assert_not_nil @first.id
-      assert @second.destroyed?, "destroyed"
+      assert_predicate @second, :destroyed?, "destroyed"
       raise ActiveRecord::Rollback
     end
 
@@ -1011,7 +1011,7 @@ class TransactionTest < ActiveRecord::TestCase
     assert_nil topic_2.id
     assert_not topic_3.persisted?, "not persisted"
     assert_nil topic_3.id
-    assert @first.persisted?, "persisted"
+    assert_predicate @first, :persisted?, "persisted"
     assert_not_nil @first.id
     assert_not @second.destroyed?, "not destroyed"
   end
@@ -1197,7 +1197,7 @@ class TransactionTest < ActiveRecord::TestCase
       topic.destroy
       raise ActiveRecord::Rollback
     end
-    assert topic.frozen?, "frozen"
+    assert_predicate topic, :frozen?, "frozen"
   end
 
   def test_rollback_for_freshly_persisted_records
@@ -1206,7 +1206,7 @@ class TransactionTest < ActiveRecord::TestCase
       topic.destroy
       raise ActiveRecord::Rollback
     end
-    assert topic.persisted?, "persisted"
+    assert_predicate topic, :persisted?, "persisted"
   end
 
   def test_sqlite_add_column_in_transaction

--- a/activerecord/test/cases/validations/absence_validation_test.rb
+++ b/activerecord/test/cases/validations/absence_validation_test.rb
@@ -28,7 +28,7 @@ class AbsenceValidationTest < ActiveRecord::TestCase
     assert_equal 1, boy.errors[:face].size, "should only add one error"
 
     boy.face.mark_for_destruction
-    assert boy.valid?, "should be valid if association is marked for destruction"
+    assert_predicate boy, :valid?, "should be valid if association is marked for destruction"
   end
 
   def test_has_many_marked_for_destruction

--- a/activerecord/test/cases/validations/association_validation_test.rb
+++ b/activerecord/test/cases/validations/association_validation_test.rb
@@ -84,7 +84,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
       Interest.validates_presence_of(:human)
       human = Human.new(name: "John")
       interest = human.interests.build(topic: "Airplanes")
-      assert interest.valid?, "Expected interest to be valid, but was not. Interest should have a human object associated"
+      assert_predicate interest, :valid?, "Expected interest to be valid, but was not. Interest should have a human object associated"
     end
   end
 
@@ -93,7 +93,7 @@ class AssociationValidationTest < ActiveRecord::TestCase
       Interest.validates_presence_of(:human)
       human = Human.create!(name: "John")
       interest = human.interests.build(topic: "Airplanes")
-      assert interest.valid?, "Expected interest to be valid, but was not. Interest should have a human object associated"
+      assert_predicate interest, :valid?, "Expected interest to be valid, but was not. Interest should have a human object associated"
     end
   end
 end

--- a/activerecord/test/cases/validations/presence_validation_test.rb
+++ b/activerecord/test/cases/validations/presence_validation_test.rb
@@ -24,7 +24,7 @@ class PresenceValidationTest < ActiveRecord::TestCase
   def test_validates_presence_of_has_one
     Boy.validates_presence_of(:face)
     b = Boy.new
-    assert b.invalid?, "should not be valid if has_one association missing"
+    assert_predicate b, :invalid?, "should not be valid if has_one association missing"
     assert_equal 1, b.errors[:face].size, "validates_presence_of should only add one error"
   end
 

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -158,7 +158,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
     assert_not r2.valid?, "Saving r2 first time"
@@ -168,7 +168,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     t2 = Topic.create("title" => "I'm unique too!")
     r3 = t2.replies.create "title" => "r3", "content" => "hello world"
-    assert r3.valid?, "Saving r3"
+    assert_predicate r3, :valid?, "Saving r3"
   end
 
   def test_validate_uniqueness_with_aliases
@@ -203,7 +203,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
     assert_not r2.valid?, "Saving r2 first time"
@@ -217,16 +217,16 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       p = Person.create(first_name: "Sergey")
 
       e1 = a.essays.create(name: "Essay")
-      assert e1.valid?, "Saving e1"
+      assert_predicate e1, :valid?, "Saving e1"
 
       e2 = p.essays.create(name: "Essay")
-      assert e2.valid?, "Saving e2"
+      assert_predicate e2, :valid?, "Saving e2"
     end
   end
 
   def test_validate_uniqueness_with_composed_attribute_scope
     r1 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = ReplyWithTitleObject.create "title" => "r1", "content" => "hello world"
     assert_not r2.valid?, "Saving r2 first time"
@@ -238,7 +238,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "I'm unique!")
 
     r1 = t.replies.create "title" => "r1", "content" => "hello world"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = t.replies.create "title" => "r2", "content" => "hello world"
     assert_not r2.valid?, "Saving r2 first time"
@@ -248,7 +248,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "What, me worry?")
 
     r1 = t.unique_replies.create "title" => "r1", "content" => "a barrel of fun"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = t.silly_unique_replies.create "title" => "r2", "content" => "a barrel of fun"
     assert_not r2.valid?, "Saving r2"
@@ -256,7 +256,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     # Should succeed as validates_uniqueness_of only applies to
     # UniqueReply and its subclasses
     r3 = t.replies.create "title" => "r2", "content" => "a barrel of fun"
-    assert r3.valid?, "Saving r3"
+    assert_predicate r3, :valid?, "Saving r3"
   end
 
   def test_validate_uniqueness_with_scope_array
@@ -265,7 +265,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     t = Topic.create("title" => "The earth is actually flat!")
 
     r1 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're joking!", "content" => "Silly reply"
-    assert r1.valid?, "Saving r1"
+    assert_predicate r1, :valid?, "Saving r1"
 
     r2 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're joking!", "content" => "Silly reply again..."
     assert_not r2.valid?, "Saving r2. Double reply by same author."
@@ -310,7 +310,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     t2.parent_id = nil
     t2.title = nil
-    assert t2.valid?, "should validate with nil"
+    assert_predicate t2, :valid?, "should validate with nil"
     assert t2.save, "should save with nil"
 
     t_utf8 = Topic.new("title" => "Я тоже уникальный!")
@@ -367,7 +367,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
       assert_not topic2.valid?
       assert_not topic2.save
     else
-      assert topic2.valid?
+      assert_predicate topic2, :valid?
       assert topic2.save
     end
 
@@ -385,14 +385,14 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t.save, "Should still save t as unique"
 
     t2 = Topic.new("title" => "I'M UNIQUE!")
-    assert t2.valid?, "Should be valid"
+    assert_predicate t2, :valid?, "Should be valid"
     assert t2.save, "Should save t2 as unique"
     assert_empty t2.errors[:title]
     assert_empty t2.errors[:parent_id]
     assert_not_equal ["has already been taken"], t2.errors[:title]
 
     t3 = Topic.new("title" => "I'M uNiQUe!")
-    assert t3.valid?, "Should be valid"
+    assert_predicate t3, :valid?, "Should be valid"
     assert t3.save, "Should save t2 as unique"
     assert_empty t3.errors[:title]
     assert_empty t3.errors[:parent_id]
@@ -411,7 +411,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
   def test_validate_uniqueness_with_non_standard_table_names
     i1 = WarehouseThing.create(value: 1000)
     assert_not i1.valid?, "i1 should not be valid"
-    assert i1.errors[:value].any?, "Should not be empty"
+    assert_predicate i1.errors[:value], :any?, "Should not be empty"
   end
 
   def test_validates_uniqueness_inside_scoping
@@ -438,7 +438,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     if current_adapter?(:SQLite3Adapter)
       # Event.title has limit 5, but SQLite doesn't truncate.
       e1 = Event.create(title: "abcdefgh")
-      assert e1.valid?, "Could not create an event with a unique 8 characters title"
+      assert_predicate e1, :valid?, "Could not create an event with a unique 8 characters title"
 
       e2 = Event.create(title: "abcdefgh")
       assert_not e2.valid?, "Created an event whose title is not unique"
@@ -457,7 +457,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     if current_adapter?(:SQLite3Adapter)
       # Event.title has limit 5, but SQLite doesn't truncate.
       e1 = Event.create(title: "一二三四五六七八")
-      assert e1.valid?, "Could not create an event with a unique 8 characters title"
+      assert_predicate e1, :valid?, "Could not create an event with a unique 8 characters title"
 
       e2 = Event.create(title: "一二三四五六七八")
       assert_not e2.valid?, "Created an event whose title is not unique"
@@ -474,30 +474,30 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
   def test_validate_straight_inheritance_uniqueness
     w1 = IneptWizard.create(name: "Rincewind", city: "Ankh-Morpork")
-    assert w1.valid?, "Saving w1"
+    assert_predicate w1, :valid?, "Saving w1"
 
     # Should use validation from base class (which is abstract)
     w2 = IneptWizard.new(name: "Rincewind", city: "Quirm")
     assert_not w2.valid?, "w2 shouldn't be valid"
-    assert w2.errors[:name].any?, "Should have errors for name"
+    assert_predicate w2.errors[:name], :any?, "Should have errors for name"
     assert_equal ["has already been taken"], w2.errors[:name], "Should have uniqueness message for name"
 
     w3 = Conjurer.new(name: "Rincewind", city: "Quirm")
     assert_not w3.valid?, "w3 shouldn't be valid"
-    assert w3.errors[:name].any?, "Should have errors for name"
+    assert_predicate w3.errors[:name], :any?, "Should have errors for name"
     assert_equal ["has already been taken"], w3.errors[:name], "Should have uniqueness message for name"
 
     w4 = Conjurer.create(name: "The Amazing Bonko", city: "Quirm")
-    assert w4.valid?, "Saving w4"
+    assert_predicate w4, :valid?, "Saving w4"
 
     w5 = Thaumaturgist.new(name: "The Amazing Bonko", city: "Lancre")
     assert_not w5.valid?, "w5 shouldn't be valid"
-    assert w5.errors[:name].any?, "Should have errors for name"
+    assert_predicate w5.errors[:name], :any?, "Should have errors for name"
     assert_equal ["has already been taken"], w5.errors[:name], "Should have uniqueness message for name"
 
     w6 = Thaumaturgist.new(name: "Mustrum Ridcully", city: "Quirm")
     assert_not w6.valid?, "w6 shouldn't be valid"
-    assert w6.errors[:city].any?, "Should have errors for city"
+    assert_predicate w6.errors[:city], :any?, "Should have errors for city"
     assert_equal ["has already been taken"], w6.errors[:city], "Should have uniqueness message for city"
   end
 
@@ -510,7 +510,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_not t3.valid?, "t3 shouldn't be valid"
 
     t4 = Topic.new("title" => "I'm an unapproved topic", "approved" => false)
-    assert t4.valid?, "t4 should be valid"
+    assert_predicate t4, :valid?, "t4 should be valid"
   end
 
   def test_validate_uniqueness_with_non_callable_conditions_is_not_supported
@@ -530,10 +530,10 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert todays_topic.save, "1st topic written today with this title should save"
 
     todays_topic_duplicate = Topic.new(title: "Highlights of the Day", written_on: today_midday + 1.minute)
-    assert todays_topic_duplicate.invalid?, "2nd topic written today with this title should be invalid"
+    assert_predicate todays_topic_duplicate, :invalid?, "2nd topic written today with this title should be invalid"
 
     tomorrows_topic = Topic.new(title: "Highlights of the Day", written_on: today_midday + 1.day)
-    assert tomorrows_topic.valid?, "1st topic written tomorrow with this title should be valid"
+    assert_predicate tomorrows_topic, :valid?, "1st topic written tomorrow with this title should be valid"
   end
 
   def test_validate_uniqueness_on_existing_relation
@@ -598,7 +598,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t.save, "Should save t as unique"
 
     t.id += 1
-    assert t.valid?, "Should be valid"
+    assert_predicate t, :valid?, "Should be valid"
     assert t.save, "Should still save t as unique"
   end
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -20,7 +20,7 @@ class ValidationsTest < ActiveRecord::TestCase
     r = WrongReply.new
     r.title = "Wrong Create"
     assert_not_predicate r, :valid?
-    assert r.errors[:title].any?, "A reply with a bad title should mark that attribute as invalid"
+    assert_predicate r.errors[:title], :any?, "A reply with a bad title should mark that attribute as invalid"
     assert_equal ["is Wrong Create"], r.errors[:title], "A reply with a bad content should contain an error"
   end
 
@@ -33,7 +33,7 @@ class ValidationsTest < ActiveRecord::TestCase
     r.title = "Wrong Update"
     assert_not r.valid?, "Second validation should fail"
 
-    assert r.errors[:title].any?, "A reply with a bad title should mark that attribute as invalid"
+    assert_predicate r.errors[:title], :any?, "A reply with a bad title should mark that attribute as invalid"
     assert_equal ["is Wrong Update"], r.errors[:title], "A reply with a bad content should contain an error"
   end
 

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -63,8 +63,8 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_new_records_remain_new_after_round_trip
     topic = Topic.new
 
-    assert topic.new_record?, "New record should be new"
-    assert yaml_load(YAML.dump(topic)).new_record?, "Record should be new after deserialization"
+    assert_predicate topic, :new_record?, "New record should be new"
+    assert_predicate yaml_load(YAML.dump(topic)), :new_record?, "Record should be new after deserialization"
 
     topic.save!
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -46,14 +46,14 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching existing blobs to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
     assert_not @user.highlights.first.persisted?
     assert_not @user.highlights.second.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "funky.jpg", @user.highlights.reload.first.filename.to_s
@@ -62,14 +62,14 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching existing blobs from signed IDs to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.highlights.attach create_blob(filename: "funky.jpg").signed_id, create_blob(filename: "town.jpg").signed_id
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
     assert_not @user.highlights.first.persisted?
     assert_not @user.highlights.second.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "funky.jpg", @user.highlights.reload.first.filename.to_s
@@ -78,7 +78,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs from Hashes to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.highlights.attach(
       { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
@@ -88,7 +88,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal "town.jpg", @user.highlights.second.filename.to_s
     assert_not @user.highlights.first.persisted?
     assert_not @user.highlights.second.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "funky.jpg", @user.highlights.reload.first.filename.to_s
@@ -97,14 +97,14 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs from uploaded files to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.highlights.attach fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4")
     assert_equal "racecar.jpg", @user.highlights.first.filename.to_s
     assert_equal "video.mp4", @user.highlights.second.filename.to_s
     assert_not @user.highlights.first.persisted?
     assert_not @user.highlights.second.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "racecar.jpg", @user.highlights.reload.first.filename.to_s
@@ -113,7 +113,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs from uploaded files to an existing, changed record one at a time" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.highlights.attach fixture_file_upload("racecar.jpg")
     @user.highlights.attach fixture_file_upload("video.mp4")
@@ -121,7 +121,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal "video.mp4", @user.highlights.second.filename.to_s
     assert_not @user.highlights.first.persisted?
     assert_not @user.highlights.second.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
     assert_not ActiveStorage::Blob.service.exist?(@user.highlights.first.key)
     assert_not ActiveStorage::Blob.service.exist?(@user.highlights.second.key)
 
@@ -404,7 +404,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "attaching existing blobs to a new record" do
     User.new(name: "Jason").tap do |user|
       user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
-      assert user.new_record?
+      assert_predicate user, :new_record?
       assert_equal "funky.jpg", user.highlights.first.filename.to_s
       assert_equal "town.jpg", user.highlights.second.filename.to_s
 
@@ -417,7 +417,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "attaching an existing blob from a signed ID to a new record" do
     User.new(name: "Jason").tap do |user|
       user.highlights.attach create_blob(filename: "funky.jpg").signed_id
-      assert user.new_record?
+      assert_predicate user, :new_record?
       assert_equal "funky.jpg", user.highlights.first.filename.to_s
 
       user.save!
@@ -431,21 +431,21 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
         { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
         { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpeg" })
 
-      assert user.new_record?
-      assert user.highlights.first.new_record?
-      assert user.highlights.second.new_record?
-      assert user.highlights.first.blob.new_record?
-      assert user.highlights.second.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.highlights.first, :new_record?
+      assert_predicate user.highlights.second, :new_record?
+      assert_predicate user.highlights.first.blob, :new_record?
+      assert_predicate user.highlights.second.blob, :new_record?
       assert_equal "funky.jpg", user.highlights.first.filename.to_s
       assert_equal "town.jpg", user.highlights.second.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.highlights.first.key)
       assert_not ActiveStorage::Blob.service.exist?(user.highlights.second.key)
 
       user.save!
-      assert user.highlights.first.persisted?
-      assert user.highlights.second.persisted?
-      assert user.highlights.first.blob.persisted?
-      assert user.highlights.second.blob.persisted?
+      assert_predicate user.highlights.first, :persisted?
+      assert_predicate user.highlights.second, :persisted?
+      assert_predicate user.highlights.first.blob, :persisted?
+      assert_predicate user.highlights.second.blob, :persisted?
       assert_equal "funky.jpg", user.reload.highlights.first.filename.to_s
       assert_equal "town.jpg", user.highlights.second.filename.to_s
       assert ActiveStorage::Blob.service.exist?(user.highlights.first.key)
@@ -456,21 +456,21 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "attaching new blobs from uploaded files to a new record" do
     User.new(name: "Jason").tap do |user|
       user.highlights.attach fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4")
-      assert user.new_record?
-      assert user.highlights.first.new_record?
-      assert user.highlights.second.new_record?
-      assert user.highlights.first.blob.new_record?
-      assert user.highlights.second.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.highlights.first, :new_record?
+      assert_predicate user.highlights.second, :new_record?
+      assert_predicate user.highlights.first.blob, :new_record?
+      assert_predicate user.highlights.second.blob, :new_record?
       assert_equal "racecar.jpg", user.highlights.first.filename.to_s
       assert_equal "video.mp4", user.highlights.second.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.highlights.first.key)
       assert_not ActiveStorage::Blob.service.exist?(user.highlights.second.key)
 
       user.save!
-      assert user.highlights.first.persisted?
-      assert user.highlights.second.persisted?
-      assert user.highlights.first.blob.persisted?
-      assert user.highlights.second.blob.persisted?
+      assert_predicate user.highlights.first, :persisted?
+      assert_predicate user.highlights.second, :persisted?
+      assert_predicate user.highlights.first.blob, :persisted?
+      assert_predicate user.highlights.second.blob, :persisted?
       assert_equal "racecar.jpg", user.reload.highlights.first.filename.to_s
       assert_equal "video.mp4", user.highlights.second.filename.to_s
       assert ActiveStorage::Blob.service.exist?(user.highlights.first.key)
@@ -493,11 +493,11 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "creating a record with new blobs from uploaded files attached" do
     User.new(name: "Jason", highlights: [ fixture_file_upload("racecar.jpg"), fixture_file_upload("video.mp4") ]).tap do |user|
-      assert user.new_record?
-      assert user.highlights.first.new_record?
-      assert user.highlights.second.new_record?
-      assert user.highlights.first.blob.new_record?
-      assert user.highlights.second.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.highlights.first, :new_record?
+      assert_predicate user.highlights.second, :new_record?
+      assert_predicate user.highlights.first.blob, :new_record?
+      assert_predicate user.highlights.second.blob, :new_record?
       assert_equal "racecar.jpg", user.highlights.first.filename.to_s
       assert_equal "video.mp4", user.highlights.second.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.highlights.first.key)
@@ -517,7 +517,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "detaching" do
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       @user.highlights.attach blobs
-      assert @user.highlights.attached?
+      assert_predicate @user.highlights, :attached?
 
       perform_enqueued_jobs do
         @user.highlights.detach
@@ -535,7 +535,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       user = User.new
       user.highlights.attach blobs
-      assert user.highlights.attached?
+      assert_predicate user.highlights, :attached?
 
       perform_enqueued_jobs do
         user.highlights.detach
@@ -552,7 +552,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "purging" do
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       @user.highlights.attach blobs
-      assert @user.highlights.attached?
+      assert_predicate @user.highlights, :attached?
 
       assert_changes -> { @user.updated_at } do
         @user.highlights.purge
@@ -572,12 +572,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
       create_blob(filename: "worm.jpg")
     ].tap do |blobs|
       @user.highlights.attach blobs
-      assert @user.highlights.attached?
+      assert_predicate @user.highlights, :attached?
 
       another_user = User.create!(name: "John")
       shared_blobs = [blobs.second, blobs.third]
       another_user.highlights.attach shared_blobs
-      assert another_user.highlights.attached?
+      assert_predicate another_user.highlights, :attached?
 
       @user.highlights.purge
       assert_not @user.highlights.attached?
@@ -596,7 +596,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       user = User.new
       user.highlights.attach blobs
-      assert user.highlights.attached?
+      assert_predicate user.highlights, :attached?
 
       attachments = user.highlights.attachments
       user.highlights.purge
@@ -622,7 +622,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "purging later" do
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       @user.highlights.attach blobs
-      assert @user.highlights.attached?
+      assert_predicate @user.highlights, :attached?
 
       perform_enqueued_jobs do
         assert_changes -> { @user.updated_at } do
@@ -645,12 +645,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
       create_blob(filename: "worm.jpg")
     ].tap do |blobs|
       @user.highlights.attach blobs
-      assert @user.highlights.attached?
+      assert_predicate @user.highlights, :attached?
 
       another_user = User.create!(name: "John")
       shared_blobs = [blobs.second, blobs.third]
       another_user.highlights.attach shared_blobs
-      assert another_user.highlights.attached?
+      assert_predicate another_user.highlights, :attached?
 
       perform_enqueued_jobs do
         @user.highlights.purge_later
@@ -671,7 +671,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
       user = User.new
       user.highlights.attach blobs
-      assert user.highlights.attached?
+      assert_predicate user.highlights, :attached?
 
       perform_enqueued_jobs do
         user.highlights.purge_later
@@ -726,7 +726,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "clearing change on reload" do
     @user.highlights = [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ]
-    assert @user.highlights.attached?
+    assert_predicate @user.highlights, :attached?
 
     @user.reload
     assert_not @user.highlights.attached?
@@ -931,7 +931,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
       highlights_attachments_attributes: [{ id: attachment_id, _destroy: true }]
     )
 
-    assert @user.reload.highlights.attached?
+    assert_predicate @user.reload.highlights, :attached?
     assert_equal 1, @user.highlights.count
     assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
   end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -130,12 +130,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching an existing blob to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.avatar.attach create_blob(filename: "funky.jpg")
     assert_equal "funky.jpg", @user.avatar.filename.to_s
     assert_not @user.avatar.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "funky.jpg", @user.reload.avatar.filename.to_s
@@ -143,12 +143,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching an existing blob from a signed ID to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.avatar.attach create_blob(filename: "funky.jpg").signed_id
     assert_equal "funky.jpg", @user.avatar.filename.to_s
     assert_not @user.avatar.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "funky.jpg", @user.reload.avatar.filename.to_s
@@ -156,12 +156,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching a new blob from a Hash to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
     assert_equal "town.jpg", @user.avatar.filename.to_s
     assert_not @user.avatar.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "town.jpg", @user.reload.avatar.filename.to_s
@@ -169,12 +169,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching a new blob from an uploaded file to an existing, changed record" do
     @user.name = "Tina"
-    assert @user.changed?
+    assert_predicate @user, :changed?
 
     @user.avatar.attach fixture_file_upload("racecar.jpg")
     assert_equal "racecar.jpg", @user.avatar.filename.to_s
     assert_not @user.avatar.persisted?
-    assert @user.will_save_change_to_name?
+    assert_predicate @user, :will_save_change_to_name?
 
     @user.save!
     assert_equal "racecar.jpg", @user.reload.avatar.filename.to_s
@@ -368,7 +368,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       @user.avatar.attach fixture_file_upload("racecar.jpg")
     end
 
-    assert @user.avatar.reload.analyzed?
+    assert_predicate @user.avatar.reload, :analyzed?
     assert_equal 4104, @user.avatar.metadata[:width]
     assert_equal 2736, @user.avatar.metadata[:height]
   end
@@ -378,7 +378,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       @user.update! avatar: fixture_file_upload("racecar.jpg")
     end
 
-    assert @user.avatar.reload.analyzed?
+    assert_predicate @user.avatar.reload, :analyzed?
     assert_equal 4104, @user.avatar.metadata[:width]
     assert_equal 2736, @user.avatar.metadata[:height]
   end
@@ -388,7 +388,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       @user.avatar.attach directly_upload_file_blob(filename: "racecar.jpg")
     end
 
-    assert @user.avatar.reload.analyzed?
+    assert_predicate @user.avatar.reload, :analyzed?
     assert_equal 4104, @user.avatar.metadata[:width]
     assert_equal 2736, @user.avatar.metadata[:height]
   end
@@ -398,7 +398,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       @user.update! avatar: directly_upload_file_blob(filename: "racecar.jpg")
     end
 
-    assert @user.avatar.reload.analyzed?
+    assert_predicate @user.avatar.reload, :analyzed?
     assert_equal 4104, @user.avatar.metadata[:width]
     assert_equal 2736, @user.avatar.metadata[:height]
   end
@@ -407,7 +407,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     group = Group.create!(users_attributes: [{ name: "John", avatar: { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" } }])
     group.save!
     new_user = User.find_by(name: "John")
-    assert new_user.avatar.attached?
+    assert_predicate new_user.avatar, :attached?
   end
 
   test "updating an attachment as part of an autosave association" do
@@ -415,13 +415,13 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     @user.avatar = fixture_file_upload("racecar.jpg")
     group.save!
     @user.reload
-    assert @user.avatar.attached?
+    assert_predicate @user.avatar, :attached?
   end
 
   test "attaching an existing blob to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach create_blob(filename: "funky.jpg")
-      assert user.new_record?
+      assert_predicate user, :new_record?
       assert_equal "funky.jpg", user.avatar.filename.to_s
 
       user.save!
@@ -432,7 +432,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching an existing blob from a signed ID to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach create_blob(filename: "funky.jpg").signed_id
-      assert user.new_record?
+      assert_predicate user, :new_record?
       assert_equal "funky.jpg", user.avatar.filename.to_s
 
       user.save!
@@ -443,15 +443,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from a Hash to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
-      assert user.new_record?
-      assert user.avatar.attachment.new_record?
-      assert user.avatar.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.avatar.attachment, :new_record?
+      assert_predicate user.avatar.blob, :new_record?
       assert_equal "town.jpg", user.avatar.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.avatar.key)
 
       user.save!
-      assert user.avatar.attachment.persisted?
-      assert user.avatar.blob.persisted?
+      assert_predicate user.avatar.attachment, :persisted?
+      assert_predicate user.avatar.blob, :persisted?
       assert_equal "town.jpg", user.reload.avatar.filename.to_s
       assert ActiveStorage::Blob.service.exist?(user.avatar.key)
     end
@@ -460,15 +460,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching a new blob from an uploaded file to a new record" do
     User.new(name: "Jason").tap do |user|
       user.avatar.attach fixture_file_upload("racecar.jpg")
-      assert user.new_record?
-      assert user.avatar.attachment.new_record?
-      assert user.avatar.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.avatar.attachment, :new_record?
+      assert_predicate user.avatar.blob, :new_record?
       assert_equal "racecar.jpg", user.avatar.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.avatar.key)
 
       user.save!
-      assert user.avatar.attachment.persisted?
-      assert user.avatar.blob.persisted?
+      assert_predicate user.avatar.attachment, :persisted?
+      assert_predicate user.avatar.blob, :persisted?
       assert_equal "racecar.jpg", user.reload.avatar.filename.to_s
       assert ActiveStorage::Blob.service.exist?(user.avatar.key)
     end
@@ -486,9 +486,9 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "creating a record with a new blob from an uploaded file attached" do
     User.new(name: "Jason", avatar: fixture_file_upload("racecar.jpg")).tap do |user|
-      assert user.new_record?
-      assert user.avatar.attachment.new_record?
-      assert user.avatar.blob.new_record?
+      assert_predicate user, :new_record?
+      assert_predicate user.avatar.attachment, :new_record?
+      assert_predicate user.avatar.blob, :new_record?
       assert_equal "racecar.jpg", user.avatar.filename.to_s
       assert_not ActiveStorage::Blob.service.exist?(user.avatar.key)
 
@@ -505,7 +505,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "analyzing a new blob from an uploaded file after attaching it to a new record" do
     perform_enqueued_jobs do
       user = User.create!(name: "Jason", avatar: fixture_file_upload("racecar.jpg"))
-      assert user.avatar.reload.analyzed?
+      assert_predicate user.avatar.reload, :analyzed?
       assert_equal 4104, user.avatar.metadata[:width]
       assert_equal 2736, user.avatar.metadata[:height]
     end
@@ -514,7 +514,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "analyzing a directly-uploaded blob after attaching it to a new record" do
     perform_enqueued_jobs do
       user = User.create!(name: "Jason", avatar: directly_upload_file_blob(filename: "racecar.jpg"))
-      assert user.avatar.reload.analyzed?
+      assert_predicate user.avatar.reload, :analyzed?
       assert_equal 4104, user.avatar.metadata[:width]
       assert_equal 2736, user.avatar.metadata[:height]
     end
@@ -523,7 +523,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "detaching" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      assert @user.avatar.attached?
+      assert_predicate @user.avatar, :attached?
 
       perform_enqueued_jobs do
         @user.avatar.detach
@@ -539,7 +539,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     create_blob(filename: "funky.jpg").tap do |blob|
       user = User.new
       user.avatar.attach blob
-      assert user.avatar.attached?
+      assert_predicate user.avatar, :attached?
 
       perform_enqueued_jobs do
         user.avatar.detach
@@ -554,7 +554,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "purging" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      assert @user.avatar.attached?
+      assert_predicate @user.avatar, :attached?
 
       assert_changes -> { @user.updated_at } do
         @user.avatar.purge
@@ -568,11 +568,11 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "purging an attachment with a shared blob" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      assert @user.avatar.attached?
+      assert_predicate @user.avatar, :attached?
 
       another_user = User.create!(name: "John")
       another_user.avatar.attach blob
-      assert another_user.avatar.attached?
+      assert_predicate another_user.avatar, :attached?
 
       @user.avatar.purge
       assert_not @user.avatar.attached?
@@ -585,13 +585,13 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     create_blob(filename: "funky.jpg").tap do |blob|
       user = User.new
       user.avatar.attach blob
-      assert user.avatar.attached?
+      assert_predicate user.avatar, :attached?
 
       attachment = user.avatar.attachment
       user.avatar.purge
 
       assert_not user.avatar.attached?
-      assert attachment.destroyed?
+      assert_predicate attachment, :destroyed?
       assert_not ActiveStorage::Blob.exists?(blob.id)
       assert_not ActiveStorage::Blob.service.exist?(blob.key)
     end
@@ -609,7 +609,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "purging later" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      assert @user.avatar.attached?
+      assert_predicate @user.avatar, :attached?
 
       perform_enqueued_jobs do
         assert_changes -> { @user.updated_at } do
@@ -626,11 +626,11 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "purging an attachment later with shared blob" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob
-      assert @user.avatar.attached?
+      assert_predicate @user.avatar, :attached?
 
       another_user = User.create!(name: "John")
       another_user.avatar.attach blob
-      assert another_user.avatar.attached?
+      assert_predicate another_user.avatar, :attached?
 
       perform_enqueued_jobs do
         @user.avatar.purge_later
@@ -646,7 +646,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     create_blob(filename: "funky.jpg").tap do |blob|
       user = User.new
       user.avatar.attach blob
-      assert user.avatar.attached?
+      assert_predicate user.avatar, :attached?
 
       attachment = user.avatar.attachment
       perform_enqueued_jobs do
@@ -654,7 +654,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
       end
 
       assert_not user.avatar.attached?
-      assert attachment.destroyed?
+      assert_predicate attachment, :destroyed?
       assert_not ActiveStorage::Blob.exists?(blob.id)
       assert_not ActiveStorage::Blob.service.exist?(blob.key)
     end
@@ -699,7 +699,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "clearing change on reload" do
     @user.avatar = create_blob(filename: "funky.jpg")
-    assert @user.avatar.attached?
+    assert_predicate @user.avatar, :attached?
 
     @user.reload
     assert_not @user.avatar.attached?

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -21,7 +21,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
       @user.highlights.attach(blob)
     end
 
-    assert blob.reload.analyzed?
+    assert_predicate blob.reload, :analyzed?
     assert_equal 4104, blob.metadata[:width]
     assert_equal 2736, blob.metadata[:height]
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -159,7 +159,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   test "open with integrity" do
     create_file_blob(filename: "racecar.jpg").tap do |blob|
       blob.open do |file|
-        assert file.binmode?
+        assert_predicate file, :binmode?
         assert_equal 0, file.pos
         assert File.basename(file.path).start_with?("ActiveStorage-#{blob.id}-")
         assert file.path.end_with?(".jpg")
@@ -180,7 +180,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "open in a custom tmpdir" do
     create_file_blob(filename: "racecar.jpg").open(tmpdir: tmpdir = Dir.mktmpdir) do |file|
-      assert file.binmode?
+      assert_predicate file, :binmode?
       assert_equal 0, file.pos
       assert_match(/\.jpg\z/, file.path)
       assert file.path.start_with?(tmpdir)
@@ -273,7 +273,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   test "purge doesn't raise when blob is not persisted" do
     build_blob_after_unfurling.tap do |blob|
       assert_nothing_raised { blob.purge }
-      assert blob.destroyed?
+      assert_predicate blob, :destroyed?
     end
   end
 

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -59,7 +59,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
       blob.preview(resize_to_limit: [640, 280]).processed
     end
 
-    assert blob.reload.preview_image.attached?
+    assert_predicate blob.reload.preview_image, :attached?
   end
 
   test "preview of PDF is created on the same service" do

--- a/activesupport/test/actionable_error_test.rb
+++ b/activesupport/test/actionable_error_test.rb
@@ -27,8 +27,8 @@ class ActionableErrorTest < ActiveSupport::TestCase
   end
 
   test "returns no actions for non-actionable errors" do
-    assert ActiveSupport::ActionableError.actions(Exception).empty?
-    assert ActiveSupport::ActionableError.actions(Exception.new).empty?
+    assert_predicate ActiveSupport::ActionableError.actions(Exception), :empty?
+    assert_predicate ActiveSupport::ActionableError.actions(Exception.new), :empty?
   end
 
   test "dispatches actions from error and name" do

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -10,7 +10,7 @@ class CacheEntryTest < ActiveSupport::TestCase
     entry = ActiveSupport::Cache::Entry.new("value", expires_in: 60)
     assert_not entry.expired?, "entry not expired"
     Time.stub(:now, Time.at(entry.expires_at + 1)) do
-      assert entry.expired?, "entry is expired"
+      assert_predicate entry, :expired?, "entry is expired"
     end
   end
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -738,15 +738,15 @@ class DurationTest < ActiveSupport::TestCase
     assert_not 12.minutes.variable?
     assert_not 12.hours.variable?
 
-    assert 12.days.variable?
-    assert 12.weeks.variable?
-    assert 12.months.variable?
-    assert 12.years.variable?
+    assert_predicate 12.days, :variable?
+    assert_predicate 12.weeks, :variable?
+    assert_predicate 12.months, :variable?
+    assert_predicate 12.years, :variable?
 
     assert_not (12.hours + 12.minutes).variable?
 
-    assert (12.hours + 1.day).variable?
-    assert (1.day + 12.hours).variable?
+    assert_predicate (12.hours + 1.day), :variable?
+    assert_predicate (1.day + 12.hours), :variable?
   end
 
   def test_duration_symmetry

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -16,7 +16,7 @@ class DuplicableTest < ActiveSupport::TestCase
     end
 
     ALLOW_DUP.each do |v|
-      assert v.duplicable?, "#{ v.class } should be duplicable"
+      assert_predicate v, :duplicable?, "#{ v.class } should be duplicable"
       assert_nothing_raised { v.dup }
     end
   end

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -25,7 +25,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
   end
 
   def test_strip_heredoc_on_a_frozen_string
-    assert "".strip_heredoc.frozen?
+    assert_predicate "".strip_heredoc, :frozen?
   end
 
   def test_strip_heredoc_on_a_string_with_no_lines

--- a/activesupport/test/deprecation/proxy_wrappers_test.rb
+++ b/activesupport/test/deprecation/proxy_wrappers_test.rb
@@ -38,7 +38,7 @@ class ProxyWrappersTest < ActiveSupport::TestCase
     assert_deprecated("OldWaffleModule", @deprecator) do
       klass.include proxy
     end
-    assert klass.new.waffle?
+    assert_predicate klass.new, :waffle?
   end
 
   def test_prepending_proxy_module
@@ -51,7 +51,7 @@ class ProxyWrappersTest < ActiveSupport::TestCase
     assert_deprecated("OldWaffleModule", @deprecator) do
       klass.prepend proxy
     end
-    assert klass.new.waffle?
+    assert_predicate klass.new, :waffle?
   end
 
   def test_extending_proxy_module
@@ -60,6 +60,6 @@ class ProxyWrappersTest < ActiveSupport::TestCase
     assert_deprecated("OldWaffleModule", @deprecator) do
       obj.extend proxy
     end
-    assert obj.waffle?
+    assert_predicate obj, :waffle?
   end
 end

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -93,14 +93,14 @@ class EncryptedFileTest < ActiveSupport::TestCase
   end
 
   test "key? is true when key file exists" do
-    assert @encrypted_file.key?
+    assert_predicate @encrypted_file, :key?
   end
 
   test "key? is true when env key is present" do
     FileUtils.rm_rf @key_path
     ENV["CONTENT_KEY"] = @key
 
-    assert @encrypted_file.key?
+    assert_predicate @encrypted_file, :key?
   end
 
   test "key? is false and does not raise when the key is missing" do

--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -4,8 +4,8 @@ require_relative "abstract_unit"
 
 class EnvironmentInquirerTest < ActiveSupport::TestCase
   test "local predicate" do
-    assert ActiveSupport::EnvironmentInquirer.new("development").local?
-    assert ActiveSupport::EnvironmentInquirer.new("test").local?
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("development"), :local?
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("test"), :local?
     assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
   end
 

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -213,7 +213,7 @@ class SafeBufferTest < ActiveSupport::TestCase
   test "Should be safe when sliced if original value was safe" do
     new_buffer = @buffer[0, 0]
     assert_not_nil new_buffer
-    assert new_buffer.html_safe?, "should be safe"
+    assert_predicate new_buffer, :html_safe?, "should be safe"
   end
 
   test "Should continue unsafe on slice" do
@@ -294,7 +294,7 @@ class SafeBufferTest < ActiveSupport::TestCase
 
   test "Should interpolate to a safe string" do
     x = "foo %{x} bar".html_safe % { x: "qux" }
-    assert x.html_safe?, "should be safe"
+    assert_predicate x, :html_safe?, "should be safe"
   end
 
   test "Should not affect frozen objects when accessing characters" do

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -207,6 +207,6 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
 
     test_results = test_unit_class.new(:test_assert_changes).run
-    assert test_results.passed?
+    assert_predicate test_results, :passed?
   end
 end

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -257,7 +257,7 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_freeze_time_with_usec_true
     # repeatedly test in case Time.now happened to actually be 0 usec
-    assert 9.times.any? do
+    assert_predicate 9.times, :any? do
       freeze_time(with_usec: true) do
         Time.now.usec != 0
       end

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -110,7 +110,7 @@ class TransliterateTest < ActiveSupport::TestCase
   def test_transliterate_returns_a_copy_of_ascii_strings
     string = "Test String".dup
     assert_not string.frozen?
-    assert string.ascii_only?
+    assert_predicate string, :ascii_only?
     assert_not_equal string.object_id, ActiveSupport::Inflector.transliterate(string).object_id
   end
 end

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -41,7 +41,7 @@ module ApplicationTests
     def assert_file_exists(filename)
       globbed = Dir[filename]
       assert Dir.exist?(File.dirname(filename)), "Directory #{File.dirname(filename)} does not exist"
-      assert globbed.one?, "Found #{globbed.size} files matching #{filename}. All files in the directory: #{Dir.entries(File.dirname(filename)).inspect}"
+      assert_predicate globbed, :one?, "Found #{globbed.size} files matching #{filename}. All files in the directory: #{Dir.entries(File.dirname(filename)).inspect}"
     end
 
     def assert_no_file_exists(filename)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -703,7 +703,7 @@ module ApplicationTests
 
       get "/"
 
-      assert last_response.ok?
+      assert_predicate last_response, :ok?
     end
 
     test "EtagWithFlash module doesn't break for API apps" do
@@ -720,7 +720,7 @@ module ApplicationTests
 
       get "/"
 
-      assert last_response.ok?
+      assert_predicate last_response, :ok?
     end
 
     test "Use key_generator when secret_key_base is set" do
@@ -1444,7 +1444,7 @@ module ApplicationTests
     test "autoloaders" do
       app "development"
 
-      assert Rails.autoloaders.zeitwerk_enabled?
+      assert_predicate Rails.autoloaders, :zeitwerk_enabled?
       assert_instance_of Zeitwerk::Loader, Rails.autoloaders.main
       assert_equal "rails.main", Rails.autoloaders.main.tag
       assert_instance_of Zeitwerk::Loader, Rails.autoloaders.once

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -25,7 +25,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
   test "The integration is minimally looking good" do
     boot
 
-    assert Rails.autoloaders.zeitwerk_enabled?
+    assert_predicate Rails.autoloaders, :zeitwerk_enabled?
     assert_instance_of Zeitwerk::Loader, Rails.autoloaders.main
     assert_instance_of Zeitwerk::Loader, Rails.autoloaders.once
     assert_equal [Rails.autoloaders.main, Rails.autoloaders.once], Rails.autoloaders.to_a
@@ -185,7 +185,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
 
     boot
 
-    assert     Rails.autoloaders.main.reloading_enabled?
+    assert_predicate Rails.autoloaders.main, :reloading_enabled?
     assert_not Rails.autoloaders.once.reloading_enabled?
   end
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -284,7 +284,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     in_plugin_context(destination_root) do
       quietly { system "bundle install" }
       output = `bin/rails db:migrate 2>&1`
-      assert $?.success?, "Command failed: #{output}"
+      assert_predicate $?, :success?, "Command failed: #{output}"
     end
   end
 
@@ -560,7 +560,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     in_plugin_context(destination_root) do
       output = `bin/test 2>&1`
-      assert $?.success?, "Command failed: #{output}"
+      assert_predicate $?, :success?, "Command failed: #{output}"
     end
   end
 


### PR DESCRIPTION
This commit enables `Minitest/AssertPredicate` rubocop rule and autocorrects violations

This is one of the rules which has very little to debate about. Using `assert_predicate` doesn't hurt readability but its greatest benefit in the error message it produces when the assertion fails. While regular `assert` will simply tell "expected false to be truthy" the `assert_predicate` produces a very helpful error message like "expected <your_object_inspect> to be :valid?" i.e. `Expected <Order#asb123 id: 1> to be :shipped?` 


