### PR TITLE
Set load_defaults to current Rails version in bug_report_templates

### DIFF
--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -18,6 +18,8 @@ require "action_mailbox/engine"
 require "tmpdir"
 
 class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+
   config.root = __dir__
   config.hosts << "example.org"
   config.eager_load = false

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -17,6 +17,8 @@ require "action_mailbox/engine"
 require "tmpdir"
 
 class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+
   config.root = __dir__
   config.hosts << "example.org"
   config.eager_load = false

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -17,6 +17,8 @@ require "active_storage/engine"
 require "tmpdir"
 
 class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+
   config.root = __dir__
   config.hosts << "example.org"
   config.eager_load = false

--- a/guides/bug_report_templates/active_storage_main.rb
+++ b/guides/bug_report_templates/active_storage_main.rb
@@ -16,6 +16,8 @@ require "active_storage/engine"
 require "tmpdir"
 
 class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+
   config.root = __dir__
   config.hosts << "example.org"
   config.eager_load = false


### PR DESCRIPTION
Currently only Action Mailbox and Active Storage use initialized apps, so at least in those cases we can ensure the correct defaults are used by bug reporters.