### PR TITLE
[ci-skip][Docs]Add sqlite3_production_warning to configuring guide

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    psych (5.1.0)
+    psych (5.1.1.1)
       stringio
     public_suffix (5.0.1)
     puma (6.3.0)

--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -69,7 +69,9 @@ module ActiveModel
         end
 
         def apply_pending_attribute_modifications(attribute_set)
-          superclass.send(__method__, attribute_set) if superclass.respond_to?(__method__, true)
+          if superclass.respond_to?(:apply_pending_attribute_modifications, true)
+            superclass.send(:apply_pending_attribute_modifications, attribute_set)
+          end
 
           pending_attribute_modifications.each do |modification|
             modification.apply_to(attribute_set)
@@ -78,7 +80,7 @@ module ActiveModel
 
         def reset_default_attributes
           reset_default_attributes!
-          subclasses.each { |subclass| subclass.send(__method__) }
+          subclasses.each { |subclass| subclass.send(:reset_default_attributes) }
         end
 
         def reset_default_attributes!

--- a/activemodel/test/cases/attribute_registration_test.rb
+++ b/activemodel/test/cases/attribute_registration_test.rb
@@ -6,8 +6,19 @@ module ActiveModel
   class AttributeRegistrationTest < ActiveModel::TestCase
     MyType = Class.new(Type::Value)
     Type.register(MyType.name.to_sym, MyType)
+
     TYPE_1 = MyType.new(precision: 1)
     TYPE_2 = MyType.new(precision: 2)
+
+    MyDecorator = DelegateClass(Type::Value) do
+      attr_reader :name
+      alias :cast_type :__getobj__
+
+      def initialize(name, cast_type)
+        super(cast_type)
+        @name = name
+      end
+    end
 
     test "attributes can be registered" do
       attributes = default_attributes_for { attribute :foo, TYPE_1 }
@@ -52,12 +63,12 @@ module ActiveModel
       assert_not_predicate attributes["bar"], :came_from_user?
     end
 
-    test "attribute_types reflects registered attribute types" do
+    test "::attribute_types reflects registered attribute types" do
       klass = class_with { attribute :foo, TYPE_1 }
       assert_same TYPE_1, klass.attribute_types["foo"]
     end
 
-    test "attribute_types returns the default type when key is missing" do
+    test "::attribute_types returns the default type when key is missing" do
       klass = class_with { attribute :foo, TYPE_1 }
       assert_equal Type::Value.new, klass.attribute_types["bar"]
     end
@@ -135,6 +146,90 @@ module ActiveModel
       assert_equal 789, child._default_attributes["bar"].value
       assert_equal 123, parent._default_attributes["foo"].value
       assert_nil parent._default_attributes["bar"].value
+    end
+
+    test "::decorate_attributes decorates specified attributes" do
+      attributes = default_attributes_for do
+        attribute :foo, TYPE_1
+        attribute :bar, TYPE_2
+        attribute :qux, TYPE_2
+        decorate_attributes([:foo, :bar]) { |name, type| MyDecorator.new(name, type) }
+      end
+
+      assert_instance_of MyDecorator, attributes["foo"].type
+      assert_equal "foo", attributes["foo"].type.name
+      assert_same TYPE_1, attributes["foo"].type.cast_type
+
+      assert_instance_of MyDecorator, attributes["bar"].type
+      assert_equal "bar", attributes["bar"].type.name
+      assert_same TYPE_2, attributes["bar"].type.cast_type
+
+      assert_same TYPE_2, attributes["qux"].type
+    end
+
+    test "::decorate_attributes decorates all attributes when none are specified" do
+      attributes = default_attributes_for do
+        attribute :foo, TYPE_1
+        attribute :bar, TYPE_2
+        decorate_attributes { |name, type| MyDecorator.new(name, type) }
+      end
+
+      assert_same TYPE_1, attributes["foo"].type.cast_type
+      assert_same TYPE_2, attributes["bar"].type.cast_type
+    end
+
+    test "::decorate_attributes supports conditional decoration" do
+      attributes = default_attributes_for do
+        attribute :foo, TYPE_1
+        attribute :bar, TYPE_2
+        decorate_attributes { |name, type| MyDecorator.new(name, type) if name.match?(/oo/) }
+      end
+
+      assert_same TYPE_1, attributes["foo"].type.cast_type
+      assert_same TYPE_2, attributes["bar"].type
+    end
+
+    test "::decorate_attributes stacks decorators" do
+      attributes = default_attributes_for do
+        attribute :foo, TYPE_1
+        decorate_attributes { |name, type| MyDecorator.new("#{name}1", type) }
+        decorate_attributes { |name, type| MyDecorator.new("#{name}2", type) }
+      end
+
+      assert_instance_of MyDecorator, attributes["foo"].type
+      assert_equal "foo2", attributes["foo"].type.name
+
+      assert_instance_of MyDecorator, attributes["foo"].type.cast_type
+      assert_equal "foo1", attributes["foo"].type.cast_type.name
+
+      assert_same TYPE_1, attributes["foo"].type.cast_type.cast_type
+    end
+
+    test "superclass attribute types can be decorated" do
+      parent = class_with do
+        attribute :foo, TYPE_1
+      end
+
+      child = class_with(parent) do
+        decorate_attributes { |name, type| MyDecorator.new(name, type) }
+      end
+
+      assert_instance_of MyDecorator, child._default_attributes["foo"].type
+      assert_same TYPE_1, child._default_attributes["foo"].type.cast_type
+      assert_same TYPE_1, parent._default_attributes["foo"].type
+    end
+
+    test "re-registering an attribute overrides previous decorators" do
+      parent = class_with do
+        attribute :foo, TYPE_1
+        decorate_attributes { |name, type| MyDecorator.new(name, type) }
+      end
+
+      child = class_with(parent) do
+        attribute :foo, TYPE_1
+      end
+
+      assert_same TYPE_1, child._default_attributes["foo"].type
     end
 
     private

--- a/activemodel/test/cases/attribute_registration_test.rb
+++ b/activemodel/test/cases/attribute_registration_test.rb
@@ -63,12 +63,12 @@ module ActiveModel
       assert_not_predicate attributes["bar"], :came_from_user?
     end
 
-    test "::attribute_types reflects registered attribute types" do
+    test ".attribute_types reflects registered attribute types" do
       klass = class_with { attribute :foo, TYPE_1 }
       assert_same TYPE_1, klass.attribute_types["foo"]
     end
 
-    test "::attribute_types returns the default type when key is missing" do
+    test ".attribute_types returns the default type when key is missing" do
       klass = class_with { attribute :foo, TYPE_1 }
       assert_equal Type::Value.new, klass.attribute_types["bar"]
     end
@@ -148,7 +148,7 @@ module ActiveModel
       assert_nil parent._default_attributes["bar"].value
     end
 
-    test "::decorate_attributes decorates specified attributes" do
+    test ".decorate_attributes decorates specified attributes" do
       attributes = default_attributes_for do
         attribute :foo, TYPE_1
         attribute :bar, TYPE_2
@@ -167,7 +167,7 @@ module ActiveModel
       assert_same TYPE_2, attributes["qux"].type
     end
 
-    test "::decorate_attributes decorates all attributes when none are specified" do
+    test ".decorate_attributes decorates all attributes when none are specified" do
       attributes = default_attributes_for do
         attribute :foo, TYPE_1
         attribute :bar, TYPE_2
@@ -178,7 +178,7 @@ module ActiveModel
       assert_same TYPE_2, attributes["bar"].type.cast_type
     end
 
-    test "::decorate_attributes supports conditional decoration" do
+    test ".decorate_attributes supports conditional decoration" do
       attributes = default_attributes_for do
         attribute :foo, TYPE_1
         attribute :bar, TYPE_2
@@ -189,7 +189,7 @@ module ActiveModel
       assert_same TYPE_2, attributes["bar"].type
     end
 
-    test "::decorate_attributes stacks decorators" do
+    test ".decorate_attributes stacks decorators" do
       attributes = default_attributes_for do
         attribute :foo, TYPE_1
         decorate_attributes { |name, type| MyDecorator.new("#{name}1", type) }

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -214,7 +214,9 @@ module ActiveRecord
 
           column_serializer = build_column_serializer(attr_name, coder, type, yaml)
 
-          attribute(attr_name, **options) do |cast_type|
+          attribute(attr_name, **options)
+
+          decorate_attributes([attr_name]) do |attr_name, cast_type|
             if type_incompatible_with_serialize?(cast_type, coder, type)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -69,14 +69,14 @@ module ActiveRecord
       end
 
       module ClassMethods # :nodoc:
-        def define_attribute(name, cast_type, **)
-          if create_time_zone_conversion_attribute?(name, cast_type)
-            cast_type = TimeZoneConverter.new(cast_type)
-          end
-          super
-        end
-
         private
+          def hook_attribute_type(name, cast_type)
+            if create_time_zone_conversion_attribute?(name, cast_type)
+              cast_type = TimeZoneConverter.new(cast_type)
+            end
+            super
+          end
+
           def create_time_zone_conversion_attribute?(name, cast_type)
             enabled_for_column = time_zone_aware_attributes &&
               !skip_time_zone_conversion_for_attributes.include?(name.to_sym)

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -74,6 +74,7 @@ module ActiveRecord
             if create_time_zone_conversion_attribute?(name, cast_type)
               cast_type = TimeZoneConverter.new(cast_type)
             end
+
             super
           end
 

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -6,12 +6,13 @@ module ActiveRecord
   # See ActiveRecord::Attributes::ClassMethods for documentation
   module Attributes
     extend ActiveSupport::Concern
+    include ActiveModel::AttributeRegistration
 
-    included do
-      class_attribute :attributes_to_define_after_schema_loads, instance_accessor: false, default: {} # :internal:
-    end
     # = Active Record \Attributes
     module ClassMethods
+      # :method: attribute
+      # :call-seq: attribute(name, cast_type = nil, **options)
+      #
       # Defines an attribute with a type on this model. It will override the
       # type of existing attributes if needed. This allows control over how
       # values are converted to and from SQL when assigned to a model. It also
@@ -205,37 +206,13 @@ module ActiveRecord
       # tracking is performed. The methods +changed?+ and +changed_in_place?+
       # will be called from ActiveModel::Dirty. See the documentation for those
       # methods in ActiveModel::Type::Value for more details.
-      def attribute(name, cast_type = nil, default: NO_DEFAULT_PROVIDED, **options)
-        name = name.to_s
-        name = attribute_aliases[name] || name
-
-        reload_schema_from_cache
-
-        case cast_type
-        when Symbol
-          cast_type = Type.lookup(cast_type, **options, adapter: Type.adapter_name_from(self))
-        when nil
-          if (prev_cast_type, prev_default = attributes_to_define_after_schema_loads[name])
-            default = prev_default if default == NO_DEFAULT_PROVIDED
-          else
-            prev_cast_type = -> subtype { subtype }
-          end
-
-          cast_type = if block_given?
-            -> subtype { yield Proc === prev_cast_type ? prev_cast_type[subtype] : prev_cast_type }
-          else
-            prev_cast_type
-          end
-        end
-
-        self.attributes_to_define_after_schema_loads =
-          attributes_to_define_after_schema_loads.merge(name => [cast_type, default])
-      end
+      #
+      #--
+      # Implemented by ActiveModel::AttributeRegistration#attribute.
 
       # This is the low level API which sits beneath +attribute+. It only
       # accepts type objects, and will do its work immediately instead of
-      # waiting for the schema to load. Automatic schema detection and
-      # ClassMethods#attribute both call this under the hood. While this method
+      # waiting for the schema to load. While this method
       # is provided so it can be used by plugin authors, application code
       # should probably use ClassMethods#attribute.
       #
@@ -260,13 +237,24 @@ module ActiveRecord
         define_default_attribute(name, default, cast_type, from_user: user_provided_default)
       end
 
-      def load_schema! # :nodoc:
-        super
-        attributes_to_define_after_schema_loads.each do |name, (cast_type, default)|
-          cast_type = cast_type[type_for_attribute(name)] if Proc === cast_type
-          define_attribute(name, cast_type, default: default)
+      def _default_attributes # :nodoc:
+        @default_attributes ||= begin
+          attributes_hash = columns_hash.transform_values do |column|
+            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
+          end
+
+          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
+          apply_pending_attribute_modifications(attribute_set)
+          attribute_set
         end
       end
+
+      def reload_schema_from_cache(*)
+        reset_default_attributes!
+        super
+      end
+
+      alias :reset_default_attributes :reload_schema_from_cache
 
       private
         NO_DEFAULT_PROVIDED = Object.new # :nodoc:
@@ -286,6 +274,14 @@ module ActiveRecord
             default_attribute = ActiveModel::Attribute.from_database(name, value, type)
           end
           _default_attributes[name] = default_attribute
+        end
+
+        def resolve_type_name(name, **options)
+          Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
+        end
+
+        def type_for_column(column)
+          hook_attribute_type(column.name, super)
         end
     end
   end

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           def encrypt_attribute(name, key_provider: nil, key: nil, deterministic: false, support_unencrypted_data: nil, downcase: false, ignore_case: false, previous: [], **context_properties)
             encrypted_attributes << name.to_sym
 
-            attribute name do |cast_type|
+            decorate_attributes([name]) do |name, cast_type|
               scheme = scheme_for key_provider: key_provider, key: key, deterministic: deterministic, support_unencrypted_data: support_unencrypted_data, \
                 downcase: downcase, ignore_case: ignore_case, previous: previous, **context_properties
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -187,6 +187,7 @@ module ActiveRecord
               if lock_optimistically && name == locking_column
                 cast_type = LockingType.new(cast_type)
               end
+
               super
             end
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -182,14 +182,14 @@ module ActiveRecord
             super
           end
 
-          def define_attribute(name, cast_type, **) # :nodoc:
-            if lock_optimistically && name == locking_column
-              cast_type = LockingType.new(cast_type)
-            end
-            super
-          end
-
           private
+            def hook_attribute_type(name, cast_type)
+              if lock_optimistically && name == locking_column
+                cast_type = LockingType.new(cast_type)
+              end
+              super
+            end
+
             def inherited(base)
               super
               base.class_eval do

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -435,11 +435,6 @@ module ActiveRecord
         end
       end
 
-      def attribute_types # :nodoc:
-        load_schema
-        @attribute_types ||= Hash.new(Type.default_value)
-      end
-
       def yaml_encoder # :nodoc:
         @yaml_encoder ||= ActiveModel::AttributeSet::YAMLEncoder.new(attribute_types)
       end
@@ -491,11 +486,6 @@ module ActiveRecord
       def column_defaults
         load_schema
         @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
-      end
-
-      def _default_attributes # :nodoc:
-        load_schema
-        @default_attributes ||= ActiveModel::AttributeSet.new({})
       end
 
       # Returns an array of column names as strings.
@@ -577,9 +567,7 @@ module ActiveRecord
           @arel_table = nil
           @column_names = nil
           @symbol_column_to_string_name_hash = nil
-          @attribute_types = nil
           @content_columns = nil
-          @default_attributes = nil
           @column_defaults = nil
           @attributes_builder = nil
           @columns = nil
@@ -616,17 +604,7 @@ module ActiveRecord
           columns_hash = connection.schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
-          @columns_hash.each do |name, column|
-            type = connection.lookup_cast_type_from_column(column)
-            type = _convert_type_from_options(type)
-            define_attribute(
-              name,
-              type,
-              default: column.default,
-              user_provided_default: false
-            )
-            alias_attribute :id_value, :id if name == "id"
-          end
+          alias_attribute :id_value, :id if @columns_hash.key?("id")
 
           super
         end
@@ -654,12 +632,12 @@ module ActiveRecord
           end
         end
 
-        def _convert_type_from_options(type)
+        def type_for_column(column)
+          type = connection.lookup_cast_type_from_column(column)
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
-            type.to_immutable_string
-          else
-            type
+            type = type.to_immutable_string
           end
+          type
         end
     end
   end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -634,9 +634,11 @@ module ActiveRecord
 
         def type_for_column(column)
           type = connection.lookup_cast_type_from_column(column)
+
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string
           end
+
           type
         end
     end

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -78,10 +78,8 @@ module ActiveRecord # :nodoc:
       #
       #   User.normalize_value_for(:phone, "+1 (555) 867-5309") # => "5558675309"
       def normalizes(*names, with:, apply_to_nil: false)
-        names.each do |name|
-          attribute(name) do |cast_type|
-            NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)
-          end
+        decorate_attributes(names) do |name, cast_type|
+          NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)
         end
 
         self.normalized_attributes += names.map(&:to_sym)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -128,7 +128,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     Topic.reset_column_information
 
-    Topic.connection.stub(:lookup_cast_type_from_column, ->(_) { raise "Some Error" }) do
+    Topic.connection.stub(:schema_cache, -> { raise "Some Error" }) do
       assert_raises RuntimeError do
         Topic.columns_hash
       end

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -17,6 +17,7 @@ module ActiveSupport
     SUPPRESSED_WARNINGS = Regexp.union(
       # TODO: remove if https://github.com/mikel/mail/pull/1557 or similar fix
       %r{/lib/mail/parsers/.*statement not reached},
+      %r{/lib/mail/parsers/.*assigned but unused variable - disp_type_s},
       %r{/lib/mail/parsers/.*assigned but unused variable - testEof}
     )
 

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -9,6 +9,7 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.1.0"
+  gem "psych"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -9,7 +9,6 @@ gemfile(true) do
 
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.1.0"
-  gem "psych"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/action_controller_main.rb
+++ b/guides/bug_report_templates/action_controller_main.rb
@@ -8,7 +8,6 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "rack", "~> 2.0"
 end
 
 require "action_controller/railtie"

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -8,7 +8,6 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "rack", "~> 2.0"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_storage_main.rb
+++ b/guides/bug_report_templates/active_storage_main.rb
@@ -8,7 +8,6 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   gem "rails", github: "rails/rails", branch: "main"
-  gem "rack", "~> 2.0"
   gem "sqlite3"
 end
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -407,10 +407,21 @@ production:
   primary_shard_one:
     database: my_primary_shard_one
     adapter: mysql2
+    migrations_paths: db/migrate_shards
   primary_shard_one_replica:
     database: my_primary_shard_one
     adapter: mysql2
     replica: true
+    migrations_paths: db/migrate_shards
+  primary_shard_two:
+    database: my_primary_shard_two
+    adapter: mysql2
+    migrations_paths: db/migrate_shards
+  primary_shard_two_replica:
+    database: my_primary_shard_two
+    adapter: mysql2
+    replica: true
+    migrations_paths: db/migrate_shards
 ```
 
 Models are then connected with the `connects_to` API via the `shards` key:
@@ -419,18 +430,27 @@ Models are then connected with the `connects_to` API via the `shards` key:
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  connects_to database: { writing: :primary, reading: :primary_replica }
+end
+
+class ShardRecord < ApplicationRecord
   connects_to shards: {
-    default: { writing: :primary, reading: :primary_replica },
     shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+    shard_two: { writing: :primary_shard_two, reading: :primary_shard_two_replica }
   }
 end
 ```
 
-You are not required to use `default` as the first shard name. Rails will assume the first
-shard name in the `connects_to` hash is the "default" connection. This connection is used
-internally to load type data and other information where the schema is the same across shards.
+If you're using shards, make sure to set the `migrations_paths` to the same path for
+all the shards. When generating a migration you can pass the `--database` option and
+use one of the shard names. Since they all set the same path, it doesn't matter which
+one you choose.
 
-Then models can swap connections manually via the `connected_to` API. If
+```
+$ bin/rails g scaffold Dog name:string --database primary_shard_one
+```
+
+Then models can swap shards manually via the `connected_to` API. If
 using sharding, both a `role` and a `shard` must be passed:
 
 ```ruby

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -428,12 +428,14 @@ Models are then connected with the `connects_to` API via the `shards` key:
 
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
+  primary_abstract_class
 
   connects_to database: { writing: :primary, reading: :primary_replica }
 end
 
 class ShardRecord < ApplicationRecord
+  self.abstract_class = true
+
   connects_to shards: {
     shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
     shard_two: { writing: :primary_shard_two, reading: :primary_shard_two_replica }

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -437,7 +437,7 @@ class ShardRecord < ApplicationRecord
   self.abstract_class = true
 
   connects_to shards: {
-    shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+    shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica },
     shard_two: { writing: :primary_shard_two, reading: :primary_shard_two_replica }
   }
 end

--- a/guides/source/classic_to_zeitwerk_howto.md
+++ b/guides/source/classic_to_zeitwerk_howto.md
@@ -133,7 +133,7 @@ All is good!
 
 There can be additional output depending on the application configuration, but the last "All is good!" is what you are looking for.
 
-If the double-check explained in the previous section determined actually there have to be some custom autoload paths outside the eager load paths, the task will detect and warn about them. However, if the test suite loads those files successfully, you're good.
+If the double-check explained in the previous section determined that there have to be some custom autoload paths outside the eager load paths, the task will detect and warn about them. However, if the test suite loads those files successfully, you're good.
 
 Now, if there's any file that does not define the expected constant, the task will tell you. It does so one file at a time, because if it moved on, the failure loading one file could cascade into other failures unrelated to the check we want to run and the error report would be confusing.
 
@@ -147,7 +147,7 @@ Hold on, I am eager loading the application.
 expected file app/models/vat.rb to define constant Vat
 ```
 
-VAT is an European tax. The file `app/models/vat.rb` defines `VAT` but the autoloader expects `Vat`, why?
+VAT is a European tax. The file `app/models/vat.rb` defines `VAT` but the autoloader expects `Vat`, why?
 
 ### Acronyms
 
@@ -198,7 +198,7 @@ By default, `app/models/concerns` belongs to the autoload paths and therefore it
 
 If your application uses `Concerns` as namespace, you have two options:
 
-1. Remove the `Concerns` namespace from those classes and modules and update client code.
+1. Remove the `Concerns` namespace from those classes and modules and update the client code.
 2. Leave things as they are by removing `app/models/concerns` from the autoload paths:
 
   ```ruby
@@ -455,7 +455,7 @@ Delete any `require` Calls
 
 In my experience, projects generally do not do this. But I've seen a couple, and have heard of a few others.
 
-In Rails application you use `require` exclusively to load code from `lib` or from 3rd party like gem dependencies or the standard library. **Never load autoloadable application code with `require`**. See why this was a bad idea already in `classic` [here](https://guides.rubyonrails.org/v6.1/autoloading_and_reloading_constants_classic_mode.html#autoloading-and-require).
+In a Rails application you use `require` exclusively to load code from `lib` or from 3rd party like gem dependencies or the standard library. **Never load autoloadable application code with `require`**. See why this was a bad idea already in `classic` [here](https://guides.rubyonrails.org/v6.1/autoloading_and_reloading_constants_classic_mode.html#autoloading-and-require).
 
 ```ruby
 require "nokogiri" # GOOD

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1935,19 +1935,19 @@ config.action_dispatch.rescue_responses = {
   'ActionController::RoutingError' => :not_found,
   'AbstractController::ActionNotFound' => :not_found,
   'ActionController::MethodNotAllowed' => :method_not_allowed,
-  'ActionController::UnknownHttpMethod'=> :method_not_allowed,
+  'ActionController::UnknownHttpMethod' => :method_not_allowed,
   'ActionController::NotImplemented' => :not_implemented,
-  'ActionController::UnknownFormat'=> :not_acceptable,
+  'ActionController::UnknownFormat' => :not_acceptable,
   'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
-  'ActionController::InvalidCrossOriginRequest'=> :unprocessable_entity,
+  'ActionController::InvalidCrossOriginRequest' => :unprocessable_entity,
   'ActionDispatch::Http::Parameters::ParseError' => :bad_request,
   'ActionController::BadRequest' => :bad_request,
   'ActionController::ParameterMissing' => :bad_request,
-  'Rack::QueryParser::ParameterTypeError'=> :bad_request,
+  'Rack::QueryParser::ParameterTypeError' => :bad_request,
   'Rack::QueryParser::InvalidParameterError' => :bad_request,
   'ActiveRecord::RecordNotFound' => :not_found,
   'ActiveRecord::StaleObjectError' => :conflict,
-  'ActiveRecord::RecordInvalid'=> :unprocessable_entity,
+  'ActiveRecord::RecordInvalid' => :unprocessable_entity,
   'ActiveRecord::RecordNotSaved' => :unprocessable_entity
 }
 ```
@@ -3552,7 +3552,7 @@ Database Pooling
 
 Active Record database connections are managed by `ActiveRecord::ConnectionAdapters::ConnectionPool` which ensures that a connection pool synchronizes the amount of thread access to a limited number of database connections. This limit defaults to 5 and can be configured in `database.yml`.
 
-```ruby
+```yaml
 development:
   adapter: sqlite3
   database: storage/development.sqlite3
@@ -3568,7 +3568,7 @@ If you try to use more connections than are available, Active Record will block
 you and wait for a connection from the pool. If it cannot get a connection, a
 timeout error similar to that given below will be thrown.
 
-```ruby
+```
 ActiveRecord::ConnectionTimeoutError - could not obtain a database connection within 5.000 seconds (waited 5.000 seconds)
 ```
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1463,6 +1463,7 @@ The default value depends on the `config.load_defaults` target version:
 Specifies whether a warning should be raised when using SQLite3 in production environment.
 
 The default value is `true`
+
 #### `config.active_record.async_query_executor`
 
 Specifies how asynchronous queries are pooled.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2802,7 +2802,7 @@ Accepts an array of strings indicating the content types that Active Storage all
 By default, this is defined as:
 
 ```ruby
-config.active_storage.content_types_allowed_inline` = %w(image/png image/gif image/jpeg image/tiff image/vnd.adobe.photoshop image/vnd.microsoft.icon application/pdf)
+config.active_storage.content_types_allowed_inline = %w(image/png image/gif image/jpeg image/tiff image/vnd.adobe.photoshop image/vnd.microsoft.icon application/pdf)
 ```
 
 #### `config.active_storage.queues.analysis`

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1462,13 +1462,7 @@ The default value depends on the `config.load_defaults` target version:
 
 Specifies whether a warning should be raised when using SQLite3 in production environment.
 
-The default value depends on the `config.load_defaults` target version:
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `false`              |
-| 7.0                   | `true`               |
-
+The default value is `true`
 #### `config.active_record.async_query_executor`
 
 Specifies how asynchronous queries are pooled.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1458,6 +1458,17 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 7.1                   | `true`               |
 
+#### `config.active_record.sqlite3_production_warning`
+
+Specifies whether a warning should be raised when using SQLite3 in production environment.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.0                   | `true`               |
+
 #### `config.active_record.async_query_executor`
 
 Specifies how asynchronous queries are pooled.

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -578,7 +578,7 @@ module Rails
     end
 
     initializer :set_eager_load_paths, before: :bootstrap_hook do
-      ActiveSupport::Dependencies._eager_load_paths.merge(config.eager_load_paths)
+      ActiveSupport::Dependencies._eager_load_paths.merge(config.all_eager_load_paths)
       config.eager_load_paths.freeze
     end
 
@@ -705,14 +705,14 @@ module Rails
       end
 
       def _all_autoload_once_paths
-        config.autoload_once_paths.uniq
+        config.all_autoload_once_paths.uniq
       end
 
       def _all_autoload_paths
         @_all_autoload_paths ||= begin
-          autoload_paths  = config.autoload_paths
-          autoload_paths += config.eager_load_paths
-          autoload_paths -= config.autoload_once_paths
+          autoload_paths  = config.all_autoload_paths
+          autoload_paths += config.all_eager_load_paths
+          autoload_paths -= config.all_autoload_once_paths
           autoload_paths.uniq
         end
       end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -9,12 +9,45 @@ module Rails
       attr_accessor :middleware, :javascript_path
       attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths
 
+      # An array of custom autoload paths to be added to the ones defined
+      # automatically by Rails. These won't be eager loaded, unless you push
+      # them to +eager_load_paths+ too, which is recommended.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib+.
+      attr_reader :autoload_paths
+
+      # An array of custom autoload once paths. These won't be eager loaded
+      # unless you push them to +eager_load_paths+ too, which is recommended.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib_once+.
+      attr_reader :autoload_once_paths
+
+      # An array of custom eager load paths to be added to the ones defined
+      # automatically by Rails. Anything in this collection is considered to be
+      # an autoload path regardless of whether it was added to +autoload_paths+.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib+.
+      attr_reader :eager_load_paths
+
       def initialize(root = nil)
         super()
         @root = root
         @generators = app_generators.dup
         @middleware = Rails::Configuration::MiddlewareStackProxy.new
         @javascript_path = "javascript"
+
+        @autoload_paths = []
+        @autoload_once_paths = []
+        @eager_load_paths = []
       end
 
       # Holds generators configuration:
@@ -81,16 +114,22 @@ module Rails
         @root = paths.path = Pathname.new(value).expand_path
       end
 
-      def eager_load_paths
-        @eager_load_paths ||= paths.eager_load
+      # Private method that adds custom autoload paths to the ones defined by
+      # +paths+.
+      def all_autoload_paths # :nodoc:
+        autoload_paths + paths.autoload_paths
       end
 
-      def autoload_once_paths
-        @autoload_once_paths ||= paths.autoload_once
+      # Private method that adds custom autoload once paths to the ones defined
+      # by +paths+.
+      def all_autoload_once_paths # :nodoc:
+        autoload_once_paths + paths.autoload_once
       end
 
-      def autoload_paths
-        @autoload_paths ||= paths.autoload_paths
+      # Private method that adds custom eager load paths to the ones defined by
+      # +paths+.
+      def all_eager_load_paths # :nodoc:
+        eager_load_paths + paths.eager_load
       end
     end
   end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -52,6 +52,7 @@ group :development do
   # gem "spring"
 <%- if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" -%>
 
+  # Highlight the fine-grained location where an error occurred [https://github.com/ruby/error_highlight]
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 <%- end -%>
 end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -50,8 +50,8 @@ group :development do
 <%- end -%>
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-
 <%- if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" -%>
+
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 <%- end -%>
 end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -720,7 +720,11 @@ class ActionsTest < Rails::Generators::TestCase
 
   private
     def action(...)
-      capture(:stdout) { generator.send(...) }
+      if ENV["RAILS_LOG_TO_STDOUT"] == "true"
+        generator.send(...)
+      else
+        capture(:stdout) { generator.send(...) }
+      end
     end
 
     def revoke(...)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `config.active_record.sqlite3_production_warning` config that was merged as https://github.com/rails/rails/pull/42191 in [Rails 7.0.0.alpha1](https://github.com/rails/rails/blob/7-0-stable/activerecord/CHANGELOG.md#rails-700alpha1-september-15-2021) still has not been added to the configuring guide.

### Detail

This Pull Request adds the entry for `config.active_record.sqlite3_production_warning`.

### Additional information

As far as I see, the current config entries for Active Record are unsorted and I'm a bit wondering if the line I added is appropriate or not. This time I added it to the next line of `sqlite3_adapter_strict_strings_by_default`.

Or if you think adding `config.active_record.sqlite3_production_warning` to the configuring guide is redundant because the warning indicates the one, just close the PR.

```
Oct 14 05:38:10 PM  W, [2023-10-14T08:38:07.617001 #1]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
```

cc: @intrip

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`