### PR TITLE
ActionCable PostgreSQL adapter: support payloads larger than 8000 bytes

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Support large payloads in Action Cable's PostgreSQL adapter.
+
+    *David Backeus*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
**UPDATE:** Since getting this enhanced merged into rails might take some time I've released [a gem](https://rubygems.org/gems/actioncable-enhanced-postgresql-adapter) which can be used in the meantime. Documentation can be found in the [GitHub README](https://github.com/reclaim-the-stack/actioncable-enhanced-postgresql-adapter#readme).

### Motivation / Background

PostgreSQL's `NOTIFY` command which is used by the ActionCable PostgreSQL adapter has a hard coded payload limit of 8000 bytes. As stated in the [NOTIFY docs](https://www.postgresql.org/docs/16/sql-notify.html):

> The “payload” string to be communicated along with the notification. This must be specified as a simple string literal. In the default configuration it must be shorter than 8000 bytes. (If binary data or large amounts of information need to be communicated, it's best to put it in a database table and send the key of the record.)

Note that the limit can not be reconfigured, even though the documentation makes it seem like it by mentioning "default configuration".

In practice this implies that whenever `ActionCable::SubscriptionAdapter::PostgreSQL#broadcast` is invoked with a large payload it will fail with the `PG::InvalidParameterValue: ERROR: payload string too long` exception.

When googling for information about this adapter, this issue surfaced in quite a few places and seems to be a major reason why it sees so little real world usage.

Also, given the push from 37 signals to move caching and queuing to the SQL database layer via Solid Cache / Solid Queue this leaves only ActionCable left to enable a super simple "SQL database only" deployment possibility for a fully featured Rails app. Which was a big motivation for me to look into solving this issue.

### Detail

This Pull Request evolves the implementation of the adapter by following the advice given in the Postgres documentation, ie. to store large payloads in a table, then pass the record ID as the message payload, then fetch the payload from the table when running the listener callback.

Documentation is provided in the Rails Guides for how to create the table. If no table exists, instead of the previous `PG::InvalidParameterValue` exception, a helpful custom exception will be raised instead, linking to the documentation.

### Additional information

#### Performance

Storing and fetching payloads from a table will clearly have a performance impact. However, since the approach is used only for payloads violating the limit, and only if a dedicated table has been explicitly created, this PR avoids any performance implications for existing users (if there even are any 😅).

#### Alternatives / ideas

Having to manually create the large payloads table doesn't make for a completely seamless developer experience. I considered lazily creating the table "on the fly" as needed. However this might go too far in hiding what's going on in the database from the developer, it would also create confusing diffs from `db:schema:dump` which would now include the lazily created table unless we also add the table to `ActiveRecord::SchemaDumper.ignore_tables` during Rails boot.

Not having built in expiry of old payloads could be reconsidered. One approach of doing it would be to delete old payloads at the same time as we insert new entries (simiilar to how [Solid Cache approaches this problem](https://github.com/rails/solid_cache/blob/e4865809025d650736d818fce26d09737f6623b1/lib/solid_cache/cluster/expiry.rb#L6-L7)). To avoid too much database churn we could do it for every 100 or 1000 messages by looking at the auto incrementing ID returned during insert-time. Feedback appreciated!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
