### PR TITLE
Do not memoize auto/eager load paths in engines

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -578,7 +578,7 @@ module Rails
     end
 
     initializer :set_eager_load_paths, before: :bootstrap_hook do
-      ActiveSupport::Dependencies._eager_load_paths.merge(config.eager_load_paths)
+      ActiveSupport::Dependencies._eager_load_paths.merge(config.all_eager_load_paths)
       config.eager_load_paths.freeze
     end
 
@@ -705,14 +705,14 @@ module Rails
       end
 
       def _all_autoload_once_paths
-        config.autoload_once_paths.uniq
+        config.all_autoload_once_paths.uniq
       end
 
       def _all_autoload_paths
         @_all_autoload_paths ||= begin
-          autoload_paths  = config.autoload_paths
-          autoload_paths += config.eager_load_paths
-          autoload_paths -= config.autoload_once_paths
+          autoload_paths  = config.all_autoload_paths
+          autoload_paths += config.all_eager_load_paths
+          autoload_paths -= config.all_autoload_once_paths
           autoload_paths.uniq
         end
       end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -9,12 +9,45 @@ module Rails
       attr_accessor :middleware, :javascript_path
       attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths
 
+      # An array of custom autoload paths to be added to the ones defined
+      # automatically by Rails. These won't be eager loaded, unless you push
+      # them to +eager_load_paths+ too, which is recommended.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib+.
+      attr_reader :autoload_paths
+
+      # An array of custom autoload once paths. These won't be eager loaded
+      # unless you push them to +eager_load_paths+ too, which is recommended.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib_once+.
+      attr_reader :autoload_once_paths
+
+      # An array of custom eager load paths to be added to the ones defined
+      # automatically by Rails. Anything in this collection is considered to be
+      # an autoload path regardless of whether it was added to +autoload_paths+.
+      #
+      # This collection is empty by default, it accepts strings and +Pathname+
+      # objects.
+      #
+      # If you'd like to add +lib+ to it, please see +autoload_lib+.
+      attr_reader :eager_load_paths
+
       def initialize(root = nil)
         super()
         @root = root
         @generators = app_generators.dup
         @middleware = Rails::Configuration::MiddlewareStackProxy.new
         @javascript_path = "javascript"
+
+        @autoload_paths = []
+        @autoload_once_paths = []
+        @eager_load_paths = []
       end
 
       # Holds generators configuration:
@@ -81,16 +114,22 @@ module Rails
         @root = paths.path = Pathname.new(value).expand_path
       end
 
-      def eager_load_paths
-        @eager_load_paths ||= paths.eager_load
+      # Private method that adds custom autoload paths to the ones defined by
+      # +paths+.
+      def all_autoload_paths # :nodoc:
+        autoload_paths + paths.autoload_paths
       end
 
-      def autoload_once_paths
-        @autoload_once_paths ||= paths.autoload_once
+      # Private method that adds custom autoload once paths to the ones defined
+      # by +paths+.
+      def all_autoload_once_paths # :nodoc:
+        autoload_once_paths + paths.autoload_once
       end
 
-      def autoload_paths
-        @autoload_paths ||= paths.autoload_paths
+      # Private method that adds custom eager load paths to the ones defined by
+      # +paths+.
+      def all_eager_load_paths # :nodoc:
+        eager_load_paths + paths.eager_load
       end
     end
   end


### PR DESCRIPTION
## Root issue

Rails 3 introduced engines and the way to configure them.

In particular, there are two ways to manipulate the auto/eager load paths:

1. Defining `paths` with corresponding options, as in

    ```ruby
    paths.add "app/models", eager_load: true
    ```

2. Pushing custom paths to `config.{autoload,autoload_once,eager_load}_paths)`.

For example, applications can do this:

```ruby
config.paths["app/helpers"] << "#{Rails.root}/custom/helpers"
config.eager_load_paths << "#{Rails.root}/extras"
```

However, due to some internal memoizations, if you did that the other way around:

```ruby
config.eager_load_paths << "#{Rails.root}/extras"
config.paths["app/helpers"] << "#{Rails.root}/custom/helpers"
```

then `custom/helpers` would **not** end up in the autoload and eager load paths. This is wrong.

## Fix

To fix this, we let `config.autoload_paths` and friends do what the documentation says: These are collections where you put your custom stuff, period. Before, they would also collect and memoize what was in place at the time of the call via `paths`, which led to the bug explained above.

So, you can use both (1) and (2) now, and they won't interfere.

## It's been +13 years, why now?

Newly generated Rails 7.1 applications by default push `lib` to `config.eager_load_paths`. If they are used together with something that edits `config.paths` afterwards, that latent bug now surfaces. I guess this combination, while possible, was not happening much in practice until now.

## Extra ball

Since I was on it, the patch adds API documentation for them.

Fixes #49629.