### PR TITLE
Introduce `ActiveModel::NestedAttributes`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Introduce `ActiveModel::NestedAttributes`
+
+    Handle assignment of `_attributes`-suffixed values in an ActionView- and
+    ActionPack-compliant way:
+
+    ```ruby
+    class Article
+      include ActiveModel::Model
+      include ActiveModel::NestedAttributes
+
+      attr_accessor :author
+      attr_accessor :tags
+
+      accepts_nested_attributes_for :author, class_name: Author
+      accepts_nested_attributes_for :tags, class_name: Tag
+    end
+
+
+    article = Article.new(
+      author_attributes: { name: "Pseudo Nym" },
+      tags_attributes: {
+         0 => { name: "actionview" },
+         1 => { name: "actionpack" },
+      }
+    )
+
+    article.author.name # => "Pseudo Nym"
+    article.tags.pluck(:name) # => ["actionview", "actionpack"]
+    ```
+
+    *Sean Doyle*
+
 *   Changes `ActiveModel::Validations#read_attribute_for_validation` to return `nil` if the record doesn't
     respond to the attribute instead of raising an error.
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -49,6 +49,7 @@ module ActiveModel
   autoload :Model
   autoload :Name, "active_model/naming"
   autoload :Naming
+  autoload :NestedAttributes
   autoload :SecurePassword
   autoload :Serialization
   autoload :Translation

--- a/activemodel/lib/active_model/nested_attributes.rb
+++ b/activemodel/lib/active_model/nested_attributes.rb
@@ -1,0 +1,582 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash/except"
+require "active_support/inflector"
+require "active_support/hash_with_indifferent_access"
+
+module ActiveModel
+  module NestedAttributes
+    extend ActiveSupport::Concern
+
+    class TooManyModels < ArgumentError
+    end
+
+    included do
+      class_attribute :nested_attributes_options, instance_writer: false, default: {}
+    end
+
+    # = Active Model Nested \Attributes
+    #
+    # Nested attributes allow you to write attributes on associated models
+    # through the parent. By default nested attribute writing is turned off
+    # and you can enable it using the accepts_nested_attributes_for class
+    # method. When you enable nested attributes an attribute writer is
+    # defined on the model.
+    #
+    # The attribute writer is named after the association, which means that
+    # in the following example, two new methods are added to your model:
+    #
+    # <tt>author_attributes=(attributes)</tt> and
+    # <tt>pages_attributes=(attributes)</tt>.
+    #
+    #   class Book
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :author
+    #     attr_accessor :pages
+    #
+    #     accepts_nested_attributes_for :author, class_name: Author
+    #     accepts_nested_attributes_for :pages, class_name: Page
+    #   end
+    #
+    # === One-to-one
+    #
+    # Consider a Member model that has an +:avatar+ attribute:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :avatar
+    #     accepts_nested_attributes_for :avatar, class_name: Avatar
+    #   end
+    #
+    # Enabling nested attributes on a one-to-one association allows you to
+    # create the member and avatar in one go:
+    #
+    #   params = { member: { name: "Jack", avatar_attributes: { icon: "smiling" } } }
+    #   member = Member.new(params[:member])
+    #   member.name # => "Jack"
+    #   member.avatar.icon # => "smiling"
+    #
+    # It also allows you to write to the avatar through the member:
+    #
+    #   params = { member: { avatar_attributes: { id: "2", icon: "sad" } } }
+    #   member.assign_attributes params[:member]
+    #   member.avatar.icon # => "sad"
+    #
+    # Note When defining nested attributes defined through +attr_accessor+ or
+    # +attr_write+, Active Model will infer a one-to-one relationship for
+    # singular attribute names. To force a one-to-one relationship, pass
+    # <tt>array: false</tt>:
+    #
+    #   class Shepherd
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :sheep
+    #     accepts_nested_attributes_for :sheep, array: false, class_name: Sheep
+    #   end
+    #
+    # If you omit the <tt>:class_name</tt> option, the class is responsible
+    # for defining a method to build instances from the attributes. In the
+    # case of this example, the Member class must define a
+    # <tt>build_avatar</tt> method:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :avatar
+    #     accepts_nested_attributes_for :avatar
+    #
+    #     def build_avatar(attributes)
+    #       Avatar.new(attributes)
+    #     end
+    #   end
+    #
+    # Note that the presence of a <tt>build_</tt>-prefixed method will have
+    # precedent over a <tt>:class_name</tt> option when both are available.
+    #
+    # By default you will only be able to set attributes on the
+    # associated model. If you want to destroy the associated model through the
+    # attributes hash, you have to enable it first using the
+    # <tt>:allow_destroy</tt> option.
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :avatar
+    #     accepts_nested_attributes_for :avatar, class_name: Avatar, allow_destroy: true
+    #   end
+    #
+    # Now, when you add the <tt>_destroy</tt> key to the attributes hash, with a
+    # value that evaluates to +true+, you will unassign the associated model:
+    #
+    #   member.avatar_attributes = { _destroy: "1" }
+    #   member.avatar # => nil
+    #
+    # If you add the <tt>_destroy</tt> key to the attributes hash and the
+    # assigned instance responds to <tt>mark_for_destruction?</tt>, assignment
+    # will call that method on the associated model:
+    #
+    #   member.avatar_attributes = { _destroy: "1" }
+    #   member.avatar.marked_for_destruction? # => true
+    #
+    # Note that the model will _not_ be unassigned automatically. It is the
+    # parent's responsibility to remove models marked for destruction.
+    #
+    # You may also set a +:reject_if+ proc to silently ignore any new record
+    # hashes if they fail to pass your criteria. For example, the previous
+    # example could be rewritten as:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :avatar
+    #     accepts_nested_attributes_for :avatar, class_name: Avatar,
+    #       reject_if: proc { |attributes| attributes["icon"].blank? }
+    #   end
+    #
+    #   params = { member: { name: "joe", avatar_attributes: { icon: "" } } }
+    #
+    #   member = Member.new(params[:member])
+    #   member.icon # => nil
+    #
+    # Alternatively, +:reject_if+ also accepts a symbol for using methods:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :avatar
+    #     accepts_nested_attributes_for :avatar, class_name: Avatar,
+    #       reject_if: :reject_avatar
+    #
+    #     def reject_avatar(attributes)
+    #       attributes["icon"].blank?
+    #     end
+    #   end
+    #
+    # === One-to-many
+    #
+    # Consider a member that has a number of posts:
+    #
+    #   class Member < ActiveRecord::Base
+    #     attr_accessor :posts
+    #     accepts_nested_attributes_for :posts, class_name: Post
+    #   end
+    #
+    # You can now set attributes on the associated posts through
+    # an attribute hash for a member: include the key +:posts_attributes+
+    # with an array of hashes of post attributes as a value.
+    #
+    # For each hash a new model will be instantiated, unless the hash also
+    # contains a <tt>_destroy</tt> key that evaluates to +true+.
+    #
+    #   params = { member: {
+    #     name: "joe", posts_attributes: [
+    #       { title: "Kari, the awesome Ruby documentation browser!" },
+    #       { title: "The egalitarian assumption of the modern citizen" },
+    #       { title: "", _destroy: "1" } # this will be ignored
+    #     ]
+    #   }}
+    #
+    #   member = Member.new(params[:member])
+    #   member.posts.length # => 2
+    #   member.posts.first.title # => "Kari, the awesome Ruby documentation browser!"
+    #   member.posts.second.title # => "The egalitarian assumption of the modern citizen"
+    #
+    # You may also set a +:reject_if+ proc to silently ignore any new model
+    # hashes if they fail to pass your criteria. For example, the previous
+    # example could be rewritten as:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :posts
+    #     accepts_nested_attributes_for :posts, class_name: Post,
+    #       reject_if: proc { |attributes| attributes["title"].blank? }
+    #   end
+    #
+    #   params = { member: {
+    #     name: "joe", posts_attributes: [
+    #       { title: "Kari, the awesome Ruby documentation browser!" },
+    #       { title: "The egalitarian assumption of the modern citizen" },
+    #       { title: "" } # this will be ignored because of the :reject_if proc
+    #     ]
+    #   }}
+    #
+    #   member = Member.new(params[:member])
+    #   member.posts.length # => 2
+    #   member.posts.first.title # => "Kari, the awesome Ruby documentation browser!"
+    #   member.posts.second.title # => "The egalitarian assumption of the modern citizen"
+    #
+    # Alternatively, +:reject_if+ also accepts a symbol for using methods:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :posts
+    #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
+    #
+    #     def reject_posts(attributes)
+    #       attributes["title"].blank?
+    #     end
+    #   end
+    #
+    # By default the associated models are protected from being destroyed. If
+    # you want to destroy any of the associated models through the attributes
+    # hash, you have to enable it first using the <tt>:allow_destroy</tt>
+    # option. This will allow you to also use the <tt>_destroy</tt> key to
+    # destroy existing models:
+    #
+    #   class Member
+    #     include ActiveModel::Model
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attr_accessor :posts
+    #     accepts_nested_attributes_for :posts, class_name: Post, allow_destroy: true
+    #   end
+    #
+    #   params = { member: {
+    #     posts_attributes: [{ _destroy: "1" }]
+    #   }}
+    #
+    #   member.attributes = params[:member]
+    #   member.posts.length # => 0
+    #
+    # If you add the <tt>_destroy</tt> key to the attributes hash and the
+    # assigned instances respond to <tt>mark_for_destruction?</tt>, assignment
+    # will call that method on the associated models:
+    #
+    #   params = { member: {
+    #     posts_attributes: [{ _destroy: "1" }]
+    #   }}
+    #   member.posts.length # => 1
+    #   member.posts.first.marked_for_destruction? # => true
+    #
+    # Note that the models will _not_ be unassigned automatically. It is the
+    # parent's responsibility to remove models marked for destruction.
+    #
+    # Nested attributes for an associated collection can also be passed in
+    # the form of a hash of hashes instead of an array of hashes:
+    #
+    #   Member.new(
+    #     name: "joe",
+    #     posts_attributes: {
+    #       first:  { title: "Foo" },
+    #       second: { title: "Bar" }
+    #     }
+    #   )
+    #
+    # has the same effect as
+    #
+    #   Member.new(
+    #     name: "joe",
+    #     posts_attributes: [
+    #       { title: "Foo" },
+    #       { title: "Bar" }
+    #     ]
+    #   )
+    #
+    # The keys of the hash which is the value for +:posts_attributes+ are
+    # ignored in this case.
+    #
+    # Passing attributes for an associated collection in the form of a hash
+    # of hashes can be used with hashes generated from HTTP/HTML parameters,
+    # where there may be no natural way to submit an array of hashes.
+    #
+    # === Integration with ActiveModel::Attributes
+    #
+    # When attributes are declared with the +.attribute+ class method provided
+    # by the Attributes module, support
+    # for nested attributes will construct instances using available
+    # Type information. For example, the +accepts_nested_attributes_for+
+    # declarations in the following code sample will use the Type that corresponds
+    # to +:user+ when assigning to +author_attributes+ and the Type that
+    # correpsonds to +:tags+ when assigning to +tags_attributes+:
+    #
+    #   class Article
+    #     include ActiveModel::Model
+    #     include ActiveModel::Attributes
+    #     include ActiveModel::NestedAttributes
+    #
+    #     attribute :author, :user
+    #     attribute :tags, :tag
+    #
+    #     accepts_nested_attributes_for :author
+    #     accepts_nested_attributes_for :tags
+    #   end
+    #
+    #   article = Article.new(
+    #     author_attributes: { name: "Pseudo Nym" },
+    #     tags_attributes: {
+    #       "0" => { name: "actionpack" },
+    #       "1" => { name: "actionview" },
+    #     }
+    #   )
+    #   article.author.class # => User
+    #   article.tags.map(&:class) # => [Tag, Tag]
+    #
+    # === Creating forms with nested attributes
+    #
+    # Use ActionView::Helpers::FormHelper#fields_for to create form elements for
+    # nested attributes.
+    #
+    # Integration test params should reflect the structure of the form. For
+    # example:
+    #
+    #   post members_path, params: {
+    #     member: {
+    #       name: "joe",
+    #       posts_attributes: {
+    #         "0" => { title: "Foo" },
+    #         "1" => { title: "Bar" }
+    #       }
+    #     }
+    #   }
+    module ClassMethods
+      REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key, value| key == "_destroy" || value.blank? } }
+
+      # Defines an attributes writer for the specified model(s).
+      #
+      # Supported options:
+      # [:allow_destroy]
+      #   If true, destroys any members from the attributes hash with a
+      #   <tt>_destroy</tt> key and a value that evaluates to +true+ (e.g. 1,
+      #   "1", true, or "true"). If the model responds to
+      #   <tt>mark_for_destruction</tt>, assignment will call that method and
+      #   the member will not be omitted assigned to +nil+. If the model does
+      #   not respond to <tt>mark_for_destruction</tt>, it will be omitted from
+      #   a collection or assigned to +nil+. This option is +false+ by default.
+      # [:reject_if]
+      #   Allows you to specify a Proc or a Symbol pointing to a method
+      #   that checks whether a model should be built for a certain attribute
+      #   hash. The hash is passed to the supplied Proc or the method
+      #   and it should return either +true+ or +false+. When no +:reject_if+
+      #   is specified, a model will be built for all attribute hashes that
+      #   do not have a <tt>_destroy</tt> value that evaluates to true.
+      #   Passing <tt>:all_blank</tt> instead of a Proc will create a proc
+      #   that will reject a model where all the attributes are blank excluding
+      #   any value for +_destroy+.
+      # [:limit]
+      #   Allows you to specify the maximum number of associated model that
+      #   can be processed with the nested attributes. Limit also can be specified
+      #   as a Proc or a Symbol pointing to a method that should return a number.
+      #   If the size of the nested attributes array exceeds the specified limit,
+      #   NestedAttributes::TooManyRecords exception is raised. If omitted, any
+      #   number of associations can be processed.
+      #   Note that the +:limit+ option is only applicable to one-to-many
+      #   associations.
+      # [:class_name]
+      #   Instructs the model on how to transform the attributes into an
+      #   instance or collection of instances. Accepts either the Class or the
+      #   class name as a String. If this option is omitted, the Class will be
+      #   inferred from the attribute name. If the singularized attribute name
+      #   does not correspond to a Class, the model must define a method to
+      #   build an instance from attributes. For example, a +:post+ one-to-one
+      #   attribute would call a <tt>build_post(attributes)</tt>
+      #   method. Similarly, a +:posts+ one-to-many attribute would also call a
+      #   <tt>build_post(attributes)</tt> method.
+      # [:array]
+      #   Optional boolean to control the type. When `false`,  the relationship
+      #   will be one-to-one. When `array: true`, the relationship will be
+      #   +:has_many+ . If omitted, the type will be inferred by whether or not
+      #   the attribute name is singular or plural.
+      #
+      # === Examples:
+      #   # creates avatar_attributes=
+      #   accepts_nested_attributes_for :avatar, class_name: Avatar, reject_if: proc { |attributes| attributes["name"].blank? }
+      #   # creates avatar_attributes=
+      #   accepts_nested_attributes_for :avatar, class_name: Avatar, reject_if: :all_blank
+      #   # creates avatar_attributes= and posts_attributes=
+      #   accepts_nested_attributes_for :deer, class_name: Animal, array: true, allow_destroy: true
+      def accepts_nested_attributes_for(*nested_attribute_names, **options)
+        options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] == :all_blank
+
+        nested_attribute_names.each do |attribute_name|
+          if instance_methods.include?(:"#{attribute_name}=")
+            nested_attributes_options[attribute_name.to_sym] = options.with_defaults(allow_destroy: false)
+
+            type =
+              case options[:array]
+              when true then :has_many
+              when false then :has_one
+              else
+                attribute_name.to_s.pluralize == attribute_name.to_s ? :has_many : :has_one
+              end
+            generate_attribute_writer(attribute_name, type)
+          else
+            raise ArgumentError, "No attribute found for name `#{attribute_name}`. Has it been defined yet?"
+          end
+        end
+      end
+
+      private
+        def generate_attribute_writer(attribute_name, type)
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            silence_redefinition_of_method :#{attribute_name}_attributes=
+            def #{attribute_name}_attributes=(attributes)
+              assign_nested_attributes_for_#{type}_attribute(:#{attribute_name}, attributes)
+            end
+          RUBY
+        end
+    end
+
+    private
+      UNASSIGNABLE_KEYS = %w( _destroy )
+
+      def assign_nested_attributes_for_has_one_attribute(attribute_name, attributes)
+        options = nested_attributes_options.fetch(attribute_name)
+        attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes.to_h)
+        existing_model = public_send(attribute_name)
+        assignable_attributes = attributes.except(*UNASSIGNABLE_KEYS)
+
+        if existing_model
+          unless call_reject_if(attribute_name, attributes)
+            existing_model.assign_attributes(assignable_attributes)
+            if has_destroy_flag?(attributes) && options[:allow_destroy]
+              existing_model.try(:mark_for_destruction) || public_send("#{attribute_name}=", nil)
+            end
+          end
+        elsif !reject_new_model?(attribute_name, attributes)
+          method = "build_#{attribute_name}"
+          if respond_to?(method)
+            assign_attributes attribute_name => public_send(method, assignable_attributes)
+          elsif can_infer_type_from_attribute_definition?(attribute_name)
+            assign_attributes attribute_name => assignable_attributes
+          elsif (model_class = infer_class_from_attribute_name(attribute_name.to_s))
+            assign_attributes attribute_name => model_class.new(assignable_attributes)
+          elsif (class_name = nested_attributes_options.dig(attribute_name, :class_name))
+            model_class =
+              case class_name
+              when String then ActiveSupport::Inflector.constantize(class_name)
+              when Class then class_name
+              else raise ArgumentError, "Cannot build attribute `#{attribute_name}` with class_name: #{class_name}"
+              end
+
+            assign_attributes attribute_name => model_class.new(assignable_attributes)
+          else
+            raise ArgumentError, "Cannot build attribute `#{attribute_name}`. Specify a class_name: option or define `##{method}`"
+          end
+        end
+      end
+
+      def assign_nested_attributes_for_has_many_attribute(attribute_name, attributes_collection)
+        options = nested_attributes_options[attribute_name]
+
+        unless attributes_collection.is_a?(Hash) || attributes_collection.is_a?(Array)
+          raise ArgumentError, "Hash or Array expected for attribute `#{attribute_name}`, got #{attributes_collection.class.name} (#{attributes_collection.inspect})"
+        end
+
+        attributes_collection = attributes_collection.to_h
+        check_record_limit!(options[:limit], attributes_collection)
+
+        if attributes_collection.is_a? Hash
+          keys = attributes_collection.keys
+          attributes_collection =
+            if keys.include?("id") || keys.include?(:id)
+              [attributes_collection]
+            else
+              attributes_collection.values
+            end
+        end
+
+        if can_infer_type_from_attribute_definition?(attribute_name)
+          assignable_attributes = attributes_collection.map do |attributes|
+            attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes.to_h)
+            attributes.except(*UNASSIGNABLE_KEYS)
+          end
+
+          assign_attributes attribute_name => assignable_attributes
+        else
+          models = attributes_collection.map do |attributes|
+            attributes = ActiveSupport::HashWithIndifferentAccess.new(attributes.to_h)
+            assignable_attributes = attributes.except(*UNASSIGNABLE_KEYS)
+
+            unless reject_new_model?(attribute_name, attributes)
+              method = "build_#{attribute_name.to_s.singularize}"
+              if respond_to?(method)
+                public_send(method, assignable_attributes)
+              elsif (model_class = infer_class_from_attribute_name(attribute_name.to_s.singularize))
+                model_class.new(assignable_attributes)
+              elsif (class_name = nested_attributes_options.dig(attribute_name, :class_name))
+                model_class =
+                  case class_name
+                  when String then ActiveSupport::Inflector.constantize(class_name)
+                  when Class then class_name
+                  else raise ArgumentError, "Cannot build attribute `#{attribute_name}` with class_name: #{class_name}"
+                  end
+
+                model_class.new(assignable_attributes)
+              else
+                raise ArgumentError, "Cannot build attribute `#{attribute_name}`. Specify a class_name: option or define `#{method}`"
+              end
+            end
+          end
+
+          assign_attributes attribute_name => models.tap(&:compact!)
+        end
+      end
+
+      def can_infer_type_from_attribute_definition?(attribute_name)
+        self.class.try(:type_for_attribute, attribute_name).present?
+      end
+
+      def infer_class_from_attribute_name(attribute_name)
+        attribute_name.classify.safe_constantize
+      end
+
+      def reject_new_model?(attribute_name, attributes)
+        will_be_destroyed?(attribute_name, attributes) || call_reject_if(attribute_name, attributes)
+      end
+
+      def will_be_destroyed?(attribute_name, attributes)
+        allow_destroy?(attribute_name) && has_destroy_flag?(attributes)
+      end
+
+      def allow_destroy?(attribute_name)
+        nested_attributes_options.dig(attribute_name, :allow_destroy)
+      end
+
+      # Determines if a hash contains a truthy _destroy key.
+      def has_destroy_flag?(hash)
+        Type::Boolean.new.cast(hash["_destroy"])
+      end
+
+      def call_reject_if(attribute_name, attributes)
+        return false if will_be_destroyed?(attribute_name, attributes)
+
+        case callback = nested_attributes_options.dig(attribute_name, :reject_if)
+        when Symbol
+          method(callback).arity == 0 ? send(callback) : send(callback, attributes)
+        when Proc
+          callback.call(attributes)
+        end
+      end
+
+      def check_record_limit!(limit, attributes_collection)
+        if limit
+          limit = \
+            case limit
+            when Symbol
+              send(limit)
+            when Proc
+              limit.call
+            else
+              limit
+            end
+
+          if limit && attributes_collection.size > limit
+            raise TooManyModels, "Maximum #{limit} models are allowed. Got #{attributes_collection.size} models instead."
+          end
+        end
+      end
+  end
+end

--- a/activemodel/test/cases/nested_attributes_test.rb
+++ b/activemodel/test/cases/nested_attributes_test.rb
@@ -1,0 +1,527 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+NestedStruct = Struct.new(:name)
+
+class NestedModel
+  class Type < ActiveModel::Type::Value
+    private
+      def cast_value(value)
+        case value
+        when NestedModel then value
+        else NestedModel.new(value)
+        end
+      end
+  end
+
+  class ArrayType < Type
+    private
+      def cast_value(value)
+        case value
+        when Array then value.map { |attributes| cast(attributes) }
+        else super
+        end
+      end
+  end
+
+  include ActiveModel::Model
+
+  attr_accessor :name
+
+  def attributes
+    { "name" => name }
+  end
+end
+
+class NestedRecord < NestedModel
+  def mark_for_destruction
+    @marked_for_destruction = true
+  end
+
+  def marked_for_destruction?
+    @marked_for_destruction
+  end
+
+  def _destroy
+    marked_for_destruction?
+  end
+end
+
+module ActiveModel
+  class NestedAttributesTest < ActiveModel::TestCase
+    test "accepts attributes for one-to-one Active Model" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel"
+      end
+
+      instance = model.new has_one_model_attributes: { name: "Has One" }
+
+      assert_kind_of NestedModel, instance.has_one_model
+      assert_equal "Has One", instance.has_one_model.name
+      assert_not_predicate instance.has_one_model, :persisted?
+    end
+
+    test "accepts attributes for one-to-one Active Model by inferring its class_name: through inflection" do
+      model = model_class do
+        attr_accessor :nested_model
+
+        accepts_nested_attributes_for :nested_model
+      end
+
+      instance = model.new nested_model_attributes: { name: "Has One" }
+
+      assert_kind_of NestedModel, instance.nested_model
+      assert_equal "Has One", instance.nested_model.name
+      assert_not_predicate instance.nested_model, :persisted?
+    end
+
+    test "accepts attributes for one-to-one Active Model by inferring its class_name: through Attribute definition" do
+      model = model_class do
+        include ActiveModel::Attributes
+
+        attribute :nested_model, NestedModel::Type.new
+
+        accepts_nested_attributes_for :nested_model
+      end
+
+      instance = model.new nested_model_attributes: { name: "Has One" }
+
+      assert_kind_of NestedModel, instance.nested_model
+      assert_equal "Has One", instance.nested_model.name
+      assert_not_predicate instance.nested_model, :persisted?
+    end
+
+    test "omits unassignable attributes for one-to-one Active Model inferred through Attribute definition" do
+      model = model_class do
+        include ActiveModel::Attributes
+
+        attribute :nested_model, NestedModel::Type.new
+
+        accepts_nested_attributes_for :nested_model
+      end
+
+      instance = model.new nested_model_attributes: { _destroy: true }
+
+      assert_kind_of NestedModel, instance.nested_model
+      assert_not_includes instance.nested_model.attributes.keys, "_destroy"
+    end
+
+    test "overrides one-to-one inference when array: false" do
+      model = model_class do
+        attr_accessor :deer
+
+        accepts_nested_attributes_for :deer, array: false, class_name: "NestedModel"
+      end
+
+      instance = model.new deer_attributes: { name: "Has One" }
+
+      assert_kind_of NestedModel, instance.deer
+      assert_equal "Has One", instance.deer.name
+      assert_not_predicate instance.deer, :persisted?
+    end
+
+    test "builds an instance of a one-to-one Active Model from attributes" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model
+
+        def build_has_one_model(attributes)
+          NestedModel.new(attributes)
+        end
+      end
+
+      instance = model.new has_one_model_attributes: { name: "Has One" }
+
+      assert_kind_of NestedModel, instance.has_one_model
+      assert_equal "Has One", instance.has_one_model.name
+      assert_not_predicate instance.has_one_model, :persisted?
+    end
+
+    test "gives precedent to the build method over the class_name: option for one-to-one Active Model instances" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel"
+
+        def build_has_one_model(attributes)
+          NestedStruct.new(attributes[:name])
+        end
+      end
+
+      instance = model.new has_one_model_attributes: { name: "Has One" }
+
+      assert_kind_of NestedStruct, instance.has_one_model
+      assert_equal "Has One", instance.has_one_model.name
+    end
+
+    test "builds an instance using the reject_if: option" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel",
+          reject_if: -> (attributes) { attributes[:name] == "reject" }
+      end
+
+      instance = model.new has_one_model_attributes: { name: "reject" }
+
+      assert_nil instance.has_one_model
+    end
+
+    test "accepts_attributes_for one-to-many of Active Models" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel"
+      end
+
+      instance = model.new has_many_models_attributes: { 0 => { name: "Has Many" } }
+
+      instance.has_many_models.each { |model| assert_kind_of NestedModel, model }
+      assert_not instance.has_many_models.any?(&:persisted?)
+      assert_equal ["Has Many"], instance.has_many_models.map(&:name)
+    end
+
+    test "accepts_attributes_for one-to-many of Active Models inferring their class_name: through inflection" do
+      model = model_class do
+        attr_accessor :nested_models
+
+        accepts_nested_attributes_for :nested_models
+      end
+
+      instance = model.new nested_models_attributes: { 0 => { name: "Has Many" } }
+
+      instance.nested_models.each { |model| assert_kind_of NestedModel, model }
+      assert_not instance.nested_models.any?(&:persisted?)
+      assert_equal ["Has Many"], instance.nested_models.map(&:name)
+    end
+
+    test "accepts attributes for one-to-many Active Model by inferring its class_name: through Attribute definition" do
+      model = model_class do
+        include ActiveModel::Attributes
+
+        attribute :nested_models, NestedModel::ArrayType.new
+
+        accepts_nested_attributes_for :nested_models
+      end
+
+      instance = model.new nested_models_attributes: { 0 => { name: "Has Many" } }
+
+      instance.nested_models.each { |model| assert_kind_of NestedModel, model }
+      assert_not instance.nested_models.any?(&:persisted?)
+      assert_equal ["Has Many"], instance.nested_models.map(&:name)
+    end
+
+    test "ignores unassignable attributes for one-to-many inferred through Attribute definition" do
+      model = model_class do
+        include ActiveModel::Attributes
+
+        attribute :nested_models, NestedModel::ArrayType.new
+
+        accepts_nested_attributes_for :nested_models
+      end
+
+      instance = model.new nested_models_attributes: { 0 => { name: "Has Many", _destroy: false } }
+
+      instance.nested_models.each { |model| assert_kind_of NestedModel, model }
+      assert_not instance.nested_models.any?(&:persisted?)
+      assert_equal ["Has Many"], instance.nested_models.map(&:name)
+    end
+
+    test "builds one-to-many Active Model from attributes" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models
+
+        def build_has_many_model(attributes)
+          NestedModel.new(attributes)
+        end
+      end
+
+      instance = model.new has_many_models_attributes: {
+        0 => { name: "First" },
+        1 => { name: "Last" },
+      }
+
+      instance.has_many_models.each { |model| assert_kind_of NestedModel, model }
+      instance.has_many_models.each { |model| assert_not_predicate model, :persisted? }
+      assert_equal ["First", "Last"], instance.has_many_models.map(&:name)
+    end
+
+    test "overrides one-to-many inference when array: true" do
+      model = model_class do
+        attr_accessor :deer
+
+        accepts_nested_attributes_for :deer, array: true, class_name: "NestedModel"
+      end
+
+      instance = model.new deer_attributes: {
+        0 => { name: "First" },
+        1 => { name: "Last" },
+      }
+
+      instance.deer.each { |model| assert_kind_of NestedModel, model }
+      instance.deer.each { |model| assert_not_predicate model, :persisted? }
+      assert_equal ["First", "Last"], instance.deer.map(&:name)
+    end
+
+    test "gives precedent to the build method for a one-to-many attributes" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel"
+
+        def build_has_many_model(attributes)
+          NestedStruct.new(attributes[:name])
+        end
+      end
+
+      instance = model.new has_many_models_attributes: { 0 => { name: "Has Many" } }
+
+      instance.has_many_models.each { |model| assert_kind_of NestedStruct, model }
+      assert_equal ["Has Many"], instance.has_many_models.map(&:name)
+    end
+
+    test "builds a one-to-many instances excluding nils" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models
+
+        def build_has_many_model(attributes)
+          NestedModel.new(name: "include") if attributes[:include]
+        end
+      end
+
+      instance = model.new has_many_models_attributes: {
+        0 => { include: true },
+        1 => { include: false },
+      }
+
+      instance.has_many_models.each { |model| assert_kind_of NestedModel, model }
+      instance.has_many_models.each { |model| assert_not_predicate model, :persisted? }
+      assert_equal ["include"], instance.has_many_models.map(&:name)
+    end
+
+    test "builds a one-to-many instances using the reject_if: option" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel",
+          reject_if: -> (attributes) { attributes[:name] == "reject" }
+      end
+
+      instance = model.new has_many_models_attributes: {
+        0 => { name: "reject" },
+        1 => { name: "include" },
+      }
+
+      instance.has_many_models.each { |model| assert_kind_of NestedModel, model }
+      instance.has_many_models.each { |model| assert_not_predicate model, :persisted? }
+      assert_equal ["include"], instance.has_many_models.map(&:name)
+    end
+
+    test "raises TooManyModels if one-to-many is larger than configured limit:" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel",
+          limit: 1
+      end
+
+      assert_raises ActiveModel::NestedAttributes::TooManyModels do
+        model.new has_many_models_attributes: {
+          0 => { name: "ignored" },
+          1 => { name: "ignored" },
+        }
+      end
+    end
+
+    test "raises TooManyModels if one-to-many is larger than Symbol limit:" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel",
+          limit: :models_limit
+
+        def models_limit
+          1
+        end
+      end
+
+      assert_raises ActiveModel::NestedAttributes::TooManyModels do
+        model.new has_many_models_attributes: {
+          0 => { name: "ignored" },
+          1 => { name: "ignored" },
+        }
+      end
+    end
+
+    test "raises TooManyModels if one-to-many is larger than Proc limit:" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel",
+          limit: -> { 1 }
+      end
+
+      assert_raises ActiveModel::NestedAttributes::TooManyModels do
+        model.new has_many_models_attributes: {
+          0 => { name: "ignored" },
+          1 => { name: "ignored" },
+        }
+      end
+    end
+
+    test "base has empty nested_attributes_options" do
+      model = model_class
+
+      assert_equal({}, model.nested_attributes_options)
+    end
+
+    test "replaces nested_attributes_options[:reject_if] with a proc" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel", reject_if: :all_blank
+      end
+
+      assert_equal ActiveModel::NestedAttributes::ClassMethods::REJECT_ALL_BLANK_PROC,
+        model.nested_attributes_options.dig(:has_one_model, :reject_if)
+    end
+
+    test "does not build a new model if reject_if: :all_blank returns false" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel", reject_if: :all_blank
+      end
+
+      instance = model.new has_many_models_attributes: { 0 => { name: "" } }
+
+      assert_empty instance.has_many_models
+    end
+
+    test "builds a new model if reject_if: :all_blank is truthy" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel", reject_if: :all_blank
+      end
+
+      instance = model.new has_many_models_attributes: { 0 => { name: "valid" } }
+
+      assert_equal ["valid"], instance.has_many_models.map(&:name)
+    end
+
+    test "raises an ArgumentError for one-to-many attributes that are not Hash or Array" do
+      model = model_class do
+        attr_accessor :has_many_models
+
+        accepts_nested_attributes_for :has_many_models, class_name: "NestedModel"
+      end
+
+      assert_raises ArgumentError, match: "Hash or Array expected for attribute `has_many_models`, got #{1.class.name} (#{1.inspect})" do
+        model.new has_many_models_attributes: 1
+      end
+    end
+
+    test "raises an ArgumentError for undeclared attributes" do
+      assert_raises ArgumentError, match: "No attribute found for name `undeclared`. Has it been defined yet?" do
+        model_class.accepts_nested_attributes_for :undeclared
+      end
+    end
+
+    test "raises an ArgumentError for when the class_name: option is neither a String nor a Class" do
+      model = model_class do
+        attr_accessor :unknown
+
+        accepts_nested_attributes_for :unknown, class_name: :invalid
+      end
+
+      assert_raises ArgumentError, match: "Cannot build attribute `unknown` with class_name: invalid" do
+        model.new unknown_attributes: { ignored: true }
+      end
+    end
+
+    test "raises an ArgumentError for when the class_name: option is missing" do
+      model = model_class do
+        attr_accessor :unknown
+
+        accepts_nested_attributes_for :unknown
+      end
+
+      assert_raises ArgumentError, match: "Cannot build attribute `unknown`. Specify a class_name: option or define `#build_unknown`" do
+        model.new unknown_attributes: { ignored: true }
+      end
+    end
+
+    test "raises an UnknownAttributeError for undeclared attributes on the nested model" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel"
+      end
+
+      assert_raises ActiveModel::UnknownAttributeError, match: "unknown attribute 'not_declared' for NestedModel." do
+        model.new(has_one_model_attributes: { not_declared: true })
+      end
+    end
+
+    test "defaults to allow_destroy: false" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel"
+      end
+
+      attributes = { "name" => "Has One" }
+      nested_model = NestedModel.new(attributes)
+      instance = model.new(has_one_model: nested_model)
+
+      instance.assign_attributes(has_one_model_attributes: attributes.merge("_destroy" => true))
+
+      assert_equal attributes, instance.has_one_model.attributes
+    end
+
+    test "supports allow_destroy: true with a model" do
+      model = model_class do
+        attr_accessor :has_one_model
+
+        accepts_nested_attributes_for :has_one_model, class_name: "NestedModel", allow_destroy: true
+      end
+      instance = model.new(has_one_model: NestedModel.new(name: "Has One"))
+
+      instance.assign_attributes(has_one_model_attributes: { "_destroy" => true })
+
+      assert_nil instance.has_one_model
+    end
+
+    test "supports allow_destroy: true with a record" do
+      model = model_class do
+        attr_accessor :has_one_record
+
+        accepts_nested_attributes_for :has_one_record, class_name: "NestedRecord", allow_destroy: true
+      end
+      instance = model.new(has_one_record: NestedRecord.new(name: "Has One"))
+
+      instance.assign_attributes(has_one_record_attributes: { "_destroy" => true })
+
+      assert_predicate instance.has_one_record, :marked_for_destruction?
+      assert_predicate instance.has_one_record, :_destroy
+    end
+
+    def model_class(&block)
+      Class.new do
+        include ActiveModel::Model
+        include ActiveModel::NestedAttributes
+
+        class_eval(&block) unless block.nil?
+      end
+    end
+  end
+end

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -1113,6 +1113,28 @@ end
 
 This creates an `addresses_attributes=` method on `Person` that allows you to create, update, and destroy addresses.
 
+Similarly, Active Model also provides model level support via the
+[`ActiveModel::NestedAttributes`](https://api.rubyonrails.org/classes/ActiveModel/NestedAttributes.html)
+module and its
+[`accepts_nested_attributes_for`](https://api.rubyonrails.org/classes/ActiveModel/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for)
+method:
+
+```ruby
+class Person
+  include ActiveModel::Model
+  include ActiveModel::NestedAttributes
+
+  attr_accessor :addresses
+  accepts_nested_attributes_for :addresses
+end
+
+class Address
+  include ActiveModel::Model
+
+  attr_accessor :street, :kind
+end
+```
+
 ### Nested Forms in the View
 
 The following form allows a user to create a `Person` and its associated addresses.


### PR DESCRIPTION

### Motivation / Background

Largely inspired by the Active Record implementation, this commit introduces support for assigning instances of objects to classes that `include ActiveModel::Model`.

### Detail

It aims to handle assignment of `_attributes`-suffixed values in an ActionView- and ActionPack-compliant way:

```ruby
Author = Struct.new(:name)
Category = Struct.new(:name)

class Article
  include ActiveModel::Model
  include ActiveModel::NestedAttributes

  attr_accessor :author
  attr_accessor :tags

  accepts_nested_attributes_for :author
  accepts_nested_attributes_for :tags, class_name: Category
end

article = Article.new(
  author_attributes: { name: "Pseudo Nym" },
  tags_attributes: {
      0 => { name: "actionview" },
      1 => { name: "actionpack" },
  }
)

article.author.name # => "Pseudo Nym"
article.tags.pluck(:name) # => ["actionview", "actionpack"]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
