### PR TITLE
Add conditional options to ErrorReporter

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add support for the conditional arguments `:if` and `:unless` to `ErrorHandler`'s `handle` and
+    `report` methods.
+
+    This allows for more fine-grained control over when an error should be handled or reported.
+
+    *Dustin Brown*, *dustinbrownman*
+
 *   Fix compatibility with the `semantic_logger` gem.
 
     The `semantic_logger` gem doesn't behave exactly like stdlib logger in that


### PR DESCRIPTION
This allows for conditional execution of ErrorReporter's `handle` and `record` methods. :if/:unless options can be passed to the methods to if the handling/recording should continue. Either way the given block is executed.

This allows for finer control over the error handling and is especially useful when you only want to handle/record errors in certain environments.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I was beginning to work on replacing some of our current way of swallowing errors with this newer `Rails.errors.handle...`. I noticed that there were a number of places where we did this, but only in certain environments. For example:

```ruby
def do_something
  this_might_raise
rescue SomeError => e
  # Swallow the error unless this is a test
  raise if Rails.env.test?
end
```

There wasn't a great way to reproduce this conditional handling with `AS::ErrorReporter`. If I wanted to only handle these conditions in certain environments, I'd have to duplicate the block with something like this:

```ruby
if Rails.env.test?
  # some logic
  raise "Always raises in test environment
else
  Rails.errors.handle do
    # some logic
    raise "Won't raise in non-test environments
  end
end

### Detail

This adds the conditional options of `:if` and `:unless` to `AS::ErrorReporter`'s `handle` and `record` methods. Handling and reporting will only happen if the condition is met.

```ruby
Rails.errors.handle(if: Rails.env.production?) do
  # some logic
  raise "Won't raise in production"
end

Rails.errors.report(unless: Rails.env.test?) do
  # some logic
  raise "Error won't be reported in the test environment"
end
```

### Additional information

This pattern is based on what Rails has for callbacks and before_actions. Unlike those, this doesn't take a callable. I considered adding support for that (and could still), but it seems unnecessary since it would need to be called immediately. I'm definitely open to feedback on that.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
