### PR TITLE
Decouple ActionView and Rails HTML Sanitizer to Allow Other Frameworks to Use ActionView

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails-html-sanitizer"
-
 module ActionView
   module Helpers # :nodoc:
     # = Action View Sanitize \Helpers
@@ -9,7 +7,8 @@ module ActionView
     # The SanitizeHelper module provides a set of methods for scrubbing text of undesired HTML elements.
     # These helper methods extend Action View making them callable within your template files.
     module SanitizeHelper
-      mattr_accessor :sanitizer_vendor, default: Rails::HTML4::Sanitizer
+      # The default sanitizer is set in actionview railtie
+      mattr_accessor :sanitizer_vendor
 
       extend ActiveSupport::Concern
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -2,6 +2,7 @@
 
 require "action_view"
 require "rails"
+require "rails-html-sanitizer"
 
 module ActionView
   # = Action View Railtie
@@ -14,6 +15,7 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
+    config.action_view.sanitizer_vendor = Rails::HTML5::Sanitizer
 
     config.eager_load_namespaces << ActionView
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it decouples ActionView and Rails::HTML::Sanitizer. This allows other frameworks like [Jets](https://rubyonjets.com/) to use ActionView for rendering.

### Detail

This Pull Request changes the actionview `sanitize_helper.rb` to remove 

* https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/actionview/lib/action_view/helpers/sanitize_helper.rb#L3
* https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/actionview/lib/action_view/helpers/sanitize_helper.rb#L12

I've found that these are only spot in actionview that refers to `Rails`.

Instead, this PR sets the default `config.action_view.sanitizer_vendor` is set in the actionview railtie. This decouples actionview from Rails. It makes ActionView easier to use with other frameworks. 

Thanks for considering this PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
