### PR TITLE
Fix `Rails.application.secrets` deprecation warnings in railties tests

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -749,9 +749,7 @@ module ApplicationTests
 
     test "Use key_generator when secret_key_base is set" do
       make_basic_app do |application|
-        Rails.deprecator.silence do
-          application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
-        end
+        application.credentials.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
         application.config.session_store :disabled
       end
 
@@ -771,9 +769,7 @@ module ApplicationTests
 
     test "application verifier can be used in the entire application" do
       make_basic_app do |application|
-        Rails.deprecator.silence do
-          application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
-        end
+        application.credentials.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
         application.config.session_store :disabled
       end
 
@@ -924,16 +920,14 @@ module ApplicationTests
       end
     end
 
-    test "secrets.secret_key_base is used when config/secrets.yml is present" do
+    test "credentials.secret_key_base is used when config/secrets.yml is present" do
       app_file "config/secrets.yml", <<-YAML
         development:
           secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
       YAML
 
       app "development"
-      Rails.deprecator.silence do
-        assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
-      end
+      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.credentials.secret_key_base
       assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -19,7 +19,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       add_to_env_config("production", "config.read_encrypted_secrets = false")
       app("production")
 
-      assert_not Rails.application.secrets.yeah_yeah
+      assert_not Rails.application.credentials.yeah_yeah
     end
   end
 
@@ -85,7 +85,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       add_to_env_config("production", "config.read_encrypted_secrets = true")
       app("production")
 
-      assert_equal "lets-walk-in-the-cool-evening-light", Rails.application.secrets.yeah_yeah
+      assert_equal "lets-walk-in-the-cool-evening-light", Rails.application.credentials.yeah_yeah
     end
   end
 
@@ -97,7 +97,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       end_of_yaml
 
       add_to_env_config "production", <<-end_of_config
-        config.dereferenced_secret = Rails.application.secrets.some_secret
+        config.dereferenced_secret = Rails.application.credentials.some_secret
       end_of_config
 
       app("production")
@@ -137,7 +137,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
       app("production")
 
-      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.secrets.api_key
+      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.credentials.api_key
     end
   end
 
@@ -156,7 +156,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
       app("production")
 
-      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.secrets.api_key
+      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.credentials.api_key
     end
   end
 

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -19,7 +19,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       add_to_env_config("production", "config.read_encrypted_secrets = false")
       app("production")
 
-      assert_not Rails.application.credentials.yeah_yeah
+      assert_not Rails.application.secrets.yeah_yeah
     end
   end
 
@@ -85,7 +85,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       add_to_env_config("production", "config.read_encrypted_secrets = true")
       app("production")
 
-      assert_equal "lets-walk-in-the-cool-evening-light", Rails.application.credentials.yeah_yeah
+      assert_equal "lets-walk-in-the-cool-evening-light", Rails.application.secrets.yeah_yeah
     end
   end
 
@@ -97,10 +97,12 @@ class Rails::SecretsTest < ActiveSupport::TestCase
       end_of_yaml
 
       add_to_env_config "production", <<-end_of_config
-        config.dereferenced_secret = Rails.application.credentials.some_secret
+        config.dereferenced_secret = Rails.application.secrets.some_secret
       end_of_config
 
-      app("production")
+      assert_deprecated(Rails.deprecator) do
+        app("production")
+      end
 
       assert_equal "yeah yeah", Rails.application.config.dereferenced_secret
     end
@@ -137,7 +139,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
       app("production")
 
-      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.credentials.api_key
+      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.secrets.api_key
     end
   end
 
@@ -156,7 +158,7 @@ class Rails::SecretsTest < ActiveSupport::TestCase
 
       app("production")
 
-      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.credentials.api_key
+      assert_equal "00112233445566778899aabbccddeeff…", Rails.application.secrets.api_key
     end
   end
 


### PR DESCRIPTION
```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from require at /Users/zzak/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38)
```

There is already a test covering this:
https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/railties/test/application/configuration_test.rb#L919-L925

This commit is not to _remove_ any deprecation, just silence unnecessary noise in the Railties test suite.

Interesting was that `app.secrets` does not raise any deprecation warning, like here: https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/railties/test/application/configuration_test.rb#L960-L961

Even though `app` is just a method which returns `Rails.application`: https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/railties/test/isolation/abstract_unit.rb#L80

/cc @p8
