### PR TITLE
Add `AR::Base::normalizes_attributes_of_type`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `ActiveRecord::Base.normalizes_each`, which behaves like
+    `ActiveRecord::Base.normalizes`, but targets each attribute of the specified
+    types. For example:
+
+      ```ruby
+      class Post < ActiveRecord::Base
+        normalizes_each :string, :text, with: -> { _1.strip }
+      end
+
+      post = Post.new(title: "  Title", body: "Body.\n")
+      post.title # => "Title"
+      post.body  # => "Body."
+      ```
+
+    *Niklas Häusele* and *Jonathan Hefner*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*


### PR DESCRIPTION
`ActiveRecord::Base::normalizes_attributes_of_type` behaves like `ActiveRecord::Base::normalizes`, but targets attributes having one of the specified types.  For example:

  ```ruby
  class Snippet < ActiveRecord::Base
    normalizes_each :string, :text, with: -> { _1.strip }
  end

  snippet = Snippet.new(title: "  Title", description: "Description.\n", code: "  code\n")
  snippet.title        # => "Title"
  snippet.description  # => "Description."
  snippet.code         # => "  code\n"
  ```

---

Closes #49314.

@codergeek121 I've added you as a co-author for your work on #49314.
