### PR TITLE
Show the error messages next to the related fields instead of on top of the form

### DIFF
--- a/actiontext/test/dummy/app/views/messages/_form.html.erb
+++ b/actiontext/test/dummy/app/views/messages/_form.html.erb
@@ -1,25 +1,15 @@
 <%= form_with(model: message) do |form| %>
-  <% if message.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(message.errors.count, "error") %> prohibited this message from being saved:</h2>
-
-      <ul>
-      <% message.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div class="field">
     <%= form.label :subject %>
     <%= form.text_field :subject %>
+    <%= form.error :subject, style: "color: red" %>
   </div>
 
   <div class="field">
     <%= form.label :content, "Message content label" %>
     <%= form.rich_text_area :content, class: "trix-content",
           placeholder: "Your message here", aria: { label: "Message content aria-label" } %>
+    <%= form.error :content, style: "color: red" %>
   </div>
 
   <div class="actions">

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Added `error` method to the form builder in order to display the error messages next to the corresponding field.
+
+    Examples:
+
+    ```erb
+    <%= form_with(model: user) do |form| %>
+      <div>
+        <%= form.label :name, style: "display: block" %>
+        <%= form.text_field :name %>
+        # Returns the error messages for the `name` attribute
+        <%= form.error :name, style: "color: red" %>
+      </div>
+
+      <div>
+        <%= form.submit %>
+      </div>
+    <% end %>
+    ```
+
+    *Matthew Nguyen*
+
 *   Fix the `capture` view helper compatibility with HAML and Slim
 
     When a blank string was captured in HAML or Slim (and possibly other template engines)

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2658,6 +2658,24 @@ module ActionView
         @template.button_tag(value, options)
       end
 
+      # Returns a div tag displaying the error messages for a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+).
+      # Additional options on the div tag can be passed as a hash with +options+. These options will be tagged
+      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:separator</tt> option.
+      #
+      # ==== Examples
+      #   error(:title, class: "error_explanation", separator: "<br />")
+      #   # => <div class="error_explanation">Title can't be blank<br />Title is too short (minimum is 2 characters)</div>
+      #
+      def error(method, options = {})
+        return unless @object.respond_to?(:errors) && @object.errors.include?(method)
+
+        separator = options.delete(:separator) || ", "
+        @template.content_tag(:div, options) do
+          @template.safe_join(@object.errors.full_messages_for(method), @template.raw(separator))
+        end
+      end
+
       def emitted_hidden_id? # :nodoc:
         @emitted_hidden_id ||= nil
       end

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -48,7 +48,10 @@ Post = Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on,
   def initialize(*args)
     super
     @persisted = false
+    @errors = ActiveModel::Errors.new(self)
   end
+
+  attr_reader :errors
 
   attr_accessor :author
   def author_attributes=(attributes); end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -108,14 +108,7 @@ class FormHelperTest < ActionView::TestCase
 
     @post = Post.new
     @comment = Comment.new
-    def @post.errors
-      Class.new {
-        def [](field); field == "author_name" ? ["can't be empty"] : [] end
-        def empty?() false end
-        def count() 1 end
-        def full_messages() ["Author name can't be empty"] end
-      }.new
-    end
+    @post.errors.add(:author_name, "can't be empty")
     def @post.to_key; [123]; end
     def @post.id; 0; end
     def @post.id_before_type_cast; "omg"; end
@@ -2807,6 +2800,36 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
       "<button type='submit' formmethod='delete' name='button' value='existing'>Delete</button>"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_error_with_method_name
+    @post.errors.add(:title, "can't be blank")
+    @post.errors.add(:title, "is too short (minimum is 10 characters)")
+
+    form_for(@post) do |f|
+      concat f.error(:title)
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      %(<div>Title can't be blank, Title is too short (minimum is 10 characters)</div>)
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
+  def test_error_with_method_name_and_options
+    @post.errors.add(:title, "can't be blank")
+    @post.errors.add(:title, "is too short (minimum is 10 characters)")
+
+    form_for(@post) do |f|
+      concat f.error(:title, class: "error_explanation", separator: "<br />")
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      %(<div class="error_explanation">Title can't be blank<br />Title is too short (minimum is 10 characters)</div>)
     end
 
     assert_dom_equal expected, @rendered

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -1,32 +1,24 @@
 <%%= form_with(model: <%= model_resource_name %>) do |form| %>
-  <%% if <%= singular_table_name %>.errors.any? %>
-    <div style="color: red">
-      <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>
-
-      <ul>
-        <%% <%= singular_table_name %>.errors.each do |error| %>
-          <li><%%= error.full_message %></li>
-        <%% end %>
-      </ul>
-    </div>
-  <%% end %>
-
 <% attributes.each do |attribute| -%>
   <div>
 <% if attribute.password_digest? -%>
     <%%= form.label :password, style: "display: block" %>
     <%%= form.password_field :password %>
+    <%%= form.error :password, style: "color: red" %>
   </div>
 
   <div>
     <%%= form.label :password_confirmation, style: "display: block" %>
     <%%= form.password_field :password_confirmation %>
+    <%%= form.error :password_confirmation, style: "color: red" %>
 <% elsif attribute.attachments? -%>
     <%%= form.label :<%= attribute.column_name %>, style: "display: block" %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
+    <%%= form.error :<%= attribute.column_name %>, style: "color: red" %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %>, style: "display: block" %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>
+    <%%= form.error :<%= attribute.column_name %>, style: "color: red" %>
 <% end -%>
   </div>
 


### PR DESCRIPTION
### Motivation / Background

The default scaffold in Rails displays all the form errors in a `<div>` on top of the form.

```erb
  <% if user.errors.any? %>
    <div style="color: red">
      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>

      <ul>
        <% user.errors.each do |error| %>
          <li><%= error.full_message %></li>
        <% end %>
      </ul>
    </div>
  <% end %>
```

Which is not a common UX pattern on most websites.

It's way more usual to display the error messages right next to the field related to the error.
IMO, it would be much nicer/more intuitive to have something like this instead:

```erb
<%= form_with(model: user) do |form| %>
  <div>
    <%= form.label :name, style: "display: block" %>
    <%= form.text_field :name %>
    <%= form.error :name, style: "color: red" %>
  </div>

  <div>
    <%= form.submit %>
  </div>
<% end %>
```

### Detail

This Pull Request adds the method `error` to the form builder and updates the forms generated via scaffold.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
