### PR TITLE
Better example for backtrace filter add_filter

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -17,7 +17,8 @@ module ActiveSupport
   # can focus on the rest.
   #
   #   bc = ActiveSupport::BacktraceCleaner.new
-  #   bc.add_filter   { |line| line.gsub(Rails.root.to_s, '') } # strip the Rails.root prefix
+  #   root = "#{Rails.root}/"
+  #   bc.add_filter   { |line| line.start_with?(root) ? line.from(root.size) : line } # strip the Rails.root prefix
   #   bc.add_silencer { |line| /puma|rubygems/.match?(line) } # skip any lines from puma or rubygems
   #   bc.clean(exception.backtrace) # perform the cleanup
   #
@@ -75,8 +76,9 @@ module ActiveSupport
     # Adds a filter from the block provided. Each line in the backtrace will be
     # mapped against this filter.
     #
-    #   # Will turn "/my/rails/root/app/models/person.rb" into "/app/models/person.rb"
-    #   backtrace_cleaner.add_filter { |line| line.gsub(Rails.root.to_s, '') }
+    #   # Will turn "/my/rails/root/app/models/person.rb" into "app/models/person.rb"
+    #   root = "#{Rails.root}/"
+    #   backtrace_cleaner.add_filter { |line| line.start_with?(root) ? line.from(root.size) : line }
     def add_filter(&block)
       @filters << block
     end


### PR DESCRIPTION
The previous example doesn't work as expected in all cases:
If `Rails.root` is just `/app` a backtrace of `/app/app/controllers/application_controller.rb` will be filtered down to `app/controllerslication_controller.rb`.
If have copied the example from the default rails backtrace cleaner which already handles this correctly. The new example also produces relative paths, like Rails does by default. https://github.com/rails/rails/blob/e4e242685efc74e4bacccd5c5878bc671fd63fb7/railties/lib/rails/backtrace_cleaner.rb#L13-L16

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
