### PR TITLE
Fix failing linter in `guides/source`

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -437,7 +437,7 @@ class ShardRecord < ApplicationRecord
   self.abstract_class = true
 
   connects_to shards: {
-    shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
+    shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica },
     shard_two: { writing: :primary_shard_two, reading: :primary_shard_two_replica }
   }
 end


### PR DESCRIPTION
### Motivation / Background

Fix [Failing CI Lint][]

Adds a missing comma to make an example Ruby block syntactically valid.

[Failing CI Lint]: https://github.com/rails/rails/actions/runs/6539678344/job/17758241844?pr=49486#step:4:12

