### PR TITLE
Accept `&block` in `ActiveModel::API` constructor

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,12 @@
+*   Add `&block` support for `ActiveModel::API#initialize`
+
+    Supports a block like `ActiveRecord::Base`:
+
+    ```ruby
+    person = Person.new { |person| person.name = "Ruby" }
+    person.name # => "Ruby"
+    ```
+
+    *Sean Doyle*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/api.rb
+++ b/activemodel/lib/active_model/api.rb
@@ -67,20 +67,34 @@ module ActiveModel
       extend ActiveModel::Translation
     end
 
-    # Initializes a new model with the given +params+.
+    ##
+    # :call-seq:
+    #   initialize(attributes, &block)
+    #
+    # Initializes a new model with the given +params+. Yields the instance
+    # when passed a +block+ argument.
     #
     #   class Person
     #     include ActiveModel::API
     #     attr_accessor :name, :age
     #   end
     #
-    #   person = Person.new(name: 'bob', age: '18')
+    #   person = Person.new(name: "bob", age: "18")
     #   person.name # => "bob"
     #   person.age  # => "18"
+
+    #   person = Person.new { |person| person.assign_attributes name: "bob", age: "18" }
+    #   person.name # => "bob"
+    #   person.age  # => "18"
+    #
+    #   person = Person.new(name: "bob") { |person| person.age = "18" }
+    #   person.name # => "bob"
+    #   person.age  # => "18"
+    #
     def initialize(attributes = {})
       assign_attributes(attributes) if attributes
 
-      super()
+      super().tap { yield self if block_given? }
     end
 
     # Indicates if the model is persisted. Default is +false+.

--- a/activemodel/test/cases/api_test.rb
+++ b/activemodel/test/cases/api_test.rb
@@ -42,6 +42,16 @@ class APITest < ActiveModel::TestCase
     assert_equal "value", object.attr
   end
 
+  def test_initialize_with_and_block
+    object = BasicModel.new { |model| model.attr = "value" }
+    assert_equal "value", object.attr
+  end
+
+  def test_initialize_with_params_and_block
+    object = BasicModel.new(attr: "value") { |model| model.attr = "reassigned" }
+    assert_equal "reassigned", object.attr
+  end
+
   def test_initialize_with_params_and_mixins_reversed
     object = BasicModelWithReversedMixins.new(attr: "value")
     assert_equal "value", object.attr


### PR DESCRIPTION
### Motivation / Background

Extend the constructor defined by `ActiveModel::API` so that its interface matches match [ActiveRecord::Base#new][]'s -- namely the support for yielding the new instance its block argument.

```ruby
person = Person.new { |person| person.name = "Ruby" }
person.name # => "Ruby"
```

[ActiveRecord::Base#new]: https://guides.rubyonrails.org/active_record_basics.html#create

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
