### PR TITLE
Backport `ActiveRecord::Persistence.build` to Active Model from Active Record

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,9 @@
+*   Add `ActiveModel::AttributeAssignment.build`
+
+    Imports `ActiveModel::AttributeAssignment.build` implementation from
+    `ActiveRecord::Persistence.build` to make individual and bulk construction
+    of both `ActiveModel` and `ActiveRecord` objects share the same code.
+
+    *Sean Doyle*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -6,6 +6,42 @@ module ActiveModel
   module AttributeAssignment
     include ActiveModel::ForbiddenAttributesProtection
 
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      # Builds an object (or multiple objects) and returns either the built object or a list of built
+      # objects.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be built.
+      #
+      # ==== Examples
+      #   # Build a single new object
+      #   User.build(first_name: 'Jamie')
+      #
+      #   # Build an Array of new objects
+      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Build a single object and pass it into a block to set other attributes.
+      #   User.build(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Building an Array of new objects using a block, where the block is executed for each object:
+      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def build(attributes = nil, &block)
+        if attributes.is_a?(Array)
+          attributes.collect { |attr| build(attr, &block) }
+        else
+          new(attributes, &block)
+        end
+      end
+    end
+
     # Allows you to set all the attributes by passing in a hash of attributes with
     # keys matching the attribute names.
     #

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   "Backport" `ActiveRecord::Persistence.build` to `ActiveModel::AttributeAssignment`
+
+    Implement `.build` in `ActiveModel::AttributeAssignment` for transitive
+    inclusion in `ActiveRecord::Base`.
+
+    *Sean Doyle*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -7,6 +7,10 @@ module ActiveRecord
   module Persistence
     extend ActiveSupport::Concern
 
+    included do
+      extend ActiveModel::AttributeAssignment::ClassMethods
+    end
+
     module ClassMethods
       # Creates an object (or multiple objects) and saves it to the database, if validations pass.
       # The resulting object is returned whether the object was saved successfully to the database or not.
@@ -54,36 +58,6 @@ module ActiveRecord
           object = new(attributes, &block)
           object.save!
           object
-        end
-      end
-
-      # Builds an object (or multiple objects) and returns either the built object or a list of built
-      # objects.
-      #
-      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
-      # attributes on the objects that are to be built.
-      #
-      # ==== Examples
-      #   # Build a single new object
-      #   User.build(first_name: 'Jamie')
-      #
-      #   # Build an Array of new objects
-      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
-      #
-      #   # Build a single object and pass it into a block to set other attributes.
-      #   User.build(first_name: 'Jamie') do |u|
-      #     u.is_admin = false
-      #   end
-      #
-      #   # Building an Array of new objects using a block, where the block is executed for each object:
-      #   User.build([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
-      #     u.is_admin = false
-      #   end
-      def build(attributes = nil, &block)
-        if attributes.is_a?(Array)
-          attributes.collect { |attr| build(attr, &block) }
-        else
-          new(attributes, &block)
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

Extracted out of https://github.com/rails/rails/pull/49647

### Detail

Imports `ActiveModel::AttributeAssignment.build` implementation from `ActiveRecord::Persistence.build` to make individual and bulk construction of both `ActiveModel` and `ActiveRecord` objects share the same code.

### Additional information

Opened as a complementary pull request alongside [#49661][].

[#49661]: https://github.com/rails/rails/pull/49661

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
