### PR TITLE
Backport `ActiveRecord::Persistence.{create!,create}` to Active Model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,10 @@
+*   Backport `ActiveRecord::Persistence.create!` and `.create` to Active Model from Active Record
+
+    Migrates `ActiveModel::Persistence.create!` and `.create` implementations
+    from `ActiveRecord::Persistence.create!` and `.create` to make individual and
+    bulk construction of both `ActiveModel` and `ActiveRecord` objects share the
+    same code.
+
+    *Sean Doyle*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -49,6 +49,7 @@ module ActiveModel
   autoload :Model
   autoload :Name, "active_model/naming"
   autoload :Naming
+  autoload :Persistence
   autoload :SecurePassword
   autoload :Serialization
   autoload :Translation

--- a/activemodel/lib/active_model/persistence.rb
+++ b/activemodel/lib/active_model/persistence.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  # = Active Model \Persistence
+  module Persistence
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Builds an object (or multiple objects), then calls +#save+ if the objects responds to +#save+.
+      # The resulting object is returned whether the object was saved successfully or not.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be created.
+      #
+      # ==== Examples
+      #   # Create a single new object
+      #   User.create(first_name: 'Jamie')
+      #
+      #   # Create an Array of new objects
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Create a single object and pass it into a block to set other attributes.
+      #   User.create(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Creating an Array of new objects using a block, where the block is executed for each object:
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def create(attributes = nil, &block)
+        if attributes.is_a?(Array)
+          attributes.collect { |attr| create(attr, &block) }
+        else
+          object = new(attributes, &block)
+          object.save if object.respond_to?(:save)
+          object
+        end
+      end
+
+      # Builds an object (or multiple objects), then calls +#save!+ if the objects responds to +#save!+.
+      # The resulting object is returned whether the object was saved successfully or not.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
+      # These describe which attributes to be created on the object, or
+      # multiple objects when given an Array of Hashes.
+      def create!(attributes = nil, &block)
+        if attributes.is_a?(Array)
+          attributes.collect { |attr| create!(attr, &block) }
+        else
+          object = new(attributes, &block)
+          object.save! if object.respond_to?(:save!)
+          object
+        end
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/persistence_test.rb
+++ b/activemodel/test/cases/persistence_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PersistenceTest < ActiveModel::TestCase
+  class Model
+    include ActiveModel::Persistence
+
+    attr_accessor :name, :description
+
+    def initialize(attributes, &block)
+      attributes.each { |k, v| send("#{k}=", v) }
+
+      tap { yield self if block_given? }
+    end
+  end
+
+  test "create many" do
+    models = Model.create([ { "name" => "first" }, { "name" => "second" }])
+    assert_equal 2, models.size
+    assert_equal "first", models.first.name
+  end
+
+  test "create through factory with block" do
+    model = Model.create("name" => "New Model") do |t|
+      t.description = "Description"
+    end
+    assert_equal("New Model", model.name)
+    assert_equal("Description", model.description)
+  end
+
+  test "create many through factory with block" do
+    model1, model2, *rest = Model.create([ { "name" => "first" }, { "name" => "second" }]) do |t|
+      t.description = "Description"
+    end
+    assert_empty rest
+    assert_equal "first", model1.name
+    assert_equal "Description", model1.description
+    assert_equal "second", model2.name
+    assert_equal "Description", model2.description
+  end
+
+  test "create! many" do
+    models = Model.create!([ { "name" => "first" }, { "name" => "second" }])
+    assert_equal 2, models.size
+    assert_equal "first", models.first.name
+  end
+
+  test "create! through factory with block" do
+    model = Model.create!("name" => "New Model") do |t|
+      t.description = "Description"
+    end
+    assert_equal("New Model", model.name)
+    assert_equal("Description", model.description)
+  end
+
+  test "create! many through factory with block" do
+    model1, model2, *rest = Model.create!([ { "name" => "first" }, { "name" => "second" }]) do |t|
+      t.description = "Description"
+    end
+    assert_empty rest
+    assert_equal "first", model1.name
+    assert_equal "Description", model1.description
+    assert_equal "second", model2.name
+    assert_equal "Description", model2.description
+  end
+end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   "Backport" `ActiveRecord::Persistence.create!` and `.create` to `ActiveModel::Persistence`
+
+    Extract `.create!` and `.create` into `ActiveModel::Persistence`, then
+    include in `ActiveRecord::Persistence`.
+
+    *Sean Doyle*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -6,8 +6,15 @@ module ActiveRecord
   # = Active Record \Persistence
   module Persistence
     extend ActiveSupport::Concern
+    include ActiveModel::Persistence
 
     module ClassMethods
+      ##
+      # :method: create
+      #
+      # :call-seq:
+      #   create(attributes = nil, &block)
+      #
       # Creates an object (or multiple objects) and saves it to the database, if validations pass.
       # The resulting object is returned whether the object was saved successfully to the database or not.
       #
@@ -30,16 +37,16 @@ module ActiveRecord
       #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
       #     u.is_admin = false
       #   end
-      def create(attributes = nil, &block)
-        if attributes.is_a?(Array)
-          attributes.collect { |attr| create(attr, &block) }
-        else
-          object = new(attributes, &block)
-          object.save
-          object
-        end
-      end
+      #
+      #--
+      # Implemented by ActiveModel::Persistence.create.
 
+      ##
+      # :method: create!
+      #
+      # :call-seq:
+      #   create!(attributes = nil, &block)
+      #
       # Creates an object (or multiple objects) and saves it to the database,
       # if validations pass. Raises a RecordInvalid error if validations fail,
       # unlike Base#create.
@@ -47,15 +54,9 @@ module ActiveRecord
       # The +attributes+ parameter can be either a Hash or an Array of Hashes.
       # These describe which attributes to be created on the object, or
       # multiple objects when given an Array of Hashes.
-      def create!(attributes = nil, &block)
-        if attributes.is_a?(Array)
-          attributes.collect { |attr| create!(attr, &block) }
-        else
-          object = new(attributes, &block)
-          object.save!
-          object
-        end
-      end
+      #
+      #--
+      # Implemented by ActiveModel::Persistence.create!.
 
       # Builds an object (or multiple objects) and returns either the built object or a list of built
       # objects.


### PR DESCRIPTION
### Motivation / Background

Extracted out of https://github.com/rails/rails/pull/49647

### Detail

Migrates `.create!` and `.create` implementations from
`ActiveRecord::Persistence` into `ActiveModel::Persistence` to make
individual and bulk construction of both `ActiveModel` and
`ActiveRecord` objects share the same code.

### Additional information

Opened as a complementary pull request alongside [#49662][].

[#49662]: https://github.com/rails/rails/pull/49662

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
