### PR TITLE
Fix extra blank line when no error_highlight

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -50,8 +50,8 @@ group :development do
 <%- end -%>
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-
 <%- if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" -%>
+
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 <%- end -%>
 end


### PR DESCRIPTION
### Motivation / Background

A new condition was recently [added][1] to exclude error_highlight from the Gemfile when the Ruby version is 3.2 or greater. However, this change leads to an extra blank line after `gem "spring"` on Ruby 3.2+. This could also happen to new apps generated on Rubies < 3.1, but my guess is that is less common.

### Detail

This commit fixes the issue by moving the extra blank line into the condition.

[1]: https://github.com/rails/rails/commit/d7b395145c644434b1c2be07ef334ea5cb643b75

### Additional Information

I think this should definitely be backported to 7.1, ~and I can see an argument for 7.0 as well since a 7.0 app generated on ruby 2.7 or 3.0 would have the same issue.~

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
