### PR TITLE
Fix decoding data encoded using a non-String purpose

### DIFF
--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -82,7 +82,7 @@ module ActiveSupport
             throw :invalid_message_content, "expired"
           end
 
-          if hash["pur"] != purpose&.to_s
+          if hash["pur"].to_s != purpose.to_s
             throw :invalid_message_content, "mismatched purpose"
           end
 

--- a/activesupport/test/messages/message_metadata_tests.rb
+++ b/activesupport/test/messages/message_metadata_tests.rb
@@ -92,6 +92,13 @@ module MessageMetadataTests
       assert_roundtrip "a string", codec, { purpose: "x", expires_in: 1.year }, { purpose: "x" }
     end
 
+    test "messages with non-string purpose are readable" do
+      each_scenario do |data, codec|
+        message = encode(data, codec, purpose: [ "x", 1 ])
+        assert_equal data, decode(message, codec, purpose: [ "x", 1 ])
+      end
+    end
+
     test "messages are readable regardless of use_message_serializer_for_metadata" do
       each_scenario do |data, codec|
         message = encode(data, codec, purpose: "x")


### PR DESCRIPTION
Data encoded using a non-String purpose and `use_message_serializer_for_metadata == false` was incorrectly decoded,
triggering a "mismatched purpose" error during decode.
Fix this by ensuring that we compare both sides as a String.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
