### PR TITLE
Drop dependency on `mutex_m`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ PATH
       drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
-      mutex_m
       tzinfo (~> 2.0)
     rails (7.2.0.alpha)
       actioncable (= 7.2.0.alpha)
@@ -342,7 +341,6 @@ GEM
     msgpack (1.7.0)
     multi_json (1.15.0)
     multipart-post (2.2.3)
-    mutex_m (0.1.2)
     mysql2 (0.5.5)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -84,11 +84,7 @@ module ActionController
 
     EXCLUDE_PARAMETERS = %w(authenticity_token _method utf8)
 
-    require "mutex_m"
-
     class Options < Struct.new(:name, :format, :include, :exclude, :klass, :model) # :nodoc:
-      include Mutex_m
-
       def self.from_hash(hash)
         name    = hash[:name]
         format  = Array(hash[:format])
@@ -99,6 +95,7 @@ module ActionController
 
       def initialize(name, format, include, exclude, klass, model) # :nodoc:
         super
+        @mutex = Mutex.new
         @include_set = include
         @name_set    = name
       end
@@ -111,7 +108,7 @@ module ActionController
         return super if @include_set
 
         m = model
-        synchronize do
+        @mutex.synchronize do
           return super if @include_set
 
           @include_set = true
@@ -144,7 +141,7 @@ module ActionController
         return super if @name_set
 
         m = model
-        synchronize do
+        @mutex.synchronize do
           return super if @name_set
 
           @name_set = true

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "mutex_m"
 require "active_support/core_ext/module/delegation"
 
 module ActiveRecord
@@ -67,10 +66,10 @@ module ActiveRecord
     end
 
     class GeneratedRelationMethods < Module # :nodoc:
-      include Mutex_m
+      MUTEX = Mutex.new
 
       def generate_method(method)
-        synchronize do
+        MUTEX.synchronize do
           return if method_defined?(method)
 
           if /\A[a-zA-Z_]\w*[!?]?\z/.match?(method) && !DELEGATION_RESERVED_METHOD_NAMES.include?(method.to_s)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -41,6 +41,5 @@ Gem::Specification.new do |s|
   s.add_dependency "minitest",        ">= 5.1"
   s.add_dependency "base64"
   s.add_dependency "drb"
-  s.add_dependency "mutex_m"
   s.add_dependency "bigdecimal"
 end


### PR DESCRIPTION
It used to be stdlib but is being extracted in modern rubies.

Overall its usefulness is dubious. In all cases it is included in Rails, it's only for the `synchronize` method, but end up exposing a dozen other useless methods.

In the end just using a Mutex is clearer and simpler.

In some cases we can even get away with a single mutex in a constant.
