### PR TITLE
Migrate `ActiveRecord::AttributeAssignment` support for multiparameter attributes to Active Model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Migrate `ActiveRecord::AttributeAssignment` support for multiparameter attributes to Active Model
+
+    ```ruby
+    class Topic
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :last_read_on, :date
+    end
+
+    topic = Topic.new
+    topic.attributes = {
+      "last_read_on(1i)" => "2023",
+      "last_read_on(2i)" => "10",
+      "last_read_on(3i)" => "17"
+    )
+    topic.last_read_on == Date.new(2023, 10, 17) # => true
+    ```
+
+    *Sean Doyle*
+
 *   Combine `:if`, `:unless`, and `:on` options when specified at both the
     `validates` level and the per-validator level, instead of the per-validator
     options silently replacing the top-level ones.

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -3,6 +3,31 @@
 require "active_support/core_ext/hash/keys"
 
 module ActiveModel
+  # Raised when an error occurred while doing a mass assignment to an attribute through the
+  # {AttributeAssignment#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  # The exception has an +attribute+ property that is the name of the offending attribute.
+  class AttributeAssignmentError < StandardError
+    attr_reader :exception, :attribute
+
+    def initialize(message = nil, exception = nil, attribute = nil)
+      super(message)
+      @exception = exception
+      @attribute = attribute
+    end
+  end
+
+  # Raised when there are multiple errors while doing a mass assignment through the
+  # {AttributeAssignment#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
+  # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
+  # objects, each corresponding to the error while assigning to an attribute.
+  class MultiparameterAssignmentErrors < StandardError
+    attr_reader :errors
+
+    def initialize(errors = nil)
+      @errors = errors
+    end
+  end
+
   module AttributeAssignment
     include ActiveModel::ForbiddenAttributesProtection
 
@@ -59,9 +84,22 @@ module ActiveModel
 
     private
       def _assign_attributes(attributes)
+        multi_parameter_attributes = nil
+        nested_parameter_attributes = nil
+
         attributes.each_pair do |k, v|
-          _assign_attribute(k, v)
+          k = k.to_s
+          if k.include?("(")
+            (multi_parameter_attributes ||= {})[k] = v
+          elsif v.is_a?(Hash)
+            (nested_parameter_attributes ||= {})[k] = v
+          else
+            _assign_attribute(k, v)
+          end
         end
+
+        assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
+        assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
       end
 
       def _assign_attribute(k, v)
@@ -73,6 +111,63 @@ module ActiveModel
         else
           attribute_writer_missing(k.to_s, v)
         end
+      end
+
+      # Assign any deferred nested attributes after the base attributes have been set.
+      def assign_nested_parameter_attributes(pairs)
+        pairs.each { |k, v| _assign_attribute(k, v) }
+      end
+
+      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
+      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
+      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
+      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
+      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
+      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
+      def assign_multiparameter_attributes(pairs)
+        execute_callstack_for_multiparameter_attributes(
+          extract_callstack_for_multiparameter_attributes(pairs)
+        )
+      end
+
+      def execute_callstack_for_multiparameter_attributes(callstack)
+        errors = []
+        callstack.each do |name, values_with_empty_parameters|
+          if values_with_empty_parameters.each_value.all?(NilClass)
+            values = nil
+          else
+            values = values_with_empty_parameters
+          end
+          send("#{name}=", values)
+        rescue => ex
+          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
+        end
+        unless errors.empty?
+          error_descriptions = errors.map(&:message).join(",")
+          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
+        end
+      end
+
+      def extract_callstack_for_multiparameter_attributes(pairs)
+        attributes = {}
+
+        pairs.each do |(multiparameter_name, value)|
+          attribute_name = multiparameter_name.split("(").first
+          attributes[attribute_name] ||= {}
+
+          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
+          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
+        end
+
+        attributes
+      end
+
+      def type_cast_attribute_value(multiparameter_name, value)
+        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
+      end
+
+      def find_parameter_position(multiparameter_name)
+        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
       end
   end
 end

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -159,3 +159,310 @@ class AttributeAssignmentTest < ActiveModel::TestCase
     assert_equal "world", model.description
   end
 end
+
+class MultiparameterAttributeAssignmentTest < ActiveModel::TestCase
+  class Model
+    include ActiveModel::AttributeAssignment
+    include ActiveModel::Attributes
+
+    def initialize(attributes = {})
+      super()
+      assign_attributes(attributes)
+    end
+  end
+
+  class Customer < Model
+    attribute :address
+
+    def address=(value)
+      if value.is_a?(Hash)
+        street, city, country = value[1], value[2], value[3]
+
+        super(Address.new(street, city, country))
+      else
+        super
+      end
+    end
+  end
+
+  class Address < Model
+    attr_reader :street, :city, :country
+
+    def initialize(street, city, country)
+      @street, @city, @country = street, city, country
+    end
+
+    def ==(other)
+      [street, city, country] == [other.street, other.city, other.country]
+    end
+  end
+
+  class Topic < Model
+    attribute :last_read, :date
+    attribute :written_on, :datetime
+    attribute :bonus_time, :time
+  end
+
+  test "multiparameter attributes on date" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "6", "last_read(3i)" => "24" }
+
+    assert_equal Date.new(2004, 6, 24), topic.last_read.to_date
+  end
+
+  test "multiparameter attributes on date with empty year" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "", "last_read(2i)" => "6", "last_read(3i)" => "24" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with empty month" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "", "last_read(3i)" => "24" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with empty day" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "6", "last_read(3i)" => "" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with empty day and year" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "", "last_read(2i)" => "6", "last_read(3i)" => "" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with empty day and month" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "2004", "last_read(2i)" => "", "last_read(3i)" => "" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with empty year and month" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "", "last_read(2i)" => "", "last_read(3i)" => "24" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on date with all empty" do
+    topic = Topic.new
+    topic.attributes = { "last_read(1i)" => "", "last_read(2i)" => "", "last_read(3i)" => "" }
+
+    assert_nil topic.last_read
+  end
+
+  test "multiparameter attributes on time" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+    }
+
+    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+  end
+
+  test "multiparameter attributes on time with no date" do
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      topic = Topic.new
+      topic.attributes = {
+        "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+      }
+    end
+    assert_equal("written_on", ex.errors[0].attribute)
+  end
+
+  test "multiparameter attributes on time with invalid time params" do
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      topic = Topic.new
+      topic.attributes = {
+        "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+        "written_on(4i)" => "2004", "written_on(5i)" => "36", "written_on(6i)" => "64",
+      }
+    end
+    assert_equal("written_on", ex.errors[0].attribute)
+  end
+
+  test "multiparameter attributes on time with old date" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "1850", "written_on(2i)" => "6", "written_on(3i)" => "24",
+      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+    }
+
+    # testing against to_fs(:db) representation because either a Time or a DateTime might be returned, depending on platform
+    assert_equal "1850-06-24 16:24:00", topic.written_on.to_fs(:db)
+  end
+
+  test "multiparameter attributes on time will raise on big time if missing date parts" do
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      topic = Topic.new
+      topic.attributes = {
+        "written_on(4i)" => "16", "written_on(5i)" => "24"
+      }
+    end
+    assert_equal("written_on", ex.errors[0].attribute)
+  end
+
+  test "multiparameter attributes on time with raise on small time if missing date parts" do
+    ex = assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      topic = Topic.new
+      topic.attributes = {
+        "written_on(4i)" => "16", "written_on(5i)" => "12", "written_on(6i)" => "02"
+      }
+    end
+    assert_equal("written_on", ex.errors[0].attribute)
+  end
+
+  test "multiparameter attributes on time will ignore hour if missing" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "2004", "written_on(2i)" => "12", "written_on(3i)" => "12",
+      "written_on(5i)" => "12", "written_on(6i)" => "02"
+    }
+
+    assert_equal Time.utc(2004, 12, 12, 0, 12, 2), topic.written_on
+  end
+
+  test "multiparameter attributes on time will ignore hour if blank" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "", "written_on(2i)" => "", "written_on(3i)" => "",
+      "written_on(4i)" => "", "written_on(5i)" => "12", "written_on(6i)" => "02"
+    }
+
+    assert_nil topic.written_on
+  end
+
+  test "multiparameter attributes on time will ignore date if empty" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "", "written_on(2i)" => "", "written_on(3i)" => "",
+      "written_on(4i)" => "16", "written_on(5i)" => "24"
+    }
+
+    assert_nil topic.written_on
+  end
+
+  test "multiparameter attributes on time with seconds will ignore date if empty" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "", "written_on(2i)" => "", "written_on(3i)" => "",
+      "written_on(4i)" => "16", "written_on(5i)" => "12", "written_on(6i)" => "02"
+    }
+
+    assert_nil topic.written_on
+  end
+
+  test "multiparameter attributes on time with utc" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => "00"
+    }
+
+    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+  end
+
+  test "multiparameter attributes setting time attribute" do
+    topic = Topic.new
+    topic.attributes = { "bonus_time(4i)" => "01", "bonus_time(5i)" => "05" }
+
+    assert_equal 1, topic.bonus_time.hour
+    assert_equal 5, topic.bonus_time.min
+  end
+
+  test "multiparameter attributes on time with empty seconds" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "2004", "written_on(2i)" => "6", "written_on(3i)" => "24",
+      "written_on(4i)" => "16", "written_on(5i)" => "24", "written_on(6i)" => ""
+    }
+
+    assert_equal Time.utc(2004, 6, 24, 16, 24, 0), topic.written_on
+  end
+
+  test "multiparameter attributes setting date attribute" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "1952", "written_on(2i)" => "3", "written_on(3i)" => "11"
+    }
+
+    assert_equal 1952, topic.written_on.year
+    assert_equal 3, topic.written_on.month
+    assert_equal 11, topic.written_on.day
+  end
+
+  test "multiparameter attributes setting date and time attribute" do
+    topic = Topic.new
+    topic.attributes = {
+      "written_on(1i)" => "1952",
+      "written_on(2i)" => "3",
+      "written_on(3i)" => "11",
+      "written_on(4i)" => "13",
+      "written_on(5i)" => "55"
+    }
+
+    assert_equal 1952, topic.written_on.year
+    assert_equal 3, topic.written_on.month
+    assert_equal 11, topic.written_on.day
+    assert_equal 13, topic.written_on.hour
+    assert_equal 55, topic.written_on.min
+  end
+
+  test "multiparameter attributes setting time but not date on date field" do
+    assert_raise(ActiveModel::MultiparameterAssignmentErrors) do
+      topic = Topic.new
+      topic.attributes = { "written_on(4i)" => "13", "written_on(5i)" => "55" }
+    end
+  end
+
+  test "multiparameter assignment of aggregation" do
+    address = Address.new("The Street", "The City", "The Country")
+    customer = Customer.new
+    customer.attributes = { "address(1)" => address.street, "address(2)" => address.city, "address(3)" => address.country }
+
+    assert_equal address, customer.address
+  end
+
+  test "multiparameter assignment of aggregation out of order" do
+    customer = Customer.new
+    address = Address.new("The Street", "The City", "The Country")
+    customer.attributes = { "address(3)" => address.country, "address(2)" => address.city, "address(1)" => address.street }
+
+    assert_equal address, customer.address
+  end
+
+  test "multiparameter assignment of aggregation with missing values" do
+    customer = Customer.new
+    address = Address.new("The Street", "The City", "The Country")
+    customer.attributes = { "address(2)" => address.city, "address(3)" => address.country }
+
+    assert_nil customer.address.street
+    assert_equal address.city, customer.address.city
+    assert_equal address.country, customer.address.country
+  end
+
+  test "multiparameter assignment of aggregation with blank values" do
+    customer = Customer.new
+    address = Address.new("The Street", "The City", "The Country")
+    attributes = { "address(1)" => "", "address(2)" => address.city, "address(3)" => address.country }
+    customer.attributes = attributes
+
+    assert_equal Address.new(nil, "The City", "The Country"), customer.address
+  end
+
+  test "multiparameter assignment of aggregation from #initialize" do
+    address = Address.new("The Street", "The City", "The Country")
+    customer = Customer.new("address(1)" => address.street, "address(2)" => address.city, "address(3)" => address.country)
+
+    assert_equal address, customer.address
+  end
+end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Migrate `ActiveRecord::AttributeAssignment` support for multi-parameter attributes to Active Model
+
+    Implement assignment in terms of including `ActiveModel::AttributeAssignment`
+
+    *Sean Doyle*
+
 *   Bump the minimum PostgreSQL version to 10.0.
 
     As part of this change, `supports_pgcrypto_uuid?` is deprecated because

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -2,81 +2,32 @@
 
 module ActiveRecord
   module AttributeAssignment
-    private
-      def _assign_attributes(attributes)
-        multi_parameter_attributes = nested_parameter_attributes = nil
-
-        attributes.each do |k, v|
-          key = k.to_s
-
-          if key.include?("(")
-            (multi_parameter_attributes ||= {})[key] = v
-          elsif v.is_a?(Hash)
-            (nested_parameter_attributes ||= {})[key] = v
-          else
-            _assign_attribute(key, v)
-          end
-        end
-
-        assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
-        assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
+    # Allows you to set all the attributes by passing in a hash of attributes with
+    # keys matching the attribute names.
+    #
+    # If the passed hash responds to <tt>permitted?</tt> method and the return value
+    # of this method is +false+ an ActiveModel::ForbiddenAttributesError
+    # exception is raised.
+    #
+    #   class Cat < ApplicationRecord
+    #   end
+    #
+    #   cat = Cat.new
+    #   cat.assign_attributes(name: "Gorby", status: "yawning")
+    #   cat.name # => "Gorby"
+    #   cat.status # => "yawning"
+    #   cat.assign_attributes(status: "sleeping")
+    #   cat.name # => "Gorby"
+    #   cat.status # => "sleeping"
+    def assign_attributes(attributes)
+      super
+    rescue ActiveModel::MultiparameterAssignmentErrors => error
+      errors = error.errors.map do |error|
+        ActiveRecord::AttributeAssignmentError.new(error.message, error.exception, error.attribute)
       end
+      raise ActiveRecord::MultiparameterAssignmentErrors.new(errors)
+    end
 
-      # Assign any deferred nested attributes after the base attributes have been set.
-      def assign_nested_parameter_attributes(pairs)
-        pairs.each { |k, v| _assign_attribute(k, v) }
-      end
-
-      # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
-      # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
-      # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
-      # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
-      # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
-      # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
-      def assign_multiparameter_attributes(pairs)
-        execute_callstack_for_multiparameter_attributes(
-          extract_callstack_for_multiparameter_attributes(pairs)
-        )
-      end
-
-      def execute_callstack_for_multiparameter_attributes(callstack)
-        errors = []
-        callstack.each do |name, values_with_empty_parameters|
-          if values_with_empty_parameters.each_value.all?(NilClass)
-            values = nil
-          else
-            values = values_with_empty_parameters
-          end
-          send("#{name}=", values)
-        rescue => ex
-          errors << AttributeAssignmentError.new("error on assignment #{values_with_empty_parameters.values.inspect} to #{name} (#{ex.message})", ex, name)
-        end
-        unless errors.empty?
-          error_descriptions = errors.map(&:message).join(",")
-          raise MultiparameterAssignmentErrors.new(errors), "#{errors.size} error(s) on assignment of multiparameter attributes [#{error_descriptions}]"
-        end
-      end
-
-      def extract_callstack_for_multiparameter_attributes(pairs)
-        attributes = {}
-
-        pairs.each do |(multiparameter_name, value)|
-          attribute_name = multiparameter_name.split("(").first
-          attributes[attribute_name] ||= {}
-
-          parameter_value = value.empty? ? nil : type_cast_attribute_value(multiparameter_name, value)
-          attributes[attribute_name][find_parameter_position(multiparameter_name)] ||= parameter_value
-        end
-
-        attributes
-      end
-
-      def type_cast_attribute_value(multiparameter_name, value)
-        multiparameter_name =~ /\([0-9]*([if])\)/ ? value.send("to_" + $1) : value
-      end
-
-      def find_parameter_position(multiparameter_name)
-        multiparameter_name.scan(/\(([0-9]*).*\)/).first.first.to_i
-      end
+    alias_method :attributes=, :assign_attributes
   end
 end


### PR DESCRIPTION
Duplicate of https://github.com/rails/rails/pull/36183

### Motivation / Background

Prior to this commit, the only difference between
`ActiveRecord::AttributeAssignment` and
`ActiveModel::AttributeAssignment` was support for multi-parameter attributes like those generated by Action View form helpers.

### Detail

This commit reduces `ActiveRecord::AttributeAssignment`'s responsibility, and instead relies on its inclusion of `ActiveModel::AttributeAssignment` to implement that behavior.

The added benefit of upstreaming this behavior is that Active Model POROs can be designed to be compatible with Action View Date, DateTime, and Time `<select>` elements:

```ruby
class Topic
  include ActiveModel::Model
  include ActiveModel::Attributes

  attribute :last_read_on, :date
end

topic = Topic.new(
  "last_read_on(1i)" => "2023",
  "last_read_on(2i)" => "10",
  "last_read_on(3i)" => "17"
)
topic.last_read_on == Date.new(2023, 10, 17) # => true
```

To maintain backwards compatibility, this commit preserves the `ActiveRecord::AttributeAssignment` module, despite the fact that it's mostly empty. Additionally, it makes sure that
`ActiveRecord::AttributeAssignmentError` and
`ActiveRecord::MultiparameterAssignmentErrors` are still thrown. This is important for applications that have generic
`ActiveRecord::ActiveRecordError` handling, since the new `ActiveModel::AttributeAssignmentError` and
`ActiveModel::MultiparameterAssignmentErrors` do not inherit from `ActiveRecord::ActiveRecordError`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
