### PR TITLE
Make `==(other)` method of AttributeSet safe #49670

### DIFF
--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -104,7 +104,7 @@ module ActiveModel
     end
 
     def ==(other)
-      attributes == other.attributes
+      other.is_a?(AttributeSet) && attributes == other.send(:attributes)
     end
 
     protected

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -279,6 +279,14 @@ module ActiveModel
       assert_not_equal attributes2, attributes3
     end
 
+    test "==(other) is safe to use with any instance" do
+      attribute_set = AttributeSet.new({})
+
+      assert_equal false, attribute_set == nil
+      assert_equal false, attribute_set == 1
+      assert_equal true, attribute_set == attribute_set
+    end
+
     private
       def attributes_with_uninitialized_key
         builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new)


### PR DESCRIPTION
The `==(other)` should be able to work with any instances without exception. To do so, we check if the other instance is an AttributeSet.

### Detail

This Pull Request changes Fixes #49670

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
