### PR TITLE
Remove `ActiveRecord::AttributeAssignment#assign_nested_parameter_attributes`

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -4,27 +4,19 @@ module ActiveRecord
   module AttributeAssignment
     private
       def _assign_attributes(attributes)
-        multi_parameter_attributes = nested_parameter_attributes = nil
+        multi_parameter_attributes = nil
 
         attributes.each do |k, v|
           key = k.to_s
 
           if key.include?("(")
             (multi_parameter_attributes ||= {})[key] = v
-          elsif v.is_a?(Hash)
-            (nested_parameter_attributes ||= {})[key] = v
           else
             _assign_attribute(key, v)
           end
         end
 
-        assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
         assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
-      end
-
-      # Assign any deferred nested attributes after the base attributes have been set.
-      def assign_nested_parameter_attributes(pairs)
-        pairs.each { |k, v| _assign_attribute(k, v) }
       end
 
       # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done


### PR DESCRIPTION
### Motivation / Background

The private `#assign_nested_parameter_attributes` was introduced in [774ff18][] (Dec 15, 2011), moved to `ActiveRecord::AttributeAssignment` in [ceb33f8][] (also Dec 15, 2011), then most recently modified in [2606fb3][] (Jan 23, 2015) when `ActiveModel::AttributeAssignment` was extracted.

Support for `accepts_nested_attributes_for` (introduced in [ec8f045][] Feb 1, 2009) pre-dates those commits, and has evolved enough to cover this behavior in other ways.


### Detail

With its removal, Active Record's test suite still passes, so if it's a crucial piece of code to retain, we should expand the suite to exercise it.

### Additional information

The fact that removing these methods doesn't fail the test suite came out of https://github.com/rails/rails/pull/49675. If that PR isn't deemed to be viable, removing the code in this PR might still have value. If that PR **is** deemed to be viable, we might want to merge this PR ahead of it, then **make similar changes to remove the calls** from https://github.com/rails/rails/pull/49675/files#diff-bd47ea9eef412ec5aca24908af217592cef01d24fd54eeec976bd37bd9a18151R80.

[774ff18]: https://github.com/rails/rails/commit/774ff18c095145f544e845dbb940378546748969
[ceb33f8]: https://github.com/rails/rails/commit/ceb33f84933639d3b61aac62e5e71fd087ab65ed
[2606fb3]: https://github.com/rails/rails/commit/2606fb339797a99c50e531105fc92071cef3db01
[ec8f045]: https://github.com/rails/rails/commit/ec8f04584479aff895b0b511a7ba1e9d33f84067