### PR TITLE
🤫 Quiet down railties tests

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -89,6 +89,7 @@ module ApplicationTests
     def restore_default_config
       FileUtils.rm_rf("#{app_path}/config/environments")
       FileUtils.mv("#{app_path}/config/__environments__", "#{app_path}/config/environments")
+      remove_from_env_config "production", "config.log_level = :error"
     end
 
     test "Rails.env does not set the RAILS_ENV environment variable which would leak out into rake tasks" do

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -168,19 +168,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "#{app_moved_root}/config/environment.rb", /Rails\.application\.initialize!/
   end
 
-  def test_new_application_load_defaults
+  def test_app_update
     run_generator
-    assert_file "config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/
-  end
 
-  def test_app_update_create_new_framework_defaults
     defaults_path = "config/initializers/new_framework_defaults_#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}.rb"
 
-    run_generator
     assert_no_file defaults_path
+    assert_no_file "config/initializers/cors.rb"
 
     run_app_update
+
     assert_file defaults_path
+    assert_no_file "config/initializers/cors.rb"
   end
 
   def test_app_update_supports_skip
@@ -209,13 +208,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       defaults_path = "config/initializers/new_framework_defaults_#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}.rb"
       assert_no_file defaults_path
     end
-  end
-
-  def test_app_update_does_not_create_rack_cors
-    run_generator
-    run_app_update
-
-    assert_no_file "config/initializers/cors.rb"
   end
 
   def test_app_update_does_not_remove_rack_cors_if_already_present
@@ -331,23 +323,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_gem_for_active_storage
-    run_generator
-    assert_file "Gemfile", /^# gem "image_processing"/
-  end
-
-  def test_gem_for_active_storage_when_skip_active_storage_is_given
-    run_generator [destination_root, "--skip-active-storage"]
-
-    assert_no_gem "image_processing"
-
-    assert_file "Dockerfile" do |content|
-      assert_no_match(/libvips/, content)
-    end
-  end
-
   def test_app_update_does_not_generate_active_storage_contents_when_skip_active_storage_is_given
     run_generator [destination_root, "--skip-active-storage"]
+
     run_app_update
 
     assert_file "config/environments/development.rb" do |content|
@@ -389,28 +367,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
   end
 
-  def test_generator_skips_action_mailbox_when_skip_active_record_is_given
-    run_generator [destination_root, "--skip-active-record"]
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
-  end
-
-  def test_generator_skips_action_mailbox_when_skip_active_storage_is_given
-    run_generator [destination_root, "--skip-active-storage"]
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
-  end
-
   def test_generator_skips_action_text_when_skip_action_text_is_given
     run_generator [destination_root, "--skip-action-text"]
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_text\/engine["']/
-  end
-
-  def test_generator_skips_action_text_when_skip_active_record_is_given
-    run_generator [destination_root, "--skip-active-record"]
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_text\/engine["']/
-  end
-
-  def test_generator_skips_action_text_when_skip_active_storage_is_given
-    run_generator [destination_root, "--skip-active-storage"]
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_text\/engine["']/
   end
 
@@ -796,14 +754,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     assert_equal 1, @bundle_commands.count("binstubs bundler")
-  end
-
-  def test_skip_active_record_option
-    run_generator [destination_root, "--skip-active-record"]
-
-    assert_file ".gitattributes" do |content|
-      assert_no_match(/schema.rb/, content)
-    end
   end
 
   def test_skip_active_job_option
@@ -1483,6 +1433,36 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   private
+    def assert_load_defaults
+      assert_file "config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/
+    end
+
+    def assert_gem_for_active_storage
+      assert_file "Gemfile", /^# gem "image_processing"/
+    end
+
+    def assert_frameworks_are_not_required_when_active_storage_is_skipped
+      super
+      assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/
+      assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_text\/engine["']/
+    end
+
+    def assert_dockerfile_when_active_storage_is_skipped
+      assert_file "Dockerfile" do |content|
+        assert_no_match(/libvips/, content)
+      end
+    end
+
+    def assert_gems_when_active_storage_is_skipped
+      assert_no_gem "image_processing"
+    end
+
+    def assert_gitattributes_does_not_have_schema_file
+      assert_file ".gitattributes" do |content|
+        assert_no_match(/schema.rb/, content)
+      end
+    end
+
     def assert_node_files
       assert_file ".node-version" do |content|
         assert_match %r/\d+\.\d+\.\d+/, content

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -244,14 +244,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/config/manifest.js"
   end
 
-  def test_app_update_does_not_generate_manifest_config_when_propshaft_is_used
-    run_generator [destination_root, "-a", "propshaft"]
-    run_app_update
-
-    assert_file "config/initializers/assets.rb"
-    assert_no_file "app/assets/config/manifest.js"
-  end
-
   def test_app_update_does_not_generate_action_cable_contents_when_skip_action_cable_is_given
     run_generator [destination_root, "--skip-action-cable"]
     run_app_update
@@ -328,8 +320,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_app_update_preserves_propshaft
-    run_generator [destination_root, "-a", "propshaft"]
+  def test_app_update_preserves_sprockets
+    run_generator [destination_root, "-a", "sprockets"]
 
     FileUtils.cd(destination_root) do
       config = "config/environments/production.rb"
@@ -949,7 +941,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_asset_pipeline_tailwind
-    generator [destination_root], ["--css=tailwind", "--asset-pipeline=sprockets"]
+    generator [destination_root], ["--css=tailwind"]
     run_generator_instance
 
     assert_includes @rails_commands, "tailwindcss:install", "`tailwindcss:install` expected to be called, but wasn't."
@@ -964,7 +956,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_asset_pipeline_sass
-    generator [destination_root], ["--css=sass", "--asset-pipeline=sprockets"]
+    generator [destination_root], ["--css=sass"]
     run_generator_instance
 
     assert_includes @rails_commands, "dartsass:install", "`dartsass:install` expected to be called, but wasn't."
@@ -979,7 +971,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_cssbundling_gem
-    generator [destination_root], ["--css=postcss", "--asset-pipeline=sprockets"]
+    generator [destination_root], ["--css=postcss"]
     run_generator_instance
 
     assert_includes @rails_commands, "css:install:postcss", "`css:install:postcss` expected to be called, but wasn't."

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -247,13 +247,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /mysql/
   end
 
-  def test_skip_database_dependency
-    run_generator [destination_root, "--skip-active-record"]
-    assert_file "Gemfile" do |contents|
-      assert_no_match(/sqlite/, contents)
-    end
-  end
-
   def test_ensure_that_skip_active_record_option_is_passed_to_app_generator
     run_generator [destination_root, "--skip_active_record"]
     assert_file "test/test_helper.rb" do |contents|

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -50,7 +50,7 @@ module SharedGeneratorTests
     assert_match %r/conflicting option/i, error.message
   end
 
-  def test_skeleton_is_created
+  def test_codebase_is_created
     run_generator
 
     generated_files_and_folders = []
@@ -78,6 +78,25 @@ module SharedGeneratorTests
     assert_equal generated_files_and_folders.sort, default_files, "The expected list of generated files is not alphabetical"
 
     default_files.each { |path| assert_file path }
+
+    assert_file "#{application_path}/config/application.rb", /\s+require\s+["']rails\/all["']/
+
+    assert_file "#{application_path}/config/environments/development.rb" do |content|
+      assert_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
+      assert_match(/config\.active_storage/, content)
+    end
+    assert_file "#{application_path}/config/environments/test.rb" do |content|
+      assert_match(/config\.action_mailer\.delivery_method = :test/, content)
+      assert_match(/config\.active_storage/, content)
+    end
+    assert_file "#{application_path}/config/environments/production.rb" do |content|
+      assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
+      assert_match(/^  # config\.require_master_key = true/, content)
+      assert_match(/config\.active_storage/, content)
+    end
+
+    assert_load_defaults
+    assert_gem_for_active_storage
   end
 
   def test_plugin_new_generate_pretend
@@ -223,59 +242,51 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /^require\s+["']rails\/test_unit\/railtie["']/
   end
 
-  def test_generator_without_skips
-    run_generator
-    assert_file "#{application_path}/config/application.rb", /\s+require\s+["']rails\/all["']/
-    assert_file "#{application_path}/config/environments/development.rb" do |content|
-      assert_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
-    end
-    assert_file "#{application_path}/config/environments/test.rb" do |content|
-      assert_match(/config\.action_mailer\.delivery_method = :test/, content)
-    end
-    assert_file "#{application_path}/config/environments/production.rb" do |content|
-      assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
-      assert_match(/^  # config\.require_master_key = true/, content)
-    end
-  end
-
   def test_generator_if_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
     assert_no_directory "#{application_path}/db/"
     assert_no_file "#{application_path}/config/database.yml"
     assert_no_file "#{application_path}/app/models/application_record.rb"
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_record\/railtie["']/
+
+    assert_file "#{application_path}/config/application.rb" do |content|
+      assert_match(/#\s+require\s+["']active_record\/railtie["']/, content)
+      assert_match(/#\s+require\s+["']active_storage\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_mailbox\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_text\/engine["']/, content)
+    end
+
     assert_file "test/test_helper.rb" do |helper_content|
       assert_no_match(/fixtures :all/, helper_content)
     end
     assert_file "#{application_path}/bin/setup" do |setup_content|
       assert_no_match(/db:prepare/, setup_content)
     end
-  end
-
-  def test_generator_for_active_storage
-    run_generator([destination_root])
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|
-      assert_match(/config\.active_storage/, content)
+      assert_no_match(/config\.active_storage/, content)
     end
 
     assert_file "#{application_path}/config/environments/production.rb" do |content|
-      assert_match(/config\.active_storage/, content)
+      assert_no_match(/config\.active_storage/, content)
     end
 
     assert_file "#{application_path}/config/environments/test.rb" do |content|
-      assert_match(/config\.active_storage/, content)
+      assert_no_match(/config\.active_storage/, content)
     end
 
-    assert_file "#{application_path}/config/storage.yml"
-    assert_directory "#{application_path}/storage"
-    assert_directory "#{application_path}/tmp/storage"
+    assert_no_file "#{application_path}/config/storage.yml"
+
+    assert_gitattributes_does_not_have_schema_file
+
+    assert_file "Gemfile" do |contents|
+      assert_no_match(/sqlite/, contents)
+    end
   end
 
   def test_generator_if_skip_active_storage_is_given
     run_generator [destination_root, "--skip-active-storage"]
 
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
+    assert_frameworks_are_not_required_when_active_storage_is_skipped
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|
       assert_no_match(/config\.active_storage/, content)
@@ -290,26 +301,9 @@ module SharedGeneratorTests
     end
 
     assert_no_file "#{application_path}/config/storage.yml"
-  end
 
-  def test_generator_does_not_generate_active_storage_contents_if_skip_active_record_is_given
-    run_generator [destination_root, "--skip-active-record"]
-
-    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
-
-    assert_file "#{application_path}/config/environments/development.rb" do |content|
-      assert_no_match(/config\.active_storage/, content)
-    end
-
-    assert_file "#{application_path}/config/environments/production.rb" do |content|
-      assert_no_match(/config\.active_storage/, content)
-    end
-
-    assert_file "#{application_path}/config/environments/test.rb" do |content|
-      assert_no_match(/config\.active_storage/, content)
-    end
-
-    assert_no_file "#{application_path}/config/storage.yml"
+    assert_gems_when_active_storage_is_skipped
+    assert_dockerfile_when_active_storage_is_skipped
   end
 
   def test_generator_does_not_create_storage_dir_if_skip_active_storage_is_given_and_not_using_sqlite
@@ -405,6 +399,25 @@ module SharedGeneratorTests
   end
 
   private
+    def assert_load_defaults
+    end
+
+    def assert_gem_for_active_storage
+    end
+
+    def assert_frameworks_are_not_required_when_active_storage_is_skipped
+      assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_storage\/engine["']/
+    end
+
+    def assert_gems_when_active_storage_is_skipped
+    end
+
+    def assert_dockerfile_when_active_storage_is_skipped
+    end
+
+    def assert_gitattributes_does_not_have_schema_file
+    end
+
     def fixtures_root
       File.expand_path("../fixtures", __dir__)
     end

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -413,8 +413,13 @@ module SharedGeneratorTests
       @bundle_commands = []
       @bundle_command_stub ||= -> (command, *) { @bundle_commands << command }
 
+      @rails_commands = []
+      @rails_command_stub ||= -> (command, *_) { @rails_commands << command }
+
       generator.stub(:bundle_command, @bundle_command_stub) do
-        super
+        generator.stub(:rails_command, @rails_command_stub) do
+          super
+        end
       end
     end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -145,6 +145,7 @@ module TestHelpers
       add_to_env_config :development, "config.action_view.annotate_rendered_view_with_filenames = false"
 
       remove_from_env_config("development", "config.generators.apply_rubocop_autocorrect_after_generate!")
+      add_to_env_config :production, "config.log_level = :error"
     end
 
     def teardown_app
@@ -262,7 +263,7 @@ module TestHelpers
       @app.config.eager_load = false
       @app.config.session_store :cookie_store, key: "_myapp_session"
       @app.config.active_support.deprecation = :log
-      @app.config.log_level = :info
+      @app.config.log_level = :error
       @app.config.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"
 
       yield @app if block_given?


### PR DESCRIPTION
This PR addressed several unrelated issues in the Railties test suite, in order to reduce the amount of noise.

**After**

```
$ bundle exec rake test >> railties_output_patched 2>&1
$ wc -l railties_output_patched
    1491 railties_output_patched
```

**Before**

```
$ bundle exec rake test >> railties_output_unpatched 2>&1
$ wc -l railties_output_unpatched
   19023 railties_output_unpatched
```