### PR TITLE
Include `ActiveModel::API` in `ActiveRecord::Base`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include `ActiveModel::API` in `ActiveRecord::Base`
+
+    *Sean Doyle*
+
 *   Ensure `#signed_id` outputs `url_safe` strings.
 
     *Jason Meller*

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -2,8 +2,6 @@
 
 module ActiveRecord
   module AttributeAssignment
-    include ActiveModel::AttributeAssignment
-
     private
       def _assign_attributes(attributes)
         multi_parameter_attributes = nested_parameter_attributes = nil

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -280,7 +280,7 @@ module ActiveRecord # :nodoc:
   # So it's possible to assign a logger to the class through <tt>Base.logger=</tt> which will then be used by all
   # instances in the current object space.
   class Base
-    extend ActiveModel::Naming
+    include ActiveModel::API
 
     extend ActiveSupport::Benchmarkable
     extend ActiveSupport::DescendantsTracker
@@ -304,7 +304,6 @@ module ActiveRecord # :nodoc:
     include Scoping
     include Sanitization
     include AttributeAssignment
-    include ActiveModel::Conversion
     include Integration
     include Validations
     include CounterCache

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -428,7 +428,7 @@ module ActiveRecord
       init_internals
       initialize_internals_callback
 
-      assign_attributes(attributes) if attributes
+      super
 
       yield self if block_given?
       _run_initialize_callbacks

--- a/activerecord/lib/active_record/translation.rb
+++ b/activerecord/lib/active_record/translation.rb
@@ -2,8 +2,6 @@
 
 module ActiveRecord
   module Translation
-    include ActiveModel::Translation
-
     # Set the lookup ancestors for ActiveModel.
     def lookup_ancestors # :nodoc:
       klass = self

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -39,7 +39,6 @@ module ActiveRecord
   # {new_record?}[rdoc-ref:Persistence#new_record?].
   module Validations
     extend ActiveSupport::Concern
-    include ActiveModel::Validations
 
     # The validation process on save can be skipped by passing <tt>validate: false</tt>.
     # The validation context can be changed by passing <tt>context: context</tt>.


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::Base` does not (and has never) inherit from `ActiveModel::Model`.

`ActiveModel::API` was introduced in as an extraction from `ActiveModel::Model`. At that time (Sep 15, 2021), it was included back into `ActiveModel::Model`, but was never included in `ActiveRecord` at all.

### Detail

The intent communicated around the introduction of `ActiveModel::API` stated:

> By moving `ActiveModel::Model`'s implementation to a new
> `ActiveModel::API` we keep a definition of the minimum API to talk with
> Action Pack and Action View.

Active Record is also designed to integrate with Action Pack and Action View. It already does (and its integration predates `ActiveModel::API` by more than a decade). It's integration is powered by including and extending the same set of foundational modules, with some database-specific overrides.

This commit adds an `include ActiveModel::API` statement to `ActiveRecord::Base`, then re-structures those overrides to comply with the new module resolution order.

[c477d95]: https://github.com/rails/rails/commit/c477d95604e80e04d1aa8113a8236353235eb86a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
