### PR TITLE
Add strada-rails to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"
 gem "turbo-rails"
+gem "strada-rails"
 gem "jsbundling-rails"
 gem "cssbundling-rails"
 gem "importmap-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,6 +514,8 @@ GEM
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    strada-rails (0.0.3)
+      railties (>= 6.0.0)
     stringio (3.0.8)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
@@ -635,6 +637,7 @@ DEPENDENCIES
   sqlite3 (~> 1.6, >= 1.6.6)
   stackprof
   stimulus-rails
+  strada-rails
   sucker_punch
   syntax_tree (= 6.1.1)
   tailwindcss-rails

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add strada-rails to the generated Gemfile.
+
+    *Lázaro Nixon*
+
 *   Disallow invalid values for rails new options.
 
     The `--database`, `--asset-pipeline`, `--css`, and `--javascript` flags for

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -474,7 +474,10 @@ module Rails
         stimulus_rails_entry =
           GemfileEntry.floats "stimulus-rails", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]"
 
-        [ turbo_rails_entry, stimulus_rails_entry ]
+        strada_rails_entry =
+          GemfileEntry.floats "strada-rails", "Hotwire's native mobile bridge framework [https://strada.hotwired.dev]"
+
+        [ turbo_rails_entry, stimulus_rails_entry, strada_rails_entry ]
       end
 
       def using_js_runtime?
@@ -707,7 +710,7 @@ module Rails
       def run_hotwire
         return if options[:skip_hotwire] || !bundle_install?
 
-        rails_command "turbo:install stimulus:install"
+        rails_command "turbo:install stimulus:install strada:install"
       end
 
       def run_css

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -842,6 +842,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_skip_javascript_option_with_skip_javascript_argument
     run_generator [destination_root, "--skip-javascript"]
+    assert_no_gem "strada-rails"
     assert_no_gem "stimulus-rails"
     assert_no_gem "turbo-rails"
     assert_no_gem "importmap-rails"
@@ -849,6 +850,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_skip_javascript_option_with_J_argument
     run_generator [destination_root, "-J"]
+    assert_no_gem "strada-rails"
     assert_no_gem "stimulus-rails"
     assert_no_gem "turbo-rails"
     assert_no_gem "importmap-rails"
@@ -856,6 +858,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_skip_javascript_option_with_skip_js_argument
     run_generator [destination_root, "--skip-js"]
+    assert_no_gem "strada-rails"
     assert_no_gem "stimulus-rails"
     assert_no_gem "turbo-rails"
     assert_no_gem "importmap-rails"
@@ -865,6 +868,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator_and_bundler [destination_root]
     assert_gem "turbo-rails"
     assert_gem "stimulus-rails"
+    assert_gem "strada-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_match(/data-turbo-track/, content)
     end


### PR DESCRIPTION
### Motivation / Background

In the same way that we have `turbo-rails`, and `stimulus-rails` I'm proposing to add `strada-rails` to the generated Gemfile.

### Detail

Strada Rails is a gem with a similar purpose and shape to `stimulus-rails` so it provides:

- [A task](https://github.com/lazaronixon/strada-rails/blob/master/lib/install/strada_with_importmap.rb) `strada:install` compatible with `import-map`, `node`, and `bun`. This command is responsible for adding the dependency, copying some strada controllers,  adding a `strada.css` file, and adding a `.hide-on-mobile` style.
- [A generator](https://github.com/lazaronixon/strada-rails/blob/master/lib/generators/strada/USAGE) for creating Strada stimulus controllers. `bin/rails generate strada notice`.
- [Replace the default ERB scaffolds ](https://github.com/lazaronixon/strada-rails/tree/master/lib/generators/strada/scaffold/templates) adding the required data attributes to connect the elements to mobile.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
