### PR TITLE
Move SQLite pragma configuration to the database configuration file

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Move pragma statements and defaults to the database configuration file
+
+    *Brett Suwyn*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -88,6 +88,18 @@ module ActiveRecord
         json:         { name: "json" },
       }
 
+      PRAGMA_STATEMENTS = [
+        :cache_size,
+        :foreign_keys,
+        :journal_mode,
+        :journal_size_limit,
+        :mmap_size,
+        :locking_mode,
+        :page_size,
+        :synchronous,
+        :temp_store
+      ]
+
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         alias reset clear
 
@@ -727,29 +739,11 @@ module ActiveRecord
 
           super
 
-          # Enforce foreign key constraints
-          # https://www.sqlite.org/pragma.html#pragma_foreign_keys
-          # https://www.sqlite.org/foreignkeys.html
           raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
-          unless @memory_database
-            # Journal mode WAL allows for greater concurrency (many readers + one writer)
-            # https://www.sqlite.org/pragma.html#pragma_journal_mode
-            raw_execute("PRAGMA journal_mode = WAL", "SCHEMA")
-            # Set more relaxed level of database durability
-            # 2 = "FULL" (sync on every write), 1 = "NORMAL" (sync every 1000 written pages) and 0 = "NONE"
-            # https://www.sqlite.org/pragma.html#pragma_synchronous
-            raw_execute("PRAGMA synchronous = NORMAL", "SCHEMA")
-            # Set the global memory map so all processes can share some data
-            # https://www.sqlite.org/pragma.html#pragma_mmap_size
-            # https://www.sqlite.org/mmap.html
-            raw_execute("PRAGMA mmap_size = #{128.megabytes}", "SCHEMA")
+
+          (@config.keys & PRAGMA_STATEMENTS).each do |key|
+            @raw_connection.send "#{key}=", @config[key]
           end
-          # Impose a limit on the WAL file to prevent unlimited growth
-          # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
-          raw_execute("PRAGMA journal_size_limit = #{64.megabytes}", "SCHEMA")
-          # Set the local connection cache to 2000 pages
-          # https://www.sqlite.org/pragma.html#pragma_cache_size
-          raw_execute("PRAGMA cache_size = 2000", "SCHEMA")
         end
     end
     ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, SQLite3Adapter)

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -119,10 +119,21 @@ connections:
       database: <%= FIXTURES_ROOT %>/fixture_database.sqlite3
       timeout:  5000
       strict:   true
+      journal_mode: WAL
+      synchronous: NORMAL
+      mmap_size: 134217728
+      journal_size_limit: 67108864
+      cache_size: 2000
+
     arunit2:
       database: <%= FIXTURES_ROOT %>/fixture_database_2.sqlite3
       timeout:  5000
       strict:   true
+      journal_mode: WAL
+      synchronous: NORMAL
+      mmap_size: 134217728
+      journal_size_limit: 67108864
+      cache_size: 2000
 
   sqlite3_mem:
     arunit:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -8,6 +8,11 @@ default: &default
   adapter: sqlite3
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  journal_mode: WAL
+  synchronous: NORMAL
+  mmap_size: 134217728
+  journal_size_limit: 67108864
+  cache_size: 2000
 
 development:
   <<: *default


### PR DESCRIPTION
### Motivation / Background

A recent PR #49349 introduced a number of SQLite optimizations to improve database performance.   

Those optimizations were hard coded in the SQLite adapter which left developers in the same position they were before - that if they wanted to configure SQLite beyond that default configuration, they still needed to rely on monkey patching the adapter.   

Hard coding those parameters also introduce the potential for breakage.   For example, the write ahead log is now the default journal mode.  The side effect of this is that SQLite will use three files instead of one for the database which may break any operational scripts (e.g. the backup strategy must change).

Another issue is that WAL mode is an optimization for writing to databases, and now with Rails 7.1 it makes a false assumption that you'll always want to write to any SQLite database.  

Rails 7.1 now throws an error connecting to read-only sqlite database that isn't already in WAL mode.  

A use case where that is problematic. Let's say on each build of my application I embed the latest version of a Zipcode database that we receive from a 3rd party.  The database, since it is readonly, has the correct file permissions (readonly) and is embedded with journal mode turned off (no -shm or -wal files).   7.1 will throw an error now since it can't change the database to use WAL.

### Detail

This Pull Request moves those performance optimizations into the database configuration file.   Developers will now have the option to tune their SQLite configurations by specifying PRAGMA values along with the rest of their database configuration, in `config/database.yml`.

The defaults that were introduced in 7.1 have been moved to the database.yml generator so new applications can benefit from them while existing applications upgrading 7.1+ won't be impacted side effects.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

