### PR TITLE
Implement `OrderedOptions#dig!`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `OrderedOptions#dig!` to raise an exception when specifying a non-existent key
+
+    *Takumi Shotoku*
+
 *   Fix compatibility with the `semantic_logger` gem.
 
     The `semantic_logger` gem doesn't behave exactly like stdlib logger in that

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -50,9 +50,9 @@ module ActiveSupport
       super(*keys.flatten.map(&:to_sym))
     end
 
-    def dig!(*keys)
-      keys.flatten.inject(self) do |h, key|
-        h[key.to_sym].presence || raise(KeyError.new(":#{key} is blank"))
+    def dig!(key, *identifiers)
+      [key.to_sym, *identifiers].inject(self) do |h, k|
+        h.dig(k).presence || raise(KeyError.new(":#{k} is blank"))
       end
     end
 

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -30,6 +30,10 @@ module ActiveSupport
   #
   #   h.dog! # => raises KeyError: :dog is blank
   #
+  # Or use the +dig!+ method.
+  #
+  #   h.dig!(:dog) # => raises KeyError: :dog is blank
+  #
   class OrderedOptions < Hash
     alias_method :_get, :[] # preserve the original #[] method
     protected :_get # make it protected
@@ -44,6 +48,12 @@ module ActiveSupport
 
     def dig(*keys)
       super(*keys.flatten.map(&:to_sym))
+    end
+
+    def dig!(*keys)
+      keys.flatten.inject(self) do |h, key|
+        h[key.to_sym].presence || raise(KeyError.new(":#{key} is blank"))
+      end
     end
 
     def method_missing(name, *args)

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -36,7 +36,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_string_dig
+  def test_dig
     a = ActiveSupport::OrderedOptions.new
 
     a[:test_key] = 56
@@ -44,6 +44,16 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal 56, a["test_key"]
     assert_equal 56, a.dig(:test_key)
     assert_equal 56, a.dig("test_key")
+    assert_equal nil, a.dig(:non_existing_key)
+  end
+
+  def test_dig_bang
+    a = ActiveSupport::OrderedOptions.new
+    a[:foo] = { bar: :buz }
+
+    assert_equal :buz, a.dig!(:foo, :bar)
+    assert_equal :buz, a.dig!("foo", "bar")
+    assert_raises(KeyError) { a.dig!(:foo, :non_existing_key) }
   end
 
   def test_method_access

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -49,11 +49,11 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
   def test_dig_bang
     a = ActiveSupport::OrderedOptions.new
-    a[:foo] = { bar: :buz }
+    a[:foo] = { bar: :buz, none: nil }
 
     assert_equal :buz, a.dig!(:foo, :bar)
-    assert_equal :buz, a.dig!("foo", "bar")
     assert_raises(KeyError) { a.dig!(:foo, :non_existing_key) }
+    assert_raises(KeyError) { a.dig!(:foo, :none) }
   end
 
   def test_method_access

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -44,7 +44,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal 56, a["test_key"]
     assert_equal 56, a.dig(:test_key)
     assert_equal 56, a.dig("test_key")
-    assert_equal nil, a.dig(:non_existing_key)
+    assert_nil a.dig(:non_existing_key)
   end
 
   def test_dig_bang


### PR DESCRIPTION
### Motivation / Background

We often use `dig` with credentials and custom configurations, but the method
returns `nil` instead of an error if a non-existent key is specified by a typo.

It is possible to write without dig to quickly notice a wrong key, but this is tedious.

```ruby
# Before
Rails.application.credentials.fetch(:aws).fetch(:access_key_id)
Rails.application.config_for(:example).fetch(:foo).fetch(:bar)
```

To make this simple to write, this commit adds a bang version method.

```ruby
# After
Rails.application.credentials.dig!(:aws, :access_key_id)
Rails.application.config_for(:example).dig!(:foo, :bar)
```

### Detail

This Pull Request implements `OrderedOptions#dig!` to raise an exception if a non-existent key is specified.

### Additional information

There was discussion about a similar feature in Ruby, but it was last updated a year ago.

- [Version of dig that raises error if a key is not present](https://bugs.ruby-lang.org/issues/14602)
- [#dig that throws an exception if a key doesn't exist](https://bugs.ruby-lang.org/issues/15563)

In my use case, `OrderedOptions#dig!` is sufficient, so I avoided `Hash#dig!` which has a large impact.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
