### PR TITLE
Fix file cache store `delete_matched` to work on keys longer than allowed filename size

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -176,7 +176,7 @@ module ActiveSupport
 
         # Translate a file path into a key.
         def file_path_key(path)
-          fname = path[cache_path.to_s.size..-1].split(File::SEPARATOR, 4).last
+          fname = path[cache_path.to_s.size..-1].split(File::SEPARATOR, 4).last.delete(File::SEPARATOR)
           URI.decode_www_form_component(fname, Encoding::UTF_8)
         end
 

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -91,6 +91,18 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal "B", File.basename(path)
   end
 
+  def test_delete_matched_when_key_exceeds_max_filename_size
+    submaximal_key = "_" * (ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE - 1)
+
+    @cache.write(submaximal_key + "AB", "value")
+    @cache.delete_matched(/AB/)
+    assert_not @cache.exist?(submaximal_key + "AB")
+
+    @cache.write(submaximal_key + "/A", "value")
+    @cache.delete_matched(/A/)
+    assert_not @cache.exist?(submaximal_key + "/A")
+  end
+
   # If nothing has been stored in the cache, there is a chance the cache directory does not yet exist
   # Ensure delete_matched gracefully handles this case
   def test_delete_matched_when_cache_directory_does_not_exist


### PR DESCRIPTION
Fixes #49690.

For file cache store we url-encode keys to not to clash to with the file system path separators, like `/`. When the resulting key is longer than the FS max file name length, we split it into parts. But this splitting can be done incorrectly and made in-between the encode-sequence, while it should be done only on the boundaries. 

Example: for key `foo%20bar` splitting into `['foo%2', '0bar']` is incorrect, should be `['foo', '%20bar']` or `['foo%20', 'bar']`. 

Then when we use `delete_matched`, we traverse the FS directories and try to decode dir names and get an error if we previously made a split in the incorrect place.