### PR TITLE
Cast "False" to false for boolean casting

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,7 @@
+*   Cast "False" to `false` in `ActiveModel::Type::Boolean`
+
+    Fixes #49697
+
+    *Mike Stone*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -18,6 +18,7 @@ module ActiveModel
         "f", :f,
         "F", :F,
         "false", :false,
+        "False", :False,
         "FALSE", :FALSE,
         "off", :off,
         "OFF", :OFF,

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -38,6 +38,7 @@ module ActiveModel
         assert_equal false, type.cast("f")
         assert_equal false, type.cast("F")
         assert_equal false, type.cast("false")
+        assert_equal false, type.cast("False")
         assert_equal false, type.cast("FALSE")
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")


### PR DESCRIPTION
Fixes #49697

This change casts "False" string values to `false` boolean values using `ActiveModel::Type::Boolean`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
