### PR TITLE
Typo fix in BigDecimal job arguments warning

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -98,7 +98,7 @@ module ActiveJob
               Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
               Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 
-              Note that if you application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
+              Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
               This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
             MSG
             return argument

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -64,7 +64,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
       Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
 
-      Note that if you application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
+      Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
       This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
     MSG
       assert_equal(


### PR DESCRIPTION
### Detail

Fixes the typo in BigDecimal job arguments warning message in ActiveJob

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
