### PR TITLE
Use custom class for pending migrations connection

### DIFF
--- a/activerecord/lib/active_record/migration/pending_migration_connection.rb
+++ b/activerecord/lib/active_record/migration/pending_migration_connection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PendingMigrationConnection # :nodoc:
+    def self.establish_temporary_connection(db_config, &block)
+      pool = ActiveRecord::Base.connection_handler.establish_connection(db_config, owner_name: self)
+
+      yield pool.connection
+    ensure
+      ActiveRecord::Base.connection_handler.remove_connection_pool(self.name)
+    end
+
+    def self.primary_class?
+      false
+    end
+
+    def self.current_preventing_writes
+      false
+    end
+  end
+end


### PR DESCRIPTION
In bensheldon/good_job#1103 it was reported that a connection not established is being seen when there are multiple configs for an environment (a multi-db app).

While I think that something is happening where Good Job is accessing the connection while we're checking for pending migrations, this could happen in other gems if we're clobbering the connection on `ActiveRecord::Base` that is needed.

Here we are making a special class to establish connections to the database. Because the class does not inherit from `Base` and establishes it's own connection, it won't clobber any existing connections on `Base`, leaving them in-tact while the app boots.

The reason this wasn't seen in 7.0 is because pending migrations didn't check all the available configs. Once that was fixed this error appeared.

I didn't add a test for this because it's really hard to reproduce without good job and actually booting a server and running a request.

Fixes: #49689