### PR TITLE
Render proper URLs for singular resource routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -206,7 +206,6 @@ module ActionDispatch
 
           def self.polymorphic_method(recipient, record_or_hash_or_array, action, type, options)
             builder = get action, type
-
             case record_or_hash_or_array
             when Array
               record_or_hash_or_array = record_or_hash_or_array.compact
@@ -228,10 +227,12 @@ module ActionDispatch
             else
               method, args = builder.handle_model record_or_hash_or_array
             end
+            method_type = method.delete_suffix "_path"
 
-            if options.empty?
+            if options.empty? && method_type != method_type.singularize
               recipient.public_send(method, *args)
             else
+              options[:format] ||= nil
               recipient.public_send(method, *args, options)
             end
           end

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -22,6 +22,23 @@ module TestGenerationPrefix
     def to_model; self; end
     def persisted?; true; end
   end
+  class Author
+    extend ActiveModel::Naming
+
+    def to_param
+      "1"
+    end
+
+    def self.model_name
+      klass = +"Author"
+      def klass.name; self end
+
+      ActiveModel::Name.new(klass)
+    end
+
+    def to_model; self; end
+    def persisted?; true; end
+  end
 
   class WithMountedEngine < ActionDispatch::IntegrationTest
     class BlogEngine < Rails::Engine
@@ -46,6 +63,8 @@ module TestGenerationPrefix
         get "/absolute_option_redirect", to: redirect(path: "/foo")
         get "/absolute_custom_root",     to: redirect { |params, request| "/" }
         get "/absolute_custom_redirect", to: redirect { |params, request| "/foo" }
+
+        resource :author
       end
     end
 
@@ -325,6 +344,14 @@ module TestGenerationPrefix
 
       path = engine_object.polymorphic_url(Post.new, host: "www.example.com")
       assert_equal "http://www.example.com/awesome/blog/posts/1", path
+    end
+
+    test "[OBJECT] generating engine's route with polymorphic_url from singular resource" do
+      path = engine_object.polymorphic_path(Author.new)
+      assert_equal "/awesome/blog/author", path
+
+      path = engine_object.polymorphic_url(Author.new, host: "www.example.com")
+      assert_equal "http://www.example.com/awesome/blog/author", path
     end
 
     private


### PR DESCRIPTION
This fix allows the `polymorphic_method` in the `HelperMethodBuilder` class in `polymorphic_routes.rb` to discern whether or not a singular resource is being passed into it.  If it finds a singular resource it will pass in `format: nil` to the options(if it doesn't already have a format set) so that we can have an edited object using the patch method get sent to the proper URL  instead of appending a period and number to the end.

This is trying to make the method a little smarter as suggested in the Issue thread so we can render urls properly.

The current bug behavior in 7.1:
```Ruby
Started PATCH "/author.1" for ::1 at 2023-10-12 15:03:31 -0400
```

This fix corrects this to:
```Ruby
Started PATCH "/author" for ::1 at 2023-10-12 15:03:31 -0400
```


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
