### PR TITLE
Fix time travel helpers to work when nested using with separate classes

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -25,7 +25,7 @@ module ActiveSupport
           unstub_object(stub)
         end
 
-        new_name = "__simple_stub__#{method_name}"
+        new_name = "__simple_stub__#{method_name}__#{object_id}"
 
         @stubs[object.object_id][method_name] = Stub.new(object, method_name, new_name)
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -13,6 +13,18 @@ class TimeTravelTest < ActiveSupport::TestCase
   class DateSubclass < ::Date; end
   class DateTimeSubclass < ::DateTime; end
 
+  class TravelClass
+    include ActiveSupport::Testing::TimeHelpers
+
+    def travel_to_no_block(date)
+      travel_to(date)
+    end
+
+    def travel_to_block(date)
+      travel_to(date) { }
+    end
+  end
+
   def test_time_helper_travel
     Time.stub(:now, Time.now) do
       expected_time = Time.now + 1.day
@@ -121,6 +133,31 @@ class TimeTravelTest < ActiveSupport::TestCase
           end
         end
       end
+    end
+  end
+
+  def test_time_helper_travel_to_with_separate_class
+    travel_object = TravelClass.new
+    date1 = Date.new(2004, 11, 24)
+    date2 = Date.new(2005, 11, 24)
+
+    Time.stub(:now, now = Time.now) do
+      travel_to(date1) do
+        travel_object.travel_to_no_block(date2)
+      end
+      assert_equal now, Time.now
+
+      travel_to(date1) do
+        travel_object.travel_to_no_block(date2)
+        assert_equal date2, Date.today
+      end
+      assert_equal now, Time.now
+
+      travel_to(date1) do
+        travel_object.travel_to_block(date2)
+        assert_equal date1, Date.today
+      end
+      assert_equal now, Time.now
     end
   end
 


### PR DESCRIPTION
Fixes #49706.

When using nested `travel_to` with separate classes (see the issue description for the details), we stub original methods with new ones https://github.com/rails/rails/blob/df507240dfc83f120a60b8e2e967d5d96663f67b/activesupport/lib/active_support/testing/time_helpers.rb#L28-L33 and restore in https://github.com/rails/rails/blob/df507240dfc83f120a60b8e2e967d5d96663f67b/activesupport/lib/active_support/testing/time_helpers.rb#L59-L64

For a call as
```ruby
travel_to(...) do # outer
  travel_to(...) do # inner
    # ...
  end
end
```

when "inner" restores original methods, it removes the stub method (`"__simple_stub__#{method_name}"` in this case) and defines original name with the original implementation. Then when "outer" tries to restore the stub method, it is not defined in the object because of the previously mentioned case. So we need somehow differentiate these stub methods. I added `object_id` to them to make them unique.