### PR TITLE
Remove SQLite production warning

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Remove warning message when running SQLite in production
+
+    SQLite is becoming a more capable database and there are more companies using it in production.
+    It's really good for self-hosted/small environments where you don't want to boot a
+    separate server for the DB. There's no more need to discourage his usage via a warning.
+
+    *Jacopo Beschi*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -31,7 +31,6 @@ module ActiveRecord
     config.active_record.check_schema_cache_dump_version = true
     config.active_record.maintain_test_schema = true
     config.active_record.has_many_inversing = false
-    config.active_record.sqlite3_production_warning = true
     config.active_record.query_log_tags_enabled = false
     config.active_record.query_log_tags = [ :application ]
     config.active_record.query_log_tags_format = :legacy
@@ -230,16 +229,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    SQLITE3_PRODUCTION_WARN = "You are running SQLite in production, this is generally not recommended."\
-      " You can disable this warning by setting \"config.active_record.sqlite3_production_warning=false\"."
-    initializer "active_record.sqlite3_production_warning" do
-      if config.active_record.sqlite3_production_warning && Rails.env.production?
-        ActiveSupport.on_load(:active_record_sqlite3adapter) do
-          Rails.logger.warn(SQLITE3_PRODUCTION_WARN)
-        end
-      end
-    end
-
     initializer "active_record.sqlite3_adapter_strict_strings_by_default" do
       config.after_initialize do
         if config.active_record.sqlite3_adapter_strict_strings_by_default
@@ -276,7 +265,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :query_log_tags,
           :query_log_tags_format,
           :cache_query_log_tags,
-          :sqlite3_production_warning,
           :sqlite3_adapter_strict_strings_by_default,
           :check_schema_cache_dump_version,
           :use_schema_cache_dump

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -31,17 +31,6 @@ class ::MySanitizerVendor < ::Rails::HTML::Sanitizer
   end
 end
 
-class MyLogRecorder < Logger
-  def initialize
-    @io = StringIO.new
-    super(@io)
-  end
-
-  def recording
-    @io.string
-  end
-end
-
 module ApplicationTests
   class ConfigurationTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
@@ -79,7 +68,6 @@ module ApplicationTests
     def setup
       build_app
       suppress_default_config
-      suppress_sqlite3_warning
     end
 
     def teardown
@@ -94,14 +82,6 @@ module ApplicationTests
     def restore_default_config
       FileUtils.rm_rf("#{app_path}/config/environments")
       FileUtils.mv("#{app_path}/config/__environments__", "#{app_path}/config/environments")
-    end
-
-    def suppress_sqlite3_warning
-      add_to_config "config.active_record.sqlite3_production_warning = false"
-    end
-
-    def restore_sqlite3_warning
-      remove_from_config ".*config.active_record.sqlite3_production_warning.*\n"
     end
 
     test "Rails.env does not set the RAILS_ENV environment variable which would leak out into rake tasks" do
@@ -4052,57 +4032,6 @@ module ApplicationTests
       app "development"
 
       assert_equal false, Rails.application.env_config["action_dispatch.log_rescued_responses"]
-    end
-
-    test "logs a warning when running SQLite3 in production" do
-      restore_sqlite3_warning
-      app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-      RUBY
-      add_to_config "config.logger = MyLogRecorder.new"
-
-      app "production"
-
-      assert_match(/You are running SQLite in production, this is generally not recommended/, Rails.logger.recording)
-    end
-
-    test "doesn't log a warning when running SQLite3 in production and sqlite3_production_warning=false" do
-      app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-      RUBY
-      add_to_config "config.logger = MyLogRecorder.new"
-
-      app "production"
-
-      assert_no_match(/You are running SQLite in production, this is generally not recommended/, Rails.logger.recording)
-    end
-
-    test "doesn't log a warning when running MySQL in production" do
-      restore_sqlite3_warning
-      original_configurations = ActiveRecord::Base.configurations
-      ActiveRecord::Base.configurations = { production: { db1: { adapter: "mysql2" } } }
-      app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "mysql2")
-      RUBY
-      add_to_config "config.logger = MyLogRecorder.new"
-
-      app "production"
-
-      assert_no_match(/You are running SQLite in production, this is generally not recommended/, Rails.logger.recording)
-    ensure
-      ActiveRecord::Base.configurations = original_configurations
-    end
-
-    test "doesn't log a warning when running SQLite3 in development" do
-      restore_sqlite3_warning
-      app_file "config/initializers/active_record.rb", <<~RUBY
-        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-      RUBY
-      add_to_config "config.logger = MyLogRecorder.new"
-
-      app "development"
-
-      assert_no_match(/You are running SQLite in production, this is generally not recommended/, Rails.logger.recording)
     end
 
     test "app starts with LocalCache middleware" do

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -418,7 +418,6 @@ class LoadingTest < ActiveSupport::TestCase
   end
 
   test "active record query cache hooks are installed before first request in production" do
-    add_to_config "config.active_record.sqlite3_production_warning = false"
     app_file "app/controllers/omg_controller.rb", <<-RUBY
       begin
         class OmgController < ActionController::Metal

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -10,7 +10,6 @@ module ApplicationTests
 
     def setup
       build_app(multi_db: true)
-      add_to_config "config.active_record.sqlite3_production_warning = false"
       rails("generate", "scaffold", "Pet", "name:string", "--database=animals")
       app_file "app/models/user.rb", <<-RUBY
         class User < ActiveRecord::Base


### PR DESCRIPTION
### Motivation / Background

SQLite is becoming a more capable database and there are more companies using it in production. It's really good for self-hosted/small environments where you don't want to boot a separate server for the DB. There's no more need to discourage his usage via a warning.

See https://github.com/rails/rails/pull/49633

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
