### PR TITLE
Handle outdated Marshal payloads in Cache::Entry with 6.1 cache_format

### DIFF
--- a/activesupport/lib/active_support/cache/entry.rb
+++ b/activesupport/lib/active_support/cache/entry.rb
@@ -121,7 +121,13 @@ module ActiveSupport
 
       private
         def uncompress(value)
-          Marshal.load(Zlib::Inflate.inflate(value))
+          marshal_load(Zlib::Inflate.inflate(value))
+        end
+
+        def marshal_load(payload)
+          Marshal.load(payload)
+        rescue ArgumentError => error
+          raise Cache::DeserializationError, error.message
         end
     end
   end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -332,7 +332,10 @@ module ActiveSupport
             if value
               entry = deserialize_entry(value, raw: raw)
               unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(name, options))
-                results[name] = entry.value
+                begin
+                  results[name] = entry.value
+                rescue DeserializationError
+                end
               end
             end
           end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/48611
Followup: https://github.com/rails/rails/pull/48663

If the payload is compressed, and we use the 6.1 cache format then it's deserialized elsewhere, we need to handle it there too.
