### PR TITLE
Fix `OrderedOptions#dig` for array indexes

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -42,8 +42,8 @@ module ActiveSupport
       super(key.to_sym)
     end
 
-    def dig(*keys)
-      super(*keys.flatten.map(&:to_sym))
+    def dig(key, *identifiers)
+      super(key.to_sym, *identifiers)
     end
 
     def method_missing(name, *args)

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -46,6 +46,14 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal 56, a.dig("test_key")
   end
 
+  def test_nested_dig
+    a = ActiveSupport::OrderedOptions.new
+
+    a[:test_key] = [{ a: 1 }]
+    assert_equal 1, a.dig(:test_key, 0, :a)
+    assert_nil a.dig(:test_key, 1, :a)
+  end
+
   def test_method_access
     a = ActiveSupport::OrderedOptions.new
 


### PR DESCRIPTION
For `OrderedOptions#dig` we need to convert to symbol only the first key.
Method added in https://github.com/rails/rails/pull/44644.

Fixes #49713.