### PR TITLE
Add `BroadcastLogger#deep_dup`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `BroadcastLogger#dup` so that it duplicates the logger's `broadcasts`.
+
+    *Andrew Novoselac*
+
 *   Fix issue where `bootstrap.rb` overwrites the `level` of a `BroadcastLogger`'s `broadcasts`.
 
     *Andrew Novoselac*

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -218,6 +218,14 @@ module ActiveSupport
       dispatch { |logger| logger.fatal! }
     end
 
+    def initialize_copy(other)
+      @broadcasts = []
+      @progname = other.progname.dup
+      @formatter = other.formatter.dup
+
+      broadcast_to(*other.broadcasts.map(&:dup))
+    end
+
     private
       def dispatch(&block)
         @broadcasts.each { |logger| block.call(logger) }

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -290,6 +290,18 @@ module ActiveSupport
       assert(logger.qux(param: "foo"))
     end
 
+    test "#dup duplicates the broadcasts" do
+      logger = CustomLogger.new
+      logger.level = ::Logger::WARN
+      broadcast_logger = BroadcastLogger.new(logger)
+
+      duplicate = broadcast_logger.dup
+
+      assert_equal ::Logger::WARN, duplicate.broadcasts.sole.level
+      assert_not_same logger, duplicate.broadcasts.sole
+      assert_same logger, broadcast_logger.broadcasts.sole
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because, I want to easily duplicate instances of `BroadcastLogger` in my app. Just calling `dup` is no good because it does not duplicate the `broadcasts`. So I believe we could use a `deep_dup` method.

### Detail

This Pull Request adds a `ActiveSupport::BroadcastLogger#deep_dup`. Calling `deep_dup` dups the broadcast logger, and then iterates through each of it's broadcasts and duplicates them.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
