### PR TITLE
Fix issue where `bootstrap.rb` overwrites the `level` of a `BroadcastLogger`'s `broadcasts`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix issue where `bootstrap.rb` overwrites the `level` of a `BroadcastLogger`'s `broadcasts`.
+
+    *Andrew Novoselac*
+
 *   Fix compatibility with the `semantic_logger` gem.
 
     The `semantic_logger` gem doesn't behave exactly like stdlib logger in that

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -54,9 +54,9 @@ module Rails
           )
           logger
         end
-        Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
 
         unless Rails.logger.is_a?(ActiveSupport::BroadcastLogger)
+          Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
           broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
           broadcast_logger.formatter = Rails.logger.formatter
           Rails.logger = broadcast_logger


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because in `bootstrap.rb` we set the `Rails.logger.level` to `config.log_level`. But at this point, we may have already set up a `BroadcastLogger` with multiple broadcasts that have different levels. So, calling `level=` on the `BroadcastLogger` will overwrite the level of the individual broadcasts. So instead, let's only set the `Rails.logger.level` if the logger is not a `BroadcastLogger`.

### Detail

We already have an `unless Rails.logger.is_a?(ActiveSupport::BroadcastLogger)` block on the next line of the code, so I just move the call to `Rails.logger.level =` within there.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
