### PR TITLE
Add racc dependency because it will be bundled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ PATH
       actionview (= 7.2.0.alpha)
       activesupport (= 7.2.0.alpha)
       nokogiri (>= 1.8.5)
+      racc
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add `racc` as a dependency since it will become a bundled gem in Ruby 3.4.0
+
+    *Hartley McGuire*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
 
   s.add_dependency "nokogiri", ">= 1.8.5"
+  s.add_dependency "racc"
   s.add_dependency "rack",      ">= 2.2.4"
   s.add_dependency "rack-session", ">= 1.0.1"
   s.add_dependency "rack-test", ">= 0.6.3"


### PR DESCRIPTION
### Motivation / Background

Ruby 3.3.0 is going to start warning for racc not being specififed as a dependency, and Ruby 3.4.0 will raise if it is not specified.

### Detail

This commit prevents those issues by adding racc to the Action Pack gemspec, since `racc/parser` is a runtime dependency of the Journey parser.

### Additional information

Ref ruby/ruby@2a56a6c3af9b36bc762855995723a23f9f5bd4d8
Ref ruby/ruby#7877

Alternatively, we could vendor `racc/parser` into Journey's generated parser but that then requires the parser to be regenerated to get any upstream improvements

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
