### PR TITLE
Ignore invalid PRIMARY KEY values in `ActiveRecord::Persistence.delete` method

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -563,6 +563,8 @@ module ActiveRecord
       #   # Delete multiple rows
       #   Todo.delete([2,3,4])
       def delete(id_or_array)
+        return 0 if id_or_array.nil? || (id_or_array.is_a?(Array) && id_or_array.empty?)
+
         delete_by(primary_key => id_or_array)
       end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1357,6 +1357,17 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_nothing_raised { Reply.find(should_not_be_destroyed_reply.id) }
   end
 
+  def test_class_level_delete_with_invalid_ids
+    assert_no_queries do
+      assert_equal 0, Topic.delete(nil)
+      assert_equal 0, Topic.delete([])
+    end
+
+    assert_difference -> { Topic.count }, -1 do
+      assert_equal 1, Topic.delete(topics(:first).id)
+    end
+  end
+
   def test_class_level_delete_is_affected_by_scoping
     should_not_be_destroyed_reply = Reply.create("title" => "hello", "content" => "world")
     Topic.find(1).replies << should_not_be_destroyed_reply


### PR DESCRIPTION
When some invalid primary key values are passed to `ActiveRecord::Persistence.delete` method, ActiveRecord still perform a `DELETE` query even if it is not needed. For example,
```ruby
irb(main):001> User.delete([])
  User Delete All (0.6ms)  DELETE FROM "users" WHERE 1=0
=> 0
```

So people usually add conditions around the call like `User.delete(ids) if ids.compact.any?` or `User.delete(id) if id` or just forget these conditions and unneeded queries are ran. But we can remove this burden from the user. Recent real-world example https://github.com/rails/solid_cache/blob/9be6755a2d8c8fd1c294912e1fbf6bbb69410c61/app/models/solid_cache/entry.rb#L64-L66

But, can `NULL` be a valid value and can we actually ignore it? I checked, and it turns out that primary keys cannot be `NULL` - ANSI standard says so, PostgreSQL, MySQL, SQL Server and Oracle Server conform to that. There is an exception from SQLite. In [the docs](https://www.sqlite.org/lang_createtable.html#the_primary_key) it says that it allows `NULL`s due to some historical reasons, unless some conditions are met (one of them is explicit `NOT NULL` or table is created in `STRICT` mode, read the docs from the link for the details). But in rails, we explicitly set it `NOT NULL` https://github.com/rails/rails/blob/ad1e443e535a6709cc314b614e757eb843d8c208/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L77 and have a `strict` mode (https://github.com/rails/rails/pull/45346). So, I think it is safe to ignore `nil`s as values provided to `#delete`.