### PR TITLE
Don't use deprecated `#to_default_s` in `Date#to_fs`

### DIFF
--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -52,7 +52,7 @@ class Date
         strftime(formatter)
       end
     else
-      to_default_s
+      to_s
     end
   end
   alias_method :to_formatted_s, :to_fs

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -37,6 +37,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "2005-02-21",          date.to_fs(:inspect)
     assert_equal "21 Feb 2005",         date.to_fs(:rfc822)
     assert_equal "2005-02-21",          date.to_fs(:iso8601)
+    assert_equal date.to_s,             date.to_fs(:doesnt_exist)
     assert_equal "21 Feb",              date.to_formatted_s(:short)
   end
 


### PR DESCRIPTION
## Detail

In Rails 7.1.1, using `Date#to_fs` with an un-exist format, shows the deprecation warning like the following.

```ruby
Date.current.to_fs(:doesnt_exist)
#=> DEPRECATION WARNING: to_default_s is deprecated and will be removed from Rails 7.2 (use to_s instead) (called from <main> at ./bin/rails:4)
```

But other date-time-related classes still allow to use this.

https://github.com/rails/rails/blob/6f6c211f4781e7bda63e5f47089f9d2612dc0a52/activesupport/lib/active_support/core_ext/time/conversions.rb#L57 https://github.com/rails/rails/blob/6f6c211f4781e7bda63e5f47089f9d2612dc0a52/activesupport/lib/active_support/core_ext/date_time/conversions.rb#L39

So I thought this was just a typo and fixed to use `#to_s` like other classes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
