### PR TITLE
add strict loading config comments to sample app generator

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -63,6 +63,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Enables strict loading across all models
+  # config.active_record.strict_loading_by_default = true
+
   <%- end -%>
   <%- unless options[:skip_active_job] -%>
   # Highlight code that enqueued background job in logs.


### PR DESCRIPTION
 ### Motivation / Background

The introduction of ["strict loading" associations in Ruby on Rails 6.1](https://github.com/rails/rails/pull/37400
) was a significant enhancement towards solving the common N+1 query problem faced by beginners. Despite its utility, this feature is not yet widely adopted in the development community. One way to promote its usage could be by integrating it more prominently within the sample app. By doing so, it could serve as a practical example for developers.

### Detail

This adds comments to development.rb in the sample app generator template

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
