### PR TITLE
Add SQL keyword capitalization consistency

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -856,8 +856,8 @@ module ActiveRecord
         def load_types_queries(initializer, oids)
           query = <<~SQL
             SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
-            FROM pg_type as t
-            LEFT JOIN pg_range as r ON oid = rngtypid
+            FROM pg_type AS t
+            LEFT JOIN pg_range AS r ON oid = rngtypid
           SQL
           if oids
             yield query + "WHERE t.oid IN (%s)" % oids.join(", ")
@@ -1082,7 +1082,7 @@ module ActiveRecord
                      pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
                      c.collname, col_description(a.attrelid, a.attnum) AS comment,
                      #{supports_identity_columns? ? 'attidentity' : quote('')} AS identity,
-                     #{supports_virtual_columns? ? 'attgenerated' : quote('')} as attgenerated
+                     #{supports_virtual_columns? ? 'attgenerated' : quote('')} AS attgenerated
                 FROM pg_attribute a
                 LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                 LEFT JOIN pg_type t ON a.atttypid = t.oid
@@ -1175,7 +1175,7 @@ module ActiveRecord
           known_coder_types = coders_by_name.keys.map { |n| quote(n) }
           query = <<~SQL % known_coder_types.join(", ")
             SELECT t.oid, t.typname
-            FROM pg_type as t
+            FROM pg_type AS t
             WHERE t.typname IN (%s)
           SQL
           coders = execute_and_clear(query, "SCHEMA", [], allow_retry: true, materialize_transactions: false) do |result|

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -706,7 +706,7 @@ module ActiveRecord
                   when "Mysql2"
                     @connection.execute("SELECT CONNECTION_ID()").to_a[0][0]
                   when "Trilogy"
-                    @connection.execute("SELECT CONNECTION_ID() as connection_id").to_a[0][0]
+                    @connection.execute("SELECT CONNECTION_ID() AS connection_id").to_a[0][0]
                   when "PostgreSQL"
                     @connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
                   else

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
@@ -97,7 +97,7 @@ class AdapterPreventWritesTest < ActiveRecord::AbstractMysqlTestCase
 
   def test_doesnt_error_when_a_kill_query_is_called_while_preventing_writes
     ActiveRecord::Base.while_preventing_writes do
-      conn_id = @conn.execute("SELECT CONNECTION_ID() as connection_id").to_a[0][0]
+      conn_id = @conn.execute("SELECT CONNECTION_ID() AS connection_id").to_a[0][0]
       assert_raises(ActiveRecord::QueryCanceled) do
         @conn.execute("KILL QUERY #{conn_id}")
       end

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -13,7 +13,7 @@ class PostgresqlDomainTest < ActiveRecord::PostgreSQLTestCase
   def setup
     @connection = ActiveRecord::Base.connection
     @connection.transaction do
-      @connection.execute "CREATE DOMAIN custom_money as numeric(8,2)"
+      @connection.execute "CREATE DOMAIN custom_money AS numeric(8,2)"
       @connection.create_table("postgresql_domains") do |t|
         t.column :price, :custom_money
       end

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -127,10 +127,10 @@ class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_load_infinity_and_beyond
-    d = Developer.find_by_sql("select 'infinity'::timestamp as legacy_updated_at")
+    d = Developer.find_by_sql("select 'infinity'::timestamp AS legacy_updated_at")
     assert_predicate d.first.updated_at, :infinite?, "timestamp should be infinite"
 
-    d = Developer.find_by_sql("select '-infinity'::timestamp as legacy_updated_at")
+    d = Developer.find_by_sql("select '-infinity'::timestamp AS legacy_updated_at")
     time = d.first.updated_at
     assert_predicate time, :infinite?, "timestamp should be infinite"
     assert_operator time, :<, 0

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -330,7 +330,7 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_id_allows_default_override_via_nil
-    col_desc = connection.execute("SELECT pg_get_expr(d.adbin, d.adrelid) as default
+    col_desc = connection.execute("SELECT pg_get_expr(d.adbin, d.adrelid) AS default
                                   FROM pg_attribute a
                                   LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                                   WHERE a.attname='id' AND a.attrelid = 'pg_uuids'::regclass").first

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1255,7 +1255,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_eager_loading_with_select_on_joined_table_preloads
     posts = assert_queries(2) do
-      Post.all.merge!(select: "posts.*, authors.name as author_name", includes: :comments, joins: :author, order: "posts.id").to_a
+      Post.all.merge!(select: "posts.*, authors.name AS author_name", includes: :comments, joins: :author, order: "posts.id").to_a
     end
     assert_equal "David", posts[0].author_name
     assert_equal posts(:welcome).comments.sort_by(&:id), assert_no_queries { posts[0].comments.sort_by(&:id) }

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -716,7 +716,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_grouped
     all_posts_from_category1 = Post.all.merge!(where: "category_id = 1", joins: :categories).to_a
-    grouped_posts_of_category1 = Post.all.merge!(where: "category_id = 1", group: "author_id", select: "count(posts.id) as posts_count", joins: :categories).to_a
+    grouped_posts_of_category1 = Post.all.merge!(where: "category_id = 1", group: "author_id", select: "count(posts.id) AS posts_count", joins: :categories).to_a
     assert_equal 5, all_posts_from_category1.size
     assert_equal 2, grouped_posts_of_category1.size
   end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -979,7 +979,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_grouped
     all_clients_of_firm1 = Client.all.merge!(where: "firm_id = 1").to_a
-    grouped_clients_of_firm1 = Client.all.merge!(where: "firm_id = 1", group: "firm_id", select: "firm_id, count(id) as clients_count").to_a
+    grouped_clients_of_firm1 = Client.all.merge!(where: "firm_id = 1", group: "firm_id", select: "firm_id, COUNT(id) AS clients_count").to_a
     assert_equal 3, all_clients_of_firm1.size
     assert_equal 1, grouped_clients_of_firm1.size
   end

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -108,7 +108,7 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
   end
 
   def test_does_not_override_select
-    authors = Author.select("authors.name, #{%{(authors.author_address_id || ' ' || authors.author_address_extra_id) as addr_id}}").left_outer_joins(:posts)
+    authors = Author.select("authors.name, #{%{(authors.author_address_id || ' ' || authors.author_address_extra_id) AS addr_id}}").left_outer_joins(:posts)
     assert_predicate authors, :any?
     assert_respond_to authors.first, :addr_id
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -595,7 +595,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "custom field attribute predicate" do
     object = Company.find_by_sql(<<~SQL).first
-      SELECT c1.*, c2.type as string_value, c2.rating as int_value
+      SELECT c1.*, c2.type AS string_value, c2.rating AS int_value
         FROM companies c1, companies c2
        WHERE c1.firm_id = c2.id
          AND c1.id = 2
@@ -682,9 +682,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     Topic.create(title: "Budget")
     # Oracle does not support boolean expressions in SELECT.
     if current_adapter?(:OracleAdapter)
-      topic = Topic.all.merge!(select: "topics.*, 0 as is_test").first
+      topic = Topic.all.merge!(select: "topics.*, 0 AS is_test").first
     else
-      topic = Topic.all.merge!(select: "topics.*, 1=2 as is_test").first
+      topic = Topic.all.merge!(select: "topics.*, 1=2 AS is_test").first
     end
     assert_not_predicate topic, :is_test?
   end
@@ -693,9 +693,9 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     Topic.create(title: "Budget")
     # Oracle does not support boolean expressions in SELECT.
     if current_adapter?(:OracleAdapter)
-      topic = Topic.all.merge!(select: "topics.*, 1 as is_test").first
+      topic = Topic.all.merge!(select: "topics.*, 1 AS is_test").first
     else
-      topic = Topic.all.merge!(select: "topics.*, 2=2 as is_test").first
+      topic = Topic.all.merge!(select: "topics.*, 2=2 AS is_test").first
     end
     assert_predicate topic, :is_test?
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -200,7 +200,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_limit_should_sanitize_sql_injection_for_limit_without_commas
     assert_raises(ArgumentError) do
-      Topic.limit("1 select * from schema").to_a
+      Topic.limit("1 * FROM schema").to_a
     end
   end
 
@@ -1447,7 +1447,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_assert_queries
-    query = lambda { ActiveRecord::Base.connection.execute "select count(*) from developers" }
+    query = lambda { ActiveRecord::Base.connection.execute "SELECT COUNT(*) FROM developers" }
     assert_queries(2) { 2.times { query.call } }
     assert_queries 1, &query
     assert_no_queries { assert true }
@@ -1663,7 +1663,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_typecasting_aliases
-    assert_equal 10, Topic.select("10 as tenderlove").first.tenderlove
+    assert_equal 10, Topic.select("10 AS tenderlove").first.tenderlove
   end
 
   def test_default_values_are_deeply_dupped

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -52,7 +52,7 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_relation_with_virtual_field
-    relation = Topic.limit(1).select("1 as virtual_field")
+    relation = Topic.limit(1).select("1 AS virtual_field")
     assert_match(/virtual_field: 1/, relation.inspect)
   end
 

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -27,12 +27,12 @@ if ActiveRecord::Base.connection.supports_explain?
 
     def test_collects_nothing_if_collect_is_false
       ActiveRecord::ExplainRegistry.collect = false
-      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "select 1 from users", binds: [1, 2])
+      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "SELECT 1 FROM users", binds: [1, 2])
       assert_empty queries
     end
 
     def test_collects_pairs_of_queries_and_binds
-      sql   = "select 1 from users"
+      sql   = "SELECT 1 FROM users"
       binds = [1, 2]
       SUBSCRIBER.finish(nil, nil, name: "SQL", sql: sql, binds: binds)
       assert_equal 1, queries.size
@@ -51,12 +51,12 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def test_collects_cte_queries
-      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "with s as (values(3)) select 1 from s")
+      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "WITH s AS (VALUES(3)) SELECT 1 FROM s")
       assert_equal 1, queries.size
     end
 
     def test_collects_queries_starting_with_comment
-      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "/* comment */ select 1 from users")
+      SUBSCRIBER.finish(nil, nil, name: "SQL", sql: "/* comment */ SELECT 1 FROM users")
       assert_equal 1, queries.size
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -481,8 +481,8 @@ class FinderTest < ActiveRecord::TestCase
     bob = authors(:bob)
     mary = authors(:mary)
 
-    assert_equal false, Author.select("COUNT(*) as total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(bob)
-    assert_equal true, Author.select("COUNT(*) as total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(mary)
+    assert_equal false, Author.select("COUNT(*) AS total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(bob)
+    assert_equal true, Author.select("COUNT(*) AS total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(mary)
   end
 
   def test_include_on_loaded_relation_with_match
@@ -1656,7 +1656,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_with_limiting_with_custom_select
     posts = Post.references(:authors).merge(
-      includes: :author, select: 'posts.*, authors.id as "author_id"',
+      includes: :author, select: 'posts.*, authors.id AS "author_id"',
       limit: 3, order: "posts.id"
     ).to_a
     assert_equal 3, posts.size

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -117,7 +117,7 @@ class InsertAllTest < ActiveRecord::TestCase
   def test_insert_all_returns_requested_sql_fields
     skip unless supports_insert_returning?
 
-    result = Book.insert_all! [{ name: "Rework", author_id: 1 }], returning: Arel.sql("UPPER(name) as name")
+    result = Book.insert_all! [{ name: "Rework", author_id: 1 }], returning: Arel.sql("UPPER(name) AS name")
     assert_equal %w[ REWORK ], result.pluck("name")
   end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1401,7 +1401,7 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_reload_removes_custom_selects
-    post = Post.select("posts.*, 1 as wibble").last!
+    post = Post.select("posts.*, 1 AS wibble").last!
 
     assert_equal 1, post[:wibble]
     assert_nil post.reload[:wibble]

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -247,7 +247,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     def test_invalid_encoding_query
       ActiveRecord::QueryLogs.tags = [ :application ]
       assert_nothing_raised do
-        ActiveRecord::Base.connection.execute "select 1 as '\xFF'"
+        ActiveRecord::Base.connection.execute "SELECT 1 AS '\xFF'"
       end
     end
   end

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -74,7 +74,7 @@ module ActiveRecord
         relation = Post
           .with(commented_posts: Comment.select(:post_id).distinct)
           .left_outer_joins(:commented_posts)
-          .select("posts.*, commented_posts.post_id as has_comments")
+          .select("posts.*, commented_posts.post_id AS has_comments")
 
         records = relation.order(:id).to_a
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -285,14 +285,14 @@ module ActiveRecord
       post = Post.select(:title).first
       assert_not_respond_to post, :body, "post should not respond_to?(:body) since invoking it raises exception"
 
-      silence_warnings { post = Post.select("'title' as post_title").first }
+      silence_warnings { post = Post.select("'title' AS post_title").first }
       assert_not_respond_to post, :title, "post should not respond_to?(:body) since invoking it raises exception"
     end
 
     def test_select_quotes_when_using_from_clause
       skip_if_sqlite3_version_includes_quoting_bug
       quoted_join = ActiveRecord::Base.connection.quote_table_name("join")
-      selected = Post.select(:join).from(Post.select("id as #{quoted_join}")).map(&:join)
+      selected = Post.select(:join).from(Post.select("id AS #{quoted_join}")).map(&:join)
       assert_equal Post.pluck(:id).sort, selected.sort
     end
 

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -78,7 +78,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_types_of_virtual_columns_are_not_changed_on_round_trip
-    author = Author.select("authors.*, count(posts.id) as posts_count")
+    author = Author.select("authors.*, count(posts.id) AS posts_count")
       .joins(:posts)
       .group("authors.id")
       .first

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -7,7 +7,7 @@ class Category < ActiveRecord::Base
   has_and_belongs_to_many :posts_with_authors_sorted_by_author_id, -> { includes(:authors).order("authors.id") }, class_name: "Post"
 
   has_and_belongs_to_many :select_testing_posts,
-                          -> { select "posts.*, 1 as correctness_marker" },
+                          -> { select "posts.*, 1 AS correctness_marker" },
                           class_name: "Post",
                           foreign_key: "category_id",
                           association_foreign_key: "post_id"

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -18,7 +18,7 @@ end
 
 class SelectedMembership < Membership
   def self.default_scope
-    select("'1' as foo")
+    select("'1' AS foo")
   end
 end
 

--- a/activerecord/test/models/owner.rb
+++ b/activerecord/test/models/owner.rb
@@ -10,11 +10,11 @@ class Owner < ActiveRecord::Base
   scope :including_last_pet, -> {
     select('
       owners.*, (
-        select p.pet_id from pets p
-        where p.owner_id = owners.owner_id
-        order by p.name desc
-        limit 1
-      ) as last_pet_id
+        SELECT p.pet_id FROM pets p
+        WHERE p.owner_id = owners.owner_id
+        ORDER BY p.name DESC
+        LIMIT 1
+      ) AS last_pet_id
     ').includes(:last_pet)
   }
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -122,8 +122,8 @@ class Post < ActiveRecord::Base
   has_many :taggings, as: :taggable, counter_cache: :tags_count
   has_many :tags, through: :taggings do
     def add_joins_and_select
-      select("tags.*, authors.id as author_id")
-        .joins("left outer join posts on taggings.taggable_id = posts.id left outer join authors on posts.author_id = authors.id")
+      select("tags.*, authors.id AS author_id")
+        .joins("LEFT OUTER JOIN posts ON taggings.taggable_id = posts.id LEFT OUTER JOIN authors ON posts.author_id = authors.id")
         .to_a
     end
   end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -13,7 +13,7 @@ class Project < ActiveRecord::Base
                             after_add: Proc.new { |o, r| o.developers_log << "after_adding#{r.id || '<new>'}" },
                             before_remove: Proc.new { |o, r| o.developers_log << "before_removing#{r.id}" },
                             after_remove: Proc.new { |o, r| o.developers_log << "after_removing#{r.id}" }
-  has_and_belongs_to_many :well_paid_salary_groups, -> { group("developers.salary").having("SUM(salary) > 10000").select("SUM(salary) as salary") }, class_name: "Developer"
+  has_and_belongs_to_many :well_paid_salary_groups, -> { group("developers.salary").having("SUM(salary) > 10000").select("SUM(salary) AS salary") }, class_name: "Developer"
   belongs_to :firm
   has_one :lead_developer, through: :firm, inverse_of: :contracted_projects
   has_one :lead_developer_disable_joins, through: :firm, inverse_of: :contracted_projects, source: :lead_developer, disable_joins: true


### PR DESCRIPTION
### Motivation / Background

This PR does not change behavior, fix a bug, or change documentation. It improves SQL keyword capitalization consistency in a minor way, for keywords like `as`, with examples in `lib` code but mostly in `test`.

Consistent SQL keyword capitalization helps for reading SQL queries, making the keywords stand out more from other aspects like table names, column names, etc.

### Detail

Capitalizing places in `lib` with mixed lowercase and uppercase makes them consistent with adjacent code. 

Although there are only a couple of spots in `lib`, there are a lot of spots in `test` where SQL query text wasn't as consistent in capitalization. I could also see a justification of "leaving it be". However, in lieu of changing 1 or 2, I tried to change all instances in order to get the capitalization standards updated at once.

I don't believe query text capitalization is currently enforced by Rubocop. It might be quite tricky to separate it out.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

No CHANGELOG update was made because this doesn't change the end-user experience, since it's formatting only. 