### PR TITLE
Fix `StrongParameters#extract_value` to include blank values

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -967,8 +967,14 @@ module ActionController
     #   params.extract_value(:id) # => ["1", "123"]
     #   params.extract_value(:tags, delimiter: ",") # => ["ruby", "rails"]
     #   params.extract_value(:non_existent_key) # => nil
+    #
+    # Note that if the given +key+'s value contains blank elements, then
+    # the returned array will include empty strings.
+    #
+    #   params = ActionController::Parameters.new(tags: "ruby,rails,,web")
+    #   params.extract_value(:tags) # => ["ruby", "rails", "", "web"]
     def extract_value(key, delimiter: "_")
-      @parameters[key]&.split(delimiter)
+      @parameters[key]&.split(delimiter, -1)
     end
 
     protected

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -425,11 +425,13 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "#extract_value splits param by delimiter" do
     params = ActionController::Parameters.new(
       id: "1_123",
-      tags: "ruby,rails,web"
+      tags: "ruby,rails,web",
+      blank_tags: ",ruby,,rails,"
     )
 
     assert_equal(["1", "123"], params.extract_value(:id))
     assert_equal(["ruby", "rails", "web"], params.extract_value(:tags, delimiter: ","))
+    assert_equal(["", "ruby", "", "rails", ""], params.extract_value(:blank_tags, delimiter: ","))
     assert_nil(params.extract_value(:non_existent_key))
   end
 end


### PR DESCRIPTION
Fixes #49695 (see there for the discussion).