### PR TITLE
Fix ActiveJob method name in sucker_punch 1.0 error

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -33,7 +33,7 @@ module ActiveJob
           delay = timestamp - Time.current.to_f
           JobWrapper.perform_in delay, job.serialize
         else
-          raise NotImplementedError, "sucker_punch 1.0 does not support `enqueued_at`. Please upgrade to version ~> 2.0.0 to enable this behavior."
+          raise NotImplementedError, "sucker_punch 1.0 does not support `enqueue_at`. Please upgrade to version ~> 2.0.0 to enable this behavior."
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was searching the Rails source for `enqueued_at`, and found it in a place that on further inspection seemed to be a typo. This error is alerting the user that they have called the `enqueue_at` method while using SuckerPunch 1.0, where it isn't supported. Since the error message says `enqueued_at`, it could confuse and mislead users for a bit.

I hope I got this right! Thanks!

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
