### PR TITLE
Clarify ActiveModel::SecurePassword maximum password length [ci skip]

### DIFF
--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -527,7 +527,8 @@ The following validations are added automatically:
 
 1. Password should be present.
 2. Password should be equal to its confirmation (provided `XXX_confirmation` is passed along).
-3. The maximum length of a password is 72 (required by `bcrypt` on which ActiveModel::SecurePassword depends)
+3. The maximum length of a password is 72 bytes (required as `bcrypt`, on which
+   ActiveModel::SecurePassword depends, truncates the string to this size before encrypting it).
 
 #### Examples
 


### PR DESCRIPTION
### Motivation / Background

While 74264f4 improved the secure_password length validation to match bcrypt limit of 72 bytes, the ActiveModel basics guide only documents an unit-less `72` as the maximum length allowed.

### Detail

This Pull Request modifies the ActiveModel basics guide to more accurately describe secure_password length validation.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
