### PR TITLE
Deprecate `STATS_DIRECTORIES` in favor of `config.code_statistics.directories`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -250,6 +250,10 @@ Old setting equivalent to `!config.enable_reloading`. Supported for backwards co
 
 Configures which cache store to use for Rails caching. Options include one of the symbols `:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`, or an object that implements the cache API. Defaults to `:file_store`. See [Cache Stores](caching_with_rails.html#cache-stores) for per-store configuration options.
 
+#### `config.code_statistics.directories`
+
+Defines the directories that will be used by the `bin/rails stats` command.
+
 #### `config.colorize_logging`
 
 Specifies whether or not to use ANSI color codes when logging information. Defaults to `true`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate `::STATS_DIRECTORIES`.
+
+    Global constant `STATS_DIRECTORIES` has been deprecated in favor of
+    `Rails.application.config.code_statistics.directories`.
+
+    *Petrik de Heus*
+
 *   Disallow invalid values for rails new options.
 
     The `--database`, `--asset-pipeline`, `--css`, and `--javascript` flags for

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -7,6 +7,7 @@ require "active_support/file_update_checker"
 require "active_support/configuration_file"
 require "rails/engine/configuration"
 require "rails/source_annotation_extractor"
+require "rails/code_statistics"
 
 module Rails
   class Application
@@ -23,7 +24,7 @@ module Rails
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version
+                    :dom_testing_default_html_version, :code_statistics
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -83,6 +84,7 @@ module Rails
         @rake_eager_load                         = false
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
+        @code_statistics                         = ActiveSupport::InheritableOptions.new(code_statistics_defaults)
       end
 
       # Loads default configuration values for a target version. This includes
@@ -590,6 +592,12 @@ module Rails
       end
 
       private
+        def code_statistics_defaults
+          {
+            directories: CodeStatistics::DIRECTORIES
+          }
+        end
+
         def credentials_defaults
           content_path = root.join("config/credentials/#{Rails.env}.yml.enc")
           content_path = root.join("config/credentials.yml.enc") if !content_path.exist?

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -4,6 +4,31 @@ require "rails/code_statistics_calculator"
 require "active_support/core_ext/enumerable"
 
 class CodeStatistics # :nodoc:
+  DIRECTORIES = [
+    %w(Controllers        app/controllers),
+    %w(Helpers            app/helpers),
+    %w(Jobs               app/jobs),
+    %w(Models             app/models),
+    %w(Mailers            app/mailers),
+    %w(Mailboxes          app/mailboxes),
+    %w(Channels           app/channels),
+    %w(Views              app/views),
+    %w(JavaScripts        app/assets/javascripts),
+    %w(Stylesheets        app/assets/stylesheets),
+    %w(JavaScript         app/javascript),
+    %w(Libraries          lib/),
+    %w(APIs               app/apis),
+    %w(Controller\ tests  test/controllers),
+    %w(Helper\ tests      test/helpers),
+    %w(Job\ tests         test/jobs),
+    %w(Model\ tests       test/models),
+    %w(Mailer\ tests      test/mailers),
+    %w(Mailbox\ tests     test/mailboxes),
+    %w(Channel\ tests     test/channels),
+    %w(Integration\ tests test/integration),
+    %w(System\ tests      test/system),
+  ]
+
   TEST_TYPES = ["Controller tests",
                 "Helper tests",
                 "Model tests",

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -1,37 +1,15 @@
 # frozen_string_literal: true
 
-# While global constants are bad, many 3rd party tools depend on this one (e.g
-# rspec-rails & cucumber-rails). So a deprecation warning is needed if we want
-# to remove it.
-STATS_DIRECTORIES ||= [
-  %w(Controllers        app/controllers),
-  %w(Helpers            app/helpers),
-  %w(Jobs               app/jobs),
-  %w(Models             app/models),
-  %w(Mailers            app/mailers),
-  %w(Mailboxes          app/mailboxes),
-  %w(Channels           app/channels),
-  %w(Views              app/views),
-  %w(JavaScripts        app/assets/javascripts),
-  %w(Stylesheets        app/assets/stylesheets),
-  %w(JavaScript         app/javascript),
-  %w(Libraries          lib/),
-  %w(APIs               app/apis),
-  %w(Controller\ tests  test/controllers),
-  %w(Helper\ tests      test/helpers),
-  %w(Job\ tests         test/jobs),
-  %w(Model\ tests       test/models),
-  %w(Mailer\ tests      test/mailers),
-  %w(Mailbox\ tests     test/mailboxes),
-  %w(Channel\ tests     test/channels),
-  %w(Integration\ tests test/integration),
-  %w(System\ tests      test/system),
-]
+STATS_DIRECTORIES = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+  Rails.application.config.code_statistics.directories,
+  "`STATS_DIRECTORIES` is deprecated! Use `Rails.application.config.code_statistics.directories` instead.",
+  Rails.deprecator
+)
 
 desc "Report code statistics (KLOCs, etc) from the application or engine"
 task :stats do
   require "rails/code_statistics"
-  stat_directories = STATS_DIRECTORIES.collect do |name, dir|
+  stat_directories = Rails.application.config.code_statistics.directories.collect do |name, dir|
     [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
   end.select { |name, dir| File.directory?(dir) }
   CodeStatistics.new(*stat_directories).to_s


### PR DESCRIPTION
`STATS_DIRECTORIES` is used by third parties to add directories to the statistics output. It's a global constant defined in a Rake file, that gets loaded anytime a rails command is executed.

To remove the dependency on Rake and avoid a global constant we can move
the constant to the Rails.application.configuration.

`deprecate_constant` couldn't be used here as that doesn't seem to work for the root namespace.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
