### PR TITLE
Support the ability to run find_each/find_in_batches queries without order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support the ability to run find_each/find_in_batches queries without order
+
+    *Shayon Mukherjee*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -39,8 +39,8 @@ module ActiveRecord
     # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
     #   an order is present in the relation.
-    # * <tt>:order</tt> - Specifies the primary key order (can be +:asc+ or +:desc+ or an array consisting
-    #   of :asc or :desc). Defaults to +:asc+.
+    # * <tt>:order</tt> - Specifies the primary key order (can be +:asc+ or +:desc+, an array consisting
+    #   of :asc or :desc, or nil). A value of nil would skip any ordering. Defaults to +:asc+.
     #
     #     class Order < ActiveRecord::Base
     #       self.primary_key = [:id_1, :id_2]
@@ -69,7 +69,7 @@ module ActiveRecord
     #     person.party_all_night!
     #   end
     #
-    # NOTE: Order can be ascending (:asc) or descending (:desc). It is automatically set to
+    # NOTE: Order can be ascending (:asc), descending (:desc) or nil. It is automatically set to
     # ascending on the primary key ("id ASC").
     # This also means that this method only works when the primary key is
     # orderable (e.g. an integer or string).
@@ -317,6 +317,7 @@ module ActiveRecord
       end
 
       def build_batch_orders(order)
+        return [] if order.nil?
         get_the_order_of_primary_key(order).map do |column, ord|
           [column, ord || DEFAULT_ORDER]
         end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -170,6 +170,33 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_find_in_batches_should_not_query_with_order
+    assert_sql(/^(?:(?!ORDER).)*$/) do
+      Post.find_in_batches(batch_size: 1, order: nil) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
+      end
+    end
+  end
+
+
+  def test_find_in_batches_should_query_with_limit_and_no_order
+    assert_sql(/LIMIT/) do
+      Post.find_in_batches(batch_size: 1, order: nil) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Post, batch.first
+      end
+    end
+  end
+
+  def test_find_each_should_not_query_with_order
+    assert_sql(/^(?:(?!ORDER).)*$/) do
+      Post.find_each(batch_size: 1, order: nil) do |post|
+        assert_kind_of Post, post
+      end
+    end
+  end
+
   def test_each_should_raise_if_order_is_invalid
     assert_raise(ArgumentError) do
       Post.select(:title).find_each(batch_size: 1, order: :invalid) { |post|


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background + Detail
Currently, the default option for `order` is `asc` and can also be set to `desc` or passed an array with those values. This works great in most cases, however sometimes forcing the `ORDER` clause for the primary key can result into a sort + heap scan in Postgresql, by passing an index lookup and may cause a performance tax and in those situations where we don't care about order, it'd be lovely to continue using `in_batches` with no order instead of having to write custom SQL. Example usage

```ruby
Event
  .where(story_run_id: ids)
  .lock("FOR UPDATE SKIP LOCKED")
  .in_batches(of: 1000, order: nil, &:delete_all)
```

### Additional information

Chose to support `nil` for the `order` option over coming up with a new function like `find_in_unordered_batches` or similar.

Curious to hear more. For instance, this works for when `delete_all` is passed, but may not work as expected if `order: nil`, in any other case because the offset would be off?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
