### PR TITLE
Make the output of `ActiveRecord::Core#inspect` configurable.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Make the output of `ActiveRecord::Core#inspect` configurable.
+
+    By default, calling `inspect` on a record will yield a formatted string including just the `id`.
+
+    ```ruby
+    Post.first.inspect #=> "#<Post id: 1>"
+    ```
+
+    The attributes to be included in the output of `inspect` can be configured with
+    `ActiveRecord::Core#attributes_for_inspect`.
+
+    ```ruby
+    Post.attributes_for_inspect = [:id, :title]
+    Post.first.inspect #=> "#<Post id: 1, title: "Hello, World!">"
+    ```
+
+    With the `attributes_for_inspect` set to `:all`, `inspect` will list all the record's attributes.
+
+    ```ruby
+    Post.attributes_for_inspect = :all
+    Post.first.inspect #=> "#<Post id: 1, title: "Hello, World!", published_at: "2023-10-23 14:28:11 +0000">"
+    ```
+
+    In development and test mode, `attributes_for_inspect` will be set to `:all` by default.
+
+    You can also call `full_inspect` to get an inspection with all the attributes.
+
+    The attributes in `attribute_for_inspect` will also be used for `pretty_print`.
+
+    *Andrew Novoselac*
+
 *   Don't mark Float::INFINITY as changed when reassigning it
 
     When saving a record with a float infinite value, it shouldn't mark as changed

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -458,5 +458,15 @@ To keep using the current cache store, you can turn off cache versioning entirel
         end
       end
     end
+
+    initializer "active_record.attributes_for_inspect" do |app|
+      ActiveSupport.on_load(:active_record) do
+        if app.config.consider_all_requests_local
+          if app.config.active_record.attributes_for_inspect.nil?
+            ActiveRecord::Base.attributes_for_inspect = :all
+          end
+        end
+      end
+    end
   end
 end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -343,7 +343,7 @@ module ActiveRecord
     end
 
     test "attributes not backed by database columns appear in inspect" do
-      inspection = OverloadedType.new.inspect
+      inspection = OverloadedType.new.full_inspect
 
       assert_includes inspection, "non_existent_decimal"
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -17,18 +17,28 @@ class CoreTest < ActiveRecord::TestCase
     assert_match(/^Topic\(id: integer, title: string/, Topic.inspect)
   end
 
-  def test_inspect_instance
+  def test_inspect_instance_includes_just_id_by_default
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_fs(:inspect)}", bonus_time: "#{topic.bonus_time.to_fs(:inspect)}", last_read: "#{topic.last_read.to_fs(:inspect)}", content: "Have a nice day", important: nil, binary_content: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_fs(:inspect)}", updated_at: "#{topic.updated_at.to_fs(:inspect)}">), topic.inspect
+    assert_equal %(#<Topic id: 1>), topic.inspect
+  end
+
+  def test_inspect_includes_attributes_from_attributes_for_inspect
+    Topic.with(attributes_for_inspect: [:id, :title, :author_name]) do
+      topic = topics(:first)
+
+      assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David">), topic.inspect
+    end
   end
 
   def test_inspect_instance_with_lambda_date_formatter
     before = Time::DATE_FORMATS[:inspect]
-    Time::DATE_FORMATS[:inspect] = ->(date) { "my_format" }
-    topic = topics(:first)
 
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "my_format", bonus_time: "my_format", last_read: "2004-04-15", content: "Have a nice day", important: nil, binary_content: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "my_format", updated_at: "my_format">), topic.inspect
+    Topic.with(attributes_for_inspect: [:id, :last_read]) do
+      Time::DATE_FORMATS[:inspect] = ->(date) { "my_format" }
+      topic = topics(:first)
 
+      assert_equal %(#<Topic id: 1, last_read: "2004-04-15">), topic.inspect
+    end
   ensure
     Time::DATE_FORMATS[:inspect] = before
   end
@@ -38,8 +48,10 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_limited_select_instance
-    assert_equal %(#<Topic id: 1>), Topic.all.merge!(select: "id", where: "id = 1").first.inspect
-    assert_equal %(#<Topic id: 1, title: "The First Topic">), Topic.all.merge!(select: "id, title", where: "id = 1").first.inspect
+    Topic.with(attributes_for_inspect: [:id, :title]) do
+      assert_equal %(#<Topic id: 1>), Topic.all.merge!(select: "id", where: "id = 1").first.inspect
+      assert_equal %(#<Topic id: 1, title: "The First Topic">), Topic.all.merge!(select: "id, title", where: "id = 1").first.inspect
+    end
   end
 
   def test_inspect_instance_with_non_primary_key_id_attribute
@@ -51,9 +63,27 @@ class CoreTest < ActiveRecord::TestCase
     assert_equal "NonExistentTable(Table doesn't exist)", NonExistentTable.inspect
   end
 
+  def test_inspect_with_attributes_for_inspect_all_lists_all_attributes
+    Topic.with(attributes_for_inspect: :all) do
+      topic = topics(:first)
+
+      assert_equal <<~STRING.squish, topic.inspect
+        #<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_fs(:inspect)}", bonus_time: "#{topic.bonus_time.to_fs(:inspect)}", last_read: "#{topic.last_read.to_fs(:inspect)}", content: "Have a nice day", important: nil, binary_content: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_fs(:inspect)}", updated_at: "#{topic.updated_at.to_fs(:inspect)}">
+      STRING
+    end
+  end
+
   def test_inspect_relation_with_virtual_field
     relation = Topic.limit(1).select("1 as virtual_field")
-    assert_match(/virtual_field: 1/, relation.inspect)
+    assert_match(/virtual_field: 1/, relation.first.full_inspect)
+  end
+
+  def test_full_inspect_lists_all_attributes
+    topic = topics(:first)
+
+    assert_equal <<~STRING.squish, topic.full_inspect
+      #<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_fs(:inspect)}", bonus_time: "#{topic.bonus_time.to_fs(:inspect)}", last_read: "#{topic.last_read.to_fs(:inspect)}", content: "Have a nice day", important: nil, binary_content: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_fs(:inspect)}", updated_at: "#{topic.updated_at.to_fs(:inspect)}">
+    STRING
   end
 
   def test_pretty_print_new
@@ -61,26 +91,7 @@ class CoreTest < ActiveRecord::TestCase
     actual = +""
     PP.pp(topic, StringIO.new(actual))
     expected = <<~PRETTY
-      #<Topic:0xXXXXXX
-       id: nil,
-       title: nil,
-       author_name: nil,
-       author_email_address: "test@test.com",
-       written_on: nil,
-       bonus_time: nil,
-       last_read: nil,
-       content: nil,
-       important: nil,
-       binary_content: nil,
-       approved: true,
-       replies_count: 0,
-       unique_replies_count: 0,
-       parent_id: nil,
-       parent_title: nil,
-       type: nil,
-       group: nil,
-       created_at: nil,
-       updated_at: nil>
+      #<Topic:0xXXXXXX id: nil>
     PRETTY
     assert actual.start_with?(expected.split("XXXXXX").first)
     assert actual.end_with?(expected.split("XXXXXX").last)
@@ -91,28 +102,40 @@ class CoreTest < ActiveRecord::TestCase
     actual = +""
     PP.pp(topic, StringIO.new(actual))
     expected = <<~PRETTY
-      #<Topic:0x\\w+
-       id: 1,
-       title: "The First Topic",
-       author_name: "David",
-       author_email_address: "david@loudthinking.com",
-       written_on: 2003-07-16 14:28:11(?:\.2233)? UTC,
-       bonus_time: 2000-01-01 14:28:00 UTC,
-       last_read: Thu, 15 Apr 2004,
-       content: "Have a nice day",
-       important: nil,
-       binary_content: nil,
-       approved: false,
-       replies_count: 1,
-       unique_replies_count: 0,
-       parent_id: nil,
-       parent_title: nil,
-       type: nil,
-       group: nil,
-       created_at: [^,]+,
-       updated_at: [^,>]+>
+      #<Topic:0x\\w+ id: 1>
     PRETTY
     assert_match(/\A#{expected}\z/, actual)
+  end
+
+  def test_pretty_print_full
+    Topic.with(attributes_for_inspect: :all) do
+      topic = topics(:first)
+      actual = +""
+      PP.pp(topic, StringIO.new(actual))
+      expected = <<~PRETTY
+        #<Topic:0x\\w+
+         id: 1,
+         title: "The First Topic",
+         author_name: "David",
+         author_email_address: "david@loudthinking.com",
+         written_on: 2003-07-16 14:28:11(?:\.2233)? UTC,
+         bonus_time: 2000-01-01 14:28:00 UTC,
+         last_read: Thu, 15 Apr 2004,
+         content: "Have a nice day",
+         important: nil,
+         binary_content: nil,
+         approved: false,
+         replies_count: 1,
+         unique_replies_count: 0,
+         parent_id: nil,
+         parent_title: nil,
+         type: nil,
+         group: nil,
+         created_at: [^,]+,
+         updated_at: [^,>]+>
+      PRETTY
+      assert_match(/\A#{expected}\z/, actual)
+    end
   end
 
   def test_pretty_print_uninitialized

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -11,12 +11,15 @@ class FilterAttributesTest < ActiveRecord::TestCase
   fixtures :"admin/users", :"admin/accounts"
 
   setup do
+    @previous_attributes_for_inspect = ActiveRecord::Base.attributes_for_inspect
+    ActiveRecord::Base.attributes_for_inspect = :all
     @previous_filter_attributes = ActiveRecord::Base.filter_attributes
     ActiveRecord::Base.filter_attributes = [:name]
     ActiveRecord.use_yaml_unsafe_load = true
   end
 
   teardown do
+    ActiveRecord::Base.attributes_for_inspect = @previous_attributes_for_inspect
     ActiveRecord::Base.filter_attributes = @previous_filter_attributes
   end
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -132,6 +132,8 @@ end
 class AuditLog < ActiveRecord::Base
   belongs_to :developer, validate: true
   belongs_to :unvalidated_developer, class_name: "Developer"
+
+  self.attributes_for_inspect = [:id, :message]
 end
 
 class AuditLogRequired < ActiveRecord::Base

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4718,6 +4718,44 @@ module ApplicationTests
       assert_equal(:html4, Rails.application.config.dom_testing_default_html_version)
     end
 
+    test "sets ActiveRecord::Base.attributes_for_inspect to [:id] when config.consider_all_requests_local = false" do
+      add_to_config "config.consider_all_requests_local = false"
+
+      app "production"
+
+      assert_equal [:id], ActiveRecord::Base.attributes_for_inspect
+    end
+
+    test "sets ActiveRecord::Base.attributes_for_inspect to :all when config.consider_all_requests_local = true" do
+      add_to_config "config.consider_all_requests_local = true"
+
+      app "development"
+
+      assert_equal :all, ActiveRecord::Base.attributes_for_inspect
+    end
+
+    test "app configuration takes precedence over default" do
+      add_to_config "config.consider_all_requests_local = true"
+      add_to_config "config.active_record.attributes_for_inspect = [:foo]"
+
+      app "development"
+
+      assert_equal [:foo], ActiveRecord::Base.attributes_for_inspect
+    end
+
+    test "model's configuration takes precedence over default" do
+      add_to_config "config.consider_all_requests_local = true"
+      app_file "app/models/foo.rb", <<-RUBY
+        class Foo < ApplicationRecord
+          self.attributes_for_inspect = [:foo]
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal [:foo], Foo.attributes_for_inspect
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/49707

This Pull Request has been created because we noticed that `ActiveRecord::Core#inspect` was taking >9s to run for some large objects in production. This is because the parameter filter is be executed for every attribute.

### Detail

This Pull Request introduces configuration for `ActiveRecord::Core#inspect`. By default, `inspect` just returns the object with its id (eg `#<Post id: 1>`. The attributes to include can be configured with `Post.attributes_to_inspect=`. If you want to full output with all the attributes you can call `Post.full_inspect`. 

### Additional information

In my first draft I had a config to disable this, if you just always want to use `full_inspect`. But it seems easy enough just to do `alias_method :inspect, :full_inspect` on the model, or in `ApplicationRecord` if you want to disable it globally. So the config didn't seem worth it to me.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
