### PR TITLE
Fix Object.with test class name typo

### DIFF
--- a/activesupport/test/core_ext/object/with_test.rb
+++ b/activesupport/test/core_ext/object/with_test.rb
@@ -3,7 +3,7 @@
 require_relative "../../abstract_unit"
 require "active_support/core_ext/object/with"
 
-class BlankTest < ActiveSupport::TestCase
+class WithTest < ActiveSupport::TestCase
   class Record
     def initialize
       @public_attr = :public


### PR DESCRIPTION
### Motivation / Background

In reviewing the implementation of #46681, I noticed a typo in `activesupport/test/core_ext/object/with_test.rb`.

### Detail

`with_test.rb` should define a class named `WithTest`. Instead, it redefines `BlankTest`. This seems to be a copy/paste typo.

This commit renames `BlankTest` to `WithTest` to follow convention, and to avoid any potential conflicts of 2 test files defining the same class.
