### PR TITLE
Support non-column-backed attributes for `enum`

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -167,14 +167,6 @@ module ActiveRecord
       base.class_attribute(:defined_enums, instance_writer: false, default: {})
     end
 
-    def load_schema! # :nodoc:
-      defined_enums.each_key do |name|
-        unless columns_hash.key?(resolve_attribute_name(name))
-          raise "Unknown enum attribute '#{name}' for #{self.name}"
-        end
-      end
-    end
-
     class EnumType < Type::Value # :nodoc:
       delegate :type, to: :subtype
 
@@ -255,7 +247,13 @@ module ActiveRecord
 
         attribute(name, **options)
 
-        decorate_attributes([name]) do |name, subtype|
+        decorate_attributes([name]) do |_name, subtype|
+          if subtype == ActiveModel::Type.default_value
+            raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
+              " backed by a database column or declared with an explicit type" \
+              " via `attribute`."
+          end
+
           subtype = subtype.subtype if EnumType === subtype
           EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
         end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -605,8 +605,6 @@ module ActiveRecord
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
           alias_attribute :id_value, :id if @columns_hash.key?("id")
-
-          super
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1055,18 +1055,24 @@ class EnumTest < ActiveRecord::TestCase
     ActiveRecord::Base.logger = old_logger
   end
 
-  test "raises for columnless enums" do
-    klass = Class.new(ActiveRecord::Base) do
-      def self.name
-        "Book"
-      end
-      enum columnless_genre: [:adventure, :comic]
+  test "raises for attributes with undeclared type" do
+    klass = Class.new(Book) do
+      enum typeless_genre: [:adventure, :comic]
     end
 
     error = assert_raises(RuntimeError) do
-      klass.columns # load schema
+      klass.type_for_attribute(:typeless_genre)
     end
-    assert_equal "Unknown enum attribute 'columnless_genre' for Book", error.message
+    assert_match "Undeclared attribute type for enum 'typeless_genre'", error.message
+  end
+
+  test "supports attributes declared with a explicit type" do
+    klass = Class.new(Book) do
+      attribute :my_genre, :integer
+      enum my_genre: [:adventure, :comic]
+    end
+
+    assert_equal :integer, klass.type_for_attribute(:my_genre).type
   end
 
   test "default methods can be disabled by :_instance_methods" do

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -335,11 +335,14 @@ Expected: ["id", "name"]
 
       app_file "app/models/user.rb", <<-RUBY
         class User < ApplicationRecord
-          enum :type, [:admin, :user]
+          def self.load_schema!
+            super
+            raise "SCHEMA LOADED!"
+          end
         end
       RUBY
 
-      assert_unsuccessful_run "models/user_test.rb", "Unknown enum attribute 'type' for User"
+      assert_unsuccessful_run "models/user_test.rb", "SCHEMA LOADED!"
     end
 
     private


### PR DESCRIPTION
Follow-up to #45734.

This re-adds support for using `enum` with non-column-backed attributes while still guarding against typos in enum attribute names.  When using `enum` with a non-column-backed attribute, the attribute must be previously declared with an explicit type.  For example:

  ```ruby
  class Post < ActiveRecord::Base
    attribute :topic, :string
    enum topic: %i[science tech engineering math]
  end
  ```

Fixes #49717.
