### PR TITLE
respect that `named_variants` can be `nil`

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -131,7 +131,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
     end
 
     def transform_variants_later
-      named_variants.each do |_name, named_variant|
+      named_variants&.each do |_name, named_variant|
         blob.preprocessed(named_variant.transformations) if named_variant.preprocessed?(record)
       end
     end
@@ -152,10 +152,14 @@ class ActiveStorage::Attachment < ActiveStorage::Record
       case transformations
       when Symbol
         variant_name = transformations
-        named_variants.fetch(variant_name) do
+        variants = named_variants&.[](variant_name)
+
+        if !variants
           record_model_name = record.to_model.model_name.name
           raise ArgumentError, "Cannot find variant :#{variant_name} for #{record_model_name}##{name}"
-        end.transformations
+        end
+
+        variants.transformations
       else
         transformations
       end

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -131,7 +131,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
     end
 
     def transform_variants_later
-      named_variants&.each do |_name, named_variant|
+      named_variants.each do |_name, named_variant|
         blob.preprocessed(named_variant.transformations) if named_variant.preprocessed?(record)
       end
     end
@@ -145,21 +145,17 @@ class ActiveStorage::Attachment < ActiveStorage::Record
     end
 
     def named_variants
-      record.attachment_reflections[name]&.named_variants
+      record.attachment_reflections[name]&.named_variants || {}
     end
 
     def transformations_by_name(transformations)
       case transformations
       when Symbol
         variant_name = transformations
-        variants = named_variants&.[](variant_name)
-
-        if !variants
+        named_variants.fetch(variant_name) do
           record_model_name = record.to_model.model_name.name
           raise ArgumentError, "Cannot find variant :#{variant_name} for #{record_model_name}##{name}"
-        end
-
-        variants.transformations
+        end.transformations
       else
         transformations
       end


### PR DESCRIPTION
### Motivation

This Pull Request has been created since `named_variants` can be `nil` and some code doesn't respect it.

Admittedly I can only trigger the code path with a somewhat contrived example, namely creating an `ActiveRecord::Attachment` manually without declaring a `has_one_attached` or similar:

```rb
class User < ActiveRecord::Base; end

user = User.create!

blob = ActiveStorage::Blob.create_and_upload!(
  io: StringIO.new('xxx'),
  filename: 'some_filename'
)

ActiveStorage::Attachment.create(
  name: 'test',
  blob: blob,
  record: user
)

# => NoMethodError: undefined method `each' for nil:NilClass
# /.../activestorage/app/models/active_storage/attachment.rb:134:in `transform_variants_later'
```

### Reproduction template

You can reproduce it yourself with this template:

<details><summary>Full reproduction template</summary>

```rb
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem 'rails', github: 'rails/rails', branch: 'main'
  gem 'sqlite3'
end

require 'active_record/railtie'
require 'active_storage/engine'
require 'tmpdir'

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << 'example.org'
  config.eager_load = false
  config.session_store :cookie_store, key: 'cookie_store_key'
  config.secret_key_base = 'secret_key_base'

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  config.active_storage.service = :local
  config.active_storage.service_configurations = {
    local: {
      root: Dir.tmpdir,
      service: 'Disk'
    }
  }
end

ENV['DATABASE_URL'] = 'sqlite3::memory:'

Rails.application.initialize!

require ActiveStorage::Engine.root.join('db/migrate/20170806125915_create_active_storage_tables.rb').to_s

ActiveRecord::Schema.define do
  CreateActiveStorageTables.new.change

  create_table :users, force: true
end

class User < ActiveRecord::Base
  has_one_attached :profile
end

require 'minitest/autorun'

class BugTest < Minitest::Test
  def test_upload_and_download
    user = User.create!

    blob = ActiveStorage::Blob.create_and_upload!(
      io: StringIO.new('xxx'),
      filename: 'some_filename'
    )

    ActiveStorage::Attachment.create(
      name: 'test',
      blob: blob,
      record: user
    )
  end
end
```
</details>

### Background

I'm doing something like above in an app and I'm not sure if this is even an intended use case.

Though even if not, maybe it could still be merged since `#named_variants` itself already considers the case where the reflection is `nil`:

```rb
    # app/models/active_storage/attachment.rb:147
    def named_variants
      record.attachment_reflections[name]&.named_variants
    end
```

So at least it is consistent that other methods using `#named_variants` can now deal with that possible `nil`.

For reference: #47473 introduced the code that fails in this example.

### Test

I didn't add any test for this. If you think this is merge-worthy and needs tests I can do so, please give me a ping. Thanks!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
