### PR TITLE
Improve STI documentation

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -204,7 +204,7 @@ module ActiveRecord
           "Please rename this column if you didn't intend it to be used for storing the inheritance class " \
           "or overwrite #{name}.inheritance_column to use another column for that information. " \
           "If you wish to disable single-table inheritance for #{name} set " \
-          "#{name}.inheritance_column to :disabled."
+          "#{name}.inheritance_column to nil"
       end
 
       # Returns the value to be stored in the polymorphic type column for Polymorphic Associations.

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -202,7 +202,9 @@ module ActiveRecord
           "The single-table inheritance mechanism failed to locate the subclass: '#{type_name}'. " \
           "This error is raised because the column '#{inheritance_column}' is reserved for storing the class in case of inheritance. " \
           "Please rename this column if you didn't intend it to be used for storing the inheritance class " \
-          "or overwrite #{name}.inheritance_column to use another column for that information."
+          "or overwrite #{name}.inheritance_column to use another column for that information. " \
+          "If you wish to disable single-table inheritance for #{name} set " \
+          "#{name}.inheritance_column to :disabled."
       end
 
       # Returns the value to be stored in the polymorphic type column for Polymorphic Associations.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -148,9 +148,9 @@ module ActiveRecord
     #     self.inheritance_column = 'zoink'
     #
     # If you wish to disable single-table inheritance altogether you can set
-    # +inheritance_column+ to +:disabled+
+    # +inheritance_column+ to +nil+
     #
-    #     self.inheritance_column = :disabled
+    #     self.inheritance_column = nil
 
     ##
     # :singleton-method: inheritance_column=

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -146,6 +146,11 @@ module ActiveRecord
     # your own model for something else, you can set +inheritance_column+:
     #
     #     self.inheritance_column = 'zoink'
+    #
+    # If you wish to disable single-table inheritance altogether you can set
+    # +inheritance_column+ to +:disabled+
+    #
+    #     self.inheritance_column = :disabled
 
     ##
     # :singleton-method: inheritance_column=

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2937,12 +2937,12 @@ There may be cases (like when working with a legacy database) where you need to
 disable Single Table Inheritance altogether. Otherwise, you'll raise
 [`ActiveRecord::SubclassNotFound`][].
 
-This can be achieved by setting the [inheritance_column][] to `:disabled`.
+This can be achieved by setting the [inheritance_column][] to `nil`.
 
 ```ruby
 # Schema: vehicles[ id, type, created_at, updated_at ]
 class Vehicle < ApplicationRecord
-  self.inheritance_column = :disabled
+  self.inheritance_column = nil
 end
 
 Vehicle.create!(type: "Car")

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2912,6 +2912,46 @@ will run a query like:
 SELECT "vehicles".* FROM "vehicles" WHERE "vehicles"."type" IN ('Car')
 ```
 
+### Overriding the inheritance column
+
+There may be cases (like when working with a legacy database) where you need to
+override the name of the inheritance column. This can be achieved with the
+[inheritance_column][] method.
+
+```ruby
+# Schema: vehicles[ id, kind, created_at, updated_at ]
+class Vehicle < ApplicationRecord
+  self.inheritance_column = "kind"
+end
+
+class Car < Vehicle
+end
+
+Car.create
+# => #<Car kind: "Car">
+```
+
+### Disabling the inheritance column
+
+There may be cases (like when working with a legacy database) where you need to
+disable Single Table Inheritance altogether. Otherwise, you'll raise
+[`ActiveRecord::SubclassNotFound`][].
+
+This can be achieved by setting the [inheritance_column][] to `:disabled`.
+
+```ruby
+# Schema: vehicles[ id, type, created_at, updated_at ]
+class Vehicle < ApplicationRecord
+  self.inheritance_column = :disabled
+end
+
+Vehicle.create!(type: "Car")
+# => #<Vehicle type: "Car">
+```
+
+[inheritance_column]: https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema.html#method-c-inheritance_column
+[`ActiveRecord::SubclassNotFound`]: https://api.rubyonrails.org/classes/ActiveRecord/SubclassNotFound.html
+
 Delegated Types
 ----------------
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current [STI Guides][] don't document how to override or disable the [inheritance_column][].

~~Additionally, it's not clear that you can set `inheritance_column = :disabled`. Initially, I had tried  `inheritance_column = nil` which had the same behavior, but is not as clear as the former.~~

Setting `inheritance_column = nil` disabled STI.

### Detail

Add new sections to [STI Guides][] demonstrating how to override or disable the [inheritance_column][].

Also improve error message when `ActiveRecord::SubclassNotFound` is raised.

[STI Guides]: https://guides.rubyonrails.org/association_basics.html#single-table-inheritance-sti
[inheritance_column]: https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema.html#method-c-inheritance_column

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
