### PR TITLE
Build trilogy adapter with newer API

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -21,19 +21,10 @@ module ActiveRecord
       # matched rather than number of rows updated.
       configuration[:found_rows] = true
 
-      options = [
-        configuration[:host],
-        configuration[:port],
-        configuration[:database],
-        configuration[:username],
-        configuration[:password],
-        configuration[:socket],
-        0
-      ]
-
-      trilogy_adapter_class.new nil, logger, options, configuration
+      trilogy_adapter_class.new(configuration)
     end
   end
+
   module ConnectionAdapters
     class TrilogyAdapter < AbstractMysqlAdapter
       ER_BAD_DB_ERROR = 1049


### PR DESCRIPTION
### Motivation / Background

Prior to this commit we were using the [older, soft-deprecated arguments][deprecated args] to initialize a Trilogy adapter.

I don't think the [options array][] we were passing in made any sense anyway. It becomes `@connection_options`, which Trilogy doesn't appear to use. Trilogy expects hash args so I'm not sure how an array of args would help us anyway. I think we were building that array for no reason.

This commit switches over to the newer single-argument construction that the other adapters are already using.

[deprecated args]: https://github.com/rails/rails/blob/4c5c904a212a850c43adb7a3c3a719ca3d2b9159/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L128
[options array]: https://github.com/rails/rails/blob/4c5c904a212a850c43adb7a3c3a719ca3d2b9159/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb#L24-L32

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
