### PR TITLE
Add Symbol#blank? to skip respond_to?(:empty?)

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -100,6 +100,14 @@ class Hash
   alias_method :blank?, :empty?
 end
 
+class Symbol
+  # A Symbol is blank if it's empty:
+  #
+  #   :''.blank?     # => true
+  #   :symbol.blank? # => false
+  alias_method :blank?, :empty?
+end
+
 class String
   BLANK_RE = /\A[[:space:]]*\z/
   ENCODED_BLANKS = Concurrent::Map.new do |h, enc|


### PR DESCRIPTION
### Motivation / Background

Any classes that don't implement #blank? will fall back to Object's implementation, which checks whether #empty? is defined before either using #empty? or implicit truthiness. Since checking whether #empty? is defined is expensive, some core classes (Array/Hash) alias #blank? directly to #empty? to skip the respond_to? check.

### Detail

This commit applies the alias optimization to Symbol. #blank? is called on Symbols for many Active Record query methods (select, includes, group, order, joins, etc.) so it seems reasonable to define the #blank? alias on Symbol as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
