### PR TITLE
Fix (2) case in money.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/money.rb
@@ -27,9 +27,10 @@ module ActiveRecord
             value = value.sub(/^\((.+)\)$/, '-\1') # (4)
             case value
             when /^-?\D*+[\d,]+\.\d{2}$/  # (1)
-              value.gsub!(/[^-\d.]/, "")
+              value.delete!("^-0-9.")
             when /^-?\D*+[\d.]+,\d{2}$/  # (2)
-              value.gsub!(/[^-\d,]/, "").sub!(/,/, ".")
+              value.delete!("^-0-9,")
+              value.tr!(",", ".")
             end
 
             super(value)

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -54,14 +54,22 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
 
   def test_money_type_cast
     type = PostgresqlMoney.type_for_attribute("wealth")
-    assert_equal(12345678.12, type.cast(+"$12,345,678.12"))
-    assert_equal(12345678.12, type.cast(+"$12.345.678,12"))
-    assert_equal(12345678.12, type.cast(+"12,345,678.12"))
-    assert_equal(12345678.12, type.cast(+"12.345.678,12"))
-    assert_equal(-1.15, type.cast(+"-$1.15"))
-    assert_equal(-2.25, type.cast(+"($2.25)"))
-    assert_equal(-1.15, type.cast(+"-1.15"))
-    assert_equal(-2.25, type.cast(+"(2.25)"))
+
+    {
+      "12,345,678.12" => 12345678.12,
+      "12.345.678,12" => 12345678.12,
+      "0.12" => 0.12,
+      "0,12" => 0.12,
+    }.each do |string, number|
+      assert_equal number, type.cast(string)
+      assert_equal number, type.cast("$#{string}")
+
+      assert_equal(-number, type.cast("-#{string}"))
+      assert_equal(-number, type.cast("-$#{string}"))
+
+      assert_equal(-number, type.cast("(#{string})"))
+      assert_equal(-number, type.cast("($#{string})"))
+    end
   end
 
   def test_money_regex_backtracking


### PR DESCRIPTION
`gsub!` returns nil for me (on Ruby 3.2)

I guess we should fix this.
Simple enough or please make a proper fix!

Is there no unit test for this?