### PR TITLE
[Fix #49761] allow an injection of collection locals.

### DIFF
--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -194,7 +194,7 @@ module ActionView
 
           _template = (cache[path] ||= (template || find_template(path, @locals.keys + [as, counter, iteration])))
 
-          content = _template.render(view, locals, injected_locals: [counter, iteration])
+          content = _template.render(view, locals, implicit_locals: [counter, iteration])
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           build_rendered_template(content, _template)

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -194,7 +194,7 @@ module ActionView
 
           _template = (cache[path] ||= (template || find_template(path, @locals.keys + [as, counter, iteration])))
 
-          content = _template.render(view, locals)
+          content = _template.render(view, locals, injected_locals: [counter, iteration])
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           build_rendered_template(content, _template)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -250,7 +250,7 @@ module ActionView
 
         if strict_locals? && injected_locals.present?
           # It seems much easier to extract strict locals keys this way than parsing @strict_locals variable
-          strict_locals = view.method(method_name).parameters.select { |type, name| type.in?(%i[keyreq key]) }.map(&:last)
+          strict_locals = view.method(method_name).parameters.filter_map { |type, name| name if type.in?(%i[keyreq key]) }
           locals_to_ignore = injected_locals - strict_locals
           locals.except!(*locals_to_ignore)
         end

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -62,8 +62,8 @@ class TestERBTemplate < ActiveSupport::TestCase
     ActionView::Template.new(body.dup, "hello template", details.delete(:handler) || ERBHandler, virtual_path: "hello", **details)
   end
 
-  def render(locals = {})
-    @template.render(@context, locals)
+  def render(injected_locals: [], **locals)
+    @template.render(@context, locals, injected_locals:)
   end
 
   def setup
@@ -198,6 +198,16 @@ class TestERBTemplate < ActiveSupport::TestCase
     end
 
     assert_match(/unknown local: :foo/, error.message)
+  end
+
+  def test_rails_injected_locals_does_not_raise_error_if_not_passed
+    @template = new_template("<%# locals: (message:) -%>")
+    render(message: "Hi", message_counter: 1, message_iteration: 1, injected_locals: %i[message_counter message_iteration])
+  end
+
+  def test_rails_injected_locals_can_be_specified
+    @template = new_template("<%# locals: (message: 'Hello') -%>\n<%= message %>")
+    assert_equal "Hello", render(message: "Hello", injected_locals: %i[message])
   end
 
   # TODO: This is currently handled inside ERB. The case of explicitly

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -63,7 +63,7 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def render(injected_locals: [], **locals)
-    @template.render(@context, locals, injected_locals:)
+    @template.render(@context, locals, injected_locals: injected_locals)
   end
 
   def setup

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -62,8 +62,8 @@ class TestERBTemplate < ActiveSupport::TestCase
     ActionView::Template.new(body.dup, "hello template", details.delete(:handler) || ERBHandler, virtual_path: "hello", **details)
   end
 
-  def render(injected_locals: [], **locals)
-    @template.render(@context, locals, injected_locals: injected_locals)
+  def render(implicit_locals: [], **locals)
+    @template.render(@context, locals, implicit_locals: implicit_locals)
   end
 
   def setup
@@ -202,12 +202,12 @@ class TestERBTemplate < ActiveSupport::TestCase
 
   def test_rails_injected_locals_does_not_raise_error_if_not_passed
     @template = new_template("<%# locals: (message:) -%>")
-    render(message: "Hi", message_counter: 1, message_iteration: 1, injected_locals: %i[message_counter message_iteration])
+    render(message: "Hi", message_counter: 1, message_iteration: 1, implicit_locals: %i[message_counter message_iteration])
   end
 
   def test_rails_injected_locals_can_be_specified
     @template = new_template("<%# locals: (message: 'Hello') -%>\n<%= message %>")
-    assert_equal "Hello", render(message: "Hello", injected_locals: %i[message])
+    assert_equal "Hello", render(message: "Hello", implicit_locals: %i[message])
   end
 
   # TODO: This is currently handled inside ERB. The case of explicitly


### PR DESCRIPTION
### Motivation / Background

Discussed in this issue https://github.com/rails/rails/issues/49761

### Detail

This Pull Request allows ActionView::Template#render method to accept an array `injected_locals`, which is an array of keys of locals that were inejected by rails, for example ActionView::Renderer::CollectionRenderer injects `*_counter` and `*_iteration` locals. With those values `render` method can filter out locals that were injected, but not specified in strict locals to prevent errors described in referring issue.

### Additional information
I'm not sure if I should add anything to changelog or documentation. From one side it's an internal change, from the other some docs might be updated. So, please, let me know if I should add any of the info to changelog/docs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
