### PR TITLE
Ignore implicit locals if not declared by templates with strict locals

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Automatically discard the implicit locals injected by collection rendering for template that can't accept them
+
+    When rendering a collection, two implicit variables are injected, which breaks templates with strict locals.
+
+    Now they are only passed if the template will actually accept them.
+
+    *Yasha Krasnou*, *Jean Boussier*
+
 *   Fix `@rails/ujs` calling `start()` an extra time when using bundlers
 
     *Hartley McGuire*, *Ryunosuke Sato*

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -194,7 +194,7 @@ module ActionView
 
           _template = (cache[path] ||= (template || find_template(path, @locals.keys + [as, counter, iteration])))
 
-          content = _template.render(view, locals)
+          content = _template.render(view, locals, implicit_locals: [counter, iteration])
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           build_rendered_template(content, _template)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/49780
Fix: https://github.com/rails/rails/issues/49761

`CollectionRenderer` implictly inject `<name>_counter` and `<name>_iteration` locals, but in the overwhelming majority of cases they aren't used.

So when the rendered template has strict locals we shouldn't require these to be declared, and if they aren't we should simply not pass them.

Co-Authored-By: @HolyWalley

@HolyWalley I hope you don't mind, I directly refactored your PR to save a bit of time. Most of it was good, but I had to change the parameters parsing a bit.