### PR TITLE
Refactor `db:migrate` task for multiple dbs to use per-database rake tasks

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1245,7 +1245,7 @@ module ActiveRecord
     def migrate(target_version = nil, &block)
       case
       when target_version.nil?
-        up(target_version, &block)
+        up(&block)
       when current_version == 0 && target_version == 0
         []
       when current_version > target_version

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -91,19 +91,12 @@ db_namespace = namespace :db do
 
     if db_configs.size == 1
       ActiveRecord::Tasks::DatabaseTasks.migrate
+      db_namespace["_dump"].invoke
     else
-      mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
-
-      mapped_versions.sort.each do |version, db_configs|
-        db_configs.each do |db_config|
-          ActiveRecord::Tasks::DatabaseTasks.with_temporary_connection(db_config) do
-            ActiveRecord::Tasks::DatabaseTasks.migrate(version)
-          end
-        end
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        db_namespace["migrate:#{name}"].invoke
       end
     end
-
-    db_namespace["_dump"].invoke
   end
 
   # IMPORTANT: This task won't dump the schema if ActiveRecord.dump_schema_after_migration is set to false

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -255,23 +255,6 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
-      def db_configs_with_versions(db_configs) # :nodoc:
-        db_configs_with_versions = Hash.new { |h, k| h[k] = [] }
-
-        with_temporary_connection_for_each do |conn|
-          db_config = conn.pool.db_config
-          versions_to_run = conn.migration_context.pending_migration_versions
-          target_version = ActiveRecord::Tasks::DatabaseTasks.target_version
-
-          versions_to_run.each do |version|
-            next if target_version && target_version != version
-            db_configs_with_versions[version] << db_config
-          end
-        end
-
-        db_configs_with_versions
-      end
-
       def migrate_status
         unless migration_connection.schema_migration.table_exists?
           Kernel.abort "Schema migrations table does not exist yet."


### PR DESCRIPTION
Fixes #49273.

We can remove some code by refactoring `db:migrate` for multiple dbs to use individual database rake tasks.

cc @sobrinho 