### PR TITLE
Add `#destroy_all!` method to `ActiveRecord::Relation`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `#destroy_all!` method to `ActiveRecord::Relation`
+
+    If the `before_destroy` callback throws abort the action is cancelled and `destroy_all!` raises `ActiveRecord::RecordNotDestroyed`.
+
+    If you have multiple target records and want to ensure that all records are deleted, you must accomplish this by explicitly using a transaction to perform a rollback, as shown below:
+
+    ```ruby
+    class User < ApplicationRecord
+      before_destroy do
+        throw :abort if id == 3
+      end
+    end
+
+    ActiveRecord::Base.transaction do
+      User.where(id: 1..3).destroy_all!
+    end
+    ```
+
+    *Shodai Suzuki*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,
-      :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
+      :destroy_all, :destroy_all!, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -610,6 +610,29 @@ module ActiveRecord
       records.each(&:destroy).tap { reset }
     end
 
+    # Destroys the records by instantiating each
+    # record and calling its {#destroy!}[rdoc-ref:Persistence#destroy!] method.
+    # Each object's callbacks are executed (including <tt>:dependent</tt> association options).
+    # Returns the collection of objects that were destroyed; each will be frozen, to
+    # reflect that no changes should be made (since they can't be persisted).
+    # If the <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy_all! raises ActiveRecord::RecordNotDestroyed.
+    # See ActiveRecord::Callbacks for further details.
+    #
+    # Note: Instantiation, callback execution, and deletion of each
+    # record can be time consuming when you're removing many records at
+    # once. It generates at least one SQL +DELETE+ query per record (or
+    # possibly more, to enforce your callbacks). If you want to delete many
+    # rows quickly, without concern for their associations or callbacks, use
+    # #delete_all instead.
+    #
+    # ==== Examples
+    #
+    #   Person.where(age: 0..18).destroy_all!
+    def destroy_all!
+      records.each(&:destroy!).tap { reset }
+    end
+
     # Deletes the records without instantiating the records
     # first, and hence not calling the {#destroy}[rdoc-ref:Persistence#destroy]
     # method nor invoking callbacks.

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
-        :destroy_all, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by
+        :destroy_all, :destroy_all!, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by
       ]
 
     def test_delegate_querying_methods


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is already `destroy_all`, but there are cases where you want to raise an exception if it fails. It is useful to have `destroy_all!`.
This change was previously implemented at https://github.com/rails/rails/pull/37782, but it was closed. I've re-opened this PR because it was recently mentioned by @rafaelfranca.

### Detail

This Pull Request changes add `#destroy_all!` method to `ActiveRecord::Relation`

If the `before_destroy` callback throws abort the action is cancelled and `destroy_all!` raises `ActiveRecord::RecordNotDestroyed`.

If there is more than one target record and you want to ensure that all records are deleted, you should realize this by explicitly using transaction to cause rollback.

```ruby
class User < ApplicationRecord
  before_destroy do
     throw :abort if id == 3
   end
end

ActiveRecord::Base.transaction do 
  User.where(id: 1..3).destroy_all!  
end  
 
=>  TRANSACTION (1.5ms)  BEGIN
  user Load (1.5ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` BETWEEN 1 AND 3
  user Destroy (1.2ms)  DELETE FROM `users` WHERE `users`.`id` = 1
  user Destroy (1.1ms)  DELETE FROM `users` WHERE `users`.`id` = 2
  TRANSACTION (4.4ms)  ROLLBACK
ActiveRecord::RecordNotDestroyed: Failed to destroy the record
```

Also, if the deletion is successful, an Array containing the target object that was successfully deleted is returned.

### Additional information

- [Previously opened PR](https://github.com/rails/rails/pull/37782)
- [proposal](https://discuss.rubyonrails.org/t/proposal-add-destroy-all-method-to-activerecord-relation/80959)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
