### PR TITLE
Handle negative numbers in `NumberToHumanSizeConverter`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix the `number_to_human_size` view helper to correctly work with negative numbers.
+
+    *Earlopain*
+
 *   Automatically discard the implicit locals injected by collection rendering for template that can't accept them
 
     When rendering a collection, two implicit variables are injected, which breaks templates with strict locals.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `#to_fs(:human_size)` to correctly work with negative numbers.
+
+    *Earlopain*
+
 *   Fix `BroadcastLogger#dup` so that it duplicates the logger's `broadcasts`.
 
     *Andrew Novoselac*

--- a/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_human_size_converter.rb
@@ -43,13 +43,13 @@ module ActiveSupport
 
         def exponent
           max = STORAGE_UNITS.size - 1
-          exp = (Math.log(number) / Math.log(base)).to_i
+          exp = (Math.log(number.abs) / Math.log(base)).to_i
           exp = max if exp > max # avoid overflow for the highest unit
           exp
         end
 
         def smaller_than_base?
-          number.to_i < base
+          number.to_i.abs < base
         end
 
         def base

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -310,6 +310,16 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal "10 Bytes",  10.to_fs(:human_size)
   end
 
+  def test_to_fs__human_size_with_negative_number
+    assert_equal "-1 Bytes",   -1.to_fs(:human_size)
+    assert_equal "-3 Bytes",   -3.14159265.to_fs(:human_size)
+    assert_equal "-123 Bytes", -123.to_fs(:human_size)
+    assert_equal "-12.1 KB",   -12345.to_fs(:human_size)
+    assert_equal "-444 KB",    kilobytes(-444).to_fs(:human_size)
+    assert_equal "-1.12 TB",   -1234567890123.to_fs(:human_size)
+    assert_equal "-1.01 KB",   kilobytes(-1.0100).to_fs(:human_size, precision: 4)
+  end
+
   def test_to_fs__human_size_with_options_hash
     assert_equal "1.2 MB",   1234567.to_fs(:human_size, precision: 2)
     assert_equal "3 Bytes",  3.14159265.to_fs(:human_size, precision: 4)

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -282,6 +282,18 @@ module ActiveSupport
         end
       end
 
+      def test_number_number_to_human_size_with_negative_number
+        [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
+          assert_equal "-1 Bytes",   number_helper.number_to_human_size(-1)
+          assert_equal "-3 Bytes",   number_helper.number_to_human_size(-3.14159265)
+          assert_equal "-123 Bytes", number_helper.number_to_human_size(-123)
+          assert_equal "-12.1 KB",   number_helper.number_to_human_size(-12345)
+          assert_equal "-444 KB",    number_helper.number_to_human_size(kilobytes(-444))
+          assert_equal "-1.12 TB",   number_helper.number_to_human_size(-1234567890123)
+          assert_equal "-1.01 KB",   number_helper.number_to_human_size(kilobytes(-1.0100), precision: 4)
+        end
+      end
+
       def test_number_to_human_size_with_options_hash
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal "1.2 MB",   number_helper.number_to_human_size(1234567, precision: 2)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `number_to_human_size` doesn't handle negative numbers.

```rb
# Old behaviour
helper.number_to_human_size(-1234567)
# => "-1234567 Bytes"

# New behaviour
helper.number_to_human_size(-1234567)
# => "-1.18 MB"
```

### Detail

`number_to_human` already supports negative numbers, this aligns the two methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
