### PR TITLE
Fix deprecation warnings for `secrets:edit/show`

### DIFF
--- a/railties/lib/rails/commands/secrets/secrets_command.rb
+++ b/railties/lib/rails/commands/secrets/secrets_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/core_ext/string/filters"
 require "rails/secrets"
 require "rails/command/helpers/editor"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there is a bug in the deprecation notices on the tasks `secrets:edit` and `secrets:show` which means they can raise `undefined method 'squish'`

### Reproduction

Create a new rails 7.1.1 app using `rails new`.

`cd` into the new app and run `bin/rails secrets:edit` or `bin/rails secrets:show`. 

For example:
```
$ bin/rails secrets:show
...gems/3.2.0/gems/railties-7.1.1/lib/rails/commands/secrets/secrets_command.rb:37:in `show': undefined method `squish' for "`bin/rails secrets:show` is deprecated in favor of credentials and will be removed in Rails 7.2.\nRun `bin/rails credentials:help` for more information.\n":String (NoMethodError)

        Rails.deprecator.warn(<<~MSG.squish)
                                    ^^^^^^^
	from ...gems/3.2.0/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
        ...
```

### Detail

The warning string is `#squish`ed however `active_support/core_ext/string/filters` is not being required. 

The tests are passing because the dummy test application does a `require 'rails/all'` on boot which requires the String extensions. https://github.com/rails/rails/blob/main/railties/test/isolation/abstract_unit.rb#L605

This is not necessarily the case for other applications, eg ones freshly created with `rails new` so in this case an error is raised.

The fix is to just require the necessary String extensions.

I am not sure if there is anything that could be done to the tests to have caught this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.

