### PR TITLE
Dump schema only for a specific db for rollback/up/down tasks for multiple dbs

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -204,7 +204,7 @@ db_namespace = namespace :db do
             conn.migration_context.run(:up, ActiveRecord::Tasks::DatabaseTasks.target_version)
           end
 
-          db_namespace["_dump"].invoke
+          db_namespace["_dump:#{name}"].invoke
         end
       end
     end
@@ -235,7 +235,7 @@ db_namespace = namespace :db do
             conn.migration_context.run(:down, ActiveRecord::Tasks::DatabaseTasks.target_version)
           end
 
-          db_namespace["_dump"].invoke
+          db_namespace["_dump:#{name}"].invoke
         end
       end
     end
@@ -269,7 +269,7 @@ db_namespace = namespace :db do
           conn.migration_context.rollback(step)
         end
 
-        db_namespace["_dump"].invoke
+        db_namespace["_dump:#{name}"].invoke
       end
     end
   end


### PR DESCRIPTION
Currently, `rails db:migrate:primary` (and `rails db:up:primary`, `rails db:down:primary`) dumps schema files for all the databases, even though this is not necessary.

Fixes #49351 (see there for the problem description).