### PR TITLE
Enable `Lint/InterpolationCheck`  rubocop's cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -257,6 +257,11 @@ Lint/UselessAssignment:
 Lint/DeprecatedClassMethods:
   Enabled: true
 
+Lint/InterpolationCheck:
+  Enabled: true
+  Exclude:
+    - '**/test/**/*'
+
 Style/EvalWithLocation:
   Enabled: true
   Exclude:

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -195,7 +195,7 @@ db_namespace = namespace :db do
 
     namespace :up do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
-        desc 'Run the "up" on #{name} database for a given migration VERSION.'
+        desc "Run the \"up\" on #{name} database for a given migration VERSION."
         task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
 
@@ -226,7 +226,7 @@ db_namespace = namespace :db do
 
     namespace :down do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
-        desc 'Run the "down" on #{name} database for a given migration VERSION.'
+        desc "Run the \"down\" on #{name} database for a given migration VERSION."
         task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
 


### PR DESCRIPTION
Identified a problem with interpolation in the description of the rake tasks:
```
$ bin/rails -T | grep db:migrate:

bin/rails db:migrate:down:animals            # Run the "down" on #{name} database for a given migration VERSION
bin/rails db:migrate:down:primary            # Run the "down" on #{name} database for a given migration VERSION
bin/rails db:migrate:up:animals              # Run the "up" on #{name} database for a given migration VERSION
bin/rails db:migrate:up:primary              # Run the "up" on #{name} database for a given migration VERSION
```

I enabled the relevant rubocop's cop to avoid such mistakes in the future.