### PR TITLE
Remove note about inline changelog credit in contributing guide

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -540,9 +540,6 @@ A CHANGELOG entry should summarize what was changed and should end with the auth
     *Your Name*
 ```
 
-Your name can be added directly after the last word if there are no code
-examples or multiple paragraphs. Otherwise, it's best to make a new paragraph.
-
 ### Breaking Changes
 
 Anytime a change could break existing applications it's considered a breaking


### PR DESCRIPTION
In practise have not seen any changelog entries where the name of the contributor was inline with the change description.

See for example https://github.com/rails/rails/releases/tag/v7.1.1 or https://github.com/rails/rails/releases/tag/v7.1.0