### PR TITLE
Fix double-encoding in `InlinePreviewInterceptor`

### DIFF
--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -49,7 +49,7 @@ module ActionMailer
       end
 
       def data_url(part)
-        "data:#{part.mime_type};base64,#{strict_encode64(part.body.raw_source)}"
+        "data:#{part.mime_type};base64,#{strict_encode64(part.body.decoded)}"
       end
 
       def find_part(cid)

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -839,6 +839,54 @@ module ApplicationTests
       assert_match %r[src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEWzIioca/JlAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJgggo="], last_response.body
     end
 
+    test "multipart mailer preview read from string" do
+      image_file "pixel.png", "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEWzIioca/JlAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJgggo="
+
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            attachments['pixel.png'] = File.binread("#{app_path}/public/images/pixel.png")
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Hello, World!
+      RUBY
+
+      html_template "notifier/foo", <<-RUBY
+        <p>Hello, World!</p>
+        <%= image_tag attachments['pixel.png'].url %>
+      RUBY
+
+      mailer_preview "notifier", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            mail = Notifier.foo
+            Mail.read_from_string(mail.to_s)
+          end
+        end
+      RUBY
+
+      app("development")
+
+      get "/rails/mailers/notifier/foo"
+      assert_equal 200, last_response.status
+      assert_match %r[<iframe name="messageBody"], last_response.body
+
+      get "/rails/mailers/notifier/foo?part=text/plain"
+      assert_equal 200, last_response.status
+      assert_match %r[Hello, World!], last_response.body
+
+      get "/rails/mailers/notifier/foo?part=text/html"
+      assert_equal 200, last_response.status
+      assert_match %r[<p>Hello, World!</p>], last_response.body
+      assert_match %r[src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEWzIioca/JlAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJgggo="], last_response.body
+    end
+
     test "multipart mailer preview with attached email" do
       mailer "notifier", <<-RUBY
         class Notifier < ActionMailer::Base


### PR DESCRIPTION
`ActionMailer::InlinePreviewInterceptor` is useful not only for previewing the template but also for displaying actual emails loaded from a string/file using `Mail.read_from_string`. For example, you might want to archive all outgoing emails to the database/filesystem and display these emails in a browser.

The interceptor assumes that attachments are represented as binary data. But if an email is loaded from string, the attachments have already been encoded as base64, so they end up being encoded twice.
