### PR TITLE
Add ActiveModel attribute type for duration

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Add `ActiveModel::Type::Duration` to provide attribute type for
+    `ActiveSupport::Duration` representation.
+
+    *Ross Kaffenberger*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -10,6 +10,7 @@ require "active_model/type/boolean"
 require "active_model/type/date"
 require "active_model/type/date_time"
 require "active_model/type/decimal"
+require "active_model/type/duration"
 require "active_model/type/float"
 require "active_model/type/immutable_string"
 require "active_model/type/integer"
@@ -45,6 +46,7 @@ module ActiveModel
     register(:boolean, Type::Boolean)
     register(:date, Type::Date)
     register(:datetime, Type::DateTime)
+    register(:duration, Type::Duration)
     register(:decimal, Type::Decimal)
     register(:float, Type::Float)
     register(:immutable_string, Type::ImmutableString)

--- a/activemodel/lib/active_model/type/duration.rb
+++ b/activemodel/lib/active_model/type/duration.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Type
+    # = Active Model \Duration \Type
+    #
+    # Attribute type for ActiveSupport::Duration representation. It is registered under the
+    # +:duration+ key.
+    #
+    #   class Run
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :lasted, :duration
+    #   end
+    #
+    #   run = Run.new
+    #   run.lasted = 2.hours
+    #
+    # Integer values are parsed as seconds.
+    #
+    #   run = Run.new
+    #   run.lasted = 120
+    #
+    #   run.lasted.class # => ActiveSupport::Duration
+    #   run.lasted       # => 2 hours
+    #
+    # String values are parsed using the ISO 8601 duration format.
+    #
+    #   run = Run.new
+    #   run.lasted = "PT2H"
+    #
+    #   run.lasted.class # => ActiveSupport::Duration
+    #   run.lasted       # => 2 hours
+    #
+    # The degree of sub-second precision can be customized when declaring an
+    # attribute:
+    #
+    #   class Run
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :lasted, :duration, precision: 4
+    #   end
+    class Duration < Value
+      def cast_value(value)
+        case value
+        when ::ActiveSupport::Duration
+          value
+        when ::Numeric
+          value.seconds
+        when ::String
+          begin
+            ::ActiveSupport::Duration.parse(value)
+          rescue ::ActiveSupport::Duration::ISO8601Parser::ParsingError
+            nil
+          end
+        else
+          super
+        end
+      end
+
+      def serialize(value)
+        case value
+        when ::ActiveSupport::Duration
+          value.iso8601(precision: self.precision)
+        when ::Numeric
+          # Sometimes operations on Times returns just float number of seconds so we need to handle that.
+          # Example: Time.current - (Time.current + 1.hour) # => -3600.000001776 (Float)
+          value.seconds.iso8601(precision: self.precision)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/type/duration_test.rb
+++ b/activemodel/test/cases/type/duration_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveModel
+  module Type
+    class DurationTest < ActiveModel::TestCase
+      def test_type_cast_from_integer
+        type = Duration.new
+
+        assert type.cast(123).is_a?(ActiveSupport::Duration)
+
+        assert_equal 0.seconds, type.cast(0)
+        assert_equal 123.seconds, type.cast(123)
+        assert_equal (-123.seconds), type.cast(-123)
+      end
+
+      def test_type_cast_from_decimal
+        type = Duration.new
+
+        assert type.cast(123.0).is_a?(ActiveSupport::Duration)
+
+        assert_equal 0.0.seconds, type.cast(0.0)
+        assert_equal 123.0.seconds, type.cast(123.0)
+        assert_equal (-123.seconds), type.cast(-123.0)
+      end
+
+      def test_type_cast_from_from_string
+        type = Duration.new
+
+        assert_equal 1.year + 2.minutes, type.cast("P1YT2M")
+        assert_equal 10.hours, type.cast("PT10H")
+        assert_equal 1.day + 1.hour, type.cast("P1DT1H")
+      end
+
+      def test_type_cast_from_invalid_string
+        type = Duration.new
+        assert_nil type.cast("")
+        assert_nil type.cast("1ignore")
+        assert_nil type.cast("1 year 2 minutes")
+        assert_nil type.cast("PTbad")
+      end
+
+      def test_type_serialize_duration_with_large_precision
+        type = Duration.new(precision: ::Float::DIG + 2)
+
+        assert_equal (1.year + 2.minutes + 5.7777.seconds).iso8601(precision: ::Float::DIG + 2), type.serialize(1.year + 2.minutes + 5.7777.seconds)
+      end
+
+      def test_type_serialize_duration_with_precision
+        type = Duration.new(precision: 2)
+
+        assert_equal (1.year + 2.minutes + 5.7777.seconds).iso8601(precision: 2), type.serialize(1.year + 2.minutes + 5.7777.seconds)
+      end
+
+      def test_changed?
+        type = Duration.new
+
+        assert type.changed?(0.1.seconds, 0.seconds, 0)
+        assert type.changed?(123.seconds, -123.seconds, -123)
+        assert type.changed?(1.year + 3.minutes, 1.year + 2.minutes, "P1YT2M")
+        assert_not type.changed?(1.year + 2.minutes, 1.year + 2.minutes, "P1YT2M")
+        assert_not type.changed?(3.hours / 2, 3.hours / 2, 3.hours / 2)
+        assert_not type.changed?(3.hours / 2, 3.0.hours / 2.0, 3.0.hours / 2.0)
+        assert type.changed?(3.hours / 2, 3.0.hours / 1, 3.0.hours / 1)
+      end
+    end
+  end
+end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Interval` now inherits
+    from `ActiveModel::Type::Duration`.
+
+    *Ross Kaffenberger*
+
 *   Include `ActiveModel::API` in `ActiveRecord::Base`
 
     *Sean Doyle*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/interval.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/interval.rb
@@ -6,37 +6,9 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module OID # :nodoc:
-        class Interval < Type::Value # :nodoc:
+        class Interval < ActiveModel::Type::Duration # :nodoc:
           def type
             :interval
-          end
-
-          def cast_value(value)
-            case value
-            when ::ActiveSupport::Duration
-              value
-            when ::String
-              begin
-                ::ActiveSupport::Duration.parse(value)
-              rescue ::ActiveSupport::Duration::ISO8601Parser::ParsingError
-                nil
-              end
-            else
-              super
-            end
-          end
-
-          def serialize(value)
-            case value
-            when ::ActiveSupport::Duration
-              value.iso8601(precision: self.precision)
-            when ::Numeric
-              # Sometimes operations on Times returns just float number of seconds so we need to handle that.
-              # Example: Time.current - (Time.current + 1.hour) # => -3600.000001776 (Float)
-              value.seconds.iso8601(precision: self.precision)
-            else
-              super
-            end
           end
 
           def type_cast_for_schema(value)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I've often had the need to desire a to create a duration type for Ruby classes including `ActiveModel::Attributes` or for ActiveRecord models backed by non-PostgreSQL database adapters, similar to [this StackOverflow answer](https://stackoverflow.com/a/45359178/771838). 

The Rails community would benefit from having this type available as an `ActiveModel` attribute whereas currently only `ActiveRecord` models with the PostgreSQL adapter support `ActiveSupport::Duration` through the `:interval` data type. .

### Detail

This changeset adds `ActiveModel::Type::Duration` to provide representation for `ActiveSupport::Duration` via the `:duration` key.

```rb
class Run
  include ActiveModel::Attributes

  attribute :lasted, :duration
end

run = Run.new
run.lasted = 2.hours
```

Numeric values are cast to `ActiveSupport::Duration` as seconds.

```rb    
run = Run.new
run.lasted = 120 # => 120 seconds
```

String values are parsed using the ISO 8601 duration format.

```rb
run = Run.new
run.lasted = "PT2H"

run.lasted.class # => ActiveSupport::Duration
run.lasted       # => 2 hours
```

The serialization/deserialization logic is extracted from `ActiveRecord::ConnectionAdapters::PostreSQL::OID::Interval`, which is here modified to inherit from `ActiveModel::Type::Duration`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
