### PR TITLE
[Fix #49796] Prevent global cache options being overwritten

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1053,6 +1053,8 @@ module ActiveSupport
         end
 
         def save_block_result_to_cache(name, options)
+          options = options.dup
+
           result = instrument(:generate, name, options) do
             yield(name, WriteOptions.new(options))
           end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -702,6 +702,17 @@ module CacheStoreBehavior
     ActiveSupport::Notifications.unsubscribe "cache_read.active_support"
   end
 
+  def test_setting_options_in_fetch_block_does_not_change_cache_options
+    key = SecureRandom.uuid
+
+    assert_no_changes -> { @cache.options.dup } do
+      @cache.fetch(key) do |_key, options|
+        options.expires_in = 5.minutes
+        "bar"
+      end
+    end
+  end
+
   private
     def with_raise_on_invalid_cache_expiration_time(new_value, &block)
       old_value = ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time


### PR DESCRIPTION
### Motivation / Background

Issue https://github.com/rails/rails/issues/49796

### Detail

During investigation of the issue above I found that `Rails.cache.fetch` in case when no options were passed as arguments passes global cache options to fetch block (wrapped in WriteOptions, but anyway), so, global cache options will be overwritten by those manipulations.

### Additional information

Let me know if I need to update changelog

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
