### PR TITLE
Introduce `alias_association` feature

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Introduce `alias_association` feature to allow defining an alias to an existing association.
+
+    *Nikita Vasilevsky*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1697,6 +1697,18 @@ module ActiveRecord
           Reflection.add_reflection(self, name, reflection)
         end
 
+        def alias_association(new_name, old_name)
+          new_name = new_name.to_s
+          old_name = old_name.to_s
+          existing_reflection = reflections[old_name]
+          raise ArgumentError, "Can't alias a non-existing `#{old_name}` association" unless existing_reflection
+          self.querying_aliases = querying_aliases.merge(new_name => old_name)
+
+          builder = Builder::Association.builder_for(existing_reflection.macro)
+          builder.define_association_methods(self, existing_reflection, as: new_name)
+          Reflection.add_reflection self, new_name, existing_reflection
+        end
+
         # Specifies a many-to-many relationship with another class. This associates two classes via an
         # intermediate join table. Unless the join table is explicitly specified as an option, it is
         # guessed using the lexical order of the class names. So a join between Developer and Project

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -2,9 +2,7 @@
 
 module ActiveRecord::Associations::Builder # :nodoc:
   class BelongsTo < SingularAssociation # :nodoc:
-    def self.macro
-      :belongs_to
-    end
+    register_builder_for :belongs_to
 
     def self.valid_options(options)
       valid = super + [:polymorphic, :counter_cache, :optional, :default]
@@ -142,13 +140,13 @@ module ActiveRecord::Associations::Builder # :nodoc:
       end
     end
 
-    def self.define_change_tracking_methods(model, reflection)
+    def self.define_change_tracking_methods(model, reflection, as:)
       model.generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{reflection.name}_changed?
+        def #{as}_changed?
           association(:#{reflection.name}).target_changed?
         end
 
-        def #{reflection.name}_previously_changed?
+        def #{as}_previously_changed?
           association(:#{reflection.name}).target_previously_changed?
         end
       CODE

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -55,21 +55,21 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     # Defines the setter and getter methods for the collection_singular_ids.
-    def self.define_readers(mixin, name)
+    def self.define_readers(mixin, name, as:)
       super
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids
+        def #{as.to_s.singularize}_ids
           association(:#{name}).ids_reader
         end
       CODE
     end
 
-    def self.define_writers(mixin, name)
+    def self.define_writers(mixin, name, as:)
       super
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name.to_s.singularize}_ids=(ids)
+        def #{as.to_s.singularize}_ids=(ids)
           association(:#{name}).ids_writer(ids)
         end
       CODE

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -2,9 +2,7 @@
 
 module ActiveRecord::Associations::Builder # :nodoc:
   class HasMany < CollectionAssociation # :nodoc:
-    def self.macro
-      :has_many
-    end
+    register_builder_for :has_many
 
     def self.valid_options(options)
       valid = super + [:counter_cache, :join_table, :index_errors, :as, :through]
@@ -18,6 +16,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
       [:destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception, :destroy_async]
     end
 
-    private_class_method :macro, :valid_options, :valid_dependent_options
+    private_class_method :valid_options, :valid_dependent_options
   end
 end

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -2,9 +2,7 @@
 
 module ActiveRecord::Associations::Builder # :nodoc:
   class HasOne < SingularAssociation # :nodoc:
-    def self.macro
-      :has_one
-    end
+    register_builder_for :has_one
 
     def self.valid_options(options)
       valid = super + [:class_name, :as, :through]

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -8,36 +8,36 @@ module ActiveRecord::Associations::Builder # :nodoc:
       super + [:required, :touch]
     end
 
-    def self.define_accessors(model, reflection)
+    def self.define_accessors(model, reflection, as:)
       super
       mixin = model.generated_association_methods
       name = reflection.name
 
-      define_constructors(mixin, name) unless reflection.polymorphic?
+      define_constructors(mixin, name, as: as) unless reflection.polymorphic?
 
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def reload_#{name}
+        def reload_#{as}
           association(:#{name}).force_reload_reader
         end
 
-        def reset_#{name}
+        def reset_#{as}
           association(:#{name}).reset
         end
       CODE
     end
 
     # Defines the (build|create)_association methods for belongs_to or has_one association
-    def self.define_constructors(mixin, name)
+    def self.define_constructors(mixin, name, as:)
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def build_#{name}(*args, &block)
+        def build_#{as}(*args, &block)
           association(:#{name}).build(*args, &block)
         end
 
-        def create_#{name}(*args, &block)
+        def create_#{as}(*args, &block)
           association(:#{name}).create(*args, &block)
         end
 
-        def create_#{name}!(*args, &block)
+        def create_#{as}!(*args, &block)
           association(:#{name}).create!(*args, &block)
         end
       CODE

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -64,6 +64,7 @@ module ActiveRecord
       #   Person.where(nickname: "Bob")
       #   # SELECT "people".* FROM "people" WHERE "people"."name" = "Bob"
       def alias_attribute(new_name, old_name)
+        self.querying_aliases = querying_aliases.merge(new_name => old_name)
         super
 
         if @alias_attributes_mass_generated

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -22,6 +22,8 @@ module ActiveRecord
 
       class_attribute :_destroy_association_async_job, instance_accessor: false, default: "ActiveRecord::DestroyAssociationAsyncJob"
 
+      class_attribute :querying_aliases, instance_accessor: false, default: {}
+
       # The job class used to destroy associations in the background.
       def self.destroy_association_async_job
         if _destroy_association_async_job.is_a?(String)
@@ -287,7 +289,7 @@ module ActiveRecord
 
         hash = hash.each_with_object({}) do |(key, value), h|
           key = key.to_s
-          key = attribute_aliases[key] || key
+          key = querying_aliases[key] || key
 
           return super if reflect_on_aggregation(key)
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -211,10 +211,11 @@ module ActiveRecord
       def load_schema! # :nodoc:
         super
 
-        association_names = _reflections.filter_map do |name, reflection|
+        association_names = _reflections.filter_map do |_, reflection|
           next unless reflection.belongs_to? && reflection.counter_cache_column
 
-          name.to_sym
+          # not using the key from `_reflections` as it may be aliased
+          reflection.name
         end
 
         self.counter_cached_association_names |= association_names

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1635,10 +1635,10 @@ module ActiveRecord
         when Hash
           opts = opts.transform_keys do |key|
             if key.is_a?(Array)
-              key.map { |k| model.attribute_aliases[k.to_s] || k.to_s }
+              key.map { |k| model.querying_aliases[k.to_s] || k.to_s }
             else
               key = key.to_s
-              model.attribute_aliases[key] || key
+              model.querying_aliases[key] || key
             end
           end
           references = PredicateBuilder.references(opts)

--- a/activerecord/test/cases/associations/alias_association_test.rb
+++ b/activerecord/test/cases/associations/alias_association_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+
+class AliasAssociationTest < ActiveRecord::TestCase
+  setup do
+    @post = Post.create(title: "hello world", body: "I'm going to test alias association feature")
+    @comment = @post.comments.create(body: "what a wonderful feature")
+  end
+
+  def test_raises_error_when_aliasing_a_non_existing_association
+    assert_raises(ArgumentError, match: "Can't alias a non-existing `actually_i_do_not_exist` association") do
+      Class.new(ActiveRecord::Base) do
+        alias_association :new_shiny_name, :actually_i_do_not_exist
+      end
+    end
+  end
+
+  def test_has_many_association_reader
+    assert_equal [@comment], @post.opinions.to_a
+  end
+
+  def test_has_many_association_writer
+    post = Post.new
+    comment1 = Comment.new
+    post.opinions = [comment1]
+    comment2 = Comment.new
+    post.opinions << comment2
+
+    assert_equal [comment1, comment2], post.comments
+  end
+
+  def test_belongs_to_association_reader
+    assert_equal @post, @comment.subject
+  end
+
+  def test_belongs_to_association_writer
+    comment = Comment.new
+    post = Post.new
+    comment.subject = post
+    assert_equal post, comment.post
+  end
+
+  def test_belongs_to_build_association_record
+    comment = Comment.new
+    comment.build_subject(title: "i was built", body: "I'm glad this is working")
+    assert_equal "i was built", comment.post.title
+  end
+
+  def test_belongs_to_alias_in_where
+    comments = Comment.where(subject: @post).to_a
+    assert_equal [@comment], comments
+  end
+
+  def test_has_many_alias_in_where
+    post = Post.where(opinions: @comment).take
+    assert_equal @post, post
+  end
+
+  def test_includes_has_many_alias
+    post = Post.where(id: @post.id).includes(:opinions).take
+    comments = assert_no_queries { post.comments.to_a }
+    assert_equal [@comment], comments
+  end
+
+  def test_includes_belongs_to_alias
+    comment = Comment.where(id: @comment.id).includes(:subject).take
+    post = assert_no_queries { comment.post }
+    assert_equal @post, post
+  end
+
+  def test_belong_to_aliased_change_tracking_methods
+    assert_not_predicate @comment, :subject_changed?
+    assert_predicate @comment, :subject_previously_changed?
+  end
+end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -13,6 +13,7 @@ class Comment < ActiveRecord::Base
   scope :ordered_by_post_id, -> { order("comments.post_id DESC") }
 
   belongs_to :post, counter_cache: true
+  alias_association :subject, :post
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
   belongs_to :origin, polymorphic: true

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -91,6 +91,8 @@ class Post < ActiveRecord::Base
     end
   end
 
+  alias_association :opinions, :comments
+
   has_many :comments_with_extend, extend: NamedExtension, class_name: "Comment", foreign_key: "post_id" do
     def greeting
       "hello"


### PR DESCRIPTION
### Motivation / Background

Implements - https://discuss.rubyonrails.org/t/feature-proposal-alias-association/83439/4

Rails 7.1 deprecated using `alias_attribute` for anything other than an attribute. Many applications end up using `alias_attribute` to alias associations and removing such usages would be challenging in many cases. Recognizing this, Rails introduces a new feature to alias associations called `alias_association`.

### Detail

Given an alias like `BlogPost.alias_association :author, :user` where `author` is an alias and `user` is the original association name of the `belong_to :user` association the feature provides the following capabilities:

#### Aliased association methods

Defines association reader and writer: `BlogPost#author` and `BlogPost#author=` 
(`belongs_to` only) Defines `build_#{assoc_name}` and `create_#{assoc_name}` constructors: `BlogPost#build_author`,  `BlogPost#create_author` and `BlogPost#create_author!` 
(`belongs_to` only)  Defines change tracking methods: `BlogPost#author_changed?` and `BlogPost#author_previously_changed?` 

#### Aliases support in `where()` clauses

`BlogPost.where(author: User.find_by(name: "Nikita")).to_a` #=> searches by `user_id`

#### Aliases support in `includes()` clauses

`BlogPost.all.includes(:author).to_a` # => preloads `user` association

### Implementation details

#### Aliased association methods

A new `define_association_methods ` method was defined on `ActiveRecord::Associations::Builder::Association` builder. Its job to define association-related instance methods. This method is being reused in the original `build` method. 
`define_accessors`, `define_change_tracking_methods` and all downstream methods now accept `as:` to serve as a publicly facing name of the new methods while the method body itself will point to the original association.

Since `alias_association` methods needs to know which builder to use for method definition builders now self-register themselves into a registry using `register_builder_for` method by providing a `macro` which later can be used to fetch the builder for a given reflection. 

#### Aliases support in `where()` clauses

To support aliased association names in `where()` clauses we introduced `querying_aliases` storage which will serve as a registry of aliases for both associations and attributes. This way we can avoid checking two places (attribute aliases & association aliases) when processing `where()` arguments.

#### Aliases support in `includes()` clauses

To support aliases in `includes()` (and most likely more capabilities that look into the `_reflections` hash) we register the same reflection under the new name 
https://github.com/rails/rails/blob/8917147631838b5c5b85240a61027b39f3adbde2/activerecord/lib/active_record/associations.rb#L1900 

### Additional information

The capabilities this feature provides are pretty standalone and could be extracted or completely descoped from this PR if needed. 

Also while the utility of this feature might be concerning the feature comes at no cost for applications that are not interested in utilizing it. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
