### PR TITLE
Recover from failed connections in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -907,10 +907,10 @@ module ActiveRecord
 
           update_typemap_for_default_timezone
 
-          stmt_key = prepare_statement(sql, binds)
-          type_casted_binds = type_casted_binds(binds)
-
           with_raw_connection do |conn|
+            stmt_key = prepare_statement(sql, binds, conn)
+            type_casted_binds = type_casted_binds(binds)
+
             log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
               conn.exec_prepared(stmt_key, type_casted_binds)
             end
@@ -960,22 +960,20 @@ module ActiveRecord
 
         # Prepare the statement if it hasn't been prepared, return
         # the statement key.
-        def prepare_statement(sql, binds)
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
-            sql_key = sql_key(sql)
-            unless @statements.key? sql_key
-              nextkey = @statements.next_key
-              begin
-                conn.prepare nextkey, sql
-              rescue => e
-                raise translate_exception_class(e, sql, binds)
-              end
-              # Clear the queue
-              conn.get_last_result
-              @statements[sql_key] = nextkey
+        def prepare_statement(sql, binds, conn)
+          sql_key = sql_key(sql)
+          unless @statements.key? sql_key
+            nextkey = @statements.next_key
+            begin
+              conn.prepare nextkey, sql
+            rescue => e
+              raise translate_exception_class(e, sql, binds)
             end
-            @statements[sql_key]
+            # Clear the queue
+            conn.get_last_result
+            @statements[sql_key] = nextkey
           end
+          @statements[sql_key]
         end
 
         # Connects to a PostgreSQL server and sets up the adapter depending on the

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -612,6 +612,20 @@ module ActiveRecord
         assert_predicate @connection, :active?
       end
 
+      test "querying after a failed query restores and succeeds" do
+        Post.first # Connection verified (and prepared statement pool populated if enabled)
+
+        remote_disconnect @connection
+
+        assert_raises(ActiveRecord::ConnectionFailed) do
+          Post.first # Connection no longer verified after failed query
+        end
+
+        assert Post.first # Verifying the connection causes a reconnect and the query succeeds
+
+        assert_predicate @connection, :active?
+      end
+
       test "transaction restores after remote disconnection" do
         remote_disconnect @connection
         Post.transaction do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49781

Prior to this commit, the PostgreSQL adapter could end up holding onto a broken connection longer than expected, potentially **into the next request after the executor checkin/checkout**.

The problem is that the PostgreSQL adapter was using [two separate calls] to `with_raw_connection`, one for preparing a statement and another for executing it. That's fine before the statement is added to the statement pool, but once it the statement exists the first call to `with_raw_connection` [does not actually use the connection]. But that doesn't stop us from marking the connection as [`@verified`][verified], thereby preventing the second `with_raw_connection` from verifying and getting a chance to reconnect.

[two separate calls]: https://github.com/rails/rails/blob/e33dbe1b3d423143685154b97ae0992f4ab821b8/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L910-L917
[does not actually use the connection]: https://github.com/rails/rails/blob/490b9fc22faefca30565a970a8727c915de589ff/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L964-L966
[verified]: https://github.com/rails/rails/blob/e33dbe1b3d423143685154b97ae0992f4ab821b8/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1032

```rb
Post.first
#=> prepare_statement verifies the connection (if needed) and populates the statement pool
#=> exec_prepared succeeds

#=> Oops!, we lost the connection for whatever reason

Post.first
#=> prepare_statement returns the statement from the statement pool, connection still marked as verified
#=> exec_prepared fails, marks the connection as unverified

Post.first
#=> prepare_statement returns the statement from the statement pool, marks the connection as verified!!!
#=> exec_prepared fails, marks the connection as unverified

#=> request finishes, connection gets marked as unverified for the next request

Post.first
#=> prepare_statement returns the statement from the statement pool, marks the connection as verified!!!
#=> exec_prepared fails, marks the connection as unverified
```

The only way to recover is to execute a statement that hasn't been prepared yet, one that isn't prepared because it has no binds, or one that has `allow_retry: true` (which I think is limited to a few internal queries at the moment—we don't pass the value through to `with_raw_connection` for prepared statements anyway).

This commit fixes the problem by preparing and executing the statement within a single `with_raw_connection` block. This is what the other adapters with prepared statements already do.

It makes more sense this way—even if we managed to reconnect before executing the statement in the old code, we'd be referencing a prepared statement from a different connection, so it'd fail anyway. Having the prepare and execute in the same `with_raw_connection` means if we do need to reconnect, we'll start from the beginning and prepare the statement again on the fresh connection.

Note that this change does get rid of connection retries on preparing statements, but I think that's OK. It matches the other adapters, matches the Rails 7.0 behavior, and it's still better than ending up with a broken connection.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
