### PR TITLE
CSP Report-to reponse header field for browser Reporting API

### DIFF
--- a/actionmailbox/test/dummy/config/initializers/content_security_policy.rb
+++ b/actionmailbox/test/dummy/config/initializers/content_security_policy.rb
@@ -14,6 +14,8 @@
 #     policy.style_src   :self, :https
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
+#     # Specify report group for violation reports using Reporting API
+#     # policy.report_to "csp-endpoint"
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `report-to` CSP response header field.
+
+    *Espen Antonsen*
+
 *   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
 
     *DHH*

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -239,6 +239,16 @@ module ActionDispatch # :nodoc:
       @directives["report-uri"] = [uri]
     end
 
+    # Enable the [report-to]
+    # (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
+    # directive. Violation reports will be sent to the specified Reporting API group:
+    #
+    #   policy.report_to "csp-endpoint"
+    #
+    def report_to(group)
+      @directives["report-to"] = [group]
+    end
+
     # Specify asset types for which [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) is required:
     #
     #     policy.require_sri_for :script, :style

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -228,6 +228,11 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_match %r{report-uri /violations}, @policy.build
   end
 
+  def test_report_group_directives
+    @policy.report_to "csp-endpoint"
+    assert_match %r{report-to csp-endpoint}, @policy.build
+  end
+
   def test_other_directives
     @policy.block_all_mixed_content
     assert_match %r{block-all-mixed-content}, @policy.build

--- a/actiontext/test/dummy/config/initializers/content_security_policy.rb
+++ b/actiontext/test/dummy/config/initializers/content_security_policy.rb
@@ -14,6 +14,8 @@
 #     policy.style_src   :self, :https
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
+#     # Specify report group for violation reports using Reporting API
+#     # policy.report_to "csp-endpoint"
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.

--- a/activestorage/test/dummy/config/initializers/content_security_policy.rb
+++ b/activestorage/test/dummy/config/initializers/content_security_policy.rb
@@ -14,6 +14,8 @@
 #     policy.style_src   :self, :https
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
+#     # Specify report group for violation reports using Reporting API
+#     # policy.report_to "csp-endpoint"
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1429,6 +1429,14 @@ Rails.application.config.content_security_policy do |policy|
 end
 ```
 
+Enable the [`report-to`][] directive to report violations to the specified Reporting API group:
+
+```ruby
+Rails.application.config.content_security_policy do |policy|
+  policy.report_to "csp-endpoint"
+end
+```
+
 When migrating legacy content, you might want to report violations without
 enforcing the policy. Set the [`Content-Security-Policy-Report-Only`][]
 response header to only report violations:
@@ -1447,6 +1455,7 @@ end
 
 [`Content-Security-Policy-Report-Only`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 [`report-uri`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+[`report-to`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
 
 #### Adding a Nonce
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -14,6 +14,8 @@
 #     policy.style_src   :self, :https
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
+#     # Specify report group for violation reports using Reporting API
+#     # policy.report_to "csp-endpoint"
 #   end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.


### PR DESCRIPTION
### Motivation / Background

The current Rails CSP uses `report-uri` which is deprecated. There is a newer Reporting API which uses endpoints that can be references from the CSP policy using `report-to`.

For more info see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to

### Detail

Adds Reporting API endpoint to CSP policy using `report-to`.

This requires the Report-To HTTP header to be set manually. Example:
```
response.set_header('Report-To', '{"group":"csp-endpoint","max_age":31536000,"endpoints":[{"url":"https://example.org/csp-endpoint"}],"include_subdomains":true}')
```

### Additional information

This is my first PR to Rails so let me know if there is any improvement to be made. I wasn't sure whether to include info about the Report-To HTTP header in the docs or code.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
