### PR TITLE
Prevent marking broken connections as verified

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -102,6 +102,7 @@ module ActiveRecord
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
                 sync_timezone_changes(conn)
                 result = conn.query(sql)
+                verified!
                 handle_warnings(sql)
                 result
               end
@@ -130,6 +131,8 @@ module ActiveRecord
                   result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                     stmt.execute(*type_casted_binds)
                   end
+                  verified!
+                  result
                 rescue ::Mysql2::Error => e
                   if cache_stmt
                     @statements.delete(sql)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -16,7 +16,9 @@ module ActiveRecord
 
           log(sql, name) do
             with_raw_connection do |conn|
-              conn.async_exec(sql).map_types!(@type_map_for_results).values
+              result = conn.async_exec(sql).map_types!(@type_map_for_results).values
+              verified!
+              result
             end
           end
         end
@@ -51,6 +53,7 @@ module ActiveRecord
           log(sql, name, async: async) do
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
               result = conn.async_exec(sql)
+              verified!
               handle_warnings(result)
               result
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -893,7 +893,9 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async) do
             with_raw_connection do |conn|
-              conn.exec_params(sql, type_casted_binds)
+              result = conn.exec_params(sql, type_casted_binds)
+              verified!
+              result
             end
           end
         end
@@ -908,7 +910,9 @@ module ActiveRecord
             type_casted_binds = type_casted_binds(binds)
 
             log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
-              conn.exec_prepared(stmt_key, type_casted_binds)
+              result = conn.exec_prepared(stmt_key, type_casted_binds)
+              verified!
+              result
             end
           end
         rescue ActiveRecord::StatementInvalid => e

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -50,6 +50,7 @@ module ActiveRecord
                 stmt.bind_params(type_casted_binds)
                 records = stmt.to_a
               end
+              verified!
 
               build_result(columns: cols, rows: records)
             end
@@ -76,7 +77,9 @@ module ActiveRecord
         def begin_db_transaction # :nodoc:
           log("begin transaction", "TRANSACTION") do
             with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
-              conn.transaction
+              result = conn.transaction
+              verified!
+              result
             end
           end
         end
@@ -112,7 +115,9 @@ module ActiveRecord
           def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: false)
             log(sql, name, async: async) do
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-                conn.execute(sql)
+                result = conn.execute(sql)
+                verified!
+                result
               end
             end
           end
@@ -133,7 +138,9 @@ module ActiveRecord
 
             log(sql, name) do
               with_raw_connection do |conn|
-                conn.execute_batch2(sql)
+                result = conn.execute_batch2(sql)
+                verified!
+                result
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -47,6 +47,7 @@ module ActiveRecord
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
                 sync_timezone_changes(conn)
                 result = conn.query(sql)
+                verified!
                 handle_warnings(sql)
                 result
               end


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/49802 (we may want both PRs)

Prior to this commit `with_raw_connection` would always mark the connection as `@verified = true` after yielding it. But yielding a connection is not enough to determine that a connection is healthy. Marking a broken connection as verified can prevent further reconnects, leaving us with a broken connection for longer than expected (including into the next request).

For example,

* Connection is broken and not verified
* Quote string succeeds, and marks the broken connection as verified
* Because the connection is verified, querying will not trigger a reconnect
* Query fails and the connection is no longer verified
* Repeat ad infinitum (or until we reach a query with `allow_retry: true`, or one that isn't preceded by a call to quote string)

This commit solves the problem by only marking the connection as verified if we have definitively exercised that connection. This is safer, but it does put more responsibility on each individual adapter. If a call to `verified!` is missing things should still work OK, but we'll end up pinging the connection more to see if it is active.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


cc @matthewd 