### PR TITLE
[skip ci] Fix minor typo in ActiveStorage::FixtureSet example

### DIFF
--- a/activestorage/lib/active_storage/fixture_set.rb
+++ b/activestorage/lib/active_storage/fixture_set.rb
@@ -48,7 +48,7 @@ module ActiveStorage
     #
     # === Examples
     #
-    #   # tests/fixtures/action_text/blobs.yml
+    #   # tests/fixtures/active_storage/blobs.yml
     #   second_thumbnail_blob: <%= ActiveStorage::FixtureSet.blob(
     #     filename: "second.svg",
     #   ) %>


### PR DESCRIPTION
Minor typo in ActiveStorage fixture example.