### PR TITLE
Prebuild list of counter cache associations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -303,6 +303,10 @@ module ActiveRecord
       autoload :AliasTracker
     end
 
+    included do
+      class_attribute :counter_cached_association_names, instance_writer: false, default: []
+    end
+
     def self.eager_load!
       super
       Preloader.eager_load!
@@ -1885,6 +1889,9 @@ module ActiveRecord
         #   belong_to  :note, query_constraints: [:organization_id, :note_id]
         def belongs_to(name, scope = nil, **options)
           reflection = Builder::BelongsTo.build(self, name, scope, options)
+          if reflection.counter_cache_column
+            self.counter_cached_association_names = counter_cached_association_names + [name]
+          end
           Reflection.add_reflection self, name, reflection
         end
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -186,8 +186,8 @@ module ActiveRecord
       def _create_record(attribute_names = self.attribute_names)
         id = super
 
-        each_counter_cached_associations do |association|
-          association.increment_counters
+        counter_cached_association_names.each do |association_name|
+          association(association_name).increment_counters
         end
 
         id
@@ -197,7 +197,8 @@ module ActiveRecord
         affected_rows = super
 
         if affected_rows > 0
-          each_counter_cached_associations do |association|
+          counter_cached_association_names.each do |association_name|
+            association = association(association_name)
             foreign_key = association.reflection.foreign_key.to_sym
             unless destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
               association.decrement_counters
@@ -206,12 +207,6 @@ module ActiveRecord
         end
 
         affected_rows
-      end
-
-      def each_counter_cached_associations
-        _reflections.each do |name, reflection|
-          yield association(name.to_sym) if reflection.belongs_to? && reflection.counter_cache_column
-        end
       end
   end
 end


### PR DESCRIPTION
Currently when we `_create_record` or `destroy_row` we have to iterate over the list of `_reflections` and find the ones that are `belongs_to` type and have a `counter_cache_column`. This is inefficient as we don't expect the result of this selection to change during runtime. To make it prettier and more efficient we will prebuild a list of associations that have a counter cache column.

### Motivation / Background

I have two reasons to implement this change
1. It will unblock https://github.com/rails/rails/pull/49801 . I'd like to introduce an `alias_association` feature which will populate `_reflections` mapping with duplicated reflections under different keys (aliases) and the current approach relies on `_reflections` to be unique
2. Instead of trying to address the "uniqueness" problem I'd like to also improve the performance of this particular piece. It seems inefficient to iterate over the same `_reflections` hash again and again and performing the same checks to get the same result for a given model class. It would be much better to have the list we are interested in prebuilt and ready for use.

Even though performance is not my ultimate goal and the main reason for this change is to unblock `alias_association` here is the benchmark:

<details>
<summary>Benchmark</summary>

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "sqlite3"
  gem "benchmark-ips"
  gem "debug"
end

require "active_record"
require "benchmark/ips"

module ActiveRecord
  module CounterCache
    # legacy implementation
    def each_counter_cached_associations
      _reflections.each do |name, reflection|
        yield association(name.to_sym) if reflection.belongs_to? && reflection.counter_cache_column
      end
    end
  end
end


ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :users do |t|
    t.string :first_name
    t.string :last_name
    t.integer :comments_count
  end

  create_table :comments do |t|
    t.integer :user_id
    t.text :body
  end
end

class User < ActiveRecord::Base
end

class Comment < ActiveRecord::Base
  belongs_to :user, counter_cache: true
end

user = User.create!(first_name: "Nikita", last_name: "V")
puts RUBY_DESCRIPTION

legacy_associations = []
user.send(:each_counter_cached_associations) { |assoc| legacy_associations << assoc.name }

new_associations = User.counter_cached_association_names.each { |name| User.association(name) }
raise if legacy_associations != new_associations


Benchmark.ips do |x|
  x.report("memoized counter_cache association names") do
    User.counter_cached_association_names.each { |name| User.association(name) }
  end

  x.report("each_counter_cached_associations") do
    user.send(:each_counter_cached_associations) do |assoc|
      assoc # no need to do anything
    end
  end

  x.compare!
end

```

</details>

```
Calculating -------------------------------------
memoized counter_cache association names
                          9.143M (± 6.0%) i/s -     46.355M in   5.091984s
each_counter_cached_associations
                          3.401M (± 6.1%) i/s -     16.914M in   5.001597s

Comparison:
memoized counter_cache association names:  9142732.6 i/s
each_counter_cached_associations:  3401378.9 i/s - 2.69x  slower
```

### What reviewers should focus on

Does it need a changelog entry? 

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
