### PR TITLE
Move `quote_string` from trilogy and mysql2 adapters to abstract mysql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -659,6 +659,17 @@ module ActiveRecord
         end
       end
 
+      #--
+      # QUOTING ==================================================
+      #++
+
+      # Quotes strings for use in SQL input.
+      def quote_string(string)
+        with_raw_connection(allow_retry: true, materialize_transactions: false) do |connection|
+          connection.escape(string)
+        end
+      end
+
       class << self
         def extended_type_map(default_timezone: nil, emulate_booleans:) # :nodoc:
           super(default_timezone: default_timezone).tap do |m|

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -116,17 +116,6 @@ module ActiveRecord
       end
 
       #--
-      # QUOTING ==================================================
-      #++
-
-      # Quotes strings for use in SQL input.
-      def quote_string(string)
-        with_raw_connection(allow_retry: true, materialize_transactions: false) do |connection|
-          connection.escape(string)
-        end
-      end
-
-      #--
       # CONNECTION MANAGEMENT ====================================
       #++
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -125,12 +125,6 @@ module ActiveRecord
         true
       end
 
-      def quote_string(string)
-        with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
-          conn.escape(string)
-        end
-      end
-
       def connected?
         !(@raw_connection.nil? || @raw_connection.closed?)
       end


### PR DESCRIPTION
Implementations of the method are exactly the same for trilogy and mysql2 adapters so we will benefit from it being explicitly shared from the abstract mysql adapter

It is close to being a cosmetic change but I think it's an important one to make. We can anticipate many applications to migrate from `mysql2` to `trilogy` and in case of any issues developers may potentially be looking into differences between mysql2 and trilogy adapters. Having two exact the same methods in both trilogy and mysql2 doesn't help with debugging and having it in the common class clearly indicates that the behavior is the same

### PostgreSQL

To be fair postgresql adapter has exactly the same implementation but I didn't feel confident moving it further to the abstract adapter since I don't think it's an implementation that fits any potential adapter.
https://github.com/rails/rails/blob/403447d06165b0e9a13f0942f11b97e2f9d426b8/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L74-L78

Also moving it to the abstract adapter would make the `Quoting#quote_string` method unused, if I'm following it correctly:
https://github.com/rails/rails/blob/403447d06165b0e9a13f0942f11b97e2f9d426b8/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L88-L90