### PR TITLE
Make with_routing test helper work for integration tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for `with_routing` test helper in `ActionDispatch::IntegrationTest`
+
+    *Gannon McGibbon*
+
 *   Remove deprecated support to set `Rails.application.config.action_dispatch.show_exceptions` to `true` and `false`.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -11,6 +11,65 @@ module ActionDispatch
     module RoutingAssertions
       extend ActiveSupport::Concern
 
+      module WithIntegrationRouting # :nodoc:
+        extend ActiveSupport::Concern
+
+        module ClassMethods
+          def with_routing(&block)
+            old_routes = nil
+            old_integration_session = nil
+
+            setup do
+              old_routes = app.routes
+              old_integration_session = integration_session
+              create_routes(&block)
+            end
+
+            teardown do
+              reset_routes(old_routes, old_integration_session)
+            end
+          end
+        end
+
+        def with_routing(&block)
+          old_routes = app.routes
+          old_integration_session = integration_session
+          create_routes(&block)
+        ensure
+          reset_routes(old_routes, old_integration_session)
+        end
+
+        private
+          def create_routes
+            app = self.app
+            routes = ActionDispatch::Routing::RouteSet.new
+            rack_app = app.config.middleware.build(routes)
+            https = integration_session.https?
+            host = integration_session.host
+
+            app.instance_variable_set(:@routes, routes)
+            app.instance_variable_set(:@app, rack_app)
+            @integration_session = Class.new(ActionDispatch::Integration::Session) do
+              include app.routes.url_helpers
+              include app.routes.mounted_helpers
+            end.new(app)
+            @integration_session.https! https
+            @integration_session.host! host
+            @routes = routes
+
+            yield routes
+          end
+
+          def reset_routes(old_routes, old_integration_session)
+            old_rack_app = app.config.middleware.build(old_routes)
+
+            app.instance_variable_set(:@routes, old_routes)
+            app.instance_variable_set(:@app, old_rack_app)
+            @integration_session = old_integration_session
+            @routes = old_routes
+          end
+      end
+
       module ClassMethods
         # A helper to make it easier to test different route configurations.
         # This method temporarily replaces @routes with a new RouteSet instance
@@ -42,6 +101,26 @@ module ActionDispatch
       def setup # :nodoc:
         @routes ||= nil
         super
+      end
+
+      # A helper to make it easier to test different route configurations.
+      # This method temporarily replaces @routes with a new RouteSet instance.
+      #
+      # The new instance is yielded to the passed block. Typically the block
+      # will create some routes using <tt>set.draw { match ... }</tt>:
+      #
+      #   with_routing do |set|
+      #     set.draw do
+      #       resources :users
+      #     end
+      #     assert_equal "/users", users_path
+      #   end
+      #
+      def with_routing(&block)
+        old_routes, old_controller = @routes, @controller
+        create_routes(&block)
+      ensure
+        reset_routes(old_routes, old_controller)
       end
 
       # Asserts that the routing of the given +path+ was handled correctly and that the parsed options (given in the +expected_options+ hash)
@@ -165,26 +244,6 @@ module ActionDispatch
 
         generate_options = options.dup.delete_if { |k, _| defaults.key?(k) }
         assert_generates(path.is_a?(Hash) ? path[:path] : path, generate_options, defaults, extras, message)
-      end
-
-      # A helper to make it easier to test different route configurations.
-      # This method temporarily replaces @routes with a new RouteSet instance.
-      #
-      # The new instance is yielded to the passed block. Typically the block
-      # will create some routes using <tt>set.draw { match ... }</tt>:
-      #
-      #   with_routing do |set|
-      #     set.draw do
-      #       resources :users
-      #     end
-      #     assert_equal "/users", users_path
-      #   end
-      #
-      def with_routing(&block)
-        old_routes, old_controller = @routes, @controller
-        create_routes(&block)
-      ensure
-        reset_routes(old_routes, old_controller)
       end
 
       # ROUTES TODO: These assertions should really work in an integration context

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -657,6 +657,7 @@ module ActionDispatch
       included do
         include ActionDispatch::Routing::UrlFor
         include UrlOptions # don't let UrlFor override the url_options method
+        include ActionDispatch::Assertions::RoutingAssertions::WithIntegrationRouting
         ActiveSupport.run_load_hooks(:action_dispatch_integration_test, self)
         @@app = nil
       end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -377,18 +377,20 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       super(path, **options)
     end
 
+    def app
+      @app ||= self.class.build_app do |middleware|
+        middleware.use ActionDispatch::Session::CookieStore, key: SessionKey
+        middleware.use ActionDispatch::Flash
+        middleware.delete ActionDispatch::ShowExceptions
+      end
+    end
+
     def with_test_route_set
       with_routing do |set|
         set.draw do
           ActionDispatch.deprecator.silence do
             get ":action", to: FlashIntegrationTest::TestController
           end
-        end
-
-        @app = self.class.build_app(set) do |middleware|
-          middleware.use ActionDispatch::Session::CookieStore, key: SessionKey
-          middleware.use ActionDispatch::Flash
-          middleware.delete ActionDispatch::ShowExceptions
         end
 
         yield

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -172,13 +172,15 @@ class RackLintIntegrationTest < ActionDispatch::IntegrationTest
         get "/", to: ->(_) { [200, {}, [""]] }
       end
 
-      @app = self.class.build_app(set) do |middleware|
-        middleware.unshift Rack::Lint
-      end
-
       get "/"
 
       assert_equal 200, status
+    end
+  end
+
+  def app
+    @app ||= self.class.build_app do |middleware|
+      middleware.unshift Rack::Lint
     end
   end
 end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -157,15 +157,18 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
   end
 
   private
+    def app
+      @app ||= self.class.build_app do |middleware|
+        middleware.use(EarlyParse)
+      end
+    end
+
     def assert_parses(expected, actual)
       with_routing do |set|
         set.draw do
           ActionDispatch.deprecator.silence do
             get ":action", to: ::QueryStringParsingTest::TestController
           end
-        end
-        @app = self.class.build_app(set) do |middleware|
-          middleware.use(EarlyParse)
         end
 
         get "/parse", params: actual

--- a/actionpack/test/dispatch/server_timing_test.rb
+++ b/actionpack/test/dispatch/server_timing_test.rb
@@ -120,16 +120,18 @@ class ServerTimingTest < ActionDispatch::IntegrationTest
   end
 
   private
+    def app
+      @app ||= self.class.build_app do |middleware|
+        @middlewares.each { |m| middleware.use m }
+      end
+    end
+
     def with_test_route_set
       with_routing do |set|
         set.draw do
           get "/", to: ::ServerTimingTest::TestController.action(:index)
           get "/id", to: ::ServerTimingTest::TestController.action(:show)
           post "/", to: ::ServerTimingTest::TestController.action(:create)
-        end
-
-        @app = self.class.build_app(set) do |middleware|
-          @middlewares.each { |m| middleware.use m }
         end
 
         yield

--- a/actionpack/test/dispatch/session/cache_store_test.rb
+++ b/actionpack/test/dispatch/session/cache_store_test.rb
@@ -204,18 +204,20 @@ class CacheStoreTest < ActionDispatch::IntegrationTest
   end
 
   private
+    def app
+      @app ||= self.class.build_app do |middleware|
+        @cache = ActiveSupport::Cache::MemoryStore.new
+        middleware.use ActionDispatch::Session::CacheStore, key: "_session_id", cache: @cache
+        middleware.delete ActionDispatch::ShowExceptions
+      end
+    end
+
     def with_test_route_set
       with_routing do |set|
         set.draw do
           ActionDispatch.deprecator.silence do
             get ":action", to: ::CacheStoreTest::TestController
           end
-        end
-
-        @app = self.class.build_app(set) do |middleware|
-          @cache = ActiveSupport::Cache::MemoryStore.new
-          middleware.use ActionDispatch::Session::CacheStore, key: "_session_id", cache: @cache
-          middleware.delete ActionDispatch::ShowExceptions
         end
 
         yield

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -187,20 +187,22 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
   end
 
   private
+    def app
+      @app ||= self.class.build_app do |middleware|
+        middleware.use ActionDispatch::Session::MemCacheStore,
+          key: "_session_id", namespace: "mem_cache_store_test:#{SecureRandom.hex(10)}",
+          memcache_server: ENV["MEMCACHE_SERVERS"] || "localhost:11211",
+          socket_timeout: 60
+        middleware.delete ActionDispatch::ShowExceptions
+      end
+    end
+
     def with_test_route_set
       with_routing do |set|
         set.draw do
           ActionDispatch.deprecator.silence do
             get ":action", to: ::MemCacheStoreTest::TestController
           end
-        end
-
-        @app = self.class.build_app(set) do |middleware|
-          middleware.use ActionDispatch::Session::MemCacheStore,
-            key: "_session_id", namespace: "mem_cache_store_test:#{SecureRandom.hex(10)}",
-            memcache_server: ENV["MEMCACHE_SERVERS"] || "localhost:11211",
-            socket_timeout: 60
-          middleware.delete ActionDispatch::ShowExceptions
         end
 
         yield


### PR DESCRIPTION
Adds support for `with_routing` test helpers in `ActionDispatch::IntegrationTest`. Previously, this helper didn't work in an integration context (only for `ActionController::TestCase`) because the rack app and integration session under test were not mutated. Because controller tests are integration tests by default, we should support test routes for these kinds of test cases as well.

### Motivation / Background

This Pull Request has been created because I needed to use with_routing in an integration test, and [it doesn't seem to work](https://gist.github.com/gmcgibbon/23648062f6e5a55436b5df0799525996).

### Detail

This Pull Request changes routing assertions in integration tests by including `ActionDispatch::Assertions::RoutingAssertions::WithIntegrationRouting` which overrides the standard `with_routing` machinery to mutate the app under test and integration session.

### Additional information

I used a shared test module approach for the existing routing assertion tests so that we can test the same way in controller and integration tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
