### PR TITLE
Move route helper method_missing to ActionController::TestCase

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -602,6 +602,15 @@ module ActionController
       end
 
       private
+        def method_missing(selector, *args, &block)
+          if defined?(@controller) && @controller && defined?(@routes) && @routes && @routes.named_routes.route_defined?(selector)
+            @controller.public_send(selector, *args, &block)
+          else
+            super
+          end
+        end
+        ruby2_keywords(:method_missing)
+
         def setup_request(controller_class_name, action, parameters, session, flash, xhr)
           generated_extras = @routes.generate_extras(parameters.merge(controller: controller_class_name, action: action))
           generated_path = generated_path(generated_extras)

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -269,15 +269,6 @@ module ActionDispatch
         assert_generates(path.is_a?(Hash) ? path[:path] : path, generate_options, defaults, extras, message)
       end
 
-      # ROUTES TODO: These assertions should really work in an integration context
-      def method_missing(selector, ...)
-        if @controller && @routes&.named_routes&.route_defined?(selector)
-          @controller.public_send(selector, ...)
-        else
-          super
-        end
-      end
-
       private
         def create_routes(config = nil)
           @routes = ActionDispatch::Routing::RouteSet.new(config || ActionDispatch::Routing::RouteSet::DEFAULT_CONFIG)

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -502,6 +502,19 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     assert_in_body "request method: POST"
     assert_not_in_body "request method: GET"
   end
+
+  def test_url_helper_delegation
+    @controller = ActionPackAssertionsController.new
+    @controller.request = ActionDispatch::TestRequest.create
+
+    with_routing do |set|
+      set.draw do
+        get "/route_one", to: "action_pack_assertions#nothing", as: :route_one
+      end
+
+      assert_equal("/route_one", route_one_path)
+    end
+  end
 end
 
 class ActionPackHeaderTest < ActionController::TestCase


### PR DESCRIPTION
Integration tests use the integration session to access URL helpers. The method_missing in routing assertions is only for controller tests, so let's just move it there.

### Motivation / Background

This Pull Request has been created because this method had a TODO on it that looks out of date to me.

### Detail

This Pull Request moves the method_missing on the route assertions module to `ActionController::TestCase`. Integration tests already delegate to the `integration_session` route helpers here: https://github.com/rails/rails/blob/421df52bf859120371b82a67529fee20e1f548f8/actionpack/lib/action_dispatch/testing/integration.rb#L436 https://github.com/rails/rails/blob/421df52bf859120371b82a67529fee20e1f548f8/actionpack/lib/action_dispatch/testing/integration.rb#L358

### Additional information

The method_missing I moved might be public API, but I think we only expect it to be used in a controller test context, right? Integration tests include routing assertions to the [integration session](https://github.com/rails/rails/blob/421df52bf859120371b82a67529fee20e1f548f8/actionpack/lib/action_dispatch/testing/integration.rb#L93). Regardless of if we choose to move the method_missing, we can probably better test this behaviour to make sure it doesn't regress.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
