### PR TITLE
Do not use title-case in number helper

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -282,7 +282,7 @@ module ActionView
       #
       # ==== Examples
       #
-      #   number_to_human_size(123)                                          # => 123 Bytes
+      #   number_to_human_size(123)                                          # => 123 bytes
       #   number_to_human_size(1234)                                         # => 1.21 KB
       #   number_to_human_size(12345)                                        # => 12.1 KB
       #   number_to_human_size(1234567)                                      # => 1.18 MB
@@ -301,7 +301,7 @@ module ActionView
 
       # Pretty prints (formats and approximates) a number in a way it
       # is more readable by humans (e.g.: 1200000000 becomes "1.2
-      # Billion"). This is useful for numbers that can get very large
+      # billion"). This is useful for numbers that can get very large
       # (and too hard to read).
       #
       # See <tt>number_to_human_size</tt> if you want to print a file
@@ -349,23 +349,23 @@ module ActionView
       # ==== Examples
       #
       #   number_to_human(123)                                          # => "123"
-      #   number_to_human(1234)                                         # => "1.23 Thousand"
-      #   number_to_human(12345)                                        # => "12.3 Thousand"
-      #   number_to_human(1234567)                                      # => "1.23 Million"
-      #   number_to_human(1234567890)                                   # => "1.23 Billion"
-      #   number_to_human(1234567890123)                                # => "1.23 Trillion"
-      #   number_to_human(1234567890123456)                             # => "1.23 Quadrillion"
-      #   number_to_human(1234567890123456789)                          # => "1230 Quadrillion"
-      #   number_to_human(489939, precision: 2)                         # => "490 Thousand"
-      #   number_to_human(489939, precision: 4)                         # => "489.9 Thousand"
+      #   number_to_human(1234)                                         # => "1.23 thousand"
+      #   number_to_human(12345)                                        # => "12.3 thousand"
+      #   number_to_human(1234567)                                      # => "1.23 billion"
+      #   number_to_human(1234567890)                                   # => "1.23 billion"
+      #   number_to_human(1234567890123)                                # => "1.23 trillion"
+      #   number_to_human(1234567890123456)                             # => "1.23 quadrillion"
+      #   number_to_human(1234567890123456789)                          # => "1230 quadrillion"
+      #   number_to_human(489939, precision: 2)                         # => "490 thousand"
+      #   number_to_human(489939, precision: 4)                         # => "489.9 thousand"
       #   number_to_human(1234567, precision: 4,
-      #                           significant: false)                   # => "1.2346 Million"
+      #                           significant: false)                   # => "1.2346 million"
       #   number_to_human(1234567, precision: 1,
       #                           separator: ',',
-      #                           significant: false)                   # => "1,2 Million"
+      #                           significant: false)                   # => "1,2 million"
       #
-      #   number_to_human(500000000, precision: 5)                      # => "500 Million"
-      #   number_to_human(12345012345, significant: false)              # => "12.345 Billion"
+      #   number_to_human(500000000, precision: 5)                      # => "500 million"
+      #   number_to_human(12345012345, significant: false)              # => "12.345 billion"
       #
       # Non-significant zeros after the decimal separator are stripped
       # out by default (set <tt>:strip_insignificant_zeros</tt> to

--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -60,15 +60,15 @@ class NumberHelperTest < ActionView::TestCase
 
   def test_number_to_human_size
     assert_nil number_to_human_size(nil)
-    assert_equal "3 Bytes", number_to_human_size(3.14159265)
+    assert_equal "3 bytes", number_to_human_size(3.14159265)
     assert_equal "1.2 MB", number_to_human_size(1234567, precision: 2)
   end
 
   def test_number_to_human
     assert_nil number_to_human(nil)
     assert_equal "0",   number_to_human(0)
-    assert_equal "1.23 Thousand", number_to_human(1234)
-    assert_equal "489.0 Thousand", number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
+    assert_equal "1.23 thousand", number_to_human(1234)
+    assert_equal "489.0 thousand", number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
   end
 
   def test_number_to_human_escape_units
@@ -114,7 +114,7 @@ class NumberHelperTest < ActionView::TestCase
     assert_equal "9&lt;script&gt;&lt;/script&gt;86 KB", number_to_human_size(10100, separator: "<script></script>")
 
     assert_equal "1&lt;script&gt;&lt;/script&gt;01", number_to_human(1.01, separator: "<script></script>")
-    assert_equal "100&lt;script&gt;&lt;/script&gt;000 Quadrillion", number_to_human(10**20, delimiter: "<script></script>")
+    assert_equal "100&lt;script&gt;&lt;/script&gt;000 quadrillion", number_to_human(10**20, delimiter: "<script></script>")
   end
 
   def test_number_to_human_with_custom_translation_scope

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -77,8 +77,8 @@ module ActiveSupport
     #  1111.2345.to_fs(:rounded, precision: 2, separator: ',', delimiter: '.')
     #  # => "1.111,23"
     #
-    #  Human-friendly size in Bytes:
-    #  123.to_fs(:human_size)                                    # => "123 Bytes"
+    #  Human-friendly size in bytes:
+    #  123.to_fs(:human_size)                                    # => "123 bytes"
     #  1234.to_fs(:human_size)                                   # => "1.21 KB"
     #  12345.to_fs(:human_size)                                  # => "12.1 KB"
     #  1234567.to_fs(:human_size)                                # => "1.18 MB"
@@ -95,21 +95,21 @@ module ActiveSupport
     #
     #  Human-friendly format:
     #  123.to_fs(:human)                                       # => "123"
-    #  1234.to_fs(:human)                                      # => "1.23 Thousand"
-    #  12345.to_fs(:human)                                     # => "12.3 Thousand"
-    #  1234567.to_fs(:human)                                   # => "1.23 Million"
-    #  1234567890.to_fs(:human)                                # => "1.23 Billion"
-    #  1234567890123.to_fs(:human)                             # => "1.23 Trillion"
-    #  1234567890123456.to_fs(:human)                          # => "1.23 Quadrillion"
-    #  1234567890123456789.to_fs(:human)                       # => "1230 Quadrillion"
-    #  489939.to_fs(:human, precision: 2)                      # => "490 Thousand"
-    #  489939.to_fs(:human, precision: 2, round_mode: :down)   # => "480 Thousand"
-    #  489939.to_fs(:human, precision: 4)                      # => "489.9 Thousand"
+    #  1234.to_fs(:human)                                      # => "1.23 thousand"
+    #  12345.to_fs(:human)                                     # => "12.3 thousand"
+    #  1234567.to_fs(:human)                                   # => "1.23 million"
+    #  1234567890.to_fs(:human)                                # => "1.23 billion"
+    #  1234567890123.to_fs(:human)                             # => "1.23 trillion"
+    #  1234567890123456.to_fs(:human)                          # => "1.23 quadrillion"
+    #  1234567890123456789.to_fs(:human)                       # => "1230 quadrillion"
+    #  489939.to_fs(:human, precision: 2)                      # => "490 thousand"
+    #  489939.to_fs(:human, precision: 2, round_mode: :down)   # => "480 thousand"
+    #  489939.to_fs(:human, precision: 4)                      # => "489.9 thousand"
     #  1234567.to_fs(:human, precision: 4,
-    #                   significant: false)                             # => "1.2346 Million"
+    #                   significant: false)                             # => "1.2346 million"
     #  1234567.to_fs(:human, precision: 1,
     #                   separator: ',',
-    #                   significant: false)                             # => "1,2 Million"
+    #                   significant: false)                             # => "1,2 million"
     def to_fs(format = nil, options = nil)
       return to_s if format.nil?
 

--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -105,8 +105,8 @@ en:
         format: "%n %u"
         units:
           byte:
-            one:   "Byte"
-            other: "Bytes"
+            one:   "byte"
+            other: "bytes"
           kb: "KB"
           mb: "MB"
           gb: "GB"
@@ -122,20 +122,20 @@ en:
         # but the commented ones might be defined or overridden
         # by the user.
         units:
-          # femto: Quadrillionth
-          # pico: Trillionth
-          # nano: Billionth
-          # micro: Millionth
-          # mili: Thousandth
-          # centi: Hundredth
-          # deci: Tenth
+          # femto: quadrillionth
+          # pico: trillionth
+          # nano: billionth
+          # micro: millionth
+          # mili: thousandth
+          # centi: hundredth
+          # deci: tenth
           unit: ""
           # ten:
-          #   one: Ten
-          #   other: Tens
-          # hundred: Hundred
-          thousand: Thousand
-          million: Million
-          billion: Billion
-          trillion: Trillion
-          quadrillion: Quadrillion
+          #   one: ten
+          #   other: tens
+          # hundred: hundred
+          thousand: thousand
+          million: million
+          billion: billion
+          trillion: trillion
+          quadrillion: quadrillion

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -266,7 +266,7 @@ module ActiveSupport
     #
     # ==== Examples
     #
-    #   number_to_human_size(123)                                    # => "123 Bytes"
+    #   number_to_human_size(123)                                    # => "123 bytes"
     #   number_to_human_size(1234)                                   # => "1.21 KB"
     #   number_to_human_size(12345)                                  # => "12.1 KB"
     #   number_to_human_size(1234567)                                # => "1.18 MB"
@@ -286,7 +286,7 @@ module ActiveSupport
 
     # Pretty prints (formats and approximates) a number in a way it
     # is more readable by humans (e.g.: 1200000000 becomes "1.2
-    # Billion"). This is useful for numbers that can get very large
+    # billion"). This is useful for numbers that can get very large
     # (and too hard to read).
     #
     # See <tt>number_to_human_size</tt> if you want to print a file
@@ -334,25 +334,25 @@ module ActiveSupport
     # ==== Examples
     #
     #   number_to_human(123)                         # => "123"
-    #   number_to_human(1234)                        # => "1.23 Thousand"
-    #   number_to_human(12345)                       # => "12.3 Thousand"
-    #   number_to_human(1234567)                     # => "1.23 Million"
-    #   number_to_human(1234567890)                  # => "1.23 Billion"
-    #   number_to_human(1234567890123)               # => "1.23 Trillion"
-    #   number_to_human(1234567890123456)            # => "1.23 Quadrillion"
-    #   number_to_human(1234567890123456789)         # => "1230 Quadrillion"
-    #   number_to_human(489939, precision: 2)        # => "490 Thousand"
-    #   number_to_human(489939, precision: 4)        # => "489.9 Thousand"
+    #   number_to_human(1234)                        # => "1.23 thousand"
+    #   number_to_human(12345)                       # => "12.3 thousand"
+    #   number_to_human(1234567)                     # => "1.23 million"
+    #   number_to_human(1234567890)                  # => "1.23 billion"
+    #   number_to_human(1234567890123)               # => "1.23 trillion"
+    #   number_to_human(1234567890123456)            # => "1.23 quadrillion"
+    #   number_to_human(1234567890123456789)         # => "1230 quadrillion"
+    #   number_to_human(489939, precision: 2)        # => "490 thousand"
+    #   number_to_human(489939, precision: 4)        # => "489.9 thousand"
     #   number_to_human(489939, precision: 2
-    #                         , round_mode: :down)   # => "480 Thousand"
+    #                         , round_mode: :down)   # => "480 thousand"
     #   number_to_human(1234567, precision: 4,
-    #                            significant: false) # => "1.2346 Million"
+    #                            significant: false) # => "1.2346 million"
     #   number_to_human(1234567, precision: 1,
     #                            separator: ',',
-    #                            significant: false) # => "1,2 Million"
+    #                            significant: false) # => "1,2 million"
     #
-    #   number_to_human(500000000, precision: 5)           # => "500 Million"
-    #   number_to_human(12345012345, significant: false)   # => "12.345 Billion"
+    #   number_to_human(500000000, precision: 5)           # => "500 million"
+    #   number_to_human(12345012345, significant: false)   # => "12.345 billion"
     #
     # Non-significant zeros after the decimal separator are stripped
     # out by default (set <tt>:strip_insignificant_zeros</tt> to

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -80,7 +80,7 @@ module ActiveSupport
             # %u is the storage unit, %n is the number (default: 2 MB)
             format: "%n %u",
             units: {
-              byte: "Bytes",
+              byte: "bytes",
               kb: "KB",
               mb: "MB",
               gb: "GB",
@@ -95,23 +95,23 @@ module ActiveSupport
             # but the commented ones might be defined or overridden
             # by the user.
             units: {
-              # femto: Quadrillionth
-              # pico: Trillionth
-              # nano: Billionth
-              # micro: Millionth
-              # mili: Thousandth
-              # centi: Hundredth
-              # deci: Tenth
+              # femto: quadrillionth
+              # pico: trillionth
+              # nano: billionth
+              # micro: millionth
+              # mili: thousandth
+              # centi: hundredth
+              # deci: tenth
               unit: "",
               # ten:
-              #   one: Ten
-              #   other: Tens
-              # hundred: Hundred
-              thousand: "Thousand",
-              million: "Million",
-              billion: "Billion",
-              trillion: "Trillion",
-              quadrillion: "Quadrillion"
+              #   one: ten
+              #   other: tens
+              # hundred: hundred
+              thousand: "thousand",
+              million: "million",
+              billion: "billion",
+              trillion: "trillion",
+              quadrillion: "quadrillion"
             }
           }
         }

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -284,11 +284,11 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_to_fs__human_size
-    assert_equal "0 Bytes",   0.to_fs(:human_size)
-    assert_equal "1 Byte",    1.to_fs(:human_size)
-    assert_equal "3 Bytes",   3.14159265.to_fs(:human_size)
-    assert_equal "123 Bytes", 123.0.to_fs(:human_size)
-    assert_equal "123 Bytes", 123.to_fs(:human_size)
+    assert_equal "0 bytes",   0.to_fs(:human_size)
+    assert_equal "1 byte",    1.to_fs(:human_size)
+    assert_equal "3 bytes",   3.14159265.to_fs(:human_size)
+    assert_equal "123 bytes", 123.0.to_fs(:human_size)
+    assert_equal "123 bytes", 123.to_fs(:human_size)
     assert_equal "1.21 KB",   1234.to_fs(:human_size)
     assert_equal "12.1 KB",   12345.to_fs(:human_size)
     assert_equal "1.18 MB",   1234567.to_fs(:human_size)
@@ -302,17 +302,17 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal "1020 MB",   megabytes(1023).to_fs(:human_size)
     assert_equal "3 TB",      terabytes(3).to_fs(:human_size)
     assert_equal "1.2 MB",    1234567.to_fs(:human_size, precision: 2)
-    assert_equal "3 Bytes",   3.14159265.to_fs(:human_size, precision: 4)
+    assert_equal "3 bytes",   3.14159265.to_fs(:human_size, precision: 4)
     assert_equal "1 KB",      kilobytes(1.0123).to_fs(:human_size, precision: 2)
     assert_equal "1.01 KB",   kilobytes(1.0100).to_fs(:human_size, precision: 4)
     assert_equal "10 KB",     kilobytes(10.000).to_fs(:human_size, precision: 4)
-    assert_equal "1 Byte",    1.1.to_fs(:human_size)
-    assert_equal "10 Bytes",  10.to_fs(:human_size)
+    assert_equal "1 byte",    1.1.to_fs(:human_size)
+    assert_equal "10 bytes",  10.to_fs(:human_size)
   end
 
   def test_to_fs__human_size_with_options_hash
     assert_equal "1.2 MB",   1234567.to_fs(:human_size, precision: 2)
-    assert_equal "3 Bytes",  3.14159265.to_fs(:human_size, precision: 4)
+    assert_equal "3 bytes",  3.14159265.to_fs(:human_size, precision: 4)
     assert_equal "1 KB",     kilobytes(1.0123).to_fs(:human_size, precision: 2)
     assert_equal "1.01 KB",  kilobytes(1.0100).to_fs(:human_size, precision: 4)
     assert_equal "10 KB",    kilobytes(10.000).to_fs(:human_size, precision: 4)
@@ -340,21 +340,21 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal "0",   0.to_fs(:human)
     assert_equal "0.5", 0.5.to_fs(:human)
     assert_equal "123", 123.to_fs(:human)
-    assert_equal "1.23 Thousand", 1234.to_fs(:human)
-    assert_equal "12.3 Thousand", 12345.to_fs(:human)
-    assert_equal "1.23 Million", 1234567.to_fs(:human)
-    assert_equal "1.23 Billion", 1234567890.to_fs(:human)
-    assert_equal "1.23 Trillion", 1234567890123.to_fs(:human)
-    assert_equal "1.23 Quadrillion", 1234567890123456.to_fs(:human)
-    assert_equal "1230 Quadrillion", 1234567890123456789.to_fs(:human)
-    assert_equal "490 Thousand", 489939.to_fs(:human, precision: 2)
-    assert_equal "489.9 Thousand", 489939.to_fs(:human, precision: 4)
-    assert_equal "489 Thousand", 489000.to_fs(:human, precision: 4)
-    assert_equal "480 Thousand", 489939.to_fs(:human, precision: 2, round_mode: :down)
-    assert_equal "489.0 Thousand", 489000.to_fs(:human, precision: 4, strip_insignificant_zeros: false)
-    assert_equal "1.2346 Million", 1234567.to_fs(:human, precision: 4, significant: false)
-    assert_equal "1,2 Million", 1234567.to_fs(:human, precision: 1, significant: false, separator: ",")
-    assert_equal "1 Million", 1234567.to_fs(:human, precision: 0, significant: true, separator: ",") # significant forced to false
+    assert_equal "1.23 thousand", 1234.to_fs(:human)
+    assert_equal "12.3 thousand", 12345.to_fs(:human)
+    assert_equal "1.23 million", 1234567.to_fs(:human)
+    assert_equal "1.23 billion", 1234567890.to_fs(:human)
+    assert_equal "1.23 trillion", 1234567890123.to_fs(:human)
+    assert_equal "1.23 quadrillion", 1234567890123456.to_fs(:human)
+    assert_equal "1230 quadrillion", 1234567890123456789.to_fs(:human)
+    assert_equal "490 thousand", 489939.to_fs(:human, precision: 2)
+    assert_equal "489.9 thousand", 489939.to_fs(:human, precision: 4)
+    assert_equal "489 thousand", 489000.to_fs(:human, precision: 4)
+    assert_equal "480 thousand", 489939.to_fs(:human, precision: 2, round_mode: :down)
+    assert_equal "489.0 thousand", 489000.to_fs(:human, precision: 4, strip_insignificant_zeros: false)
+    assert_equal "1.2346 million", 1234567.to_fs(:human, precision: 4, significant: false)
+    assert_equal "1,2 million", 1234567.to_fs(:human, precision: 1, significant: false, separator: ",")
+    assert_equal "1 million", 1234567.to_fs(:human, precision: 0, significant: true, separator: ",") # significant forced to false
   end
 
   def test_number_to_human_with_custom_units
@@ -390,16 +390,16 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   end
 
   def test_number_to_human_with_custom_format
-    assert_equal "123 times Thousand", 123456.to_fs(:human, format: "%n times %u")
+    assert_equal "123 times thousand", 123456.to_fs(:human, format: "%n times %u")
     volume = { unit: "ml", thousand: "lt", million: "m3" }
     assert_equal "123.lt", 123456.to_fs(:human, units: volume, format: "%n.%u")
   end
 
   def test_to_fs__injected_on_proper_types
-    assert_equal "1.23 Thousand", 1230.to_fs(:human)
-    assert_equal "1.23 Thousand", Float(1230).to_fs(:human)
-    assert_equal "100000 Quadrillion", (100**10).to_fs(:human)
-    assert_equal "1 Million", BigDecimal("1000010").to_fs(:human)
+    assert_equal "1.23 thousand", 1230.to_fs(:human)
+    assert_equal "1.23 thousand", Float(1230).to_fs(:human)
+    assert_equal "100000 quadrillion", (100**10).to_fs(:human)
+    assert_equal "1 million", BigDecimal("1000010").to_fs(:human)
   end
 
   def test_to_fs_with_invalid_formatter

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -126,7 +126,7 @@ module ActiveSupport
 
     def test_number_to_i18n_human_size_with_empty_i18n_store
       assert_equal("2 KB", number_to_human_size(2048, locale: "empty"))
-      assert_equal("42 Bytes", number_to_human_size(42, locale: "empty"))
+      assert_equal("42 bytes", number_to_human_size(42, locale: "empty"))
     end
 
     def test_number_to_human_with_default_translation_scope
@@ -135,17 +135,17 @@ module ActiveSupport
       # Significant was set to true with precision 2, using b for billion
       assert_equal "1.2 b", number_to_human(1234567890, locale: "ts")
       # Using pluralization (Ten/Tens and Tenth/Tenths)
-      assert_equal "1 Tenth", number_to_human(0.1, locale: "ts")
-      assert_equal "1.3 Tenth", number_to_human(0.134, locale: "ts")
-      assert_equal "2 Tenths", number_to_human(0.2, locale: "ts")
-      assert_equal "1 Ten", number_to_human(10, locale: "ts")
-      assert_equal "1.2 Ten", number_to_human(12, locale: "ts")
-      assert_equal "2 Tens", number_to_human(20, locale: "ts")
+      assert_equal "1 tenth", number_to_human(0.1, locale: "ts")
+      assert_equal "1.3 tenth", number_to_human(0.134, locale: "ts")
+      assert_equal "2 tenths", number_to_human(0.2, locale: "ts")
+      assert_equal "1 ten", number_to_human(10, locale: "ts")
+      assert_equal "1.2 ten", number_to_human(12, locale: "ts")
+      assert_equal "2 tens", number_to_human(20, locale: "ts")
     end
 
     def test_number_to_human_with_empty_i18n_store
-      assert_equal "2 Thousand", number_to_human(2000, locale: "empty")
-      assert_equal "1.23 Billion", number_to_human(1234567890, locale: "empty")
+      assert_equal "2 thousand", number_to_human(2000, locale: "empty")
+      assert_equal "1.23 billion", number_to_human(1234567890, locale: "empty")
     end
 
     def test_number_to_human_with_custom_translation_scope

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -253,11 +253,11 @@ module ActiveSupport
 
       def test_number_number_to_human_size
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal "0 Bytes",   number_helper.number_to_human_size(0)
-          assert_equal "1 Byte",    number_helper.number_to_human_size(1)
-          assert_equal "3 Bytes",   number_helper.number_to_human_size(3.14159265)
-          assert_equal "123 Bytes", number_helper.number_to_human_size(123.0)
-          assert_equal "123 Bytes", number_helper.number_to_human_size(123)
+          assert_equal "0 bytes",   number_helper.number_to_human_size(0)
+          assert_equal "1 byte",    number_helper.number_to_human_size(1)
+          assert_equal "3 bytes",   number_helper.number_to_human_size(3.14159265)
+          assert_equal "123 bytes", number_helper.number_to_human_size(123.0)
+          assert_equal "123 bytes", number_helper.number_to_human_size(123)
           assert_equal "1.21 KB",    number_helper.number_to_human_size(1234)
           assert_equal "12.1 KB",   number_helper.number_to_human_size(12345)
           assert_equal "1.18 MB",    number_helper.number_to_human_size(1234567)
@@ -271,13 +271,13 @@ module ActiveSupport
           assert_equal "3 TB",      number_helper.number_to_human_size(terabytes(3))
           assert_equal "1.2 MB",   number_helper.number_to_human_size(1234567, precision: 2)
           assert_equal "1.1 MB",   number_helper.number_to_human_size(1234567, precision: 2, round_mode: :down)
-          assert_equal "3 Bytes",   number_helper.number_to_human_size(3.14159265, precision: 4)
-          assert_equal "123 Bytes", number_helper.number_to_human_size("123")
+          assert_equal "3 bytes",   number_helper.number_to_human_size(3.14159265, precision: 4)
+          assert_equal "123 bytes", number_helper.number_to_human_size("123")
           assert_equal "1 KB",   number_helper.number_to_human_size(kilobytes(1.0123), precision: 2)
           assert_equal "1.01 KB",   number_helper.number_to_human_size(kilobytes(1.0100), precision: 4)
           assert_equal "10 KB",   number_helper.number_to_human_size(kilobytes(10.000), precision: 4)
-          assert_equal "1 Byte",   number_helper.number_to_human_size(1.1)
-          assert_equal "10 Bytes", number_helper.number_to_human_size(10)
+          assert_equal "1 byte",   number_helper.number_to_human_size(1.1)
+          assert_equal "10 bytes", number_helper.number_to_human_size(10)
           assert_equal "16 ZB", number_helper.number_to_human_size(zettabytes(16))
         end
       end
@@ -285,7 +285,7 @@ module ActiveSupport
       def test_number_to_human_size_with_options_hash
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
           assert_equal "1.2 MB",   number_helper.number_to_human_size(1234567, precision: 2)
-          assert_equal "3 Bytes",   number_helper.number_to_human_size(3.14159265, precision: 4)
+          assert_equal "3 bytes",   number_helper.number_to_human_size(3.14159265, precision: 4)
           assert_equal "1 KB",   number_helper.number_to_human_size(kilobytes(1.0123), precision: 2)
           assert_equal "1.01 KB",   number_helper.number_to_human_size(kilobytes(1.0100), precision: 4)
           assert_equal "10 KB",     number_helper.number_to_human_size(kilobytes(10.000), precision: 4)
@@ -316,23 +316,23 @@ module ActiveSupport
           assert_equal "0",   number_helper.number_to_human(0)
           assert_equal "0.5", number_helper.number_to_human(0.5)
           assert_equal "123", number_helper.number_to_human(123)
-          assert_equal "1.23 Thousand", number_helper.number_to_human(1234)
-          assert_equal "12.3 Thousand", number_helper.number_to_human(12345)
-          assert_equal "1.23 Million", number_helper.number_to_human(1234567)
-          assert_equal "1.23 Billion", number_helper.number_to_human(1234567890)
-          assert_equal "1.23 Trillion", number_helper.number_to_human(1234567890123)
-          assert_equal "1.23 Quadrillion", number_helper.number_to_human(1234567890123456)
-          assert_equal "1230 Quadrillion", number_helper.number_to_human(1234567890123456789)
-          assert_equal "490 Thousand", number_helper.number_to_human(489939, precision: 2)
-          assert_equal "489.9 Thousand", number_helper.number_to_human(489939, precision: 4)
-          assert_equal "489 Thousand", number_helper.number_to_human(489000, precision: 4)
-          assert_equal "480 Thousand", number_helper.number_to_human(489939, precision: 2, round_mode: :down)
-          assert_equal "489.0 Thousand", number_helper.number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
-          assert_equal "1.2346 Million", number_helper.number_to_human(1234567, precision: 4, significant: false)
-          assert_equal "1,2 Million", number_helper.number_to_human(1234567, precision: 1, significant: false, separator: ",")
-          assert_equal "1 Million", number_helper.number_to_human(1234567, precision: 0, significant: true, separator: ",") # significant forced to false
-          assert_equal "1 Million", number_helper.number_to_human(999999)
-          assert_equal "1 Billion", number_helper.number_to_human(999999999)
+          assert_equal "1.23 thousand", number_helper.number_to_human(1234)
+          assert_equal "12.3 thousand", number_helper.number_to_human(12345)
+          assert_equal "1.23 million", number_helper.number_to_human(1234567)
+          assert_equal "1.23 billion", number_helper.number_to_human(1234567890)
+          assert_equal "1.23 trillion", number_helper.number_to_human(1234567890123)
+          assert_equal "1.23 quadrillion", number_helper.number_to_human(1234567890123456)
+          assert_equal "1230 quadrillion", number_helper.number_to_human(1234567890123456789)
+          assert_equal "490 thousand", number_helper.number_to_human(489939, precision: 2)
+          assert_equal "489.9 thousand", number_helper.number_to_human(489939, precision: 4)
+          assert_equal "489 thousand", number_helper.number_to_human(489000, precision: 4)
+          assert_equal "480 thousand", number_helper.number_to_human(489939, precision: 2, round_mode: :down)
+          assert_equal "489.0 thousand", number_helper.number_to_human(489000, precision: 4, strip_insignificant_zeros: false)
+          assert_equal "1.2346 million", number_helper.number_to_human(1234567, precision: 4, significant: false)
+          assert_equal "1,2 million", number_helper.number_to_human(1234567, precision: 1, significant: false, separator: ",")
+          assert_equal "1 million", number_helper.number_to_human(1234567, precision: 0, significant: true, separator: ",") # significant forced to false
+          assert_equal "1 million", number_helper.number_to_human(999999)
+          assert_equal "1 billion", number_helper.number_to_human(999999999)
         end
       end
 
@@ -385,7 +385,7 @@ module ActiveSupport
 
       def test_number_to_human_with_custom_format
         [@instance_with_helpers, TestClassWithClassNumberHelpers, ActiveSupport::NumberHelper].each do |number_helper|
-          assert_equal "123 times Thousand", number_helper.number_to_human(123456, format: "%n times %u")
+          assert_equal "123 times thousand", number_helper.number_to_human(123456, format: "%n times %u")
           volume = { unit: "ml", thousand: "lt", million: "m3" }
           assert_equal "123.lt", number_helper.number_to_human(123456, units: volume, format: "%n.%u")
         end

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -340,8 +340,8 @@ number_to_currency(1234567890.50) # => $1,234,567,890.50
 Pretty prints (formats and approximates) a number so it is more readable by users; useful for numbers that can get very large.
 
 ```ruby
-number_to_human(1234)    # => 1.23 Thousand
-number_to_human(1234567) # => 1.23 Million
+number_to_human(1234)    # => 1.23 thousand
+number_to_human(1234567) # => 1.23 million
 ```
 
 #### number_to_human_size

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2077,7 +2077,7 @@ Produce a string representation of a number rounded to a precision:
 Produce a string representation of a number as a human-readable number of bytes:
 
 ```ruby
-123.to_fs(:human_size)                  # => 123 Bytes
+123.to_fs(:human_size)                  # => 123 bytes
 1234.to_fs(:human_size)                 # => 1.21 KB
 12345.to_fs(:human_size)                # => 12.1 KB
 1234567.to_fs(:human_size)              # => 1.18 MB
@@ -2091,12 +2091,12 @@ Produce a string representation of a number in human-readable words:
 
 ```ruby
 123.to_fs(:human)               # => "123"
-1234.to_fs(:human)              # => "1.23 Thousand"
-12345.to_fs(:human)             # => "12.3 Thousand"
-1234567.to_fs(:human)           # => "1.23 Million"
-1234567890.to_fs(:human)        # => "1.23 Billion"
-1234567890123.to_fs(:human)     # => "1.23 Trillion"
-1234567890123456.to_fs(:human)  # => "1.23 Quadrillion"
+1234.to_fs(:human)              # => "1.23 thousand"
+12345.to_fs(:human)             # => "12.3 thousand"
+1234567.to_fs(:human)           # => "1.23 million"
+1234567890.to_fs(:human)        # => "1.23 billion"
+1234567890123.to_fs(:human)     # => "1.23 trillion"
+1234567890123456.to_fs(:human)  # => "1.23 quadrillion"
 ```
 
 NOTE: Defined in `active_support/core_ext/numeric/conversions.rb`.


### PR DESCRIPTION
The number helper uses Title Case for formatting byte sizes (e.g. “4 Bytes”) and human numbers (e.g. “5 Million”). This style is not suitable for use in inline text.

I suggest changing this to lowercase (“4 bytes” and “5 million”). If you want to use it in a title, you can easily run `.titleize`. You cannot just run `.downcase` on the existing strings, because that would also affect words which must be written in uppercase such as “MB” (megabyte).

The most flexible is to store words in the casing used in a dictionary and then convert it to the requested form at display time.