### PR TITLE
Use double quotes more consistenly in doc and error messages

### DIFF
--- a/actionpack/lib/action_controller/template_assertions.rb
+++ b/actionpack/lib/action_controller/template_assertions.rb
@@ -4,8 +4,8 @@ module ActionController
   module TemplateAssertions # :nodoc:
     def assert_template(options = {}, message = nil)
       raise NoMethodError,
-        "assert_template has been extracted to a gem. To continue using it,
-        add `gem 'rails-controller-testing'` to your Gemfile."
+        'assert_template has been extracted to a gem. To continue using it,
+        add `gem "rails-controller-testing"` to your Gemfile.'
     end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -29,7 +29,7 @@
         </table>
       </div>
       <%- unless self.error_highlight_available? -%>
-        <p class="error_highlight_tip">Tip: You may want to add <code>gem 'error_highlight', '&gt;= 0.4.0'</code> into your Gemfile, which will display the fine-grained error location.</p>
+        <p class="error_highlight_tip">Tip: You may want to add <code>gem "error_highlight", "&gt;= 0.4.0"</code> into your Gemfile, which will display the fine-grained error location.</p>
       <%- end -%>
     </div>
   <% end %>

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -30,8 +30,8 @@ module ActionDispatch
 
     def assigns(key = nil)
       raise NoMethodError,
-        "assigns has been extracted to a gem. To continue using it,
-        add `gem 'rails-controller-testing'` to your Gemfile."
+        'assigns has been extracted to a gem. To continue using it,
+        add `gem "rails-controller-testing"` to your Gemfile.'
     end
 
     def session

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -41,7 +41,7 @@ module ActiveModel
       #
       # To use +has_secure_password+, add bcrypt (~> 3.1.7) to your Gemfile:
       #
-      #   gem 'bcrypt', '~> 3.1.7'
+      #   gem "bcrypt", "~> 3.1.7"
       #
       # ==== Examples
       #

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -5,7 +5,7 @@ begin
 rescue LoadError
   raise LoadError, <<~ERROR.squish
     Generating image variants require the image_processing gem.
-    Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
+    Please add `gem "image_processing", "~> 1.2"` to your Gemfile.
   ERROR
 end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -89,7 +89,7 @@ module ActiveSupport
       begin
         TZInfo::DataSource.get
       rescue TZInfo::DataSourceNotFound => e
-        raise e.exception "tzinfo-data is not present. Please add gem 'tzinfo-data' to your Gemfile and run bundle install"
+        raise e.exception('tzinfo-data is not present. Please add gem "tzinfo-data" to your Gemfile and run bundle install')
       end
       require "active_support/core_ext/time/zones"
       Time.zone_default = Time.find_zone!(app.config.time_zone)

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   # = \XmlMini
   #
   # To use the much faster libxml parser:
-  #   gem 'libxml-ruby'
+  #   gem "libxml-ruby"
   #   XmlMini.backend = 'LibXML'
   module XmlMini
     extend self

--- a/guides/source/3_1_release_notes.md
+++ b/guides/source/3_1_release_notes.md
@@ -37,18 +37,18 @@ The following changes are meant for upgrading your application to Rails 3.1.3, t
 Make the following changes to your `Gemfile`.
 
 ```ruby
-gem 'rails', '= 3.1.3'
-gem 'mysql2'
+gem "rails", "= 3.1.3"
+gem "mysql2"
 
 # Needed for the new asset pipeline
 group :assets do
-  gem 'sass-rails',   "~> 3.1.5"
-  gem 'coffee-rails', "~> 3.1.1"
-  gem 'uglifier',     ">= 1.0.3"
+  gem "sass-rails",   "~> 3.1.5"
+  gem "coffee-rails", "~> 3.1.1"
+  gem "uglifier",     ">= 1.0.3"
 end
 
 # jQuery is the default JavaScript library in Rails 3.1
-gem 'jquery-rails'
+gem "jquery-rails"
 ```
 
 #### config/application.rb

--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -179,7 +179,7 @@ change your code to use the explicit form (`render file: "foo/bar"`) instead.
 
 `respond_with` and the corresponding class-level `respond_to` have been moved
 to the [responders](https://github.com/plataformatec/responders) gem. Add
-`gem 'responders', '~> 2.0'` to your `Gemfile` to use it:
+`gem "responders", "~> 2.0"` to your `Gemfile` to use it:
 
 ```ruby
 # app/controllers/users_controller.rb
@@ -445,7 +445,7 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 ### Removals
 
 *   `respond_with` and the class-level `respond_to` have been removed from Rails and
-    moved to the `responders` gem (version 2.0). Add `gem 'responders', '~> 2.0'`
+    moved to the `responders` gem (version 2.0). Add `gem "responders", "~> 2.0"`
     to your `Gemfile` to continue using these features.
     ([Pull Request](https://github.com/rails/rails/pull/16526),
      [More Details](https://guides.rubyonrails.org/v4.2/upgrading_ruby_on_rails.html#responders))

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -152,7 +152,7 @@ It's similar to Builder but is used to generate JSON, instead of XML.
 If you don't have it, you can add the following to your `Gemfile`:
 
 ```ruby
-gem 'jbuilder'
+gem "jbuilder"
 ```
 
 A Jbuilder object named `json` is automatically made available to templates with

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -805,5 +805,5 @@ You can use `ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags` to configu
 For example, to exclude comments from your structure dump, add this to an initializer:
 
 ```ruby
-ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = ['--no-comments']
+ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = ["--no-comments"]
 ```

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -139,7 +139,7 @@ NOTE: Defined in `active_support/core_ext/object/blank.rb`.
 The [`presence`][Object#presence] method returns its receiver if `present?`, and `nil` otherwise. It is useful for idioms like this:
 
 ```ruby
-host = config[:host].presence || 'localhost'
+host = config[:host].presence || "localhost"
 ```
 
 NOTE: Defined in `active_support/core_ext/object/blank.rb`.
@@ -179,20 +179,20 @@ NOTE: Defined in `active_support/core_ext/object/duplicable.rb`.
 The [`deep_dup`][Object#deep_dup] method returns a deep copy of a given object. Normally, when you `dup` an object that contains other objects, Ruby does not `dup` them, so it creates a shallow copy of the object. If you have an array with a string, for example, it will look like this:
 
 ```ruby
-array     = ['string']
+array     = ["string"]
 duplicate = array.dup
 
-duplicate.push 'another-string'
+duplicate.push "another-string"
 
 # the object was duplicated, so the element was added only to the duplicate
-array     # => ['string']
-duplicate # => ['string', 'another-string']
+array     # => ["string"]
+duplicate # => ["string", "another-string"]
 
-duplicate.first.gsub!('string', 'foo')
+duplicate.first.gsub!("string", "foo")
 
 # first element was not duplicated, it will be changed in both arrays
-array     # => ['foo']
-duplicate # => ['foo', 'another-string']
+array     # => ["foo"]
+duplicate # => ["foo, "another-string"]
 ```
 
 As you can see, after duplicating the `Array` instance, we got another object, therefore we can modify it and the original object will stay unchanged. This is not true for array's elements, however. Since `dup` does not make a deep copy, the string inside the array is still the same object.
@@ -200,13 +200,13 @@ As you can see, after duplicating the `Array` instance, we got another object, t
 If you need a deep copy of an object, you should use `deep_dup`. Here is an example:
 
 ```ruby
-array     = ['string']
+array     = ["string"]
 duplicate = array.deep_dup
 
-duplicate.first.gsub!('string', 'foo')
+duplicate.first.gsub!("string", "foo")
 
-array     # => ['string']
-duplicate # => ['foo']
+array     # => ["string"]
+duplicate # => ["foo"]
 ```
 
 If the object is not duplicable, `deep_dup` will just return it:
@@ -242,8 +242,8 @@ Another example is this code from `ActiveRecord::ConnectionAdapters::AbstractAda
 ```ruby
 def log_info(sql, name, ms)
   if @logger.try(:debug?)
-    name = '%s (%.1fms)' % [name || 'SQL', ms]
-    @logger.debug(format_log_entry(name, sql.squeeze(' ')))
+    name = "%s (%.1fms)" % [name || "SQL", ms]
+    @logger.debug(format_log_entry(name, sql.squeeze(" ")))
   end
 end
 ```
@@ -372,13 +372,13 @@ end
 we get:
 
 ```ruby
-current_user.to_query('user') # => "user=357-john-smith"
+current_user.to_query("user") # => "user=357-john-smith"
 ```
 
 This method escapes whatever is needed, both for the key and the value:
 
 ```ruby
-account.to_query('company[name]')
+account.to_query("company[name]")
 # => "company%5Bname%5D=Johnson+%26+Johnson"
 ```
 
@@ -387,7 +387,7 @@ so its output is ready to be used in a query string.
 Arrays return the result of applying `to_query` to each element with `key[]` as key, and join the result with "&":
 
 ```ruby
-[3.4, -45.6].to_query('sample')
+[3.4, -45.6].to_query("sample")
 # => "sample%5B%5D=3.4&sample%5B%5D=-45.6"
 ```
 
@@ -400,7 +400,7 @@ Hashes also respond to `to_query` but with a different signature. If no argument
 The method [`Hash#to_query`][Hash#to_query] accepts an optional namespace for the keys:
 
 ```ruby
-{ id: 89, name: "John Smith" }.to_query('user')
+{ id: 89, name: "John Smith" }.to_query("user")
 # => "user%5Bid%5D=89&user%5Bname%5D=John+Smith"
 ```
 
@@ -1201,7 +1201,7 @@ The method [`truncate`][String#truncate] returns a copy of its receiver truncate
 Ellipsis can be customized with the `:omission` option:
 
 ```ruby
-"Oh dear! Oh dear! I shall be late!".truncate(20, omission: '&hellip;')
+"Oh dear! Oh dear! I shall be late!".truncate(20, omission: "&hellip;")
 # => "Oh dear! Oh &hellip;"
 ```
 
@@ -1212,7 +1212,7 @@ Pass a `:separator` to truncate the string at a natural break:
 ```ruby
 "Oh dear! Oh dear! I shall be late!".truncate(18)
 # => "Oh dear! Oh dea..."
-"Oh dear! Oh dear! I shall be late!".truncate(18, separator: ' ')
+"Oh dear! Oh dear! I shall be late!".truncate(18, separator: " ")
 # => "Oh dear! Oh..."
 ```
 
@@ -1261,14 +1261,14 @@ The method [`truncate_words`][String#truncate_words] returns a copy of its recei
 Ellipsis can be customized with the `:omission` option:
 
 ```ruby
-"Oh dear! Oh dear! I shall be late!".truncate_words(4, omission: '&hellip;')
+"Oh dear! Oh dear! I shall be late!".truncate_words(4, omission: "&hellip;")
 # => "Oh dear! Oh dear!&hellip;"
 ```
 
 Pass a `:separator` to truncate the string at a natural break:
 
 ```ruby
-"Oh dear! Oh dear! I shall be late!".truncate_words(3, separator: '!')
+"Oh dear! Oh dear! I shall be late!".truncate_words(3, separator: "!")
 # => "Oh dear! Oh dear! I shall be late..."
 ```
 
@@ -1812,7 +1812,7 @@ The capitalization of the first word can be turned off by setting the
 If "SSL" was defined to be an acronym:
 
 ```ruby
-'ssl_error'.humanize # => "SSL error"
+"ssl_error".humanize # => "SSL error"
 ```
 
 The helper method `full_messages` uses `humanize` as a fallback to include
@@ -1825,7 +1825,7 @@ end
 
 def full_message
   # ...
-  attr_name = attribute.to_s.tr('.', '_').humanize
+  attr_name = attribute.to_s.tr(".", "_").humanize
   attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
   # ...
 end
@@ -2048,7 +2048,7 @@ Produce a string representation of a number as a percentage:
 # => 100.000%
 100.to_fs(:percentage, precision: 0)
 # => 100%
-1000.to_fs(:percentage, delimiter: '.', separator: ',')
+1000.to_fs(:percentage, delimiter: ".", separator: ",")
 # => 1.000,000%
 302.24398923423.to_fs(:percentage, precision: 5)
 # => 302.24399%
@@ -2208,7 +2208,7 @@ It iterates through the collection and passes each element to a block. The eleme
 
 ```ruby
 invoices.index_by(&:number)
-# => {'2009-032' => <Invoice ...>, '2009-008' => <Invoice ...>, ...}
+# => {"2009-032" => <Invoice ...>, "2009-008" => <Invoice ...>, ...}
 ```
 
 WARNING. Keys should normally be unique. If the block returns the same value for different elements no collection is built for that key. The last item will win.
@@ -3024,7 +3024,7 @@ NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
 The method [`deep_transform_values`][Hash#deep_transform_values] returns a new hash with all values converted by the block operation. This includes the values from the root hash and from all nested hashes and arrays.
 
 ```ruby
-hash = { person: { name: 'Rob', age: '28' } }
+hash = { person: { name: "Rob", age: "28" } }
 
 hash.deep_transform_values { |value| value.to_s.upcase }
 # => {person: {name: "ROB", age: "28"}}
@@ -3097,8 +3097,8 @@ The method [`multiline?`][Regexp#multiline?] says whether a regexp has the `/m` 
 %r{.}.multiline?  # => false
 %r{.}m.multiline? # => true
 
-Regexp.new('.').multiline?                    # => false
-Regexp.new('.', Regexp::MULTILINE).multiline? # => true
+Regexp.new(".").multiline?                    # => false
+Regexp.new(".", Regexp::MULTILINE).multiline? # => true
 ```
 
 Rails uses this method in a single place, also in the routing code. Multiline regexps are disallowed for route requirements and this flag eases enforcing that constraint.

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -522,13 +522,13 @@ was rescued.
 To get started, add the redis gem to your Gemfile:
 
 ```ruby
-gem 'redis'
+gem "redis"
 ```
 
 Finally, add the configuration in the relevant `config/environments/*.rb` file:
 
 ```ruby
-config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"] }
 ```
 
 A more complex, production Redis cache store may look something like this:

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3681,7 +3681,7 @@ evented file system monitor to detect changes when reloading is enabled:
 
 ```ruby
 group :development do
-  gem 'listen', '~> 3.5'
+  gem "listen", "~> 3.5"
 end
 ```
 

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -151,7 +151,7 @@ When you include the engine into an application later on, you will do so with
 this line in the Rails application's `Gemfile`:
 
 ```ruby
-gem 'blorgh', path: 'engines/blorgh'
+gem "blorgh", path: "engines/blorgh"
 ```
 
 Don't forget to run `bundle install` as usual. By specifying it as a gem within
@@ -626,14 +626,14 @@ Usually, specifying the engine inside the `Gemfile` would be done by specifying 
 as a normal, everyday gem.
 
 ```ruby
-gem 'devise'
+gem "devise"
 ```
 
 However, because you are developing the `blorgh` engine on your local machine,
 you will need to specify the `:path` option in your `Gemfile`:
 
 ```ruby
-gem 'blorgh', path: 'engines/blorgh'
+gem "blorgh", path: "engines/blorgh"
 ```
 
 Then run `bundle` to install the gem.

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1351,7 +1351,7 @@ steps.
 To get started, add the rack-cors gem to your Gemfile:
 
 ```ruby
-gem 'rack-cors'
+gem "rack-cors"
 ```
 
 Next, add an initializer to configure the middleware:

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1292,7 +1292,7 @@ The `app:update` command sets it up in `boot.rb`. If you want to use it, then ad
 
 ```ruby
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', require: false
+gem "bootsnap", require: false
 ```
 
 Otherwise change the `boot.rb` to not use bootsnap.
@@ -1443,7 +1443,7 @@ See [#19034](https://github.com/rails/rails/pull/19034) for more details.
 #### Extraction of some helper methods to `rails-controller-testing`
 
 `assigns` and `assert_template` have been extracted to the `rails-controller-testing` gem. To
-continue using these methods in your controller tests, add `gem 'rails-controller-testing'` to
+continue using these methods in your controller tests, add `gem "rails-controller-testing"` to
 your `Gemfile`.
 
 If you are using RSpec for testing, please see the extra configuration required in the gem's
@@ -1475,7 +1475,7 @@ production, set `Rails.application.config.enable_dependency_loading` to true.
 ### XML Serialization
 
 `ActiveModel::Serializers::Xml` has been extracted from Rails to the `activemodel-serializers-xml`
-gem. To continue using XML serialization in your application, add `gem 'activemodel-serializers-xml'`
+gem. To continue using XML serialization in your application, add `gem "activemodel-serializers-xml"`
 to your `Gemfile`.
 
 ### Removed Support for Legacy `mysql` Database Adapter
@@ -1547,7 +1547,7 @@ You can now just call the dependency once with a wildcard.
 `content_tag_for` and `div_for` have been removed in favor of just using `content_tag`. To continue using the older methods, add the `record_tag_helper` gem to your `Gemfile`:
 
 ```ruby
-gem 'record_tag_helper', '~> 1.0'
+gem "record_tag_helper", "~> 1.0"
 ```
 
 See [#18411](https://github.com/rails/rails/pull/18411) for more details.
@@ -1715,11 +1715,11 @@ Upgrading from Rails 4.1 to Rails 4.2
 
 ### Web Console
 
-First, add `gem 'web-console', '~> 2.0'` to the `:development` group in your `Gemfile` and run `bundle install` (it won't have been included when you upgraded Rails). Once it's been installed, you can simply drop a reference to the console helper (i.e., `<%= console %>`) into any view you want to enable it for. A console will also be provided on any error page you view in your development environment.
+First, add `gem "web-console", "~> 2.0"` to the `:development` group in your `Gemfile` and run `bundle install` (it won't have been included when you upgraded Rails). Once it's been installed, you can simply drop a reference to the console helper (i.e., `<%= console %>`) into any view you want to enable it for. A console will also be provided on any error page you view in your development environment.
 
 ### Responders
 
-`respond_with` and the class-level `respond_to` methods have been extracted to the `responders` gem. To use them, simply add `gem 'responders', '~> 2.0'` to your `Gemfile`. Calls to `respond_with` and `respond_to` (again, at the class level) will no longer work without having included the `responders` gem in your dependencies:
+`respond_with` and the class-level `respond_to` methods have been extracted to the `responders` gem. To use them, simply add `gem "responders", "~> 2.0"` to your `Gemfile`. Calls to `respond_with` and `respond_to` (again, at the class level) will no longer work without having included the `responders` gem in your dependencies:
 
 ```ruby
 # app/controllers/users_controller.rb
@@ -1868,7 +1868,7 @@ can gain complete control over when and how elements should be stripped.
 If your application needs to use the old sanitizer implementation, include `rails-deprecated_sanitizer` in your `Gemfile`:
 
 ```ruby
-gem 'rails-deprecated_sanitizer'
+gem "rails-deprecated_sanitizer"
 ```
 
 ### Rails DOM Testing
@@ -1963,7 +1963,7 @@ you must now explicitly skip CSRF protection on those actions.
 
 If you want to use Spring as your application preloader you need to:
 
-1. Add `gem 'spring', group: :development` to your `Gemfile`.
+1. Add `gem "spring", group: :development` to your `Gemfile`.
 2. Install spring using `bundle install`.
 3. Generate the Spring binstub with `bundle exec spring binstub`.
 
@@ -2571,7 +2571,7 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 
 * Rails 4.0 changes the default `layout` lookup set using symbols or procs that return nil. To get the "no layout" behavior, return false instead of nil.
 
-* Rails 4.0 changes the default memcached client from `memcache-client` to `dalli`. To upgrade, simply add `gem 'dalli'` to your `Gemfile`.
+* Rails 4.0 changes the default memcached client from `memcache-client` to `dalli`. To upgrade, simply add `gem "dalli"` to your `Gemfile`.
 
 * Rails 4.0 deprecates the `dom_id` and `dom_class` methods in controllers (they are fine in views). You will need to include the `ActionView::RecordIdentifier` module in controllers requiring this feature.
 
@@ -2710,12 +2710,12 @@ The following changes are meant for upgrading your application to the latest
 Make the following changes to your `Gemfile`.
 
 ```ruby
-gem 'rails', '3.2.21'
+gem "rails", "3.2.21"
 
 group :assets do
-  gem 'sass-rails',   '~> 3.2.6'
-  gem 'coffee-rails', '~> 3.2.2'
-  gem 'uglifier',     '>= 1.0.3'
+  gem "sass-rails",   "~> 3.2.6"
+  gem "coffee-rails", "~> 3.2.2"
+  gem "uglifier",     ">= 1.0.3"
 end
 ```
 
@@ -2761,18 +2761,18 @@ The following changes are meant for upgrading your application to Rails 3.1.12, 
 Make the following changes to your `Gemfile`.
 
 ```ruby
-gem 'rails', '3.1.12'
-gem 'mysql2'
+gem "rails", "3.1.12"
+gem "mysql2"
 
 # Needed for the new asset pipeline
 group :assets do
-  gem 'sass-rails',   '~> 3.1.7'
-  gem 'coffee-rails', '~> 3.1.1'
-  gem 'uglifier',     '>= 1.0.3'
+  gem "sass-rails",   "~> 3.1.7"
+  gem "coffee-rails", "~> 3.1.1"
+  gem "uglifier",     ">= 1.0.3"
 end
 
 # jQuery is the default JavaScript library in Rails 3.1
-gem 'jquery-rails'
+gem "jquery-rails"
 ```
 
 ### config/application.rb
@@ -2781,7 +2781,7 @@ The asset pipeline requires the following additions:
 
 ```ruby
 config.assets.enabled = true
-config.assets.version = '1.0'
+config.assets.version = "1.0"
 ```
 
 If your application is using an "/assets" route for a resource you may want to change the prefix used for assets to avoid conflicts:

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -180,7 +180,7 @@ module Rails
 
       gemfile_in_app_path = File.join(rails_app_path, "Gemfile")
       if File.exist? gemfile_in_app_path
-        entry = "\ngem '#{name}', path: '#{relative_path}'"
+        entry = %{\ngem "#{name}", path: "#{relative_path}"}
         append_file gemfile_in_app_path, entry
       end
     end

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -13,7 +13,7 @@ module Rails
           setup do
             copy_gemfile <<~ENTRY
               # Use sqlite3 as the database for Active Record
-              gem 'sqlite3'
+              gem "sqlite3"
             ENTRY
 
             copy_dockerfile

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -710,7 +710,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
       run_generator
 
-      assert_file gemfile_path, /^gem 'bukkits', path: 'tmp\/bukkits'/
+      assert_file gemfile_path, /^gem "bukkits", path: "tmp\/bukkits"/
     end
   end
 
@@ -719,7 +719,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       FileUtils.cd(destination_root)
       run_generator ["bukkits"]
 
-      assert_file gemfile_path, /gem 'bukkits', path: 'bukkits'/
+      assert_file gemfile_path, /gem "bukkits", path: "bukkits"/
     end
   end
 
@@ -728,7 +728,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       run_generator [destination_root, "--skip-gemfile-entry"]
 
       assert_file gemfile_path do |contents|
-        assert_no_match(/gem 'bukkits', path: 'tmp\/bukkits'/, contents)
+        assert_no_match(/gem "bukkits", path: "tmp\/bukkits"/, contents)
       end
     end
   end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -44,8 +44,8 @@ module RailtiesTests
           f.write <<-GEMFILE.gsub(/^ {12}/, "")
             source "https://rubygems.org"
 
-            gem 'rails', path: '#{RAILS_FRAMEWORK_ROOT}'
-            gem 'sqlite3'
+            gem "rails", path: "#{RAILS_FRAMEWORK_ROOT}"
+            gem "sqlite3"
           GEMFILE
         end
       end

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -214,8 +214,8 @@ namespace :all do
     end
 
     # Replace the generated gemfile entry with the exact version.
-    substitute.call("Gemfile", /^gem 'rails.*/, "gem 'rails', '#{version}'")
-    substitute.call("Gemfile", /^# gem 'image_processing/, "gem 'image_processing")
+    substitute.call("Gemfile", /^gem "rails.*/, %{gem "rails", "#{version}"})
+    substitute.call("Gemfile", /^# gem "image_processing/, 'gem "image_processing')
     sh "bundle"
     sh "rails action_mailbox:install"
     sh "rails action_text:install"


### PR DESCRIPTION
For better or worse, the Rails guide settled on double quotes and a large part of the community also use rubocop which enforce them by default.

So we might as well try to follow that style when providing code snippets in the documentation or error messages.

Fix: https://github.com/rails/rails/issues/49822

I certainly didn't get them all, but consistency should be significantly improved.
