### PR TITLE
Ignore inline attachments and show attached emails in attachment list

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   In Action Mailer previews, list inline attachments separately from normal
+    attachments. For example, attachments that were previously listed like
+
+      > Attachments: logo.png file1.pdf file2.pdf
+
+    will now be listed like
+
+      > Attachments: file1.pdf file2.pdf (Inline: logo.png)
+
+    *Christian Schmidt* and *Jonathan Hefner*
+
 *   In mailer preview, only show SMTP-To if it differs from the union of To, Cc and Bcc.
 
     *Christian Schmidt*

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -98,12 +98,16 @@
     <dt>Subject:</dt>
     <dd><strong id="subject"><%= @email.subject %></strong></dd>
 
-    <% unless @email.attachments.nil? || @email.attachments.empty? %>
+    <% if @attachments.any? || @inline_attachments.any? %>
       <dt>Attachments:</dt>
       <dd>
-        <% @email.attachments.each do |a| %>
-          <% filename = a.respond_to?(:original_filename) ? a.original_filename : a.filename %>
-          <%= link_to filename, "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(a.body.to_s)}", download: filename %>
+        <% @attachments.each do |filename, attachment| %>
+          <%= link_to filename, attachment_url(attachment), download: filename %>
+        <% end %>
+
+        <% if @inline_attachments.any? %>
+          (Inline: <% @inline_attachments.each do |filename, attachment| %>
+            <%= link_to filename, attachment_url(attachment), download: filename %><% end %>)
         <% end %>
       </dd>
     <% end %>

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -771,7 +771,10 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe name="messageBody"], last_response.body
+      assert_match %[<iframe name="messageBody"], last_response.body
+      assert_match %[<dt>Attachments:</dt>], last_response.body
+      assert_no_match %[Inline:], last_response.body
+      assert_match %[<a download="pixel.png" href="data:application/octet-stream;charset=utf-8;base64,iVBORw0K], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -819,7 +822,10 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe name="messageBody"], last_response.body
+      assert_match %[<iframe name="messageBody"], last_response.body
+      assert_match %[<dt>Attachments:</dt>], last_response.body
+      assert_no_match %[Inline:], last_response.body
+      assert_match %[<a download="pixel.png" href="data:application/octet-stream;charset=utf-8;base64,iVBORw0K], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -838,7 +844,7 @@ module ApplicationTests
           default from: "from@example.com"
 
           def foo
-            attachments['pixel.png'] = File.binread("#{app_path}/public/images/pixel.png")
+            attachments.inline['pixel.png'] = File.binread("#{app_path}/public/images/pixel.png")
             mail to: "to@example.org"
           end
         end
@@ -865,7 +871,9 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe name="messageBody"], last_response.body
+      assert_match %[<iframe name="messageBody"], last_response.body
+      assert_match %[<dt>Attachments:</dt>], last_response.body
+      assert_match %r[\(Inline:\s+<a download="pixel.png" href="data:application/octet-stream;charset=utf-8;base64,iVBORw0K], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -875,6 +883,10 @@ module ApplicationTests
       assert_equal 200, last_response.status
       assert_match %r[<p>Hello, World!</p>], last_response.body
       assert_match %r[src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEWzIioca/JlAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJgggo="], last_response.body
+
+      get "/rails/mailers/download/notifier/foo"
+      email = Mail.read_from_string(last_response.body)
+      assert_equal "inline; filename=pixel.png", email.attachments.inline["pixel.png"].content_disposition
     end
 
     test "multipart mailer preview with attached email" do
@@ -923,7 +935,10 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe name="messageBody"], last_response.body
+      assert_match %[<iframe name="messageBody"], last_response.body
+      assert_match %[<dt>Attachments:</dt>], last_response.body
+      assert_no_match %[Inline:], last_response.body
+      assert_match %[<a download="message.eml" href="data:application/octet-stream;charset=utf-8;base64,RGF0ZTog], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status


### PR DESCRIPTION
This PR fixes two issues with the mailer preview:
- Do not list inline attachments in the attachment list. This is similar to what most email clients do.
- Show attached emails in the attachment list. TIL that `mail.attachments` includes any files attached inside the attached email, but it does not include the message/rfc822 part itself.
