### PR TITLE
Remove respond_to? in assign_attribute happy path

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -45,8 +45,10 @@ module ActiveModel
 
       def _assign_attribute(k, v)
         setter = :"#{k}="
+        public_send(setter, v)
+      rescue NoMethodError
         if respond_to?(setter)
-          public_send(setter, v)
+          raise
         else
           raise UnknownAttributeError.new(self, k.to_s)
         end


### PR DESCRIPTION
### Motivation / Background

Kernel#respond_to? is generally slow, and so it should be avoided especially in hot loops. In this case, assign_attributes ends up calling respond_to? for each attribute being assigned. The purpose of the check here is to raise UnknownAttributeError when the attribute setter method doesn't exist.

### Detail

This commit moves the respond_to? inside a rescue. For a single attribute being assigned, the performance is about the same. However, the performance is ~10% better for 10 attributes being assigned and ~30% better for 100 attributes. There is a tradeoff here since using rescue for control flow is generally not good for performance, however in this case the ~10% decrease in performance only applies to the exceptional case when attempting to assign an unknown attribute.

This also partially reverts a225d4bec51778d99ccba5f0d6700dd00d2474f4. The commit message doesn't have much info so it's unclear to me why this was changed.

Benchmark:

```
require "active_record"
require "benchmark/ips"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    100.times do |i|
      t.text :"body_#{i}"
    end
  end
end

class Post < ActiveRecord::Base
end

one_attribute = { "body_1" => "1" }
ten_attributes = {}
hundered_attributes = {}

invalid_attribute = { "body__1" => "1" }

100.times do |i|
  ten_attributes["body_#{i}"] = i.to_s if i < 11
  hundered_attributes["body_#{i}"] = i.to_s
end

Benchmark.ips do |x|
  x.report("1 attribute") { Post.new(one_attribute) }
  x.report("10 attribute") { Post.new(ten_attributes) }
  x.report("100 attribute") { Post.new(hundered_attributes) }
  x.report("invalid attribute") do
    Post.new(invalid_attribute)
  rescue ActiveModel::UnknownAttributeError
  end
end
```

Before:

```
Warming up --------------------------------------
         1 attribute     1.090k i/100ms
        10 attribute   805.000  i/100ms
       100 attribute   251.000  i/100ms
   invalid attribute   966.000  i/100ms
Calculating -------------------------------------
         1 attribute     10.882k (± 1.3%) i/s -     54.500k in   5.009085s
        10 attribute      8.070k (± 1.2%) i/s -     41.055k in   5.088110s
       100 attribute      2.548k (± 1.6%) i/s -     12.801k in   5.026321s
   invalid attribute      9.687k (± 2.5%) i/s -     49.266k in   5.089246s
```

After:

```
Warming up --------------------------------------
         1 attribute     1.098k i/100ms
        10 attribute   884.000  i/100ms
       100 attribute   341.000  i/100ms
   invalid attribute   868.000  i/100ms
Calculating -------------------------------------
         1 attribute     11.004k (± 1.1%) i/s -     55.998k in   5.089635s
        10 attribute      8.817k (± 1.8%) i/s -     44.200k in   5.014699s
       100 attribute      3.410k (± 0.4%) i/s -     17.391k in   5.100166s
   invalid attribute      8.695k (± 0.9%) i/s -     44.268k in   5.091846s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
