### PR TITLE
Ensure `{down,up}case_first` returns non-frozen string

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -164,7 +164,7 @@ module ActiveSupport
     #   upcase_first('w')                 # => "W"
     #   upcase_first('')                  # => ""
     def upcase_first(string)
-      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
+      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : +""
     end
 
     # Converts the first character in the string to lowercase.
@@ -173,7 +173,7 @@ module ActiveSupport
     #   downcase_first('I')                          # => "i"
     #   downcase_first('')                           # => ""
     def downcase_first(string)
-      string.length > 0 ? string[0].downcase.concat(string[1..-1]) : ""
+      string.length > 0 ? string[0].downcase.concat(string[1..-1]) : +""
     end
 
     # Capitalizes all the words and replaces some characters in the string to

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -100,6 +100,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
 
   def test_downcase_first_with_empty_string
     assert_equal "", "".downcase_first
+    assert_not_predicate "".downcase_first, :frozen?
   end
 
   def test_upcase_first
@@ -112,6 +113,7 @@ class StringInflectionsTest < ActiveSupport::TestCase
 
   def test_upcase_first_with_empty_string
     assert_equal "", "".upcase_first
+    assert_not_predicate "".upcase_first, :frozen?
   end
 
   def test_camelize


### PR DESCRIPTION
Prior to this commit, `String#downcase_first` and `String#upcase_first` would return a frozen string when called on an empty string:

  ```ruby
  # BEFORE
  "foo".downcase_first.frozen? # => false
  "".downcase_first.frozen?    # => true

  # AFTER
  "foo".downcase_first.frozen? # => false
  "".downcase_first.frozen?    # => false
  ```
