### PR TITLE
Fix config.secret_key_base warning about secrets

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -477,7 +477,21 @@ module Rails
         config.secret_key_base ||= generate_local_secret
       else
         validate_secret_key_base(
-          ENV["SECRET_KEY_BASE"] || credentials.secret_key_base || secrets.secret_key_base
+          ENV["SECRET_KEY_BASE"] || credentials.secret_key_base || begin
+            secret_skb = secrets_secret_key_base
+
+            if secret_skb.equal?(config.secret_key_base)
+              config.secret_key_base
+            else
+              Rails.deprecator.warn(<<~MSG.squish)
+                Your `secret_key_base is configured in `Rails.application.secrets`,
+                which is deprecated in favor of `Rails.application.credentials` and
+                will be removed in Rails 7.2.
+              MSG
+
+              secret_skb
+            end
+          end
         )
       end
     end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -947,6 +947,20 @@ module ApplicationTests
       assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 
+    test "config.secret_key_base does not lead to a deprecation" do
+      remove_file "config/secrets.yml"
+      app_file "config/initializers/secret_token.rb", <<-RUBY
+        Rails.application.credentials.secret_key_base = nil
+        Rails.application.config.secret_key_base = "3b7cd727ee24e8444053437c36cc66c3"
+      RUBY
+
+      app "production"
+
+      assert_not_deprecated(Rails.deprecator) do
+        assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
+      end
+    end
+
     test "custom secrets saved in config/secrets.yml are loaded in app secrets" do
       app_file "config/secrets.yml", <<-YAML
         development:


### PR DESCRIPTION
### Motivation / Background

Using `config.secret_key_base` currently raises a deprecation warning when used in production because `config.secret_key_base` gets merged into the `secrets` hash instead of being looked up specifically in the `secret_key_base` method.

### Detail

This commit addresses this by not raising a deprecation warning if `secrets.secret_key_base` and `config.secret_key_base` are the same object (meaning `config.secret_key_base` was merged into `secrets).

Additionally, an improved deprecation warning is added for apps that continue to set `secret_key_base` in their secrets. The current warning is not great because it isn't directly actionable for users. Currently they will see the warning, not see `secrets` being referenced in their app, and potentially end up confused. The new warning helps users understand the actual change they need to make: not removing a reference to `secrets` but moving `secret_key_base` out of `secrets`.

### Additional Information

I based this on `main` because the deprecation hasn't been removed yet, but I can change the base to `7-1-stable` since that's really where this change should be made.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
