### PR TITLE
Support `RETURNING` clause for MariaDB

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support `RETURNING` clause for MariaDB
+
+    *fatkodima*, *Nikolay Kondratyev*
+
 *   The SQLite3 adapter now implements the `supports_deferrable_constraints?` contract
 
     Allows foreign keys to be deferred by adding the `:deferrable` key to the `foreign_key` options.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -580,7 +580,7 @@ module ActiveRecord
       end
 
       def return_value_after_insert?(column) # :nodoc:
-        column.auto_incremented_by_db?
+        column.auto_populated?
       end
 
       def async_enabled? # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -55,6 +55,14 @@ module ActiveRecord
             super unless column.auto_increment?
           end
 
+          def returning_column_values(result)
+            if supports_insert_returning?
+              result.rows.first
+            else
+              super
+            end
+          end
+
           def combine_multi_statements(total_sql)
             total_sql.each_with_object([]) do |sql, total_sql_chunks|
               previous_packet = total_sql_chunks.last

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -66,7 +66,11 @@ module ActiveRecord
           end
 
           def last_inserted_id(result)
-            @raw_connection&.last_id
+            if supports_insert_returning?
+              super
+            else
+              @raw_connection&.last_id
+            end
           end
 
           def multi_statements_enabled?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -290,10 +290,6 @@ module ActiveRecord
         { concurrently: "CONCURRENTLY" }
       end
 
-      def return_value_after_insert?(column) # :nodoc:
-        column.auto_populated?
-      end
-
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         def initialize(connection, max)
           super(max)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -202,10 +202,6 @@ module ActiveRecord
 
       alias_method :active?, :connected?
 
-      def return_value_after_insert?(column) # :nodoc:
-        column.auto_populated?
-      end
-
       alias :reset! :reconnect!
 
       # Disconnects from the database if already connected. Otherwise, this

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -26,7 +26,8 @@ module ActiveRecord
           check_if_write_query(sql)
           mark_transaction_written_if_write(sql)
 
-          raw_execute(to_sql(sql, binds), name)
+          sql, _binds = sql_for_insert(sql, pk, binds, returning)
+          raw_execute(sql, name)
         end
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
@@ -53,7 +54,11 @@ module ActiveRecord
           end
 
           def last_inserted_id(result)
-            result.last_insert_id
+            if supports_insert_returning?
+              super
+            else
+              result.last_insert_id
+            end
           end
 
           def sync_timezone_changes(conn)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -115,7 +115,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -205,7 +205,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -271,7 +271,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -173,7 +173,7 @@ class MysqlDefaultExpressionTest < ActiveRecord::TestCase
     if supports_default_expression?
       test "schema dump includes default expression" do
         output = dump_table_schema("defaults")
-        assert_match %r/t\.binary\s+"uuid",\s+limit: 36,\s+default: -> { "\(uuid\(\)\)" }/i, output
+        assert_match %r/t\.binary\s+"uuid",\s+limit: 36,\s+default: -> { "\(?uuid\(\)\)?" }/i, output
       end
     end
 

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -22,7 +22,8 @@ module AdapterHelper
       true
     elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       conn = ActiveRecord::Base.connection
-      !conn.mariadb? && conn.database_version >= "8.0.13"
+      (conn.mariadb? && conn.database_version >= "10.2.1") ||
+        (!conn.mariadb? && conn.database_version >= "8.0.13")
     end
   end
 
@@ -57,6 +58,8 @@ module AdapterHelper
     supports_optimizer_hints?
     supports_datetime_with_precision?
     supports_nulls_not_distinct?
+    supports_identity_columns?
+    supports_virtual_columns?
   ].each do |method_name|
     define_method method_name do
       ActiveRecord::Base.connection.public_send(method_name)


### PR DESCRIPTION
This is a rebased https://github.com/rails/rails/pull/49315 PR with addressed feedback.
I will need these changes for [my effort](https://github.com/rails/rails/issues/49752#issuecomment-1783439384) of supporting `uuid` data type for MySQL/MariaDB.

I added a test case which tests that dynamic database defaults are populated after the `INSERT`. `insert_all`-like methods also support `:returning`, but these are already tested https://github.com/rails/rails/blob/820fbd9102a5488f3bfcc91ec35324b7076cc83e/activerecord/test/cases/insert_all_test.rb#L90

Closes #49315.

cc @nvasilevski @adrianna-chang-shopify 