### PR TITLE
Support `uuid` type for MariaDB 10.7.0+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Support `uuid` type for MariaDB 10.7.0+
+
+    ```ruby
+    create_table :users, id: :uuid do |t| # uuid primary key
+      t.uuid :guid, default: "sys_guid()" # uuid regular column with custom default
+      # ...
+    end
+    ```
+
+    *fatkodima*
+
 *   Fix inconsistency in PostgreSQL handling of unbounded time range types
 
     Use `-infinity` rather than `NULL` for the lower value of PostgreSQL time

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -543,6 +543,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support UUID data type?
+      def supports_uuid?
+        false
+      end
+
       # Does this adapter support metadata comments on database objects (tables, columns, indexes)?
       def supports_comments?
         false

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -2,6 +2,7 @@
 
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
+require "active_record/connection_adapters/mysql/type/uuid"
 require "active_record/connection_adapters/mysql/column"
 require "active_record/connection_adapters/mysql/database_statements"
 require "active_record/connection_adapters/mysql/explain_pretty_printer"
@@ -44,6 +45,7 @@ module ActiveRecord
         blob:        { name: "blob" },
         boolean:     { name: "boolean" },
         json:        { name: "json" },
+        uuid:        { name: "uuid" },
       }
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
@@ -190,6 +192,10 @@ module ActiveRecord
         else
           database_version >= "8.0.0"
         end
+      end
+
+      def supports_uuid?
+        mariadb? && database_version >= "10.7.0"
       end
 
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -81,6 +81,14 @@ module ActiveRecord
           "x'#{value.hex}'"
         end
 
+        def quote_default_expression(value, column) # :nodoc:
+          if column.type == :uuid && value.is_a?(String) && value.include?("()")
+            value # Do not quote function default values for UUID columns
+          else
+            super
+          end
+        end
+
         def unquote_identifier(identifier)
           if identifier && identifier.start_with?("`")
             identifier[1..-2]

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -7,6 +7,45 @@ module ActiveRecord
         extend ActiveSupport::Concern
         extend ConnectionAdapters::ColumnMethods::ClassMethods
 
+        # Defines the primary key field.
+        # Use of the native MariaDB UUID type is supported, and can be used
+        # by defining your tables as such:
+        #
+        #   create_table :stuffs, id: :uuid do |t|
+        #     t.string :content
+        #     t.timestamps
+        #   end
+        #
+        # By default, this will use the <tt>uuid()</tt> function, which generates
+        # UUIDv1 values. You may also explicitly pass a different UUID generation function:
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: "sys_guid()"
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # To use a UUID primary key without any defaults, set the
+        # +:default+ option to +nil+:
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: nil
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # Note that setting the UUID primary key default value to +nil+ will
+        # require you to assure that you always provide a UUID value before saving
+        # a record (as primary keys cannot be +nil+). This might be done via the
+        # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
+        def primary_key(name, type = :primary_key, **options)
+          if type == :uuid
+            options[:default] = options.fetch(:default, "uuid()")
+          end
+
+          super
+        end
+
         ##
         # :method: blob
         # :call-seq: blob(*names, **options)
@@ -43,8 +82,12 @@ module ActiveRecord
         # :method: unsigned_bigint
         # :call-seq: unsigned_bigint(*names, **options)
 
+        ##
+        # :method: uuid
+        # :call-seq: uuid(*names, **options)
+
         define_column_methods :blob, :tinyblob, :mediumblob, :longblob,
-          :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint
+          :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint, :uuid
       end
 
       # = Active Record MySQL Adapter \Index Definition

--- a/activerecord/lib/active_record/connection_adapters/mysql/type/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type/uuid.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module Type # :nodoc:
+        class Uuid < ActiveModel::Type::Value # :nodoc:
+          ACCEPTABLE_UUID = /\A\h(-*\h-*){30}\h\z/
+
+          alias :serialize :deserialize
+
+          def type
+            :uuid
+          end
+
+          def changed?(old_value, new_value, _new_value_before_type_cast)
+            old_value.class != new_value.class ||
+              new_value && old_value.casecmp(new_value) != 0
+          end
+
+          def changed_in_place?(raw_old_value, new_value)
+            raw_old_value.class != new_value.class ||
+              new_value && raw_old_value.casecmp(new_value) != 0
+          end
+
+          private
+            def cast_value(value)
+              value = value.to_s
+              format_uuid(value) if value.match?(ACCEPTABLE_UUID)
+            end
+
+            def format_uuid(uuid)
+              uuid = uuid.delete("-").downcase
+              "#{uuid[..7]}-#{uuid[8..11]}-#{uuid[12..15]}-#{uuid[16..19]}-#{uuid[20..]}"
+            end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -48,6 +48,7 @@ module ActiveRecord
 
             m.register_type %r(^enum)i, Type.lookup(:string, adapter: :mysql2)
             m.register_type %r(^set)i,  Type.lookup(:string, adapter: :mysql2)
+            m.register_type "uuid",     MySQL::Type::Uuid.new
           end
       end
 
@@ -195,6 +196,7 @@ module ActiveRecord
         end
 
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
+        ActiveRecord::Type.register(:uuid, MySQL::Type::Uuid, adapter: :mysql2)
     end
 
     ActiveSupport.run_load_hooks(:active_record_mysql2adapter, Mysql2Adapter)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -249,6 +249,10 @@ module ActiveRecord
         true
       end
 
+      def supports_uuid?
+        true
+      end
+
       def supports_comments?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -69,6 +69,7 @@ module ActiveRecord
 
             m.register_type %r(^enum)i, Type.lookup(:string, adapter: :trilogy)
             m.register_type %r(^set)i,  Type.lookup(:string, adapter: :trilogy)
+            m.register_type "uuid",     MySQL::Type::Uuid.new
           end
       end
 
@@ -205,6 +206,7 @@ module ActiveRecord
         end
 
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :trilogy)
+        ActiveRecord::Type.register(:uuid, MySQL::Type::Uuid, adapter: :trilogy)
     end
 
     ActiveSupport.run_load_hooks(:active_record_trilogyadapter, TrilogyAdapter)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/uuid_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/uuid_test.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+if ActiveRecord::Base.connection.supports_uuid?
+  module MySQLUUIDHelper
+    def connection
+      @connection ||= ActiveRecord::Base.lease_connection
+    end
+
+    def drop_table(name)
+      connection.drop_table name, if_exists: true
+    end
+  end
+
+  class MySQLUUIDTest < ActiveRecord::AbstractMysqlTestCase
+    self.use_transactional_tests = false
+
+    include MySQLUUIDHelper
+    include SchemaDumpingHelper
+
+    class UUIDType < ActiveRecord::Base
+      self.table_name = "uuid_data_type"
+    end
+
+    def setup
+      connection.create_table("uuid_data_type", force: true) do |t|
+        t.uuid "guid"
+      end
+    end
+
+    def teardown
+      UUIDType.reset_column_information
+      connection.drop_table("uuid_data_type")
+    end
+
+    def test_uuid_column
+      column = UUIDType.columns_hash["guid"]
+      assert_equal :uuid, column.type
+      assert_equal "uuid", column.sql_type
+    end
+
+    def test_treat_blank_uuid_as_nil
+      UUIDType.create!(guid: "")
+      assert_nil UUIDType.last.guid
+    end
+
+    def test_treat_invalid_uuid_as_nil
+      uuid = UUIDType.create!(guid: "foobar")
+      assert_nil uuid.guid
+    end
+
+    def test_invalid_uuid_dont_modify_before_type_cast
+      uuid = UUIDType.new(guid: "foobar")
+      assert_equal "foobar", uuid.guid_before_type_cast
+    end
+
+    def test_invalid_uuid_dont_match_to_nil
+      UUIDType.create!
+      assert_empty UUIDType.where(guid: "")
+      assert_empty UUIDType.where(guid: "foobar")
+    end
+
+    def test_uuid_change_case_does_not_mark_dirty
+      model = UUIDType.create!(guid: "abcd-0123-4567-89ef-dead-beef-0101-1010")
+      model.guid = model.guid.swapcase
+      assert_not_predicate model, :changed?
+    end
+
+    class DuckUUID
+      def initialize(uuid)
+        @uuid = uuid
+      end
+
+      def to_s
+        @uuid
+      end
+    end
+
+    def test_acceptable_uuid_regex
+      # Valid uuids
+      ["f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4",
+        "F8AA-ED66-1A1B-11EC-AB4E-F859-713E-4BE4",
+        "f8aaed661a1b11ecab4ef859713e4be4",
+        "f8aaed66-1a1b-11ec-ab4e-f859-713e-4be4",
+        "f8aaed66-1-a---1b-11ec-ab4e-f859-713e-4be4",
+        "f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4",
+        "F8AA-ED66-1A1B-11EC-AB4E-F859-713E-4BE4",
+       DuckUUID.new("f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4"),
+      ].each do |valid_uuid|
+        uuid = UUIDType.new guid: valid_uuid
+        assert_instance_of String, uuid.guid
+      end
+
+      # Invalid uuids
+      [["F8AA-ED66-1A1B-11EC-AB4E-F859-713E-4BE4"],
+       Hash.new,
+       0,
+       0.0,
+       true,
+       "{f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4}",
+       "f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be",
+       "f8aa-ed66-1a1b-11ec-ab4e-f859-713e-4be4-"].each do |invalid_uuid|
+        uuid = UUIDType.new guid: invalid_uuid
+        assert_nil uuid.guid
+      end
+    end
+
+    def test_uuid_formats
+      ["A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11",
+       "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+       "a0eebc999c0b4ef8bb6d6bb9bd380a11",
+       "a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11"].each do |valid_uuid|
+        UUIDType.create(guid: valid_uuid)
+        uuid = UUIDType.last
+        assert_equal "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", uuid.guid
+      end
+    end
+
+    def test_schema_dump_with_shorthand
+      output = dump_table_schema("uuid_data_type")
+      assert_match %r{t\.uuid "guid"}, output
+    end
+
+    def test_uniqueness_validation_ignores_uuid
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "uuid_data_type"
+        validates :guid, uniqueness: { case_sensitive: false }
+
+        def self.name
+          "UUIDType"
+        end
+      end
+
+      record = klass.create!(guid: "a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11")
+      duplicate = klass.new(guid: record.guid)
+
+      assert_predicate record.guid, :present? # Ensure we actually are testing a UUID
+      assert_not_predicate duplicate, :valid?
+    end
+  end
+
+  class MySQLUUIDGenerationTest < ActiveRecord::AbstractMysqlTestCase
+    self.use_transactional_tests = false
+
+    include MySQLUUIDHelper
+    include SchemaDumpingHelper
+
+    class UUID < ActiveRecord::Base
+      self.table_name = "mysql_uuids"
+    end
+
+    def setup
+      connection.create_table("mysql_uuids", id: :uuid, force: true) do |t|
+        t.uuid "other_uuid", default: "uuid()"
+      end
+
+      # Create such a table with other system function as default value generator
+      connection.create_table("mysql_uuids_2", id: :uuid, default: "sys_guid()", force: true) do |t|
+        t.uuid "other_uuid_2", default: "sys_guid()"
+      end
+    end
+
+    def teardown
+      connection.drop_table("mysql_uuids")
+      connection.drop_table("mysql_uuids_2")
+    end
+
+    def test_id_is_uuid
+      column = UUID.columns_hash["id"]
+
+      assert_equal :uuid, column.type
+      assert_equal "uuid", column.sql_type
+      assert_equal "uuid()", column.default_function
+      assert UUID.primary_key
+    end
+
+    def test_defaults_are_populated
+      u = UUID.create!
+      assert_not_nil u.id
+      assert_not_nil u.other_uuid
+    end
+
+    def test_schema_dumper_for_uuid_primary_key
+      schema = dump_table_schema("mysql_uuids")
+      assert_match(/\bcreate_table "mysql_uuids", id: :uuid, default: -> { "uuid\(\)" }/, schema)
+      assert_match(/t\.uuid "other_uuid", default: -> { "uuid\(\)" }/, schema)
+    end
+
+    def test_schema_dumper_for_uuid_primary_key_with_custom_default
+      schema = dump_table_schema("mysql_uuids_2")
+      assert_match(/\bcreate_table "mysql_uuids_2", id: :uuid, default: -> { "sys_guid\(\)" }/, schema)
+      assert_match(/t\.uuid "other_uuid_2", default: -> { "sys_guid\(\)" }/, schema)
+    end
+  end
+
+  class MySQLUUIDTestInverseOf < ActiveRecord::AbstractMysqlTestCase
+    self.use_transactional_tests = false
+
+    include MySQLUUIDHelper
+
+    class UuidPost < ActiveRecord::Base
+      self.table_name = "uuid_posts"
+      has_many :uuid_comments, inverse_of: :uuid_post
+    end
+
+    class UuidComment < ActiveRecord::Base
+      self.table_name = "uuid_comments"
+      belongs_to :uuid_post
+    end
+
+    def setup
+      connection.create_table("uuid_posts", id: :uuid, force: true) do |t|
+        t.string "title"
+      end
+      connection.create_table("uuid_comments", id: :uuid, force: true) do |t|
+        t.references "uuid_post", type: :uuid
+        t.string "content"
+      end
+    end
+
+    def teardown
+      connection.drop_table("uuid_comments")
+      connection.drop_table("uuid_posts")
+    end
+
+    def test_collection_association_with_uuid
+      post = UuidPost.create!
+      comment = post.uuid_comments.create!
+      assert_equal comment, post.uuid_comments.find(comment.id)
+    end
+
+    def test_find_with_uuid
+      UuidPost.create!
+      assert_raise(ActiveRecord::RecordNotFound) do
+        UuidPost.find(123456)
+      end
+    end
+
+    def test_find_by_with_uuid
+      UuidPost.create!
+      assert_nil UuidPost.find_by(id: 789)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #49752.

MariaDB since version 10.7 natively supports [`uuid` data type](https://mariadb.com/kb/en/uuid-data-type/). Also, since 10.5 supports [`INSERT ... RETURNING`](https://mariadb.com/kb/en/insertreturning/).

This PR adds support for `uuid` type for MariaDB only.

MySQL, unfortunately, as usual does not support anything. There are some hacks on how people manually implement "uuid" data type. For example, using a `BINARY(16)` column with a `UUID_TO_BIN(UUID())` as a default or a `VARCHAR(36)` with `UUID()` as a default. See https://blogs.oracle.com/mysql/post/mysql-uuids or https://dev.mysql.com/blog-archive/mysql-8-0-uuid-support/ for detailed examples. But since MySQL does not support `RETURNING`, there is no way we can retrieve these values during the `INSERT` without the `record.reload`. Or, differently, we must manually set the uuid before creating a record.

So, the question is: Should we add also support for MySQL, expecting that people will manually set the default? 
Something like: 
```ruby
attribute :guid, :uuid, default: -> { SomeUuidGenerator.generate }
```

The added test cases are basically adopted tests for PostgreSQL uuid (https://github.com/rails/rails/blob/main/activerecord/test/cases/adapters/postgresql/uuid_test.rb).

~~Before merging this PR, https://github.com/rails/rails/pull/49840 should be merged, because these have overlapping code regarding `RETURNING` for MariaDB.~~ (done)