### PR TITLE
[7-1-stable] Quiet sqlite3_production_warning on railties/configuration_test

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -97,7 +97,9 @@ module ApplicationTests
     end
 
     def suppress_sqlite3_warning
-      add_to_config "config.active_record.sqlite3_production_warning = false"
+      add_to_config <<-RUBY
+        config.active_record.sqlite3_production_warning = false
+      RUBY
     end
 
     def restore_sqlite3_warning

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -10,7 +10,6 @@ module ApplicationTests
 
     def setup
       build_app(multi_db: true)
-      add_to_config "config.active_record.sqlite3_production_warning = false"
       rails("generate", "scaffold", "Pet", "name:string", "--database=animals")
       app_file "app/models/user.rb", <<-RUBY
         class User < ActiveRecord::Base

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -142,6 +142,7 @@ module TestHelpers
         config.active_support.deprecation = :log
         config.action_controller.allow_forgery_protection = false
         config.active_support.cache_format_version = 7.1
+        config.active_record.sqlite3_production_warning = false
       RUBY
     end
 


### PR DESCRIPTION
This warning occurs three times before this:

```
.W, [2023-10-17T19:15:46.723620 #9821]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
........W, [2023-10-17T19:15:47.315464 #9832]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
....W, [2023-10-17T19:16:03.776050 #10140]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
```

**:green_circle: Merged!**: ~This** PR is blocked by #49834 since there are now multiple settings for `config.active_record`, which results in the following errors:~

```
Error:
ApplicationTests::ConfigurationTest#test_the_application_root_can_be_set:
NoMethodError: undefined method `active_record' for #<Rails::Application::Configuration:0x000000000032c8>
    /Users/zzak/code/rails/railties/lib/rails/railtie/configuration.rb:109:in `method_missing'
    /Users/zzak/code/rails/tmp/d20231030-66254-n6lfzq/app/config/application.rb:34:in `<class:Application>'
    /Users/zzak/code/rails/tmp/d20231030-66254-n6lfzq/app/config/application.rb:10:in `<module:AppTemplate>'
    /Users/zzak/code/rails/tmp/d20231030-66254-n6lfzq/app/config/application.rb:9:in `<top (required)>'
    /Users/zzak/code/rails/tmp/d20231030-66254-n6lfzq/app/config/environment.rb:2:in `require_relative'
    /Users/zzak/code/rails/tmp/d20231030-66254-n6lfzq/app/config/environment.rb:2:in `<top (required)>'
    /Users/zzak/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
    /Users/zzak/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
    /Users/zzak/code/rails/railties/test/application/configuration_test.rb:63:in `app'
    /Users/zzak/code/rails/railties/test/application/configuration_test.rb:270:in `block in <class:ConfigurationTest>'
```
