### PR TITLE
[7-0-stable] Quiet sqlite3_production_warning on railties/configuration_test

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -89,7 +89,9 @@ module ApplicationTests
     end
 
     def suppress_sqlite3_warning
-      add_to_config "config.active_record.sqlite3_production_warning = false"
+      add_to_config <<-RUBY
+        config.active_record.sqlite3_production_warning = false
+      RUBY
     end
 
     def restore_sqlite3_warning

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -212,6 +212,7 @@ module TestHelpers
         config.cache_store = :mem_cache_store
         config.active_support.deprecation = :log
         config.action_controller.allow_forgery_protection = false
+        config.active_record.sqlite3_production_warning = false
       RUBY
     end
 


### PR DESCRIPTION
This warning occurs three times before this:

```
.W, [2023-10-17T19:15:46.723620 9821]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
........W, [2023-10-17T19:15:47.315464 9832]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
....W, [2023-10-17T19:16:03.776050 10140]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
```

This PR is blocked by #49835 since there are now multiple settings for config.active_record, which results in the following errors:

```
Error:
ApplicationTests::ConfigurationTest#test_the_application_root_can_be_set:
NoMethodError: undefined method `active_record' for #<Rails::Application::Configuration:0x00000001063d7320>
    /Users/zzak/code/rails/railties/lib/rails/railtie/configuration.rb:96:in `method_missing'
    /Users/zzak/code/rails/tmp/d20231030-68543-vf3ndb/app/config/application.rb:28:in `<class:Application>'
    /Users/zzak/code/rails/tmp/d20231030-68543-vf3ndb/app/config/application.rb:10:in `<module:AppTemplate>'
    /Users/zzak/code/rails/tmp/d20231030-68543-vf3ndb/app/config/application.rb:9:in `<top (required)>'
    /Users/zzak/code/rails/tmp/d20231030-68543-vf3ndb/app/config/environment.rb:2:in `require_relative'
    /Users/zzak/code/rails/tmp/d20231030-68543-vf3ndb/app/config/environment.rb:2:in `<top (required)>'
    <internal:/Users/zzak/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    <internal:/Users/zzak/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
    /Users/zzak/code/rails/railties/test/application/configuration_test.rb:55:in `app'
    /Users/zzak/code/rails/railties/test/application/configuration_test.rb:260:in `block in <class:ConfigurationTest>'
```
