### PR TITLE
Field name added in ArgumentError when include_blank is false for a required select field

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -14,7 +14,7 @@ module ActionView
             add_default_name_and_id(html_options)
 
             if placeholder_required?(html_options)
-              raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
+              raise ArgumentError, "include_blank cannot be false for the required field: #{html_options["name"]}" if options[:include_blank] == false
               options[:include_blank] ||= true unless options[:prompt]
             end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -760,7 +760,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     @post.category = "<mus>"
     e = assert_raises(ArgumentError) { select("post", "category", %w( abe <mus> hest), { include_blank: false }, { required: "required" }) }
-    assert_match(/include_blank cannot be false for a required field./, e.message)
+    assert_match("include_blank cannot be false for the required field: post[category]", e.message)
   end
 
   def test_select_with_blank_as_string


### PR DESCRIPTION
### Motivation / Background

As part of this https://github.com/rails/rails/pull/20124, We are raising an `ArgumentError` when `include_blank` is false for a required select field. The message is bit confusing for identifying the issue.

### Detail

This Pull Request includes the field name in the error message.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @zzak 