### PR TITLE
[Fix #48688] Duplicate callback execution when child autosaves parent with `has_one` and `belongs_to`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix duplicate callback execution when child autosaves parent with `has_one` and `belongs_to`.
+
+    Before, persisting a new child record with a new associated parent record would run `before_validation`,
+    `after_validation`, `before_save` and `after_save` callbacks twice.
+
+    Now, these callbacks are only executed once as expected.
+
+    *Joshua Young*
+
 *   `ActiveRecord::Encryption::Encryptor` now supports a `:compressor` option to customize the compression algorithm used.
 
     ```ruby

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -304,6 +304,26 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     assert_equal [false, false, false, false], eye.after_save_callbacks_stack
   end
 
+  def test_callbacks_on_child_when_parent_autosaves_child
+    eye = Eye.create(iris: Iris.new)
+    assert_equal 1, eye.iris.before_validation_callbacks_counter
+    assert_equal 1, eye.iris.before_create_callbacks_counter
+    assert_equal 1, eye.iris.before_save_callbacks_counter
+    assert_equal 1, eye.iris.after_validation_callbacks_counter
+    assert_equal 1, eye.iris.after_create_callbacks_counter
+    assert_equal 1, eye.iris.after_save_callbacks_counter
+  end
+
+  def test_callbacks_on_child_when_child_autosaves_parent
+    iris = Iris.create(eye: Eye.new)
+    assert_equal 1, iris.before_validation_callbacks_counter
+    assert_equal 1, iris.before_create_callbacks_counter
+    assert_equal 1, iris.before_save_callbacks_counter
+    assert_equal 1, iris.after_validation_callbacks_counter
+    assert_equal 1, iris.after_create_callbacks_counter
+    assert_equal 1, iris.after_save_callbacks_counter
+  end
+
   def test_foreign_key_attribute_is_not_set_unless_changed
     eye = Eye.create!(iris_with_read_only_foreign_key_attributes: { color: "honey" })
     assert_nothing_raised do

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -19,35 +19,85 @@ class Eye < ActiveRecord::Base
   after_update :trace_after_update2, if: :iris
   after_save   :trace_after_save2, if: :iris
 
-  def trace_after_create
-    (@after_create_callbacks_stack ||= []) << !iris.persisted?
-  end
-  alias trace_after_create2 trace_after_create
+  private
+    def trace_after_create
+      (@after_create_callbacks_stack ||= []) << !iris.persisted?
+    end
+    alias trace_after_create2 trace_after_create
 
-  def trace_after_update
-    (@after_update_callbacks_stack ||= []) << iris.has_changes_to_save?
-  end
-  alias trace_after_update2 trace_after_update
+    def trace_after_update
+      (@after_update_callbacks_stack ||= []) << iris.has_changes_to_save?
+    end
+    alias trace_after_update2 trace_after_update
 
-  def trace_after_save
-    (@after_save_callbacks_stack ||= []) << iris.has_changes_to_save?
-  end
-  alias trace_after_save2 trace_after_save
+    def trace_after_save
+      (@after_save_callbacks_stack ||= []) << iris.has_changes_to_save?
+    end
+    alias trace_after_save2 trace_after_save
 
-  has_one :iris_with_read_only_foreign_key, class_name: "IrisWithReadOnlyForeignKey", foreign_key: :eye_id
-  accepts_nested_attributes_for :iris_with_read_only_foreign_key
+  public
+    has_one :iris_with_read_only_foreign_key, class_name: "IrisWithReadOnlyForeignKey", foreign_key: :eye_id
+    accepts_nested_attributes_for :iris_with_read_only_foreign_key
 
-  before_save :set_iris_with_read_only_foreign_key_color_to_blue, if: -> {
-    iris_with_read_only_foreign_key && @override_iris_with_read_only_foreign_key_color
-  }
+    before_save :set_iris_with_read_only_foreign_key_color_to_blue, if: -> {
+      iris_with_read_only_foreign_key && @override_iris_with_read_only_foreign_key_color
+    }
 
-  def set_iris_with_read_only_foreign_key_color_to_blue
-    iris_with_read_only_foreign_key.color = "blue"
-  end
+  private
+    def set_iris_with_read_only_foreign_key_color_to_blue
+      iris_with_read_only_foreign_key.color = "blue"
+    end
 end
 
 class Iris < ActiveRecord::Base
+  attr_reader :before_validation_callbacks_counter
+  attr_reader :before_create_callbacks_counter
+  attr_reader :before_save_callbacks_counter
+
+  attr_reader :after_validation_callbacks_counter
+  attr_reader :after_create_callbacks_counter
+  attr_reader :after_save_callbacks_counter
+
   belongs_to :eye
+
+  before_validation :update_before_validation_counter
+  before_create :update_before_create_counter
+  before_save :update_before_save_counter
+
+  after_validation :update_after_validation_counter
+  after_create :update_after_create_counter
+  after_save :update_after_save_counter
+
+  private
+    def update_before_validation_counter
+      @before_validation_callbacks_counter ||= 0
+      @before_validation_callbacks_counter += 1
+    end
+
+    def update_before_create_counter
+      @before_create_callbacks_counter ||= 0
+      @before_create_callbacks_counter += 1
+    end
+
+    def update_before_save_counter
+      @before_save_callbacks_counter ||= 0
+      @before_save_callbacks_counter += 1
+    end
+
+    def update_after_validation_counter
+      @after_validation_callbacks_counter ||= 0
+      @after_validation_callbacks_counter += 1
+    end
+
+    def update_after_create_counter
+      @after_create_callbacks_counter ||= 0
+      @after_create_callbacks_counter += 1
+    end
+
+    def update_after_save_counter
+      @after_save_callbacks_counter ||= 0
+      @after_save_callbacks_counter += 1
+    end
 end
 
 class IrisWithReadOnlyForeignKey < Iris


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/48688

### Detail

This Pull Request updates `ActiveRecord::AutosaveAssociation#save_has_one_association` and `ActiveRecord::AutosaveAssociation#validate_single_association` to return early and not re-save the child record via autosave if the inverse association (`belongs_to`) has already set the child target, which happens after the child has been saved.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

Some additional context in https://github.com/rails/rails/issues/48688#issuecomment-1774942159.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
