### PR TITLE
Update documentation for config.public_file_server.enabled [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -500,7 +500,11 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.public_file_server.enabled`
 
-Configures Rails to serve static files from the public directory. This option defaults to `true`, but in the production environment it is set to `false` because the server software (e.g. NGINX or Apache) used to run the application should serve static files instead. If you are running or testing your app in production using WEBrick (it is not recommended to use WEBrick in production), set the option to `true`. Otherwise, you won't be able to use page caching and request for files that exist under the public directory.
+Configures whether Rails should serve static files from the public directory.
+Defaults to `true`.
+
+If the server software (e.g. NGINX or Apache) should serve static files instead,
+set this value to `false`.
 
 #### `config.railties_order`
 


### PR DESCRIPTION
### Motivation / Background

#47137 turned on static file server by default for all environments. The documentation still mentions that it's set to `false` in the production environment, which is not the case anymore. This PR changes the docs to reflect the change in the previously mentioned pull request.

### Detail

This Pull Request changes the docs for `config.public_file_server.enabled`.

### Additional information

None :)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

P.s. Sorry for forgetting to include [ci skip] in the PR title, I had to re-open the tab when writing the PR message and did not include it the second time :S

