### PR TITLE
SQLite3 transaction modes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   The SQLite3 transaction mode can now by configured
+
+    The options are `deferred` (default), `immediate`, and `exclusive`
+
+    ```yaml
+    development:
+      adapter: sqlite3
+      database: storage/development.sqlite3
+      transaction_mode: immediate
+    ```
+
+    *Donal McBreen*
+
 *   Support `RETURNING` clause for MariaDB
 
     *fatkodima*, *Nikolay Kondratyev*

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -74,9 +74,9 @@ module ActiveRecord
         end
 
         def begin_db_transaction # :nodoc:
-          log("begin transaction", "TRANSACTION") do
+          log("begin #{@transaction_mode} transaction", "TRANSACTION") do
             with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
-              conn.transaction
+              conn.transaction(@transaction_mode)
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -36,6 +36,7 @@ module ActiveRecord
     # * <tt>:database</tt> - Path to the database file.
     class SQLite3Adapter < AbstractAdapter
       ADAPTER_NAME = "SQLite"
+      TRANSACTION_MODES = [:deferred, :immediate, :exclusive]
 
       class << self
         def new_client(config)
@@ -127,6 +128,10 @@ module ActiveRecord
         @config[:strict] = ConnectionAdapters::SQLite3Adapter.strict_strings_by_default unless @config.key?(:strict)
         @connection_parameters = @config.merge(database: @config[:database].to_s, results_as_hash: true)
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
+        @transaction_mode = @config.fetch(:transaction_mode, :deferred)&.to_sym&.downcase
+        unless TRANSACTION_MODES.include?(@transaction_mode)
+          raise ArgumentError, "transaction_mode must be one of #{TRANSACTION_MODES.map(&:inspect).join(", ")} but #{@transaction_mode.inspect} was provided"
+        end
       end
 
       def database_exists?

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3105,6 +3105,17 @@ development:
   timeout: 5000
 ```
 
+SQLite supports [three different transaction modes](https://www.sqlite.org/lang_transaction.html) - `deferred`, `immediate`, and `exclusive`.
+
+NOTE: Rails enables WAL mode by default, which means that `exclusive` and `immediate` modes are identical.
+
+You can set the mode to use (the default is `deferred`):
+
+```yaml
+development:
+  transaction_mode: immediate
+```
+
 NOTE: Rails uses an SQLite3 database for data storage by default because it is a zero configuration database that just works. Rails also supports MySQL (including MariaDB) and PostgreSQL "out of the box", and has plugins for many database systems. If you are using a database in a production environment Rails most likely has an adapter for it.
 
 #### Configuring a MySQL or MariaDB Database


### PR DESCRIPTION
### Motivation / Background

SQLite3 supports three different transaction modes - DEFERRED, IMMEDIATE and EXCLUSIVE, see
https://www.sqlite.org/lang_transaction.html.

Rails currently uses the default which is DEFERRED. While this is best for read concurrency, it can lead to `SQLite3::BusyException`s when you read first and then write in the transaction.

If you only create transactions when you are planning to write, then IMMEDIATE may be a better choice, as it will block all other write transactions and prevent stale reads.

### Detail

Add a `transaction_mode` option to the SQLite database configuration to allow the transaction mode to be changed:

```yaml
development:
  adapter: sqlite3
  database: storage/development.sqlite3
  transaction_mode: immediate
```

### Additional information

SQLite3 transaction docs: https://www.sqlite.org/lang_transaction.html
SQLIte3 gem transaction method: https://github.com/sparklemotion/sqlite3-ruby/blob/e60035e8f01c13ee986ddfee501a93bd6d6394a2/lib/sqlite3/database.rb#L637-L653

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
