### PR TITLE
Remove `config.public_file_server.enabled` from environment templates

### DIFF
--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -18,7 +18,6 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -18,7 +18,6 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -18,7 +18,6 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -37,4 +37,9 @@
 
     *Steve Polito*
 
+*   Remove the option `config.public_file_server.enabled` from the generators
+    for all environments, as the value is the same in all environments.
+
+    *Adrian Hirt*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -18,7 +18,6 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -250,7 +250,6 @@ module ApplicationTests
     test "assets do not require any assets group gem when manifest file is present" do
       app_file "app/assets/javascripts/application.js", "alert();"
       app_file "app/assets/config/manifest.js", "//= link application.js"
-      add_to_env_config "production", "config.public_file_server.enabled = true"
 
       precompile! RAILS_ENV: "production"
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -695,6 +695,24 @@ module ApplicationTests
       assert_equal Pathname.new(app_path).join("somewhere"), Rails.public_path
     end
 
+    test "In development mode, config.public_file_server.enabled is on by default" do
+      restore_default_config
+
+      with_rails_env "development" do
+        app "development"
+        assert app.config.public_file_server.enabled
+      end
+    end
+
+    test "In test mode, config.public_file_server.enabled is on by default" do
+      restore_default_config
+
+      with_rails_env "test" do
+        app "test"
+        assert app.config.public_file_server.enabled
+      end
+    end
+
     test "In production mode, config.public_file_server.enabled is on by default" do
       restore_default_config
 


### PR DESCRIPTION
### Motivation / Background

#47137 turned on static file server by default for all environments.

I already opened a PR to update the documentation to reflect this change (#49848), I think it might be reasonable to remove this setting from the default generated environments. It's already absent in the `config/environments/development.rb` file, and this PR removes it from the templates for `production.rb` and `test.rb`.

### Detail

This PR removes the setting `config.public_file_server.enabled` from the `production.rb.tt` and `test.rb.tt` files, as well as from the testcases where this setting is set to `true`.

Users wishing to disable this may still set the value to `false` by including it in the respective environment config file, but I think removing this setting might make sense if it has the same value in all environments anyway.

### Additional information

As the other PR (#49848) is only concerned with updating the docs to reflect the current state of the code, I opened a separate PR here to change the code. Feel free to accept / refuse either PRs, both or none :)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
