### PR TITLE
Avoid calling Headers#env_name when static header

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -55,6 +55,8 @@ module ActionDispatch
       METHOD
     end
 
+    TRANSFER_ENCODING = "HTTP_TRANSFER_ENCODING" # :nodoc:
+
     def self.empty
       new({})
     end
@@ -282,7 +284,7 @@ module ActionDispatch
 
     # Returns the content length of the request as an integer.
     def content_length
-      return raw_post.bytesize if headers.key?("Transfer-Encoding")
+      return raw_post.bytesize if has_header?(TRANSFER_ENCODING)
       super.to_i
     end
 
@@ -467,7 +469,7 @@ module ActionDispatch
 
       def read_body_stream
         reset_stream(body_stream) do
-          if headers.key?("Transfer-Encoding")
+          if has_header?(TRANSFER_ENCODING)
             body_stream.read # Read body stream until EOF if "Transfer-Encoding" is present
           else
             body_stream.read(content_length)

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -25,11 +25,12 @@ module ActionDispatch
     def initialize(app, header:)
       @app = app
       @header = header
+      @env_header = "HTTP_#{header.upcase.tr("-", "_")}"
     end
 
     def call(env)
       req = ActionDispatch::Request.new env
-      req.request_id = make_request_id(req.headers[@header])
+      req.request_id = make_request_id(req.get_header(@env_header))
       @app.call(env).tap { |_status, headers, _body| headers[@header] = req.request_id }
     end
 


### PR DESCRIPTION
### Motivation / Background

`env_name` has to transform given strings into the `HTTP_` type headers that are put in the Rack env. This involves at least one String allocation and a few additional transformations performed on the string.

### Detail

This commit avoids the extra allocations/transformations by precomputing some request header strings so that `env_name` can be avoided. The places changed here show up in a basic controller request, but there may be other places that could be changed as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
