### PR TITLE
Rename `ActionView::TestCase::Behavior::{Content,RenderedViewContent}`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rename `ActionView::TestCase::Behavior::{Content,RenderedViewContent}`
+
+    *Sean Doyle*
+
 *   Raise `ArgumentError` when `nil` is passed as `model:` argument value to the `form_with` method.
 
     *Collin Jilbert*

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -198,7 +198,7 @@ module ActionView
       end
 
       included do
-        class_attribute :content_class, instance_accessor: false, default: Content
+        class_attribute :content_class, instance_accessor: false, default: RenderedViewContent
 
         setup :setup_with_controller
 
@@ -299,7 +299,7 @@ module ActionView
         @controller._routes if @controller.respond_to?(:_routes)
       end
 
-      class Content < SimpleDelegator
+      class RenderedViewContent < String # :nodoc:
       end
 
       # Need to experiment if this priority is the best one: rendered => output_buffer

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -369,7 +369,7 @@ module ActionView
     include ::Capybara::Minitest::Assertions
 
     def page
-      Capybara.string(document_root_element)
+      Capybara.string(rendered)
     end
 
     test "document_root_element can be configured to utilize Capybara" do
@@ -382,15 +382,16 @@ module ActionView
     end
   end
 
-  class RenderedMethodMissingTest < ActionView::TestCase
-    test "rendered delegates methods to the String" do
+  class RenderedViewContentTest < ActionView::TestCase
+    test "#rendered inherits from String" do
       developer = DeveloperStruct.new("Eloy")
 
       render "developers/developer", developer: developer
 
+      assert_kind_of String, rendered
       assert_kind_of String, rendered.to_s
       assert_equal developer.name, rendered
-      assert_match rendered, /#{developer.name}/
+      assert_match(/#{developer.name}/, rendered)
       assert_includes rendered, developer.name
     end
   end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1797,7 +1797,7 @@ class ViewPartialTestCase < ActionView::TestCase
   include Capybara::Minitest::Assertions
 
   def page
-    Capybara.string(document_root_element)
+    Capybara.string(rendered)
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Closes #49818

### Detail

Renames `ActionView::TestCase::Behavior::Content` to
`RenderedViewContent`, with the goal of making it more of an internal
implementation detail that's unlikely to collide with an
application-side `::Content` class.

The `RenderedView`-prefix mirrors the module's `RenderedViewsCollection`
class. Since the intention is to treat it as a private implementation
detail, `RenderedViewContent` is marked with `:nodoc:`.

Along with the rename, this commit also modifies the class inheritance,
replacing the `SimpleDelegator` superclass with `String`. [String.new][]
accepts a `String` positional argument in the same way as
`SimpleDelegator.new` accepts a delegate object positional argument.
Sharing the `String` superclass also makes it a good candidate for being
passed to [Capybara.string][] (and [Capybara::Node::Simple.new][]) like
the documentation suggests.

[Capybara.string]: https://github.com/teamcapybara/capybara/blob/3.39.2/lib/capybara.rb#L212-L242
[Capybara::Node::Simple.new]: https://github.com/teamcapybara/capybara/blob/3.39.2/lib/capybara/node/simple.rb#L23
[String.new]: https://ruby-doc.org/core/String.html#method-c-new

### Additional information

Is this worth backporting into a `7.1` release?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
