### PR TITLE
Cover railties check_schema_cache_dump_version errors

### DIFF
--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -822,8 +822,11 @@ module ApplicationTests
         cache_tables_a = rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')").strip
         assert_includes cache_tables_a, "title", "expected cache_tables_a to include a title entry"
 
-        cache_size_b = rails("runner", "p AnimalsBase.connection.schema_cache.size", stderr: true).strip
-        assert_equal "0", cache_size_b
+        expired_warning = capture(:stderr) do
+          cache_size_b = rails("runner", "p AnimalsBase.connection.schema_cache.size", stderr: true).strip
+          assert_equal "0", cache_size_b
+        end
+        assert_match(/Ignoring .*\.yml because it has expired/, expired_warning)
 
         cache_tables_b = rails("runner", "p AnimalsBase.connection.schema_cache.columns('dogs')").strip
         assert_includes cache_tables_b, "name", "expected cache_tables_b to include a name entry"


### PR DESCRIPTION
* "Ignoring db/schema_cache.yml because it has expired."

Before:

```
bin/test test/application/rake/multi_dbs_test.rb -n "schema_cache is loaded on primary db in multi-db app"
Run options: -n "schema_cache is loaded on primary db in multi-db app" --seed 13139

Ignoring db/schema_cache.yml because it has expired. The current schema version is 20231017102756, but the one in the schema cache file is 20231017102755.
.
```

Added test cases for this error and "Failed to validate schema cache" in `test/application/rake/dbs_test.rb`.

This was pulled from #49679 since the scope grew and added more tests than just "denoise".
