### PR TITLE
Reset indentation of equals assignation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   <%- unless options.api? -%>
   config.action_controller.perform_caching = true
   <%- end -%>
@@ -77,7 +77,7 @@ Rails.application.configure do
 
   <%- unless options[:skip_active_job] -%>
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "<%= app_name %>_production"
 
   <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -24,7 +24,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 


### PR DESCRIPTION
### Motivation / Background

This indentation does not feel natural, and is often trimmed by linters.

```diff
- config.consider_all_requests_local       = true
+ config.consider_all_requests_local = true
```