### PR TITLE
Use Consistent name for several libraries

### DIFF
--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -52,7 +52,7 @@ class QueuingTest < ActiveSupport::TestCase
     assert_match(/HelloJob \[[0-9a-f-]+\] from DelayedJob\(default\) with arguments: \[\]/, job.name)
   end
 
-  test "resque JobWrapper should have instance variable queue" do
+  test "Resque JobWrapper should have instance variable queue" do
     skip unless adapter_is?(:resque)
     job = ::HelloJob.set(wait: 5.seconds).perform_later
     hash = Resque.decode(Resque.find_delayed_selection { true }[0])

--- a/activejob/test/support/integration/adapters/backburner.rb
+++ b/activejob/test/support/integration/adapters/backburner.rb
@@ -19,7 +19,7 @@ module BackburnerJobsManager
   end
 
   def start_workers
-    @thread = Thread.new { Backburner.work "integration-tests" } # backburner dasherizes the queue name
+    @thread = Thread.new { Backburner.work "integration-tests" } # Backburner dasherizes the queue name
   end
 
   def stop_workers
@@ -27,7 +27,7 @@ module BackburnerJobsManager
   end
 
   def tube
-    @tube ||= Beaneater::Tube.new(@worker.connection, "backburner.worker.queue.integration-tests") # backburner dasherizes the queue name
+    @tube ||= Beaneater::Tube.new(@worker.connection, "backburner.worker.queue.integration-tests") # Backburner dasherizes the queue name
   end
 
   def can_run?

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -46,7 +46,7 @@ module SneakersJobsManager
       end
     rescue Timeout::Error
       stop_workers
-      raise "Failed to start sneakers worker"
+      raise "Failed to start Sneakers worker"
     end
   end
 

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -204,7 +204,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     member = assert_queries(4) { Member.includes(:organization_member_details_2).first }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
-    # postgresql test if randomly executed then executes "SHOW max_identifier_length". Hence
+    # PostgreSQL test if randomly executed then executes "SHOW max_identifier_length". Hence
     # the need to ignore certain predefined sqls that deal with system calls.
     assert_no_queries do
       assert_equal [groucho_details, other_details], member.organization_member_details_2.sort_by(&:id)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
While working in the codebase, found that we are not using several library names consistently across the repo. 
For example, referring `PostgreSQL` as `Postgresql`, `Backburner` as `backburner`, `Sneakers` as `sneakers`. We should be consistent while referring to these and use the actual name.
Also, it's a continuation of https://github.com/rails/rails/pull/49846, grepping today gave me additional results, thought to fix these too.

### Detail

This Pull Request updates the names of different libraries to use consistent upcase.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
