### PR TITLE
Fix `VideoAnalyzerTest` with FFmpeg 6.0

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -64,7 +64,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
 
     assert_not_includes metadata, :width
     assert_not_includes metadata, :height
-    assert_equal 1.022000, metadata[:duration]
+    assert_includes 1.000000..1.022000, metadata[:duration]
     assert_not metadata[:video]
     assert metadata[:audio]
   end


### PR DESCRIPTION
FFmpeg 6.0 now reports the duration of `video_without_video_stream.mp4` as 1.000000 instead of 1.022000.  This discrepancy was [reported][] to the FFmpeg mailing list, and the [reply][] indicated that the change is intentional.

For this test, the exact duration isn't significant.  We merely want to assert that the metadata includes the duration reported by FFmpeg. Therefore, this commit changes the assertion to accomodate the duration reported by FFmpeg 6.0 as well as previous versions.

Fixes #49650.

[reported]: https://ffmpeg.org/pipermail/ffmpeg-user/2023-October/057067.html
[reply]: http://ffmpeg.org/pipermail/ffmpeg-user/2023-October/057083.html
