### PR TITLE
Fix upserting for custom `:on_duplicate` and `:unique_by` consisting of all inserts keys

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -23,8 +23,6 @@ module ActiveRecord
         @keys = @inserts.first.keys
       end
 
-      configure_on_duplicate_update_logic
-
       if model.scope_attributes?
         @scope_attributes = model.scope_attributes
         @keys |= @scope_attributes.keys
@@ -35,8 +33,8 @@ module ActiveRecord
       @returning = false if @returning == []
 
       @unique_by = find_unique_index_for(@unique_by)
-      @on_duplicate = :skip if @on_duplicate == :update && updatable_columns.empty?
 
+      configure_on_duplicate_update_logic
       ensure_valid_options_for_connection!
     end
 
@@ -135,6 +133,8 @@ module ActiveRecord
         elsif custom_update_sql_provided?
           @update_sql = on_duplicate
           @on_duplicate = :update
+        elsif @on_duplicate == :update && updatable_columns.empty?
+          @on_duplicate = :skip
         end
       end
 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -739,6 +739,20 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "written", Book.find(2).status
   end
 
+  def test_upsert_all_updates_using_provided_sql_and_unique_by
+    skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
+
+    book = books(:rfr)
+    assert_equal "proposed", book.status
+
+    Book.upsert_all(
+      [{ name: book.name, author_id: book.author_id }],
+      unique_by: [:name, :author_id],
+      on_duplicate: Arel.sql("status = 2")
+    )
+    assert_equal "published", book.reload.status
+  end
+
   def test_upsert_all_with_unique_by_fails_cleanly_for_adapters_not_supporting_insert_conflict_target
     skip if supports_insert_conflict_target?
 


### PR DESCRIPTION
Fixes #49867.

Before, when `@on_duplicate = :skip if @on_duplicate == :update && updatable_columns.empty?` line run, it incorrectly ignores the fact that custom `:on_duplicate` was passed and `@on_duplicate` is already configured in the `configure_on_duplicate_update_logic` method. So I moved that logic into that method.