### PR TITLE
Introduce `ActiveModel::Enum`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Introduce `ActiveModel::Enum`.
+
+    ```ruby
+    class Conversation
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum :status, [ :active, :archived ]
+    end
+
+    conversation = Conversation.new
+    conversation.active!
+    conversation.active? # => true
+    conversation.status  # => "active"
+    ```
+
+    *Petrik de Heus*
+
 *   Port the `BeforeTypeCast` module to Active Model. Classes that include
     `ActiveModel::Attributes` will now automatically define methods such as
     `*_before_type_cast`, `*_for_database`, etc. These methods behave the same

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -45,6 +45,7 @@ module ActiveModel
   autoload :Conversion
   autoload :Dirty
   autoload :EachValidator, "active_model/validator"
+  autoload :Enum
   autoload :ForbiddenAttributesProtection
   autoload :Lint
   autoload :Model

--- a/activemodel/lib/active_model/enum.rb
+++ b/activemodel/lib/active_model/enum.rb
@@ -1,0 +1,361 @@
+# frozen_string_literal: true
+
+require "active_support/hash_with_indifferent_access"
+require "active_support/core_ext/hash/slice"
+require "active_support/core_ext/object/deep_dup"
+
+module ActiveModel
+  # Declare an enum attribute where the values map to integers in the database,
+  # but can be queried by name. Example:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     attribute :status, :integer
+  #     enum :status, [ :active, :archived ]
+  #   end
+  #
+  #   conversation.active!
+  #   conversation.active? # => true
+  #   conversation.status  # => "active"
+  #
+  #   conversation.archived!
+  #   conversation.archived? # => true
+  #   conversation.status    # => "archived"
+  #
+  #   conversation.status = nil
+  #   conversation.status.nil? # => true
+  #   conversation.status      # => nil
+  #
+  # You can set the default enum value by setting +:default+, like:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     attribute :status, :integer
+  #     enum :status, [ :active, :archived ], default: :active
+  #   end
+  #
+  #   conversation = Conversation.new
+  #   conversation.status # => "active"
+  #
+  # It's possible to explicitly map the relation between attribute and
+  # database integer with a hash:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     attribute :status, :integer
+  #     enum :status, active: 0, archived: 1
+  #   end
+  #
+  # Finally it's also possible to use a string column to persist the enumerated value.
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     attribute :status, :integer
+  #     enum :status, active: "active", archived: "archived"
+  #   end
+  #
+  # Note that when an array is used, the implicit mapping from the values to database
+  # integers is derived from the order the values appear in the array. In the example,
+  # <tt>:active</tt> is mapped to +0+ as it's the first element, and <tt>:archived</tt>
+  # is mapped to +1+. In general, the +i+-th element is mapped to <tt>i-1</tt> in the
+  # database.
+  #
+  # Therefore, once a value is added to the enum array, its position in the array must
+  # be maintained, and new values should only be added to the end of the array. To
+  # remove unused values, the explicit hash syntax should be used.
+  #
+  # In rare circumstances you might need to access the mapping directly.
+  # The mappings are exposed through a class method with the pluralized attribute
+  # name, which return the mapping in a ActiveSupport::HashWithIndifferentAccess :
+  #
+  #   Conversation.statuses[:active]    # => 0
+  #   Conversation.statuses["archived"] # => 1
+  #
+  # Use that class method when you need to know the ordinal value of an enum.
+  # For example, you can use that when manually building SQL strings:
+  #
+  #   Conversation.where("status <> ?", Conversation.statuses[:archived])
+  #
+  # You can use the +:prefix+ or +:suffix+ options when you need to define
+  # multiple enums with same values. If the passed value is +true+, the methods
+  # are prefixed/suffixed with the name of the enum. It is also possible to
+  # supply a custom value:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     enum :status, [ :active, :archived ], suffix: true
+  #     enum :comments_status, [ :active, :inactive ], prefix: :comments
+  #   end
+  #
+  # With the above example, the bang and predicate methods along with the
+  # associated scopes are now prefixed and/or suffixed accordingly:
+  #
+  #   conversation.active_status!
+  #   conversation.archived_status? # => false
+  #
+  #   conversation.comments_inactive!
+  #   conversation.comments_active? # => false
+  #
+  # If you want to disable the auto-generated methods on the model, you can do
+  # so by setting the +:instance_methods+ option to false:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     enum :status, [ :active, :archived ], instance_methods: false
+  #   end
+  #
+  # If you want the enum value to be validated before saving, use the option +:validate+:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     enum :status, [ :active, :archived ], validate: true
+  #   end
+  #
+  #   conversation = Conversation.new
+  #
+  #   conversation.status = :unknown
+  #   conversation.valid? # => false
+  #
+  #   conversation.status = nil
+  #   conversation.valid? # => false
+  #
+  #   conversation.status = :active
+  #   conversation.valid? # => true
+  #
+  # It is also possible to pass additional validation options:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     enum :status, [ :active, :archived ], validate: { allow_nil: true }
+  #   end
+  #
+  #   conversation = Conversation.new
+  #
+  #   conversation.status = :unknown
+  #   conversation.valid? # => false
+  #
+  #   conversation.status = nil
+  #   conversation.valid? # => true
+  #
+  #   conversation.status = :active
+  #   conversation.valid? # => true
+  #
+  # Otherwise +ArgumentError+ will raise:
+  #
+  #   class Conversation
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Enum
+  #     enum :status, [ :active, :archived ]
+  #   end
+  #
+  #   conversation = Conversation.new
+  #
+  #   conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
+  module Enum
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute(:defined_enums, instance_writer: false, default: {})
+    end
+
+    class EnumType < Type::Value # :nodoc:
+      delegate :type, to: :subtype
+
+      def initialize(name, mapping, subtype, raise_on_invalid_values: true)
+        @name = name
+        @mapping = mapping
+        @subtype = subtype
+        @_raise_on_invalid_values = raise_on_invalid_values
+      end
+
+      def cast(value)
+        if mapping.has_key?(value)
+          value.to_s
+        elsif mapping.has_value?(value)
+          mapping.key(value)
+        else
+          value.presence
+        end
+      end
+
+      def deserialize(value)
+        mapping.key(subtype.deserialize(value))
+      end
+
+      def serialize(value)
+        subtype.serialize(mapping.fetch(value, value))
+      end
+
+      def serializable?(value, &block)
+        subtype.serializable?(mapping.fetch(value, value), &block)
+      end
+
+      def assert_valid_value(value)
+        return unless @_raise_on_invalid_values
+
+        unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
+          raise ArgumentError, "'#{value}' is not a valid #{name}"
+        end
+      end
+
+      attr_reader :subtype
+
+      private
+        attr_reader :name, :mapping
+    end
+
+    module ClassMethods
+      def enum(name = nil, values = nil, **options)
+        if name
+          values, options = options, {} unless values
+          return _enum(name, values, **options)
+        end
+
+        definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
+        options.transform_keys! { |key| :"#{key[1..-1]}" }
+
+        definitions.each { |name, values| _enum(name, values, **options) }
+      end
+
+      private
+        def inherited(base)
+          base.defined_enums = defined_enums.deep_dup
+          super
+        end
+
+        def _enum(name, values, prefix: nil, suffix: nil, scopes: false, instance_methods: true, validate: false, **options)
+          assert_valid_enum_definition_values(values)
+          # statuses = { }
+          enum_values = ActiveSupport::HashWithIndifferentAccess.new
+          name = name.to_s
+
+          ## def self.statuses() statuses end
+          detect_enum_conflict!(name, name.pluralize, true)
+          singleton_class.define_method(name.pluralize) { enum_values }
+          defined_enums[name] = enum_values
+
+          detect_enum_conflict!(name, name)
+          detect_enum_conflict!(name, "#{name}=")
+
+          attribute(name, **options)
+
+          decorate_attributes([name]) do |_name, subtype|
+            if subtype == ActiveModel::Type.default_value
+              raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
+                " backed by a database column or declared with an explicit type" \
+                " via `attribute`."
+            end
+
+            subtype = subtype.subtype if ActiveModel::Enum::EnumType === subtype
+            ActiveModel::Enum::EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
+          end
+
+          value_method_names = []
+          _enum_methods_module.module_eval do
+            prefix = if prefix
+              prefix == true ? "#{name}_" : "#{prefix}_"
+            end
+
+            suffix = if suffix
+              suffix == true ? "_#{name}" : "_#{suffix}"
+            end
+
+            pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+            pairs.each do |label, value|
+              enum_values[label] = value
+              label = label.to_s
+
+              value_method_name = "#{prefix}#{label}#{suffix}"
+              value_method_names << value_method_name
+              define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+
+              method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+              value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
+
+              if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
+                value_method_names << value_method_alias
+                define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+              end
+            end
+          end
+          detect_negative_enum_conditions!(value_method_names) if scopes
+
+          if validate
+            validate = {} unless Hash === validate
+            validates_inclusion_of name, in: enum_values.keys, **validate
+          end
+
+          enum_values.freeze
+        end
+
+        class EnumMethods < Module # :nodoc:
+          def initialize(klass)
+            @klass = klass
+          end
+
+          private
+            attr_reader :klass
+
+            def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+              if instance_methods
+                ## def active?() status_for_database == 0 end
+                define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
+
+                ## def active!() update!(status: 0) end
+                define_method("#{value_method_name}!") { public_send(:"#{name}=", value) }
+              end
+            end
+        end
+        private_constant :EnumMethods
+
+        def _enum_methods_module
+          @_enum_methods_module ||= begin
+            mod = EnumMethods.new(self)
+            include mod
+            mod
+          end
+        end
+
+        def assert_valid_enum_definition_values(values)
+          case values
+          when Hash
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            if values.keys.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          when Array
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            unless values.all?(Symbol) || values.all?(String)
+              raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
+            end
+
+            if values.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          else
+            raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
+          end
+        end
+
+        def detect_enum_conflict!(enum_name, method_name, klass_method = false)
+        end
+
+        def detect_negative_enum_conditions!(method_names)
+        end
+    end
+  end
+end

--- a/activemodel/test/cases/enum_test.rb
+++ b/activemodel/test/cases/enum_test.rb
@@ -1,0 +1,833 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/author"
+require "models/book"
+require "active_support/log_subscriber/test_helper"
+
+class EnumTest < ActiveModel::TestCase
+  setup do
+    @book = Book.new(
+      status: :published,
+      last_read: :read,
+      language: :english,
+      author_visibility: :visible,
+      illustrator_visibility: :visible,
+      font_size: :medium,
+      difficulty: :medium,
+      boolean_status: :enabled,
+      cover: "soft"
+    )
+    @book.changes_applied
+  end
+
+  test "type.cast" do
+    type = Book.type_for_attribute(:status)
+
+    assert_equal "proposed",  type.cast(0)
+    assert_equal "written",   type.cast(1)
+    assert_equal "published", type.cast(2)
+
+    assert_equal "proposed",  type.cast(:proposed)
+    assert_equal "written",   type.cast(:written)
+    assert_equal "published", type.cast(:published)
+
+    assert_equal "proposed",  type.cast("proposed")
+    assert_equal "written",   type.cast("written")
+    assert_equal "published", type.cast("published")
+
+    assert_equal :unknown,    type.cast(:unknown)
+    assert_equal "unknown",   type.cast("unknown")
+  end
+
+  test "type.serialize" do
+    type = Book.type_for_attribute(:status)
+
+    assert_equal 0, type.serialize(0)
+    assert_equal 1, type.serialize(1)
+    assert_equal 2, type.serialize(2)
+
+    assert_equal 0, type.serialize(:proposed)
+    assert_equal 1, type.serialize(:written)
+    assert_equal 2, type.serialize(:published)
+
+    assert_equal 0, type.serialize("proposed")
+    assert_equal 1, type.serialize("written")
+    assert_equal 2, type.serialize("published")
+
+    assert_nil type.serialize(:unknown)
+    assert_nil type.serialize("unknown")
+  end
+
+  test "query state by predicate" do
+    assert_predicate @book, :published?
+    assert_not_predicate @book, :written?
+    assert_not_predicate @book, :proposed?
+
+    assert_predicate @book, :read?
+    assert_predicate @book, :in_english?
+    assert_predicate @book, :author_visibility_visible?
+    assert_predicate @book, :illustrator_visibility_visible?
+    assert_predicate @book, :with_medium_font_size?
+    assert_predicate @book, :medium_to_read?
+  end
+
+  test "query state with strings" do
+    assert_equal "published", @book.status
+    assert_equal "read", @book.last_read
+    assert_equal "english", @book.language
+    assert_equal "visible", @book.author_visibility
+    assert_equal "visible", @book.illustrator_visibility
+    assert_equal "medium", @book.difficulty
+    assert_equal "soft", @book.cover
+  end
+
+  test "update by declaration" do
+    @book.written!
+    assert_predicate @book, :written?
+    @book.in_english!
+    assert_predicate @book, :in_english?
+    @book.author_visibility_visible!
+    assert_predicate @book, :author_visibility_visible?
+    @book.hard!
+    assert_predicate @book, :hard?
+  end
+
+  test "enum methods are overwritable" do
+    assert_equal "do publish work...", @book.published!
+    assert_predicate @book, :published?
+  end
+
+  test "direct assignment" do
+    @book.status = :written
+    assert_predicate @book, :written?
+    @book.cover = :hard
+    assert_predicate @book, :hard?
+  end
+
+  test "assign string value" do
+    @book.status = "written"
+    assert_predicate @book, :written?
+    @book.cover = "hard"
+    assert_predicate @book, :hard?
+  end
+
+  test "enum changed attributes" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :spanish
+    assert_equal old_status, @book.changed_attributes[:status]
+    assert_equal old_language, @book.changed_attributes[:language]
+  end
+
+  test "enum value after write symbol" do
+    @book.status = :proposed
+    assert_equal "proposed", @book.status
+  end
+
+  test "enum value after write string" do
+    @book.status = "proposed"
+    assert_equal "proposed", @book.status
+  end
+
+  test "enum changes" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :spanish
+    assert_equal [old_status, "proposed"], @book.changes[:status]
+    assert_equal [old_language, "spanish"], @book.changes[:language]
+  end
+
+  test "enum attribute was" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :published
+    @book.language = :spanish
+    assert_equal old_status, @book.attribute_was(:status)
+    assert_equal old_language, @book.attribute_was(:language)
+  end
+
+  test "enum attribute changed" do
+    @book.status = :proposed
+    @book.language = :french
+    assert @book.attribute_changed?(:status)
+    assert @book.attribute_changed?(:language)
+  end
+
+  test "enum attribute changed to" do
+    @book.status = :proposed
+    @book.language = :french
+    assert @book.attribute_changed?(:status, to: "proposed")
+    assert @book.attribute_changed?(:language, to: "french")
+  end
+
+  test "enum attribute changed from" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :french
+    assert @book.attribute_changed?(:status, from: old_status)
+    assert @book.attribute_changed?(:language, from: old_language)
+  end
+
+  test "enum attribute changed from old status to new status" do
+    old_status = @book.status
+    old_language = @book.language
+    @book.status = :proposed
+    @book.language = :french
+    assert @book.attribute_changed?(:status, from: old_status, to: "proposed")
+    assert @book.attribute_changed?(:language, from: old_language, to: "french")
+  end
+
+  test "enum didn't change" do
+    old_status = @book.status
+    @book.status = old_status
+    assert_not @book.attribute_changed?(:status)
+  end
+
+  test "persist changes that are dirty" do
+    @book.status = :proposed
+    assert @book.attribute_changed?(:status)
+    @book.status = :written
+    assert @book.attribute_changed?(:status)
+  end
+
+  test "reverted changes that are not dirty" do
+    old_status = @book.status
+    @book.status = :proposed
+    assert @book.attribute_changed?(:status)
+    @book.status = old_status
+    assert_not @book.attribute_changed?(:status)
+  end
+
+  test "reverted changes are not dirty going from nil to value and back" do
+    book = Book.new(nullable_status: nil)
+
+    book.nullable_status = :married
+    assert book.attribute_changed?(:nullable_status)
+
+    book.nullable_status = nil
+    assert_not book.attribute_changed?(:nullable_status)
+  end
+
+  test "assign non existing value raises an error" do
+    e = assert_raises(ArgumentError) do
+      @book.status = :unknown
+    end
+    assert_equal "'unknown' is not a valid status", e.message
+  end
+
+  test "validation with 'validate: true' option" do
+    klass = Class.new do
+      def self.name; "Book"; end
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum :status, [:proposed, :written], validate: true
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+  end
+
+  test "validation with 'validate: hash' option" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+      include ActiveModel::Enum
+      attribute :status, :integer
+      def self.name; "Book"; end
+      enum :status, [:proposed, :written], validate: { allow_nil: true }
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: nil)
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+  end
+
+  test "assign nil value" do
+    @book.status = nil
+    assert_nil @book.status
+  end
+
+  test "assign nil value to enum which defines nil value to hash" do
+    @book.last_read = nil
+    assert_equal "forgotten", @book.last_read
+  end
+
+  test "assign empty string value" do
+    @book.status = ""
+    assert_nil @book.status
+  end
+
+  test "assign false value to a field defined as not boolean" do
+    @book.status = false
+    assert_nil @book.status
+  end
+
+  test "assign false value to a field defined as boolean" do
+    @book.boolean_status = false
+    assert_equal "disabled", @book.boolean_status
+  end
+
+  test "assign long empty string value" do
+    @book.status = "   "
+    assert_nil @book.status
+  end
+
+  test "constant to access the mapping" do
+    assert_equal 0, Book.statuses[:proposed]
+    assert_equal 1, Book.statuses["written"]
+    assert_equal 2, Book.statuses[:published]
+  end
+
+  test "attribute_before_type_cast" do
+    assert_equal 2, @book.status_before_type_cast
+    assert_equal "published", @book.status
+
+    @book.status = "published"
+
+    assert_equal "published", @book.status_before_type_cast
+    assert_equal "published", @book.status
+  end
+
+  test "attribute_for_database" do
+    assert_equal 2, @book.status_for_database
+    assert_equal "published", @book.status
+
+    @book.status = "published"
+
+    assert_equal 2, @book.status_for_database
+    assert_equal "published", @book.status
+  end
+
+  test "attributes_for_database" do
+    assert_equal 2, @book.attributes_for_database["status"]
+
+    @book.status = "published"
+
+    assert_equal 2, @book.attributes_for_database["status"]
+  end
+
+  test "invalid definition values raise an ArgumentError" do
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum :status
+      end
+    end
+
+    assert_match(/must not be empty\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum(:status, {}, **{})
+      end
+    end
+
+    assert_match(/must not be empty\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum :status, []
+      end
+    end
+
+    assert_match(/must not be empty\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum status: [proposed: 1, written: 2, published: 3]
+      end
+    end
+
+    assert_match(/must only contain symbols or strings\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum status: { "" => 1, "active" => 2 }
+      end
+    end
+
+    assert_match(/must not contain a blank name\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum status: ["active", ""]
+      end
+    end
+
+    assert_match(/must not contain a blank name\.$/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum status: Object.new
+      end
+    end
+
+    assert_match(/must be either a non-empty hash or an array\.$/, e.message)
+  end
+
+  test "can use id as a value with a prefix or suffix" do
+    assert_nothing_raised do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+        enum status_1: [:id], _prefix: true
+        enum status_2: [:id], _suffix: true
+      end
+    end
+  end
+
+  test "overriding enum method should not raise" do
+    assert_nothing_raised do
+      Class.new do
+        include ActiveModel::Attributes
+        include ActiveModel::Enum
+        attribute :status, :integer
+
+        def published!
+          super
+          "do publish work..."
+        end
+
+        enum status: [:proposed, :written, :published]
+
+        def written!
+          super
+          "do written work..."
+        end
+      end
+    end
+  end
+
+  test "validate inclusion of value in array" do
+    klass = Class.new do
+      def self.name; "Book"; end
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: [:proposed, :written]
+      validates_inclusion_of :status, in: ["written"]
+    end
+    invalid_book = klass.new(status: "proposed")
+    assert_not_predicate invalid_book, :valid?
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+  end
+
+  test "enums are distinct per class" do
+    klass1 = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Dirty
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: [:proposed, :written]
+    end
+
+    klass2 = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Dirty
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: [:drafted, :uploaded]
+    end
+
+    book1 = klass1.new(status: "proposed")
+    book1.changes_applied
+    book1.status = :written
+    assert_equal ["proposed", "written"], book1.status_change
+
+    book2 = klass2.new(status: "drafted")
+    book2.changes_applied
+    book2.status = :uploaded
+    assert_equal ["drafted", "uploaded"], book2.status_change
+  end
+
+  test "enums are inheritable" do
+    subklass1 = Class.new(Book)
+
+    subklass2 = Class.new(Book) do
+      enum status: [:drafted, :uploaded]
+    end
+
+    book1 = subklass1.new(status: "proposed")
+    book1.changes_applied
+    book1.status = :written
+    assert_equal ["proposed", "written"], book1.status_change
+
+    book2 = subklass2.new(status: "drafted")
+    book2.changes_applied
+    book2.status = :uploaded
+    assert_equal ["drafted", "uploaded"], book2.status_change
+  end
+
+  test "attempting to modify enum raises error" do
+    e = assert_raises(RuntimeError) do
+      Book.statuses["bad_enum"] = 40
+    end
+
+    assert_match(/can't modify frozen/, e.message)
+
+    e = assert_raises(RuntimeError) do
+      Book.statuses.delete("published")
+    end
+
+    assert_match(/can't modify frozen/, e.message)
+  end
+
+  test "declare multiple enums at a time" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      attribute :nullable_status, :integer
+      enum status: [:proposed, :written, :published],
+           nullable_status: [:single, :married]
+    end
+
+    book1 = klass.new(status: :proposed)
+    assert_predicate book1, :proposed?
+
+    book2 = klass.new(nullable_status: :single)
+    assert_predicate book2, :single?
+  end
+
+  test "declare multiple enums with { _prefix: true }" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      attribute :last_read, :integer
+
+      enum(
+        status: [:value_1],
+        last_read: [:value_1],
+        _prefix: true
+      )
+    end
+
+    instance = klass.new
+    assert_respond_to instance, :status_value_1?
+    assert_respond_to instance, :last_read_value_1?
+  end
+
+  test "declare multiple enums with { _suffix: true }" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      attribute :last_read, :integer
+
+      enum(
+        status: [:value_1],
+        last_read: [:value_1],
+        _suffix: true
+      )
+    end
+
+    instance = klass.new
+    assert_respond_to instance, :value_1_status?
+    assert_respond_to instance, :value_1_last_read?
+  end
+
+  test "enum with alias_attribute" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      alias_attribute :aliased_status, :status
+      enum aliased_status: [:proposed, :written, :published]
+    end
+
+    book = klass.new(status: "proposed")
+    assert_predicate book, :proposed?
+    assert_equal "proposed", book.aliased_status
+  end
+
+  test "query state by predicate with prefix" do
+    assert_predicate @book, :author_visibility_visible?
+    assert_not_predicate @book, :author_visibility_invisible?
+    assert_predicate @book, :illustrator_visibility_visible?
+    assert_not_predicate @book, :illustrator_visibility_invisible?
+  end
+
+  test "query state by predicate with custom prefix" do
+    assert_predicate @book, :in_english?
+    assert_not_predicate @book, :in_spanish?
+    assert_not_predicate @book, :in_french?
+  end
+
+  test "query state by predicate with custom suffix" do
+    assert_predicate @book, :medium_to_read?
+    assert_not_predicate @book, :easy_to_read?
+    assert_not_predicate @book, :hard_to_read?
+  end
+
+  test "enum methods with custom suffix defined" do
+    assert_respond_to @book, :easy_to_read?
+    assert_respond_to @book, :medium_to_read?
+    assert_respond_to @book, :hard_to_read?
+
+    assert_respond_to @book, :easy_to_read!
+    assert_respond_to @book, :medium_to_read!
+    assert_respond_to @book, :hard_to_read!
+  end
+
+  test "update enum attributes with custom suffix" do
+    @book.medium_to_read!
+    assert_not_predicate @book, :easy_to_read?
+    assert_predicate @book, :medium_to_read?
+    assert_not_predicate @book, :hard_to_read?
+
+    @book.easy_to_read!
+    assert_predicate @book, :easy_to_read?
+    assert_not_predicate @book, :medium_to_read?
+    assert_not_predicate @book, :hard_to_read?
+
+    @book.hard_to_read!
+    assert_not_predicate @book, :easy_to_read?
+    assert_not_predicate @book, :medium_to_read?
+    assert_predicate @book, :hard_to_read?
+  end
+
+  test "data type of Enum type" do
+    assert_equal :integer, Book.type_for_attribute("status").type
+  end
+
+  test "enum on custom attribute with default" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer, default: 2
+      enum status: [:proposed, :written, :published]
+    end
+
+    assert_equal "published", klass.new.status
+  end
+
+  test "overloaded default by :_default" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: [:proposed, :written, :published], _default: :published
+    end
+
+    assert_equal "published", klass.new.status
+  end
+
+  test "overloaded default by :default" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum :status, [:proposed, :written, :published], default: :published
+    end
+
+    assert_equal "published", klass.new.status
+  end
+
+  test "query state by predicate with :prefix" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      attribute :last_read, :integer
+      enum :status, { proposed: 0, written: 1 }, prefix: true
+      enum :last_read, { unread: 0, reading: 1, read: 2 }, prefix: :being
+    end
+
+    book = klass.new
+    assert_respond_to book, :status_proposed?
+    assert_respond_to book, :being_unread?
+  end
+
+  test "query state by predicate with :suffix" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :cover, :integer
+      attribute :difficulty, :integer
+      enum :cover, { hard: 0, soft: 1 }, suffix: true
+      enum :difficulty, { easy: 0, medium: 1, hard: 2 }, suffix: :to_read
+    end
+
+    book = klass.new
+    assert_respond_to book, :hard_cover?
+    assert_respond_to book, :easy_to_read?
+  end
+
+  test "option names can be used as label" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer, default: 0
+      enum :status, default: 0, scopes: 1, prefix: 2, suffix: 3
+    end
+
+    book = klass.new
+    assert_predicate book, :default?
+    assert_not_predicate book, :scopes?
+    assert_not_predicate book, :prefix?
+    assert_not_predicate book, :suffix?
+  end
+
+  test "capital characters for enum names" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :extendedWarranty, :integer
+      enum extendedWarranty: [:extendedSilver, :extendedGold]
+    end
+
+    computer = klass.new(extendedWarranty: :extendedSilver)
+    assert_predicate computer, :extendedSilver?
+    assert_not_predicate computer, :extendedGold?
+  end
+
+  test "unicode characters for enum names" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :language, :integer
+      enum language: [:🇺🇸, :🇪🇸, :🇫🇷]
+    end
+
+    book = klass.new(language: :🇺🇸)
+    assert_predicate book, :🇺🇸?
+    assert_not_predicate book, :🇪🇸?
+  end
+
+  test "mangling collision for enum names" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :timezone, :integer
+      enum timezone: [:"Etc/GMT+1", :"Etc/GMT-1"]
+    end
+
+    computer = klass.new(timezone: :"Etc/GMT+1")
+    assert_predicate computer, :"Etc/GMT+1?"
+    assert_not_predicate computer, :"Etc/GMT-1?"
+  end
+
+  test "deserialize enum value to original hash key" do
+    proposed = Struct.new(:to_s).new("proposed")
+    written = Struct.new(:to_s).new("written")
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: { proposed => 0, written => 1 }
+    end
+
+    book = klass.new(status: 0)
+    assert_equal proposed, book.status
+    assert_predicate book, :proposed?
+    assert_not_predicate book, :written?
+  end
+
+  test "serializable? with large number label" do
+    klass = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum :status, ["9223372036854775808", "-9223372036854775809"]
+    end
+
+    type = klass.type_for_attribute(:status)
+
+    assert type.serializable?("9223372036854775808")
+    assert type.serializable?("-9223372036854775809")
+
+    assert_not type.serializable?(9223372036854775808)
+    assert_not type.serializable?(-9223372036854775809)
+
+    book1 = klass.new(status: "9223372036854775808")
+    book2 = klass.new(status: "-9223372036854775809")
+
+    assert_equal 0, book1.status_for_database
+    assert_equal 1, book2.status_for_database
+  end
+
+  test "raises for attributes with undeclared type" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      enum typeless_genre: [:adventure, :comic]
+    end
+
+    error = assert_raises(RuntimeError) do
+      klass.type_for_attribute(:typeless_genre)
+    end
+    assert_match "Undeclared attribute type for enum 'typeless_genre'", error.message
+  end
+
+  test "default methods can be disabled by :_instance_methods" do
+    klass = Class.new do
+      include ActiveModel::Attributes
+      include ActiveModel::Enum
+      attribute :status, :integer
+      enum status: [:proposed, :written], _instance_methods: false
+    end
+
+    instance = klass.new
+    assert_raises(NoMethodError) { instance.proposed? }
+    assert_raises(NoMethodError) { instance.proposed! }
+  end
+end

--- a/activemodel/test/models/author.rb
+++ b/activemodel/test/models/author.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Author
+end

--- a/activemodel/test/models/book.rb
+++ b/activemodel/test/models/book.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Book
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Dirty
+  include ActiveModel::Enum
+
+  attribute :status, :integer
+  attribute :last_read, :integer
+  attribute :nullable_status, :integer
+  attribute :language, :integer
+  attribute :author_visibility, :integer
+  attribute :illustrator_visibility, :integer
+  attribute :font_size, :integer
+  attribute :difficulty, :integer
+  attribute :cover, :string
+  attribute :boolean_status, :boolean
+
+  enum status: [:proposed, :written, :published]
+  enum last_read: { unread: 0, reading: 2, read: 3, forgotten: nil }
+  enum nullable_status: [:single, :married]
+  enum language: [:english, :spanish, :french], _prefix: :in
+  enum author_visibility: [:visible, :invisible], _prefix: true
+  enum illustrator_visibility: [:visible, :invisible], _prefix: true
+  enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
+  enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
+  enum cover: { hard: "hard", soft: "soft" }
+  enum boolean_status: { enabled: true, disabled: false }
+
+  def published!
+    super
+    "do publish work..."
+  end
+end

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -292,7 +292,6 @@ module ActiveRecord # :nodoc:
     extend DynamicMatchers
     extend DelegatedType
     extend Explain
-    extend Enum
     extend Delegation::DelegateCache
     extend Aggregations::ClassMethods
 
@@ -318,6 +317,7 @@ module ActiveRecord # :nodoc:
     include SecurePassword
     include AutosaveAssociation
     include NestedAttributes
+    include Enum
     include Transactions
     include TouchLater
     include NoTouching

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -163,8 +163,10 @@ module ActiveRecord
   #
   #   conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
   module Enum
-    def self.extended(base) # :nodoc:
-      base.class_attribute(:defined_enums, instance_writer: false, default: {})
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute(:defined_enums, instance_writer: false, default: {})
     end
 
     class EnumType < Type::Value # :nodoc:
@@ -213,197 +215,199 @@ module ActiveRecord
         attr_reader :name, :mapping
     end
 
-    def enum(name = nil, values = nil, **options)
-      if name
-        values, options = options, {} unless values
-        return _enum(name, values, **options)
+    module ClassMethods
+      def enum(name = nil, values = nil, **options)
+        if name
+          values, options = options, {} unless values
+          return _enum(name, values, **options)
+        end
+
+        definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
+        options.transform_keys! { |key| :"#{key[1..-1]}" }
+
+        definitions.each { |name, values| _enum(name, values, **options) }
       end
 
-      definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
-      options.transform_keys! { |key| :"#{key[1..-1]}" }
+      private
+        def inherited(base)
+          base.defined_enums = defined_enums.deep_dup
+          super
+        end
 
-      definitions.each { |name, values| _enum(name, values, **options) }
+        def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
+          assert_valid_enum_definition_values(values)
+          # statuses = { }
+          enum_values = ActiveSupport::HashWithIndifferentAccess.new
+          name = name.to_s
+
+          # def self.statuses() statuses end
+          detect_enum_conflict!(name, name.pluralize, true)
+          singleton_class.define_method(name.pluralize) { enum_values }
+          defined_enums[name] = enum_values
+
+          detect_enum_conflict!(name, name)
+          detect_enum_conflict!(name, "#{name}=")
+
+          attribute(name, **options)
+
+          decorate_attributes([name]) do |_name, subtype|
+            if subtype == ActiveModel::Type.default_value
+              raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
+                " backed by a database column or declared with an explicit type" \
+                " via `attribute`."
+            end
+
+            subtype = subtype.subtype if EnumType === subtype
+            EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
+          end
+
+          value_method_names = []
+          _enum_methods_module.module_eval do
+            prefix = if prefix
+              prefix == true ? "#{name}_" : "#{prefix}_"
+            end
+
+            suffix = if suffix
+              suffix == true ? "_#{name}" : "_#{suffix}"
+            end
+
+            pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+            pairs.each do |label, value|
+              enum_values[label] = value
+              label = label.to_s
+
+              value_method_name = "#{prefix}#{label}#{suffix}"
+              value_method_names << value_method_name
+              define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+
+              method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+              value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
+
+              if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
+                value_method_names << value_method_alias
+                define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+              end
+            end
+          end
+          detect_negative_enum_conditions!(value_method_names) if scopes
+
+          if validate
+            validate = {} unless Hash === validate
+            validates_inclusion_of name, in: enum_values.keys, **validate
+          end
+
+          enum_values.freeze
+        end
+
+        class EnumMethods < Module # :nodoc:
+          def initialize(klass)
+            @klass = klass
+          end
+
+          private
+            attr_reader :klass
+
+            def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+              if instance_methods
+                # def active?() status_for_database == 0 end
+                klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
+                define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
+
+                # def active!() update!(status: 0) end
+                klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
+                define_method("#{value_method_name}!") { update!(name => value) }
+              end
+
+              if scopes
+                # scope :active, -> { where(status: 0) }
+                klass.send(:detect_enum_conflict!, name, value_method_name, true)
+                klass.scope value_method_name, -> { where(name => value) }
+
+                # scope :not_active, -> { where.not(status: 0) }
+                klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
+                klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              end
+            end
+        end
+        private_constant :EnumMethods
+
+        def _enum_methods_module
+          @_enum_methods_module ||= begin
+            mod = EnumMethods.new(self)
+            include mod
+            mod
+          end
+        end
+
+        def assert_valid_enum_definition_values(values)
+          case values
+          when Hash
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            if values.keys.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          when Array
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            unless values.all?(Symbol) || values.all?(String)
+              raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
+            end
+
+            if values.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          else
+            raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
+          end
+        end
+
+        ENUM_CONFLICT_MESSAGE = \
+          "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
+          "this will generate a %{type} method \"%{method}\", which is already defined " \
+          "by %{source}."
+        private_constant :ENUM_CONFLICT_MESSAGE
+
+        def detect_enum_conflict!(enum_name, method_name, klass_method = false)
+          if klass_method && dangerous_class_method?(method_name)
+            raise_conflict_error(enum_name, method_name, type: "class")
+          elsif klass_method && method_defined_within?(method_name, Relation)
+            raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
+          elsif klass_method && method_name.to_sym == :id
+            raise_conflict_error(enum_name, method_name)
+          elsif !klass_method && dangerous_attribute_method?(method_name)
+            raise_conflict_error(enum_name, method_name)
+          elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
+            raise_conflict_error(enum_name, method_name, source: "another enum")
+          end
+        end
+
+        def raise_conflict_error(enum_name, method_name, type: "instance", source: "Active Record")
+          raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+            enum: enum_name,
+            klass: name,
+            type: type,
+            method: method_name,
+            source: source
+          }
+        end
+
+        def detect_negative_enum_conditions!(method_names)
+          return unless logger
+
+          method_names.select { |m| m.start_with?("not_") }.each do |potential_not|
+            inverted_form = potential_not.sub("not_", "")
+            if method_names.include?(inverted_form)
+              logger.warn "Enum element '#{potential_not}' in #{self.name} uses the prefix 'not_'." \
+                " This has caused a conflict with auto generated negative scopes." \
+                " Avoid using enum elements starting with 'not' where the positive form is also an element."
+            end
+          end
+        end
     end
-
-    private
-      def inherited(base)
-        base.defined_enums = defined_enums.deep_dup
-        super
-      end
-
-      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-        assert_valid_enum_definition_values(values)
-        # statuses = { }
-        enum_values = ActiveSupport::HashWithIndifferentAccess.new
-        name = name.to_s
-
-        # def self.statuses() statuses end
-        detect_enum_conflict!(name, name.pluralize, true)
-        singleton_class.define_method(name.pluralize) { enum_values }
-        defined_enums[name] = enum_values
-
-        detect_enum_conflict!(name, name)
-        detect_enum_conflict!(name, "#{name}=")
-
-        attribute(name, **options)
-
-        decorate_attributes([name]) do |_name, subtype|
-          if subtype == ActiveModel::Type.default_value
-            raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
-              " backed by a database column or declared with an explicit type" \
-              " via `attribute`."
-          end
-
-          subtype = subtype.subtype if EnumType === subtype
-          EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
-        end
-
-        value_method_names = []
-        _enum_methods_module.module_eval do
-          prefix = if prefix
-            prefix == true ? "#{name}_" : "#{prefix}_"
-          end
-
-          suffix = if suffix
-            suffix == true ? "_#{name}" : "_#{suffix}"
-          end
-
-          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-          pairs.each do |label, value|
-            enum_values[label] = value
-            label = label.to_s
-
-            value_method_name = "#{prefix}#{label}#{suffix}"
-            value_method_names << value_method_name
-            define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-
-            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
-            value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
-
-            if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
-              value_method_names << value_method_alias
-              define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
-            end
-          end
-        end
-        detect_negative_enum_conditions!(value_method_names) if scopes
-
-        if validate
-          validate = {} unless Hash === validate
-          validates_inclusion_of name, in: enum_values.keys, **validate
-        end
-
-        enum_values.freeze
-      end
-
-      class EnumMethods < Module # :nodoc:
-        def initialize(klass)
-          @klass = klass
-        end
-
-        private
-          attr_reader :klass
-
-          def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-            if instance_methods
-              # def active?() status_for_database == 0 end
-              klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-              define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
-
-              # def active!() update!(status: 0) end
-              klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
-              define_method("#{value_method_name}!") { update!(name => value) }
-            end
-
-            if scopes
-              # scope :active, -> { where(status: 0) }
-              klass.send(:detect_enum_conflict!, name, value_method_name, true)
-              klass.scope value_method_name, -> { where(name => value) }
-
-              # scope :not_active, -> { where.not(status: 0) }
-              klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
-            end
-          end
-      end
-      private_constant :EnumMethods
-
-      def _enum_methods_module
-        @_enum_methods_module ||= begin
-          mod = EnumMethods.new(self)
-          include mod
-          mod
-        end
-      end
-
-      def assert_valid_enum_definition_values(values)
-        case values
-        when Hash
-          if values.empty?
-            raise ArgumentError, "Enum values #{values} must not be empty."
-          end
-
-          if values.keys.any?(&:blank?)
-            raise ArgumentError, "Enum values #{values} must not contain a blank name."
-          end
-        when Array
-          if values.empty?
-            raise ArgumentError, "Enum values #{values} must not be empty."
-          end
-
-          unless values.all?(Symbol) || values.all?(String)
-            raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
-          end
-
-          if values.any?(&:blank?)
-            raise ArgumentError, "Enum values #{values} must not contain a blank name."
-          end
-        else
-          raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
-        end
-      end
-
-      ENUM_CONFLICT_MESSAGE = \
-        "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
-        "this will generate a %{type} method \"%{method}\", which is already defined " \
-        "by %{source}."
-      private_constant :ENUM_CONFLICT_MESSAGE
-
-      def detect_enum_conflict!(enum_name, method_name, klass_method = false)
-        if klass_method && dangerous_class_method?(method_name)
-          raise_conflict_error(enum_name, method_name, type: "class")
-        elsif klass_method && method_defined_within?(method_name, Relation)
-          raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
-        elsif klass_method && method_name.to_sym == :id
-          raise_conflict_error(enum_name, method_name)
-        elsif !klass_method && dangerous_attribute_method?(method_name)
-          raise_conflict_error(enum_name, method_name)
-        elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
-          raise_conflict_error(enum_name, method_name, source: "another enum")
-        end
-      end
-
-      def raise_conflict_error(enum_name, method_name, type: "instance", source: "Active Record")
-        raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
-          enum: enum_name,
-          klass: name,
-          type: type,
-          method: method_name,
-          source: source
-        }
-      end
-
-      def detect_negative_enum_conditions!(method_names)
-        return unless logger
-
-        method_names.select { |m| m.start_with?("not_") }.each do |potential_not|
-          inverted_form = potential_not.sub("not_", "")
-          if method_names.include?(inverted_form)
-            logger.warn "Enum element '#{potential_not}' in #{self.name} uses the prefix 'not_'." \
-              " This has caused a conflict with auto generated negative scopes." \
-              " Avoid using enum elements starting with 'not' where the positive form is also an element."
-          end
-        end
-      end
   end
 end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -164,139 +164,12 @@ module ActiveRecord
   #   conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
   module Enum
     extend ActiveSupport::Concern
-
-    included do
-      class_attribute(:defined_enums, instance_writer: false, default: {})
-    end
-
-    class EnumType < Type::Value # :nodoc:
-      delegate :type, to: :subtype
-
-      def initialize(name, mapping, subtype, raise_on_invalid_values: true)
-        @name = name
-        @mapping = mapping
-        @subtype = subtype
-        @_raise_on_invalid_values = raise_on_invalid_values
-      end
-
-      def cast(value)
-        if mapping.has_key?(value)
-          value.to_s
-        elsif mapping.has_value?(value)
-          mapping.key(value)
-        else
-          value.presence
-        end
-      end
-
-      def deserialize(value)
-        mapping.key(subtype.deserialize(value))
-      end
-
-      def serialize(value)
-        subtype.serialize(mapping.fetch(value, value))
-      end
-
-      def serializable?(value, &block)
-        subtype.serializable?(mapping.fetch(value, value), &block)
-      end
-
-      def assert_valid_value(value)
-        return unless @_raise_on_invalid_values
-
-        unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
-          raise ArgumentError, "'#{value}' is not a valid #{name}"
-        end
-      end
-
-      attr_reader :subtype
-
-      private
-        attr_reader :name, :mapping
-    end
+    include ActiveModel::Enum
 
     module ClassMethods
-      def enum(name = nil, values = nil, **options)
-        if name
-          values, options = options, {} unless values
-          return _enum(name, values, **options)
-        end
-
-        definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
-        options.transform_keys! { |key| :"#{key[1..-1]}" }
-
-        definitions.each { |name, values| _enum(name, values, **options) }
-      end
-
       private
-        def inherited(base)
-          base.defined_enums = defined_enums.deep_dup
-          super
-        end
-
         def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-          assert_valid_enum_definition_values(values)
-          # statuses = { }
-          enum_values = ActiveSupport::HashWithIndifferentAccess.new
-          name = name.to_s
-
-          # def self.statuses() statuses end
-          detect_enum_conflict!(name, name.pluralize, true)
-          singleton_class.define_method(name.pluralize) { enum_values }
-          defined_enums[name] = enum_values
-
-          detect_enum_conflict!(name, name)
-          detect_enum_conflict!(name, "#{name}=")
-
-          attribute(name, **options)
-
-          decorate_attributes([name]) do |_name, subtype|
-            if subtype == ActiveModel::Type.default_value
-              raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
-                " backed by a database column or declared with an explicit type" \
-                " via `attribute`."
-            end
-
-            subtype = subtype.subtype if EnumType === subtype
-            EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
-          end
-
-          value_method_names = []
-          _enum_methods_module.module_eval do
-            prefix = if prefix
-              prefix == true ? "#{name}_" : "#{prefix}_"
-            end
-
-            suffix = if suffix
-              suffix == true ? "_#{name}" : "_#{suffix}"
-            end
-
-            pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-            pairs.each do |label, value|
-              enum_values[label] = value
-              label = label.to_s
-
-              value_method_name = "#{prefix}#{label}#{suffix}"
-              value_method_names << value_method_name
-              define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-
-              method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
-              value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
-
-              if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
-                value_method_names << value_method_alias
-                define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
-              end
-            end
-          end
-          detect_negative_enum_conditions!(value_method_names) if scopes
-
-          if validate
-            validate = {} unless Hash === validate
-            validates_inclusion_of name, in: enum_values.keys, **validate
-          end
-
-          enum_values.freeze
+          super
         end
 
         class EnumMethods < Module # :nodoc:
@@ -336,33 +209,6 @@ module ActiveRecord
             mod = EnumMethods.new(self)
             include mod
             mod
-          end
-        end
-
-        def assert_valid_enum_definition_values(values)
-          case values
-          when Hash
-            if values.empty?
-              raise ArgumentError, "Enum values #{values} must not be empty."
-            end
-
-            if values.keys.any?(&:blank?)
-              raise ArgumentError, "Enum values #{values} must not contain a blank name."
-            end
-          when Array
-            if values.empty?
-              raise ArgumentError, "Enum values #{values} must not be empty."
-            end
-
-            unless values.all?(Symbol) || values.all?(String)
-              raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
-            end
-
-            if values.any?(&:blank?)
-              raise ArgumentError, "Enum values #{values} must not contain a blank name."
-            end
-          else
-            raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
           end
         end
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -455,7 +455,7 @@ module ActiveRecord
           if operation != "count"
             type = column.try(:type_caster) ||
               lookup_cast_type_from_join_dependencies(column_name.to_s) || Type.default_value
-            type = type.subtype if Enum::EnumType === type
+            type = type.subtype if ActiveModel::Enum::EnumType === type
           end
 
           type_cast_calculated_value(result.cast_values.first, operation, type)
@@ -526,7 +526,7 @@ module ActiveRecord
           if operation != "count"
             type = column.try(:type_caster) ||
               lookup_cast_type_from_join_dependencies(column_name.to_s) || Type.default_value
-            type = type.subtype if Enum::EnumType === type
+            type = type.subtype if ActiveModel::Enum::EnumType === type
           end
 
           hash_rows.each_with_object({}) do |row, result|


### PR DESCRIPTION
This moves most of the implementation of ActiveRecord::Enum to
ActiveModel::Enum. This excludes:
* scopes, as scopes aren't supported by ActiveModel.
* method conflict detection, as this is difficult to implement in
  ActiveModel.

```ruby
class Conversation
  include ActiveModel::Attributes
  include ActiveModel::Enum
  attribute :status, :integer
  enum :status, [ :active, :archived ]
end

conversation = Conversation.new
conversation.active!
conversation.active? # => true
conversation.status  # => "active"
```

The current implementation supports using integers for values and
strings for labels, if defined.

This also introduces ActiveSupport::Concern to ActiveRecord::Enum as
this allows both ActiveModel::Enum and ActiveRecord::Enum to be mixed in
with `include` instead of `extend`, like most other ActiveModel modules.

The tests were copied from ActiveRecord and modified for ActiveModel.
Scoping and method conflict detection tests were excluded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
