### PR TITLE
Make return value of `Cache::Store#write` consistent

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Make return values of `Cache::Store#write` consistent.
+
+    The return value was not specified before. Now it returns `true` on a successful write,
+    `nil` if there was an error talking to the cache backend, and `false` if the write failed
+    for another reason (e.g. the key already exists and `unless_exist: true` was passed).
+
+    *Sander Verdonschot*
+
 *   Fix logged cache keys not always matching actual key used by cache action.
 
     *Hartley McGuire*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -166,7 +166,7 @@ module ActiveSupport
     #   cache = ActiveSupport::Cache::MemoryStore.new
     #
     #   cache.read('city')   # => nil
-    #   cache.write('city', "Duckburgh")
+    #   cache.write('city', "Duckburgh") # => true
     #   cache.read('city')   # => "Duckburgh"
     #
     #   cache.write('not serializable', Proc.new {}) # => TypeError
@@ -629,6 +629,9 @@ module ActiveSupport
 
       # Writes the value to the cache with the key. The value must be supported
       # by the +coder+'s +dump+ and +load+ methods.
+      #
+      # Returns +true+ if the write succeeded, +nil+ if there was an error talking
+      # to the cache backend, or +false+ if the write failed for another reason.
       #
       # By default, cache entries larger than 1kB are compressed. Compression
       # allows more data to be stored in the same memory footprint, leading to

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -263,10 +263,10 @@ module ActiveSupport
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
             expires_in += 5.minutes
           end
-          rescue_error_with false do
+          rescue_error_with nil do
             # Don't pass compress option to Dalli since we are already dealing with compression.
             options.delete(:compress)
-            @data.with { |c| c.send(method, key, payload, expires_in, **options) }
+            @data.with { |c| !!c.send(method, key, payload, expires_in, **options) }
           end
         end
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -368,8 +368,8 @@ module ActiveSupport
           if pipeline
             pipeline.set(key, payload, **modifiers)
           else
-            failsafe :write_entry, returning: false do
-              redis.then { |c| c.set key, payload, **modifiers }
+            failsafe :write_entry, returning: nil do
+              redis.then { |c| !!c.set(key, payload, **modifiers) }
             end
           end
         end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -7,14 +7,14 @@ require "active_support/error_reporter/test_helper"
 module CacheStoreBehavior
   def test_should_read_and_write_strings
     key = SecureRandom.uuid
-    assert @cache.write(key, "bar")
+    assert_equal true, @cache.write(key, "bar")
     assert_equal "bar", @cache.read(key)
   end
 
   def test_should_overwrite
     key = SecureRandom.uuid
-    @cache.write(key, "bar")
-    @cache.write(key, "baz")
+    assert_equal true, @cache.write(key, "bar")
+    assert_equal true, @cache.write(key, "baz")
     assert_equal "baz", @cache.read(key)
   end
 
@@ -116,25 +116,25 @@ module CacheStoreBehavior
 
   def test_should_read_and_write_hash
     key = SecureRandom.uuid
-    assert @cache.write(key, a: "b")
+    assert_equal true, @cache.write(key, a: "b")
     assert_equal({ a: "b" }, @cache.read(key))
   end
 
   def test_should_read_and_write_integer
     key = SecureRandom.uuid
-    assert @cache.write(key, 1)
+    assert_equal true, @cache.write(key, 1)
     assert_equal 1, @cache.read(key)
   end
 
   def test_should_read_and_write_nil
     key = SecureRandom.uuid
-    assert @cache.write(key, nil)
+    assert_equal true, @cache.write(key, nil)
     assert_nil @cache.read(key)
   end
 
   def test_should_read_and_write_false
     key = SecureRandom.uuid
-    assert @cache.write(key, false)
+    assert_equal true, @cache.write(key, false)
     assert_equal false, @cache.read(key)
   end
 

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -49,10 +49,10 @@ module FailureSafetyBehavior
     end
   end
 
-  def test_write_failure_returns_false
+  def test_write_failure_returns_nil
     key = SecureRandom.uuid
     emulating_unavailability do |cache|
-      assert_equal false, cache.write(key, SecureRandom.alphanumeric)
+      assert_nil cache.write(key, SecureRandom.alphanumeric)
     end
   end
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -207,6 +207,11 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_write_with_unless_exist
+    assert_equal true, @cache.write("foo", 1)
+    assert_equal false, @cache.write("foo", 1, unless_exist: true)
+  end
+
   def test_increment_expires_in
     cache = lookup_store(raw: true, namespace: nil)
     assert_called_with client(cache), :incr, [ "foo", 1, 60, 1 ] do

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -195,6 +195,11 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    def test_write_with_unless_exist
+      assert_equal true, @cache.write("foo", 1)
+      assert_equal false, @cache.write("foo", 1, unless_exist: true)
+    end
+
     def test_increment_ttl
       # existing key
       redis_backend(@cache_no_ttl) { |r| r.set "#{@namespace}:jar", 10 }


### PR DESCRIPTION
### Motivation / Background

I'm trying to use memcached to de-duplicate some work. When I start the work, I want to write a key with a 5s TTL and if the key already exists, someone else is already doing the work and started at most 5s ago, so I don't have to start it again. To avoid a race condition, I'd like to use the `unless_exist: true` option for this. If `write(..., unless_exist: true)` returns `false`, the key was already there and we don't need to do the work.

The only problem with this approach is that the `write` method also returns `false` if there is some error with memcached. But in that case I do want to do the work, to ensure it gets done at least once.

### Detail

The return value of `Cache::Store#write` was not specified before, and varied between backends. This PR makes it consistent:

- `true` indicates a successful write
- `nil` indicates an error talking to the cache backend
- `false` indicates a write that failed for another reason

This lets us distinguish the case where the key already exists from the case where there was a memcached (or Redis) error.

### Additional information

I only changed the implementation of the Redis and memcached stores. From CI, it looks like all others already followed this pattern?

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
