### PR TITLE
Add caveat about `normalizes` / `Marshal` interaction [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -49,6 +49,14 @@ module ActiveRecord # :nodoc:
       # By default, the normalization will not be applied to +nil+ values. This
       # behavior can be changed with the +:apply_to_nil+ option.
       #
+      # Be aware that if your app was created before Rails 7.1, and your app
+      # marshals instances of the targeted model (for example, when caching),
+      # then you should set ActiveRecord.marshalling_format_version to +7.1+ or
+      # higher via either <tt>config.load_defaults 7.1</tt> or
+      # <tt>config.active_record.marshalling_format_version = 7.1</tt>.
+      # Otherwise, +Marshal+ may attempt to serialize the normalization +Proc+
+      # and raise +TypeError+.
+      #
       # ==== Options
       #
       # * +:with+ - Any callable object that accepts the attribute's value as


### PR DESCRIPTION
When `ActiveRecord.marshalling_format_version` is set to `6.1`, `Marshal` will try to serialize attribute types along with the model, causing a `TypeError` if the model uses `ActiveRecord::Base.normalizes` with a normalization `Proc`.

This commit adds a caveat to the `normalizes` API documentation to warn users that they should set `marshalling_format_version` to `7.1` if they are using `normalizes` and marshalling the targeted model.

Fixes #49871.

---

@mjankowski Do you feel like this would have prevented the issue you encountered?
