### PR TITLE
Do not use `INSERT IGNORE` when upserting to MariaDB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -639,11 +639,12 @@ module ActiveRecord
       end
 
       def build_insert_sql(insert) # :nodoc:
-        sql = +"INSERT"
-        sql << " IGNORE" if insert.skip_duplicates?
-        sql << " #{insert.into} #{insert.values_list}"
+        sql = +"INSERT #{insert.into} #{insert.values_list}"
 
-        if insert.update_duplicates?
+        if insert.skip_duplicates?
+          no_op_column = quote_column_name(insert.keys.first)
+          sql << " ON DUPLICATE KEY UPDATE #{no_op_column}=#{no_op_column}"
+        elsif insert.update_duplicates?
           sql << " ON DUPLICATE KEY UPDATE "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -129,6 +129,16 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    def test_insert_all_generates_correct_sql
+      skip unless supports_insert_on_duplicate_skip?
+
+      assert_sql(/ON DUPLICATE KEY UPDATE/) do
+        Book.insert_all [{ id: 1, name: "Agile Web Development with Rails" }]
+      end
+    end
+  end
+
   def test_insert_all_with_skip_duplicates_and_autonumber_id_not_given
     skip unless supports_insert_on_duplicate_skip?
 


### PR DESCRIPTION
Follow up to #49840.

In that PR, the logic for inserting with skipping duplicates was rewritten to use `INSERT IGNORE`.
As it turned out in https://github.com/rails/rails/pull/49840#discussion_r1379329052, this change generates a warning inside the database. So in this PR, I reverted that change. Also added a test case to avoid such change in the future.

cc @jhawthorn 