### PR TITLE
Document async option in guides for query.active_record events

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -346,6 +346,7 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:binds`             | Bind parameters                          |
 | `:type_casted_binds` | Typecasted bind parameters               |
 | `:statement_name`    | SQL Statement name                       |
+| `:async`             | `true` if query is loaded asynchronously |
 | `:cached`            | `true` is added when cached queries used |
 
 Adapters may add their own data as well.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the async key in the `sql.active_record` event isn't documented in the guides.

### Detail

This Pull Request changes the guides to mention this key.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
