### PR TITLE
Move method `#processed?` to public for Variant(WithRecord) and Preview.

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -2,4 +2,8 @@
 
     *Yogesh Khater*
 
+*   Move method `#processed?` to public for Variant(WithRecord) and Preview.
+
+    *balbesina*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -39,6 +39,10 @@ class ActiveStorage::Preview
     @blob, @variation = blob, ActiveStorage::Variation.wrap(variation_or_variation_key)
   end
 
+  def processed?
+    image.attached?
+  end
+
   # Processes the preview if it has not been processed yet. Returns the receiving Preview instance for convenience:
   #
   #   blob.preview(resize_to_limit: [100, 100]).processed.url
@@ -91,10 +95,6 @@ class ActiveStorage::Preview
   end
 
   private
-    def processed?
-      image.attached?
-    end
-
     def process
       previewer.preview(service_name: blob.service_name) do |attachable|
         ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role) do

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -61,6 +61,10 @@ class ActiveStorage::Variant
     @blob, @variation = blob, ActiveStorage::Variation.wrap(variation_or_variation_key)
   end
 
+  def processed?
+    service.exist?(key)
+  end
+
   # Returns the variant instance itself after it's been processed or an existing processing has been found on the service.
   def processed
     process unless processed?
@@ -102,10 +106,6 @@ class ActiveStorage::Variant
   end
 
   private
-    def processed?
-      service.exist?(key)
-    end
-
     def process
       blob.open do |input|
         variation.transform(input) do |output|

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -13,6 +13,10 @@ class ActiveStorage::VariantWithRecord
     @blob, @variation = blob, ActiveStorage::Variation.wrap(variation)
   end
 
+  def processed?
+    record.present?
+  end
+
   def processed
     process unless processed?
     self
@@ -34,10 +38,6 @@ class ActiveStorage::VariantWithRecord
   delegate :key, :url, :download, to: :image, allow_nil: true
 
   private
-    def processed?
-      record.present?
-    end
-
     def process
       transform_blob { |image| create_or_find_record(image: image) }
     end

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -9,7 +9,7 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
   test "creates variant" do
     transformations = { resize_to_limit: [100, 100] }
 
-    assert_changes -> { @blob.variant(transformations).send(:processed?) }, from: false, to: true do
+    assert_changes -> { @blob.variant(transformations).processed? }, from: false, to: true do
       perform_enqueued_jobs do
         ActiveStorage::TransformJob.perform_later @blob, transformations
       end
@@ -21,7 +21,7 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
     transformations = { resize_to_limit: [100, 100] }
 
     begin
-      assert_changes -> { @blob.variant(transformations).send(:processed?) }, from: false, to: true do
+      assert_changes -> { @blob.variant(transformations).processed? }, from: false, to: true do
         perform_enqueued_jobs do
           ActiveStorage::TransformJob.perform_later @blob, transformations
         end


### PR DESCRIPTION
### Motivation / Background

Sometimes we need to know if variant is ready or not, without triggering the transform.

```ruby
variant.processed? ? variant.image : original_attachment
```

### Detail

This Pull Request exposes `#processed?` check for ActiveStorage::Variant(WithRecord) to public.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Minor bug fixes and documentation changes should not be included.
