### PR TITLE
add a note on the postgres limit [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -780,6 +780,8 @@ The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
 This may change in the future. [#27214](https://github.com/rails/rails/issues/27214)
 
+NOTE: PostgreSQL has a [8000 bytes limit](https://www.postgresql.org/docs/current/sql-notify.html) on `NOTIFY` (the command used under the hood for sending notifications) which might be a constraint when dealing with large payloads.
+
 ### Allowed Request Origins
 
 Action Cable will only accept requests from specified origins, which are


### PR DESCRIPTION
### Motivation / Background
Now more than before, with the upcoming Solid Queue, developers might not want to have Redis as a dependency.

The PostgreSQL adapter for ActionCable plays an important role on this transition, allowing people to transmit data over the database.

One limitation needs to be considered though, PostgreSQL [has a 8000 bytes limit](https://www.postgresql.org/docs/current/sql-notify.html) on `NOTIFY`.

This PR documents that and links a possible solution: the [actioncable-enhanced-postgresql-adapter](https://github.com/reclaim-the-stack/actioncable-enhanced-postgresql-adapter) gem.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
