### PR TITLE
[ci skip] Simplify and sync url_for options docs

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -140,6 +140,8 @@ module ActionDispatch
       #   for the named dynamic segments of path. If unused, they will be discarded.
       # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in <tt>"/archive/2009/"</tt>.
       # * <tt>:script_name</tt> - Specifies application path relative to domain root. If provided, prepends application path.
+      # * <tt>:user</tt> - Inline HTTP authentication (only plucked out if <tt>:password</tt> is also present).
+      # * <tt>:password</tt> - Inline HTTP authentication (only plucked out if <tt>:user</tt> is also present).
       #
       # Any other key (<tt>:controller</tt>, <tt>:action</tt>, etc.) given to
       # +url_for+ is forwarded to the Routes module.

--- a/actionview/lib/action_view/routing_url_for.rb
+++ b/actionview/lib/action_view/routing_url_for.rb
@@ -4,21 +4,13 @@ require "action_dispatch/routing/polymorphic_routes"
 
 module ActionView
   module RoutingUrlFor
-    # Returns the URL for the set of +options+ provided. This takes the
-    # same options as +url_for+ in Action Controller (see the
-    # documentation for ActionDispatch::Routing::UrlFor#url_for). Note that by default
+    # Returns the URL for the set of +options+ provided. Note that by default
     # <tt>:only_path</tt> is <tt>true</tt> so you'll get the relative <tt>"/controller/action"</tt>
     # instead of the fully qualified URL like <tt>"http://example.com/controller/action"</tt>.
     #
     # ==== Options
-    # * <tt>:anchor</tt> - Specifies the anchor name to be appended to the path.
-    # * <tt>:only_path</tt> - If true, returns the relative URL (omitting the protocol, host name, and port) (<tt>true</tt> by default unless <tt>:host</tt> is specified).
-    # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in <tt>"/archive/2005/"</tt>. Note that this
-    #   is currently not recommended since it breaks caching.
-    # * <tt>:host</tt> - Overrides the default (current) host if provided.
-    # * <tt>:protocol</tt> - Overrides the default (current) protocol if provided.
-    # * <tt>:user</tt> - Inline HTTP authentication (only plucked out if <tt>:password</tt> is also present).
-    # * <tt>:password</tt> - Inline HTTP authentication (only plucked out if <tt>:user</tt> is also present).
+    #
+    # Supports the same options as ActionDispatch::Routing::UrlFor#url_for
     #
     # ==== Relying on named routes
     #


### PR DESCRIPTION
### Motivation / Background

I got confused by all the supported options of `ActionView::RoutingUrlFor#url_for`, because it listed an incomplete list of options under the `==== Options` section. I know that if I had read the general description carefully, I would have seen the reference to `ActionDispatch::Routing::UrlFor#url_for` 🤦, but I just looked at the options.

I think it would be clearer to directly link to the more complete list of options, similar to what other `==== Options` sections do in various other places. Furthermore this also means that we don't need to maintain two separate lists of options, making the docs more complete with less code.

One downside would be the additional click required to get to the options. If you think this is not optimal, I'd be happy to sync both options lists.