### PR TITLE
Add picture_tag to ActionView helpers documentation [ci skip]

### DIFF
--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -78,12 +78,16 @@ image_tag("icon.png") # => <img src="/assets/icon.png" />
 Returns an HTML picture tag for the source. It supports passing a String, an Array or a Block.
 
 ```ruby
-picture_tag("icon.webp", "icon.png") # =>
+picture_tag("icon.webp", "icon.png")
+```
 
+This generates the following HTML:
+
+```html
 <picture>
-  <source srcset="/icon.webp" type="image/webp" />
-  <source srcset="/icon.png" type="image/png" />
-  <img src="/icon.png" />
+  <source srcset="/assets/icon.webp" type="image/webp" />
+  <source srcset="/assets/icon.png" type="image/png" />
+  <img src="/assets/icon.png" />
 </picture>
 ```
 

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -73,6 +73,20 @@ Returns an HTML image tag for the source. The source can be a full path or a fil
 image_tag("icon.png") # => <img src="/assets/icon.png" />
 ```
 
+#### picture_tag
+
+Returns an HTML picture tag for the source. It supports passing a String, an Array or a Block.
+
+```ruby
+picture_tag("icon.webp", "icon.png") # =>
+
+<picture class="mt-2">
+  <source srcset="/icon.webp" />
+  <source srcset="/icon.png" />
+  <img src="/icon.png" />
+</picture>
+```
+
 #### javascript_include_tag
 
 Returns an HTML script tag for each of the sources provided. You can pass in the filename (`.js` extension is optional) of JavaScript files that exist in your `app/assets/javascripts` directory for inclusion into the current page or you can pass the full path relative to your document root.

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -80,7 +80,7 @@ Returns an HTML picture tag for the source. It supports passing a String, an Arr
 ```ruby
 picture_tag("icon.webp", "icon.png") # =>
 
-<picture class="mt-2">
+<picture>
   <source srcset="/icon.webp" />
   <source srcset="/icon.png" />
   <img src="/icon.png" />

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -81,8 +81,8 @@ Returns an HTML picture tag for the source. It supports passing a String, an Arr
 picture_tag("icon.webp", "icon.png") # =>
 
 <picture>
-  <source srcset="/icon.webp" />
-  <source srcset="/icon.png" />
+  <source srcset="/icon.webp" type="image/webp" />
+  <source srcset="/icon.png" type="image/png" />
   <img src="/icon.png" />
 </picture>
 ```


### PR DESCRIPTION
Backport `picture_tag` feature (https://github.com/rails/rails/pull/48100/files#diff-5337574dfb11b221d0eff970db44926331da327e16bdaa39c3effb6a34474b0b) into Guides documentation
