### PR TITLE
Compress large payloads in all Action Cable subscription adapters with ActiveSupport::Gzip

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Compress large payloads in all subscription adapters with ActiveSupport::Gzip
+
+    This will also help broadcast payloads on average 2 to 3 times larger on adapters such as PostgreSQL that has a size limit
+
+    *Bruno Prieto*
+
 *   Add two new assertion methods for ActionCable test cases: `assert_has_no_stream`
     and `assert_has_no_stream_for`. These methods can be used to assert that a
     stream has been stopped, e.g. via `stop_stream` or `stop_stream_for`. They complement

--- a/actioncable/lib/action_cable/subscription_adapter/compressor.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/compressor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "active_support/gzip"
+require "active_support/core_ext/numeric/bytes"
+require "active_support/core_ext/string/access"
+
+module ActionCable
+  module SubscriptionAdapter
+    class Compressor
+      SCHEMA_VERSION = "v1"
+      SCHEMA_FORMAT = /#{SCHEMA_VERSION}\/(0|1)\//
+      PREFIX_SIZE = "#{SCHEMA_VERSION}/./".size
+
+      def initialize(threshold: 1.kilobyte, compressor: ActiveSupport::Gzip)
+        @threshold = threshold
+        @compressor = compressor
+      end
+
+      def compress(data)
+        return "#{SCHEMA_VERSION}/0/#{data}" if data.size < @threshold
+
+        "#{SCHEMA_VERSION}/1/#{@compressor.compress(data)}"
+      end
+
+      def decompress(data)
+        return data unless valid_schema?(data)
+
+        return data.from(PREFIX_SIZE) unless compressed?(data)
+
+        @compressor.decompress(data.from(PREFIX_SIZE))
+      end
+
+      def compressed?(data)
+        data.start_with?("#{SCHEMA_VERSION}/1/")
+      end
+
+      private
+        def valid_schema?(data)
+          data.start_with?(SCHEMA_FORMAT)
+        end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -10,6 +10,10 @@ module ActionCable
         @sync = Mutex.new
       end
 
+      def compress_with(compressor)
+        @compressor = compressor
+      end
+
       def add_subscriber(channel, subscriber, on_success)
         @sync.synchronize do
           new_channel = !@subscribers.key?(channel)
@@ -36,6 +40,7 @@ module ActionCable
       end
 
       def broadcast(channel, message)
+        message = @compressor.decompress(message) if @compressor
         list = @sync.synchronize do
           return if !@subscribers.key?(channel)
           @subscribers[channel].dup

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -128,4 +128,14 @@ module CommonSubscriptionAdapterTest
       end
     end
   end
+
+  def test_large_payload_broadcast
+    message = "hello world" * 10000
+
+    subscribe_as_queue("channel") do |queue|
+      @tx_adapter.broadcast("channel", message)
+
+      assert_equal message, queue.pop
+    end
+  end
 end

--- a/actioncable/test/subscription_adapter/compressor_test.rb
+++ b/actioncable/test/subscription_adapter/compressor_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionCable::SubscriptionAdapter::CompressorTest < ActionCable::TestCase
+  SCHEMA_VERSION = ActionCable::SubscriptionAdapter::Compressor::SCHEMA_VERSION
+
+  setup do
+    @compressor = ActionCable::SubscriptionAdapter::Compressor.new
+    @uncompressed_data = "hello" * 1000
+    @compressed_data = @compressor.compress(@uncompressed_data)
+  end
+
+  test "#compress returns uncompressed data if it's smaller than the threshold" do
+    assert @compressor.compress("hello").start_with?("#{SCHEMA_VERSION}/0/")
+  end
+
+  test "#compress returns compressed data if it's larger than the threshold" do
+    assert @compressor.compress(@uncompressed_data).start_with?("#{SCHEMA_VERSION}/1/")
+  end
+
+  test "#decompress returns uncompressed data if it's not compressed" do
+    assert_equal "hello", @compressor.decompress("#{SCHEMA_VERSION}/0/hello")
+  end
+
+  test "#decompress returns uncompressed data if it's compressed" do
+    assert_equal @uncompressed_data, @compressor.decompress(@compressed_data)
+  end
+
+  test "#decompress returns original data if schema is not valid" do
+    assert_equal "hello", @compressor.decompress("hello")
+  end
+end

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -780,7 +780,15 @@ The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
 This may change in the future. [#27214](https://github.com/rails/rails/issues/27214)
 
+```yaml
+production:
+  adapter: postgresql
+  channel_prefix: appname_production
+```
+
 NOTE: PostgreSQL has a [8000 bytes limit](https://www.postgresql.org/docs/current/sql-notify.html) on `NOTIFY` (the command used under the hood for sending notifications) which might be a constraint when dealing with large payloads.
+Nevertheless, Action Cable compresses large payloads to address this limitation,
+which should be sufficient for most use cases.
 
 ### Allowed Request Origins
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The [PostgreSQL notify command](https://www.postgresql.org/docs/16/sql-notify.html) has a limit of 8000 bytes, which means that the payload that can be broadcasted cannot be very large.

This is motivated by the simplicity of the solution and by leaving the Redis dependency, along the same lines of Solid Cache and Solid Queue.

### Detail

Like `ActiveSupport::Cache`, Payloads that are larger than 1 kilobytes are now compressed with ActiveSupport::Gzip.

```yaml
production:
  adapter: postgresql
  channel_prefix: appname_production
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

In the tests you can see a rather large string that can now be broadcasted with the PostgreSQL adapter.

Additionally, I've added the `ActionCable::SubscriptionAdapter::Compressor` class so other adapters can make use of it in the future.

There is another approach and another discussion in #49634.

Thanks to @palkan for the idea in this [comment](https://github.com/rails/rails/pull/49634#issuecomment-1765096837).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
