### PR TITLE
Don't mark Float::INFINITY as changed if didn't

### DIFF
--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -42,7 +42,8 @@ module ActiveModel
           end
 
           def number_to_non_number?(old_value, new_value_before_type_cast)
-            old_value != nil && non_numeric_string?(new_value_before_type_cast.to_s)
+            old_value != nil && !new_value_before_type_cast.is_a?(::Numeric) &&
+              non_numeric_string?(new_value_before_type_cast.to_s)
           end
 
           def non_numeric_string?(value)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't mark Float::INFINITY as changed when reassigning it
+
+    When saving a record with a float infinite value, it shouldn't mark as changed
+
+    *Maicol Bentancor*
+
 *   Support `RETURNING` clause for MariaDB
 
     *fatkodima*, *Nikolay Kondratyev*

--- a/activerecord/test/cases/adapters/postgresql/numbers_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/numbers_test.rb
@@ -48,4 +48,20 @@ class PostgresqlNumberTest < ActiveRecord::PostgreSQLTestCase
     assert_equal new_single, record.single
     assert_equal new_double, record.double
   end
+
+  def test_reassigning_infinity_does_not_mark_record_as_changed
+    record = PostgresqlNumber.create!(single: Float::INFINITY, double: -Float::INFINITY)
+    record.reload
+    record.single = Float::INFINITY
+    record.double = -Float::INFINITY
+    assert_not_predicate record, :changed?
+  end
+
+  def test_reassigning_nan_does_not_mark_record_as_changed
+    record = PostgresqlNumber.create!(single: Float::NAN, double: Float::NAN)
+    record.reload
+    record.single = Float::NAN
+    record.double = Float::NAN
+    assert_not_predicate record, :changed?
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When saving a record with a float infinite value, it shouldn't mark as changed. This can be annoying when using with [papertrail](https://github.com/paper-trail-gem/paper_trail) or any other auditing system, since it creates a new version each time you save the record without real changes.

### Detail

How to reproduce:
```ruby
record = MyRecord.create!(float_field: Float::INFINITY)
record.reload
record.float_field = Float::INFINITY
record.changed? # returns true when it should be false
 ```
 
 Detail of the change:
 - The problem was when transforming the number to string, the regex `/\A\s*[+-]?\d/` didn't match as numeric since `Infinity` is not a number. I don't think is a good idea to add that word to the regex since we can have the `Infinity` word and will be a false positive. However, let me know if you have a better approach. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
