### PR TITLE
Preload Selenium driver_path before parallelizing system tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a race condition that could cause a `Text file busy - chromedriver`
+    error with parallel system tests
+
+    *Matt Brictson*
+
 *   Add `racc` as a dependency since it will become a bundled gem in Ruby 3.4.0
 
     *Hartley McGuire*


### PR DESCRIPTION
### Motivation / Background

When the `webdrivers` gem is not present (which is the default scenario in Rails 7.1+), the Selenium `driver_path` starts out as `nil`. This means the driver is located lazily, and deferred until a system test is run.

If parallel testing is used, this leads to a race condition, where each worker process tries to resolve the driver simultaneously. The result is an error as described in #49906.

### Detail

This commit fixes the race condition by changing the implementation of `Browser#preload`. The previous implementation worked when `driver_path` was set to a Proc by the `webdrivers` gem, but doesn't work when the `webdrivers` gem is not being used and the `driver_path` is `nil`.

If the `driver_path` is `nil`, `Browser#preload` will now use the `DriverFinder` utility provided by the `selenium-webdriver` gem to eagerly resolve the driver path. This ensures that `driver_path` is set before parallel test workers are forked.

Fixes #49906.

### Additional information

This solution mimics the code within Selenium that determines the driver executable on demand:

```
service.executable_path ||= WebDriver::DriverFinder.path(options, service.class)
```

https://github.com/SeleniumHQ/selenium/blob/7680b7cf25579217cb62a0893c4b2b69c0186062/rb/lib/selenium/webdriver/common/local_driver.rb#L41

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
