### PR TITLE
Avoid recalculating `CounterCache.counter_cached_association_names`

### DIFF
--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -182,7 +182,7 @@ module ActiveRecord
         _counter_cache_columns.include?(name)
       end
 
-      def load_schema # :nodoc:
+      def load_schema! # :nodoc:
         super
 
         association_names = _reflections.filter_map do |name, reflection|


### PR DESCRIPTION
After merging https://github.com/rails/rails/pull/49866, a flaky test started to appear - https://buildkite.com/rails/rails/builds/101543#018b9610-f396-4e76-90e9-5bae14521f1e and https://buildkite.com/rails/rails/builds/101530#018b9485-eef8-49a9-8826-be82230fe7fe

```
from /rails/activesupport/lib/active_support/core_ext/module/redefine_method.rb:20:in `define_method'
from /rails/activesupport/lib/active_support/core_ext/module/redefine_method.rb:20:in `redefine_method'
from /rails/activesupport/lib/active_support/core_ext/module/redefine_method.rb:27:in `redefine_singleton_method'
from /rails/activerecord/lib/active_record/counter_cache.rb:10:in `counter_cached_association_names='
from /rails/activerecord/lib/active_record/counter_cache.rb:194:in `load_schema'
from /rails/activerecord/lib/active_record/model_schema.rb:423:in `columns_hash'
from /rails/activerecord/lib/active_record/locking/optimistic.rb:161:in `locking_enabled?'
from /rails/activerecord/lib/active_record/locking/optimistic.rb:60:in `locking_enabled?'
from /rails/activerecord/lib/active_record/locking/optimistic.rb:148:in `_query_constraints_hash'
from /rails/activerecord/lib/active_record/persistence.rb:944:in `update_columns'
from /rails/activerecord/lib/active_record/encryption/encryptable_record.rb:191:in `block in decrypt_attributes'
from /rails/activerecord/lib/active_record/encryption/contexts.rb:40:in `with_encryption_context'
from /rails/activerecord/lib/active_record/encryption/contexts.rb:50:in `without_encryption'
from /rails/activerecord/lib/active_record/encryption/encryptable_record.rb:191:in `decrypt_attributes'
from /rails/activerecord/lib/active_record/encryption/encryptable_record.rb:166:in `decrypt'
from /rails/activerecord/test/cases/encryption/concurrency_test.rb:22:in `block (2 levels) in thread_encrypting_and_decrypting'
from /rails/activerecord/test/cases/encryption/concurrency_test.rb:20:in `each'
from /rails/activerecord/test/cases/encryption/concurrency_test.rb:20:in `with_index'
from /rails/activerecord/test/cases/encryption/concurrency_test.rb:20:in `block in thread_encrypting_and_decrypting'
```

The failing line is the https://github.com/rails/rails/blob/8c82595b8c862eb087615a14f61ded528274eeae/activerecord/test/cases/encryption/concurrency_test.rb#L22

which calls down the road https://github.com/rails/rails/blob/8c82595b8c862eb087615a14f61ded528274eeae/activerecord/lib/active_record/locking/optimistic.rb#L160-L162

which calls `columns_hash` which always calls `load_schema` which always recalculates and reassigns `counter_cached_association_names` https://github.com/rails/rails/pull/49866/files#diff-0441501ea93f2580c66bc58d845fcc2ad9dc5110cce249ce184c0b59483e253bR188-R194

Since the failing test from the referenced builds uses threads and `counter_cached_association_names` is defined as a `class_attribute` which is defined via https://github.com/rails/rails/blob/8c82595b8c862eb087615a14f61ded528274eeae/activesupport/lib/active_support/core_ext/class/attribute.rb#L108 which calls `redefined_method` and which is defined as https://github.com/rails/rails/blob/8c82595b8c862eb087615a14f61ded528274eeae/activesupport/lib/active_support/core_ext/module/redefine_method.rb#L17-L22 

Lines 19-20 should be executed atomically, but I suspect, that Thread1 executes line 19, Thread2 executes line 19, then Thread1 executes line 20 and when Thread2 tries to execute line 20, it gets the mentioned error.

cc @byroot @nvasilevski 