### PR TITLE
Use ActiveSupport::Concern for ActiveRecord::Enum

### DIFF
--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -292,7 +292,6 @@ module ActiveRecord # :nodoc:
     extend DynamicMatchers
     extend DelegatedType
     extend Explain
-    extend Enum
     extend Delegation::DelegateCache
     extend Aggregations::ClassMethods
 
@@ -318,6 +317,7 @@ module ActiveRecord # :nodoc:
     include SecurePassword
     include AutosaveAssociation
     include NestedAttributes
+    include Enum
     include Transactions
     include TouchLater
     include NoTouching

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -163,8 +163,10 @@ module ActiveRecord
   #
   #   conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
   module Enum
-    def self.extended(base) # :nodoc:
-      base.class_attribute(:defined_enums, instance_writer: false, default: {})
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute(:defined_enums, instance_writer: false, default: {})
     end
 
     class EnumType < Type::Value # :nodoc:
@@ -213,197 +215,199 @@ module ActiveRecord
         attr_reader :name, :mapping
     end
 
-    def enum(name = nil, values = nil, **options)
-      if name
-        values, options = options, {} unless values
-        return _enum(name, values, **options)
+    module ClassMethods
+      def enum(name = nil, values = nil, **options)
+        if name
+          values, options = options, {} unless values
+          return _enum(name, values, **options)
+        end
+
+        definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
+        options.transform_keys! { |key| :"#{key[1..-1]}" }
+
+        definitions.each { |name, values| _enum(name, values, **options) }
       end
 
-      definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
-      options.transform_keys! { |key| :"#{key[1..-1]}" }
+      private
+        def inherited(base)
+          base.defined_enums = defined_enums.deep_dup
+          super
+        end
 
-      definitions.each { |name, values| _enum(name, values, **options) }
+        def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
+          assert_valid_enum_definition_values(values)
+          # statuses = { }
+          enum_values = ActiveSupport::HashWithIndifferentAccess.new
+          name = name.to_s
+
+          # def self.statuses() statuses end
+          detect_enum_conflict!(name, name.pluralize, true)
+          singleton_class.define_method(name.pluralize) { enum_values }
+          defined_enums[name] = enum_values
+
+          detect_enum_conflict!(name, name)
+          detect_enum_conflict!(name, "#{name}=")
+
+          attribute(name, **options)
+
+          decorate_attributes([name]) do |_name, subtype|
+            if subtype == ActiveModel::Type.default_value
+              raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
+                " backed by a database column or declared with an explicit type" \
+                " via `attribute`."
+            end
+
+            subtype = subtype.subtype if EnumType === subtype
+            EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
+          end
+
+          value_method_names = []
+          _enum_methods_module.module_eval do
+            prefix = if prefix
+              prefix == true ? "#{name}_" : "#{prefix}_"
+            end
+
+            suffix = if suffix
+              suffix == true ? "_#{name}" : "_#{suffix}"
+            end
+
+            pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+            pairs.each do |label, value|
+              enum_values[label] = value
+              label = label.to_s
+
+              value_method_name = "#{prefix}#{label}#{suffix}"
+              value_method_names << value_method_name
+              define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+
+              method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+              value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
+
+              if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
+                value_method_names << value_method_alias
+                define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+              end
+            end
+          end
+          detect_negative_enum_conditions!(value_method_names) if scopes
+
+          if validate
+            validate = {} unless Hash === validate
+            validates_inclusion_of name, in: enum_values.keys, **validate
+          end
+
+          enum_values.freeze
+        end
+
+        class EnumMethods < Module # :nodoc:
+          def initialize(klass)
+            @klass = klass
+          end
+
+          private
+            attr_reader :klass
+
+            def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+              if instance_methods
+                # def active?() status_for_database == 0 end
+                klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
+                define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
+
+                # def active!() update!(status: 0) end
+                klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
+                define_method("#{value_method_name}!") { update!(name => value) }
+              end
+
+              if scopes
+                # scope :active, -> { where(status: 0) }
+                klass.send(:detect_enum_conflict!, name, value_method_name, true)
+                klass.scope value_method_name, -> { where(name => value) }
+
+                # scope :not_active, -> { where.not(status: 0) }
+                klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
+                klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              end
+            end
+        end
+        private_constant :EnumMethods
+
+        def _enum_methods_module
+          @_enum_methods_module ||= begin
+            mod = EnumMethods.new(self)
+            include mod
+            mod
+          end
+        end
+
+        def assert_valid_enum_definition_values(values)
+          case values
+          when Hash
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            if values.keys.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          when Array
+            if values.empty?
+              raise ArgumentError, "Enum values #{values} must not be empty."
+            end
+
+            unless values.all?(Symbol) || values.all?(String)
+              raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
+            end
+
+            if values.any?(&:blank?)
+              raise ArgumentError, "Enum values #{values} must not contain a blank name."
+            end
+          else
+            raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
+          end
+        end
+
+        ENUM_CONFLICT_MESSAGE = \
+          "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
+          "this will generate a %{type} method \"%{method}\", which is already defined " \
+          "by %{source}."
+        private_constant :ENUM_CONFLICT_MESSAGE
+
+        def detect_enum_conflict!(enum_name, method_name, klass_method = false)
+          if klass_method && dangerous_class_method?(method_name)
+            raise_conflict_error(enum_name, method_name, type: "class")
+          elsif klass_method && method_defined_within?(method_name, Relation)
+            raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
+          elsif klass_method && method_name.to_sym == :id
+            raise_conflict_error(enum_name, method_name)
+          elsif !klass_method && dangerous_attribute_method?(method_name)
+            raise_conflict_error(enum_name, method_name)
+          elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
+            raise_conflict_error(enum_name, method_name, source: "another enum")
+          end
+        end
+
+        def raise_conflict_error(enum_name, method_name, type: "instance", source: "Active Record")
+          raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+            enum: enum_name,
+            klass: name,
+            type: type,
+            method: method_name,
+            source: source
+          }
+        end
+
+        def detect_negative_enum_conditions!(method_names)
+          return unless logger
+
+          method_names.select { |m| m.start_with?("not_") }.each do |potential_not|
+            inverted_form = potential_not.sub("not_", "")
+            if method_names.include?(inverted_form)
+              logger.warn "Enum element '#{potential_not}' in #{self.name} uses the prefix 'not_'." \
+                " This has caused a conflict with auto generated negative scopes." \
+                " Avoid using enum elements starting with 'not' where the positive form is also an element."
+            end
+          end
+        end
     end
-
-    private
-      def inherited(base)
-        base.defined_enums = defined_enums.deep_dup
-        super
-      end
-
-      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-        assert_valid_enum_definition_values(values)
-        # statuses = { }
-        enum_values = ActiveSupport::HashWithIndifferentAccess.new
-        name = name.to_s
-
-        # def self.statuses() statuses end
-        detect_enum_conflict!(name, name.pluralize, true)
-        singleton_class.define_method(name.pluralize) { enum_values }
-        defined_enums[name] = enum_values
-
-        detect_enum_conflict!(name, name)
-        detect_enum_conflict!(name, "#{name}=")
-
-        attribute(name, **options)
-
-        decorate_attributes([name]) do |_name, subtype|
-          if subtype == ActiveModel::Type.default_value
-            raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
-              " backed by a database column or declared with an explicit type" \
-              " via `attribute`."
-          end
-
-          subtype = subtype.subtype if EnumType === subtype
-          EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
-        end
-
-        value_method_names = []
-        _enum_methods_module.module_eval do
-          prefix = if prefix
-            prefix == true ? "#{name}_" : "#{prefix}_"
-          end
-
-          suffix = if suffix
-            suffix == true ? "_#{name}" : "_#{suffix}"
-          end
-
-          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-          pairs.each do |label, value|
-            enum_values[label] = value
-            label = label.to_s
-
-            value_method_name = "#{prefix}#{label}#{suffix}"
-            value_method_names << value_method_name
-            define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-
-            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
-            value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
-
-            if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
-              value_method_names << value_method_alias
-              define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
-            end
-          end
-        end
-        detect_negative_enum_conditions!(value_method_names) if scopes
-
-        if validate
-          validate = {} unless Hash === validate
-          validates_inclusion_of name, in: enum_values.keys, **validate
-        end
-
-        enum_values.freeze
-      end
-
-      class EnumMethods < Module # :nodoc:
-        def initialize(klass)
-          @klass = klass
-        end
-
-        private
-          attr_reader :klass
-
-          def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-            if instance_methods
-              # def active?() status_for_database == 0 end
-              klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-              define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
-
-              # def active!() update!(status: 0) end
-              klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
-              define_method("#{value_method_name}!") { update!(name => value) }
-            end
-
-            if scopes
-              # scope :active, -> { where(status: 0) }
-              klass.send(:detect_enum_conflict!, name, value_method_name, true)
-              klass.scope value_method_name, -> { where(name => value) }
-
-              # scope :not_active, -> { where.not(status: 0) }
-              klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
-            end
-          end
-      end
-      private_constant :EnumMethods
-
-      def _enum_methods_module
-        @_enum_methods_module ||= begin
-          mod = EnumMethods.new(self)
-          include mod
-          mod
-        end
-      end
-
-      def assert_valid_enum_definition_values(values)
-        case values
-        when Hash
-          if values.empty?
-            raise ArgumentError, "Enum values #{values} must not be empty."
-          end
-
-          if values.keys.any?(&:blank?)
-            raise ArgumentError, "Enum values #{values} must not contain a blank name."
-          end
-        when Array
-          if values.empty?
-            raise ArgumentError, "Enum values #{values} must not be empty."
-          end
-
-          unless values.all?(Symbol) || values.all?(String)
-            raise ArgumentError, "Enum values #{values} must only contain symbols or strings."
-          end
-
-          if values.any?(&:blank?)
-            raise ArgumentError, "Enum values #{values} must not contain a blank name."
-          end
-        else
-          raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
-        end
-      end
-
-      ENUM_CONFLICT_MESSAGE = \
-        "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
-        "this will generate a %{type} method \"%{method}\", which is already defined " \
-        "by %{source}."
-      private_constant :ENUM_CONFLICT_MESSAGE
-
-      def detect_enum_conflict!(enum_name, method_name, klass_method = false)
-        if klass_method && dangerous_class_method?(method_name)
-          raise_conflict_error(enum_name, method_name, type: "class")
-        elsif klass_method && method_defined_within?(method_name, Relation)
-          raise_conflict_error(enum_name, method_name, type: "class", source: Relation.name)
-        elsif klass_method && method_name.to_sym == :id
-          raise_conflict_error(enum_name, method_name)
-        elsif !klass_method && dangerous_attribute_method?(method_name)
-          raise_conflict_error(enum_name, method_name)
-        elsif !klass_method && method_defined_within?(method_name, _enum_methods_module, Module)
-          raise_conflict_error(enum_name, method_name, source: "another enum")
-        end
-      end
-
-      def raise_conflict_error(enum_name, method_name, type: "instance", source: "Active Record")
-        raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
-          enum: enum_name,
-          klass: name,
-          type: type,
-          method: method_name,
-          source: source
-        }
-      end
-
-      def detect_negative_enum_conditions!(method_names)
-        return unless logger
-
-        method_names.select { |m| m.start_with?("not_") }.each do |potential_not|
-          inverted_form = potential_not.sub("not_", "")
-          if method_names.include?(inverted_form)
-            logger.warn "Enum element '#{potential_not}' in #{self.name} uses the prefix 'not_'." \
-              " This has caused a conflict with auto generated negative scopes." \
-              " Avoid using enum elements starting with 'not' where the positive form is also an element."
-          end
-        end
-      end
   end
 end


### PR DESCRIPTION
Allow ActiveRecord::Enum to be mixed in with include instead of extend, like most other ActiveModel inherited modules.

This refactoring makes it easier to move `ActiveRecord::Enum` to `ActiveModel::Enum` and mixin `ActiveModel::Enum` with include instead of `extend`.

This change will make the change for #49872 smaller.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
