### PR TITLE
Accept username as valid author name in `CHANGELOG`

### DIFF
--- a/tools/rail_inspector/lib/rail_inspector/changelog.rb
+++ b/tools/rail_inspector/lib/rail_inspector/changelog.rb
@@ -39,7 +39,7 @@ module RailInspector
           return if no_changes?
 
           authors =
-            lines.reverse.find { |line| line.match?(/\*[^\d\s]+(\s[^\d\s]+)*\*/) }
+            lines.reverse.find { |line| line.match?(/^ *\*[^*\s].*[^*\s]\*$/) }
 
           return if authors
 

--- a/tools/rail_inspector/test/rail_inspector/changelog_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/changelog_test.rb
@@ -18,6 +18,14 @@ class TestChangelog < Minitest::Test
     assert_equal 2, offenses.length
   end
 
+  def test_valid_username_is_valid_author
+    assert_valid_entry <<~CHANGELOG
+      *   Cool change.
+
+          *1337-rails-c0d3r*
+    CHANGELOG
+  end
+
   def test_parses_with_extra_newlines
     @changelog = changelog_fixture("action_mailbox_83d85b2.md")
 
@@ -124,6 +132,11 @@ class TestChangelog < Minitest::Test
 
     def offenses
       entries.flat_map(&:offenses)
+    end
+
+    def assert_valid_entry(source)
+      entry = RailInspector::Changelog::Entry.new(source.lines(chomp: true), 1)
+      assert_empty entry.offenses, "Entry has offenses"
     end
 
     ANNOTATION_PATTERN = /\s*\^+ /


### PR DESCRIPTION
This fixes the `CHANGELOG` linter to accept usernames that include digits as valid author names.

---

Example failure addressed by this change: https://github.com/rails/rails/actions/runs/6756217672/job/18365428846#step:8:13

Even though the entry has an author:

https://github.com/rails/rails/blob/6c5890ad3920deb2d6be844f6044886629a2f3e3/activerecord/CHANGELOG.md?plain=1#L1-L4