### PR TITLE
Add picture_tag to ActionView helpers documentation [ci skip]

### DIFF
--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -99,6 +99,24 @@ javascript_url "common"
 # => http://www.example.com/assets/common.js
 ```
 
+#### picture_tag
+
+Returns an HTML picture tag for the source. It supports passing a String, an Array or a Block.
+
+```ruby
+picture_tag("icon.webp", "icon.png")
+```
+
+This generates the following HTML:
+
+```html
+<picture>
+  <source srcset="/assets/icon.webp" type="image/webp" />
+  <source srcset="/assets/icon.png" type="image/png" />
+  <img src="/assets/icon.png" />
+</picture>
+```
+
 #### preload_link_tag
 
 Returns a link tag that browsers can use to preload the source. The source can be the path of a resource managed by asset pipeline, a full path, or an URI.


### PR DESCRIPTION
Backport `picture_tag` feature https://github.com/rails/rails/pull/48100 into Guides documentation.

```md
#### picture_tag

Returns an HTML picture tag for the source. It supports passing a String, an Array or a Block.

```ruby
picture_tag("icon.webp", "icon.png")
```

This generates the following HTML:

```html
<picture>
  <source srcset="/assets/icon.webp" type="image/webp" />
  <source srcset="/assets/icon.png" type="image/png" />
  <img src="/assets/icon.png" />
</picture>
```

For memory, the changelog item (below) is very detailed. In Guides documentation, the philosophy seems to be very concise.



![CleanShot 2023-11-06 at 09 24 50@2x](https://github.com/rails/rails/assets/20317297/dff500c8-683b-41a1-bed8-005946f80f50)
