### PR TITLE
Fix sqlite3 dropping database with bad permissions test

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -249,15 +249,18 @@ module ApplicationTests
         end
 
         test "db:drop failure because bad permissions" do
-          with_database_existing do
-            with_bad_permissions do
-              output = rails("db:drop", allow_failure: true)
-              assert_match(/Couldn't drop/, output)
-              assert_equal 1, $?.exitstatus
+          with_env(DISABLE_DATABASE_ENVIRONMENT_CHECK: "1") do
+            with_database_existing do
+              with_bad_permissions do
+                output = rails("db:drop", allow_failure: true)
+                assert_match(/Couldn't drop/, output)
+                assert_equal 1, $?.exitstatus
+              end
             end
           end
         end
       end
+
       test "db:create works when schema cache exists and database does not exist" do
         use_postgresql
 


### PR DESCRIPTION
Fixes #49928.

It fails here https://github.com/rails/rails/blob/febd21da3438d190f0c6ce296a114baee983d1e1/activerecord/lib/active_record/railties/databases.rake#L19 when trying to create a new connection down the road because of this recent change https://github.com/rails/rails/blob/febd21da3438d190f0c6ce296a114baee983d1e1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L762 which tries to create WAL files.

We can ignore checking protected environments by setting an ENV variable, see https://github.com/rails/rails/blob/febd21da3438d190f0c6ce296a114baee983d1e1/activerecord/lib/active_record/tasks/database_tasks.rb#L65-L71
