### PR TITLE
Update `JavascriptPackageTest` tests

### DIFF
--- a/actioncable/test/javascript_package_test.rb
+++ b/actioncable/test/javascript_package_test.rb
@@ -4,10 +4,16 @@ require "test_helper"
 
 class JavascriptPackageTest < ActiveSupport::TestCase
   def test_compiled_code_is_in_sync_with_source_code
-    compiled_file = File.expand_path("../app/assets/javascripts/action_cable.js", __dir__)
+    compiled_files = %w[
+      app/assets/javascripts/actioncable.js
+      app/assets/javascripts/actioncable.esm.js
+      app/assets/javascripts/action_cable.js
+    ].map do |file|
+      Pathname(file).expand_path("#{__dir__}/..")
+    end
 
-    assert_no_changes -> { File.read(compiled_file) } do
-      system "yarn build"
+    assert_no_changes -> { compiled_files.map(&:read) } do
+      system "yarn build", exception: true
     end
   end
 end

--- a/actionview/test/javascript_package_test.rb
+++ b/actionview/test/javascript_package_test.rb
@@ -2,15 +2,15 @@
 
 class JavascriptPackageTest < ActiveSupport::TestCase
   def test_compiled_code_is_in_sync_with_source_code
-    assert_no_changes -> {
-      %w[
-        app/assets/javascripts/rails-ujs.js
-        app/assets/javascripts/rails-ujs.esm.js
-      ].map { |compiled_file|
-        File.read(File.expand_path("../#{compiled_file}", __dir__))
-      }
-    } do
-      system "yarn build"
+    compiled_files = %w[
+      app/assets/javascripts/rails-ujs.js
+      app/assets/javascripts/rails-ujs.esm.js
+    ].map do |file|
+      Pathname(file).expand_path("#{__dir__}/..")
+    end
+
+    assert_no_changes -> { compiled_files.map(&:read) } do
+      system "yarn build", exception: true
     end
   end
 end

--- a/activestorage/test/javascript_package_test.rb
+++ b/activestorage/test/javascript_package_test.rb
@@ -4,10 +4,15 @@ require "test_helper"
 
 class JavascriptPackageTest < ActiveSupport::TestCase
   def test_compiled_code_is_in_sync_with_source_code
-    compiled_file = File.expand_path("../app/assets/javascripts/activestorage.js", __dir__)
+    compiled_files = %w[
+      app/assets/javascripts/activestorage.js
+      app/assets/javascripts/activestorage.esm.js
+    ].map do |file|
+      Pathname(file).expand_path("#{__dir__}/..")
+    end
 
-    assert_no_changes -> { File.read(compiled_file) } do
-      system "yarn build"
+    assert_no_changes -> { compiled_files.map(&:read) } do
+      system "yarn build", exception: true
     end
   end
 end


### PR DESCRIPTION
This fixes an issue with `JavascriptPackageTest` tests wherein the tests would pass when the source failed to compile due to a syntax error.  In such cases, the compiled output would not change and `system "yarn build"` would simply return `false`.  By adding `exception: true` to the `system` call, an error will now be raised if `yarn build` fails.

This also adds assertions that were missing for some of the generated JavaScript files.
