### PR TITLE
Update `.gitattributes` for generated JavaScript [ci-skip]

### DIFF
--- a/actioncable/app/assets/javascripts/.gitattributes
+++ b/actioncable/app/assets/javascripts/.gitattributes
@@ -1,1 +1,3 @@
+actioncable.js linguist-generated
+actioncable.esm.js linguist-generated
 action_cable.js linguist-generated

--- a/actiontext/app/assets/javascripts/.gitattributes
+++ b/actiontext/app/assets/javascripts/.gitattributes
@@ -1,0 +1,2 @@
+actiontext.js linguist-generated
+trix.js linguist-vendored

--- a/actionview/app/assets/javascripts/.gitattributes
+++ b/actionview/app/assets/javascripts/.gitattributes
@@ -1,0 +1,2 @@
+rails-ujs.js linguist-generated
+rails-ujs.esm.js linguist-generated

--- a/activestorage/app/assets/javascripts/.gitattributes
+++ b/activestorage/app/assets/javascripts/.gitattributes
@@ -1,1 +1,2 @@
 activestorage.js linguist-generated
+activestorage.esm.js linguist-generated


### PR DESCRIPTION
This adds `linguist-generated` and `linguist-vendored` attributes where appropriate to suppress the files in diffs and exclude the files from the project's language stats on GitHub.

See https://github.com/github/linguist for more information.
