### PR TITLE
Fix PostgreSQL `Uuid#change?` to ignore uuid's value formatting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb
@@ -6,6 +6,7 @@ module ActiveRecord
       module OID # :nodoc:
         class Uuid < Type::Value # :nodoc:
           ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}
+          CANONICAL_UUID = %r{\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\z}
 
           alias :serialize :deserialize
 
@@ -15,18 +16,27 @@ module ActiveRecord
 
           def changed?(old_value, new_value, _new_value_before_type_cast)
             old_value.class != new_value.class ||
-              new_value && old_value.casecmp(new_value) != 0
+              new_value != old_value
           end
 
           def changed_in_place?(raw_old_value, new_value)
             raw_old_value.class != new_value.class ||
-              new_value && raw_old_value.casecmp(new_value) != 0
+              new_value != raw_old_value
           end
 
           private
             def cast_value(value)
-              casted = value.to_s
-              casted if casted.match?(ACCEPTABLE_UUID)
+              value = value.to_s
+              format_uuid(value) if value.match?(ACCEPTABLE_UUID)
+            end
+
+            def format_uuid(uuid)
+              if uuid.match?(CANONICAL_UUID)
+                uuid
+              else
+                uuid = uuid.delete("{}-").downcase
+                "#{uuid[..7]}-#{uuid[8..11]}-#{uuid[12..15]}-#{uuid[16..19]}-#{uuid[20..]}"
+              end
             end
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -121,9 +121,12 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     assert_empty UUIDType.where(guid: "foobar")
   end
 
-  def test_uuid_change_case_does_not_mark_dirty
+  def test_uuid_change_format_does_not_mark_dirty
     model = UUIDType.create!(guid: "abcd-0123-4567-89ef-dead-beef-0101-1010")
     model.guid = model.guid.swapcase
+    assert_not_predicate model, :changed?
+
+    model.guid = "{#{model.guid}}"
     assert_not_predicate model, :changed?
   end
 


### PR DESCRIPTION
When assigning to record's `uuid` value in PostgreSQL, `#changed?` only considers the case of the values. It should be agnostic of the format passed as a value, because PostgreSQL is flexible in the format it accepts - https://www.postgresql.org/docs/current/datatype-uuid.html.

Example:
```ruby
user = User.create! # => #<User:0x0000000110ce3f40 id: "7818f152-0b57-499d-b2e5-a42aced4031b">
user.id = user.id.upcase
user.changed? # => false (correct and is already implemented)

user.id = "{#{user.id}}"
user.changed? # => true, but should be false (fixed in this PR)
```