### PR TITLE
Handle nil form_with model argument

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ArgumentError` when `nil` is passed as `model:` argument value to the `form_with` method.
+
+    *Collin Jilbert*
+
 *   Alias `field_set_tag` helper to `fieldset_tag` to match `<fieldset>` element
 
     *Sean Doyle*

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -437,7 +437,7 @@ module ActionView
 
         case record
         when String, Symbol
-          model       = nil
+          model       = false
           object_name = record
         else
           model       = record
@@ -753,7 +753,9 @@ module ActionView
       #   def labelled_form_with(**options, &block)
       #     form_with(**options.merge(builder: LabellingFormBuilder), &block)
       #   end
-      def form_with(model: nil, scope: nil, url: nil, format: nil, **options, &block)
+      def form_with(model: false, scope: nil, url: nil, format: nil, **options, &block)
+        raise ArgumentError, "The :model argument cannot be nil" if model.nil?
+
         options = { allow_method_names_outside_object: true, skip_default_ids: !form_with_generates_ids }.merge!(options)
 
         if model

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -339,6 +339,14 @@ class FormWithActsLikeFormForTest < FormWithTest
     super
   end
 
+  def test_form_with_when_given_nil_model_argument
+    error = assert_raises(ArgumentError) do
+      form_with(model: nil) do
+      end
+    end
+    assert_equal "The :model argument cannot be nil", error.message
+  end
+
   def test_form_with
     form_with(model: @post, id: "create-post") do |f|
       concat f.label(:title) { "The Title" }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

First, thank you to everyone here for taking the time to read this description.

I would like to propose a possible change to the `form_with` method which would help provide, in my opinion, better debugging around an issue that can be encountered when passing a `nil` object to the `model:` argument in the `form_with` method.

I have come across this issue a few times myself and I know others that have as well. The most recent encounter was from a newer Rails developer that myself and others have been helping along in the process of learning Rails. 

The issue actually shows up in two ways, the first is if the form is on an index page, having nil passed to the `:model` argument this will raise an `ActionController::ParameterMissing` error. The other is in the default scenario of being on the new page and having `nil` passed to the `:model` argument. In this scenario, an `ActionController::RoutingError (No route matches [POST] "/posts/new")` (using `Post` model as an example). This happens because of Rails falling back to building the URL from the current page in this scenario.

Going back to the first form of this causing an error, I would like to outline the flow of the issue so that everyone can (hopefully) have a better understanding of this issue.

---
**Junior Dev**: I'm having an issue using strong parameters. Has there been a change in rails 7 when using strong parameters?
```ruby
def url_link_params
  params.require(:url_link).permit(:url)
end
```
where the model name is UrlLink. When I try to submit my form, I get the following error:
```ruby
ActionController::ParameterMissing (param is missing or the value is empty: url_link)
```
When I remove require and just use params.permit(:url), I can submit the form.
I'm confused, I setup my form with `form_with(model: url_link)` and have a url input field `form.url_field :url`.

**Me**: I see that you have a mismatch in instance variable naming between the instance variable declared in the controller action versus what is being passed in as a local to the form partial:
```ruby
def index
  @link = UrlLink.new
end

<%= render partial: "form", locals: { url_link: @url_link } %>
```

**Junior Dev**: Thanks, I fixed the mismatch and my form and controller are working now.

With this context, I think it would have been a better debugging experience for the junior if instead of the `ActionController::ParameterMissing` error being raised thus causing the junior to think it was a strong params issue (which it sort of is I admit) I think it would be more helpful to raise an `ArgumentError` when passing in a `nil` object to the `model:` argument in `form_with`.

---

### Detail

This PR changes the default value of the `model:` argument in `form_with` to `false` instead of `nil` and raises an `ArgumentError` in the event that the argument is `nil`.
```ruby
def form_with(model: false, other_args)
  raise ArgumentError, "Form model object is nil" if model.nil?
end
```

I tried to think reasons/scenarios of why/where `false` wouldn't be a suitable replacement for `nil` as the default value for the `model:` argument but I couldn't think of any (I'm not saying there isn't a case though and would love to hear so if there are any).

It also changes a local variable that is set in a case statement in the `form_for` method from `nil` to `false` which is needed to allow `form_for` to continue to call `form_with` successfully.

### Additional information

Thank you for taking the time to read this and for any thoughts or feedback about it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
