### PR TITLE
Add connection pool to connection timeout errors

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -614,7 +614,7 @@ module ActiveRecord
 
           msg << " (#{thread_report.join(', ')})" if thread_report.any?
 
-          raise ExclusiveConnectionTimeoutError, msg
+          raise ExclusiveConnectionTimeoutError.new(msg, connection_pool: self)
         end
 
         def with_new_connections_blocked
@@ -670,6 +670,8 @@ module ActiveRecord
             reap
             @available.poll(checkout_timeout)
           end
+        rescue ConnectionTimeoutError => ex
+          raise ex.set_pool(self)
         end
 
         #--

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -110,9 +110,10 @@ module ActiveRecord
         @pool.checkout_timeout = 0.001 # no need to delay test suite by waiting the whole full default timeout
         @pool.size.times { assert @pool.checkout }
 
-        assert_raises(ConnectionTimeoutError) do
+        error = assert_raises(ConnectionTimeoutError) do
           @pool.checkout
         end
+        assert_equal @pool, error.connection_pool
       end
 
       def test_full_pool_blocks
@@ -615,9 +616,10 @@ module ActiveRecord
         @pool.checkout_timeout = 0.001 # no need to delay test suite by waiting the whole full default timeout
         [:disconnect, :clear_reloadable_connections].each do |group_action_method|
           @pool.with_connection do |connection|
-            assert_raises(ExclusiveConnectionTimeoutError) do
+            error = assert_raises(ExclusiveConnectionTimeoutError) do
               new_thread { @pool.public_send(group_action_method) }.join
             end
+            assert_equal @pool, error.connection_pool
           end
         end
       ensure


### PR DESCRIPTION
Along the same lines as https://github.com/rails/rails/pull/48295, in multi-database applications it's helpful to have access to the pool when debugging these timeouts. For example, we might send the connection class and role along to an exception tracking system.

`ConnectionTimeout` was already set up to take a connection_pool, so this commit passes it along as needed where we raise the error.

Somewhat related to https://github.com/rails/rails/issues/49331. Whether we want more details in the message itself, or a more generic way of passing error context, seems like an ongoing subject outside the scope of this PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
