### PR TITLE
Enable YJIT by default if running Ruby 3.3+

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Enable YJIT by default on new application running Ruby 3.3+
+
+    Adds a `config/initializers/enable_yjit.rb` initializer that enable YJIT
+    when running on Ruby 3.3+.
+
+    *Jean Boussier*
+
 *   In Action Mailer previews, show date from message `Date` header if present.
 
     *Sampat Badhe*

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/enable_yjit.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/enable_yjit.rb.tt
@@ -1,0 +1,11 @@
+# Automatically enable YJIT as of Ruby 3.3, as it bring very
+# sizeable performance improvements.
+
+# If you are deploying to a memory constrained environment
+# you may want to delete this file, but otherwise it's free
+# performance.
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/yjit.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/yjit.rb.tt
@@ -1,0 +1,12 @@
+# Automatically enable YJIT if running Ruby 3.3 or newer,
+# as it brings very sizeable performance improvements.
+# Many users reported 15-25% improved latency.
+
+# If you are deploying to a memory-constrained environment,
+# you may want to delete this file, but otherwise, it's free
+# performance.
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -51,6 +51,7 @@ DEFAULT_APP_FILES = %w(
   config/initializers
   config/initializers/assets.rb
   config/initializers/content_security_policy.rb
+  config/initializers/enable_yjit.rb
   config/initializers/filter_parameter_logging.rb
   config/initializers/inflections.rb
   config/locales


### PR DESCRIPTION
There was many public reports of 15-25% latency improvements for Rails apps that did enable Ruby 3.2 YJIT, and in 3.3 it's even better.

Following https://github.com/ruby/ruby/pull/8705, in Ruby 3.3 YJIT is paused instead of disabled by default, allowing us to enable it from an initializer.

FYI: @maximecb, @k0kubun, @XrXr 