### PR TITLE
`ErrorReporter#unexpected` to report in production but raise in development

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `ErrorReported#unexpected` to report precondition violations.
+
+    For example:
+
+    ```ruby
+    def edit
+      if published?
+        Rails.error.unexpected("[BUG] Attempting to edit a published article, that shouldn't be possible")
+        return false
+      end
+      # ...
+    end
+    ```
+
+    The above will raise an error in development and test, but only report the error in production.
+
+    *Jean Boussier*
+
 *   Make the order of read_multi and write_multi notifications for `Cache::Store#fetch_multi` operations match the order they are executed in.
 
     *Adam Renberg Tamm*

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -61,8 +61,12 @@ module Rails
           broadcast_logger.formatter = Rails.logger.formatter
           Rails.logger = broadcast_logger
         end
+      end
 
-        unless config.consider_all_requests_local
+      initializer :initialize_error_reporter, group: :all do
+        if config.consider_all_requests_local
+          Rails.error.debug_mode = true
+        else
           Rails.error.logger = Rails.logger
         end
       end


### PR DESCRIPTION
It's a common useful pattern for situation where something isn't supposed to happen, but if it does we can recover from it.

So in such situation you don't want such issue to be hidden in development or test, as it's likely a bug, but do not want to fail a request if it happens in production.

In other words, it behaves like `#record` in development and test environments, and like `raise` in production.

Fix: https://github.com/rails/rails/pull/49638
Fix: https://github.com/rails/rails/pull/49339

Co-Authored-By: Andrew Novoselac <andrew.novoselac@shopify.com>
Co-Authored-By: Dustin Brown <dbrown9@gmail.com>