### PR TITLE
Auto populate primary key column for updatable database views

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -432,8 +432,13 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert # :nodoc:
-        @_returning_columns_for_insert ||= columns.filter_map do |c|
-          c.name if connection.return_value_after_insert?(c)
+        @_returning_columns_for_insert ||= columns.filter_map do |column|
+          column_name = column.name
+          if connection.return_value_after_insert?(column) ||
+              (composite_primary_key? && primary_key.include?(column_name)) ||
+              primary_key == column_name
+            column_name
+          end
         end
       end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1256,7 +1256,7 @@ module ActiveRecord
       )
 
       returning_columns.zip(returning_values).each do |column, value|
-        _write_attribute(column, value) if !_read_attribute(column)
+        _write_attribute(column, value)
       end if returning_values
 
       @new_record = false

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -193,6 +193,13 @@ if ActiveRecord::Base.connection.supports_views?
         assert_equal "Rails in Action", new_book.name
       end
 
+      if supports_insert_returning?
+        def test_insert_record_populates_primary_key
+          book = PrintedBook.create! name: "Rails in Action", status: 0, format: "paperback"
+          assert book.id > 0
+        end
+      end
+
       def test_update_record_to_fail_view_conditions
         book = PrintedBook.first
         book.format = "ebook"


### PR DESCRIPTION
Fixes #49950.

Some databases (PostgreSQL, MySQL, MariaDB) support updatable `VIEW`s. Why not get the primary key's value automatically (via `RETURNING`, for the databases that support it) when inserting a record? This PR addresses this problem.