### PR TITLE
[Fix #49104] Add server response (xhr) to direct-upload:error event.

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,31 +1,31 @@
-* Add `xhr` object to direct-upload:error event so that server generated error messages are accessible.
+*   Add `xhr` object to direct-upload:error event so that server generated error messages are accessible.
 
-Before:
-```javascript
-addEventListener("direct-upload:error", event => {
-  event.preventDefault()
-  const { id, error } = event.detail
-  const element = document.getElementById(`direct-upload-${id}`)
-  element.classList.add("direct-upload--error")
-  element.setAttribute("title", error)
-})
-```
+    Before:
+    ```javascript
+    addEventListener("direct-upload:error", event => {
+      event.preventDefault()
+      const { id, error } = event.detail
+      const element = document.getElementById(`direct-upload-${id}`)
+      element.classList.add("direct-upload--error")
+      element.setAttribute("title", error)
+    })
+    ```
 
-After:
-```javascript
-addEventListener("direct-upload:error", event => {
-  event.preventDefault()
-  const { id, error, xhr } = event.detail
-  const element = document.getElementById(`direct-upload-${id}`)
-  const errorMessage = xhr.response['error'] // Example: File size must be less than 100MB
-  element.classList.add("direct-upload--error")
-  element.setAttribute("title", errorMessage)
-})
-```
+    After:
+    ```javascript
+    addEventListener("direct-upload:error", event => {
+      event.preventDefault()
+      const { id, error, xhr } = event.detail
+      const element = document.getElementById(`direct-upload-${id}`)
+      const errorMessage = xhr.response['error'] // Example: File size must be less than 100MB
+      element.classList.add("direct-upload--error")
+      element.setAttribute("title", errorMessage)
+    })
+    ```
+
+    Fixes #49104
 
     *Sean Abrahams*
-
-Fixes #49104
 
 *   Restore ADC when signing URLs with IAM for GCS
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,32 @@
+* Add `xhr` object to direct-upload:error event so that server generated error messages are accessible.
+
+Before:
+```javascript
+addEventListener("direct-upload:error", event => {
+  event.preventDefault()
+  const { id, error } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  element.classList.add("direct-upload--error")
+  element.setAttribute("title", error)
+})
+```
+
+After:
+```javascript
+addEventListener("direct-upload:error", event => {
+  event.preventDefault()
+  const { id, error, xhr } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  const errorMessage = xhr.response['error'] // Example: File size must be less than 100MB
+  element.classList.add("direct-upload--error")
+  element.setAttribute("title", errorMessage)
+})
+```
+
+    *Sean Abrahams*
+
+Fixes #49104
+
 *   Restore ADC when signing URLs with IAM for GCS
 
     ADC was previously used for automatic authorization when signing URLs with IAM.

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -17,13 +17,12 @@
       event.preventDefault()
       const { id, error, xhr } = event.detail
       const element = document.getElementById(`direct-upload-${id}`)
-      const errorMessage = xhr.response['error'] // Example: File size must be less than 100MB
+      // Use the server's error response if provided
+      const errorMessage = xhr.response?.error || error
       element.classList.add("direct-upload--error")
       element.setAttribute("title", errorMessage)
     })
     ```
-
-    Fixes #49104
 
     *Sean Abrahams*
 

--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -1021,7 +1021,10 @@ class BlobRecord {
     }
   }
   requestDidError(event) {
-    this.callback(`Error creating Blob for "${this.file.name}". Status: ${this.status}`);
+    this.callback({
+      xhr: this.xhr,
+      message: `Error creating Blob for "${this.file.name}". Status: ${this.status}`
+    });
   }
   toJSON() {
     const result = {};
@@ -1059,7 +1062,10 @@ class BlobUpload {
     }
   }
   requestDidError(event) {
-    this.callback(`Error storing "${this.file.name}". Status: ${this.xhr.status}`);
+    this.callback({
+      xhr: this.xhr,
+      message: `Error storing "${this.file.name}". Status: ${this.xhr.status}`
+    });
   }
 }
 
@@ -1155,7 +1161,8 @@ class DirectUploadController {
   }
   dispatchError(error) {
     const event = this.dispatch("error", {
-      error: error
+      error: error.message,
+      xhr: error.xhr
     });
     if (!event.defaultPrevented) {
       alert(error);

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -1009,7 +1009,10 @@
       }
     }
     requestDidError(event) {
-      this.callback(`Error creating Blob for "${this.file.name}". Status: ${this.status}`);
+      this.callback({
+        xhr: this.xhr,
+        message: `Error creating Blob for "${this.file.name}". Status: ${this.status}`
+      });
     }
     toJSON() {
       const result = {};
@@ -1046,7 +1049,10 @@
       }
     }
     requestDidError(event) {
-      this.callback(`Error storing "${this.file.name}". Status: ${this.xhr.status}`);
+      this.callback({
+        xhr: this.xhr,
+        message: `Error storing "${this.file.name}". Status: ${this.xhr.status}`
+      });
     }
   }
   let id = 0;
@@ -1138,7 +1144,8 @@
     }
     dispatchError(error) {
       const event = this.dispatch("error", {
-        error: error
+        error: error.message,
+        xhr: error.xhr
       });
       if (!event.defaultPrevented) {
         alert(error);

--- a/activestorage/app/javascript/activestorage/blob_record.js
+++ b/activestorage/app/javascript/activestorage/blob_record.js
@@ -63,7 +63,10 @@ export class BlobRecord {
   }
 
   requestDidError(event) {
-    this.callback(`Error creating Blob for "${this.file.name}". Status: ${this.status}`)
+    this.callback({
+      xhr: this.xhr,
+      message: `Error creating Blob for "${this.file.name}". Status: ${this.status}`
+    })
   }
 
   toJSON() {

--- a/activestorage/app/javascript/activestorage/blob_upload.js
+++ b/activestorage/app/javascript/activestorage/blob_upload.js
@@ -30,6 +30,9 @@ export class BlobUpload {
   }
 
   requestDidError(event) {
-    this.callback(`Error storing "${this.file.name}". Status: ${this.xhr.status}`)
+    this.callback({
+      xhr: this.xhr,
+      message: `Error storing "${this.file.name}". Status: ${this.xhr.status}`
+    })
   }
 }

--- a/activestorage/app/javascript/activestorage/direct_upload_controller.js
+++ b/activestorage/app/javascript/activestorage/direct_upload_controller.js
@@ -50,7 +50,7 @@ export class DirectUploadController {
   }
 
   dispatchError(error) {
-    const event = this.dispatch("error", { error })
+    const event = this.dispatch("error", { error: error.message, xhr: error.xhr })
     if (!event.defaultPrevented) {
       alert(error)
     }

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1189,7 +1189,7 @@ No CORS configuration is required for the Disk service since it shares your appâ
 | `direct-upload:before-blob-request` | `<input>` | `{id, file, xhr}` | Before making a request to your application for direct upload metadata. |
 | `direct-upload:before-storage-request` | `<input>` | `{id, file, xhr}` | Before making a request to store a file. |
 | `direct-upload:progress` | `<input>` | `{id, file, progress}` | As requests to store files progress. |
-| `direct-upload:error` | `<input>` | `{id, file, error}` | An error occurred. An `alert` will display unless this event is canceled. |
+| `direct-upload:error` | `<input>` | `{id, file, error, xhr}` | An error occurred. An `alert` will display unless this event is canceled. |
 | `direct-upload:end` | `<input>` | `{id, file}` | A direct upload has ended. |
 | `direct-uploads:end` | `<form>` | None | All direct uploads have ended. |
 
@@ -1230,10 +1230,12 @@ addEventListener("direct-upload:progress", event => {
 
 addEventListener("direct-upload:error", event => {
   event.preventDefault()
-  const { id, error } = event.detail
+  const { id, error, xhr } = event.detail
   const element = document.getElementById(`direct-upload-${id}`)
+  // Use the server's error response if provided
+  const errorMessage = xhr.response?.error || error
   element.classList.add("direct-upload--error")
-  element.setAttribute("title", error)
+  element.setAttribute("title", errorMessage)
 })
 
 addEventListener("direct-upload:end", event => {


### PR DESCRIPTION
### Motivation / Background

Fixes #49104

This Pull Request has been created because ActiveStorage's javascript does not provide access to the server response for error messaging when an error occurs during a direct upload.

This is a problem because we cannot distinguish between an upload failing due to authorization or the file being too large or any other validation error.

### Detail

This Pull Request changes the error event to include the `xhr` object so that the server response is accessible to error handling code. This allows us to display the specific issues that caused the upload to be rejected such as:
- You must be an admin to upload this file.
- File must be less than 100MB.
- Uploading .exe files is not permitted.

Before:
```javascript
addEventListener("direct-upload:error", event => {
  event.preventDefault()
  const { id, error } = event.detail
  const element = document.getElementById(`direct-upload-${id}`)
  element.classList.add("direct-upload--error")
  element.setAttribute("title", error)
})
```

After:
```javascript
addEventListener("direct-upload:error", event => {
  event.preventDefault()
  const { id, error, xhr } = event.detail
  const element = document.getElementById(`direct-upload-${id}`)
  // Use the server's error response if provided
  const errorMessage = xhr.response?.error || error
  element.classList.add("direct-upload--error")
  element.setAttribute("title", errorMessage)
})
```

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. **Are there tests for the javascript code? If so, where?**
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
