### PR TITLE
Eager load ActiveSupport::Callback procs

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -250,6 +250,8 @@ module ActiveSupport
           @filter  = filter
           @if      = check_conditionals(options[:if])
           @unless  = check_conditionals(options[:unless])
+
+          compiled
         end
 
         def merge_conditional_options(chain, if_option:, unless_option:)


### PR DESCRIPTION
Follow up to #49728 where these procs were allows to be shared between subclasses. This change allocates the procs as they are first declared.