### PR TITLE
Eager load Journey Formatter cache

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -104,6 +104,11 @@ module ActionDispatch
         @cache = nil
       end
 
+      def eager_load!
+        cache
+        nil
+      end
+
       private
         def extract_parameterized_parts(route, options, recall)
           parameterized_parts = recall.merge(options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -386,6 +386,7 @@ module ActionDispatch
       def eager_load!
         router.eager_load!
         routes.each(&:eager_load!)
+        formatter.eager_load!
         nil
       end
 


### PR DESCRIPTION
This cache is used when url_for is called without a named route (ie. when it's called with hash options). Eager loading avoids building the cache on the first call and potentially allows the memory to be shared via CoW on forking servers.