### PR TITLE
Add note for `method` argument in `button_to` in js guide

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -318,6 +318,17 @@ added to the form that the `button_to` helper renders internally:
 <%= button_to "Delete post", post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } } %>
 ```
 
+Which generates:
+
+```html
+<form data-turbo-confirm="Are you sure?" method="post" action="...">
+  <input type="hidden" name="_method" value="delete" autocomplete="off">
+  <button type="submit">Delete post></button>
+  ...
+```
+
+NOTE: In this case the `method` argument should not be `turbo_method` as it is unrelated to UJS.
+
 ### Ajax Requests
 
 When making non-GET requests from JavaScript the `X-CSRF-Token` header is required.


### PR DESCRIPTION
This section describes replacing UJS attributes with Turbo.
For example replacing `method` with `turbo_method`.
However, for `button_to` `method` should not be replaced with `turbo_method`,
as it's unrelated to UJS.
This could avoid some confusion.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
