### PR TITLE
Pass along with_raw_connection params in PG adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -892,7 +892,7 @@ module ActiveRecord
 
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async) do
-            with_raw_connection do |conn|
+            with_raw_connection(allow_retry: false, materialize_transactions: materialize_transactions) do |conn|
               result = conn.exec_params(sql, type_casted_binds)
               verified!
               result
@@ -905,7 +905,7 @@ module ActiveRecord
 
           update_typemap_for_default_timezone
 
-          with_raw_connection do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: materialize_transactions) do |conn|
             stmt_key = prepare_statement(sql, binds, conn)
             type_casted_binds = type_casted_binds(binds)
 


### PR DESCRIPTION
Prior to this commit we were passing `allow_retry` and `materialize_transactions` through from `execute_and_clear` to `exec_cache`/`exec_no_cache`, but then doing nothing with them.

We've got a few internal queries using `execute_and_clear` (mostly via `internal_exec_query`) that are passing `allow_retry: true` and `materialize_transactions: false`. These calls will fail on connection errors that might have been retryable. It's also possible they are materializing transactions earlier than expected (although probably not—most of the methods look like they would be called only by us, always outside a transaction).

This commit forwards the arguments through to `with_raw_connection` so the callers get the behavior they likely expect.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
