### PR TITLE
Name the connection pool reaper thread

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -43,6 +43,7 @@ module ActiveRecord
                 # Advise multi-threaded app servers to ignore this thread for
                 # the purposes of fork safety warnings
                 Thread.current.thread_variable_set(:fork_safe, true)
+                Thread.current.name = "AR Pool Reaper"
                 running = true
                 while running
                   sleep t


### PR DESCRIPTION
Naming threads can be helpful for debugging (e.g. getting an overview of what's running with `Thread.list.map(&:name)` or `ps -T -p PID`).

We noticed our reaper didn't have a name, so this commit adds one.

We've intentionally kept the name short (< 15 characters), since there are platform limitations on the length of the underlying thread name.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
