### PR TITLE
Fix `RedisCacheStore#write_multi` with `:expires_in`

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -386,7 +386,7 @@ module ActiveSupport
         end
 
         # Nonstandard store provider API to write multiple values at once.
-        def write_multi_entries(entries, expires_in: nil, race_condition_ttl: nil, **options)
+        def write_multi_entries(entries, **options)
           return if entries.empty?
 
           failsafe :write_multi_entries do

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -174,6 +174,15 @@ module CacheStoreBehavior
     assert @cache.write_multi({})
   end
 
+  def test_write_multi_expires_in
+    key = SecureRandom.uuid
+    @cache.write_multi({ key => 1 }, expires_in: 10)
+
+    travel(11.seconds) do
+      assert_nil @cache.read(key)
+    end
+  end
+
   def test_fetch_multi
     key = SecureRandom.uuid
     other_key = SecureRandom.uuid


### PR DESCRIPTION
Fixes #49973.

This options were extracted as keyword arguments and not used then.