### PR TITLE
[Fix #49981] Support enum definition with symbol values

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -220,7 +220,7 @@ module ActiveRecord
 
     private
       def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-        assert_valid_enum_definition_values(values)
+        values = assert_valid_enum_definition_values(values)
         assert_valid_enum_options(options)
 
         # statuses = { }
@@ -341,6 +341,20 @@ module ActiveRecord
           if values.keys.any?(&:blank?)
             raise ArgumentError, "Enum values #{values} must not contain a blank name."
           end
+
+          values = values.transform_values do |value|
+            value.is_a?(Symbol) ? value.name : value
+          end
+
+          values.each_value do |value|
+            case value
+            when String, Integer, true, false, nil
+              # noop
+            else
+              raise ArgumentError, "Enum values #{values} must be only booleans, integers, symbols or strings, got: #{value.class}"
+            end
+          end
+
         when Array
           if values.empty?
             raise ArgumentError, "Enum values #{values} must not be empty."
@@ -356,6 +370,8 @@ module ActiveRecord
         else
           raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
         end
+
+        values
       end
 
       def assert_valid_enum_options(options)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -496,6 +496,15 @@ class EnumTest < ActiveRecord::TestCase
     e = assert_raises(ArgumentError) do
       Class.new(ActiveRecord::Base) do
         self.table_name = "books"
+        enum :status, { proposed: Object.new, active: :active }
+      end
+    end
+
+    assert_match(/must be only booleans, integers, symbols or strings/, e.message)
+
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
         enum :status, Object.new
       end
     end
@@ -713,6 +722,12 @@ class EnumTest < ActiveRecord::TestCase
     book = klass.find(book.id)
     assert_predicate book, :proposed?
     assert_equal "proposed", book.aliased_status
+  end
+
+  test "enum with a hash with symbol values" do
+    book = Book.create!(symbol_status: :proposed)
+    assert_equal "proposed", book.symbol_status
+    assert_predicate book, :symbol_status_proposed?
   end
 
   test "query state by predicate with prefix" do

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -24,6 +24,7 @@ class Book < ActiveRecord::Base
   enum :difficulty, [:easy, :medium, :hard], suffix: :to_read
   enum :cover, { hard: "hard", soft: "soft" }
   enum :boolean_status, { enabled: true, disabled: false }
+  enum :symbol_status, { proposed: :proposed, published: :published }, prefix: true
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define do
     t.column :font_size, :integer, **default_zero
     t.column :difficulty, :integer, **default_zero
     t.column :cover, :string, default: "hard"
+    t.column :symbol_status, :string, default: "proposed"
     t.string :isbn
     t.string :external_id
     t.column :original_name, :string

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -917,7 +917,7 @@ A `:conditions` option can be used to specify additional conditions as a `WHERE`
 SQL fragment to limit the uniqueness constraint lookup:
 
 ```ruby
-validates :name, uniqueness: { conditions: -> { where(status: 'active') } }
+validates :name, uniqueness: { conditions: -> { where(status: "active") } }
 ```
 
 The default error message is _"has already been taken"_.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because Enum definition with symbol values are not correctly typed_casted
reported here: https://github.com/rails/rails/issues/49981

Fixes #49981

### Detail
When an enum is defined with symbol values
`enum :status, { draft: :draft, published: :published }`
a warning or an exception could be raised to force fixing, same kind as invalid enum definition.
Not sure this is the correct approach since the value is correctly persisted.

I'd expect the enum symbol value to be converted to string to allow correct type_cast.

**Actual behavior**

the type_cast of a symbol value of an enum is always returning nil.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
