### PR TITLE
Add `actionview` bug report template

### DIFF
--- a/guides/bug_report_templates/action_view.rb
+++ b/guides/bug_report_templates/action_view.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  gem "rails"
+  # If you want to test against edge Rails replace the previous line with this:
+  # gem "rails", github: "rails/rails", branch: "main"
+end
+
+require "minitest/autorun"
+require "action_view"
+
+class BugTest < ActionView::TestCase
+  helper do
+    def upcase(value)
+      value.upcase
+    end
+  end
+
+  def test_stuff
+    render inline: <<~ERB, locals: { key: "value" }
+      <p><%= upcase(key) %></p>
+    ERB
+
+    element = rendered.html.at("p")
+
+    assert_equal element.text, "VALUE"
+  end
+end

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -42,6 +42,7 @@ Having a way to reproduce your issue will help people confirm, investigate, and 
 * Template for Active Record (models, database) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
 * Template for testing Active Record (migration) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
 * Template for Action Pack (controllers, routing) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
+* Template for Action View (views, helpers) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
 * Template for Active Job issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)
 * Template for Active Storage issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
 * Template for Action Mailer issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)


### PR DESCRIPTION
### Motivation / Background

Introduce Action View bug report templates for contributors to reproduce issues with failing `ActionView::TestCase` instances.

### Detail

In addition to rendering ERB with the `inline:` keyword, the sample tests also include a `Helpers` module to demonstrate how to incorporate view helpers into the reproduction script.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
