### PR TITLE
Automatically eager load TZInfo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ PATH
       drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      tzinfo (~> 2.0, >= 2.0.5)
     rails (7.2.0.alpha)
       actioncable (= 7.2.0.alpha)
       actionmailbox (= 7.2.0.alpha)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "i18n",            ">= 1.6", "< 2"
-  s.add_dependency "tzinfo",          "~> 2.0"
+  s.add_dependency "tzinfo",          "~> 2.0", ">= 2.0.5"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
   s.add_dependency "minitest",        ">= 5.1"

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -93,6 +93,7 @@ module ActiveSupport
       end
       require "active_support/core_ext/time/zones"
       Time.zone_default = Time.find_zone!(app.config.time_zone)
+      config.eager_load_namespaces << TZInfo
     end
 
     # Sets the default week start


### PR DESCRIPTION
On the first call it can be a bit slow because it needs to load a bunch of data. It's also better to do it as part of boot so that some of that data is shared via Copy-on-Write
