### PR TITLE
Fix running db:system:change with no Dockerfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix running `db:system:change` when app has no Dockerfile.
+
+    *Hartley McGuire*
+
 *   In Action Mailer previews, list inline attachments separately from normal
     attachments. For example, attachments that were previously listed like
 

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -41,6 +41,9 @@ module Rails
           end
 
           def edit_dockerfile
+            dockerfile_path = File.expand_path("Dockerfile", destination_root)
+            return unless File.exist?(dockerfile_path)
+
             build_name = docker_for_database_build
             deploy_name = docker_for_database_deploy
             if build_name

--- a/railties/test/commands/db_system_change_test.rb
+++ b/railties/test/commands/db_system_change_test.rb
@@ -60,6 +60,14 @@ class Rails::Command::DbSystemChangeTest < ActiveSupport::TestCase
     assert_match "gsub  Gemfile", output
   end
 
+  test "change works with no Dockerfile" do
+    remove_file("Dockerfile")
+
+    output = change_database(to: "sqlite3")
+
+    assert_match "gsub  Gemfile", output
+  end
+
   private
     def change_database(to:, **options)
       args = ["--to", to]


### PR DESCRIPTION
### Motivation / Background

The db:system:change command was [updated][1] to include support for changing the database packages installed in the Dockerfile. However, it never checks that the Dockerfile exists before trying to perform a substitution and will raise an error when its missing:

```
/home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/actions/file_manipulation.rb:272:in `binread': No such file or directory @ rb_sysopen - /home/hartley/test/dev_minimal/Dockerfile (Errno::ENOENT)
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/actions/file_manipulation.rb:272:in `gsub_file'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/generators/rails/db/system/change/change_generator.rb:47:in `edit_dockerfile'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:134:in `block in invoke_all'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:134:in `each'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:134:in `map'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:134:in `invoke_all'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/group.rb:232:in `dispatch'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/base.rb:584:in `start'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/commands/db/system/change/change_command.rb:20:in `perform'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/command/base.rb:178:in `invoke_command'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.3.0/lib/thor.rb:527:in `dispatch'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/command/base.rb:73:in `perform'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/command.rb:71:in `block in invoke'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/command.rb:149:in `with_argv'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/command.rb:69:in `invoke'
        from /home/hartley/src/github.com/skipkayhil/rails/railties/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```

### Detail

This commit fixes the issue by checking first whether the Dockerfile exists before trying to perform any substitution on it.

[1]: ac9f08d1c354baab6362d7050a3c9e43db09689c

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
