### PR TITLE
Let ActiveStorage::Blob#open return a tempfile for manual unlinking

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   `ActiveStorage::Blob#open` can now be used without passing a block, like `Tempfile.open`. When using this form the
+    returned temporary file must be unlinked manually.
+
+    *Bart de Water*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -272,7 +272,8 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.download_chunk key, range
   end
 
-  # Downloads the blob to a tempfile on disk. Yields the tempfile.
+  # Downloads the blob to a temporary file on disk. If a block is given, the file is automatically closed and unlinked
+  # after the block executed. Otherwise the file is returned and you are responsible for closing and unlinking.
   #
   # The tempfile's name is prefixed with +ActiveStorage-+ and the blob's ID. Its extension matches that of the blob.
   #
@@ -281,8 +282,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
   #   blob.open(tmpdir: "/path/to/tmp") do |file|
   #     # ...
   #   end
-  #
-  # The tempfile is automatically closed and unlinked after the given block is executed.
   #
   # Raises ActiveStorage::IntegrityError if the downloaded data does not match the blob's checksum.
   def open(tmpdir: nil, &block)

--- a/activestorage/lib/active_storage/analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer.rb
@@ -30,7 +30,7 @@ module ActiveStorage
     end
 
     private
-      # Downloads the blob to a tempfile on disk. Yields the tempfile.
+      # Downloads the blob to a tempfile on disk. See ActiveStorage::Blob#open for details.
       def download_blob_to_tempfile(&block) # :doc:
         blob.open tmpdir: tmpdir, &block
       end

--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -27,7 +27,7 @@ module ActiveStorage
     end
 
     private
-      # Downloads the blob to a tempfile on disk. Yields the tempfile.
+      # Downloads the blob to a tempfile on disk. See ActiveStorage::Blob#open for details.
       def download_blob_to_tempfile(&block) # :doc:
         blob.open tmpdir: tmpdir, &block
       end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -174,7 +174,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "a" * 64.kilobytes, chunks.second
   end
 
-  test "open with integrity" do
+  test "open yielding with integrity" do
     create_file_blob(filename: "racecar.jpg").tap do |blob|
       blob.open do |file|
         assert_predicate file, :binmode?
@@ -183,6 +183,21 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
         assert file.path.end_with?(".jpg")
         assert_equal file_fixture("racecar.jpg").binread, file.read, "Expected downloaded file to match fixture file"
       end
+    end
+  end
+
+  test "open returning with integrity" do
+    file = nil
+    create_file_blob(filename: "racecar.jpg").tap do |blob|
+      file = blob.open
+
+      assert_predicate file, :binmode?
+      assert_equal 0, file.pos
+      assert File.basename(file.path).start_with?("ActiveStorage-#{blob.id}-")
+      assert file.path.end_with?(".jpg")
+      assert_equal file_fixture("racecar.jpg").binread, file.read, "Expected downloaded file to match fixture file"
+    ensure
+      file&.close!
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Wrapping code in a block is not always (easily) possible, this way it behaves like stdlib Tempfile that can be unlinked manually in addition to the block form that closes for the caller.

A use case I deal with at work involves processing a handful large-ish (10-100MB) CSVs into our models. Due to the way the business logic is structured it is more natural to keep track of open File handles and manually close them out at the end, rather than nesting the outermost layer in a handful of blocks for the current API.

Similarly https://github.com/Shopify/maintenance_tasks/issues/602 could benefit from being in charge of when to unlink the temporary file. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
