### PR TITLE
Avoid extra array allocation for `where(x: [...])`

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         return attribute.in([]) if value.empty?
 
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
-        nils = values.extract!(&:nil?)
+        nils = values.compact!
         ranges = values.extract! { |v| v.is_a?(Range) }
 
         values_predicate =
@@ -23,7 +23,7 @@ module ActiveRecord
           else Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
           end
 
-        unless nils.empty?
+        if nils
           values_predicate = values_predicate.or(attribute.eq(nil))
         end
 


### PR DESCRIPTION
We do not need to construct an array of `nil`s; we merely need to determine whether any are present in the values array and remove them. Thus, we can use `compact!` instead of `extract!`.
