### PR TITLE
Warn unclarity filed if joined table has multiple fields with same name.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -947,6 +947,11 @@ module ActiveRecord
             exec_main_query
           end
 
+          if rows.is_a?(ActiveRecord::Result)
+            duplicate_columns = rows.columns.tally.select { |_, count| count > 1 }.keys
+            logger.warn("Unclarity field name: there are multiple columns with same name (#{duplicate_columns.join(', ')}). You should specify source table name for each column.") unless duplicate_columns.empty?
+          end
+
           records = instantiate_records(rows, &block)
           preload_associations(records) unless skip_preloading_value
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1656,11 +1656,13 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_with_limiting_with_custom_select
     posts = Post.references(:authors).merge(
-      includes: :author, select: 'posts.*, authors.id as "author_id"',
+      includes: :author,
+      select: 'posts.*, authors.id as "joined_author_id"', # give another name to avoid shadowing
       limit: 3, order: "posts.id"
     ).to_a
     assert_equal 3, posts.size
-    assert_equal [1, 1, nil], posts.map(&:author_id)
+    assert_equal [1, 1, 0], posts.map(&:author_id)
+    assert_equal [1, 1, nil], posts.map(&:joined_author_id)
   end
 
   def test_custom_select_takes_precedence_over_original_value


### PR DESCRIPTION
### Motivation / Background

this enhancement prevents an unintentional human error by developers.
this change helps to avoid a problem column name shadowing when `select('*')`with joined tables containing same column names.

### Detail

assume that you have models and records like this.
```ruby
class Post < ApplicationRecord
  scope :sort_by_station_matching, lambda { |near_station_ids|
    select('*')
      .select("(#{select_near_station_match_count_query(near_station_ids)}) AS near_station_match_count")
  }
  
  def select_near_station_match_count_query(railway_station_ids = [])
    return 'SELECT 0' if railway_station_ids.blank?
  
    <<~SQL.squish
      SELECT COUNT(stations.id)
      FROM stations
      WHERE stations.railway_station_id IN (#{railway_station_ids.join(',')})
    SQL
  end
end
```

posts table
id|created_at|updated_at
--|--|--
1|2023-08-03 14:30:23.040019000|2023-08-03 14:30:23.040019000

comments table
id|post_id|created_at|updated_at
--|--|--|--
2|1|2023-08-03 14:30:23.040019000|2023-08-03 14:30:23.040019000

then, the id field of the instance of post model got with joins method has unexpected value. 
```ruby
Post.joins(:comments).sort_by_station_matching.first
```

expected
```
#<User:0x0000000114db6388
 id: 1,
 near_station_match_count: 3,
 created_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00,
 updated_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00>
```

actual
```
#<User:0x0000000114db6388
 id: 2,
 near_station_match_count: 3,
 created_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00,
 updated_at:
  Thu, 03 Aug 2023 14:30:23.040019000 UTC +00:00>
```

expected is `id: 1` from posts record but actual is `id: 2` from comments record .

at first, I thought this is a bug.
but, after more research understood that this is cause a column name shadowing.
this warning will help other developers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
