### PR TITLE
Remove the git_source from gem bug report template

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.1.0"
 end

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activejob", "~> 7.1.0"
 end

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activerecord", "~> 7.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "rails", "~> 7.1.0"
   gem "sqlite3"

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   # Activate the gem you are reporting the issue against.
   gem "activesupport", "~> 7.1.0"
 end


### PR DESCRIPTION
### Motivation / Background

Currently `git_source` added to all our bug report template, but for gem template we are only using the rubygem source. Also its not required for the gem bug report templates.

### Detail

This Pull Request removes the `git_source` reference from all the gem bug_report templates.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
