### PR TITLE
Add support for WITH PARSER for full text search indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -80,4 +80,8 @@
 
     *Jason Meller*
 
+*   Add support for `WITH PARSER` option when adding a fulltext index in MySQL.
+
+    *Gonzalo Rodríguez-Baltanás Díaz*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :include, :nulls_not_distinct, :comment, :valid
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :include, :nulls_not_distinct, :comment, :valid, :with_parser
 
       def initialize(
         table, name,
@@ -22,7 +22,8 @@ module ActiveRecord
         include: nil,
         nulls_not_distinct: nil,
         comment: nil,
-        valid: true
+        valid: true,
+        with_parser: nil
       )
         @table = table
         @name = name
@@ -38,6 +39,7 @@ module ActiveRecord
         @nulls_not_distinct = nulls_not_distinct
         @comment = comment
         @valid = valid
+        @with_parser = with_parser
       end
 
       def valid?

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -863,13 +863,13 @@ module ActiveRecord
       #
       # Note: only supported by PostgreSQL
       #
-      # ====== Creating an index with a specific type
+      # ====== Creating an index with a specific type, and parser
       #
-      #   add_index(:developers, :name, type: :fulltext)
+      #   add_index(:developers, :name, type: :fulltext, with_parser: "ngram")
       #
       # generates:
       #
-      #   CREATE FULLTEXT INDEX index_developers_on_name ON developers (name) -- MySQL
+      #   CREATE FULLTEXT INDEX index_developers_on_name ON developers (name) WITH PARSER ngram -- MySQL
       #
       # Note: only supported by MySQL.
       #
@@ -1434,7 +1434,7 @@ module ActiveRecord
       end
 
       def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options) # :nodoc:
-        options.assert_valid_keys(:unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include, :nulls_not_distinct)
+        options.assert_valid_keys(:unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include, :nulls_not_distinct, :with_parser)
 
         column_names = index_column_names(column_name)
 
@@ -1455,7 +1455,8 @@ module ActiveRecord
           using: options[:using],
           include: options[:include],
           nulls_not_distinct: options[:nulls_not_distinct],
-          comment: options[:comment]
+          comment: options[:comment],
+          with_parser: options[:with_parser]
         )
 
         [index, index_algorithm(options[:algorithm]), if_not_exists]

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -49,6 +49,7 @@ module ActiveRecord
             sql << "USING #{o.using}" if o.using
             sql << "ON #{quote_table_name(o.table)}" if create
             sql << "(#{quoted_columns(o)})"
+            sql << "WITH PARSER #{o.with_parser}" if o.with_parser
 
             add_sql_comment!(sql.join(" "), o.comment)
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -257,6 +257,8 @@ module ActiveRecord
         index_parts << "nulls_not_distinct: #{index.nulls_not_distinct.inspect}" if index.nulls_not_distinct
         index_parts << "type: #{index.type.inspect}" if index.type
         index_parts << "comment: #{index.comment.inspect}" if index.comment
+        index_parts << "with_parser: #{index.with_parser.inspect}" if index.with_parser.present?
+
         index_parts
       end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -92,6 +92,27 @@ module ActiveRecord
         assert_equal :fulltext, index_c.type
       end
 
+      def test_dump_fulltext_indexes
+        index_a_name = "index_fulltext_tests_on_forename_and_surname"
+        index_b_name = "index_fulltext_tests_on_description"
+
+        table = "fulltext_tests"
+
+        indexes = @connection.indexes(table).sort_by(&:name)
+        assert_equal 2, indexes.size
+
+        index_a = indexes.select { |i| i.name == index_a_name }[0]
+        index_b = indexes.select { |i| i.name == index_b_name }[0]
+
+        assert_nil index_a.using
+        assert_equal :fulltext, index_a.type
+        assert_equal "ngram", index_a.with_parser
+
+        assert_nil index_b.using
+        assert_equal :fulltext, index_b.type
+        assert_nil index_b.with_parser
+      end
+
       unless mysql_enforcing_gtid_consistency?
         def test_drop_temporary_table
           @connection.transaction do

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       end
 
       def invalid_add_index_option_exception_message(key)
-        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include, :nulls_not_distinct"
+        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include, :nulls_not_distinct, :with_parser"
       end
 
       def invalid_create_table_option_exception_message(key)

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -354,6 +354,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{t\.index \["awesome"\], name: "index_key_tests_on_awesome", type: :fulltext$}, output
       assert_match %r{t\.index \["pizza"\], name: "index_key_tests_on_pizza"$}, output
     end
+
+    def test_schema_dumps_fulltext_index
+      output = dump_table_schema "fulltext_tests"
+
+      assert_match %r{t\.index \["forename", "surname"\], name: "index_fulltext_tests_on_forename_and_surname", type: :fulltext, with_parser: "ngram"$}, output
+      assert_match %r{t\.index \["description"\], name: "index_fulltext_tests_on_description", type: :fulltext$}, output
+    end
   end
 
   def test_schema_dump_includes_decimal_options

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -58,6 +58,14 @@ ActiveRecord::Schema.define do
     t.index :snacks, name: "index_key_tests_on_snack"
   end
 
+  create_table :fulltext_tests, force: true, options: "CHARSET=utf8 ENGINE=MyISAM" do |t|
+    t.string :surname
+    t.string :forename
+    t.text   :description
+    t.index ["forename", "surname"], type: :fulltext, name: "index_fulltext_tests_on_forename_and_surname", with_parser: "ngram"
+    t.index :description, type: :fulltext, name: "index_fulltext_tests_on_description"
+  end
+
   create_table :collation_tests, id: false, force: true do |t|
     t.string :string_cs_column, limit: 1, collation: "utf8mb4_bin"
     t.string :string_ci_column, limit: 1, collation: "utf8mb4_general_ci"

--- a/activerecord/test/schema/trilogy_specific_schema.rb
+++ b/activerecord/test/schema/trilogy_specific_schema.rb
@@ -58,6 +58,14 @@ ActiveRecord::Schema.define do
     t.index :snacks, name: "index_key_tests_on_snack"
   end
 
+  create_table :fulltext_tests, force: true, options: "CHARSET=utf8 ENGINE=MyISAM" do |t|
+    t.string :surname
+    t.string :forename
+    t.text   :description
+    t.index ["forename", "surname"], type: :fulltext, name: "index_fulltext_tests_on_forename_and_surname", with_parser: "ngram"
+    t.index :description, type: :fulltext, name: "index_fulltext_tests_on_description"
+  end
+
   create_table :collation_tests, id: false, force: true do |t|
     t.string :string_cs_column, limit: 1, collation: "utf8mb4_bin"
     t.string :string_ci_column, limit: 1, collation: "utf8mb4_general_ci"


### PR DESCRIPTION
### Motivation / Background

This PR adds support for the WITH PARSER option when creating a fulltext index in MYSQL.

### Detail

This Pull Request changes activerecord in order to support passing a `with_parser` option when creating an index.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
