### PR TITLE
Fix renaming primary key index when renaming a PostgreSQL table having uuid primary key

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -341,7 +341,7 @@ module ActiveRecord
               JOIN pg_namespace   nsp  ON (t.relnamespace = nsp.oid)
               WHERE t.oid = #{quote(quote_table_name(table))}::regclass
                 AND cons.contype = 'p'
-                AND pg_get_expr(def.adbin, def.adrelid) ~* 'nextval|uuid_generate'
+                AND pg_get_expr(def.adbin, def.adrelid) ~* 'nextval|uuid_generate|gen_random_uuid'
             SQL
           end
 


### PR DESCRIPTION
Fixes #49994.

Rails uses `gen_random_uuid()` function as a default for `uuid` primary key for PostgreSQL, which is not correctly fetched from the pg_catalog.