### PR TITLE
Fix #50005 transform_job not accepting previewables

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `preprocessed: true` option for named variants of previewable files.
+
+    *Nico Wenterodt*
+
 *   Allow accepting `service` as a proc as well in `has_one_attached` and `has_many_attached`.
 
     *Yogesh Khater*

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -7,6 +7,6 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)
-    blob.variant(transformations).processed
+    blob.representation(transformations).processed
   end
 end

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -16,6 +16,17 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
     end
   end
 
+  test "creates variant for previewable file" do
+    @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    transformations = { resize_to_limit: [100, 100] }
+
+    assert_changes -> { @blob.reload.preview(transformations).send(:processed?) }, from: false, to: true do
+      perform_enqueued_jobs do
+        ActiveStorage::TransformJob.perform_later @blob, transformations
+      end
+    end
+  end
+
   test "creates variant when untracked" do
     @was_tracking, ActiveStorage.track_variants = ActiveStorage.track_variants, false
     transformations = { resize_to_limit: [100, 100] }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR. See #50005 for details.
-->

This Pull Request has been created because the `ActiveStorage::TransformJob` crashes if you want to preprocess a previewable file like a pdf document. 

### Detail

This Pull Request changes that by determining if a blob is capable of being previewed. If so, a preview will be generated. 

### Additional information
The `ActiveStorage::TransformJob` is being used when an attachment has predefined variants with the `preprocessed` option. When you upload a file which is **not** an image but a previewable file like a pdf-document this will fail with `ActiveStorage::InvariableError`.

Example:
```
has_one_attached :file do |attachable|
    attachable.preview :thumb, resize_to_limit: [400, 600], preprocessed: true
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Fix #50005
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
