### PR TITLE
Implement a `:force` option to delete cookies not present in the request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -7,4 +7,8 @@
 
     *Hartley McGuire*
 
+*   Implement a `:force` option for `cookies.delete` to allow deleting cookies not present in the request
+
+    *Felipe Zavan*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -382,12 +382,17 @@ module ActionDispatch
       # Removes the cookie on the client machine by setting the value to an empty string
       # and the expiration date in the past. Like <tt>[]=</tt>, you can pass in
       # an options hash to delete cookies with extra data such as a <tt>:path</tt>.
+      # You can also pass the <tt>:force</tt> option to delete a cookie even if it's
+      # not present in the request. This can be useful if you're trying to delete a
+      # cookie that has a path, from a different path.
       #
       # Returns the value of the cookie, or +nil+ if the cookie does not exist.
       def delete(name, options = {})
-        return unless @cookies.has_key? name.to_s
-
         options.symbolize_keys!
+
+        force = options.delete(:force)
+        return if !force && !@cookies.has_key?(name.to_s)
+
         handle_options(options)
 
         value = @cookies.delete(name.to_s)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -153,6 +153,11 @@ class CookiesTest < ActionController::TestCase
 
     alias delete_cookie logout
 
+    def force_delete_cookie
+      cookies.delete("user_name", force: true)
+      head :ok
+    end
+
     def delete_cookie_with_path
       cookies.delete("user_name", path: "/beaten")
       head :ok
@@ -585,6 +590,18 @@ class CookiesTest < ActionController::TestCase
     request.cookies.clear
     get :delete_cookie
     assert_empty @response.cookies
+  end
+
+  def test_force_delete_cookie_marks_deleted
+    request.cookies.clear
+    cookies.delete(:user_name, force: true)
+    assert cookies.deleted?("user_name")
+  end
+
+  def test_force_delete_cookie_sets_header
+    request.cookies.clear
+    get :force_delete_cookie
+    assert_set_cookie_header "user_name=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_deleted_cookie_predicate


### PR DESCRIPTION
Implement a :force option to delete cookies not present in the request.

### Motivation / Background

This can be useful if you're trying to delete a cookie that has a path, from a different path, in which case it won't be present in the request and won't be deleted if the option is not passed.

Fixes #49746 

### Detail

This Pull Request adds a `:force` option to `cookies.delete` that skips checking if the cookie is present before marking it for removal.

### Additional information

I initially tried simply removing the guard condition altogether (I gave my rationale for this in the linked Issue), but this broke some `cookies.clear` tests, so I though it should probably be an opt-in behavior through an option.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
