### PR TITLE
Fix logged cache key normalization

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix logged cache keys not always matching actual key used by cache action.
+
+    *Hartley McGuire*
+
 *   Improve error messages of `assert_changes` and `assert_no_changes`
 
     `assert_changes` error messages now display objects with `.inspect` to make it easier

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -78,8 +78,9 @@ module ActiveSupport
 
       def delete_matched(matcher, options = nil)
         options = merged_options(options)
+        matcher = key_matcher(matcher, options)
+
         instrument(:delete_matched, matcher.inspect) do
-          matcher = key_matcher(matcher, options)
           search_dir(cache_path) do |path|
             key = file_path_key(path)
             delete_entry(path, **options) if key.match(matcher)

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -179,9 +179,11 @@ module ActiveSupport
       # <tt>raw: true</tt>, will fail and return +nil+.
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
-        instrument(:increment, name, amount: amount) do
+        key = normalize_key(name, options)
+
+        instrument(:increment, key, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.incr(normalize_key(name, options), amount, options[:expires_in], amount) }
+            @data.with { |c| c.incr(key, amount, options[:expires_in], amount) }
           end
         end
       end
@@ -203,9 +205,11 @@ module ActiveSupport
       # <tt>raw: true</tt>, will fail and return +nil+.
       def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
-        instrument(:decrement, name, amount: amount) do
+        key = normalize_key(name, options)
+
+        instrument(:decrement, key, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.decr(normalize_key(name, options), amount, options[:expires_in], 0) }
+            @data.with { |c| c.decr(key, amount, options[:expires_in], 0) }
           end
         end
       end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -168,8 +168,9 @@ module ActiveSupport
       # Deletes cache entries if the cache key matches a given pattern.
       def delete_matched(matcher, options = nil)
         options = merged_options(options)
+        matcher = key_matcher(matcher, options)
+
         instrument(:delete_matched, matcher.inspect) do
-          matcher = key_matcher(matcher, options)
           keys = synchronize { @data.keys }
           keys.each do |key|
             delete_entry(key, **options) if key.match(matcher)

--- a/activesupport/test/cache/behaviors/cache_logging_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_logging_behavior.rb
@@ -3,6 +3,56 @@
 require "active_support/core_ext/object/with"
 
 module CacheLoggingBehavior
+  def test_fetch_logging
+    assert_logs(/Cache read: #{key_pattern("foo")}/) do
+      @cache.fetch("foo")
+    end
+
+    assert_logs(/Cache read: #{key_pattern("foo", namespace: "bar")}/) do
+      @cache.fetch("foo", namespace: "bar")
+    end
+  end
+
+  def test_read_logging
+    assert_logs(/Cache read: #{key_pattern("foo")}/) do
+      @cache.read("foo")
+    end
+
+    assert_logs(/Cache read: #{key_pattern("foo", namespace: "bar")}/) do
+      @cache.read("foo", namespace: "bar")
+    end
+  end
+
+  def test_write_logging
+    assert_logs(/Cache write: #{key_pattern("foo")}/) do
+      @cache.write("foo", "qux")
+    end
+
+    assert_logs(/Cache write: #{key_pattern("foo", namespace: "bar")}/) do
+      @cache.write("foo", "qux", namespace: "bar")
+    end
+  end
+
+  def test_delete_logging
+    assert_logs(/Cache delete: #{key_pattern("foo")}/) do
+      @cache.delete("foo")
+    end
+
+    assert_logs(/Cache delete: #{key_pattern("foo", namespace: "bar")}/) do
+      @cache.delete("foo", namespace: "bar")
+    end
+  end
+
+  def test_exist_logging
+    assert_logs(/Cache exist\?: #{key_pattern("foo")}/) do
+      @cache.exist?("foo")
+    end
+
+    assert_logs(/Cache exist\?: #{key_pattern("foo", namespace: "bar")}/) do
+      @cache.exist?("foo", namespace: "bar")
+    end
+  end
+
   def test_read_multi_logging
     assert_logs("Cache read_multi: 1 key(s)") { @cache.read_multi("foo") }
     assert_logs("Cache read_multi: 2 key(s)") { @cache.read_multi("foo", "bar") }
@@ -25,5 +75,9 @@ module CacheLoggingBehavior
       io = StringIO.new
       ActiveSupport::Cache::Store.with(logger: Logger.new(io, level: :debug), &block)
       assert_match pattern, io.string
+    end
+
+    def key_pattern(key, namespace: @namespace)
+      /#{Regexp.escape namespace.to_s}#{":" if namespace}#{Regexp.escape key}/
     end
 end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -158,4 +158,9 @@ class FileStoreTest < ActiveSupport::TestCase
     @cache.write(1, nil)
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
   end
+
+  private
+    def key_pattern(key, namespace: nil)
+      /.+\/#{Regexp.escape namespace.to_s}#{/%3A/i if namespace}#{Regexp.escape key}/
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Previously, the `Cache::Store` instrumentation would call `normalize_key` when adding a key to the log. However, this resulted in the logged key not always matching the actual key written/read from the cache:

```irb
irb(main):004> cache.write("foo", "bar", namespace: "baz")
D, [2023-11-10T12:44:59.286362 #169586] DEBUG -- : Cache write: baz:foo ({:compress=>false, :compress_threshold=>1024, :namespace=>"baz"})
=> true
irb(main):005> cache.delete("foo", namespace: "baz")
D, [2023-11-10T12:45:03.071300 #169586] DEBUG -- : Cache delete: foo
=> true
```

In this example, `#write` would correctly log that the key written to was `baz:foo` because the `namespace` option would be passed to the `instrument` method. However, other methods like `#delete` would log that the `foo` key was deleted because the `namespace` option was _not_ passed to `instrument`.

### Detail

This commit fixes the issue by making the caller responsible for passing the correct key to `#instrument`. This allows `normalize_key` to be removed from the log generation which both prevents the key from being normalized a second time and removes the need to pass the full options hash into `#instrument`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
