### PR TITLE
Active Model: Call `Object#dup` on `default:` values

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,31 @@
+*   Call `Object#dup` on `default:` values
+
+    Don't share `default:` values across all instances
+
+    ```ruby
+    class Model
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :array, default: []
+      attribute :hash, default: {}
+    end
+
+    a = Model.new
+    b = Model.new
+
+    a.array << 1
+    a.hash[:a] = 1
+
+    a.array # => [1]
+    a.hash # => { a: 1 }
+
+    b.array # => []
+    b.hash # => {}
+    ```
+
+    *Sean Doyle*
+
 *   Port the `type_for_attribute` method to Active Model. Classes that include
     `ActiveModel::Attributes` will now provide this method. This method behaves
     the same for Active Model as it does for Active Record.

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -18,7 +18,7 @@ module ActiveModel
         if user_provided_value.is_a?(Proc)
           @memoized_value_before_type_cast ||= user_provided_value.call
         else
-          @user_provided_value
+          @user_provided_value.dup
         end
       end
 

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -19,6 +19,11 @@ module ActiveModel
     class ChildModelForAttributesTest < ModelForAttributesTest
     end
 
+    class ModelWithDefaultObjects < ModelForAttributesTest
+      attribute :array_with_default, default: []
+      attribute :hash_with_default, default: {}
+    end
+
     class GrandchildModelForAttributesTest < ChildModelForAttributesTest
       attribute :integer_field, :string
       attribute :string_field, default: "default string"
@@ -155,6 +160,39 @@ module ActiveModel
 
       assert_equal 1, data.integer_field
       assert_equal 2, duped.integer_field
+    end
+
+    test "Array default attributes are dup-ed" do
+      first = ModelWithDefaultObjects.new
+      second = ModelWithDefaultObjects.new
+
+      first.array_with_default << 1
+      first.array_with_default << 2
+
+      assert_equal [1, 2], first.array_with_default
+      assert_equal [], second.array_with_default
+    end
+
+    test "Hash default attributes are dup-ed" do
+      first = ModelWithDefaultObjects.new
+      second = ModelWithDefaultObjects.new
+
+      first.hash_with_default[:a] = 1
+      first.hash_with_default[:b] = 2
+
+      assert_equal({ a: 1, b: 2 }, first.hash_with_default)
+      assert_equal({}, second.hash_with_default)
+    end
+
+    test "String default attributes are dup-ed" do
+      first = ModelWithDefaultObjects.new
+      second = ModelWithDefaultObjects.new
+
+      first.string_with_default << "1"
+      first.string_with_default << "2"
+
+      assert_equal "default string12", first.string_with_default
+      assert_equal "default string", second.string_with_default
     end
 
     test "can't modify attributes if frozen" do


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, defining a `default:` Object value for an Active Model attribute meant that particular Object instance was shared across all model instances.

For example, given the following model:

```ruby
class Model
  include ActiveModel::Model
  include ActiveModel::Attributes

  attribute :array, default: []
  attribute :hash, default: {}
end
```

Each time an instance wrote to a default value, all others that relied on that default value had that value changed:

```ruby
a, b = Model.new, Model.new

a.array << 1
a.hash[:a] = 1

 # expected
a.array # => [1]
a.hash # => { a: 1 }

 # unexpected
b.array # => [1]
b.hash # => { b: 1 }
```

Equipped with the knowledge of this quirk, one common work around was to define the `default:` in a callable:

```ruby
class Model
  include ActiveModel::Model
  include ActiveModel::Attributes

  attribute :array, default: -> { [] }
  attribute :hash, default: -> { {} }
end

a, b = Model.new, Model.new

a.array << 1
a.hash[:a] = 1

a.array # => [1]
a.hash # => { a: 1 }

b.array # => []
b.hash # => {}
```

### Detail

When defining a `default:` that isn't callable, call `Object#dup`.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
