### PR TITLE
Aggregate saved changes for all updates inside of a transaction

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Aggregate saved changes for all updates inside of a transaction.
+
+    When multiple updates are made to a record inside of a transaction, each update resets
+    the dirty fields on the record so that the `saved_changes` hash only contains
+    the most recent change after a record is saved.
+
+    When a transaction is committed, all of the changes are aggregated into a single
+    change set. This fixes issues where checking `saved_changes` in an `after_commit`
+    callback could return inconsistent results depending on the order of updates in
+    the transaction.
+
+    Fixes #49898, #48077
+
+    *Brian Durand*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -370,6 +370,7 @@ module ActiveRecord
     end
 
     def before_committed! # :nodoc:
+      rollup_mutations_for_transaction!
       _run_before_commit_callbacks
     end
 
@@ -390,6 +391,7 @@ module ActiveRecord
     # Call the #after_rollback callbacks. The +force_restore_state+ argument indicates if the record
     # state should be rolled back to the beginning or just to the last savepoint.
     def rolledback!(force_restore_state: false, should_run_callbacks: true) # :nodoc:
+      rollup_mutations_for_transaction!
       if should_run_callbacks
         _run_rollback_callbacks
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there is inconsistent behavior with dirty attributes in transaction callbacks when a record is updated multiple times inside of a transaction.

Consider this case:

```ruby
class User < ApplicationRecord
  after_commit :notify_email_changes, if: :email_changed?

  def notify_email_changes
    NotifyEmailChangesJob.perform_later(id)
  end
end
```

This breaks if a record is saved twice in a single transaction.

```ruby
user.transaction do
  user.update!(email: params[:email])
  if user.last_visited_at < 1.day.ago
    user.update!(last_visited_at: Time.now)
  end
end
```

In the case where we update the `last_visited_at` field, the `email_changed?` method will return false since the email address was not changed in the last save operation and `notify_email_changes` method will not be called.

Fixes #49898, #48077

### Detail

This Pull Request changes how `saved_changes` is calculated in transactions when a record is updated multiple times.

After each save operation, the list of saved changes is pushed onto a list. `saved_changes` in an `after_save` callback is unaffected and will show only the changes for that save operation.

Before a transaction is committed, the list of saved changes for all saves in the transaction are merged by reapplying them to the original attributes. Checking `saved_changes` in an `after_commit` callback will use the merged mutation tracker which includes all changes. Checking `saved_changes` outside the transaction after it is committed will also include all changes.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
