### PR TITLE
Fix using `self.inherited` removing filter_attributes & GeneratedAssociationMethods generated multiple times

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -384,8 +384,8 @@ module ActiveRecord
             @arel_table = nil
             @predicate_builder = nil
             @inspection_filter = nil
-            @filter_attributes = nil
-            @generated_association_methods = nil
+            @filter_attributes ||= nil
+            @generated_association_methods ||= nil
           end
         end
 

--- a/activerecord/test/cases/inherited_test.rb
+++ b/activerecord/test/cases/inherited_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module Inherited
+  # When running the test with `RAILS_STRICT_WARNINGS` enabled, the `belongs_to`
+  # call should not emit a warning that the constant `GeneratedAssociationMethods`
+  # is already defined.
+  class Person < ActiveRecord::Base; end
+
+  class Device < ActiveRecord::Base
+    def self.inherited(subclass)
+      subclass.belongs_to :person, inverse_of: subclass.name.demodulize.tableize.to_sym
+      subclass.filter_attributes = [:secret_attribute, :"#{subclass.name.demodulize.downcase}_key"]
+      super
+    end
+  end
+
+  class Computer < Device; end
+
+  class Vehicle < ActiveRecord::Base
+    def self.inherited(subclass)
+      super
+      subclass.belongs_to :person, inverse_of: subclass.name.demodulize.tableize.to_sym
+      subclass.filter_attributes = [:secret_attribute, :"#{subclass.name.demodulize.downcase}_key"]
+    end
+  end
+
+  class Car < Vehicle; end
+end
+
+class InheritedTest < ActiveRecord::TestCase
+  def test_super_before_filter_attributes
+    assert_equal %i[secret_attribute car_key], Inherited::Car.filter_attributes
+  end
+
+  def test_super_after_filter_attributes
+    assert_equal %i[secret_attribute computer_key], Inherited::Computer.filter_attributes
+  end
+end


### PR DESCRIPTION
This PR fixes issue #50003 where using `super` after adding relations to the subclass or defining filter attributes in the subclass in the method `self.inherited` lead to warnings and removed previously defined filter_attributes.

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #50003.

### Detail

I only added the `||=` to `@filter_attributes` and `@generated_association_methods`, the other 3 variables in this code should not be affected. That way, only two additional `OR` operations are introduced.

### Additional information

I added some tests as well, if the tests are run in an environment with [strict warnings enabled](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#warnings) it also verifies that the constant mentioned in #50003 is not redefined.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
