### PR TITLE
Move PG-specific tests to `PostgresqlRenameTableTest`

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -12,6 +12,15 @@ class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_table "after_rename", if_exists: true
   end
 
+  test "renaming a table also renames the primary key sequence" do
+    @connection.create_table :before_rename, force: true
+
+    @connection.rename_table :before_rename, :after_rename
+
+    pk, seq = @connection.pk_and_sequence_for("after_rename")
+    assert_equal "after_rename_#{pk}_seq", seq.identifier
+  end
+
   test "renaming a table also renames the primary key index" do
     @connection.create_table :before_rename, force: true
 

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -86,48 +86,6 @@ module ActiveRecord
 
         assert_equal ["special_url_idx"], connection.indexes(:octopi).map(&:name)
       end
-
-      if current_adapter?(:PostgreSQLAdapter)
-        def test_rename_table_for_postgresql_should_also_rename_default_sequence
-          rename_table :test_models, :octopi
-
-          pk, seq = connection.pk_and_sequence_for("octopi")
-
-          assert_equal ConnectionAdapters::PostgreSQL::Name.new("public", "octopi_#{pk}_seq"), seq
-        end
-
-        def test_renaming_table_renames_primary_key
-          connection.create_table :cats, id: :uuid, default: "uuid_generate_v4()"
-          rename_table :cats, :felines
-
-          assert connection.table_exists? :felines
-          assert_not connection.table_exists? :cats
-
-          primary_key_name = connection.select_values(<<~SQL, "SCHEMA")[0]
-            SELECT c.relname
-              FROM pg_class c
-              JOIN pg_index i
-                ON c.oid = i.indexrelid
-             WHERE i.indisprimary
-               AND i.indrelid = 'felines'::regclass
-          SQL
-
-          assert_equal "felines_pkey", primary_key_name
-        ensure
-          connection.drop_table :cats, if_exists: true
-          connection.drop_table :felines, if_exists: true
-        end
-
-        def test_renaming_table_doesnt_attempt_to_rename_non_existent_sequences
-          connection.create_table :cats, id: :uuid, default: "uuid_generate_v4()"
-          assert_nothing_raised { rename_table :cats, :felines }
-          assert connection.table_exists? :felines
-          assert_not connection.table_exists? :cats
-        ensure
-          connection.drop_table :cats, if_exists: true
-          connection.drop_table :felines, if_exists: true
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This moves PostgreSQL-specific `rename_table` tests from `activerecord/test/cases/migration/rename_table_test.rb` to `activerecord/test/cases/adapters/postgresql/rename_table_test.rb`. Note that `test_renaming_table_renames_primary_key` was added after `test_renaming_table_doesnt_attempt_to_rename_non_existent_sequences` and made the latter redundant, and that both are already covered by the "renaming a table with uuid primary key and uuid_generate_v4() default also renames the primary key index" test.
