### PR TITLE
Fix order of scope- vs user-derived attribute assignments

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -477,6 +477,26 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal invoice.id, line_item.invoice_id
   end
 
+  def test_association_foreign_key_from_scope_is_accessible_in_attributes_from_user
+    invoice = Invoice.create
+
+    assert_nothing_raised do
+      line_items = invoice.line_items.where(amount: 42)
+
+      line_item = line_items.create(invoice_id: invoice.id + 1, amount: 1, raise_unless_invoice_present: true)
+      assert_equal invoice.id, line_item.invoice_id
+      assert_equal 1, line_item.amount
+
+      line_item = line_items.build(invoice_id: invoice.id + 1, amount: 2, raise_unless_invoice_present: true)
+      assert_equal invoice.id, line_item.invoice_id
+      assert_equal 2, line_item.amount
+
+      line_item = line_items.new(invoice_id: invoice.id + 1, amount: 3, raise_unless_invoice_present: true)
+      assert_equal invoice.id, line_item.invoice_id
+      assert_equal 3, line_item.amount
+    end
+  end
+
   class SpecialAuthor < ActiveRecord::Base
     self.table_name = "authors"
     has_many :books, class_name: "SpecialBook", foreign_key: :author_id

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1423,7 +1423,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     author = organization.author
     post_direct = author.posts.build
     post_through = organization.posts.build
-    assert_equal post_direct.author_id, post_through.author_id
+    assert_equal author.id, post_through.author_id
+    assert_equal author.id, post_direct.author_id
   end
 
   def test_has_many_through_with_scope_that_should_not_be_fully_merged

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -631,6 +631,18 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal pirate.id, ship.pirate_id
   end
 
+  def test_association_foreign_key_from_scope_is_accessible_in_attributes_from_user
+    pirate = Pirate.create!(catchphrase: "You best start believing in ghost stories... you're in one!")
+
+    assert_nothing_raised do
+      ship = pirate.create_ship(pirate_id: pirate.id + 1, raise_unless_pirate_present: true)
+      assert_equal pirate.id, ship.pirate_id
+
+      ship = pirate.build_ship(pirate_id: pirate.id + 1, raise_unless_pirate_present: true)
+      assert_equal pirate.id, ship.pirate_id
+    end
+  end
+
   def test_build_with_block
     car = Car.create(name: "honda")
 

--- a/activerecord/test/models/line_item.rb
+++ b/activerecord/test/models/line_item.rb
@@ -3,6 +3,12 @@
 class LineItem < ActiveRecord::Base
   belongs_to :invoice, touch: true
   has_many :discount_applications, class_name: "LineItemDiscountApplication"
+
+  def raise_unless_invoice_present=(should_assert)
+    return unless should_assert
+
+    raise Exception, "Invoice is not present" unless invoice.present?
+  end
 end
 
 class LineItemDiscountApplication < ActiveRecord::Base

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -20,6 +20,12 @@ class Ship < ActiveRecord::Base
   def cancel_save_callback_method
     throw(:abort)
   end
+
+  def raise_unless_pirate_present=(should_assert)
+    return unless should_assert
+
+    raise Exception, "Pirate is not present" unless pirate.present?
+  end
 end
 
 class ShipWithoutNestedAttributes < ActiveRecord::Base


### PR DESCRIPTION
### Motivation / Background

Fixes #26295. It was closed due to the issue becoming stale, not because it was fixed. It never had a satisfactory fix.

### Detail

This Pull Request modifies the order of attribute assignments for associations, e.g. `collection.build` and `build_foo`. Previously, if you were to build a record from an association, the attributes derived from the scope would be applied last. This is problematic when a setter on the model expects those scope values to be present, since they were technically defined first. This has bitten me a few times in a multi-tenant application, requiring a workaround where you supply the scope attributes again in `#build`.

I've tried to make this backwards compatible, by first applying the attributes from the scope via `#scope_for_create`, then applying the provided attributes to `#build` minus foreign keys from `#scope_for_create`, and then finally initializing the record normally.

Here's a small reproduction script of the problem: https://gist.github.com/ezekg/5722f5af2b79061a4f945d49f3ce734b (modified from @heaven's original reproduction script: https://github.com/rails/rails/issues/26295#issuecomment-246189123)

I've written tests that fail without the changes to the `#build_record` method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
