### PR TITLE
Make schema dumper to account for `ActiveRecord.dump_schemas` when dumping in `:ruby` format

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make schema dumper to account for `ActiveRecord.dump_schemas` when dumping in `:ruby` format.
+
+    *fatkodima*
+
 *   Add `:touch` option to `update_column`/`update_columns` methods.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -5,6 +5,23 @@ module ActiveRecord
     module PostgreSQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+          attr_accessor :schema_name
+
+          def initialize(connection, options = {})
+            super
+
+            @dump_schemas =
+              case ActiveRecord.dump_schemas
+              when :schema_search_path
+                connection.current_schemas
+              when String
+                schema_names = ActiveRecord.dump_schemas.split(",").map(&:strip)
+                schema_names & connection.schema_names
+              else
+                connection.schema_names
+              end
+          end
+
           def extensions(stream)
             extensions = @connection.extensions
             if extensions.any?
@@ -17,25 +34,35 @@ module ActiveRecord
           end
 
           def types(stream)
-            types = @connection.enum_types
-            if types.any?
-              stream.puts "  # Custom types defined in this database."
-              stream.puts "  # Note that some types may not work with other database engines. Be careful if changing database."
-              types.sort.each do |name, values|
-                stream.puts "  create_enum #{name.inspect}, #{values.inspect}"
+            within_each_schema do
+              types = @connection.enum_types
+              if types.any?
+                stream.puts "  # Custom types defined in this database."
+                stream.puts "  # Note that some types may not work with other database engines. Be careful if changing database."
+                types.sort.each do |name, values|
+                  stream.puts "  create_enum #{relation_name(name).inspect}, #{values.inspect}"
+                end
               end
-              stream.puts
             end
           end
 
           def schemas(stream)
-            schema_names = @connection.schema_names - ["public"]
+            schema_names = @dump_schemas - ["public"]
 
             if schema_names.any?
               schema_names.sort.each do |name|
                 stream.puts "  create_schema #{name.inspect}"
               end
               stream.puts
+            end
+          end
+
+          def tables(stream)
+            previous_schema_had_tables = false
+            within_each_schema do
+              stream.puts if previous_schema_had_tables
+              super
+              previous_schema_had_tables = @connection.tables.any?
             end
           end
 
@@ -109,6 +136,26 @@ module ActiveRecord
 
           def extract_expression_for_virtual_column(column)
             column.default_function.inspect
+          end
+
+          def within_each_schema
+            @dump_schemas.each do |schema_name|
+              old_search_path = @connection.schema_search_path
+              @connection.schema_search_path = schema_name
+              self.schema_name = schema_name
+              yield
+            ensure
+              self.schema_name = nil
+              @connection.schema_search_path = old_search_path
+            end
+          end
+
+          def relation_name(name)
+            if @dump_schemas.size == 1
+              name
+            else
+              "#{schema_name}.#{name}"
+            end
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -235,6 +235,14 @@ module ActiveRecord
           query_value("SELECT current_schema", "SCHEMA")
         end
 
+        # Returns an array of the names of all schemas presently in the effective search path,
+        # in their priority order.
+        def current_schemas # :nodoc:
+          schemas = query_value("SELECT current_schemas(false)", "SCHEMA")
+          decoder = PG::TextDecoder::Array.new
+          decoder.decode(schemas)
+        end
+
         # Returns the current database encoding format.
         def encoding
           query_value("SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()", "SCHEMA")

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -165,7 +165,7 @@ module ActiveRecord
           # first dump primary key column
           pk = @connection.primary_key(table)
 
-          tbl.print "  create_table #{remove_prefix_and_suffix(table).inspect}"
+          tbl.print "  create_table #{relation_name(remove_prefix_and_suffix(table)).inspect}"
 
           case pk
           when String
@@ -233,7 +233,7 @@ module ActiveRecord
         if (indexes = @connection.indexes(table)).any?
           add_index_statements = indexes.map do |index|
             table_name = remove_prefix_and_suffix(index.table).inspect
-            "  add_index #{([table_name] + index_parts(index)).join(', ')}"
+            "  add_index #{([relation_name(table_name)] + index_parts(index)).join(', ')}"
           end
 
           stream.puts add_index_statements.sort.join("\n")
@@ -318,8 +318,8 @@ module ActiveRecord
         if (foreign_keys = @connection.foreign_keys(table)).any?
           add_foreign_key_statements = foreign_keys.map do |foreign_key|
             parts = [
-              remove_prefix_and_suffix(foreign_key.from_table).inspect,
-              remove_prefix_and_suffix(foreign_key.to_table).inspect,
+              relation_name(remove_prefix_and_suffix(foreign_key.from_table)).inspect,
+              relation_name(remove_prefix_and_suffix(foreign_key.to_table)).inspect,
             ]
 
             if foreign_key.column != @connection.foreign_key_column_for(foreign_key.to_table, "id")
@@ -359,6 +359,10 @@ module ActiveRecord
         else
           options.inspect
         end
+      end
+
+      def relation_name(name)
+        name
       end
 
       def remove_prefix_and_suffix(table)

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -249,7 +249,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       output = dump_table_schema("postgresql_enums_in_test_schema")
 
       assert_includes output, 'create_enum "public.mood", ["sad", "ok", "happy"]'
-      assert_includes output, 'create_enum "mood_in_test_schema", ["sad", "ok", "happy"]'
+      assert_includes output, 'create_enum "test_schema.mood_in_test_schema", ["sad", "ok", "happy"]'
       assert_includes output, 't.enum "current_mood", enum_type: "mood_in_test_schema"'
       assert_not_includes output, 'create_enum "other_schema.mood_in_other_schema"'
     end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/default"
 require "support/schema_dumping_helper"
+require "active_support/core_ext/object/with"
 
 module PGSchemaHelper
   def with_schema_search_path(schema_search_path)
@@ -12,6 +13,10 @@ module PGSchemaHelper
   ensure
     @connection.schema_search_path = "'$user', public"
     @connection.schema_cache.clear!
+  end
+
+  def with_dump_schemas(value, &block)
+    ActiveRecord.with(dump_schemas: value, &block)
   end
 end
 
@@ -555,11 +560,13 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_dumping_schemas
-    output = dump_all_table_schema(/./)
+    with_dump_schemas("test_schema,test_schema2,public") do
+      output = dump_all_table_schema(/./)
 
-    assert_no_match %r{create_schema "public"}, output
-    assert_match %r{create_schema "test_schema"}, output
-    assert_match %r{create_schema "test_schema2"}, output
+      assert_no_match %r{create_schema "public"}, output
+      assert_match %r{create_schema "test_schema"}, output
+      assert_match %r{create_schema "test_schema2"}, output
+    end
   end
 
   private
@@ -983,5 +990,77 @@ class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
     output = dump_table_schema "trains"
 
     assert_no_match("options:", output)
+  end
+end
+
+class DumpSchemasTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+  include PGSchemaHelper
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @connection.create_schema("test_schema")
+    @connection.create_schema("test_schema2")
+    @connection.create_enum("test_schema.test_enum_in_test_schema", ["foo", "bar"])
+    @connection.create_enum("test_enum_in_public", ["foo", "bar"])
+    @connection.create_table("test_schema.test_table")
+    @connection.create_table("test_schema.test_table2") do |t|
+      t.integer "test_table_id"
+      t.foreign_key "test_schema.test_table"
+    end
+  end
+
+  def teardown
+    @connection.drop_schema("test_schema")
+    @connection.drop_schema("test_schema2")
+    @connection.drop_enum("test_enum_in_public")
+  end
+
+  def test_schema_dump_with_dump_schemas_all
+    with_dump_schemas(:all) do
+      output = dump_all_table_schema
+
+      assert_includes output, 'create_schema "test_schema"'
+      assert_not_includes output, 'create_schema "public"'
+      assert_includes output, 'create_enum "test_schema.test_enum_in_test_schema"'
+      assert_includes output, 'create_enum "public.test_enum_in_public"'
+      assert_includes output, 'create_table "test_schema.test_table"'
+      assert_includes output, 'create_table "public.authors"'
+      assert_includes output, 'add_foreign_key "test_schema.test_table2", "test_schema.test_table"'
+      assert_includes output, 'add_foreign_key "public.authors", "public.author_addresses"'
+    end
+  end
+
+  def test_schema_dump_with_dump_schemas_string
+    with_dump_schemas("test_schema") do
+      output = dump_all_table_schema
+
+      assert_includes output, 'create_schema "test_schema"'
+      assert_not_includes output, 'create_schema "public"'
+      assert_includes output, 'create_enum "test_enum_in_test_schema"'
+      assert_not_includes output, "test_enum_in_public"
+      assert_includes output, 'create_table "test_table"'
+      assert_not_includes output, 'create table "authors"'
+      assert_includes output, 'add_foreign_key "test_table2", "test_table"'
+      assert_not_includes output, 'add_foreign_key "authors", "author_addresses"'
+    end
+  end
+
+  def test_schema_dump_with_dump_schemas_schema_search_path
+    with_dump_schemas(:schema_search_path) do
+      with_schema_search_path("'$user',test_schema2,test_schema") do
+        output = dump_all_table_schema
+
+        assert_includes output, 'create_schema "test_schema"'
+        assert_includes output, 'create_schema "test_schema2"'
+        assert_not_includes output, 'create_schema "public"'
+        assert_includes output, 'create_enum "test_schema.test_enum_in_test_schema"'
+        assert_not_includes output, 'create_enum "public.test_enum_in_public"'
+        assert_includes output, 'create_table "test_schema.test_table"'
+        assert_not_includes output, 'create_table "public.authors"'
+        assert_includes output, 'add_foreign_key "test_schema.test_table2", "test_schema.test_table"'
+        assert_not_includes output, 'add_foreign_key "public.authors", "public.author_addresses"'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #49926.

Currently, `ActiveRecord.dump_schemas` (introduced in #19347) is only considered when dumping schema in a `:sql` format. This PR fixes that by considering it also when dumping in a `:ruby` format.