### PR TITLE
Remove uglifier from guide [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -616,7 +616,7 @@ Defines the CSS compressor to use. It is set by default by `sass-rails`. The uni
 
 #### `config.assets.js_compressor`
 
-Defines the JavaScript compressor to use. Possible values are `:terser`, `:closure`, `:uglifier`, and `:yui`, which require the use of the `terser`, `closure-compiler`, `uglifier`, or `yui-compressor` gems respectively.
+Defines the JavaScript compressor to use. Possible values are `:terser`, `:closure`, and `:yui`, which require the use of the `terser`, `closure-compiler`, or `yui-compressor` gems respectively.
 
 #### `config.assets.gzip`
 


### PR DESCRIPTION
`uglifier` is an outdated and not used in modernjs application instead of that it recommends to use `terser`.
ref: https://github.com/rails/rails/pull/43623

### Detail

This Pull Request removes `uglifier` from the guide.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
