### PR TITLE
[ActiveStorage] Fix TransformJob to preprocess preview image variant

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `preprocessed: true` option to generate preview images for previewable
+    files as well as the variant associated with the preview image.
+
+    *Chedli Bourguiba*
+
 *   Fix `preprocessed: true` option for named variants of previewable files.
 
     *Nico Wenterodt*

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -7,6 +7,6 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)
-    blob.representation(transformations).processed.key
+    blob.representation(transformations).processed
   end
 end

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -7,6 +7,6 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)
-    blob.representation(transformations).processed
+    blob.representation(transformations).processed.key
   end
 end

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -92,7 +92,7 @@ class ActiveStorage::Preview
 
   private
     def processed?
-      image.attached?
+      image.attached? && variant.processed?
     end
 
     def process
@@ -101,12 +101,12 @@ class ActiveStorage::Preview
           image.attach(attachable)
         end
       end
+      variant
     end
 
     def variant
       image.variant(variation).processed
     end
-
 
     def previewer
       previewer_class.new(blob)

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -101,11 +101,11 @@ class ActiveStorage::Variant
     service.delete(key)
   end
 
-  private
-    def processed?
-      service.exist?(key)
-    end
+  def processed? # :nodoc:
+    service.exist?(key)
+  end
 
+  private
     def process
       blob.open do |input|
         variation.transform(input) do |output|

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -33,11 +33,11 @@ class ActiveStorage::VariantWithRecord
 
   delegate :key, :url, :download, to: :image, allow_nil: true
 
-  private
-    def processed?
-      record.present?
-    end
+  def processed? # :nodoc:
+    record.present?
+  end
 
+  private
     def process
       transform_blob { |image| create_or_find_record(image: image) }
     end

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -16,11 +16,22 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
     end
   end
 
-  test "creates variant for previewable file" do
+  test "creates preview_image for previewable file" do
     @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
     transformations = { resize_to_limit: [100, 100] }
 
     assert_changes -> { @blob.reload.preview(transformations).send(:processed?) }, from: false, to: true do
+      perform_enqueued_jobs do
+        ActiveStorage::TransformJob.perform_later @blob, transformations
+      end
+    end
+  end
+
+  test "creates a variant associated with a preview_image for a previewable file" do
+    @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    transformations = { resize_to_limit: [100, 100] }
+
+    assert_changes -> { @blob.reload.preview_image.variant(transformations)&.send(:processed?) }, from: nil, to: true do
       perform_enqueued_jobs do
         ActiveStorage::TransformJob.perform_later @blob, transformations
       end


### PR DESCRIPTION
Followup #50006 cc @jonathanhefner @nicowenterodt 


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `TransformJob` for previewable files only preprocess the preview image, but not the associated preview_image variant.


### Detail

This Pull Request changes `ActiveStorage::TransformJob` to also trigger the preprocessing of the variant. It is also compatible with both previewable and variable records, as they both implement the `#key` method

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
Every `ActiveStorage::Blob` has a `has_one_attached :preview_image` which is technically another AS blob.

Right now `ActiveStorage::Preview#processed` only generates the `preview_image` blob, but not the variant that's associated with it (with transformations available in the `@variation` instance variable)

One way to solve this is to force the `ActiveStorage::TransformJob` to preprocess the variant as well by calling `ActiveStorage::Preview#key` ( or `ActiveStorage::Variant#key` but it just calculates a key here)  this would return the key value that's inside the variant, which can be safely discarded in the context of `ActiveStorage::TransformJob`

The `ActiveStorage::Preview#processed` method can be subject to a refactor to handle multiple transformations depending on the `@variation` instance variable ( which might require refactoring the `#processed?` method )

the `ActiveStorage::Preview#key`, as well as `ActiveStorage::Preview#url`, also can be refactored, because right now they perform two things: 
1. Generate a variant ( System and network calls )
2. return the key or url

Compared to the `ActiveStorage::Variant#key` that simply calculates a key

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
