### PR TITLE
Add ability to detect a half-open connection

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Detect half-open Action Cable connections via a ping/pong heartbeat.
+
+    A new protocol revision, `actioncable-v1.1-json`, has the client respond
+    to server heartbeat pings with a pong. If no pong (or any other message)
+    arrives within two heartbeats, the server force-closes the connection
+    instead of letting it linger for up to half an hour.
+
+    Round-trip latency is emitted as the `connection_latency.action_cable`
+    Active Support notification.
+
+    *Stanko Krtalić Rusendić*
+
 *   Fix Action Cable origin check to respect `X-Forwarded-Host` behind reverse proxies.
 
     The `allow_same_origin_as_host` check previously compared against the raw

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -114,6 +114,7 @@
       welcome: "welcome",
       disconnect: "disconnect",
       ping: "ping",
+      pong: "pong",
       confirmation: "confirm_subscription",
       rejection: "reject_subscription"
     },
@@ -121,10 +122,11 @@
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
       server_restart: "server_restart",
-      remote: "remote"
+      remote: "remote",
+      heartbeat_timeout: "heartbeat_timeout"
     },
     default_mount_path: "/cable",
-    protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
+    protocols: [ "actioncable-v1.1-json", "actioncable-v1-json", "actioncable-unsupported" ]
   };
   const {message_types: message_types, protocols: protocols} = INTERNAL;
   const supportedProtocols = protocols.slice(0, protocols.length - 1);
@@ -227,6 +229,11 @@
         this.webSocket[`on${eventName}`] = function() {};
       }
     }
+    expectsPongResponse() {
+      const protocol = this.getProtocol();
+      if (!protocol) return;
+      return protocol.startsWith("actioncable-v1.1-");
+    }
   }
   Connection.reopenDelay = 500;
   Connection.prototype.events = {
@@ -251,6 +258,12 @@
         });
 
        case message_types.ping:
+        if (this.expectsPongResponse()) {
+          this.send({
+            type: message_types.pong,
+            message: message
+          });
+        }
         return null;
 
        case message_types.confirmation:

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -116,6 +116,7 @@ var INTERNAL = {
     welcome: "welcome",
     disconnect: "disconnect",
     ping: "ping",
+    pong: "pong",
     confirmation: "confirm_subscription",
     rejection: "reject_subscription"
   },
@@ -123,10 +124,11 @@ var INTERNAL = {
     unauthorized: "unauthorized",
     invalid_request: "invalid_request",
     server_restart: "server_restart",
-    remote: "remote"
+    remote: "remote",
+    heartbeat_timeout: "heartbeat_timeout"
   },
   default_mount_path: "/cable",
-  protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
+  protocols: [ "actioncable-v1.1-json", "actioncable-v1-json", "actioncable-unsupported" ]
 };
 
 const {message_types: message_types, protocols: protocols} = INTERNAL;
@@ -233,6 +235,11 @@ class Connection {
       this.webSocket[`on${eventName}`] = function() {};
     }
   }
+  expectsPongResponse() {
+    const protocol = this.getProtocol();
+    if (!protocol) return;
+    return protocol.startsWith("actioncable-v1.1-");
+  }
 }
 
 Connection.reopenDelay = 500;
@@ -259,6 +266,12 @@ Connection.prototype.events = {
       });
 
      case message_types.ping:
+      if (this.expectsPongResponse()) {
+        this.send({
+          type: message_types.pong,
+          message: message
+        });
+      }
       return null;
 
      case message_types.confirmation:

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -114,6 +114,7 @@
       welcome: "welcome",
       disconnect: "disconnect",
       ping: "ping",
+      pong: "pong",
       confirmation: "confirm_subscription",
       rejection: "reject_subscription"
     },
@@ -121,10 +122,11 @@
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
       server_restart: "server_restart",
-      remote: "remote"
+      remote: "remote",
+      heartbeat_timeout: "heartbeat_timeout"
     },
     default_mount_path: "/cable",
-    protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]
+    protocols: [ "actioncable-v1.1-json", "actioncable-v1-json", "actioncable-unsupported" ]
   };
   const {message_types: message_types, protocols: protocols} = INTERNAL;
   const supportedProtocols = protocols.slice(0, protocols.length - 1);
@@ -227,6 +229,11 @@
         this.webSocket[`on${eventName}`] = function() {};
       }
     }
+    expectsPongResponse() {
+      const protocol = this.getProtocol();
+      if (!protocol) return;
+      return protocol.startsWith("actioncable-v1.1-");
+    }
   }
   Connection.reopenDelay = 500;
   Connection.prototype.events = {
@@ -251,6 +258,12 @@
         });
 
        case message_types.ping:
+        if (this.expectsPongResponse()) {
+          this.send({
+            type: message_types.pong,
+            message: message
+          });
+        }
         return null;
 
        case message_types.confirmation:

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -120,6 +120,13 @@ class Connection {
     }
   }
 
+  expectsPongResponse() {
+    const protocol = this.getProtocol()
+
+    if (!protocol) return
+
+    return protocol.startsWith("actioncable-v1.1-")
+  }
 }
 
 Connection.reopenDelay = 500
@@ -140,6 +147,10 @@ Connection.prototype.events = {
         logger.log(`Disconnecting. Reason: ${reason}`)
         return this.close({allowReconnect: reconnect})
       case message_types.ping:
+        if (this.expectsPongResponse()) {
+          this.send({type: message_types.pong, message: message})
+        }
+
         return null
       case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier)

--- a/actioncable/app/javascript/action_cable/internal.js
+++ b/actioncable/app/javascript/action_cable/internal.js
@@ -3,6 +3,7 @@ export default {
     "welcome": "welcome",
     "disconnect": "disconnect",
     "ping": "ping",
+    "pong": "pong",
     "confirmation": "confirm_subscription",
     "rejection": "reject_subscription"
   },
@@ -10,10 +11,12 @@ export default {
     "unauthorized": "unauthorized",
     "invalid_request": "invalid_request",
     "server_restart": "server_restart",
-    "remote": "remote"
+    "remote": "remote",
+    "heartbeat_timeout": "heartbeat_timeout"
   },
   "default_mount_path": "/cable",
   "protocols": [
+    "actioncable-v1.1-json",
     "actioncable-v1-json",
     "actioncable-unsupported"
   ]

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -60,6 +60,7 @@ module ActionCable
       welcome: "welcome",
       disconnect: "disconnect",
       ping: "ping",
+      pong: "pong",
       confirmation: "confirm_subscription",
       rejection: "reject_subscription"
     },
@@ -67,10 +68,11 @@ module ActionCable
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
       server_restart: "server_restart",
-      remote: "remote"
+      remote: "remote",
+      heartbeat_timeout: "heartbeat_timeout"
     },
     default_mount_path: "/cable",
-    protocols: ["actioncable-v1-json", "actioncable-unsupported"].freeze
+    protocols: ["actioncable-v1.1-json", "actioncable-v1-json", "actioncable-unsupported"].freeze
   }
 
   # Singleton instance of the server

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -62,6 +62,8 @@ module ActionCable
       include Callbacks
       include ActiveSupport::Rescuable
 
+      HALF_OPEN_CONNECTION_TIMEOUT = ActionCable::Server::Connections::BEAT_INTERVAL.seconds * 2
+
       attr_reader :server, :env, :subscriptions, :logger, :worker_pool, :protocol
       delegate :event_loop, :pubsub, :config, to: :server
 
@@ -76,7 +78,7 @@ module ActionCable
         @message_buffer = ActionCable::Connection::MessageBuffer.new(self)
 
         @_internal_subscriptions = nil
-        @started_at = Time.now
+        @started_at = @last_message_received_at = Time.now
       end
 
       # Called by the server when a new WebSocket connection is established. This
@@ -96,12 +98,17 @@ module ActionCable
       # Decodes WebSocket messages and dispatches them to subscribed channels.
       # WebSocket message transfer encoding is always JSON.
       def receive(websocket_message) # :nodoc:
+        @last_message_received_at = Time.now
         send_async :dispatch_websocket_message, websocket_message
       end
 
       def dispatch_websocket_message(websocket_message) # :nodoc:
         if websocket.alive?
-          handle_channel_command decode(websocket_message)
+          payload = decode(websocket_message)
+
+          return handle_pong(payload) if payload["type"] == ActionCable::INTERNAL[:message_types][:pong]
+
+          handle_channel_command(payload)
         else
           logger.error "Ignoring message processed after the WebSocket was closed: #{websocket_message.inspect})"
         end
@@ -117,14 +124,18 @@ module ActionCable
         websocket.transmit encode(cable_message)
       end
 
-      # Close the WebSocket connection.
-      def close(reason: nil, reconnect: true)
-        transmit(
-          type: ActionCable::INTERNAL[:message_types][:disconnect],
-          reason: reason,
-          reconnect: reconnect
-        )
-        websocket.close
+      # Close the WebSocket connection. When `force: true`, the disconnect
+      # message is skipped and the socket is shut down without a graceful
+      # close handshake. Use only when the client is presumed unreachable.
+      def close(reason: nil, reconnect: true, force: false)
+        unless force
+          transmit(
+            type: ActionCable::INTERNAL[:message_types][:disconnect],
+            reason: reason,
+            reconnect: reconnect
+          )
+        end
+        websocket.close(force: force)
       end
 
       # Invoke a method on the connection asynchronously through the pool of thread
@@ -134,19 +145,28 @@ module ActionCable
       end
 
       # Return a basic hash of statistics for the connection keyed with `identifier`,
-      # `started_at`, `subscriptions`, and `request_id`. This can be returned by a
-      # health check against the connection.
+      # `started_at`, `subscriptions`, `request_id`, and `last_message_received_at`.
+      # This can be returned by a health check against the connection.
       def statistics
         {
           identifier: connection_identifier,
           started_at: @started_at,
           subscriptions: subscriptions.identifiers,
-          request_id: @env["action_dispatch.request_id"]
+          request_id: @env["action_dispatch.request_id"],
+          last_message_received_at: @last_message_received_at
         }
       end
 
       def beat
-        transmit type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i
+        unless expects_pong?
+          return transmit(type: ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_i)
+        end
+
+        if connection_idle?
+          return close(reason: ::ActionCable::INTERNAL[:disconnect_reasons][:heartbeat_timeout], force: true)
+        end
+
+        transmit type: ::ActionCable::INTERNAL[:message_types][:ping], message: Time.now.to_f
       end
 
       def on_open # :nodoc:
@@ -201,6 +221,7 @@ module ActionCable
 
         def handle_open
           @protocol = websocket.protocol
+          @expects_pong = @protocol&.start_with?("actioncable-v1.1-")
           connect if respond_to?(:connect)
           subscribe_to_internal_channel
           send_welcome_message
@@ -289,6 +310,28 @@ module ActionCable
           "Successfully upgraded to WebSocket (REQUEST_METHOD: %s, HTTP_CONNECTION: %s, HTTP_UPGRADE: %s)" % [
             env["REQUEST_METHOD"], env["HTTP_CONNECTION"], env["HTTP_UPGRADE"]
           ]
+        end
+
+        def expects_pong?
+          @expects_pong
+        end
+
+        def connection_idle?
+          expects_pong? && @last_message_received_at.before?(HALF_OPEN_CONNECTION_TIMEOUT.ago)
+        end
+
+        def handle_pong(payload)
+          message = payload["message"]
+          latency = Time.now.to_f - message.to_f if message.is_a?(Numeric)
+
+          if latency&.positive? && latency < HALF_OPEN_CONNECTION_TIMEOUT
+            ActiveSupport::Notifications.instrument(
+              "connection_latency.action_cable",
+              value: latency,
+              connection_identifier: connection_identifier,
+              identifiers: identifiers.index_with { |id| instance_variable_get("@#{id}") }
+            )
+          end
         end
     end
   end

--- a/actioncable/lib/action_cable/connection/client_socket.rb
+++ b/actioncable/lib/action_cable/connection/client_socket.rb
@@ -89,7 +89,7 @@ module ActionCable
         end
       end
 
-      def close(code = nil, reason = nil)
+      def close(code = nil, reason = nil, force: false)
         code   ||= 1000
         reason ||= ""
 
@@ -101,6 +101,7 @@ module ActionCable
 
         @ready_state = CLOSING unless @ready_state == CLOSED
         @driver.close(reason, code)
+        begin_close(reason, code) if force
       end
 
       def parse(data)

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -99,6 +99,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
       assert_predicate statistics[:identifier], :blank?
       assert_kind_of Time, statistics[:started_at]
       assert_equal [], statistics[:subscriptions]
+      assert_kind_of Time, statistics[:last_message_received_at]
     end
   end
 
@@ -139,6 +140,100 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
       assert_match(/\A#<ActionCable::Connection::BaseTest::Connection:0x[0-9a-f]+>\z/, connection.inspect)
     end
   end
+
+  test "v1.1 connection is force-closed when no message received within the heartbeat timeout" do
+    run_in_eventmachine do
+      connection = open_connection
+      connection.process
+
+      connection.instance_variable_set(:@expects_pong, true)
+      connection.instance_variable_set(:@last_message_received_at, 1.hour.ago)
+
+      captured = []
+      connection.websocket.define_singleton_method(:close) { |**kwargs| captured << kwargs }
+
+      connection.beat
+
+      assert_equal [{ force: true }], captured
+    end
+  end
+
+  test "v1 connection is not closed on heartbeat even when idle" do
+    run_in_eventmachine do
+      connection = open_connection
+      connection.process
+
+      connection.instance_variable_set(:@expects_pong, false)
+      connection.instance_variable_set(:@last_message_received_at, 1.hour.ago)
+
+      close_called = false
+      connection.websocket.define_singleton_method(:close) { |**| close_called = true }
+
+      connection.beat
+
+      assert_not close_called
+    end
+  end
+
+  test "processing of an incoming PONG message" do
+    run_in_eventmachine do
+      connection = open_connection
+      connection.process
+
+      wait_for_async
+
+      websocket_message = { type: "pong", message: 1.second.ago.to_f }.to_json
+
+      notification_data = nil
+      callback = ->(_name, _started, _finished, _unique_id, data) do
+        notification_data = data
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "connection_latency.action_cable") do
+        connection.receive(websocket_message)
+      end
+
+      assert_predicate notification_data[:value], :positive?
+      assert_in_delta 1, notification_data[:value], 0.5
+    end
+  end
+
+  test "PONG with non-numeric or implausible timestamp does not emit a latency notification" do
+    run_in_eventmachine do
+      connection = open_connection
+      connection.process
+
+      wait_for_async
+
+      notifications = []
+      callback = ->(_name, _started, _finished, _unique_id, data) { notifications << data }
+
+      ActiveSupport::Notifications.subscribed(callback, "connection_latency.action_cable") do
+        connection.receive({ type: "pong", message: "garbage" }.to_json)
+        connection.receive({ type: "pong", message: nil }.to_json)
+        connection.receive({ type: "pong", message: 0 }.to_json)
+        connection.receive({ type: "pong", message: (Time.now.to_f + 60) }.to_json)
+      end
+
+      assert_empty notifications
+    end
+  end
+
+  test "receiving a message updates the last message received at timestamp" do
+    run_in_eventmachine do
+      connection = open_connection
+      connection.process
+
+      wait_for_async
+
+      connection.instance_variable_set(:@last_message_received_at, 1.hour.ago)
+
+      connection.receive({ type: "pong", message: 123.456 }.to_json)
+
+      assert_in_delta Time.now, connection.instance_variable_get(:@last_message_received_at), 1
+    end
+  end
+
 
   private
     def open_connection

--- a/actioncable/test/javascript/src/unit/connection_test.js
+++ b/actioncable/test/javascript/src/unit/connection_test.js
@@ -25,4 +25,38 @@ module("ActionCable.Connection", () => {
       assert.equal(connection.webSocket instanceof FakeWebSocket, true)
     })
   })
+
+  module("#expectsPongResponse", () => {
+    test("returns true for actioncable-v1.1-* protocols", assert => {
+      const connection = new ActionCable.Connection({})
+      connection.webSocket = { protocol: "actioncable-v1.1-foo" }
+      assert.equal(connection.expectsPongResponse(), true)
+
+      connection.webSocket = { protocol: "actioncable-v1-json" }
+      assert.equal(connection.expectsPongResponse(), false)
+    })
+  })
+
+  module("#events", () => {
+    test("#message responds to a PING message with a PONG, if expected to do so", assert => {
+      const connection = new ActionCable.Connection({})
+
+      const sentMessages = []
+      connection.send = (payload) => sentMessages.push(payload)
+      connection.isProtocolSupported = () => true
+
+      const messageHandler = connection.events.message.bind(connection)
+
+      connection.getProtocol = () => "actioncable-v1.1-json"
+      messageHandler({ data: "{\"type\":\"ping\",\"message\":123.456}" })
+
+      assert.equal(sentMessages.length, 1)
+      assert.deepEqual(sentMessages[0], {type: "pong", message: 123.456})
+
+      connection.getProtocol = () => "actioncable-v1-json"
+      messageHandler({ data: "{\"type\":\"ping\",\"message\":123.456}" })
+
+      assert.equal(sentMessages.length, 1)
+    })
+  })
 })

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -127,6 +127,14 @@ Within the Ruby on Rails framework, there are a number of hooks provided for com
 | `:message`      | A hash of message    |
 | `:coder`        | The coder            |
 
+#### `connection_latency.action_cable`
+
+| Key                      | Value                |
+| ------------------------ | -------------------- |
+| `:value`                 | The latency in seconds as a float with sub-seconds included |
+| `:connection_identifier` | The identifier string of the connection                     |
+| `:identifiers`           | A hash of identifier objects of the connection              |
+
 ### Action Controller
 
 #### `start_processing.action_controller`


### PR DESCRIPTION
### Motivation / Background

I have IoT devices connecting to my Rails app via ActionCable, and I want to log when a device connects or disconnects.

This is already doable via `Cahnnel#subscribed` and `Channel#unsubscribed`; and it works pretty well when a device properly connects, subscribes, and disconnects.

But when a device improperly disconnects - e.g. if it gets unplugged from the network - its ActionCable connection doesn't close and can linger in the system for up to half an hour.

This means that the server is using up resources to manage this connection, and send messages to it, when there isn't a client to receive them (since a client will reconnect if it misses 2 heartbeats which is about 6 sec). Some of these issues have been commented on in #45112 and #24908

Currently, ActionCable doesn't have a mechanism to detect if its connection is half-open (if there is a client listening on the other end). 

This PR changes the protocol so that a client has to respond to a PING message with a PONG message. If it doesn't do so within 2 heartbeats (6 sec) the connection is assumed to be half-open and is closed.

Fixes #45112
Fixes #24908
Fixes #29307
Fixes #32828

### Detail

#### Why not client-initiated heartbeats?

I've considered implementing client-initiated heartbeats ([and did a proof of concept for it](https://github.com/monorkin/actioncable-presence-detection-demo/commit/82a851f0de0f8db414e3c8055fa28be4031ffd90)) as was suggested in #45112 and in #24908, but opted for PONG responses because [Chrome recently added a feature that throttles setTimeout and setInterval to run at most once a minute if a tab isn't in focus](https://developer.chrome.com/blog/timer-throttling-in-chrome-88/). 

This throttling would cause clients to reconnect loop if the half-open threshold is set to below 1 min. And heartbeats with intervals greater than 1 min aren't always desirable, like in my case where I want to know that a device went offline within seconds. Chrome's throttling also [prompted socket.io to change it's heartbeat to be server-initated](https://github.com/socketio/socket.io/issues/2769#issuecomment-639300952).

#### Backwards and forwards compatibility

To ensure that clients that *don't* know about PONG messages can still work with servers that *do*, and for clients that *do* know about PONG messages to work with servers that *don't*; I've created a minor revision of the protocol - `actioncable-v1.1-json`.

If a client sends that in a `Sec-WebSocket-Protocol` header to the server and the server responds with `actioncable-v1.1-json` both the client and server know that they should send and expect PONG messages.

If the client doesn't send `Sec-WebSocket-Protocol: actioncable-v1.1-json` or the server doesn't respond with `Sec-WebSocket-Protocol: actioncable-v1.1-json` then the behavior from `actioncable-v1-json` is used.

#### Why is this logic on the connection object instead of the stream object?

In #45112 there was a suggestion to implement this as a timeout in the event-loop / select-loop.
From my understanding implementing it that way wouldn't be that much different from the implementation in this PR.
There would be some kind of last_message_read_at timestamp that's checked in each iteration, and if a threshold is exceeded the socket would be closed.

I implemented everything on the connection object because doimainwise it makes sense to me that a connection keeps the heartbeat and responds to it. 

Though I can see the benefits of having everything in the event loop. I have no strong opinion on this.

#### What about dropped message detection from #24908?

I've opted not to tackle that in this PR as that seems like it could become a mini-framework within ActionCable.

#### What about client-side latency measurements from #24908?

I've opted not to include that in this PR. But this could probably be done by adding an `echo` type message (or repurposing `ping`) that just echos back what the client sends to the server.

#### What about client-set heartbeat frequency from #24908?

I've opted not to include that in this PR as it's an unrelated feature to this one.

#### Why not native WebSocket PING and PONG messages like #32828?

It currently isn't possible to process native PING and PONG messages in browsers, so an additional sub-protocol level heartbeat would be needed for JS clients in browsers to be able to detect that they have been disconnected. Therefore it makes more sense to have just the one sub-protocol level heartbeat for everything.

#### What about the changelog?

~The CHANGELOG file contains a link to the changes in Rails 7.1. I'm not sure what to do.~

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
