### PR TITLE
Ensure globals reset after Active Storage tests

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -105,6 +105,7 @@ class ActiveSupport::TestCase
       strict_loading_was = ActiveRecord::Base.strict_loading_by_default
       ActiveRecord::Base.strict_loading_by_default = true
       yield
+    ensure
       ActiveRecord::Base.strict_loading_by_default = strict_loading_was
     end
 
@@ -112,6 +113,7 @@ class ActiveSupport::TestCase
       variant_tracking_was = ActiveStorage.track_variants
       ActiveStorage.track_variants = false
       yield
+    ensure
       ActiveStorage.track_variants = variant_tracking_was
     end
 


### PR DESCRIPTION
This ensures `ActiveRecord::Base.strict_loading_by_default` and `ActiveStorage.track_variants` are reset to their original values even when an error (e.g. an assertion failure) is raised inside `with_strict_loading_by_default` and `without_variant_tracking` blocks.
