### PR TITLE
minor: fixes a link to an old blog post about Valgrind in the docs [ci skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -866,7 +866,7 @@ extension in the interpreter calls `malloc()` but doesn't properly call
 `free()`, this memory won't be available until the app terminates.
 
 For further information on how to install Valgrind and use with Ruby, refer to
-[Valgrind and Ruby](https://blog.evanweaver.com/2008/02/05/valgrind-and-ruby/)
+[Valgrind and Ruby](https://web.archive.org/web/20230518081626/https://blog.evanweaver.com/2008/02/05/valgrind-and-ruby/)
 by Evan Weaver.
 
 ### Find a Memory Leak


### PR DESCRIPTION
In the debugging_rails_applications.md in the docs, a link to a post about Valgrind and Ruby by Evan Weaver isn't available anymore. 

This minor change simply links to an archived version of the post.

Btw: I checked all other external links on that specific page about debugging rails apps (and many more ext. links for the current docs), and they still work.