### PR TITLE
Process preview variant when processing preview

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Process preview image variant when calling `ActiveStorage::Preview#processed`.
+    For example, `attached_pdf.preview(:thumb).processed` will now immediately
+    generate the full-sized preview image and the `:thumb` variant of it.
+    Previously, the `:thumb` variant would not be generated until a further call
+    to e.g. `processed.url`.
+
+    *Chedli Bourguiba* and *Jonathan Hefner*
+
 *   Prevent `ActiveRecord::StrictLoadingViolationError` when strict loading is
     enabled and the variant of an Active Storage preview has already been
     processed (for example, by calling `ActiveStorage::Preview#url`).

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -47,6 +47,7 @@ class ActiveStorage::Preview
   # image is stored with the blob, it is only generated once.
   def processed
     process unless processed?
+    variant.processed
     self
   end
 

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -20,11 +20,14 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
     @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
     transformations = { resize_to_limit: [100, 100] }
 
-    assert_changes -> { @blob.reload.preview(transformations).send(:processed?) }, from: false, to: true do
+    assert_changes -> { @blob.preview(transformations).send(:processed?) }, from: false, to: true do
       perform_enqueued_jobs do
         ActiveStorage::TransformJob.perform_later @blob, transformations
       end
+      @blob.reload
     end
+
+    assert @blob.preview(transformations).image.variant(transformations).send(:processed?)
   end
 
   test "creates variant when untracked" do

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -62,6 +62,16 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     assert_predicate blob.reload.preview_image, :attached?
   end
 
+  test "#processed also processes the preview's image variant" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    transformations = { resize_to_limit: [640, 280] }
+    preview = blob.preview(transformations)
+
+    assert_changes -> { !!preview.image.variant(transformations)&.send(:processed?) }, to: true do
+      preview.processed
+    end
+  end
+
   test "preview of PDF is created on the same service" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf", service_name: "local_public")
     preview = blob.preview(resize_to_limit: [640, 280]).processed


### PR DESCRIPTION
Prior to this commit, `ActiveStorage::Preview#processed` would only process the preview image, not the specified variant of the preview image.  For example, `thumb = attached_pdf.preview(:thumb).processed` would only generate the full-sized preview image, not the `:thumb` variant of it, until e.g. `thumb.url` was called.

This commit updates `ActiveStorage::Preview#processed` to generate both the full-sized preview image and the requested variant.

Closes #50026.
