### PR TITLE
[ActiveStorage] Prevent `AS::Preview#processed` to generate a variant for an empty transformation

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Prevent `ActiveStorage::Blob#preview` to generate a variant if an empty variation is passed.
+    Calls to `#url`, `#key` or `#download` will now use the original preview
+    image instead of generating a variant with the exact same dimensions.
+
+    *Chedli Bourguiba*
+
 *   Process preview image variant when calling `ActiveStorage::Preview#processed`.
     For example, `attached_pdf.preview(:thumb).processed` will now immediately
     generate the full-sized preview image and the `:thumb` variant of it.

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -47,7 +47,7 @@ class ActiveStorage::Preview
   # image is stored with the blob, it is only generated once.
   def processed
     process unless processed?
-    variant.processed
+    variant.processed if variant?
     self
   end
 
@@ -63,7 +63,7 @@ class ActiveStorage::Preview
   # a stable URL that redirects to the URL returned by this method.
   def url(**options)
     if processed?
-      variant.url(**options)
+      presentation.url(**options)
     else
       raise UnprocessedError
     end
@@ -72,7 +72,7 @@ class ActiveStorage::Preview
   # Returns a combination key of the blob and the variation that together identifies a specific variant.
   def key
     if processed?
-      variant.key
+      presentation.key
     else
       raise UnprocessedError
     end
@@ -85,7 +85,7 @@ class ActiveStorage::Preview
   # if the preview has not been processed yet.
   def download(&block)
     if processed?
-      variant.download(&block)
+      presentation.download(&block)
     else
       raise UnprocessedError
     end
@@ -105,7 +105,15 @@ class ActiveStorage::Preview
     end
 
     def variant
-      image.variant(variation).processed
+      image.variant(variation)
+    end
+
+    def variant?
+      variation.transformations.present?
+    end
+
+    def presentation
+      variant? ? variant.processed : image
     end
 
 

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -72,6 +72,27 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     end
   end
 
+  test "image-related methods raise UnprocessedError when preview is not processed" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    preview = blob.preview(resize_to_limit: [640, 280])
+
+    assert_raises(ActiveStorage::Preview::UnprocessedError) { preview.url }
+    assert_raises(ActiveStorage::Preview::UnprocessedError) { preview.key }
+    assert_raises(ActiveStorage::Preview::UnprocessedError) { preview.download }
+  end
+
+  test "previewing with empty transformations does not generate a variant" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    preview = blob.preview({})
+
+    preview.processed
+
+    freeze_time { assert_equal blob.preview_image.url, preview.url }
+    assert_equal blob.preview_image.key, preview.key
+    assert_equal blob.preview_image.download, preview.download
+    assert_empty preview.image.variant_records
+  end
+
   test "preview of PDF is created on the same service" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf", service_name: "local_public")
     preview = blob.preview(resize_to_limit: [640, 280]).processed


### PR DESCRIPTION
Followup #50044 cc @jonathanhefner 


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->


if an empty hash is passed to a preview call (`blob.preview({})`) We go through the original preview instead of regenerating a variation based on the original preview image which would result in a performance penalty.

### Detail

Calls to `#url` or `#key` would now use the original `blob.preview_image` instead of generating a variant that has an empty transformation.

==> Resulting in saving both a `MiniMagic/vips` call. + a network/IO call to the storage service

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
