### PR TITLE
Handle case in MySQL where the `ActiveRecord.db_warnings_action` is not called even when a DB query has warnings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In cases where MySQL returns `warning_count` greater than zero, but returns no warnings when
+    the `SHOW WARNINGS` query is executed, `ActiveRecord.db_warnings_action` proc will still be
+    called with a generic warning message rather than silently ignoring the warning(s).
+
+    *Kevin McPhillips*
+
 *   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -750,7 +750,11 @@ module ActiveRecord
           return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
           @affected_rows_before_warnings = @raw_connection.affected_rows
+          warning_count = @raw_connection.warning_count
           result = @raw_connection.query("SHOW WARNINGS")
+          result = [
+            ["Warning", nil, "Query had warning_count=#{warning_count} but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration."],
+          ] if result.count == 0
           result.each do |level, code, message|
             warning = SQLWarning.new(message, code, level, sql, @pool)
             next if warning_ignored?(warning)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/error_reporter/test_helper"
+
+class WarningsTest < ActiveRecord::AbstractMysqlTestCase
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @original_db_warnings_action = :ignore
+  end
+
+  test "db_warnings_action :raise on warning" do
+    with_db_warnings_action(:raise) do
+      error = assert_raises(ActiveRecord::SQLWarning) do
+        @connection.execute('SELECT 1 + "foo"')
+      end
+
+      assert_equal @connection.pool, error.connection_pool
+    end
+  end
+
+  test "db_warnings_action :ignore on warning" do
+    with_db_warnings_action(:ignore) do
+      result = @connection.execute('SELECT 1 + "foo"')
+      assert_equal [1], result.to_a.first
+    end
+  end
+
+  test "db_warnings_action :log on warning" do
+    with_db_warnings_action(:log) do
+      mysql_warning = "[ActiveRecord::SQLWarning] Truncated incorrect DOUBLE value: 'foo' (1292)"
+
+      assert_called_with(ActiveRecord::Base.logger, :warn, [mysql_warning]) do
+        @connection.execute('SELECT 1 + "foo"')
+      end
+    end
+  end
+
+  test "db_warnings_action :report on warning" do
+    with_db_warnings_action(:report) do
+      error_reporter = ActiveSupport::ErrorReporter.new
+      subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+
+      Rails.define_singleton_method(:error) { error_reporter }
+      Rails.error.subscribe(subscriber)
+
+      @connection.execute('SELECT 1 + "foo"')
+
+      warning_event, * = subscriber.events.first
+
+      assert_kind_of ActiveRecord::SQLWarning, warning_event
+      assert_equal "Truncated incorrect DOUBLE value: 'foo'", warning_event.message
+    end
+  end
+
+  test "db_warnings_action custom proc on warning" do
+    warning_message = nil
+    warning_level = nil
+    warning_action = ->(warning) do
+      warning_message = warning.message
+      warning_level = warning.level
+    end
+
+    with_db_warnings_action(warning_action) do
+      @connection.execute('SELECT 1 + "foo"')
+
+      assert_equal "Truncated incorrect DOUBLE value: 'foo'", warning_message
+      assert_equal "Warning", warning_level
+    end
+  end
+
+  test "db_warnings_action allows a list of warnings to ignore" do
+    with_db_warnings_action(:raise, [/Truncated incorrect DOUBLE value/]) do
+      result = @connection.execute('SELECT 1 + "foo"')
+
+      assert_equal [1], result.to_a.first
+    end
+  end
+
+  test "db_warnings_action allows a list of codes to ignore" do
+    with_db_warnings_action(:raise, ["1062"]) do
+      row_id = @connection.insert("INSERT INTO posts (title, body) VALUES('Title', 'Body')")
+      result = @connection.execute("INSERT IGNORE INTO posts (id, title, body) VALUES(#{row_id}, 'Title', 'Body')")
+
+      assert_equal [], result.to_a
+    end
+  end
+
+  test "db_warnings_action ignores note level warnings" do
+    with_db_warnings_action(:raise) do
+      result = @connection.execute("DROP TABLE IF EXISTS non_existent_table")
+
+      assert_equal [], result.to_a
+    end
+  end
+
+  test "db_warnings_action handles when warning_count does not match returned warnings" do
+    with_db_warnings_action(:raise) do
+      # force warnings to 1, but SHOW WARNINGS will return [].
+      @connection.raw_connection.stub(:warning_count, 1) do
+        error = assert_raises(ActiveRecord::SQLWarning) do
+          @connection.execute('SELECT "x"')
+        end
+
+        expected = "Query had warning_count=1 but ‘SHOW WARNINGS’ did not return the warnings. Check MySQL logs or database configuration."
+        assert_equal expected, error.message
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -3,8 +3,6 @@
 require "cases/helper"
 require "support/ddl_helper"
 
-require "active_support/error_reporter/test_helper"
-
 class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   include DdlHelper
 
@@ -301,88 +299,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       assert_changes(-> { @conn.raw_connection.query_options[:database_timezone] }, from: :utc, to: :local) do
         @conn.execute("SELECT 1")
       end
-    end
-  end
-
-  def test_ignores_warnings_when_behaviour_ignore
-    with_db_warnings_action(:ignore) do
-      result = @conn.execute('SELECT 1 + "foo"')
-      assert_equal [1], result.to_a.first
-    end
-  end
-
-  def test_logs_warnings_when_behaviour_log
-    with_db_warnings_action(:log) do
-      mysql_warning = "[ActiveRecord::SQLWarning] Truncated incorrect DOUBLE value: 'foo' (1292)"
-
-      assert_called_with(ActiveRecord::Base.logger, :warn, [mysql_warning]) do
-        @conn.execute('SELECT 1 + "foo"')
-      end
-    end
-  end
-
-  def test_raises_warnings_when_behaviour_raise
-    with_db_warnings_action(:raise) do
-      error = assert_raises(ActiveRecord::SQLWarning) do
-        @conn.execute('SELECT 1 + "foo"')
-      end
-
-      assert_equal @conn.pool, error.connection_pool
-    end
-  end
-
-  def test_reports_when_behaviour_report
-    with_db_warnings_action(:report) do
-      error_reporter = ActiveSupport::ErrorReporter.new
-      subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
-
-      Rails.define_singleton_method(:error) { error_reporter }
-      Rails.error.subscribe(subscriber)
-
-      @conn.execute('SELECT 1 + "foo"')
-
-      warning_event, * = subscriber.events.first
-
-      assert_kind_of ActiveRecord::SQLWarning, warning_event
-      assert_equal "Truncated incorrect DOUBLE value: 'foo'", warning_event.message
-    end
-  end
-
-  def test_warnings_behaviour_can_be_customized_with_a_proc
-    warning_code = nil
-    ActiveRecord.db_warnings_action = ->(warning) do
-      warning_code = warning.code
-    end
-
-    @conn.execute('SELECT 1 + "foo"')
-
-    assert_equal 1292, warning_code
-  ensure
-    ActiveRecord.db_warnings_action = @original_db_warnings_action
-  end
-
-  def test_allowlist_of_warnings_to_ignore
-    with_db_warnings_action(:raise, [/Truncated incorrect DOUBLE value/]) do
-      result = @conn.execute('SELECT 1 + "foo"')
-
-      assert_equal [1], result.to_a.first
-    end
-  end
-
-  def test_allowlist_of_warning_codes_to_ignore
-    with_db_warnings_action(:raise, ["1062"]) do
-      row_id = @conn.insert("INSERT INTO posts (title, body) VALUES('Title', 'Body')")
-      result = @conn.execute("INSERT IGNORE INTO posts (id, title, body) VALUES(#{row_id}, 'Title', 'Body')")
-
-      assert_nil result
-    end
-  end
-
-  def test_does_not_raise_note_level_warnings
-    with_db_warnings_action(:raise) do
-      result = @conn.execute("DROP TABLE IF EXISTS non_existent_table")
-
-      assert_equal [], result.to_a
     end
   end
 

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -5,8 +5,6 @@ require "support/ddl_helper"
 require "models/book"
 require "models/post"
 
-require "active_support/error_reporter/test_helper"
-
 class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   setup do
     @conn = ActiveRecord::Base.connection


### PR DESCRIPTION
## Problem

When [`ActiveRecord.db_warnings_action`](https://github.com/rails/rails/blob/757f4896417f86b58303e416f4040a2b434abdd6/activerecord/lib/active_record.rb#L208-L213) is set to anything other than `:ignore`, I would expect that it would _always be called_ when there are warnings.

In MySQL this is not necessarily the case though. In the `AbstractMysqlAdapter` the warnings are handled in two statements:
https://github.com/rails/rails/blob/757f4896417f86b58303e416f4040a2b434abdd6/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L750-L754

Simplified, but the logic is:
```ruby
query_result = raw_connection.query(sql)
if raw_connection.warning_count != 0
  warning_result = raw_connection.query("SHOW WARNINGS")
  warning_result.each do |warning|
    ActiveRecord.db_warnings_action(warning)
  end
end
```

So the query returns `warning_count` as metadata from the result. A second `"SHOW WARNINGS"` query is executed to get the warnings, and is assumed to always be correct. I know of two instances where this will return `[]` despite `warning_count` being greater than 0:

* If MySQL `max_error_count` is set to 0, warnings are counted but never persisted, so `SHOW WARNINGS` is always empty. [(source)](https://dev.mysql.com/doc/refman/8.0/en/show-warnings.html)
* If you are using ProxySQL it does not appear to propagate warnings at all. (see https://github.com/sysown/proxysql/issues/1751)

There may be others.

So the behaviour to the user is that even when `db_warnings_action` is set to something like `:raise` or a proc, **it is never executed and no warning is ever surfaced**.


## Solution

In the case where `warning_count` is non-zero, but `SHOW WARNINGS` returns `[]`, add a single warning with an error message. This isn't a super helpful message, but it is better than silently hiding that any warnings were encountered. This allows the user to update their DB config, or add a custom proc to report on or track warnings as is appropriate for their use case. 

I also found that `trilogy` did not test the warning behaviour at all, so I first added tests for warnings that are essentially copies of what is done in the `mysql2` tests.


### Questions

* How is the voice and tone of the error message? I'm not tied to it, but it's the best I could come up with.
* Should I include documentation around `db_warnings_action` with hints on how to tune the DB to prevent this state from occurring? I don't feel like it's the right place and I'm not sure if we give hints on infra in other places in the docs. Seems too specific and like it would get out of date.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @rafaelfranca @adrianna-chang-shopify 