### PR TITLE
Raise `ArgumentError` when reading from `config.x` with arguments

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Raise `ArgumentError` when reading `config.x.something` with arguments
+
+    ```ruby
+    config.x.this_works.this_raises true # raises ArgumentError
+    ```
+
+    *Sean Doyle*
+
 *   Add default PWA files for manifest and service-worker that are served from `app/views/pwa` and can be dynamically rendered through erb. Mount these files explicitly at the root with default routes in the generated routes file.
 
     *DHH*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -569,10 +569,14 @@ module Rails
         def method_missing(method, *args)
           if method.end_with?("=")
             @configurations[:"#{method[0..-2]}"] = args.first
-          else
+          elsif args.none?
             @configurations.fetch(method) {
               @configurations[method] = ActiveSupport::OrderedOptions.new
             }
+          else
+            arguments = args.map(&:inspect)
+
+            raise ArgumentError.new("unexpected arguments (%s) while reading `%s` configuration" % [arguments.join(", "), method])
           end
         end
 

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -36,6 +36,10 @@ module ApplicationTests
         assert_respond_to x, :i_do_not_exist
         assert_kind_of Method, x.method(:i_do_not_exist)
         assert_kind_of ActiveSupport::OrderedOptions, x.i_do_not_exist
+
+        assert_raises ArgumentError, match: "unexpected arguments (true, false) while reading `i_do_not_exist` configuration" do
+          x.i_do_not_exist(true, false)
+        end
       end
 
       private


### PR DESCRIPTION
### Motivation / Background

The flexibility provided by `config.x` supports arbitrarily defining new configuration objects on-the-fly. Each new intermediate configuration object is constructed during chaining from its ancestor through a method invocation made without arguments.

Conversely, writing to leaf configuration values occurs when the invoked method's name ends with `=`, and the new configuration value is assigned to whatever that method's arguments are.

There are no cases when reading from a `config.x` value or building the intermediate values 
involves arguments.

### Detail

Prior to this commit, a read invoked with a method arguments would ignore those arguments. While this is robust and error-free, it's possible to obscure misuse.

For example, consider a line like:

```ruby
config.x.my_config.enabled = true
config.x.my_config.enabled #=> true
```

Now consider that first line with a typo that omits the `=`:

```ruby
config.x.my_config.enabled true
config.x.my_config.enabled #=> nil
```

This commit aims to provide more direct feedback for scenarios like the one above. There aren't legitimate use cases for invoking `#enabled` with arguments, so raise a `ArgumentError` when encountering a read with arguments.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
