### PR TITLE
ActiveSupport::Deprecation handle blaming generated code

### DIFF
--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -951,6 +951,18 @@ class DeprecationTest < ActiveSupport::TestCase
     assert_equal __LINE__ - 2, @callstack.first.lineno
   end
 
+  class_eval(<<~RUBY, "/path/to/template.html.erb", 1)
+    def generated_method_that_call_deprecation(deprecator)
+      deprecator.warn("Here", caller_locations(0, 10))
+    end
+  RUBY
+
+  test "warn deprecation can blame code generated with eval" do
+    @deprecator.behavior = ->(message, *) { @message = message }
+    generated_method_that_call_deprecation(@deprecator)
+    assert_equal "DEPRECATION WARNING: Here (called from generated_method_that_call_deprecation at /path/to/template.html.erb:2)", @message
+  end
+
   private
     def method_that_emits_deprecation(deprecator)
       deprecator.warn


### PR DESCRIPTION
Fix: #50047

`Backtrace::Location` instance for code generated with eval always have their `absolute_path` set to `nil`. So if absolute path is nil we should fallback to checking `#path`.

Co-Authored-By: @fatkodima 

cc @jagthedrummer @gazayas. 

I'll backport this to 7.1 and 7.0.