### PR TITLE
Formally deprecate passing `caller` to `Deprecation#warn`

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -151,7 +151,12 @@ module ActiveSupport
         end
 
         def _extract_callstack(callstack)
-          warn "Please pass `caller_locations` to the deprecation API" if $VERBOSE
+          ActiveSupport.deprecator.warn(<<~MESSAGE)
+            Passing the result of `caller` to ActiveSupport::Deprecation#warn is deprecated and will be removed in Rails 7.2.
+
+            Please pass the result of `caller_locations` instead.
+          MESSAGE
+
           offending_line = callstack.find { |line| !ignored_callstack?(line) } || callstack.first
 
           if offending_line

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -39,6 +39,14 @@ class DeprecationTest < ActiveSupport::TestCase
     end
   end
 
+  test "passing callstack as `caller` is deprecated" do
+    assert_deprecated(/Passing the result of `caller` to ActiveSupport::Deprecation#warn/, ActiveSupport.deprecator) do
+      assert_deprecated(@deprecator) do
+        @deprecator.warn("Yo dawg!", caller)
+      end
+    end
+  end
+
   test "assert_deprecated is deprecated without a deprecator" do
     assert_deprecated(ActiveSupport.deprecator) do
       assert_deprecated do


### PR DESCRIPTION
This emitted a warning since 2015, but it's likely most offenders never saw it.

Ref: https://github.com/rails/rails/commit/211f55d4fdb5b962ef25037b035e69791915d4de
