### PR TITLE
Fix `rails db:create:all` to not touch databases before they are created

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `rails db:create:all` to not touch databases before they are created.
+
+    *fatkodima*
+
+
 ## Rails 7.1.2 (November 10, 2023) ##
 
 *   Fix renaming primary key index when renaming a table with a UUID primary key

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -125,11 +125,11 @@ module ActiveRecord
       end
 
       def create_all
-        db_config = migration_connection.pool.db_config
-
-        each_local_configuration { |db_config| create(db_config) }
-
-        migration_class.establish_connection(db_config)
+        each_local_configuration do |db_config|
+          with_temporary_connection(db_config) do
+            create(db_config)
+          end
+        end
       end
 
       def setup_initial_database_yaml # :nodoc:

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -469,7 +469,9 @@ module ActiveRecord
 
         # To refrain from connecting to a newly created empty DB in
         # sqlite3_mem tests
-        ActiveRecord::Base.connection_handler.stub(:establish_connection, nil, &block)
+        pool_mock = Minitest::Mock.new
+        pool_mock.expect(:connection, nil)
+        ActiveRecord::Base.connection_handler.stub(:establish_connection, pool_mock, &block)
       ensure
         ActiveRecord::Base.configurations = old_configurations
       end


### PR DESCRIPTION
Fixes #50038.