### PR TITLE
ActionView::Template fix computation of strict locals

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -501,7 +501,7 @@ module ActionView
         end
 
         unless parameters.any? { |type, _| type == :keyrest }
-          parameters.map!(&:first)
+          parameters.map!(&:last)
           parameters.sort!
           @strict_local_keys = parameters.freeze
         end

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -215,6 +215,11 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "1-2", render(message: "Hello", message_counter: 1, message_iteration: 2, implicit_locals: %i[message_counter message_iteration])
   end
 
+  def test_rails_injected_locals_can_be_specified_as_required_argument
+    @template = new_template("<%# locals: (message: 'Hello', message_iteration:) -%>\n<%= message %>-<%= message_iteration %>")
+    assert_equal "Hello-2", render(message: "Hello", message_counter: 1, message_iteration: 2, implicit_locals: %i[message_counter message_iteration])
+  end
+
   # TODO: This is currently handled inside ERB. The case of explicitly
   # lying about encodings via the normal Rails API should be handled
   # inside Rails.


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/49782

There was a bug in how we computed the list of required keys which wasn't caught by the test.
