### PR TITLE
Document `#in?` can perform queries for Active Record relations

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -12,6 +12,15 @@ class Object
   #
   # For non +Range+ arguments, this will throw an +ArgumentError+ if the argument
   # doesn't respond to +#include?+.
+  #
+  # As Active Record relations respond to +include?+, calling +in?+ will
+  # perform a query if the relation hasn't been loaded yet:
+  #
+  #   mary = Person.create(name: "Mary")
+  #   => #<Person id: 654, name: "Mary">
+  #   mary.in?(Person.where(name: "Alice"))
+  #   # SELECT 1 AS one FROM "people" WHERE "people"."name" ="Alice" ...
+  #
   def in?(another_object)
     case another_object
     when Range


### PR DESCRIPTION
As Active Record relations respond to `include?`, calling `in?` will perform a query if the relation hasn't been loaded yet:

```ruby
mary = Person.create(name: "Mary")
# => #<Person id: 654, name: "Mary">
mary.in?(Person.where(name: "Alice"))
# SELECT 1 AS one FROM "people" WHERE "people"."name" ="Alice" ...
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
