### PR TITLE
DatabaseConfigurations#configs_for can accept a symbol in the name param

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
+
+    *Andrew Novoselac*
+
 *   Fix `where(field: values)` queries when `field` is a serialized attribute
     (for example, when `field` uses `ActiveRecord::Base.serialize` or is a JSON
     column).

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -113,7 +113,7 @@ module ActiveRecord
 
       if name
         configs.find do |db_config|
-          db_config.name == name
+          db_config.name == name.to_s
         end
       else
         configs

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -35,6 +35,17 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     ENV["RAILS_ENV"] = previous_env
   end
 
+  def test_configs_for_with_name_symbol
+    previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit2"
+
+    config = ActiveRecord::Base.configurations.configs_for(name: :primary)
+
+    assert_equal "arunit2", config.env_name
+    assert_equal "primary", config.name
+  ensure
+    ENV["RAILS_ENV"] = previous_env
+  end
+
   def test_configs_for_getter_with_env_and_name
     config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I am changing usages of `find_db_config` to `configs_for` in my app. I noticed that while you can pass a symbol to `find_db_config` you cannot for `configs_for`, meaning I have to add `.to_s` at call sites where I might be passing a symbol in. I think it would be nice if `configs_for`'s `name` parameter worked with a symbol or a string.

### Detail

This Pull Request changes the `ActiveRecord::DatabaseConfigurations#configs_for` method to accept a symbol for the `name` parameter. The `name` parameter is used for comparison in one place, so I just call `to_s` on it there.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
