### PR TITLE
Fix `word_wrap` with empty string

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -266,6 +266,8 @@ module ActionView
       #   word_wrap('Once upon a time', line_width: 1, break_sequence: "\r\n")
       #   # => Once\r\nupon\r\na\r\ntime
       def word_wrap(text, line_width: 80, break_sequence: "\n")
+        return +"" if text.empty?
+
         # Match up to `line_width` characters, followed by one of
         #   (1) non-newline whitespace plus an optional newline
         #   (2) the end of the string, ignoring any trailing newlines

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -393,6 +393,11 @@ class TextHelperTest < ActionView::TestCase
     assert_equal "  1-+1-+  1-+1", word_wrap(input, line_width: 3, break_sequence: "-+")
   end
 
+  test "word_wrap when no wrapping is necessary" do
+    assert_equal "1", word_wrap("1", line_width: 3)
+    assert_equal "", word_wrap("", line_width: 3)
+  end
+
   def test_pluralization
     assert_equal("1 count", pluralize(1, "count"))
     assert_equal("2 counts", pluralize(2, "count"))


### PR DESCRIPTION
Follow-up to #45948.

This fixes `word_wrap` to return an empty string instead of `nil` when given an empty string.

Fixes #50067.
