### PR TITLE
Adjust instr. for Cache::Store#fetch_multi so writes are after reads

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make the order of read_multi and write_multi notifications for `Cache::Store#fetch_multi` operations match the order they are executed in.
+
+    *Adam Renberg Tamm*
+
 *   Make return values of `Cache::Store#write` consistent.
 
     The return value was not specified before. Now it returns `true` on a successful write,


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Before this PR, subscribing to `cache_*.active_support` notifications and performing Rails.cache#fetch_multi calls, it would seem as if the resulting write_multi operations happens _before_ the read_multi operations. That's not true, it's just a side-effect of the write_multi call being nested inside the instrumentation block for read_multi.

### Detail

This moves the write_multi out of the read_multi instrumentation block, to make the order of operations make sense.

### Additional information

I found this when writing a test helper to check what cache operations are performed in a test.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
