### PR TITLE
Do not attempt to resolve an `adapter_class` if no `adapter` is present

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -10,7 +10,7 @@ module ActiveRecord
 
       def self.new(...)
         instance = super
-        instance.adapter_class # Ensure resolution happens early
+        instance.adapter_class if instance.adapter # Ensure resolution happens early
         instance
       end
 


### PR DESCRIPTION
## Problem

In https://github.com/rails/rails/pull/50064 connection adapter initialization was moved into `register()` and adapters are resolved by name when instantiated.

When `ActiveRecord` is loaded in Rails it hits this hook:
https://github.com/rails/rails/blob/949b4d1482e41d2d8cfe1b7ed3a69df40a825225/activerecord/lib/active_record/railtie.rb#L304-L305

I believe this is an existing bug, or maybe just a quirk, but it loads the entire `database.yml` file and treats **every root level key as an env name**. You can see it by calling:
```ruby
Rails.application.config.database_configuration
=>
{"default"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000},
 "development"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/development.sqlite3"},
 "test"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/test.sqlite3"},
 "production"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/production.sqlite3"}}
```

This is the `database.yml` generated with `rails new` and the default settings. The file looks like this (comments removed):
```yaml
default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  <<: *default
  database: storage/development.sqlite3

test:
  <<: *default
  database: storage/test.sqlite3

production:
  <<: *default
  database: storage/production.sqlite3
```

It's a common pattern, and indeed in the default, to use `<<` and named node anchors to remove duplication. But rails views all top level keys as configs, so as above `"default"` is now considered a database environment.

This doesn't seem right, but wasn't a problem before. Now though as rails walks these configs and each is instantiated into a `HashConfig` instance here:
https://github.com/rails/rails/blob/949b4d1482e41d2d8cfe1b7ed3a69df40a825225/activerecord/lib/active_record/database_configurations.rb#L278-L281

It attempts to resolve the adapter name to a class in this new `self.new` line:
https://github.com/rails/rails/blob/949b4d1482e41d2d8cfe1b7ed3a69df40a825225/activerecord/lib/active_record/database_configurations/database_config.rb#L13

In cases where a fragment or invalid key is encountered that does not define `adapter:`, the value is nil and then `ActiveRecord::ConnectionAdapters.resolve(nil)` is called and raises:

```
/rails/activerecord/lib/active_record/connection_adapters.rb:31:in `resolve': database configuration specifies nonexistent '' adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile. (ActiveRecord::AdapterNotFound)
	from /rails/activerecord/lib/active_record/database_configurations/database_config.rb:24:in `adapter_class'
	from /rails/activerecord/lib/active_record/database_configurations/database_config.rb:13:in `new'
	from /rails/activerecord/lib/active_record/database_configurations.rb:69:in `block in <class:DatabaseConfigurations>'
	from /rails/activerecord/lib/active_record/database_configurations.rb:279:in `block in build_db_config_from_hash'
	from /rails/activerecord/lib/active_record/database_configurations.rb:278:in `reverse_each'
	from /rails/activerecord/lib/active_record/database_configurations.rb:278:in `build_db_config_from_hash'
	from /rails/activerecord/lib/active_record/database_configurations.rb:257:in `build_db_config_from_raw_config'
	from /rails/activerecord/lib/active_record/database_configurations.rb:208:in `block in build_configs'
	from /rails/activerecord/lib/active_record/database_configurations.rb:204:in `each'
	from /rails/activerecord/lib/active_record/database_configurations.rb:204:in `flat_map'
	from /rails/activerecord/lib/active_record/database_configurations.rb:204:in `build_configs'
	from /rails/activerecord/lib/active_record/database_configurations.rb:74:in `initialize'
	from /rails/activerecord/lib/active_record/core.rb:72:in `new'
	from /rails/activerecord/lib/active_record/core.rb:72:in `configurations='
	from /rails/activerecord/lib/active_record/railtie.rb:305:in `block (2 levels) in <class:Railtie>'
```

## Reproduction

* Generate a new app from on `main` `rails/railties/exe/rails new test1 --dev`.
* Edit `database.yml` to move the `adapter: sqlite3` key out of `default:` and into the environment entries like:
```
default: &default
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  <<: *default
  adapter: sqlite3
  database: storage/development.sqlite3
```
* Load any environment.

The configs now look like:
```
irb(main):001> Rails.application.config.database_configuration
=>
{"default"=>{"pool"=>5, "timeout"=>5000},
 "development"=>{"pool"=>5, "timeout"=>5000, "adapter"=>"sqlite3", "database"=>"storage/development.sqlite3"},
 "test"=>{"pool"=>5, "timeout"=>5000, "adapter"=>"sqlite3", "database"=>"storage/test.sqlite3"},
 "production"=>{"pool"=>5, "timeout"=>5000, "adapter"=>"sqlite3", "database"=>"storage/production.sqlite3"}}
```

And the `"default"` env has no adapter.


## Solution

This for now at least prevents validating adapters which are `nil` or blank. I don't think it's the permanent fix, but it prevents pretty bad breakages for anyone testing against head, whose `database.yml` files now cause errors.

The real solution is to maybe validate this `adapter_class` a bit later, as was suggested in the original PR.

I think it's worth considering how DB configs are parsed and loaded. I do not believe it is accurate to treat any top level key as an environment. Any key that does not match a configured rails env can maybe be skipped?

cc @byroot @matthewd @adrianna-chang-shopify 