### PR TITLE
Arel nulls first/last implementation Mysql 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -84,4 +84,8 @@
 
     *Jason Meller*
 
+*   Add `nulls_last` and working `desc.nulls_first` for MySQL.
+
+    *Tristan Fellows*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -59,9 +59,14 @@ module Arel # :nodoc: all
           infix_value o, collector, " NOT REGEXP "
         end
 
-        # no-op
         def visit_Arel_Nodes_NullsFirst(o, collector)
-          visit o.expr, collector
+          visit(o.expr.expr, collector) << " IS NOT NULL, "
+          visit(o.expr, collector)
+        end
+
+        def visit_Arel_Nodes_NullsLast(o, collector)
+          visit(o.expr.expr, collector) << " IS NULL, "
+          visit(o.expr, collector)
         end
 
         def visit_Arel_Nodes_Cte(o, collector)

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -154,10 +154,31 @@ module Arel
       end
 
       describe "Nodes::Ordering" do
-        it "should no-op ascending nulls first" do
+        it "should handle nulls first" do
           test = Table.new(:users)[:first_name].asc.nulls_first
           _(compile(test)).must_be_like %{
-            "users"."first_name" ASC
+            "users"."first_name" IS NOT NULL, "users"."first_name" ASC
+          }
+        end
+
+        it "should handle nulls last" do
+          test = Table.new(:users)[:first_name].asc.nulls_last
+          _(compile(test)).must_be_like %{
+            "users"."first_name" IS NULL, "users"."first_name" ASC
+          }
+        end
+
+        it "should handle nulls first reversed" do
+          test = Table.new(:users)[:first_name].asc.nulls_first.reverse
+          _(compile(test)).must_be_like %{
+            "users"."first_name" IS NULL, "users"."first_name" DESC
+          }
+        end
+
+        it "should handle nulls last reversed" do
+          test = Table.new(:users)[:first_name].asc.nulls_last.reverse
+          _(compile(test)).must_be_like %{
+            "users"."first_name" IS NOT NULL, "users"."first_name" DESC
           }
         end
       end


### PR DESCRIPTION
### Motivation / Background

Fixes #50078 

This Pull Request has been created because I needed to sort a column ASC with nulls last with a MySQL database and wanted to avoid using an SQL fragment to achieve this. I discovered that Arel supports this for all databases apart from MySQL. When investigating the MySQL implementation, I noticed inconsistencies with how it is implemented.

Originally, I was just aiming to make the functionality consistent, but then had a go at implementing the missing functionality.

### Detail

This Pull Request changes the implementation of `.nulls_first()` and `.nulls_last()` for MySQL databases. These methods now work as designed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]` 
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
