### PR TITLE
[ActiveStorage] Discard unrepresentable blobs while preprocessing

### DIFF
--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -3,7 +3,7 @@
 class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   queue_as { ActiveStorage.queues[:transform] }
 
-  discard_on ActiveRecord::RecordNotFound
+  discard_on ActiveRecord::RecordNotFound, ActiveStorage::UnrepresentableError
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -99,7 +99,7 @@ module ActiveStorage::Blob::Representable
   end
 
   def preprocessed(transformations) # :nodoc:
-    ActiveStorage::TransformJob.perform_later(self, transformations)
+    ActiveStorage::TransformJob.perform_later(self, transformations) if representable?
   end
 
   private

--- a/activestorage/test/jobs/transform_job_test.rb
+++ b/activestorage/test/jobs/transform_job_test.rb
@@ -44,4 +44,15 @@ class ActiveStorage::TransformJobTest < ActiveJob::TestCase
       ActiveStorage.track_variants = @was_tracking
     end
   end
+
+  test "ignores unrepresentable blob" do
+    unrepresentable_blob = create_blob(content_type: "text/plain")
+    transformations = { resize_to_limit: [100, 100] }
+
+    perform_enqueued_jobs do
+      assert_nothing_raised do
+        ActiveStorage::TransformJob.perform_later unrepresentable_blob, transformations
+      end
+    end
+  end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -917,7 +917,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later" do
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [1, 1]] do
       @user.highlights_with_preprocessed.attach blob
@@ -926,10 +926,10 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "transforms variants later conditionally via proc" do
     assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
-      @user.highlights_with_conditional_preprocessed.attach create_blob(filename: "funky.jpg")
+      @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via proc")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [2, 2]] do
@@ -939,14 +939,22 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "transforms variants later conditionally via method" do
     assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
-      @user.highlights_with_conditional_preprocessed.attach create_blob(filename: "funky.jpg")
+      @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via method")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [3, 3]] do
       @user.highlights_with_conditional_preprocessed.attach blob
+    end
+  end
+
+  test "avoids enqueuing transform later job when blob is not representable" do
+    unrepresentable_blob = create_blob(filename: "hello.txt")
+
+    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      @user.highlights_with_preprocessed.attach unrepresentable_blob
     end
   end
 

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -859,7 +859,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later" do
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [1, 1]] do
       @user.avatar_with_preprocessed.attach blob
@@ -868,10 +868,10 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "transforms variants later conditionally via proc" do
     assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
-      @user.avatar_with_conditional_preprocessed.attach create_blob(filename: "funky.jpg")
+      @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via proc")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [2, 2]] do
@@ -881,14 +881,22 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "transforms variants later conditionally via method" do
     assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
-      @user.avatar_with_conditional_preprocessed.attach create_blob(filename: "funky.jpg")
+      @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
-    blob = create_blob(filename: "funky.jpg")
+    blob = create_file_blob(filename: "racecar.jpg")
     @user.update(name: "transform via method")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [3, 3]] do
       @user.avatar_with_conditional_preprocessed.attach blob
+    end
+  end
+
+  test "avoids enqueuing transform later job when blob is not representable" do
+    unrepresentable_blob = create_blob(filename: "hello.txt")
+
+    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      @user.avatar_with_preprocessed.attach unrepresentable_blob
     end
   end
 end


### PR DESCRIPTION
cc @jonathanhefner 
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Preprocessing "unrepresentable" blobs (neither variabe, nor previewable) will result in a `ActiveStorage::UnrepresentableError`, which will retry following `ActiveJob::Base` default retry logic.

### Detail

This PR discards any blob that's not representable to cleanup the job adapter queue.
![image](https://github.com/rails/rails/assets/1371733/34e40f60-d2ad-462f-ad58-e75de6550d34)



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
