### PR TITLE
Remove top level keys in `database.yml` that do not map to valid Rails environments

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -393,6 +393,7 @@ module Rails
           paths.add "config/database",    with: "config/database.yml"
           paths.add "config/secrets",     with: "config", glob: "secrets.yml{,.enc}"
           paths.add "config/environment", with: "config/environment.rb"
+          paths.add "config/environments", glob: "*.rb"
           paths.add "lib/templates"
           paths.add "log",                with: "log/#{Rails.env}.log"
           paths.add "public"
@@ -422,6 +423,10 @@ module Rails
         else
           {}
         end
+      end
+
+      def configured_environments
+        @configured_environments ||= paths["config/environments"].existent.map { |file| File.basename(file, ".rb") }.sort
       end
 
       # Loads and returns the entire raw configuration of database from

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -436,7 +436,9 @@ module Rails
         yaml = Pathname.new(path) if path
 
         config = if yaml&.exist?
-          loaded_yaml = ActiveSupport::ConfigurationFile.parse(yaml)
+          loaded_yaml = ActiveSupport::ConfigurationFile
+            .parse(yaml)
+            .slice(*(configured_environments + ["shared"]))
           if (shared = loaded_yaml.delete("shared"))
             loaded_yaml.each do |env, config|
               if config.is_a?(Hash) && config.values.all?(Hash)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4770,6 +4770,16 @@ module ApplicationTests
       assert_equal [:foo], Foo.attributes_for_inspect
     end
 
+    test "#configured_environments lists all envs in config/environments/*.rb" do
+      restore_default_config
+
+      with_rails_env "development" do
+        app "development"
+
+        assert_equal(["development", "production", "test"], Rails.configuration.configured_environments)
+      end
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
**(This is a work in progress)**

## Problem

As described in #50075 (related to https://github.com/rails/rails/pull/50064), `#database_configuration` in the rails config, in in cases where it reads from `database.yml`, loads _all top level_ keys in the file and treats each one like an env:
https://github.com/rails/rails/blob/e5d3d782b6c89d382688b7e580a563e96bb874a4/railties/lib/rails/application/configuration.rb#L429-L434

The problem with this can even be seen with the default `database.yml` generated with `rails new`:

```yaml
default: &default
  adapter: sqlite3
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000

development:
  <<: *default
  database: storage/development.sqlite3

test:
  <<: *default
  database: storage/test.sqlite3

production:
  <<: *default
  database: storage/production.sqlite3
```
Generates:
```ruby
{"default"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000},
 "development"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/development.sqlite3"},
 "test"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/test.sqlite3"},
 "production"=>{"adapter"=>"sqlite3", "pool"=>5, "timeout"=>5000, "database"=>"storage/production.sqlite3"}}
```

Here we see the `default:` key using YAML node anchors to reduce duplication and compose the env values. This puts all kinds of useless and incorrect fragments into the database config that should really be just a YAML implementation concern. We have some large `database.yml` files at Shopify that compose many YAML keys into env configs and so this method returns a dozen or more useless key fragments and labels them all as envs.

It also causes issues with the fact that each key is parsed into a `ActiveRecord::DatabaseConfigurations::HashConfig` object in which there is logic and validation that should not be applied to these fragments.


## Solution

Ideally we remove anything that isn't a valid env, and do essentially:

```ruby
database_config = YAML.load(database_yaml_file).select { |k,v| ["production", "test", "development"].include?(k) }.to_h
```

Unfortunately we don't really have a concept of what envs are configured and exist.

The **first commit** here proposed an implementation of that. It looks in `config/environments/*.rb` and uses that as the list of envs. Which is probably pretty correct, and would allow for people to add envs like `staging` or whatever, even if it's not super supported by rails. I'm not sure about edge cases this won't cover or engine compatibility or whatever.

The **second commit is incomplete** but proposes how to filter out any top level keys that are invalid. This works, but I'm not sure if it's too aggressive an approach. It breaks a ton of tests, and I think that's just a function of generating skeleton rails apps for fast testing, but maybe not. I'm not going to get the build green till we're confident with the approach.


### Questions

_1) What is the usecase for exposing all database envs in `Rails::Application::Configuration#database_configuration`?_ 

I don't assume it's common to connect to production manually from in dev or whatever. Versus just exposing the current env. I'm not sure if it's useful and why it exists.

_2) Can we change `Rails::Application::Configuration#database_configuration` to expose just the current env?_

Another approach we could do entirely is essentially doing:

```ruby
database_config = YAML.load(database_yaml_file).select { |k,v| k == Rails.env }.to_h
```

Then we don't have to allow-list and know what all envs are, when we just know to pick _only the current env_ and ignore the rest. Then we also don't need `configured_environments` at all and just the current `Rails.env`. But again, I'm not sure who is using this and why.

They're assigned to `configurations` and are available to lookup by env [here](https://github.com/rails/rails/blob/e5d3d782b6c89d382688b7e580a563e96bb874a4/activerecord/lib/active_record/database_configurations.rb#L26), so this would be a limiting and breaking change.

cc @byroot 