### PR TITLE
Fix rails console to work with `DATABASE_URL` for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -88,7 +88,9 @@ module ActiveRecord
 
     initializer "active_record.postgresql_time_zone_aware_types" do
       ActiveSupport.on_load(:active_record_postgresqladapter) do
-        ActiveRecord::Base.time_zone_aware_types << :timestamptz
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.time_zone_aware_types << :timestamptz
+        end
       end
     end
 

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -148,5 +148,14 @@ module ApplicationTests
 
       assert_match "42", rails("runner", "puts Task.count")
     end
+
+    def test_works_with_database_url
+      db_name = use_postgresql
+      previous_url = ENV["DATABASE_URL"]
+      ENV["DATABASE_URL"] = "postgres://localhost/#{db_name}"
+      assert_equal "1", rails("runner", "print 1")
+    ensure
+      ENV["DATABASE_URL"] = previous_url
+    end
   end
 end


### PR DESCRIPTION
Fixes #50085.

The regression was introduced via https://github.com/rails/rails/pull/50064 (cc @byroot).

Previously, `ActiveRecord::Base` was loaded before any specific database adapters, see https://github.com/rails/rails/pull/50064/files#diff-d1e52309089a1c9135a7d1bb82bdfdf7410d7d7a294013e16e71f0171154eefbL324-L334 so everything worked fine. 
But with the refactoring, this is no longer the case and adapters are loaded first, see https://github.com/rails/rails/pull/50064/files#diff-4c1143afc3627a3ced3bd6f78f37888b98424844732e771c3cb323ef50415bb0R24-R37