### PR TITLE
Add `query_cache_clearing_strategy` to customize how the query cache clears

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -84,4 +84,13 @@
 
     *Jason Meller*
 
+*   Add `query_cache_clearing_strategy` to allow control of how the query cache is cleared.
+    ```ruby
+      ActiveRecord.query_cache_clearing_strategy = Proc.new do |conn|
+        conn.clear_query_cache
+      end
+    ```
+
+    *Jonathan Calvert*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -394,6 +394,15 @@ module ActiveRecord
   singleton_class.attr_accessor :dump_schemas
   self.dump_schemas = :schema_search_path
 
+  ##
+  # :singleton-method
+  # Specify a proc to call when query cache is indicated dirty. By
+  # default, call `ActiveRecord::Base.clear_query_caches_for_current_thread`
+  singleton_class.attr_accessor :query_cache_clearing_strategy
+  self.query_cache_clearing_strategy = Proc.new do
+    ActiveRecord::Base.clear_query_caches_for_current_thread
+  end
+
   def self.suppress_multiple_database_warning
     ActiveRecord.deprecator.warn(<<-MSG.squish)
       config.active_record.suppress_multiple_database_warning is deprecated and will be removed in Rails 7.2.

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -21,7 +21,7 @@ module ActiveRecord
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
               def #{method_name}(...)
-                ActiveRecord::Base.clear_query_caches_for_current_thread
+                ActiveRecord.query_cache_clearing_strategy.call(self, :#{method_name}, ...)
                 super
               end
             end_code

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1642,6 +1642,16 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `true`               |
 | 7.1                   | `false`              |
 
+#### `config.active_record.query_cache_clearing_strategy`
+
+Takes a `Proc` that executes when a method has been called that dirties the query cache. The default proc calls `ActiveRecord::Base.clear_query_caches_for_current_thread` to clear all active connections on the thread. Arguments passed are the connection object, the method name called, followed by any arguments to that method. To have only the connection with the dirty method clear the query cache:
+
+```
+config.active_record.query_cache_clearing_strategy = Proc.new do |conn|
+  conn.clear_query_cache
+end
+```
+
 ### Configuring Action Controller
 
 `config.action_controller` includes a number of configuration settings:


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I work on a rather large, robust Rails application that has some custom multi-database code. The default behavior of `ActiveRecord::Base.clear_query_caches_for_current_thread` for cache clearing can result in a substantial number of cache misses between unrelated shards, (noted in #40622) - similarly as the methods passed to `dirties_query_cache` in `ActiveRecord::ConnectionAdapters::QueryCache` has changed (such as in #48061) this again changes the number of query cache hits, which can result in performance regressions. In both cases, the default behavior absolutely makes sense, however it is difficult to carve out an exception. In order to do so this requires making `clear_query_caches_for_current_thread` a noop and then overwriting the target methods on the adapter classes.

Rather than being prescriptive, this pull request maintains the current behavior and gives a more straightforward way for applications to modify the existing cache clearing behavior instead of monkey patching core Active Record classes. 

### Detail

- Add `ActiveRecord#query_cache_clearing_strategy` as a singleton accessor that defaults to a `Proc` that just calls `ActiveRecord::Base.clear_query_caches_for_current_thread` 
- Replace the call to `ActiveRecord::Base.clear_query_caches_for_current_thread` in the inline method definition in `ActiveRecord::ConnectionAdapters::QueryCache` to call the new `Proc` with the arguments of `self`, the `method_name` and args. 
- Update the configuration guide to document this.

### Additional information

Since there is no change to the behavior as is, I have no additional tests added.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
