### PR TITLE
Delay validation of registered Active Record adapters and allow aliasing of adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters.register("mysql", "ActiveRecord::ConnectionAdapters::TrilogyAdapter", "active_record/connection_adapters/trilogy_adapter")
       #
       def register(name, class_name, path = class_name.underscore)
-        @adapters[name] = [class_name, path]
+        @adapters[name.to_s] = [class_name, path]
       end
 
       def resolve(adapter_name) # :nodoc:
@@ -26,7 +26,7 @@ module ActiveRecord
         #   1. Missing adapter gems.
         #   2. Incorrectly registered adapters.
         #   3. Adapter gems' missing dependencies.
-        class_name, path_to_adapter = @adapters[adapter_name]
+        class_name, path_to_adapter = @adapters[adapter_name.to_s]
 
         unless class_name
           raise AdapterNotFound, <<~MSG.squish

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -322,7 +322,7 @@ module ActiveRecord
         #
         def resolve_pool_config(config, connection_name, role, shard)
           db_config = Base.configurations.resolve(config)
-
+          db_config.validate!
           raise(AdapterNotSpecified, "database configuration does not specify adapter") unless db_config.adapter
           ConnectionAdapters::PoolConfig.new(connection_name, db_config, role, shard)
         end

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -8,12 +8,6 @@ module ActiveRecord
     class DatabaseConfig # :nodoc:
       attr_reader :env_name, :name
 
-      def self.new(...)
-        instance = super
-        instance.adapter_class if instance.adapter # Ensure resolution happens early
-        instance
-      end
-
       def initialize(env_name, name)
         @env_name = env_name
         @name = name
@@ -26,6 +20,12 @@ module ActiveRecord
 
       def new_connection
         adapter_class.new(configuration_hash)
+      end
+
+      def validate!
+        adapter_class if adapter
+
+        true
       end
 
       def host

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -63,6 +63,20 @@ module ActiveRecord
         ENV["RAILS_ENV"] = previous_env
       end
 
+      def test_validates_db_configuration_and_raises_on_invalid_adapter
+        config = {
+          "development" => { "adapter" => "ridiculous" },
+        }
+
+        @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          ActiveRecord::Base.establish_connection(:development)
+        end
+      ensure
+        ActiveRecord::Base.configurations = @prev_configs
+      end
+
       unless in_memory_db?
         def test_not_setting_writing_role_while_using_another_named_role_raises
           connection_handler = ActiveRecord::Base.connection_handler

--- a/activerecord/test/cases/connection_adapters/registration_test.rb
+++ b/activerecord/test/cases/connection_adapters/registration_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class RegistrationTest < ActiveRecord::TestCase
+      def setup
+        @original_adapters = ActiveRecord::ConnectionAdapters.instance_variable_get(:@adapters).dup
+        ActiveRecord::ConnectionAdapters.instance_variable_get(:@adapters).delete("fake")
+        @fake_adapter_path = File.expand_path("../../support/fake_adapter.rb", __dir__)
+      end
+
+      def teardown
+        ActiveRecord::ConnectionAdapters.instance_variable_set(:@adapters, @original_adapters)
+      end
+
+      test "#register registers a new database adapter and #resolve can find it and raises if it cannot" do
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          ActiveRecord::ConnectionAdapters.resolve("fake")
+        end
+
+        ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
+
+        assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve("fake").name
+      end
+
+      test "#register allows for symbol key" do
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          ActiveRecord::ConnectionAdapters.resolve("fake")
+        end
+
+        ActiveRecord::ConnectionAdapters.register(:fake, "FakeActiveRecordAdapter", @fake_adapter_path)
+
+        assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve("fake").name
+      end
+
+      test "#resolve allows for symbol key" do
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          ActiveRecord::ConnectionAdapters.resolve("fake")
+        end
+
+        ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
+
+        assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve(:fake).name
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -145,6 +145,15 @@ module ActiveRecord
         config = HashConfig.new("default_env", "primary", { schema_cache_path: "db/config_schema_cache.yml", adapter: "abstract" })
         assert_equal "db/config_schema_cache.yml", config.schema_cache_path
       end
+
+      def test_validate_checks_the_adapter_exists
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert config.validate!
+        config = HashConfig.new("default_env", "primary", adapter: "potato")
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          config.validate!
+        end
+      end
     end
   end
 end

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -37,6 +37,8 @@ module Rails
           "#{missing_db} configured for '#{environment}'. Available configuration: #{configurations.inspect}"
       end
 
+      @db_config.validate!
+
       @db_config
     end
 
@@ -51,7 +53,7 @@ module Rails
     private
       def adapter_class
         ActiveRecord::ConnectionAdapters.resolve(db_config.adapter)
-      rescue LoadError, ActiveRecord::AdapterNotFound
+      rescue LoadError
         ActiveRecord::ConnectionAdapters::AbstractAdapter
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4770,6 +4770,27 @@ module ApplicationTests
       assert_equal [:foo], Foo.attributes_for_inspect
     end
 
+    test "new Active Record connection adapters can be registered as aliases in application initializers" do
+      app_file "config/database.yml", <<-YAML
+        development:
+          adapter: potato
+          database: 'example_db'
+      YAML
+
+      app_file "config/initializers/active_record_connection_adapters.rb", <<-RUBY
+        ActiveRecord::ConnectionAdapters.register(
+          "potato",
+          "ActiveRecord::ConnectionAdapters::SQLite3Adapter",
+          "active_record/connection_adapters/sqlite3_adapter"
+        )
+      RUBY
+
+      app "development"
+
+      assert_equal "potato", ActiveRecord::Base.connection.pool.db_config.adapter
+      assert_equal "SQLite", ActiveRecord::Base.connection.adapter_name
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
Next step in https://github.com/rails/rails/pull/50064 by @byroot.

## Problem

We want to allow aliasing of DB adapters by name. The end state here is to allow `mysql` to be mapped to either `trilogy` or `mysql2` at an application level. And allow others to do the same.

The main refactor here is moving the adapter validation out of `DatabaseConfig.new` and into a `#validate` method that is called later.

The reason for this refactor is that currently database configs are loaded by the framework so early that there isn't really a way to hook into registering/aliasing adapters before the configs are loaded and validated with `.new`:

https://github.com/rails/rails/blob/438cad462638b02210fc48b700c29dcd0428a8b7/activerecord/lib/active_record/railtie.rb#L305-L307

The adapter needs to be registered with Active Record after it is loaded, but before configs are loaded, and because `on_load(:active_record)` hooks are executed in order the above one is always executed before anything in the rails app, including the initializers. I even tried adding a `:active_record_register_adapters` hook, but again the app initializers aren't run before this fires.


## Solution

As @matthewd suggested, extract validation into a method on `DatabaseConfig`. This has the added bonus of allowing the config subclasses further specialize validation.

Also adds a method which I will use in the next step to `alias("trilogy", as: "mysql")`.


### Reproduction steps

I have validated this in a new rails app, by naming the "sqlite3" adapter "potato", and the app will run with the following steps:

```
$ ../rails/railties/exe/rails new example --dev --skip-asset-pipeline --skip-javascript --skip-hotwire --skip-test
```
```
$ sed -i 's/adapter: sqlite3/adapter: potato/' config/database.yml
```
```
$ bin/rails environment
bin/rails aborted!
ActiveRecord::AdapterNotFound: database configuration specifies nonexistent 'potato' adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile. (ActiveRecord::AdapterNotFound)
```
```
$ echo 'ActiveSupport.on_load(:active_record) { ActiveRecord::ConnectionAdapters.register("potato", "ActiveRecord::ConnectionAdapters::SQLite3Adapter", "active_record/connection_adapters/sqlite3_adapter") }' > config/initializers/active_record_adapters.rb
```
```
$ bin/rails environment
$ bin/rails runner 'puts "#{ ActiveRecord::Base.connection.pool.db_config.adapter } / #{ ActiveRecord::Base.connection.adapter_name }"'
potato / SQLite
```