### PR TITLE
normalizer accepts symbols that the normalized object responds to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,8 @@
-*   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
+* `ActiveRecord::Normalization::NormalizedValueType` can accept a symbol in the `normalizer` parameter.
+
+    *Ahmed Khattab*
+
+* `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,8 @@
-* `ActiveRecord::Normalization::NormalizedValueType` can accept a symbol in the `normalizer` parameter.
+*   `ActiveRecord::Normalization::NormalizedValueType` can accept a symbol in the `normalizer` parameter.
 
     *Ahmed Khattab*
 
-* `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
+*   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*
 

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -60,7 +60,7 @@ module ActiveRecord # :nodoc:
       # ==== Options
       #
       # * +:with+ - Any callable object that accepts the attribute's value as
-      #   its sole argument, and returns it normalized.
+      #   its sole argument, and returns it normalized. It can also be a symbol that the normalized object responds to
       # * +:apply_to_nil+ - Whether to apply the normalization to +nil+ values.
       #   Defaults to +false+.
       #
@@ -158,7 +158,11 @@ module ActiveRecord # :nodoc:
 
         private
           def normalize(value)
-            normalizer.call(value) unless value.nil? && !normalize_nil?
+            if value.respond_to?(normalizer)
+              value.public_send(normalizer)
+            else
+              normalizer.call(value) unless value.nil? && !normalize_nil?
+            end
           end
       end
   end

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -12,6 +12,15 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     attr_accessor :validated_name
     validate { self.validated_name = name.dup }
   end
+  
+  class SymbolNormalizedAircraft < ActiveRecord::TestCase
+    normalizes :name, with: :titlecase
+    normalizes :manufactured_at, with: :noon
+    
+    attr_accessor :validated_name
+    
+    validate { self.validated_name = name.dup }
+  end
 
   setup do
     @time = Time.utc(1999, 12, 31, 12, 34, 56)
@@ -109,5 +118,10 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
     assert_equal "0", aircraft.name
     aircraft.save
     assert_equal "1", aircraft.name
+  end
+  
+  test "normalizes value from symbol" do
+    aircraft = SymbolNormalizedAircraft.create!(name: "fly HIGH", manufactured_at: @time)
+    assert_equal "Fly High", aircraft.name
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The newly introduced `ActiveRecord::Normalization` module allows to normalize attributes, it can receive any callable object that responds to `call`. While we were using it, we found that we were calling a method that already _exists_ on the normalized object, and hence can simply be "forwarded" to the object. 

To our surprise, it threw errors when we tried to supply the normalization to do as a symbol to be forwarded to the normalized object using `Object#send`. 

I found it not Rails-y to do something like the following,

```ruby
class Post
  normalizes :body, with: -> body { body.squish }
end
```

When you can simply supply the `squish` as a symbol that then gets send to the object. With this proposed change, we can slim the code above into a more Ruby-ish and subsequently, Rails-ish way. 

```ruby
class Post
  normalizes :body, with: :squish
end
```

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the current implementation of the `normalizes` method does not support a Symbol as an argument that gets forwarded to the object to normalize. 

### Detail

This Pull Request changes the `ActiveRecord::Normalization::NormalizedValueType`'s `normalizer:` argument to accept a Symbol that sends to the normalized object via `Object#public_send`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
