### PR TITLE
Skip activesupport event processing tests on platforms w/o highres clock

### DIFF
--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -108,10 +108,15 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
       assert_equal 0, event.cpu_time
       assert_equal 0, event.allocations
     else
-      assert_operator event.cpu_time, :>, 0
+      # These assertions may fail on platforms without nanosecond-resolution clocks
+      if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
+        assert_operator event.cpu_time, :>, 0
+      end
       assert_operator event.allocations, :>, 0
     end
-    assert_operator event.duration, :>, 0
+    if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
+      assert_operator event.duration, :>, 0
+    end
     assert_operator event.idle_time, :>=, 0
   end
 

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -36,9 +36,12 @@ module Notifications
       event = events.first
       assert event, "should have an event"
       assert_operator event.allocations, :>, 0
-      assert_operator event.cpu_time, :>, 0
-      assert_operator event.idle_time, :>=, 0
-      assert_operator event.duration, :>, 0
+      # These assertions may fail on platforms without nanosecond-resolution clocks
+      if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
+        assert_operator event.cpu_time, :>, 0
+        assert_operator event.idle_time, :>=, 0
+        assert_operator event.duration, :>, 0
+      end
     end
 
     def test_subscribe_to_events_where_payload_is_changed_during_instrumentation


### PR DESCRIPTION
On platforms without a high-resolution (nanosecond) clock, it is likely that the processing of an event will take less time than one complete clock resolution cycle, which means that the start and end times will be equal and the duration zero, failing these tests.  Usually these issues are fixed by adding a sleep of equal to one clock resolution cycle, but that is not applicable here since the duration measurement occurs in the actual library code rather than the test code, so just skip these tests on such platforms.  Also tested and confirmed that the tests are not skipped under normal platforms with a highres clock.
