### PR TITLE
[ActiveStorage] Fix `ActiveStorage:Representations::ProxyController` returning the wrong preview

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActiveStorage::Representations::ProxyController` not returning the proper
+    preview image variant for previewable files.
+
+    *Chedli Bourguiba*
+
 *   Fix `ActiveStorage::Representations::ProxyController` to proxy untracked
     variants.
 

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -12,7 +12,7 @@ class ActiveStorage::Representations::ProxyController < ActiveStorage::Represent
 
   def show
     http_cache_forever public: true do
-      send_blob_stream @representation.image, disposition: params[:disposition]
+      send_blob_stream @representation, disposition: params[:disposition]
     end
   end
 end

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -31,7 +31,11 @@
 # These libraries are not provided by \Rails. You must install them yourself to use the built-in previewers. Before you
 # install and use third-party software, make sure you understand the licensing implications of doing so.
 class ActiveStorage::Preview
+  include ActiveStorage::Blob::Servable
+
   class UnprocessedError < StandardError; end
+
+  delegate :filename, :content_type, to: :presentation
 
   attr_reader :blob, :variation
 

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -5,6 +5,8 @@
 # Like an ActiveStorage::Variant, but keeps detail about the variant in the database as an
 # ActiveStorage::VariantRecord. This is only used if +ActiveStorage.track_variants+ is enabled.
 class ActiveStorage::VariantWithRecord
+  include ActiveStorage::Blob::Servable
+
   attr_reader :blob, :variation
   delegate :service, to: :blob
   delegate :content_type, to: :variation

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -18,10 +18,7 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
 
     assert_response :ok
     assert_match(/^attachment/, response.headers["Content-Disposition"])
-
-    image = read_image(@blob.variant(@transformations))
-    assert_equal 100, image.width
-    assert_equal 67, image.height
+    assert_equal @blob.variant(@transformations).download, response.body
   end
 
   test "showing variant inline" do
@@ -32,10 +29,7 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
 
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
-
-    image = read_image(@blob.variant(@transformations))
-    assert_equal 100, image.width
-    assert_equal 67, image.height
+    assert_equal @blob.variant(@transformations).download, response.body
   end
 
   test "showing untracked variant" do
@@ -48,7 +42,7 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
 
       assert_response :ok
       assert_match(/^attachment/, response.headers["Content-Disposition"])
-      assert_equal @blob.representation(@transformations).download, response.body
+      assert_equal @blob.variant(@transformations).download, response.body
     end
   end
 
@@ -74,7 +68,8 @@ end
 class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "racecar.jpg"
-    @blob.variant(resize_to_limit: [100, 100]).processed
+    @transformations = { resize_to_limit: [100, 100] }
+    @blob.variant(@transformations).processed
   end
 
   test "showing existing variant record"  do
@@ -82,44 +77,37 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadi
       get rails_blob_representation_proxy_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+        variation_key: ActiveStorage::Variation.encode(@transformations))
     end
+
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
-
-    @blob.reload # became free of strict_loading?
-    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
-    assert_equal 100, image.width
-    assert_equal 67, image.height
+    assert_equal @blob.variant(@transformations).download, response.body
   end
 end
 
 class ActiveStorage::Representations::ProxyControllerWithPreviewsTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "report.pdf", content_type: "application/pdf"
+    @transformations = { resize_to_limit: [100, 100] }
   end
 
   test "showing preview inline" do
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
-      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+      variation_key: ActiveStorage::Variation.encode(@transformations))
 
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
-
-    assert_predicate @blob.preview_image, :attached?
-
-    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]).processed)
-    assert_equal 77, image.width
-    assert_equal 100, image.height
+    assert_equal @blob.preview(@transformations).download, response.body
   end
 
   test "showing preview with invalid signed blob ID" do
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: "invalid",
-      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+      variation_key: ActiveStorage::Variation.encode(@transformations))
 
     assert_response :not_found
   end
@@ -137,7 +125,8 @@ end
 class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "report.pdf", content_type: "application/pdf"
-    @blob.preview(resize_to_limit: [100, 100]).processed
+    @transformations = { resize_to_limit: [100, 100] }
+    @blob.preview(@transformations).processed
   end
 
   test "showing existing preview record" do
@@ -145,16 +134,11 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadi
       get rails_blob_representation_proxy_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+        variation_key: ActiveStorage::Variation.encode(@transformations))
     end
 
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
-    @blob.reload # became free of strict_loading?
-    assert_predicate @blob.preview_image, :attached?
-
-    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]).processed)
-    assert_equal 77, image.width
-    assert_equal 100, image.height
+    assert_equal @blob.preview(@transformations).download, response.body
   end
 end


### PR DESCRIPTION
Fixes #47071
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added) behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
When a blob is a representable of kind `previewable`, the preview
image that's being proxied is always the original preview image,
discarding completely the `variation_key` param passed in the request.



As all 3 classes are now 100% interchangeable, we can deprecate the use
of `Representable#image`. Users of this class won't need to call this
method as it's become obsolete. and in case of `Preview#image`
erroneous.

### Detail

This PR fixes this by editing `Preview` and `VariantWithRecord` to
have full synchronized API with `Variant`. this will then allow the
ProxyController to not call `representable#image` but `representable`
instead.

 As all 3 classes are now 100% interchangeable, we can deprecate the use
    of `Representable#image`. Users of this class won't need to call this
    method as it's become obsolete. and in case of `Preview#image`
    erroneous.


### Additional information
I've added missing failing tests that would have caught this issue.

It wasn't straightforward to fix. Because of some mismatches between `AS::Variant` / `AS::VariantWithRecord` / `AS::Preview` 
For example `AS::Variant` adds a lot of redundant methods like `#filename`simply because `AS::Variant#image` returns `self` ( and **not** a AS blob). and any methods that are used with `send_blob_stream`

Here are the the lines that call `@representation.image`
https://github.com/rails/rails/blob/438cad462638b02210fc48b700c29dcd0428a8b7/activestorage/app/controllers/active_storage/representations/proxy_controller.rb#L14-L16

which I changed to call `send_blob_stream @representation` getting rid of `#image` and we can deprecate it in a future PR

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
