### PR TITLE
Updated String#dup with Performance::UnfreezeString

### DIFF
--- a/actionpack/test/dispatch/uploaded_file_test.rb
+++ b/actionpack/test/dispatch/uploaded_file_test.rb
@@ -51,7 +51,7 @@ module ActionDispatch
 
     def test_headers_should_always_be_in_utf_8
       uf = Http::UploadedFile.new(filename: "foo",
-                                  head: "\xC3foo".dup.force_encoding(Encoding::ASCII_8BIT),
+                                  head: (+"\xC3foo").force_encoding(Encoding::ASCII_8BIT),
                                   tempfile: Tempfile.new)
       assert_equal "UTF-8", uf.headers.encoding.to_s
     end

--- a/activerecord/test/cases/encryption/cipher_test.rb
+++ b/activerecord/test/cases/encryption/cipher_test.rb
@@ -53,7 +53,7 @@ class ActiveRecord::Encryption::CipherTest < ActiveRecord::EncryptionTestCase
   end
 
   test "keep encoding from the source string" do
-    encrypted_text = @cipher.encrypt("some string".dup.force_encoding(Encoding::ISO_8859_1), key: @key)
+    encrypted_text = @cipher.encrypt((+"some string").force_encoding(Encoding::ISO_8859_1), key: @key)
     decrypted_text = @cipher.decrypt(encrypted_text, key: @key)
     assert_equal Encoding::ISO_8859_1, decrypted_text.encoding
   end

--- a/activerecord/test/cases/encryption/encryptor_test.rb
+++ b/activerecord/test/cases/encryption/encryptor_test.rb
@@ -65,7 +65,7 @@ class ActiveRecord::Encryption::EncryptorTest < ActiveRecord::EncryptionTestCase
   end
 
   test "decrypt respects encoding even when compression is used" do
-    text = "The Starfleet is here #{'OMG! ' * 50}!".dup.force_encoding(Encoding::ISO_8859_1)
+    text = (+"The Starfleet is here #{'OMG! ' * 50}!").force_encoding(Encoding::ISO_8859_1)
     encrypted_text = @encryptor.encrypt(text)
     decrypted_text = @encryptor.decrypt(encrypted_text)
 

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -118,7 +118,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
 
   test "filter_attributes on pretty_print" do
     user = admin_users(:david)
-    actual = "".dup
+    actual = +""
     PP.pp(user, StringIO.new(actual))
 
     assert_includes actual, 'name: "[FILTERED]"'
@@ -127,7 +127,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
 
   test "filter_attributes on pretty_print should not filter nil value" do
     user = Admin::User.new
-    actual = "".dup
+    actual = +""
     PP.pp(user, StringIO.new(actual))
 
     assert_includes actual, "name: nil"
@@ -138,7 +138,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
   test "filter_attributes on pretty_print should handle [FILTERED] value properly" do
     User.filter_attributes = ["auth"]
     user = User.new(token: "[FILTERED]", auth_token: "[FILTERED]")
-    actual = "".dup
+    actual = +""
     PP.pp(user, StringIO.new(actual))
 
     assert_includes actual, 'auth_token: "[FILTERED]"'

--- a/activesupport/test/transliterate_test.rb
+++ b/activesupport/test/transliterate_test.rb
@@ -108,7 +108,7 @@ class TransliterateTest < ActiveSupport::TestCase
   end
 
   def test_transliterate_returns_a_copy_of_ascii_strings
-    string = "Test String".dup
+    string = +"Test String"
     assert_not string.frozen?
     assert_predicate string, :ascii_only?
     assert_not_equal string.object_id, ActiveSupport::Inflector.transliterate(string).object_id


### PR DESCRIPTION
### Motivation / Background
Ref: https://www.rubydoc.info/gems/rubocop/0.61.1/RuboCop/Cop/Performance/UnfreezeString
Follow up: https://github.com/rails/rails/pull/32971

### Detail

This Pull Request used unary plus operator to unfreeze a string literal instead of `String#dup`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
