### PR TITLE
Fix `run_generator` to work for generators calling other generators

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -468,7 +468,10 @@ module Rails
             abort_on_failure: options[:abort_on_failure],
           }
 
-          in_root { run("#{sudo}#{Shellwords.escape Gem.ruby} bin/#{executor} #{command}", config) }
+          in_root do
+            executor_path = Rails.root.join("bin", executor.to_s)
+            run("#{sudo}#{Shellwords.escape Gem.ruby} #{executor_path} #{command}", config)
+          end
         end
 
         # Always returns value in double quotes.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -13,6 +13,7 @@ class ActionsTest < Rails::Generators::TestCase
 
   def setup
     Rails.application = TestApp::Application
+    Rails.application.config.root = Pathname("../fixtures/tmp").expand_path(__dir__)
     super
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -93,6 +93,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
   # brings setup, teardown, and some tests
   include SharedGeneratorTests
 
+  setup { Rails.application.config.root = Pathname(destination_root) }
+
   def default_files
     ::DEFAULT_APP_FILES
   end

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -339,7 +339,7 @@ module SharedGeneratorTests
 
   def test_dev_option
     run_generator_using_prerelease [destination_root, "--dev"]
-    rails_path = File.expand_path("../../..", Rails.root)
+    rails_path = File.expand_path("../../../..", Rails.root)
     assert_file "Gemfile", %r{^gem ["']rails["'], path: ["']#{Regexp.escape rails_path}["']$}
   end
 


### PR DESCRIPTION
Fixes #50099 (see there for the description).

Tested locally - works as expected. I am struggling to write a test for this. But since this change already was caught by existing tests and the change to the test code was needed, maybe it is not even necessary.