### PR TITLE
Improve `AdapterNotFound` error message

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -23,28 +23,32 @@ module ActiveRecord
 
       def resolve(adapter_name) # :nodoc:
         # Require the adapter itself and give useful feedback about
-        #   1. Missing adapter gems and
-        #   2. Adapter gems' missing dependencies.
+        #   1. Missing adapter gems.
+        #   2. Incorrectly registered adapters.
+        #   3. Adapter gems' missing dependencies.
         class_name, path_to_adapter = @adapters[adapter_name]
 
         unless class_name
-          raise AdapterNotFound, "database configuration specifies nonexistent '#{adapter_name}' adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile."
+          raise AdapterNotFound, <<~MSG.squish
+            Database configuration specifies nonexistent '#{adapter_name}' adapter.
+            Available adapters are: #{@adapters.keys.sort.join(", ")}.
+            Ensure that the adapter is spelled correctly in config/database.yml or that you've added the necessary
+            adapter gem to your Gemfile if it's not in the list of available adapters.
+          MSG
         end
 
         unless Object.const_defined?(class_name)
           begin
             require path_to_adapter
           rescue LoadError => error
-            # We couldn't require the adapter itself. Raise an exception that
-            # points out config typos and missing gems.
+            # We couldn't require the adapter itself.
             if error.path == path_to_adapter
-              # We can assume that a non-builtin adapter was specified, so it's
-              # either misspelled or missing from Gemfile.
-              raise LoadError, "Error loading the '#{adapter_name}' Active Record adapter. Ensure that the necessary adapter gem is in the Gemfile. #{error.message}", error.backtrace
-
+              # We can assume here that a non-builtin adapter was specified and the path
+              # registered by the adapter gem is incorrect.
+              raise LoadError, "Error loading the '#{adapter_name}' Active Record adapter. Ensure that the path registered by the adapter gem is correct. #{error.message}", error.backtrace
+            else
               # Bubbled up from the adapter require. Prefix the exception message
               # with some guidance about how to address it and reraise.
-            else
               raise LoadError, "Error loading the '#{adapter_name}' Active Record adapter. Missing a gem it depends on? #{error.message}", error.backtrace
             end
           end

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord
             Base.connection_handler.establish_connection "ridiculous://foo?encoding=utf8"
           end
 
-          assert_match "database configuration specifies nonexistent 'ridiculous' adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.", error.message
+          assert_match "Database configuration specifies nonexistent 'ridiculous' adapter. Available adapters are: abstract, fake, mysql2, postgresql, sqlite3, trilogy. Ensure that the adapter is spelled correctly in config/database.yml or that you've added the necessary adapter gem to your Gemfile if it's not in the list of available adapters.", error.message
         end
 
         # The abstract adapter is used simply to bypass the bit of code that

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -120,7 +120,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_unknown_command_line_client
     start(adapter: "unknown", database: "db")
     assert aborted
-    assert_match(/database configuration specifies nonexistent 'unknown' adapter/, output)
+    assert_match(/Database configuration specifies nonexistent 'unknown' adapter/, output)
   end
 
   def test_primary_is_automatically_picked_with_3_level_configuration


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Actions https://github.com/rails/rails/pull/50064#discussion_r1395563932

### Detail

1. Updates the error message when `AdapterNotFound` is raised (in the case where either the configured adapter name is incorrect or a custom adapter gem has not been included in the gemfile) to include a list of available (currently registered) adapters. It also rewords the message a bit to make it very clear that the issue could only be one of these two things.
2. Updates the first case when `LoadError` is raised (when the path registered by a custom adapter gem is incorrect) to make it clear that the issue is an implementation error, rather than incorrect app-level configuration.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I originally considered adding a `#corrections` to `AdapterNotFound` which utilises `DidYouMean::SpellChecker`. But I think it's much better to simply list all the available adapters for the user.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
