### PR TITLE
Change disjunction to conjunction in suggestion

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/string/filters"
+
 module ActiveRecord
   module ConnectionAdapters
     extend ActiveSupport::Autoload
@@ -32,7 +34,7 @@ module ActiveRecord
           raise AdapterNotFound, <<~MSG.squish
             Database configuration specifies nonexistent '#{adapter_name}' adapter.
             Available adapters are: #{@adapters.keys.sort.join(", ")}.
-            Ensure that the adapter is spelled correctly in config/database.yml or that you've added the necessary
+            Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary
             adapter gem to your Gemfile if it's not in the list of available adapters.
           MSG
         end

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord
             Base.connection_handler.establish_connection "ridiculous://foo?encoding=utf8"
           end
 
-          assert_match "Database configuration specifies nonexistent 'ridiculous' adapter. Available adapters are: abstract, fake, mysql2, postgresql, sqlite3, trilogy. Ensure that the adapter is spelled correctly in config/database.yml or that you've added the necessary adapter gem to your Gemfile if it's not in the list of available adapters.", error.message
+          assert_match "Database configuration specifies nonexistent 'ridiculous' adapter. Available adapters are: abstract, fake, mysql2, postgresql, sqlite3, trilogy. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile if it's not in the list of available adapters.", error.message
         end
 
         # The abstract adapter is used simply to bypass the bit of code that


### PR DESCRIPTION
Follow-up to #50104.

The error conditions are that the adapter is spelled incorrectly __or__ the necessary gem isn't in the `Gemfile`.  Therefore, to fix the error, the user must ensure that the adapter is spelled correctly __and__ the gem is in the `Gemfile`.

This commit also adds `require "active_support/core_ext/string/filters"`, which technically should be included for `String#squish`.
