### PR TITLE
Make Trilogy the default MySQL adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Make Trilogy the default MySQL adapter.
+
+    Trilogy has been production tested on very large Rails applications in the wild,
+    is much easier to install than `mysql2` as it doesn't depend on `libmysqlclient`,
+    and generally is better maintained and performs better.
+
+    `rails new --database=mysql` will now generate an application using Trilogy.
+
+    `DATABASE_URL=mysql://host` will now use the trilogy adapter.
+
+    This has no impact on existing applications.
+
+    *Jean Boussier*
+
 *   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -69,6 +69,9 @@ module ActiveRecord
     register "trilogy", "ActiveRecord::ConnectionAdapters::TrilogyAdapter", "active_record/connection_adapters/trilogy_adapter"
     register "postgresql", "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter", "active_record/connection_adapters/postgresql_adapter"
 
+    # Aliases
+    register "mysql", "ActiveRecord::ConnectionAdapters::TrilogyAdapter", "active_record/connection_adapters/trilogy_adapter"
+
     eager_autoload do
       autoload :AbstractAdapter
     end

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -4,7 +4,7 @@ module Rails
   module Generators
     module Database # :nodoc:
       JDBC_DATABASES = %w( jdbcmysql jdbcsqlite3 jdbcpostgresql jdbc )
-      DATABASES = %w( mysql trilogy postgresql sqlite3 oracle sqlserver ) + JDBC_DATABASES
+      DATABASES = %w( mysql mysql2 trilogy postgresql sqlite3 oracle sqlserver ) + JDBC_DATABASES
 
       def initialize(*)
         super
@@ -13,36 +13,34 @@ module Rails
 
       def gem_for_database(database = options[:database])
         case database
-        when "mysql"          then ["mysql2", ["~> 0.5"]]
-        when "trilogy"        then ["trilogy", ["~> 2.4"]]
-        when "postgresql"     then ["pg", ["~> 1.1"]]
-        when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
-        when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
-        when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]
-        when "jdbcmysql"      then ["activerecord-jdbcmysql-adapter", nil]
-        when "jdbcsqlite3"    then ["activerecord-jdbcsqlite3-adapter", nil]
-        when "jdbcpostgresql" then ["activerecord-jdbcpostgresql-adapter", nil]
-        when "jdbc"           then ["activerecord-jdbc-adapter", nil]
+        when "mysql","trilogy" then ["trilogy", ["~> 0.5"]]
+        when "mysql2"          then ["mysql2", ["~> 0.5"]]
+        when "postgresql"      then ["pg", ["~> 1.1"]]
+        when "sqlite3"         then ["sqlite3", ["~> 1.4"]]
+        when "oracle"          then ["activerecord-oracle_enhanced-adapter", nil]
+        when "sqlserver"       then ["activerecord-sqlserver-adapter", nil]
+        when "jdbcmysql"       then ["activerecord-jdbcmysql-adapter", nil]
+        when "jdbcsqlite3"     then ["activerecord-jdbcsqlite3-adapter", nil]
+        when "jdbcpostgresql"  then ["activerecord-jdbcpostgresql-adapter", nil]
+        when "jdbc"            then ["activerecord-jdbc-adapter", nil]
         else [database, nil]
         end
       end
 
       def docker_for_database_build(database = options[:database])
         case database
-        when "mysql"          then "build-essential default-libmysqlclient-dev git"
-        when "trilogy"        then "build-essential default-libmysqlclient-dev git"
-        when "postgresql"     then "build-essential git libpq-dev"
-        when "sqlite3"        then "build-essential git"
+        when "mysql2"                      then "build-essential git default-libmysqlclient-dev"
+        when "postgresql"                  then "build-essential git libpq-dev"
+        when "sqlite3", "mysql", "trilogy" then "build-essential git"
         else nil
         end
       end
 
       def docker_for_database_deploy(database = options[:database])
         case database
-        when "mysql"          then "curl default-mysql-client libvips"
-        when "trilogy"        then "curl default-mysql-client libvips"
-        when "postgresql"     then "curl libvips postgresql-client"
-        when "sqlite3"        then "curl libsqlite3-0 libvips"
+        when "mysql", "mysql2", "trilogy" then "curl libvips default-mysql-client"
+        when "postgresql"                 then "curl libvips postgresql-client"
+        when "sqlite3"                    then "curl libvips libsqlite3-0"
         else nil
         end
       end
@@ -61,7 +59,7 @@ module Rails
 
       def build_package_for_database(database = options[:database])
         case database
-        when "mysql" then "default-libmysqlclient-dev"
+        when "mysql2" then "default-libmysqlclient-dev"
         when "postgresql" then "libpq-dev"
         else nil
         end
@@ -69,7 +67,7 @@ module Rails
 
       def deploy_package_for_database(database = options[:database])
         case database
-        when "mysql" then "default-mysql-client"
+        when "mysql", "mysql2", "trilogy" then "default-mysql-client"
         when "postgresql" then "postgresql-client"
         when "sqlite3" then "libsqlite3-0"
         else nil

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -106,6 +106,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile"
   end
 
+  def test_default_mysql_adapter_is_trilogy
+    run_generator([destination_root, "--database=mysql"])
+    FileUtils.cd(destination_root) do
+      assert_match(/gem "trilogy"/, File.read("Gemfile"))
+    end
+  end
+
   def test_assets
     run_generator
 


### PR DESCRIPTION
Trilogy has been production tested on very large Rails applications in the wild, is much easier to install than `mysql2` as it doesn't depend on `libmysqlclient`, and generally is better maintained and performs better.

Addtionally it has always bothered me that you need to pass a `mysql2://` or `trilogy://` `DATABASE_URL` as it's a leaky abstraction, the `DATABASE_URL` should specify the protocol, not the client used.

`rails new --database=mysql` will now generate an application using Trilogy.

`DATABASE_URL=mysql://host` will now use the trilogy adapter.

This has no impact on existing applications.

FYI: @kmcphillips @adrianna-chang-shopify 