### PR TITLE
Allow the MySQL adapter implementation to be configured in an Active Record config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow database adapters to be registered through `ActiveRecord::ConnectionAdapters#register`.
+
+    Set the MySQL adapter to `mysql://...` or `adapter: mysql` in the database configuration, and
+    configure rails to use either `:mysql2` or `:trilogy` as the concrete adapter via the
+    `ActiveRecord.mysql_adapter` config.
+
+    *Jean Boussier*, *Kevin McPhillips*
+
 *   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -464,6 +464,15 @@ module ActiveRecord
     Marshalling.format_version = value
   end
 
+  ##
+  # :singleton-method:
+  # Sets the database connection adapter to be used when the adapter <tt>mysql</tt> is specified.
+  # Accepted values are <tt>:mysql2</tt>, <tt>:trilogy</tt>, and <tt>nil</tt> which does not register
+  # any <tt>mysql</tt> adapter alias.
+  # Defaults to <tt>nil</tt>.
+  singleton_class.attr_accessor :mysql_adapter
+  self.mysql_adapter = nil
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -469,9 +469,9 @@ module ActiveRecord
   # Sets the database connection adapter to be used when the adapter <tt>mysql</tt> is specified.
   # Accepted values are <tt>:mysql2</tt>, <tt>:trilogy</tt>, and <tt>nil</tt> which does not register
   # any <tt>mysql</tt> adapter alias.
-  # Defaults to <tt>nil</tt>.
+  # Defaults to <tt>:trilogy</tt>.
   singleton_class.attr_accessor :mysql_adapter
-  self.mysql_adapter = nil
+  self.mysql_adapter = :trilogy
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -28,7 +28,12 @@ module ActiveRecord
       #   ActiveRecord::ConnectionAdapters.alias("trilogy", as: "mysql")
       #
       def alias(original, as:)
-        resolve(original) # will raise if original is invalid or does not exist
+        unless @adapters.key?(original.to_s)
+          raise AdapterNotFound, <<~MSG.squish
+            Cannot alias '#{original}' as '#{as}' adapter because '#{original}' adapter does not exist.
+            Available adapters are: #{@adapters.keys.sort.join(", ")}.
+          MSG
+        end
         register(as, *@adapters[original.to_s])
       end
 

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -21,6 +21,17 @@ module ActiveRecord
         @adapters[name.to_s] = [class_name, path]
       end
 
+      # Registers name alias for a database adapter.
+      #
+      # == Example
+      #
+      #   ActiveRecord::ConnectionAdapters.alias("trilogy", as: "mysql")
+      #
+      def alias(original, as:)
+        resolve(original) # will raise if original is invalid or does not exist
+        register(as, *@adapters[original.to_s])
+      end
+
       def resolve(adapter_name) # :nodoc:
         # Require the adapter itself and give useful feedback about
         #   1. Missing adapter gems.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -300,6 +300,12 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.mysql_adapter" do |app|
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::ConnectionAdapters.alias(ActiveRecord.mysql_adapter, as: "mysql") if ActiveRecord.mysql_adapter
+      end
+    end
+
     # This sets the database configuration from Configuration#database_configuration
     # and then establishes the connection.
     initializer "active_record.initialize_database" do

--- a/activerecord/test/cases/connection_adapters/registration_test.rb
+++ b/activerecord/test/cases/connection_adapters/registration_test.rb
@@ -44,6 +44,24 @@ module ActiveRecord
 
         assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve(:fake).name
       end
+
+      test "#alias registers a new adapter alias with the same class and location as the original" do
+        ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
+        ActiveRecord::ConnectionAdapters.alias("fake", as: "potato")
+        assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve("potato").name
+      end
+
+      test "#alias accepts symbol keys" do
+        ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
+        ActiveRecord::ConnectionAdapters.alias(:fake, as: :potato)
+        assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve("potato").name
+      end
+
+      test "#alias raises if the original is invalid" do
+        assert_raises(ActiveRecord::AdapterNotFound) do
+          ActiveRecord::ConnectionAdapters.alias("carrot", as: "potato")
+        end
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -6,11 +6,14 @@
 # Ensure the MySQL gem is defined in your Gemfile
 #   gem "mysql2"
 #
+# Ensure the Active Record is configured to use mysql2
+#   config.active_record.mysql_adapter = :mysql2
+#
 # And be sure to use new-style password hashing:
 #   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
 default: &default
-  adapter: mysql2
+  adapter: mysql
   encoding: utf8mb4
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
@@ -39,7 +42,7 @@ test:
 # Instead, provide the password or a full connection URL as an environment
 # variable when you boot the app. For example:
 #
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="mysql://myuser:mypass@localhost/somedatabase"
 #
 # If the connection URL is provided in the special DATABASE_URL environment
 # variable, Rails will automatically merge its configuration values on top of

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -6,11 +6,14 @@
 # Ensure the MySQL gem is defined in your Gemfile
 #   gem "trilogy"
 #
+# Ensure the Active Record is configured to use trilogy
+#   config.active_record.mysql_adapter = :trilogy
+#
 # And be sure to use new-style password hashing:
 #   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
 #
 default: &default
-  adapter: trilogy
+  adapter: mysql
   encoding: utf8mb4
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
@@ -39,7 +42,7 @@ test:
 # Instead, provide the password or a full connection URL as an environment
 # variable when you boot the app. For example:
 #
-#   DATABASE_URL="trilogy://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="mysql://myuser:mypass@localhost/somedatabase"
 #
 # If the connection URL is provided in the special DATABASE_URL environment
 # variable, Rails will automatically merge its configuration values on top of

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -63,11 +63,14 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  <%- end -%>
+  <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+  # Database adapter used for MySQL. Supports `:mysql2` and `:trilogy`.
+  config.active_record.mysql_adapter = <%= options[:database] == "trilogy" ? ":trilogy" : ":mysql2" %>
+
+  <%- end -%><%- end -%>
   <%- unless options[:skip_active_job] -%>
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
-
   <%- end -%>
   <%- unless skip_sprockets? -%>
   # Suppress logger output for asset requests.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -99,8 +99,12 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  <%- end -%>
 
+  <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+  # Database adapter used for MySQL. Supports `:mysql2` and `:trilogy`.
+  config.active_record.mysql_adapter = <%= options[:database] == "trilogy" ? ":trilogy" : ":mysql2" %>
+
+  <%- end -%><%- end -%>
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -47,6 +47,11 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   <%- end -%>
+  <%- unless options.skip_active_record? %><%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+  # Database adapter used for MySQL. Supports `:mysql2` and `:trilogy`.
+  config.active_record.mysql_adapter = <%= options[:database] == "trilogy" ? ":trilogy" : ":mysql2" %>
+
+  <%- end -%><%- end -%>
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
Continuation of #50064 and #50093 with @byroot 

This adds the `mysql://` or `adapter: mysql` alias to be put in DB config or deploy ENV, and then allows the application to be configured to either use `mysql2` or `trilogy` as the concrete adapter. This separates environment config (ie. "this app uses MySQL and here are the credentials") from adapter choice and implementation (ie. "connect to the database from the app using trilogy or mysql2"). It also provides an easy test/upgrade path without changing the env.

It makes `mysql` the default adapter generated for new rails apps that use MySQL, but it keeps `mysql2` as the default adapter used. It's a different approach than #50110 but here it's easily swappable as to which generates by default.


### Is `alias` really necessary?

I proposed adding this once before and discussed it with Matthew and we decided to remove it. https://github.com/rails/rails/pull/50093#issuecomment-1817531767

I've added it back here for a couple reasons.

The `ActiveRecord::ConnectionAdapters` does not expose what the class name and path are for registered adapters. Since you cannot query that you cannot retrieve those two values to add an alias, so you'd need to be repeating those configuration strings in wherever you add the alias through `register()`. 

It would also mean we would need to somewhere (like in an initializer) define a switch statement like:

```ruby
case ActiveRecord.mysql_adapter
when :trilogy, "trilogy"
  ActiveRecord::ConnectionAdapters.register("mysql", "ActiveRecord::ConnectionAdapters::TrilogyAdapter", "active_record/connection_adapters/trilogy_adapter")
when :mysql2, "mysql2"
  ActiveRecord::ConnectionAdapters.register("mysql2", "ActiveRecord::ConnectionAdapters::Mysql2Adapter", "active_record/connection_adapters/mysql2_adapter")
when nil
  # noop
else
  raise "uknown adapter etc."
end
```

This reimplements some of the connection lookup validation and the location/class names of the adapters. It is very much not **DRY**.  It is also not **open/closed** as this is extremely not open for extension as we cannot easily add to the list. I could not write code that I was happy with without this.


### Why is the default `mysql_adapter` config `nil`?

I'm a little unsure on what the best behaviour is here. If we set `ActiveRecord.mysql_adapter = :trilogy` or whatever as default, the initializer attempts to alias to it no matter what. So if the app is using Postgres or SQLite it will reference the MySQL adapter(s) that are not loaded and raise.

But because the aliasing must be done before the adapters are loaded, _we do not know if we are using MySQL in the app or not_. So, the default is `nil` and it does nothing, but the _default generated app adds the config_. That makes it easy to update later.


### Should the default be `:trilogy`?

I don't know! That's a Rails vision/direction question. Easy to change that here (or soon after).