### PR TITLE
Removed Performance/UnfreezeString cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -334,9 +334,6 @@ Performance/ReverseEach:
 Performance/StringReplacement:
   Enabled: true
 
-Performance/UnfreezeString:
-  Enabled: true
-
 Performance/DeletePrefix:
   Enabled: true
 


### PR DESCRIPTION
### Motivation / Background

As per the discussion in https://github.com/rails/rails/pull/50100#issuecomment-1818973562 , decided to disable the `Performance/UnfreezeString` cop, as it makes  some confusion in the code. 
After the change in https://github.com/ruby/ruby/pull/8952, `String#dup` also having the same performance of `String#+@`.

### Detail

This Pull Request disable the ` Performance/UnfreezeString` cop from rubocop.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @byroot 
