### PR TITLE
Rebuild Action Text's JavaScript

### DIFF
--- a/actiontext/app/assets/javascripts/actiontext.esm.js
+++ b/actiontext/app/assets/javascripts/actiontext.esm.js
@@ -771,9 +771,9 @@ function start() {
 }
 
 function didClick(event) {
-  const {target: target} = event;
-  if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
-    submitButtonsByForm.set(target.form, target);
+  const submitButton = event.target.closest(":is(button, input)[type='submit']");
+  if (submitButton && submitButton.form) {
+    submitButtonsByForm.set(submitButton.form, submitButton);
   }
 }
 

--- a/actiontext/app/assets/javascripts/actiontext.js
+++ b/actiontext/app/assets/javascripts/actiontext.js
@@ -753,9 +753,9 @@
     }
   }
   function didClick(event) {
-    const {target: target} = event;
-    if ((target.tagName == "INPUT" || target.tagName == "BUTTON") && target.type == "submit" && target.form) {
-      submitButtonsByForm.set(target.form, target);
+    const submitButton = event.target.closest(":is(button, input)[type='submit']");
+    if (submitButton && submitButton.form) {
+      submitButtonsByForm.set(submitButton.form, submitButton);
     }
   }
   function didSubmitForm(event) {


### PR DESCRIPTION
Follow-up to #48290.

This incorporates recent changes from Active Storage's JavaScript.

---

This fixes [Action Text's `JavascriptPackageTest`](https://github.com/rails/rails/blob/0ad26f789013f3e07d7dc453303a8240a4da0d38/actiontext/test/javascript_package_test.rb) when running locally:

```console
$ cd actiontext
$ bin/test test/javascript_package_test.rb

Failure:
JavascriptPackageTest#test_compiled_code_is_in_sync_with_source_code [rails/actiontext/test/javascript_package_test.rb:14]:
#<Proc:0x00007fcf3ebea0e0 rails/actiontext/test/javascript_package_test.rb:14 (lambda)> changed.
--- expected
+++ actual
@@ -753,9 +753,9 @@
     }
   }
   function didClick(event) {
-    const {target: target} = event;
-    if ((target.tagName == \"INPUT\" || target.tagName == \"BUTTON\") && target.type == \"submit\" && target.form) {
-      submitButtonsByForm.set(target.form, target);
+    const submitButton = event.target.closest(\":is(button, input)[type='submit']\");
+    if (submitButton && submitButton.form) {
+      submitButtonsByForm.set(submitButton.form, submitButton);
     }
   }
   function didSubmitForm(event) {
@@ -1633,9 +1633,9 @@
 }

 function didClick(event) {
-  const {target: target} = event;
-  if ((target.tagName == \"INPUT\" || target.tagName == \"BUTTON\") && target.type == \"submit\" && target.form) {
-    submitButtonsByForm.set(target.form, target);
+  const submitButton = event.target.closest(\":is(button, input)[type='submit']\");
+  if (submitButton && submitButton.form) {
+    submitButtonsByForm.set(submitButton.form, submitButton);
   }
 }
```

It's unclear why this test does not currently fail in CI for `main`, though [it did fail](https://buildkite.com/rails/rails/builds/102112#018bedd3-812b-4d84-a585-5c8311273f8c/1089-1220) for `7-1-stable` when #48290 was backported.
