### PR TITLE
Create an :active_record_connection_adapters load hook

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Create an `active_record_connection_adapters` load hook which is run after
+    `ActiveRecord::ConnectionAdapters` is defined. It can be used to register custom
+    connection adapters.
+
+    *Andrew Novoselac*
+
 *   `DatabaseConfigurations#configs_for` can accept a symbol in the `name` parameter.
 
     *Andrew Novoselac*

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -69,6 +69,8 @@ module ActiveRecord
     register "trilogy", "ActiveRecord::ConnectionAdapters::TrilogyAdapter", "active_record/connection_adapters/trilogy_adapter"
     register "postgresql", "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter", "active_record/connection_adapters/postgresql_adapter"
 
+    ActiveSupport.run_load_hooks(:active_record_connection_adapters, self)
+
     eager_autoload do
       autoload :AbstractAdapter
     end

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1486,6 +1486,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveModel::Model`                 | `active_model`                       |
 | `ActiveRecord::Base`                 | `active_record`                      |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
+| `ActiveRecord::ConnectionAdapters`   | `active_record_connection_adapters`  |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |
 | `ActiveRecord::ConnectionAdapters::Mysql2Adapter`        | `active_record_mysql2adapter`        |
 | `ActiveRecord::ConnectionAdapters::TrilogyAdapter`       | `active_record_trilogyadapter`       |


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/commit/009c7e74117690f0dbe200188a929b345c9306c1 introduced a new API for registering connection adapters. This week, I began implementing this in my app. We have some custom adapters. So my thought was to register than in an `:active_record` load hook. However, I realized that some load hooks might try to establish a connection (for example [here in Rails](https://github.com/rails/rails/blob/c00932949f4bb6e12847b957abdb920440cea325/activerecord/lib/active_record/railtie.rb#L309)), so that introduces an element of order dependence. If the hook registering my custom adapter is not executed first, then establishing a connection will raise an exception. Of course, you can make it work with a `before` but it seems brittle to me.

### Detail

This Pull Request introduces a new `active_record_connection_adapters` load hook that can be used to register adapters. I run the load hook immediately after `ConnectionAdapters` is defined and the default adapters are registered. That way they will always be registered by the time we begin running the `active_record` hooks, which are liable to establish connections.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
