### PR TITLE
ActiveJob: removing redundant if statement on Arguments serialization of String

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -73,14 +73,10 @@ module ActiveJob
         when nil, true, false, Integer, Float # Types that can hardly be subclassed
           argument
         when String
-          if argument.class == String
+          begin
+            Serializers.serialize(argument)
+          rescue SerializationError
             argument
-          else
-            begin
-              Serializers.serialize(argument)
-            rescue SerializationError
-              argument
-            end
           end
         when GlobalID::Identification
           convert_to_global_id_hash(argument)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

After changes from #50090 and #50122, a redundant if statement remains on Arguments#serialize on String related classes serialization. A comment related to this was added [here](https://github.com/rails/rails/pull/50122#issuecomment-1820901068).

### Detail

When the begin/rescue statement was added to the else clause the if clause began to be scoped on the rescue clause as StringSerializer is not defined and will throw SerializationError (same current behaviour as other String subclasses without defined serializers). As if clause and rescue clause share same result, the if clause started to be redundant.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
