### PR TITLE
Fix: Preloader should no longer overwrites built records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -245,7 +245,8 @@ module ActiveRecord
             association = owner.association(reflection.name)
 
             if reflection.collection?
-              association.target = records
+              association.loaded!
+              association.target.concat(records)
             else
               association.target = records.first
             end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1452,6 +1452,51 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_match(expectation, preload_sql)
     assert_equal order, loaded_order_agreement.order
   end
+
+  def test_preload_keeps_built_has_many_records_no_ops
+    post = Post.new
+    comment = post.comments.build
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments).call
+
+      assert_equal [comment], post.comments.to_a
+    end
+  end
+
+  def test_preload_keeps_built_has_many_records_after_query
+    post = posts(:welcome)
+    comment = post.comments.build
+
+    assert_queries(1) do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments).call
+
+      assert_includes post.comments.to_a, comment
+    end
+  end
+
+
+  def test_preload_keeps_built_belongs_to_records_no_ops
+    post = Post.new
+    author = post.build_author
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :author).call
+
+      assert_same author, post.author
+    end
+  end
+
+  def test_preload_keeps_built_belongs_to_records_after_query
+    post = posts(:welcome)
+    author = post.build_author
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :author).call
+
+      assert_same author, post.author
+    end
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase


### PR DESCRIPTION
In short, this change makes it so that using ActiveRecord::Associations::Preloader doesn't overwrite / lose state.

Right now, here is how things are:

```ruby
post = Post.last
post.comments.build
ActiveRecord::Associations::Preloader.new(records: [post], associations: :comment)
post.comments.to_a
```

The last line would not return the comment that was built. This is unintuitive and was changed in Rails 6.0. In Rails 5.2, this code behave as one would expect and still contains the persisted comment.

Considering that the commit that introduced this behaviors was to fix a problem that, it turns out, was also fixed differently, this change is just a partial revert of said commit with no ill effects.

It would be nice to backport this to at least 7.1 since it's so new. The code hasn't changed since Rails 7.0 so that would be easy too. I'm willing to do it if there is openness to such a backport.

### Investigation

In effect, this PR undoes changes made in https://github.com/rails/rails/commit/5f9e05048d409b9c3fb35a3620fe361fb03dd4e1 which introduced this bug.

Here is the story:

Starting after Rails 5.2

(Bug1) If you have 2 distinct but equal records given to preload, only one of them will receive the preloaded records.

(BugfixA) https://github.com/rails/rails/commit/9897f50ae77d5880bac292ac35873490669fc107
This fixes Bug1. The #uniq was removing the extra distinct but equal records, so only one of them would receive sub-records in its associations.
But there is a new bug!

(Bug2) If you have a single instance twice in the records to preload on, it receives the sub-records multiple time.

(BugfixB): https://github.com/rails/rails/commit/5f9e05048d409b9c3fb35a3620fe361fb03dd4e1
This fixes Bug2. And is what I am reverting.
Instead of adding the preloaded data to what was already in the association, the received data overwrites the data that was already there.
But there is a new bug!

(Bug3) If you had unpersisted data in the association being preloaded (using #build for example), it will be gone!
This is the bug this PR wants to fix.

(BugfixC) https://github.com/rails/rails/commit/a4b20e4ffcdc9726f210c4e828927768497d7392
**This fix doesn't resolve Bug3.** 
But it also fixes Bug2, and does it more correctly. It does a better `#uniq` than the one that was removed by BugfixA due to Bug1.
Unlike BugfixB, BuugfixC doesn't introduce Bug3.

So at this point, it's safe to undo BugfixB, at least the part that causes Bug3:

* Bug2 doesn't get brought back because BugfixC also fixes it.

This is what this PR is doing, while also adding tests.

I'd like to thank `git bisect` for making this investigation so much simpler than it would have been otherwise xD