### PR TITLE
Add `multiple_of` option to `ActiveModel::Validations::NumericalityValidator`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add a `multiple_of` option to the `numericality` validator.
+
+      ```ruby
+      class MyModel
+        validates :offset, numericality: { multiple_of: 7 }
+      end
+
+      model = MyModel.new
+
+      model.offset = -7
+      model.valid? # => true
+
+      model.offset = 0
+      model.valid? # => true
+
+      model.offset = 7
+      model.valid? # => true
+
+      model.offset = 10
+      model.valid? # => false
+      ```
+
+    *Joshua Young*
+
 *   Port the `type_for_attribute` method to Active Model. Classes that include
     `ActiveModel::Attributes` will now provide this method. This method behaves
     the same for Active Model as it does for Active Record.

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add a `multiple_of` option to the `numericality` validator.
+
+      ```ruby
+      class MyModel
+        validates :offset, numericality: { multiple_of: 7 }
+      end
+
+      model = MyModel.new
+
+      model.offset = -7
+      model.valid? # => true
+
+      model.offset = 0
+      model.valid? # => true
+
+      model.offset = 7
+      model.valid? # => true
+
+      model.offset = 10
+      model.valid? # => false
+      ```
+
+    *Joshua Young*
+
 *   Implement `ActiveModel::Type::Binary::Data#as_json`
 
     Delegates JSON conversion to the underlying binary data value (instead of

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -33,6 +33,7 @@ en:
       less_than: "must be less than %{count}"
       less_than_or_equal_to: "must be less than or equal to %{count}"
       other_than: "must be other than %{count}"
+      multiple_of: "must be a multiple of %{count}"
       in: "must be in %{count}"
       odd: "must be odd"
       even: "must be even"

--- a/activemodel/lib/active_model/validations/comparability.rb
+++ b/activemodel/lib/active_model/validations/comparability.rb
@@ -5,7 +5,7 @@ module ActiveModel
     module Comparability # :nodoc:
       COMPARE_CHECKS = { greater_than: :>, greater_than_or_equal_to: :>=,
         equal_to: :==, less_than: :<, less_than_or_equal_to: :<=,
-        other_than: :!= }.freeze
+        other_than: :!=, multiple_of: :multiple_of? }.freeze
 
       def error_options(value, option_value)
         options.except(*COMPARE_CHECKS.keys).merge!(

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -2,6 +2,7 @@
 
 require "active_model/validations/comparability"
 require "active_model/validations/resolve_value"
+require "active_support/core_ext/integer/multiple"
 require "bigdecimal/util"
 
 module ActiveModel
@@ -186,6 +187,9 @@ module ActiveModel
       # * <tt>:other_than</tt> - Specifies the value must be other than the
       #   supplied value. The default error message for this option is _"must be
       #   other than %{count}"_.
+      # * <tt>:multiple_of</tt> - Specifies the value must be a multiple of
+      #   the supplied value. The default error message for this option
+      #   is _"must be a multiple of %{count}"_.
       # * <tt>:odd</tt> - Specifies the value must be an odd number. The default
       #   error message for this option is _"must be odd"_.
       # * <tt>:even</tt> - Specifies the value must be an even number. The

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -12,15 +12,16 @@ module ActiveModel
 
       RANGE_CHECKS = { in: :in? }.freeze
       NUMBER_CHECKS = { odd: :odd?, even: :even? }.freeze
+      MULTIPLE_CHECK = :multiple_of
 
-      RESERVED_OPTIONS = COMPARE_CHECKS.keys + NUMBER_CHECKS.keys + RANGE_CHECKS.keys + [:only_integer, :only_numeric]
+      RESERVED_OPTIONS = COMPARE_CHECKS.keys + NUMBER_CHECKS.keys + RANGE_CHECKS.keys + [MULTIPLE_CHECK, :only_integer, :only_numeric]
 
       INTEGER_REGEX = /\A[+-]?\d+\z/
 
       HEXADECIMAL_REGEX = /\A[+-]?0[xX]/
 
       def check_validity!
-        options.slice(*COMPARE_CHECKS.keys).each do |option, value|
+        options.slice(*COMPARE_CHECKS.keys, MULTIPLE_CHECK).each do |option, value|
           unless value.is_a?(Numeric) || value.is_a?(Proc) || value.is_a?(Symbol)
             raise ArgumentError, ":#{option} must be a number, a symbol or a proc"
           end
@@ -51,6 +52,11 @@ module ActiveModel
             unless value.to_i.public_send(NUMBER_CHECKS[option])
               record.errors.add(attr_name, option, **filtered_options(value))
             end
+          elsif option == MULTIPLE_CHECK
+            option_value = option_as_number(record, option_value, precision, scale)
+            unless multiple_of?(value, option_value)
+              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
+            end
           elsif RANGE_CHECKS.include?(option)
             option_value = resolve_value(record, option_value)
             unless option_value.is_a?(Range)
@@ -69,6 +75,10 @@ module ActiveModel
       end
 
     private
+      def multiple_of?(value, divisor)
+        divisor == 0 ? value == 0 : value % divisor == 0
+      end
+
       def option_as_number(record, option_value, precision, scale)
         parse_as_number(resolve_value(record, option_value), precision, scale)
       end
@@ -190,6 +200,9 @@ module ActiveModel
       # * <tt>:other_than</tt> - Specifies the value must be other than the
       #   supplied value. The default error message for this option is _"must be
       #   other than %{count}"_.
+      # * <tt>:multiple_of</tt> - Specifies the value must be a multiple of
+      #   the supplied value. The default error message for this option
+      #   is _"must be a multiple of %{count}"_.
       # * <tt>:odd</tt> - Specifies the value must be an odd number. The default
       #   error message for this option is _"must be odd"_.
       # * <tt>:even</tt> - Specifies the value must be an even number. The
@@ -212,6 +225,7 @@ module ActiveModel
       # * <tt>:only_integer</tt>
       # * <tt>:other_than</tt>
       # * <tt>:in</tt>
+      # * <tt>:multiple_of</tt>
       #
       # For example:
       #

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -237,6 +237,21 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_valid_values([1, 2, 3])
   end
 
+  def test_validates_numericality_with_multiple_of
+    Topic.validates_numericality_of :approved, multiple_of: 2
+
+    assert_invalid_values([-1, 1, 3], "must be a multiple of 2")
+    assert_valid_values([-2, 0, 2, 4])
+  end
+
+  def test_validates_numericality_with_multiple_of_positive_only
+    Topic.validates_numericality_of :approved, multiple_of: 2, greater_than: 0
+
+    assert_invalid_values([-2, -1, 0], "must be greater than 0")
+    assert_invalid_values([1, 3], "must be a multiple of 2")
+    assert_valid_values([2, 4, 6])
+  end
+
   def test_validates_numericality_with_other_than_using_string_value
     Topic.validates_numericality_of :approved, other_than: 0
 

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -237,6 +237,28 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_valid_values([1, 2, 3])
   end
 
+  def test_validates_numericality_with_multiple_of
+    Topic.validates_numericality_of :approved, multiple_of: 2
+
+    assert_invalid_values([-1, 1, 3], "must be a multiple of 2")
+    assert_valid_values([-2, 0, 2, 4])
+  end
+
+  def test_validates_numericality_with_multiple_of_using_decimals
+    Topic.validates_numericality_of :approved, multiple_of: 0.1
+
+    assert_invalid_values([0.15, "0.25"], "must be a multiple of 0.1")
+    assert_valid_values([0.3, "0.5"])
+  end
+
+  def test_validates_numericality_with_multiple_of_positive_only
+    Topic.validates_numericality_of :approved, multiple_of: 2, greater_than: 0
+
+    assert_invalid_values([-2, -1, 0], "must be greater than 0")
+    assert_invalid_values([1, 3], "must be a multiple of 2")
+    assert_valid_values([2, 4, 6])
+  end
+
   def test_validates_numericality_with_in_and_proc_as_value
     Topic.validates_numericality_of :approved, in: ->(o) { 1..3 }
 


### PR DESCRIPTION
### Motivation / Background

Implements https://discuss.rubyonrails.org/t/add-multiple-of-option-to-activemodel-numericalityvalidator/84263.

This generalizes the existing `odd` and `even` numericality checks and aligns with JSON Schema's `multipleOf` constraint.

### Detail

Adds a `multiple_of` option to `ActiveModel::Validations::NumericalityValidator` for integer and decimal values. Like the comparison options, its divisor may be a number, symbol, or proc.
