### PR TITLE
Fix port not displayed on host connection errors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix port not being included on database connection errors.
+
+    *Hartley McGuire*
+
 *   In cases where MySQL returns `warning_count` greater than zero, but returns no warnings when
     the `SHOW WARNINGS` query is executed, `ActiveRecord.db_warnings_action` proc will still be
     called with a generic warning message rather than silently ignoring the warning(s).

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           when ER_DBACCESS_DENIED_ERROR, ER_ACCESS_DENIED_ERROR
             raise ActiveRecord::DatabaseConnectionError.username_error(config[:username])
           when ER_CONN_HOST_ERROR, ER_UNKNOWN_HOST_ERROR
-            raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host], config[:port])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -64,7 +64,7 @@ module ActiveRecord
           elsif conn_params && conn_params[:user] && error.message.include?(conn_params[:user])
             raise ActiveRecord::DatabaseConnectionError.username_error(conn_params[:user])
           elsif conn_params && conn_params[:host] && error.message.include?(conn_params[:host])
-            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:host])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:host], conn_params[:port])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -52,7 +52,7 @@ module ActiveRecord
             ActiveRecord::DatabaseConnectionError.username_error(config[:username])
           else
             if error.message.include?("TRILOGY_DNS_ERROR")
-              ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
+              ActiveRecord::DatabaseConnectionError.hostname_error(config[:host], config[:port])
             else
               ActiveRecord::ConnectionNotEstablished.new(error.message)
             end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -96,9 +96,11 @@ module ActiveRecord
     end
 
     class << self
-      def hostname_error(hostname)
+      def hostname_error(hostname, port = nil)
+        port_suffix = ":#{port}" if port
+
         DatabaseConnectionError.new(<<~MSG)
-          There is an issue connecting with your hostname: #{hostname}.\n
+          There is an issue connecting with your hostname: #{hostname}#{port_suffix}.\n
           Please check your database configuration and ensure there is a valid connection to your database.
         MSG
       end


### PR DESCRIPTION
### Motivation / Background

Ref #50125

A [previous change][1] added a more specific interface for some database connection errors, with the goal to provide Actionable Errors for some of these issues in development. However, the errors concerning not being able to connect to a specified hostname ended up displaying less information than before. Now, they only display the hostname instead of also including the port, even though that information is also very necessary when debugging connection issues.

### Detail

This commit adds the port to the messages concerning hostname so that a more "complete" hostname is displayed to the user on connection issues.

[1]: https://github.com/rails/rails/commit/b28711ffa015217e2c24c87152a2f37d8aca1c83

### Additional Information

Since the referenced commit first appeared in 7.0, I would love for this to be backported to 7-1-stable and 7-0-stable.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
