### PR TITLE
Implement `Duration#negative?` without calling `public_send`

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -422,6 +422,11 @@ module ActiveSupport
       Duration === other && other.value.eql?(value)
     end
 
+    # Returns +true+ if the duration is less than 0 seconds.
+    def negative?
+      @value < 0
+    end
+
     def hash
       @value.hash
     end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -760,6 +760,16 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal expected_time, time + ActiveSupport::Duration.build(-1)
   end
 
+  def test_duration_negative
+    assert_not 1.hours.negative?
+    assert_not 1.days.negative?
+    assert_not (1.weeks - 1.days).negative?
+
+    assert_predicate -1.weeks, :negative?
+    assert_predicate -1.seconds, :negative?
+    assert_predicate (1.hours - 1.days), :negative?
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
### Motivation / Background

Inspired by @casperisfine change in https://github.com/rails/rails/pull/49909.

For codebases using `ActiveSupport::Duration` extensively, checking if the duration is negative currently requires going through the `method_missing` mechanism and a `public_send`` call which can be quite slow.

Instead, we can implement the method natively and get the check executed almost 4x faster.

Here's some benchmark:

```
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [arm64-darwin21]
Warming up --------------------------------------
           negative?   588.000  i/100ms
    negative_native?     2.544k i/100ms
Calculating -------------------------------------
           negative?      6.738k (± 1.9%) i/s -     34.104k in   5.063211s
    negative_native?     25.804k (± 1.3%) i/s -    129.744k in   5.028821s

Comparison:
           negative?:     6738.1 i/s
    negative_native?:    25804.4 i/s - 3.83x  (± 0.00) faster
```

```rb
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'activesupport'
end

require 'active_support/all'

class ActiveSupport::Duration
  def negative_native?
    @value < 0
  end
end

values = 1000.times.map do |i|
  rand(-100..100).hours
end

puts RUBY_DESCRIPTION
Benchmark.ips do |x|
  x.report("negative?") do
    values.each do |v|
      v.negative?
    end
  end

  x.report("negative_native?") do
    values.each do |v|
      v.negative_native?
    end
  end

  x.compare!(order: :baseline)
end
```

### Detail

This pull request implements `ActiveSupport::Duration#negative?` without relying on `method_missing` and `public_send`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
