### PR TITLE
Add a `ActiveRecord.protocol_adapters` configuration to map `DATABASE_URL` protocols to adapters at an application level

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   When using a `DATABASE_URL`, allow for a configuration to map the protocol in the URL to a specific database
+    adapter. This allows decoupling the adapter the application chooses to use from the database connection details
+    set in the deployment environment.
+
+    ```ruby
+    # ENV['DATABASE_URL'] = "mysql://localhost/example_database"
+    config.active_record.protocol_adapters.mysql = "trilogy"
+    # will connect to MySQL using the trilogy adapter
+    ```
+
+    *Jean Boussier*, *Kevin McPhillips*
+
 *   In cases where MySQL returns `warning_count` greater than zero, but returns no warnings when
     the `SHOW WARNINGS` query is executed, `ActiveRecord.db_warnings_action` proc will still be
     called with a generic warning message rather than silently ignoring the warning(s).

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -25,6 +25,7 @@
 
 require "active_support"
 require "active_support/rails"
+require "active_support/ordered_options"
 require "active_model"
 require "arel"
 require "yaml"
@@ -463,6 +464,34 @@ module ActiveRecord
   def self.marshalling_format_version=(value)
     Marshalling.format_version = value
   end
+
+  ##
+  # :singleton-method:
+  # Provides a mapping between database protocols/DBMSs and the
+  # underlying database adapter to be used. This is used only by the
+  # <tt>DATABASE_URL</tt> environment variable.
+  #
+  # == Example
+  #
+  #   DATABASE_URL="mysql://myuser:mypass@localhost/somedatabase"
+  #
+  # The above URL specifies that MySQL is the desired protocol/DBMS, and the
+  # application configuration can then decide which adapter to use. For this example
+  # the default mapping is from <tt>mysql</tt> to <tt>mysql2</tt>, but <tt>:trilogy</tt>
+  # is also supported.
+  #
+  #   ActiveRecord.protocol_adapters.mysql = "mysql2"
+  #
+  # The protocols names are arbitrary, and external database adapters can be
+  # registered and set here.
+  singleton_class.attr_accessor :protocol_adapters
+  self.protocol_adapters = ActiveSupport::InheritableOptions.new(
+    {
+      sqlite: "sqlite3",
+      mysql: "mysql2",
+      postgres: "postgresql",
+    }
+  )
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -25,8 +25,7 @@ module ActiveRecord
       def initialize(url)
         raise "Database URL cannot be empty" if url.blank?
         @uri     = uri_parser.parse(url)
-        @adapter = @uri.scheme && @uri.scheme.tr("-", "_")
-        @adapter = "postgresql" if @adapter == "postgres"
+        @adapter = resolved_adapter
 
         if @uri.opaque
           @uri.opaque, @query = @uri.opaque.split("?", 2)
@@ -78,6 +77,12 @@ module ActiveRecord
               host: uri.hostname
             )
           end
+        end
+
+        def resolved_adapter
+          adapter = uri.scheme && @uri.scheme.tr("-", "_")
+          adapter = ActiveRecord.protocol_adapters[adapter] || adapter
+          adapter
         end
 
         # Returns name of the database.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1640,6 +1640,18 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `true`               |
 | 7.1                   | `false`              |
 
+#### `config.active_record.protocol_adapters`
+
+When using a URL to configure the database connection, this option provides a mapping from the protocol to the underlying
+database adapter. For example, this means the environment can specify `DATABASE_URL=mysql://localhost/database` and Rails will map
+`mysql` to the `mysql2` adapter, but the application can also override these mappings:
+
+```ruby
+config.active_record.protocol_adapters.mysql = "trilogy"
+```
+
+If no mapping is found, the protocol is used as the adapter name.
+
 ### Configuring Action Controller
 
 `config.action_controller` includes a number of configuration settings:
@@ -2949,6 +2961,10 @@ development:
 ```
 
 The `config/database.yml` file can contain ERB tags `<%= %>`. Anything in the tags will be evaluated as Ruby code. You can use this to pull out data from an environment variable or to perform calculations to generate the needed connection information.
+
+When using a `ENV['DATABASE_URL']` or a `url` key in your `config/database.yml` file, Rails allows mapping the protocol
+in the URL to a database adapter that can be configured from within the application. This allows the adapter to be configured
+without modifying the URL set in the deployment environment. See: [`config.active_record.protocol_adapters`](#config-active_record-protocol-adapters).
 
 
 TIP: You don't have to update the database configurations manually. If you look at the options of the application generator, you will see that one of the options is named `--database`. This option allows you to choose an adapter from a list of the most used relational databases. You can even run the generator repeatedly: `cd .. && rails new blog --database=mysql`. When you confirm the overwriting of the `config/database.yml` file, your application will be configured for MySQL instead of SQLite. Detailed examples of the common database connections are below.


### PR DESCRIPTION
This takes a completely different approach to what I attempted in #50112, cc @byroot @matthewd.


## Problem

When using a `DATABASE_URL` to define a database connection, the deployment env config needs to define the adapter used as part of the URL. The adapter is actually an application level concern, and what the env should care about is the DBMS/protocol (ie. "this rails app connects to MySQL" and not "this rails app connects to MySQL and does it using a specific adapter class")

The most obvious usecase here is toggling or transitioning between `mysql2` and `trilogy` as they are both first party DB adapters including in Rails to connect to MySQL, but the same concern holds true for custom adapters and likely any future adapters.

What the env should be able to do is say `DATABASE_URL=mysql://host/db?options=whatever` and then have the application decide that `mysql -> mysql2` or `mysql -> trilogy` without having to modify the environment.


## Solution

Add an Active Record config that provides a mapping from protocol to adapter in database URLs. Use that in the `ActiveRecord::DatabaseConfigurations::UrlConfig` (the `ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver` class internally) to map from protocol to adapter.

```ruby
config.active_record.protocol_adapters.mysql = "trilogy"
```

Build in some reasonable defaults, including removing a specific `postgres` -> `postgresql` hack that was already hardcoded in. In this case:

| Protocol  | Adapter |
| ------------- | ------------- |
| `mysql`    | `mysql2`     |
| `sqlite`   | `sqlite3`    |
| `postgres` | `postgresql` |


## What should reviewers focus on?

* Oh gosh writing good documentation is hard.
* I use `ActiveSupport::InheritableOptions` but it's not strictly necessary. It provides some indifferent access and reader conveniences, but a hash would work and just be less forgiving. 
* I added `sqlite` to `sqlite3` but I honestly have no idea if this is correct or reasonable.