### PR TITLE
Reduce object allocations in AR connection handler

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -106,7 +106,14 @@ module ActiveRecord
       # all pools belonging to the connection handler will be returned.
       def connection_pool_list(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`connection_pool_list` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
           connection_name_to_pool_manager.values.flat_map { |m| m.pool_configs(role).map(&:pool) }
         elsif role == :all
@@ -172,7 +179,14 @@ module ActiveRecord
       # pools that the ConnectionHandler is managing.
       def active_connections?(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`active_connections?` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
         end
 
@@ -184,7 +198,14 @@ module ActiveRecord
       # longer alive.
       def clear_active_connections!(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`clear_active_connections!` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
         end
 
@@ -196,7 +217,14 @@ module ActiveRecord
       # See ConnectionPool#clear_reloadable_connections! for details.
       def clear_reloadable_connections!(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`clear_reloadable_connections!` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
         end
 
@@ -205,7 +233,14 @@ module ActiveRecord
 
       def clear_all_connections!(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`clear_all_connections!` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
         end
 
@@ -217,7 +252,14 @@ module ActiveRecord
       # See ConnectionPool#flush! for details.
       def flush_idle_connections!(role = nil)
         if role.nil?
-          deprecation_for_pool_handling(__method__)
+          deprecation_for_pool_handling(
+            "`flush_idle_connections!` currently only applies to connection pools in the current " \
+            "role (use `ActiveRecord::Base.current_role` to get it). In Rails 7.2, this method " \
+            "will apply to all known pools, regardless of role. To affect only those " \
+            "connections belonging to a specific role, pass the role name as an " \
+            "argument. To switch to the new behavior, pass `:all` as the role name."
+          )
+
           role = ActiveRecord::Base.current_role
         end
 
@@ -284,20 +326,14 @@ module ActiveRecord
           connection_name_to_pool_manager.values
         end
 
-        def deprecation_for_pool_handling(method)
+        def deprecation_for_pool_handling(message)
           roles = []
           pool_managers.each do |pool_manager|
             roles << pool_manager.role_names
           end
 
           if roles.flatten.uniq.count > 1
-            ActiveRecord.deprecator.warn(<<-MSG.squish)
-              `#{method}` currently only applies to connection pools in the current
-              role (`#{ActiveRecord::Base.current_role}`). In Rails 7.2, this method
-              will apply to all known pools, regardless of role. To affect only those
-              connections belonging to a specific role, pass the role name as an
-              argument. To switch to the new behavior, pass `:all` as the role name.
-            MSG
+            ActiveRecord.deprecator.warn(message)
           end
         end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because after moving to Rails 7.1 our team experienced performance degradation

### Detail

Our Rails application is establishing connections to multiple databases (primary/replica setup) with reading/writing roles. At the same time we're using [`identity_cache`](https://github.com/Shopify/identity_cache) gem for caching capabilities. Under the hood `identity_cache` uses ActiveRecord's `ActiveRecord::Base.connection_handler.connection_pool_list` ([here](https://github.com/Shopify/identity_cache/blob/main/lib/identity_cache.rb#L119)). After we moved to Rails 7.1.2 we noticed new deprecation warnings from Active Record:

> DEPRECATION WARNING: `connection_pool_list` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name.

So that I opened pull request into `identity_cache` repo to silence deprecation by passing `ActiveRecord::Base.current_role` to `ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_pool_list` - https://github.com/Shopify/identity_cache/pull/544

We decided to deploy Rails upgrade to staging though, not waiting for new `identity_cache` version being released, while setting `Rails.application.config.active_support.deprecation = :silence`. After deployment we noticed RT degradation and started the investigation. One of things that stand out is the number of allocated objects (4 times more than before). After further investigation and profiling we noticed that the issue is probably caused by identity cache gem.

The issue is that `deprecation_for_pool_handling` method (`ActiveRecord::ConnectionAdapters::ConnectionHandler`) is allocating new string objects each time it's called while interpolating `ActiveRecord::Base.current_role`, which is not memoized in any way by itself, but also (combined with method name and HEREDOC's `squish`) causes the resulting string not to be frozen. As deprecated methods are heavily used by our application through the gem, this is enough to cause issues for us.

This Pull Request changes the way deprecation messages are built by removing dynamic part (interpolation + HEREDOC's squish). It causes those strings to be frozen because of `# frozen_string_literal: true`. This way was chosen mainly because `ActiveSupport::Deprecation` does not support lazy-like syntax (passing block to `#warn`) and it's not currently possible to add this capability without public interface changes because Deprecation may have custom behaviours configured. At the same time outputting current role in deprecation message seems to be not necessary and messages duplication in `activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb` seem to be alright as well, as they will be removed in 7.2 either way.

### Additional information

I also wrote the benchmark script to provide more visibility over this issue, you can find it [here](https://gist.github.com/eiskrenkov/8777eb4fad51a3cf821534e5c5fbac03). It's testing `ActiveRecord::ConnectionAdapters::ConnectionHandler#connection_pool_list` specifically, but results should be similar for all of the patched methods

Results:

```sh
ruby test-rails-patch.rb
```

```
Warming up --------------------------------------
       without patch     5.007k i/100ms
Calculating -------------------------------------
       without patch     50.594k (± 1.6%) i/s -    255.357k in   5.048483s
```

```sh
USING_PATCH=true ruby test-rails-patch.rb
```

```
Warming up --------------------------------------
          with patch    42.019k i/100ms
Calculating -------------------------------------
          with patch    419.994k (± 0.9%) i/s -      2.101M in   5.002782s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
