### PR TITLE
Fix ActiveModel::Dirty#*_was documentation [ci skip]

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -187,7 +187,7 @@ module ActiveModel
       #
       #   person = Person.new(name: 'Steph')
       #   person.name = 'Stephanie'
-      #   person.name_change # => ['Steph', 'Stephanie']
+      #   person.name_was # => 'Steph'
 
       ##
       # :method: *_previous_change


### PR DESCRIPTION
The docs illustrated `*_change`, not `*_was`, leaving the reader to have to guess.

### Motivation / Background

This Pull Request has been created because I was reading the ActiveModel::Dirty docs, and was confused that the `*_was` code examples didn't use any `*_was` methods.

### Detail

This Pull Request changes the documentation to illustrate what the `*_was` methods return.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
