### PR TITLE
Remove deprecations part 1

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated params via `:args` for `assert_enqueued_email_with`.
+
+    *Rafael Mendonça França*
+
 *   Remove deprecated `config.action_mailer.preview_path`.
 
     *Rafael Mendonça França*

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Remove deprecated `config.action_mailer.preview_path`.
+
+    *Rafael Mendonça França*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -25,31 +25,7 @@ module ActionMailer
       mattr_accessor :preview_interceptors, instance_writer: false, default: [ActionMailer::InlinePreviewInterceptor]
     end
 
-    def preview_path
-      ActionMailer.deprecator.warn(<<-MSG.squish)
-        Using preview_path option is deprecated and will be removed in Rails 7.2.
-        Please use preview_paths instead.
-      MSG
-      self.class.preview_paths.first
-    end
-
     module ClassMethods
-      def preview_path=(value)
-        ActionMailer.deprecator.warn(<<-MSG.squish)
-          Using preview_path= option is deprecated and will be removed in Rails 7.2.
-          Please use preview_paths= instead.
-        MSG
-        self.preview_paths << value
-      end
-
-      def preview_path
-        ActionMailer.deprecator.warn(<<-MSG.squish)
-          Using preview_path option is deprecated and will be removed in Rails 7.2.
-          Please use preview_paths instead.
-        MSG
-        self.preview_paths.first
-      end
-
       # Register one or more Interceptors which will be called before mail is previewed.
       def register_preview_interceptors(*interceptors)
         interceptors.flatten.compact.each { |interceptor| register_preview_interceptor(interceptor) }

--- a/actionmailer/lib/action_mailer/test_helper.rb
+++ b/actionmailer/lib/action_mailer/test_helper.rb
@@ -160,26 +160,6 @@ module ActionMailer
         mailer = mailer.instance_variable_get(:@mailer)
       end
 
-      if args.is_a?(Hash)
-        ActionMailer.deprecator.warn <<~MSG
-          Passing a Hash to the assert_enqueued_email_with :args kwarg causes the
-          Hash to be treated as params. This behavior is deprecated and will be
-          removed in Rails 7.2.
-
-          To specify a params Hash, use the :params kwarg:
-
-            assert_enqueued_email_with MyMailer, :my_method, params: { my_param: "value" }
-
-          Or, to specify named mailer args as a Hash, wrap the Hash in an array:
-
-            assert_enqueued_email_with MyMailer, :my_method, args: [{ my_arg: "value" }]
-            # OR
-            assert_enqueued_email_with MyMailer, :my_method, args: [my_arg: "value"]
-        MSG
-
-        params, args = args, nil
-      end
-
       args = Array(args) unless args.is_a?(Proc)
       queue ||= mailer.deliver_later_queue_name || ActiveJob::Base.default_queue_name
 

--- a/actionmailer/test/test_helper_test.rb
+++ b/actionmailer/test/test_helper_test.rb
@@ -432,11 +432,9 @@ class TestHelperMailerTest < ActionMailer::TestCase
 
   def test_assert_enqueued_email_with_with_parameterized_args
     assert_nothing_raised do
-      assert_deprecated(ActionMailer.deprecator) do
-        assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" } do
-          silence_stream($stdout) do
-            TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
-          end
+      assert_enqueued_email_with TestHelperMailer, :test_parameter_args, params: { all: "good" } do
+        silence_stream($stdout) do
+          TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
         end
       end
     end
@@ -487,9 +485,7 @@ class TestHelperMailerTest < ActionMailer::TestCase
       silence_stream($stdout) do
         TestHelperMailer.with(all: "good").test_parameter_args.deliver_later
       end
-      assert_deprecated(ActionMailer.deprecator) do
-        assert_enqueued_email_with TestHelperMailer, :test_parameter_args, args: { all: "good" }
-      end
+      assert_enqueued_email_with TestHelperMailer, :test_parameter_args, params: { all: "good" }
     end
   end
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated support to set `Rails.application.config.action_dispatch.show_exceptions` to `true` and `false`.
+
+    *Rafael Mendonça França*
+
 *   Remove deprecated `speaker`, `vibrate`, and `vr` permissions policy directives.
 
     *Rafael Mendonça França*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated constant `AbstractController::Helpers::MissingHelperError`.
+
+    *Rafael Mendonça França*
+
 *   Fix a race condition that could cause a `Text file busy - chromedriver`
     error with parallel system tests
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.
+
+    *Rafael Mendonça França*
+
+*   Remove deprecated comparison between `ActionController::Parameters` and `Hash`.
+
+    *Rafael Mendonça França*
+
 *   Remove deprecated constant `AbstractController::Helpers::MissingHelperError`.
 
     *Rafael Mendonça França*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type`.
+
+    *Rafael Mendonça França*
+
 *   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.
 
     *Rafael Mendonça França*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `speaker`, `vibrate`, and `vr` permissions policy directives.
+
+    *Rafael Mendonça França*
+
 *   Remove deprecated `Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type`.
 
     *Rafael Mendonça França*

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -6,5 +6,8 @@
 *   Add `racc` as a dependency since it will become a bundled gem in Ruby 3.4.0
 
     *Hartley McGuire*
+*   Remove deprecated constant `ActionDispatch::IllegalStateError`.
+
+    *Rafael Mendonça França*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -5,7 +5,6 @@ require "active_support/core_ext/name_error"
 
 module AbstractController
   module Helpers
-    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
     extend ActiveSupport::Concern
 
     included do
@@ -23,23 +22,6 @@ module AbstractController
 
       self._helpers = define_helpers_module(self)
     end
-
-    class DeprecatedMissingHelperError < LoadError
-      def initialize(error, path)
-        @error = error
-        @path  = "helpers/#{path}.rb"
-        set_backtrace error.backtrace
-
-        if /^#{path}(\.rb)?$/.match?(error.path)
-          super("Missing helper file helpers/%s.rb" % path)
-        else
-          raise error
-        end
-      end
-    end
-    deprecate_constant "MissingHelperError", "AbstractController::Helpers::DeprecatedMissingHelperError",
-      message: "AbstractController::Helpers::MissingHelperError has been deprecated. If a Helper is not present, a NameError will be raised instead.",
-      deprecator: AbstractController.deprecator
 
     def _helpers
       self.class._helpers

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -242,9 +242,21 @@ module ActionController
     #    config.action_controller.always_permitted_parameters = %w( controller action format )
     cattr_accessor :always_permitted_parameters, default: %w( controller action )
 
-    cattr_accessor :allow_deprecated_parameters_hash_equality, default: true, instance_accessor: false
-
     class << self
+      def allow_deprecated_parameters_hash_equality
+        ActionController.deprecator.warn <<-WARNING.squish
+          `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality` is
+          deprecated and will be removed in Rails 7.3.
+        WARNING
+      end
+
+      def allow_deprecated_parameters_hash_equality=(value)
+        ActionController.deprecator.warn <<-WARNING.squish
+          `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`
+          is deprecated and will be removed in Rails 7.3.
+        WARNING
+      end
+
       def nested_attribute?(key, value) # :nodoc:
         /\A-?\d+\z/.match?(key) && (value.is_a?(Hash) || value.is_a?(Parameters))
       end
@@ -284,20 +296,7 @@ module ActionController
       if other.respond_to?(:permitted?)
         permitted? == other.permitted? && parameters == other.parameters
       else
-        if self.class.allow_deprecated_parameters_hash_equality && Hash === other
-          ActionController.deprecator.warn <<-WARNING.squish
-            Comparing equality between `ActionController::Parameters` and a
-            `Hash` is deprecated and will be removed in Rails 7.2. Please only do
-            comparisons between instances of `ActionController::Parameters`. If
-            you need to compare to a hash, first convert it using
-            `ActionController::Parameters#new`.
-            To disable the deprecated behavior set
-            `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false`.
-          WARNING
-          @parameters == other
-        else
-          super
-        end
+        super
       end
     end
 

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -44,14 +44,7 @@ end
 # such as MIME-type negotiation, decoding parameters in POST, PATCH, or PUT
 # bodies, handling HTTP caching logic, cookies and sessions.
 module ActionDispatch
-  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
   extend ActiveSupport::Autoload
-
-  class DeprecatedIllegalStateError < StandardError
-  end
-  deprecate_constant "IllegalStateError", "ActionDispatch::DeprecatedIllegalStateError",
-    message: "ActionDispatch::IllegalStateError is deprecated without replacement.",
-    deprecator: ActionDispatch.deprecator
 
   class MissingController < NameError
   end

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -16,20 +16,6 @@ module ActionDispatch
 
       included do
         mattr_accessor :ignore_accept_header, default: false
-
-        def return_only_media_type_on_content_type=(value)
-          ActionDispatch.deprecator.warn(
-            "`config.action_dispatch.return_only_request_media_type_on_content_type` is deprecated and will" \
-              " be removed in Rails 7.2."
-          )
-        end
-
-        def return_only_media_type_on_content_type
-          ActionDispatch.deprecator.warn(
-            "`config.action_dispatch.return_only_request_media_type_on_content_type` is deprecated and will" \
-            " be removed in Rails 7.2."
-          )
-        end
       end
 
       # The MIME type of the HTTP request, such as Mime[:xml].

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -132,25 +132,6 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    %w[speaker vibrate vr].each do |directive|
-      define_method(directive) do |*sources|
-        ActionDispatch.deprecator.warn(<<~MSG)
-          The `#{directive}` permissions policy directive is deprecated
-          and will be removed in Rails 7.2.
-
-          There is no browser support for this directive, and no plan
-          for browser support in the future. You can just remove this
-          directive from your application.
-        MSG
-
-        if sources.first
-          @directives[directive] = apply_mappings(sources)
-        else
-          @directives.delete(directive)
-        end
-      end
-    end
-
     def build(context = nil)
       build_directives(context).compact.join("; ")
     end

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -186,12 +186,6 @@ module ActionDispatch
         false
       when :rescuable
         rescue_response?
-      when true
-        ActionDispatch.deprecator.warn("Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead.")
-        true
-      when false
-        ActionDispatch.deprecator.warn("Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead.")
-        false
       else
         true
       end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -51,9 +51,6 @@ module ActionDispatch
 
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
-        unless app.config.action_dispatch.respond_to?(:return_only_request_media_type_on_content_type)
-          self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_request_media_type_on_content_type
-        end
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       end
 

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -264,12 +264,6 @@ class HelperTest < ActiveSupport::TestCase
     assert_equal "smth", AllHelpersController.helpers.config.my_var
   end
 
-  def test_missing_helper_error_is_deprecated
-    assert_deprecated(AbstractController.deprecator) do
-      AbstractController::Helpers::MissingHelperError
-    end
-  end
-
   private
     def expected_helper_methods
       TestHelper.instance_methods

--- a/actionpack/test/controller/parameters/equality_test.rb
+++ b/actionpack/test/controller/parameters/equality_test.rb
@@ -19,36 +19,21 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     )
   end
 
-  test "deprecated comparison works" do
+  test "parameters are not equal to the hash" do
     @hash = @params.each_pair.to_h
-    assert_deprecated(ActionController.deprecator) do
-      assert_equal @params, @hash
-    end
-  end
-
-  test "deprecated comparison disabled" do
-    without_deprecated_params_hash_equality do
-      @hash = @params.each_pair.to_h
-      assert_not_deprecated(ActionController.deprecator) do
-        assert_not_equal @params, @hash
-      end
-    end
+    assert_not_equal @params, @hash
   end
 
   test "not eql? to equivalent hash" do
     @hash = {}
     @params = ActionController::Parameters.new(@hash)
-    assert_not_deprecated(ActionController.deprecator) do
-      assert_not @params.eql?(@hash)
-    end
+    assert_not @params.eql?(@hash)
   end
 
   test "not eql? to equivalent nested hash" do
     @params1 = ActionController::Parameters.new({ foo: {} })
     @params2 = ActionController::Parameters.new({ foo: ActionController::Parameters.new({}) })
-    assert_not_deprecated(ActionController.deprecator) do
-      assert_not @params1.eql?(@params2)
-    end
+    assert_not @params1.eql?(@params2)
   end
 
   test "not eql? when permitted is different" do
@@ -62,26 +47,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   end
 
   test "has_value? converts hashes to parameters" do
-    assert_not_deprecated(ActionController.deprecator) do
-      params = ActionController::Parameters.new(foo: { bar: "baz" })
-      assert params.has_value?("bar" => "baz")
-      params[:foo] # converts value to AC::Params
-      assert params.has_value?("bar" => "baz")
-    end
+    params = ActionController::Parameters.new(foo: { bar: "baz" })
+    assert params.has_value?("bar" => "baz")
+    params[:foo] # converts value to AC::Params
+    assert params.has_value?("bar" => "baz")
   end
 
   test "has_value? works with parameters" do
-    without_deprecated_params_hash_equality do
-      params = ActionController::Parameters.new(foo: { bar: "baz" })
-      assert params.has_value?(ActionController::Parameters.new("bar" => "baz"))
-    end
+    params = ActionController::Parameters.new(foo: { bar: "baz" })
+    assert params.has_value?(ActionController::Parameters.new("bar" => "baz"))
   end
-
-  private
-    def without_deprecated_params_hash_equality
-      ActionController::Parameters.allow_deprecated_parameters_hash_equality = false
-      yield
-    ensure
-      ActionController::Parameters.allow_deprecated_parameters_hash_equality = true
-    end
 end

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -225,35 +225,5 @@ module ActionDispatch
 
       assert_equal true, wrapper.show?(request)
     end
-
-    test "#show? emits a deprecation when show_exceptions is true" do
-      exception = RuntimeError.new("")
-      wrapper = ExceptionWrapper.new(nil, exception)
-
-      env = { "action_dispatch.show_exceptions" => true }
-      request = ActionDispatch::Request.new(env)
-
-      msg = "Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead."
-      result = assert_deprecated(msg, ActionDispatch.deprecator) do
-        wrapper.show?(request)
-      end
-
-      assert_equal true, result
-    end
-
-    test "#show? emits a deprecation when show_exceptions is false" do
-      exception = RuntimeError.new("")
-      wrapper = ExceptionWrapper.new(nil, exception)
-
-      env = { "action_dispatch.show_exceptions" => false }
-      request = ActionDispatch::Request.new(env)
-
-      msg = "Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead."
-      result = assert_deprecated(msg, ActionDispatch.deprecator) do
-        wrapper.show?(request)
-      end
-
-      assert_equal false, result
-    end
   end
 end

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -39,16 +39,6 @@ class PermissionsPolicyTest < ActiveSupport::TestCase
 
     assert_equal "Invalid HTTP permissions policy source: [:non_existent]", exception.message
   end
-
-  def test_deprecated_directives
-    assert_deprecated(ActionDispatch.deprecator) { @policy.speaker :self }
-    assert_deprecated(ActionDispatch.deprecator) { @policy.vibrate :self }
-    assert_deprecated(ActionDispatch.deprecator) { @policy.vr :self }
-
-    assert_not_deprecated(ActionDispatch.deprecator) do
-      assert_equal "speaker 'self'; vibrate 'self'; vr 'self'", @policy.build
-    end
-  end
 end
 
 class PermissionsPolicyMiddlewareTest < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -10,12 +10,6 @@ class ResponseTest < ActiveSupport::TestCase
     @response.request = ActionDispatch::Request.empty
   end
 
-  def test_illegal_state_error_is_deprecated
-    assert_deprecated(ActionDispatch.deprecator) do
-      ActionDispatch::IllegalStateError
-    end
-  end
-
   def test_can_wait_until_commit
     t = Thread.new {
       @response.await_commit

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `:exponentially_longer` value for the `:wait` in `retry_on`.
+
+    *Rafael Mendonça França*
+
 *   Remove deprecated support to set numeric values to `scheduled_at` attribute.
 
     *Rafael Mendonça França*

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated support to set numeric values to `scheduled_at` attribute.
+
+    *Rafael Mendonça França*
+
 *   Deprecate `Rails.application.config.active_job.use_big_decimal_serialize`.
 
     *Rafael Mendonça França*

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,2 +1,9 @@
+*   Deprecate `Rails.application.config.active_job.use_big_decimal_serialize`.
+
+    *Rafael Mendonça França*
+
+*   Remove deprecated primitive serializer for `BigDecimal` arguments.
+
+    *Rafael Mendonça França*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -45,13 +45,17 @@ module ActiveJob
   autoload :TestCase
   autoload :TestHelper
 
-  ##
-  # :singleton-method:
-  # If false, \Rails will preserve the legacy serialization of BigDecimal job arguments as Strings.
-  # If true, \Rails will use the new BigDecimalSerializer to (de)serialize BigDecimal losslessly.
-  # Legacy serialization will be removed in \Rails 7.2, along with this config.
-  singleton_class.attr_accessor :use_big_decimal_serializer
-  self.use_big_decimal_serializer = false
+  def self.use_big_decimal_serializer
+    ActiveJob.deprecator.warn <<-WARNING.squish
+      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 7.3.
+    WARNING
+  end
+
+  def self.use_big_decimal_serializer=(value)
+    ActiveJob.deprecator.warn <<-WARNING.squish
+      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 7.3.
+    WARNING
+  end
 
   ##
   # :singleton-method:

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -101,15 +101,6 @@ module ActiveJob
         else
           if argument.respond_to?(:permitted?) && argument.respond_to?(:to_h)
             serialize_indifferent_hash(argument.to_h)
-          elsif BigDecimal === argument && !ActiveJob.use_big_decimal_serializer
-            ActiveJob.deprecator.warn(<<~MSG)
-              Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
-              Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
-
-              Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
-              This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
-            MSG
-            argument
           else
             Serializers.serialize(argument)
           end
@@ -119,8 +110,6 @@ module ActiveJob
       def deserialize_argument(argument)
         case argument
         when nil, true, false, String, Integer, Float
-          argument
-        when BigDecimal # BigDecimal may have been legacy serialized; Remove in 7.2
           argument
         when Array
           argument.map { |arg| deserialize_argument(arg) }

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -13,9 +13,7 @@ module ActiveJob
     attr_writer :serialized_arguments
 
     # Time when the job should be performed
-    attr_reader :scheduled_at
-
-    attr_reader :_scheduled_at_time # :nodoc:
+    attr_accessor :scheduled_at
 
     # Job Identifier
     attr_accessor :job_id
@@ -97,7 +95,6 @@ module ActiveJob
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name
       @scheduled_at = nil
-      @_scheduled_at_time = nil
       @priority   = self.class.priority
       @executions = 0
       @exception_executions = {}
@@ -120,7 +117,7 @@ module ActiveJob
         "locale"     => I18n.locale.to_s,
         "timezone"   => timezone,
         "enqueued_at" => Time.now.utc.iso8601(9),
-        "scheduled_at" => _scheduled_at_time ? _scheduled_at_time.utc.iso8601(9) : nil,
+        "scheduled_at" => scheduled_at ? scheduled_at.utc.iso8601(9) : nil,
       }
     end
 
@@ -172,18 +169,6 @@ module ActiveJob
       self.priority     = options[:priority].to_i if options[:priority]
 
       self
-    end
-
-    def scheduled_at=(value)
-      @_scheduled_at_time = if value.is_a?(Numeric)
-        ActiveJob.deprecator.warn(<<~MSG.squish)
-          Assigning a numeric/epoch value to scheduled_at is deprecated. Use a Time object instead.
-        MSG
-        Time.at(value)
-      else
-        value
-      end
-      @scheduled_at = value
     end
 
     private

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -23,7 +23,7 @@ module ActiveJob
             adapter_jobs.each do |job|
               job.successfully_enqueued = false
               if job.scheduled_at
-                queue_adapter.enqueue_at(job, job._scheduled_at_time.to_f)
+                queue_adapter.enqueue_at(job, job.scheduled_at.to_f)
               else
                 queue_adapter.enqueue(job)
               end
@@ -92,7 +92,7 @@ module ActiveJob
 
       run_callbacks :enqueue do
         if scheduled_at
-          queue_adapter.enqueue_at self, _scheduled_at_time.to_f
+          queue_adapter.enqueue_at self, scheduled_at.to_f
         else
           queue_adapter.enqueue self
         end

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -60,12 +60,6 @@ module ActiveJob
       #    end
       #  end
       def retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: JITTER_DEFAULT)
-        if wait == :exponentially_longer
-          ActiveJob.deprecator.warn(<<~MSG.squish)
-            `wait: :exponentially_longer` will actually wait polynomially longer and is therefore deprecated.
-            Prefer `wait: :polynomially_longer` to avoid confusion and keep the same behavior.
-          MSG
-        end
         rescue_from(*exceptions) do |error|
           executions = executions_for(exceptions)
           if attempts == :unlimited || executions < attempts
@@ -168,7 +162,7 @@ module ActiveJob
         jitter = jitter == JITTER_DEFAULT ? self.class.retry_jitter : (jitter || 0.0)
 
         case seconds_or_duration_or_algorithm
-        when :exponentially_longer, :polynomially_longer
+        when  :polynomially_longer
           # This delay uses a polynomial backoff strategy, which was previously misnamed as exponential
           delay = executions**4
           delay_jitter = determine_jitter_for_delay(delay, jitter)

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -50,7 +50,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   [ nil, 1, 1.0, 1_000_000_000_000_000_000_000,
-    "a", true, false,
+    "a", true, false, BigDecimal(5),
     :a,
     1.day,
     Date.new(2001, 2, 3),
@@ -78,28 +78,6 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   ].each do |arg|
     test "serializes #{arg.class} - #{arg.inspect} verbatim" do
       assert_arguments_unchanged arg
-    end
-  end
-
-  test "dangerously treats BigDecimal arguments as primitives not requiring serialization by default" do
-    assert_deprecated(<<~MSG.chomp, ActiveJob.deprecator) do
-      Primitive serialization of BigDecimal job arguments is deprecated as it may serialize via .to_s using certain queue adapters.
-      Enable config.active_job.use_big_decimal_serializer to use BigDecimalSerializer instead, which will be mandatory in Rails 7.2.
-
-      Note that if your application has multiple replicas, you should only enable this setting after successfully deploying your app to Rails 7.1 first.
-      This will ensure that during your deployment all replicas are capable of deserializing arguments serialized with BigDecimalSerializer.
-    MSG
-      assert_equal(
-        BigDecimal(5),
-        *ActiveJob::Arguments.deserialize(ActiveJob::Arguments.serialize([BigDecimal(5)])),
-      )
-    end
-  end
-
-  test "safely serializes BigDecimal arguments if configured to use_big_decimal_serializer" do
-    # BigDecimal(5) example should be moved back up into array above in Rails 7.2
-    with_big_decimal_serializer do
-      assert_arguments_unchanged BigDecimal(5)
     end
   end
 
@@ -296,13 +274,5 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       ArgumentsRoundTripJob.perform_later(*args) # Actually performed inline
 
       JobBuffer.last_value
-    end
-
-    def with_big_decimal_serializer(temporary = true)
-      original = ActiveJob.use_big_decimal_serializer
-      ActiveJob.use_big_decimal_serializer = temporary
-      yield
-    ensure
-      ActiveJob.use_big_decimal_serializer = original
     end
 end

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -379,29 +379,5 @@ class ExceptionsTest < ActiveSupport::TestCase
       ]
       assert_equal expected_array, JobBuffer.values.last(2)
     end
-
-    class ::LegacyExponentialNamingError < StandardError; end
-    test "wait: :exponentially_longer is deprecated but still works" do
-      assert_deprecated(ActiveJob.deprecator) do
-        class LegacyRetryJob < RetryJob
-          retry_on LegacyExponentialNamingError, wait: :exponentially_longer, attempts: 10, jitter: nil
-        end
-      end
-
-      travel_to Time.now
-      LegacyRetryJob.perform_later "LegacyExponentialNamingError", 5, :log_scheduled_at
-
-      assert_equal [
-        "Raised LegacyExponentialNamingError for the 1st time",
-        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
-        "Raised LegacyExponentialNamingError for the 2nd time",
-        "Next execution scheduled at #{(Time.now + 18.seconds).to_f}",
-        "Raised LegacyExponentialNamingError for the 3rd time",
-        "Next execution scheduled at #{(Time.now + 83.seconds).to_f}",
-        "Raised LegacyExponentialNamingError for the 4th time",
-        "Next execution scheduled at #{(Time.now + 258.seconds).to_f}",
-        "Successfully completed job"
-      ], JobBuffer.values
-    end
   end
 end

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -92,23 +92,4 @@ class JobSerializationTest < ActiveSupport::TestCase
 
     assert_equal job.serialize, deserialized_job.serialize
   end
-
-  test "deprecates and coerces numerical scheduled_at attribute to Time when serialized and deserialized" do
-    freeze_time
-    current_time = Time.now
-
-    job = HelloJob.new
-    assert_deprecated(ActiveJob.deprecator) do
-      job.scheduled_at = current_time.to_f
-    end
-
-    serialized_job = job.serialize
-    assert_kind_of String, serialized_job["scheduled_at"]
-    assert_equal current_time.utc.iso8601(9), serialized_job["scheduled_at"]
-
-    deserialized_job = HelloJob.new
-    deserialized_job.deserialize(serialized_job)
-    assert_equal current_time, deserialized_job.scheduled_at
-    assert_equal job.serialize, deserialized_job.serialize
-  end
 end

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -56,6 +56,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated comparison between `ActionController::Parameters` and `Hash`.
 
+*   Remove deprecated `Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type`.
+
 ### Deprecations
 
 *   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -50,6 +50,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 ### Removals
 
+*   Remove deprecated constant `ActionDispatch::IllegalStateError`.
+
 ### Deprecations
 
 ### Notable changes

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -58,6 +58,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated `Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type`.
 
+*   Remove deprecated `speaker`, `vibrate`, and `vr` permissions policy directives.
+
 ### Deprecations
 
 *   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -52,6 +52,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated constant `ActionDispatch::IllegalStateError`.
 
+*   Remove deprecated constant `AbstractController::Helpers::MissingHelperError`.
+
 ### Deprecations
 
 ### Notable changes

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -145,7 +145,11 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 ### Removals
 
+*   Remove deprecated primitive serializer for `BigDecimal` arguments.
+
 ### Deprecations
+
+*   Deprecate `Rails.application.config.active_job.use_big_decimal_serialize`.
 
 ### Notable changes
 

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -149,6 +149,8 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 *   Remove deprecated support to set numeric values to `scheduled_at` attribute.
 
+*   Remove deprecated `:exponentially_longer` value for the `:wait` in `retry_on`.
+
 ### Deprecations
 
 *   Deprecate `Rails.application.config.active_job.use_big_decimal_serialize`.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -72,6 +72,8 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
 
 ### Removals
 
+*   Remove deprecated `config.action_mailer.preview_path`.
+
 ### Deprecations
 
 ### Notable changes

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -54,7 +54,11 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated constant `AbstractController::Helpers::MissingHelperError`.
 
+*   Remove deprecated comparison between `ActionController::Parameters` and `Hash`.
+
 ### Deprecations
+
+*   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.
 
 ### Notable changes
 

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -60,6 +60,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 *   Remove deprecated `speaker`, `vibrate`, and `vr` permissions policy directives.
 
+*   Remove deprecated support to set `Rails.application.config.action_dispatch.show_exceptions` to `true` and `false`.
+
 ### Deprecations
 
 *   Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -147,6 +147,8 @@ Please refer to the [Changelog][active-job] for detailed changes.
 
 *   Remove deprecated primitive serializer for `BigDecimal` arguments.
 
+*   Remove deprecated support to set numeric values to `scheduled_at` attribute.
+
 ### Deprecations
 
 *   Deprecate `Rails.application.config.active_job.use_big_decimal_serialize`.

--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -74,6 +74,8 @@ Please refer to the [Changelog][action-mailer] for detailed changes.
 
 *   Remove deprecated `config.action_mailer.preview_path`.
 
+*   Remove deprecated params via `:args` for `assert_enqueued_email_with`.
+
 ### Deprecations
 
 ### Notable changes

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,7 +60,6 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 7.1
 
-- [`config.action_controller.allow_deprecated_parameters_hash_equality`](#config-action-controller-allow-deprecated-parameters-hash-equality): `false`
 - [`config.action_dispatch.debug_exception_log_level`](#config-action-dispatch-debug-exception-log-level): `:error`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.action_text.sanitizer_vendor`](#config-action-text-sanitizer-vendor): `Rails::HTML::Sanitizer.best_supported_vendor`
@@ -1789,18 +1788,6 @@ The default value depends on the `config.load_defaults` target version:
 
 Configures the [`ParamsWrapper`](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html). This can be called at
 the top level, or on individual controllers.
-
-#### `config.action_controller.allow_deprecated_parameters_hash_equality`
-
-Controls behavior of `ActionController::Parameters#==` with `Hash` arguments.
-Value of the setting determines whether an `ActionController::Parameters` instance is equal to an equivalent `Hash`.
-
-The default value depends on the `config.load_defaults` target version:
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `true`               |
-| 7.1                   | `false`              |
 
 ### Configuring Action Dispatch
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,7 +64,6 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.action_text.sanitizer_vendor`](#config-action-text-sanitizer-vendor): `Rails::HTML::Sanitizer.best_supported_vendor`
 - [`config.action_view.sanitizer_vendor`](#config-action-view-sanitizer-vendor): `Rails::HTML::Sanitizer.best_supported_vendor`
-- [`config.active_job.use_big_decimal_serializer`](#config-active-job-use-big-decimal-serializer): `true`
 - [`config.active_record.allow_deprecated_singular_associations_name`](#config-active-record-allow-deprecated-singular-associations-name): `false`
 - [`config.active_record.before_committed_on_all_records`](#config-active-record-before-committed-on-all-records): `true`
 - [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
@@ -2661,24 +2660,6 @@ The default value depends on the `config.load_defaults` target version:
 
 Determines whether job context for query tags will be automatically updated via
 an `around_perform`. The default value is `true`.
-
-#### `config.active_job.use_big_decimal_serializer`
-
-Enables the new `BigDecimal` argument serializer, which guarantees
-roundtripping. Without this serializer, some queue adapters may serialize
-`BigDecimal` arguments as simple (non-roundtrippable) strings.
-
-WARNING: When deploying an application with multiple replicas, old (pre-Rails
-7.1) replicas will not be able to deserialize `BigDecimal` arguments from this
-serializer. Therefore, this setting should only be enabled after all replicas
-have been successfully upgraded to Rails 7.1.
-
-The default value depends on the `config.load_defaults` target version:
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `false`              |
-| 7.1                   | `true`               |
 
 ### Configuring Action Cable
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -316,10 +316,6 @@ module Rails
             active_support.raise_on_invalid_cache_expiration_time = true
           end
 
-          if respond_to?(:action_controller)
-            action_controller.allow_deprecated_parameters_hash_equality = false
-          end
-
           if defined?(Rails::HTML::Sanitizer) # nested ifs to avoid linter errors
             if respond_to?(:action_view)
               action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -305,10 +305,6 @@ module Rails
             action_dispatch.debug_exception_log_level = :error
           end
 
-          if respond_to?(:active_job)
-            active_job.use_big_decimal_serializer = true
-          end
-
           if respond_to?(:active_support)
             active_support.cache_format_version = 7.1
             active_support.message_serializer = :json_allow_marshal

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3107,31 +3107,6 @@ module ApplicationTests
       assert_includes ActiveJob::Serializers.serializers, DummySerializer
     end
 
-    test "use_big_decimal_serializer is enabled in new apps" do
-      app "development"
-
-      assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled in new apps"
-    end
-
-    test "use_big_decimal_serializer is disabled if using defaults prior to 7.1" do
-      remove_from_config '.*config\.load_defaults.*\n'
-      add_to_config 'config.load_defaults "7.0"'
-      app "development"
-
-      assert_not ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be disabled in defaults prior to 7.1"
-    end
-
-    test "use_big_decimal_serializer can be enabled in config" do
-      remove_from_config '.*config\.load_defaults.*\n'
-      add_to_config 'config.load_defaults "7.0"'
-      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
-        Rails.application.config.active_job.use_big_decimal_serializer = true
-      RUBY
-      app "development"
-
-      assert ActiveJob.use_big_decimal_serializer, "use_big_decimal_serializer should be enabled if set in config"
-    end
-
     test "config.active_job.verbose_enqueue_logs defaults to true in development" do
       build_app
       app "development"

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -275,26 +275,6 @@ module ApplicationTests
       assert_no_match '<li><a href="/rails/mailers/notifier/bar">bar</a></li>', last_response.body
     end
 
-    test "mailer preview_path option is deprecated" do
-      prev = ActionMailer::Base.preview_paths
-      ActionMailer::Base.preview_paths = ["#{app_path}/lib/mailer/previews"]
-      assert_deprecated(ActionMailer.deprecator) do
-        assert_equal "#{app_path}/lib/mailer/previews", ActionMailer::Base.preview_path
-      end
-    ensure
-      ActionMailer::Base.preview_paths = prev
-    end
-
-    test "mailer preview_path= option is deprecated" do
-      prev = ActionMailer::Base.preview_paths
-      assert_deprecated(ActionMailer.deprecator) do
-        ActionMailer::Base.preview_path = "#{app_path}/lib/mailer/previews"
-      end
-      assert_equal ["#{app_path}/lib/mailer/previews"], ActionMailer::Base.preview_paths
-    ensure
-      ActionMailer::Base.preview_paths = prev
-    end
-
     test "mailer previews are reloaded from custom preview_paths" do
       app_dir "lib/mailer_previews"
       add_to_config "config.action_mailer.preview_paths = ['#{app_path}/lib/mailer_previews']"


### PR DESCRIPTION
Part 1 of #49624

- [x] Remove Action Cable deprecations
- [x] Remove Action Mailbox deprecations
- [x] Remove Action Mailer deprecations
	- [x] Remove deprecated `config.action_mailer.preview_path`
	- [x] Remove deprecated params via `:args` for `assert_enqueued_email_with`
- [ ] Remove Action Pack deprecations
	- [x] Remove deprecated constant `ActionDispatch::IllegalStateError`
	- [x] Remove deprecated constant `AbstractController::Helpers::MissingHelperError`
	- [x] Remove deprecated comparison between `ActionController::Parameters` and `Hash`
	- [x] Deprecate `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`
	- [x] Remove deprecated `Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type`
	- [x] Remove deprecated `speaker`, `vibrate`, and `vr` permissions policy directives
	- [x] Remove deprecated support to set `Rails.application.config.action_dispatch.show_exceptions` to `true` and `false`
	- [ ] Remove deprecated support to using `:controller` and `:action` in routes
- [x] Remove Action Text deprecations
- [x] Remove Action View deprecations
- [x] Remove Active Job deprecations
	- [x] Remove deprecated primitive serializer for `BigDecimal` arguments
	- [x] Remove deprecated support to set numeric values to `scheduled_at` attribute
	- [x] Remove deprecated `:exponentially_longer` value for the `:wait` in `retry_on`
- [x] Remove Active Model deprecations