### PR TITLE
Include exception causes into log messages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -141,6 +141,12 @@ module ActionDispatch
         message = []
         message << "  "
         message << "#{wrapper.exception_class_name} (#{wrapper.message}):"
+        if wrapper.has_cause?
+          message << "\nCauses:"
+          wrapper.wrapped_causes.each do |wrapped_cause|
+            message << "#{wrapped_cause.exception_class_name} (#{wrapped_cause.message})"
+          end
+        end
         message.concat(wrapper.annotated_source_code)
         message << "  "
         message.concat(trace)

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -615,6 +615,25 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_not_empty (output.rewind && output.read).lines
   end
 
+  test "logs exception causes" do
+    @app = DevelopmentApp
+
+    output = StringIO.new
+
+    env = { "action_dispatch.show_exceptions"       => :all,
+            "action_dispatch.logger"                => Logger.new(output),
+            "action_dispatch.log_rescued_responses" => true }
+
+    get "/nested_exceptions", headers: env
+    assert_response 500
+    log = output.rewind && output.read
+    assert_includes log, <<~MSG
+      Causes:
+      RuntimeError (Second error)
+      RuntimeError (First error)
+    MSG
+  end
+
   test "display backtrace when error type is SyntaxError" do
     @app = DevelopmentApp
 


### PR DESCRIPTION
Fixes #50125.

#39723 changed bad connection related errors so that we now have some (useful for debugging) details from the original database exceptions lost. 

~This PR adds original database errors to these new exceptions classes, so we can get the exception details. It also prints these added exceptions messages by default as part of the new exceptions messages.~