### PR TITLE
Add more specific exceptions to warn when an adapter is using legacy adapter format

### DIFF
--- a/activerecord/test/active_record/connection_adapters/fake_legacy_adapter.rb
+++ b/activerecord/test/active_record/connection_adapters/fake_legacy_adapter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionHandling
+    def fake_legacy_connection(config)
+      ConnectionAdapters::FakeLegacyAdapter.new nil, logger
+    end
+  end
+
+  module ConnectionAdapters
+    class FakeLegacyAdapter < AbstractAdapter
+      def active?
+        true
+      end
+    end
+  end
+end

--- a/activerecord/test/active_record/connection_adapters/fake_misleading_legacy_adapter.rb
+++ b/activerecord/test/active_record/connection_adapters/fake_misleading_legacy_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    class FakeMisleadingLegacyAdapter < AbstractAdapter
+    end
+  end
+end

--- a/activerecord/test/cases/connection_adapters/registration_test.rb
+++ b/activerecord/test/cases/connection_adapters/registration_test.rb
@@ -16,9 +16,14 @@ module ActiveRecord
       end
 
       test "#register registers a new database adapter and #resolve can find it and raises if it cannot" do
-        assert_raises(ActiveRecord::AdapterNotFound) do
+        exception = assert_raises(ActiveRecord::AdapterNotFound) do
           ActiveRecord::ConnectionAdapters.resolve("fake")
         end
+
+        assert_match(
+          /Database configuration specifies nonexistent 'fake' adapter. Available adapters are:/,
+          exception.message
+        )
 
         ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
 
@@ -26,9 +31,14 @@ module ActiveRecord
       end
 
       test "#register allows for symbol key" do
-        assert_raises(ActiveRecord::AdapterNotFound) do
+        exception = assert_raises(ActiveRecord::AdapterNotFound) do
           ActiveRecord::ConnectionAdapters.resolve("fake")
         end
+
+        assert_match(
+          /Database configuration specifies nonexistent 'fake' adapter. Available adapters are:/,
+          exception.message
+        )
 
         ActiveRecord::ConnectionAdapters.register(:fake, "FakeActiveRecordAdapter", @fake_adapter_path)
 
@@ -36,13 +46,61 @@ module ActiveRecord
       end
 
       test "#resolve allows for symbol key" do
-        assert_raises(ActiveRecord::AdapterNotFound) do
+        exception = assert_raises(ActiveRecord::AdapterNotFound) do
           ActiveRecord::ConnectionAdapters.resolve("fake")
         end
+
+        assert_match(
+          /Database configuration specifies nonexistent 'fake' adapter. Available adapters are:/,
+          exception.message
+        )
 
         ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", @fake_adapter_path)
 
         assert_equal "FakeActiveRecordAdapter", ActiveRecord::ConnectionAdapters.resolve(:fake).name
+      end
+    end
+
+    class RegistrationIsolatedTest < ActiveRecord::TestCase
+      include ActiveSupport::Testing::Isolation
+
+      def setup
+        @original_adapters = ActiveRecord::ConnectionAdapters.instance_variable_get(:@adapters).dup
+      end
+
+      test "#resolve raises if the adapter is using the pre 7.2 adapter registration API" do
+        exception = assert_raises(ActiveRecord::AdapterNotFound) do
+          assert_deprecated(ActiveRecord.deprecator) do
+            ActiveRecord::ConnectionAdapters.resolve("fake_legacy")
+          end
+        end
+
+        assert_match(
+          /Database configuration specifies 'fake_legacy' adapter but that adapter has not been registered. Ensure that the adapter in the Gemfile is at the latest version. If it is, then the adapter may need to be modified./,
+          exception.message
+        )
+      ensure
+        ActiveRecord::ConnectionAdapters.instance_variable_get(:@adapters).delete("fake_legacy")
+      end
+
+      test "#resolve raises if the adapter maybe is using the pre 7.2 adapter registration API but we are not sure" do
+        exception = assert_raises(ActiveRecord::AdapterNotFound) do
+          assert_deprecated(ActiveRecord.deprecator) do
+            ActiveRecord::ConnectionAdapters.resolve("fake_misleading_legacy")
+          end
+        end
+
+        assert_match(
+          /Database configuration specifies nonexistent 'fake_misleading_legacy' adapter. Available adapters are:/,
+          exception.message
+        )
+
+        assert_match(
+          /Ensure that the adapter is spelled correctly in config\/database.yml and that you've added the necessary adapter gem to your Gemfile and that it is at its latest version. If it is up to date, the adapter may need to be modified./,
+          exception.message
+        )
+      ensure
+        ActiveRecord::ConnectionAdapters.instance_variable_get(:@adapters).delete("fake_misleading_legacy")
       end
     end
   end


### PR DESCRIPTION
## Problem

In #50064 and #50112 we have changed the way Active Record database adapters are expected to register themselves with the framework in order to be loaded.

Previously it was by convention, as Jean so eloquently defined it as "byzantine":
* They must be defined in `active_record/connection_adapters/<name>_adapter`
* They must define `ConnectionHandling.<name>_adapter_class`
* They must define `ConnectionHandling.<name>_connection`

Now they must explicitly call `ActiveRecord::ConnectionAdapters.register` and do not need to fit this convention.

Rails has updated its internal adapters, and we will attempt to notify known maintainers of adapters. But there are plenty of use cases for private adapters we do not know about or cannot know about.

The issue with that is the error message is pretty generic "this adapter does not exist, be sure to add it to the gemfile" which is correct for most _users_ but not correct for _maintainers_. We want to make **updating as clear and easy as possible**. The code change is pretty small, but knowing where and how to make that change is the hard part.

## Solution

Add a transitionary block of extra error handling and messaging to explain how to update the adapters.

When calling `resolve("some_adapter")` and it is not found, before raising the generic error first try to require that adapter in the legacy location. If it is found raise a better error explaining exactly how to update the adapter.

The tricky part is that just because a file with that name exists, does not necessarily mean that file is an adapter. So to be extra sure we check for the existence of an adapter method. If it's not there raise a slightly different error message.

Hopefully this makes the transition path easier.


## Questions

This code can all be deleted, especially the fake test classes, when we move beyond `7.2.x`. What is the desired way to flag this to be deleted when the next major or minor version is updated on `main`?

Paired with @adrianna-chang-shopify 
cc @matthewd @byroot 