### PR TITLE
Improve `ActiveSupport::InheritableOptions` hash-like behaviour

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -92,18 +92,52 @@ module ActiveSupport
   #   h.boy  # => 'John'
   class InheritableOptions < OrderedOptions
     def initialize(parent = nil)
-      if parent.kind_of?(OrderedOptions)
+      @parent = parent
+      if @parent.kind_of?(OrderedOptions)
         # use the faster _get when dealing with OrderedOptions
-        super() { |h, k| parent._get(k) }
-      elsif parent
-        super() { |h, k| parent[k] }
+        super() { |h, k| @parent._get(k) }
+      elsif @parent
+        super() { |h, k| @parent[k] }
       else
         super()
+        @parent = {}
       end
+    end
+
+    def to_h
+      @parent.merge(self)
+    end
+
+    def ==(other)
+      to_h == other.to_h
+    end
+
+    def inspect
+      "#<#{self.class.name} #{to_h.inspect}>"
+    end
+
+    alias_method :own_key?, :key?
+    private :own_key?
+
+    def key?(key)
+      super || @parent.key?(key)
+    end
+
+    def overridden?(key)
+      !!(@parent && @parent.key?(key) && own_key?(key.to_sym))
     end
 
     def inheritable_copy
       self.class.new(self)
+    end
+
+    def to_a
+      entries
+    end
+
+    def each(&block)
+      to_h.each(&block)
+      self
     end
   end
 end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -134,7 +134,7 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_raises(KeyError) { a.non_existing_key! }
   end
 
-  def test_inspect
+  def test_ordered_option_inspect
     a = ActiveSupport::OrderedOptions.new
     assert_equal "#<ActiveSupport::OrderedOptions {}>", a.inspect
 
@@ -142,5 +142,140 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     a[:baz] = :quz
 
     assert_equal "#<ActiveSupport::OrderedOptions {:foo=>:bar, :baz=>:quz}>", a.inspect
+  end
+
+  def test_inheritable_option_inspect
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    assert_equal "#<ActiveSupport::InheritableOptions {:one=>\"first value\"}>", object.inspect
+
+    object[:two] = "second value"
+    object["three"] = "third value"
+    assert_equal "#<ActiveSupport::InheritableOptions {:one=>\"first value\", :two=>\"second value\", :three=>\"third value\"}>", object.inspect
+  end
+
+  def test_ordered_options_to_h
+    object = ActiveSupport::OrderedOptions.new
+    assert_equal({}, object.to_h)
+    object.one = "first value"
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_equal({ one: "first value", two: "second value", three: "third value" }, object.to_h)
+  end
+
+  def test_inheritable_options_to_h
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    assert_equal({ one: "first value" }, object.to_h)
+
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_equal({ one: "first value", two: "second value", three: "third value" }, object.to_h)
+  end
+
+  def test_ordered_options_dup
+    object = ActiveSupport::OrderedOptions.new
+    object.one = "first value"
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    duplicate = object.dup
+    assert_equal object, duplicate
+    assert_not_equal object.object_id, duplicate.object_id
+  end
+
+  def test_inheritable_options_dup
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    duplicate = object.dup
+    assert_equal object, duplicate
+    assert_not_equal object.object_id, duplicate.object_id
+  end
+
+  def test_ordered_options_key
+    object = ActiveSupport::OrderedOptions.new
+    object.one = "first value"
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert object.key?(:one)
+    assert_not object.key?("one")
+    assert object.key?(:two)
+    assert_not object.key?("two")
+    assert object.key?(:three)
+    assert_not object.key?("three")
+    assert_not object.key?(:four)
+  end
+
+  def test_inheritable_options_key
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert object.key?(:one)
+    assert_not object.key?("one")
+    assert object.key?(:two)
+    assert_not object.key?("two")
+    assert object.key?(:three)
+    assert_not object.key?("three")
+    assert_not object.key?(:four)
+  end
+
+  def test_inheritable_options_overridden
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value", three: "third value")
+    object["one"] = "first value override"
+    object[:two] = "second value override"
+
+    assert object.overridden?(:one)
+    assert_equal "first value override", object.one
+    assert object.overridden?(:two)
+    assert_equal "second value override", object.two
+    assert_not object.overridden?(:three)
+    assert_equal "third value", object.three
+  end
+
+  def test_inheritable_options_overridden_with_nil
+    object = ActiveSupport::InheritableOptions.new
+    object["one"] = "first value override"
+    object[:two] = "second value override"
+
+    assert_not object.overridden?(:one)
+    assert_equal "first value override", object.one
+    assert_not object.overridden?(:two)
+    assert_equal "second value override", object.two
+  end
+
+  def test_inheritable_options_each
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value")
+    object["one"] = "first value override"
+    object[:three] = "third value"
+
+    count = 0
+    keys = []
+    object.each do |key, value|
+      count += 1
+      keys << key
+    end
+    assert_equal 3, count
+    assert_equal [:one, :two, :three], keys
+  end
+
+  def test_inheritable_options_to_a
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value")
+    object["one"] = "first value override"
+    object[:three] = "third value"
+
+    assert_equal [[:one, "first value override"], [:two, "second value"], [:three, "third value"]], object.entries
+    assert_equal [[:one, "first value override"], [:two, "second value"], [:three, "third value"]], object.to_a
+  end
+
+  def test_inheritable_options_count
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value")
+    object["one"] = "first value override"
+    object[:three] = "third value"
+
+    assert_equal 3, object.count
   end
 end

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -20,8 +20,8 @@ module Rails
         load_generators
 
         if environment_specified?
-          @content_path = "config/credentials/#{environment}.yml.enc" unless config.key?(:content_path)
-          @key_path = "config/credentials/#{environment}.key" unless config.key?(:key_path)
+          @content_path = "config/credentials/#{environment}.yml.enc" unless config.overridden?(:content_path)
+          @key_path = "config/credentials/#{environment}.key" unless config.overridden?(:key_path)
         end
 
         ensure_encryption_key_has_been_added

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3124,7 +3124,7 @@ module ApplicationTests
     test "active record job queue is set" do
       app "development"
 
-      assert_equal ActiveSupport::InheritableOptions.new(destroy: :active_record_destroy), ActiveRecord.queues
+      assert_equal({}, ActiveRecord.queues)
     end
 
     test "destroy association async job should be loaded in configs" do


### PR DESCRIPTION
## Problem

Some behaviours for `ActiveSupport::InheritableOptions` are unintuitive because it implements hash lookup like so:

```ruby
def initialize
  super() { |h, k| parent[k] }
end
```

Because of this, lookups work because they fall through to the block which is stored in the closure. But if you try to do any hash-like behaviour it only operates on the keys added after inheritance, and ignores the parent hash. So when attempting to `to_h` and compare the results are silently wrong and confusing.

Specifically:
```ruby
> object = ActiveSupport::InheritableOptions.new(key: :value)
=> {}
> object.to_h
=> {}
> object[:key]
=> :value
```


## Solution

Override `to_h`, `inspect`, and `==` in order to merge the parent hash and self hash, and then behave like a hash.

cc @byroot 