### PR TITLE
Update docs for `erb_trim_mode`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2014,7 +2014,7 @@ Accepts a logger conforming to the interface of Log4r or the default Ruby Logger
 
 #### `config.action_view.erb_trim_mode`
 
-Gives the trim mode to be used by ERB. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
+Controls if certain ERB syntax should trim. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. Setting this to anything else will turn off trimming support.
 
 #### `config.action_view.frozen_string_literal`
 


### PR DESCRIPTION
### Motivation / Background

The link for erubis docs seems to be dead for a few years now http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces, see [Wayback Machine](http://web.archive.org/web/20230401000000*/http://www.kuwata-lab.com/erubis/users-guide.06.html). Even when reading it through a [working link](http://web.archive.org/web/20200218190015/http://www.kuwata-lab.com/erubis/users-guide.06.html) I'm not sure how it relates to Rails and this config value.

I updated docs to how I understand it currently works.

### Detail

Some context at #30149. To me it looks like this config value should be deprecated and replaced with a boolean since that is how it is excusivly used by rails. https://github.com/rails/rails/blob/a6099ed2b7a544d8fe67688e8a0f9237847404ee/actionview/lib/action_view/template/handlers/erb.rb#L81

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
