### PR TITLE
Fix defining `alias_attribute` for STI classes with abstract class in the inheritance chain

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -130,6 +130,7 @@ module ActiveRecord
           return false if @attribute_methods_generated
           superclass.define_attribute_methods unless base_class?
           super(attribute_names)
+          alias_attribute(:id_value, :id) if attribute_names.include?("id")
           @attribute_methods_generated = true
         end
       end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -584,7 +584,6 @@ module ActiveRecord
           columns_hash = connection.schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
-          alias_attribute :id_value, :id if @columns_hash.key?("id")
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1393,6 +1393,22 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     alias_attribute :written_by, :author
   end
 
+  test "#alias_attribute method on a STI class is available on subclasses" do
+    superclass = Class.new(ActiveRecord::Base) do
+      self.table_name = "comments"
+      alias_attribute :text, :body
+    end
+
+    subclass = Class.new(superclass) do
+      self.abstract_class = true
+    end
+
+    subsubclass = Class.new(subclass)
+
+    comment = subsubclass.build(body: "Text")
+    assert_equal "Text", comment.text
+  end
+
   test "#alias_attribute with an association method issues a deprecation warning" do
     message = <<~MESSAGE.gsub("\n", " ")
     AttributeMethodsTest::ClassWithAssociationTarget model aliases `author`, but `author` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :written_by, :author` or define the method manually.


### PR DESCRIPTION
Fixes #50154.
