### PR TITLE
Deprecate content for void elements in TagBuilder

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate passing content to void elements when using `tag.br` type tag builders.
+
+    *Hartley McGuire*
+
 *   Fix the `number_to_human_size` view helper to correctly work with negative numbers.
 
     *Earlopain*

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -27,11 +27,15 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_builder_void_tag_with_forced_content
-    assert_equal "<br>some content</br>", tag.br("some content")
+    assert_deprecated(ActionView.deprecator) do
+      assert_equal "<br>some content</br>", tag.br("some content")
+    end
   end
 
   def test_tag_builder_void_tag_with_empty_content
-    assert_equal "<br></br>", tag.br("")
+    assert_deprecated(ActionView.deprecator) do
+      assert_equal "<br></br>", tag.br("")
+    end
   end
 
   def test_tag_builder_self_closing_tag


### PR DESCRIPTION
### Motivation / Background

According to the [HTML5 Spec][1]

> Void elements can't have any contents (since there's no end tag, no
> content can be put between the start tag and the end tag).

Up to this point, the only special handling of void elements has been to use ">" to close them instead of "/>" (which is optional but valid according to the spec)

> Then, if the element is one of the void elements, ... , then there may
> be a single U+002F SOLIDUS character (/), ... . On void elements, it
> does not mark the start tag as self-closing but instead is unnecessary
> and has no effect of any kind.

### Detail

This commit deprecates the ability to pass content (either through the positional "content" parameter or a block) to a void element since it is not valid according to the Spec. This has the benefit of both encouraging more correct HTML generation, and also simplifying the method definition of void elements once the deprecation has been removed.

This commit additionally tweaks the signature of "void_tag_string" slightly with two changes. The first change is renaming it to be "self_closing_tag_string". This is more accurate than "void_tag_string" because the definition of "void element" is more specific and has more requirements than "self closing element". For example, tags in the SVG namespace _can_ be self closing but the "/" at the end of the start tag is _not_ optional because they are not void elements. The second change to this method is swapping from a boolean "self_closing" parameter to a string "tag_suffix" parameter. This enables the void element method definition to specialize the tag_suffix (to just ">") without either void elements or self closing elements having to pay the runtime cost of the self_closing conditional since we know at method definition time which suffix each type of tag should use.

[1]: https://html.spec.whatwg.org/multipage/syntax.html#void-elements

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
