### PR TITLE
Allow `object_id` as a column name for ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -33,7 +33,7 @@ module ActiveRecord
           Base.private_instance_methods -
           Base.superclass.instance_methods -
           Base.superclass.private_instance_methods +
-          %i[__id__ dup freeze frozen? hash object_id class clone]
+          %i[__id__ dup freeze frozen? hash class clone]
         ).map { |m| -m.to_s }.to_set.freeze
       end
     end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1261,7 +1261,7 @@ class PreloaderTest < ActiveRecord::TestCase
     end
 
     assert_predicate author.association(:essay_category), :loaded?
-    assert categories.map(&:object_id).include?(author.essay_category.object_id)
+    assert categories.map(&:__id__).include?(author.essay_category.__id__)
   end
 
   def test_preload_with_only_some_records_available_with_through_associations
@@ -1307,7 +1307,7 @@ class PreloaderTest < ActiveRecord::TestCase
     end
 
     assert_predicate post.association(:author), :loaded?
-    assert_not_equal david.object_id, post.author.object_id
+    assert_not_equal david.__id__, post.author.__id__
   end
 
   def test_preload_with_available_records_queries_when_collection
@@ -1319,7 +1319,7 @@ class PreloaderTest < ActiveRecord::TestCase
     end
 
     assert_predicate post.association(:comments), :loaded?
-    assert_empty post.comments.map(&:object_id) & comments.map(&:object_id)
+    assert_empty post.comments.map(&:__id__) & comments.map(&:__id__)
   end
 
   def test_preload_with_available_records_queries_when_incomplete


### PR DESCRIPTION
Fixes #50160

### Motivation / Background

The `object_id` name may be used by polymorphic relations where `object` is the best name, like `notification.object`. In that case two columns are created: `object_id` and `object_type`.

This Pull Request has been created because we have a rails application that uses the `object` as the polymorphic relationship name, and it seems to be the best name. It was allowed until rails 7.1 and was not breaking anything.

Using the `object_id` as a column name [was explicitly allowed here](https://github.com/rails/rails/pull/38990) 

### Detail

This Pull Request removes the `object_id` from the list of not allowed column names. 
For the sake of consitency, the comments and tests are updated where relevant to use the `__id__` method instead.

### Additional information

The method `object_id` [was added to the dangerous method list here](https://github.com/rails/rails/pull/45883)

Using the `object_id` as a column name [was previously explicitly allowed here](https://github.com/rails/rails/pull/38990) 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
