### PR TITLE
Improve interval overflow protection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/interval.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/interval.rb
@@ -33,7 +33,7 @@ module ActiveRecord
             when ::Numeric
               # Sometimes operations on Times returns just float number of seconds so we need to handle that.
               # Example: Time.current - (Time.current + 1.hour) # => -3600.000001776 (Float)
-              value.seconds.iso8601(precision: self.precision)
+              ActiveSupport::Duration.build(value).iso8601(precision: self.precision)
             else
               super
             end

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -44,6 +44,13 @@ class PostgresqlDataTypeTest < ActiveRecord::PostgreSQLTestCase
     assert_equal (-21.day), @first_time.scaled_time_interval
   end
 
+  def test_update_large_time_in_seconds
+    @first_time.scaled_time_interval = 70.years.to_f
+    assert @first_time.save
+    assert @first_time.reload
+    assert_equal 70.years, @first_time.scaled_time_interval
+  end
+
   def test_oid_values
     assert_equal 1234, @first_oid.obj_id
   end


### PR DESCRIPTION
> Sometimes, operations on Times returns just float numbers of seconds, so, we
need to handle that.
> Example: Time.current - (Time.current + 1.hour) # => -3600.000001776 (Float)

When this happens, it's possible to endup with a pretty large number of seconds, making the ISO 8601 formatted duration to trigger an `interval field value out range error`.

PostgreSQL 15 has already improved overflow detection when casting values to interval

However, to further reduce the likelihood of such issues and ensure better-formatted duration types, it now implements the construction of `ActiveSupport::Duration` during the serialization step.

How to reproduce (at least in versions prior to PG 15+):

``` ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "pg"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(
  adapter: 'postgresql',
  database: 'postgres',
  username: 'postgres',
  host: 'localhost'
)

ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :projects, force: true do |t|
    t.interval :duration
  end
end

class Project < ActiveRecord::Base; end

class IntervalBugTest < Minitest::Test
  def test_duration
    project = Project.create(duration: 70.years)
    assert_equal 70.years, project.duration
  end

  def test_duration_error
    duration = 70.years.ago - Time.now()

    assert_raises ActiveRecord::StatementInvalid do
      Project.create(duration: duration)
    end
  end
end
```

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
