### PR TITLE
Do not overwrite AJ logger if it is supplied

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -15,7 +15,7 @@ module ActiveJob
     end
 
     initializer "active_job.logger" do
-      ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
+      ActiveSupport.on_load(:active_job) { self.logger ||= ::Rails.logger }
     end
 
     initializer "active_job.custom_serializers" do |app|

--- a/activejob/test/cases/railtie_test.rb
+++ b/activejob/test/cases/railtie_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "helper"
+require "active_support/testing/isolation"
+
+class RailtieTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup do
+    require "rails"
+
+    rails_logger = Logger.new(nil)
+
+    @app ||= Class.new(::Rails::Application) do
+      def self.name; "AJRailtieTestApp"; end
+
+      config.eager_load = false
+      config.logger = rails_logger
+      config.active_support.cache_format_version = 7.1
+    end
+  end
+
+  test "active_job.logger initializer does not overwrite the supplied logger" do
+    custom_logger = Logger.new(nil)
+
+    @app.config.before_initialize do |app|
+      ActiveSupport.on_load(:active_job) do
+        self.logger = custom_logger
+      end
+    end
+
+    require "active_job/railtie"
+    @app.initialize!
+
+    assert_same ActiveJob::Base.logger, custom_logger
+  end
+end


### PR DESCRIPTION
### Motivation / Background

When supplying a custom logger to `ActiveJob::Base`, it gets overridden by the `active_job.logger` initializer defined [here](https://github.com/rails/rails/blob/2a4bb0bc8699688acccf78520c61acf24968c2ef/activejob/lib/active_job/railtie.rb#L18). This happens, for example, when a custom logger is set in the `config.before_initialize` hook of a different railtie or within the `ActiveSupport.on_load` hook that gets executed before the one defined in the AJ initializer.
Other Rails components [[1](https://github.com/rails/rails/blob/d316d690b9975fa00798187262c56fc0744cb74a/actionview/lib/action_view/railtie.rb#L87), [2](https://github.com/rails/rails/blob/37833debc669bd3435a0d70b1d294bda2eb14070/actionmailer/lib/action_mailer/railtie.rb#L19), [3](https://github.com/rails/rails/blob/37833debc669bd3435a0d70b1d294bda2eb14070/actionmailer/lib/action_mailer/railtie.rb#L19)] use conditional assignment when setting the logger.

### Detail

Change the `active_job.logger` initializer to use conditional assignment when setting a logger.

### Additional information

A simple test case for the AJ railtie was created which is similar in its structure to the [ActiveModel railtie test](https://github.com/rails/rails/blob/2ab10fac93899cd76b9c1fa538237c2bda027ccc/activemodel/test/cases/railtie_test.rb). After a quick skim I've not found any references for testing a framework's railtie other than the one mentioned, which seems pretty old, so let me know if there's another way to test this.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
