### PR TITLE
Fix submit button selector for `type`-less buttons

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -771,9 +771,9 @@ function start() {
 }
 
 function didClick(event) {
-  const submitButton = event.target.closest(":is(button, input)[type='submit']");
-  if (submitButton && submitButton.form) {
-    submitButtonsByForm.set(submitButton.form, submitButton);
+  const button = event.target.closest("button, input");
+  if (button && button.type === "submit" && button.form) {
+    submitButtonsByForm.set(button.form, button);
   }
 }
 

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -754,9 +754,9 @@
     }
   }
   function didClick(event) {
-    const submitButton = event.target.closest(":is(button, input)[type='submit']");
-    if (submitButton && submitButton.form) {
-      submitButtonsByForm.set(submitButton.form, submitButton);
+    const button = event.target.closest("button, input");
+    if (button && button.type === "submit" && button.form) {
+      submitButtonsByForm.set(button.form, button);
     }
   }
   function didSubmitForm(event) {

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -15,9 +15,9 @@ export function start() {
 }
 
 function didClick(event) {
-  const submitButton = event.target.closest(":is(button, input)[type='submit']")
-  if (submitButton && submitButton.form) {
-    submitButtonsByForm.set(submitButton.form, submitButton)
+  const button = event.target.closest("button, input")
+  if (button && button.type === "submit" && button.form) {
+    submitButtonsByForm.set(button.form, button)
   }
 }
 


### PR DESCRIPTION
Follow-up to #48290.

The `:is(button, input)[type='submit']` selector does not match `button` elements that omit the `type` attribute in favor relying on its default value (which is `"submit"`).
