### PR TITLE
[ActiveStorage] Take `ActiveRecord` affixes into account for `ActiveStorage` database models

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix all Active Storage database related models to respect
+    `ActiveRecord::Base.table_name_prefix` configuration.
+
+    *Chedli Bourguiba*
+
 *   Fix `ActiveStorage::Representations::ProxyController` not returning the proper
     preview image variant for previewable files.
 

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -18,8 +18,6 @@ require "active_support/core_ext/module/delegation"
 #   # preloads blobs and variant records (if using `ActiveStorage.track_variants`)
 #   User.first.avatars.with_all_variant_records
 class ActiveStorage::Attachment < ActiveStorage::Record
-  self.table_name = "active_storage_attachments"
-
   ##
   # :method:
   #

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -17,8 +17,6 @@
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
 class ActiveStorage::Blob < ActiveStorage::Record
-  self.table_name = "active_storage_blobs"
-
   MINIMUM_TOKEN_LENGTH = 28
 
   has_secure_token :key, length: MINIMUM_TOKEN_LENGTH

--- a/activestorage/app/models/active_storage/variant_record.rb
+++ b/activestorage/app/models/active_storage/variant_record.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ActiveStorage::VariantRecord < ActiveStorage::Record
-  self.table_name = "active_storage_variant_records"
-
   belongs_to :blob
   has_one_attached :image
 end

--- a/activestorage/test/migrations_test.rb
+++ b/activestorage/test/migrations_test.rb
@@ -53,7 +53,7 @@ class ActiveStorage::MigrationsTest < ActiveSupport::TestCase
     end
 
     def active_storage_tables
-      [:active_storage_blobs, :active_storage_attachments, :active_storage_variant_records]
+      @active_storage_tables ||= ActiveStorage::Record.descendants.map { |klass| klass.table_name.to_sym }
     end
 
     def primary_key(table)


### PR DESCRIPTION
EDIT: Partially Fixes #35811 ( Only AR suffix will work, prefix is a global engine issue that will be handled in a separate PR
Follow up to the closed PR #35828 

Follow up to https://github.com/rails/rails/pull/30095

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because ActiveStorage db model table names are hardcoded. Making it impossible to be compatible with ActiveRecord prefix/suffix configuration.

What's also problematic is that AS generated migrations ( with `activestorage:install` task ) respects the prefix/suffix configuration, which makes it then impossible to use AS models in a Rails application.

### Detail

To fix this issue we remove the hard coded lines. But then we need to also override an internal method for specifying the prefix. the full explanation is here: https://github.com/rails/rails/pull/50167#discussion_r1405175059

### Additional information

Some tests were refactored to remove hard coded table name references, making ActiveStorage test suite compatible with ActiveRecord config.

https://github.com/rails/rails/blob/354d68e8a63b21e47a529105a508411bfe8be869/activerecord/lib/active_record/model_schema.rb#L597-L611

- **I believe the root cause lies inside ActiveRecord model schema file** but I can't find the solution... for now ( **EDIT: solution found here: https://github.com/rails/rails/pull/50167#discussion_r1405175059 )** 
- This issue is also present in action_text, but I want to focus for now on activestorage and make sure it works properly before porting it
<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.