### PR TITLE
Fix generator tests on `arm64` platforms

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -683,6 +683,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_equal 1, @bundle_commands.count("install")
   end
 
+  def test_generation_runs_bundle_lock_for_linux
+    generator([destination_root])
+    run_generator_instance
+
+    assert_not_empty @bundle_commands.grep(/\Alock --add-platform=\S+-linux/)
+  end
+
   def test_generation_use_original_bundle_environment
     generator([destination_root])
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -393,12 +393,18 @@ module SharedGeneratorTests
 
       generator(positional_args, option_args)
 
+      prerelease_commands = []
+      prerelease_command_rails_gems = []
       rails_gem_pattern = /^gem ["']rails["'], .+/
-      bundle_command_rails_gems = []
+
       @bundle_command_stub = -> (command, *) do
         @bundle_commands << command
-        assert_file File.expand_path("Gemfile", project_path) do |gemfile|
-          bundle_command_rails_gems << gemfile[rails_gem_pattern]
+
+        if command.start_with?("install", "exec rails")
+          prerelease_commands << command
+          assert_file File.expand_path("Gemfile", project_path) do |gemfile|
+            prerelease_command_rails_gems << gemfile[rails_gem_pattern]
+          end
         end
       end
 
@@ -408,13 +414,11 @@ module SharedGeneratorTests
       end
 
       assert_file File.expand_path("Gemfile", project_path) do |gemfile|
-        assert_equal "install", @bundle_commands[0]
-        assert_match "lock --add-platform", @bundle_commands[1]
+        assert_equal "install", prerelease_commands[0]
+        assert_equal gemfile[rails_gem_pattern], prerelease_command_rails_gems[0]
 
-        assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[0]
-
-        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", @bundle_commands[2]
-        assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[1]
+        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", prerelease_commands[1]
+        assert_equal gemfile[rails_gem_pattern], prerelease_command_rails_gems[1]
       end
     end
 


### PR DESCRIPTION
Follow-up to #47516 / #47492.

When running generator tests on `arm64` platforms, there is an extra `lock --add-platform` command in `@bundle_commands` which causes `assert_match %r"^exec rails ...", @bundle_commands[2]` to fail.

However, `run_generator_using_prerelease` isn't really concerned with `lock --add-platform` commands; it is only concerned with the `install` and `exec rails` commands, and the contents of the `Gemfile` when those commands were executed.

Therefore, this commit removes `lock --add-platform` command-related assertions from `run_generator_using_prerelease` and puts them into a dedicated `test_generation_runs_bundle_lock_for_linux` test.  This approach makes `run_generator_using_prerelease` less brittle.  This change also fixes a technically incorrect assertion wherein the contents of the `Gemfile` during the `lock --add-platform` command was checked instead of the contents during the `exec rails` command.

Fixes #50168.
