### PR TITLE
Don't add `default-mysql-client` when running `db:system:change` to Trilogy

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -30,7 +30,7 @@ module Rails
       def docker_for_database_build(database = options[:database])
         case database
         when "mysql"          then "build-essential default-libmysqlclient-dev git"
-        when "trilogy"        then "build-essential default-libmysqlclient-dev git"
+        when "trilogy"        then "build-essential git"
         when "postgresql"     then "build-essential git libpq-dev"
         when "sqlite3"        then "build-essential git"
         else nil
@@ -40,7 +40,7 @@ module Rails
       def docker_for_database_deploy(database = options[:database])
         case database
         when "mysql"          then "curl default-mysql-client libvips"
-        when "trilogy"        then "curl default-mysql-client libvips"
+        when "trilogy"        then "curl libvips"
         when "postgresql"     then "curl libvips postgresql-client"
         when "sqlite3"        then "curl libsqlite3-0 libvips"
         else nil

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -90,6 +90,26 @@ module Rails
             end
           end
 
+          test "change to trilogy" do
+            run_generator ["--to", "trilogy"]
+
+            assert_file("config/database.yml") do |content|
+              assert_match "adapter: trilogy", content
+              assert_match "database: tmp_production", content
+            end
+
+            assert_file("Gemfile") do |content|
+              assert_match "# Use trilogy as the database for Active Record", content
+              assert_match 'gem "trilogy", "~> 2.4"', content
+            end
+
+            assert_file("Dockerfile") do |content|
+              assert_match "build-essential git", content
+              assert_match "curl libvips", content
+              assert_no_match "default-libmysqlclient-dev", content
+            end
+          end
+
           test "change from versioned gem to other versioned gem" do
             run_generator ["--to", "sqlite3"]
             run_generator ["--to", "mysql", "--force"]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `db:system:change --to trilogy` adds an unneeded package.

### Detail

This PR removed adding `default-mysql-client` to `Dockerfile` when running `db:system:change --to trilogy` because Trilogy doesn't depend on the libmariadb / libmysqlclient library. 
Ref: https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/#should-you-use-trilogy

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
