### PR TITLE
Check zone presence in find_zone!

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -3,6 +3,7 @@
 require "active_support/time_with_zone"
 require "active_support/core_ext/time/acts_like"
 require "active_support/core_ext/date_and_time/zones"
+require "active_support/core_ext/object/blank"
 
 class Time
   include DateAndTime::Zones

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -76,10 +76,11 @@ class Time
     #   Time.find_zone! "EST"              # => #<ActiveSupport::TimeZone @name="EST" ...>
     #   Time.find_zone! -5.hours           # => #<ActiveSupport::TimeZone @name="Bogota" ...>
     #   Time.find_zone! nil                # => nil
-    #   Time.find_zone! false              # => false
+    #   Time.find_zone! false              # => nil
+    #   Time.find_zone! ""                 # => nil
     #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
     def find_zone!(time_zone)
-      return time_zone unless time_zone
+      return unless time_zone.present?
 
       ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}")
     end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1255,9 +1255,10 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     assert_match "invalid argument to TimeZone[]", error.message
   end
 
-  def test_find_zone_with_bang_doesnt_raises_with_nil_and_false
+  def test_find_zone_with_bang_doesnt_raises_with_non_present_argument
     assert_nil Time.find_zone!(nil)
-    assert_equal false, Time.find_zone!(false)
+    assert_nil Time.find_zone!(false)
+    assert_nil Time.find_zone!("")
   end
 
   def test_time_zone_setter_with_find_zone_without_bang


### PR DESCRIPTION
### Motivation / Background

I've been running into some issues in some projects when calling `in_time_zone` which behind the scenes calls `find_zone!`. The cause was always the zone being an empty string, which I would've expected the method to behave in the same way as when passing nil as a parameter.

This Pull Request has been created because in my opinion instead of calling `.presence` each time we call `in_time_zone` the `find_zone!` method should check for the presence of the argument, making sure that what we just passed is not "equivalent" to nil. 

### Detail

This Pull Request changes the `find_zone!` method to check the `zone` argument presence before actually trying to find the corresponding time zone. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. -> Not sure if this counts as a minor bug fix, open to add the CHANGELOG file changes too
