### PR TITLE
Fix `#reload` consistency issue

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1154,6 +1154,7 @@ module ActiveRecord
     def _find_record(options)
       all_queries = options ? options[:all_queries] : nil
       base = self.class.all(all_queries: all_queries).preload(strict_loaded_associations)
+      base = base.strict_loading if strict_loading?
 
       if options && options[:lock]
         base.lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -272,6 +272,26 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_sticks_between_reloads
+    dev = Developer.strict_loading.preload(:audit_logs).first
+
+    assert_nothing_raised do
+      dev.audit_logs.to_a
+    end
+
+    dev.reload
+
+    assert_nothing_raised do
+      dev.audit_logs.to_a
+    end
+
+    dev.reload
+
+    assert_nothing_raised do
+      dev.audit_logs.to_a
+    end
+  end
+
   def test_strict_loading_with_has_many_through_cascade_down_to_middle_records
     dev = Developer.first
     firm = Firm.create!(name: "NASA")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

If you have an object that has strict_loading set and then need to call `reload` multiple times, it would only work the first time, and after that, the application would start throwing a strict loading violation errors.

### Detail
To fix this, and keep `reload` working consistently between calls, we set `strict_loading`, if the original object has `strict_loading`, to the reloaded records to avoid the strict loading error. 

This wasn't a problem for the first call, because it is using the original associations cache, but it isn't the case for the other calls of `reload` as they would be using new copies of it, and when the new cache is used to build the list of ` strict_loaded_associations`, the `assoc.owner.strict_loading?` check will return `false`, as this owner is the previous `fresh_object` reference that doesn't have `strict_loading` set.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
