### PR TITLE
Separate `bundle lock` from `bundle install`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -680,19 +680,7 @@ module Rails
       end
 
       def run_bundle
-        if bundle_install?
-          bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1")
-
-          # The vast majority of Rails apps will be deployed on `x86_64-linux`.
-          platforms = ["--add-platform=x86_64-linux"]
-
-          # Users that develop on M1 mac may use docker and would need `aarch64-linux` as well.
-          platforms << "--add-platform=aarch64-linux" if RUBY_PLATFORM.start_with?("arm64")
-
-          platforms.each do |platform|
-            bundle_command("lock #{platform}", "BUNDLE_IGNORE_MESSAGES" => "1")
-          end
-        end
+        bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
       end
 
       def run_javascript
@@ -719,6 +707,16 @@ module Rails
           rails_command "dartsass:install"
         else
           rails_command "css:install:#{options[:css]}"
+        end
+      end
+
+      def add_bundler_platforms
+        if bundle_install?
+          # The vast majority of Rails apps will be deployed on `x86_64-linux`.
+          bundle_command("lock --add-platform=x86_64-linux")
+
+          # Users that develop on M1 mac may use docker and would need `aarch64-linux` as well.
+          bundle_command("lock --add-platform=aarch64-linux") if RUBY_PLATFORM.start_with?("arm64")
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -539,6 +539,7 @@ module Rails
 
       public_task :apply_rails_template
       public_task :run_bundle
+      public_task :add_bundler_platforms
       public_task :generate_bundler_binstub
       public_task :run_javascript
       public_task :run_hotwire

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1085,6 +1085,24 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_apply_rails_template_class_method_does_not_add_bundler_platforms
+    run_generator
+
+    FileUtils.cd(destination_root) do
+      FileUtils.touch("lib/template.rb")
+
+      generator_class.no_commands do
+        # There isn't an easy way to access the generator instance in order to
+        # assert that we don't run `bundle lock --add-platform`, so the
+        # following assertion assumes that the sole call to `bundle_command` is
+        # for `bundle install`.
+        assert_called_on_instance_of(generator_class, :bundle_command, times: 1) do
+          quietly { generator_class.apply_rails_template("lib/template.rb", destination_root) }
+        end
+      end
+    end
+  end
+
   def test_gitignore
     run_generator
 


### PR DESCRIPTION
When running `bundle install` for the `bin/rails app:template` command, it is unnecessary and possibly even incorrect to also run `bundle lock --add-platform=...` (because it could add a platform that the user has intentionally removed).  Likewise, when [running `bundle install` to support a prerelease version of Rails](https://github.com/rails/rails/blob/1b67822fe40354abad06608311f55de5e3012489/railties/lib/rails/generators/app_base.rb#L669), it is unnecessary to run `bundle lock --add-platform=...`.

This commit extracts `bundle lock --add-platform=...` from `run_bundle` into its own `add_bundler_platforms` generator task.
