### PR TITLE
Use `--quiet` for `bundle install`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -680,7 +680,7 @@ module Rails
       end
 
       def run_bundle
-        bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
+        bundle_command("install --quiet", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
       end
 
       def run_javascript

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -680,7 +680,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     generator([destination_root])
     run_generator_instance
 
-    assert_equal 1, @bundle_commands.count("install")
+    assert_not_empty @bundle_commands.grep(/^install/)
   end
 
   def test_generation_runs_bundle_lock_for_linux

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -244,7 +244,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_generation_runs_bundle_install
+  def test_generation_does_not_run_bundle_install
     generator([destination_root])
     run_generator_instance
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -414,10 +414,10 @@ module SharedGeneratorTests
       end
 
       assert_file File.expand_path("Gemfile", project_path) do |gemfile|
-        assert_equal "install", prerelease_commands[0]
+        assert_match %r/^install/, prerelease_commands[0]
         assert_equal gemfile[rails_gem_pattern], prerelease_command_rails_gems[0]
 
-        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", prerelease_commands[1]
+        assert_match %r/^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}/, prerelease_commands[1]
         assert_equal gemfile[rails_gem_pattern], prerelease_command_rails_gems[1]
       end
     end


### PR DESCRIPTION
When generating a new app, `bundle install` may be run multiple times due to various application templates.  This can create a lot of noise in the output log, particularly with Bundler <= 2.4.16, which displays the full list of gems each time `bundle install` is run.

To reduce noise, this commit adds the `--quiet` flag to `bundle install` commands.

__Before__

  ```console
  $ rails new my_cool_app --dev
        create
        create  Gemfile
           run  bundle install
  Resolving dependencies...
  Fetching gem metadata from https://rubygems.org/..........
  Bundle complete! 1 Gemfile dependency, 58 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
           run  rails new my_cool_app --dev
         exist
        remove  Gemfile
        remove  Gemfile.lock
        create  README.md
  ...
           run  bundle install
  Fetching gem metadata from https://rubygems.org/..........
  Resolving dependencies...
  Bundle complete! 12 Gemfile dependencies, 78 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
  ...
         rails  importmap:install
         apply  importmap-rails-1.2.3/lib/install/install.rb
  ...
           run  bundle install
  Bundle complete! 12 Gemfile dependencies, 78 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.

         rails  turbo:install stimulus:install
         apply  turbo-rails-1.5.0/lib/install/turbo_with_importmap.rb
  ...
           run  bundle install
  Bundle complete! 12 Gemfile dependencies, 78 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
         apply  turbo-rails-1.5.0/lib/install/turbo_needs_redis.rb
    Enable redis in bundle
          gsub    Gemfile
           run    bundle install
  Fetching gem metadata from https://rubygems.org/..........
  Resolving dependencies...
  Bundle complete! 13 Gemfile dependencies, 80 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
    Switch development cable to use redis
          gsub    config/cable.yml
           run  bundle install
  Bundle complete! 13 Gemfile dependencies, 80 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
         apply  stimulus-rails-1.3.0/lib/install/stimulus_with_importmap.rb
  ...
           run  bundle install
  Bundle complete! 13 Gemfile dependencies, 80 gems now installed.
  Use `bundle info [gemname]` to see where a bundled gem is installed.
  ```

__After__

  ```console
  $ rails new my_cool_app --dev
        create
        create  Gemfile
           run  bundle install --quiet
           run  rails new my_cool_app --dev
         exist
        remove  Gemfile
        remove  Gemfile.lock
        create  README.md
  ...
           run  bundle install --quiet
  ...
         rails  importmap:install
         apply  importmap-rails-1.2.3/lib/install/install.rb
  ...
           run  bundle install --quiet
         rails  turbo:install stimulus:install
         apply  turbo-rails-1.5.0/lib/install/turbo_with_importmap.rb
  ...
           run  bundle install --quiet
         apply  turbo-rails-1.5.0/lib/install/turbo_needs_redis.rb
    Enable redis in bundle
          gsub    Gemfile
           run    bundle install --quiet
    Switch development cable to use redis
          gsub    config/cable.yml
           run  bundle install --quiet
         apply  stimulus-rails-1.3.0/lib/install/stimulus_with_importmap.rb
  ...
           run  bundle install --quiet
  ```

Note that `bundle install` still displays any errors when using the `--quiet` flag:

  ```console
  $ bundle install --quiet
  Could not find gem 'rails (= 9001.0)' in rubygems repository https://rubygems.org/ or installed locally.

  The source contains the following gems matching 'rails':
    * rails-0.8.0
    ...
    * rails-7.1.2 
  ```
