### PR TITLE
Fixes for use of namespace with ActiveSupport::Cache::Store

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -826,7 +826,7 @@ module ActiveSupport
           end
         end
 
-        def deserialize_entry(payload)
+        def deserialize_entry(payload, **)
           payload.nil? ? nil : @coder.load(payload)
         rescue DeserializationError
           nil

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -210,7 +210,10 @@ module ActiveSupport
         def write_entry(key, entry, **options)
           payload = serialize_entry(entry, **options)
           synchronize do
-            return false if options[:unless_exist] && exist?(key)
+            if options[:unless_exist]
+              entry = read_entry(key, **options)
+              return false if entry && !entry.expired? && !entry.mismatched?(normalize_version(key, options))
+            end
 
             old_payload = @data[key]
             if old_payload

--- a/activesupport/test/cache/behaviors/cache_logging_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_logging_behavior.rb
@@ -63,11 +63,11 @@ module CacheLoggingBehavior
 
   def test_write_multi_logging
     key = SecureRandom.uuid
-    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({"#{key}1" => 1}, namespace: nil) }
-    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({"#{key}1" => 1, "#{key}2" => 2}, namespace: nil) }
+    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({ "#{key}1" => 1 }, namespace: nil) }
+    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({ "#{key}1" => 1, "#{key}2" => 2 }, namespace: nil) }
 
-    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({"#{key}1" => 1}, namespace: "bar") }
-    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({"#{key}1" => 1, "#{key}2" => 2}, namespace: "bar") }
+    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({ "#{key}1" => 1 }, namespace: "bar") }
+    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({ "#{key}1" => 1, "#{key}2" => 2 }, namespace: "bar") }
   end
 
   def test_delete_multi_logging

--- a/activesupport/test/cache/behaviors/cache_logging_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_logging_behavior.rb
@@ -4,8 +4,8 @@ require "active_support/core_ext/object/with"
 
 module CacheLoggingBehavior
   def test_fetch_logging
-    assert_logs(/Cache read: #{key_pattern("foo")}/) do
-      @cache.fetch("foo")
+    assert_logs(/Cache read: #{key_pattern("foo", namespace: nil)}/) do
+      @cache.fetch("foo", namespace: nil)
     end
 
     assert_logs(/Cache read: #{key_pattern("foo", namespace: "bar")}/) do
@@ -14,8 +14,8 @@ module CacheLoggingBehavior
   end
 
   def test_read_logging
-    assert_logs(/Cache read: #{key_pattern("foo")}/) do
-      @cache.read("foo")
+    assert_logs(/Cache read: #{key_pattern("foo", namespace: nil)}/) do
+      @cache.read("foo", namespace: nil)
     end
 
     assert_logs(/Cache read: #{key_pattern("foo", namespace: "bar")}/) do
@@ -24,8 +24,8 @@ module CacheLoggingBehavior
   end
 
   def test_write_logging
-    assert_logs(/Cache write: #{key_pattern("foo")}/) do
-      @cache.write("foo", "qux")
+    assert_logs(/Cache write: #{key_pattern("foo", namespace: nil)}/) do
+      @cache.write("foo", "qux", namespace: nil)
     end
 
     assert_logs(/Cache write: #{key_pattern("foo", namespace: "bar")}/) do
@@ -34,8 +34,8 @@ module CacheLoggingBehavior
   end
 
   def test_delete_logging
-    assert_logs(/Cache delete: #{key_pattern("foo")}/) do
-      @cache.delete("foo")
+    assert_logs(/Cache delete: #{key_pattern("foo", namespace: nil)}/) do
+      @cache.delete("foo", namespace: nil)
     end
 
     assert_logs(/Cache delete: #{key_pattern("foo", namespace: "bar")}/) do
@@ -44,8 +44,8 @@ module CacheLoggingBehavior
   end
 
   def test_exist_logging
-    assert_logs(/Cache exist\?: #{key_pattern("foo")}/) do
-      @cache.exist?("foo")
+    assert_logs(/Cache exist\?: #{key_pattern("foo", namespace: nil)}/) do
+      @cache.exist?("foo", namespace: nil)
     end
 
     assert_logs(/Cache exist\?: #{key_pattern("foo", namespace: "bar")}/) do
@@ -54,20 +54,29 @@ module CacheLoggingBehavior
   end
 
   def test_read_multi_logging
-    assert_logs("Cache read_multi: 1 key(s)") { @cache.read_multi("foo") }
-    assert_logs("Cache read_multi: 2 key(s)") { @cache.read_multi("foo", "bar") }
+    assert_logs("Cache read_multi: 1 key(s)") { @cache.read_multi("foo", namespace: nil) }
+    assert_logs("Cache read_multi: 2 key(s)") { @cache.read_multi("foo", "bar", namespace: nil) }
+
+    assert_logs("Cache read_multi: 1 key(s)") { @cache.read_multi("foo", namespace: "bar") }
+    assert_logs("Cache read_multi: 2 key(s)") { @cache.read_multi("foo", "bar", namespace: "bar") }
   end
 
   def test_write_multi_logging
     key = SecureRandom.uuid
-    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi("#{key}1" => 1) }
-    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi("#{key}1" => 1, "#{key}2" => 2) }
+    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({"#{key}1" => 1}, namespace: nil) }
+    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({"#{key}1" => 1, "#{key}2" => 2}, namespace: nil) }
+
+    assert_logs("Cache write_multi: 1 key(s)") { @cache.write_multi({"#{key}1" => 1}, namespace: "bar") }
+    assert_logs("Cache write_multi: 2 key(s)") { @cache.write_multi({"#{key}1" => 1, "#{key}2" => 2}, namespace: "bar") }
   end
 
   def test_delete_multi_logging
     key = SecureRandom.uuid
-    assert_logs("Cache delete_multi: 1 key(s)") { @cache.delete_multi(["#{key}1"]) }
-    assert_logs("Cache delete_multi: 2 key(s)") { @cache.delete_multi(["#{key}1", "#{key}2"]) }
+    assert_logs("Cache delete_multi: 1 key(s)") { @cache.delete_multi(["#{key}1"], namespace: nil) }
+    assert_logs("Cache delete_multi: 2 key(s)") { @cache.delete_multi(["#{key}1", "#{key}2"], namespace: nil) }
+
+    assert_logs("Cache delete_multi: 1 key(s)") { @cache.delete_multi(["#{key}1"], namespace: "bar") }
+    assert_logs("Cache delete_multi: 2 key(s)") { @cache.delete_multi(["#{key}1", "#{key}2"], namespace: "bar") }
   end
 
   private
@@ -77,7 +86,7 @@ module CacheLoggingBehavior
       assert_match pattern, io.string
     end
 
-    def key_pattern(key, namespace: @namespace)
+    def key_pattern(key, namespace:)
       /#{Regexp.escape namespace.to_s}#{":" if namespace}#{Regexp.escape key}/
     end
 end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -102,7 +102,7 @@ class FileStoreTest < ActiveSupport::TestCase
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   def test_namespaced_key_transformation_max_filename_size
     encoded_prefix = URI.encode_www_form_component("#{@namespace}:")
-    key = "#{'A' * (ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE-encoded_prefix.length)}B"
+    key = "#{'A' * (ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE - encoded_prefix.length)}B"
     path = @namespaced_cache.send(:normalize_key, key, {})
     assert path.split("/").all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE }
     assert_equal "B", File.basename(path)

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -160,7 +160,7 @@ class FileStoreTest < ActiveSupport::TestCase
   end
 
   private
-    def key_pattern(key, namespace: nil)
+    def key_pattern(key, namespace:)
       /.+\/#{Regexp.escape namespace.to_s}#{/%3A/i if namespace}#{Regexp.escape key}/
     end
 end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -68,7 +68,7 @@ class FileStoreTest < ActiveSupport::TestCase
 
   def test_namespaced_key_transformation
     key = @namespaced_cache.send(:normalize_key, "views/index?id=1", {})
-    assert_equal "views/index?id=1", @namespaced_cache.send(:file_path_key, key)
+    assert_equal "#{@namespace}:views/index?id=1", @namespaced_cache.send(:file_path_key, key)
   end
 
   def test_key_transformation_with_pathname
@@ -101,7 +101,8 @@ class FileStoreTest < ActiveSupport::TestCase
   # Because file systems have a maximum filename size, filenames > max size should be split in to directories
   # If filename is 'AAAAB', where max size is 4, the returned path should be AAAA/B
   def test_namespaced_key_transformation_max_filename_size
-    key = "#{'A' * ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE}B"
+    encoded_prefix = URI.encode_www_form_component("#{@namespace}:")
+    key = "#{'A' * (ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE-encoded_prefix.length)}B"
     path = @namespaced_cache.send(:normalize_key, key, {})
     assert path.split("/").all? { |dir_name| dir_name.size <= ActiveSupport::Cache::FileStore::FILENAME_MAX_SIZE }
     assert_equal "B", File.basename(path)

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -7,6 +7,8 @@ require_relative "../behaviors"
 class MemoryStoreTest < ActiveSupport::TestCase
   def setup
     @cache = lookup_store(expires_in: 60)
+    @namespace = "test-#{Random.rand(16**32).to_s(16)}"
+    @namespaced_cache = lookup_store(expires_in: 60, namespace: @namespace)
   end
 
   def lookup_store(options = {})
@@ -66,6 +68,13 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
     @cache.write(1, nil)
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+  end
+
+  def test_namespaced_write_with_unless_exist # namespaced_cache
+    assert_equal true, @namespaced_cache.write(1, "aaaaaaaaaa")
+    assert_equal false, @namespaced_cache.write(1, "aaaaaaaaaa", unless_exist: true)
+    @namespaced_cache.write(1, nil)
+    assert_equal false, @namespaced_cache.write(1, "aaaaaaaaaa", unless_exist: true)
   end
 
   def test_write_expired_value_with_unless_exist

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -61,6 +61,19 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_same value, @cache.read("key")
   end
 
+  def test_write_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaaaaaaaa")
+    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+    @cache.write(1, nil)
+    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+  end
+
+  def test_write_expired_value_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
+    travel 2.seconds
+    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
+  end
+
   private
     def compression_always_disabled_by_default?
       true
@@ -186,18 +199,5 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     read_item = @cache.read(key)
     assert_not_equal item.object_id, read_item.object_id
     assert_not_equal read_item.object_id, @cache.read(key).object_id
-  end
-
-  def test_write_with_unless_exist
-    assert_equal true, @cache.write(1, "aaaaaaaaaa")
-    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
-    @cache.write(1, nil)
-    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
-  end
-
-  def test_write_expired_value_with_unless_exist
-    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
-    travel 2.seconds
-    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
   end
 end


### PR DESCRIPTION
### Motivation / Background

This PR was created because I ran into some unexpected inconsistency with how namespaces worked while using `ActiveSupport::Cache::MemoryStore` (compared to how it worked using `ActiveSupport::Cache::MemCacheStore`).

### Detail

This Pull Request adds some additional tests for use of namespace, and then fixes the broken behaviours.

* moved the `unless_exist` tests to `MemoryStoreTest` (from `MemoryStorePruningTest`)
* expanded the cache logging test behaviour to explicitly test non-namespaced and namespaced cases
* added explicit test cases for any tests that failed if I introduced namespaces for all stores
* fixed the expectations in the (previously introduced) filestore namespacing tests
* fixed the local cache strategy's implementation of `read_multi_entries` so that it accepted names instead of keys (as per the implementations in the cache stores)
* fixed `MemoryStore#write_entry` so that it directly checked existence of an entry instead of relying on `exist?` (which accepts a name rather than a key)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Tests are added or updated if you fix a bug or add a feature.
