### PR TITLE
Retry new connection on checkout after reap

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -668,7 +668,13 @@ module ActiveRecord
             conn
           else
             reap
-            @available.poll(checkout_timeout)
+            # Retry after reaping, which may return an available connection,
+            # remove an inactive connection, or both
+            if conn = @available.poll || try_to_checkout_new_connection
+              conn
+            else
+              @available.poll(checkout_timeout)
+            end
           end
         end
 


### PR DESCRIPTION
When we reap connections, we check if they are inactive (connected and responding to ping in most adapters) and if so we remove the connection instead of checking it back in.

However, in acquire_connection, we weren't checking after reaping whether we were allowed to build a new connection, only whether an existing one was in the available pool.

This still leaves a race condition where if the background reaper thread runs while a thread is polling and finds a free inactive connection, it could have the same issue and not wake the waiting thread. However we don't really expect the reaper to solve this (it only runs every 60 seconds by default, far too slow to solve for a blocked thread). I think this should be fixed, just separately (and would probably involve some more significant refactoring).


@joeldrapper showed me an example usage at RubyConf San Diego, which may have been caused (or at least worsened) by this bug. So 🤞 this helps.

Thanks to advice from @composerinteralia and @matthewd 

I think we should backport this to 7-1-stable.