### PR TITLE
Fix MemoryStore#write with unless_exist and namespace

### DIFF
--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -210,7 +210,7 @@ module ActiveSupport
         def write_entry(key, entry, **options)
           payload = serialize_entry(entry, **options)
           synchronize do
-            return false if options[:unless_exist] && exist?(key)
+            return false if options[:unless_exist] && exist?(key, namespace: nil)
 
             old_payload = @data[key]
             if old_payload

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -61,6 +61,28 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_same value, @cache.read("key")
   end
 
+  def test_write_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaaaaaaaa")
+    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+    @cache.write(1, nil)
+    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
+  end
+
+  def test_namespaced_write_with_unless_exist
+    namespaced_cache = lookup_store(expires_in: 60, namespace: "foo")
+
+    assert_equal true, namespaced_cache.write(1, "aaaaaaaaaa")
+    assert_equal false, namespaced_cache.write(1, "aaaaaaaaaa", unless_exist: true)
+    namespaced_cache.write(1, nil)
+    assert_equal false, namespaced_cache.write(1, "aaaaaaaaaa", unless_exist: true)
+  end
+
+  def test_write_expired_value_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
+    travel 2.seconds
+    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
+  end
+
   private
     def compression_always_disabled_by_default?
       true
@@ -186,18 +208,5 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     read_item = @cache.read(key)
     assert_not_equal item.object_id, read_item.object_id
     assert_not_equal read_item.object_id, @cache.read(key).object_id
-  end
-
-  def test_write_with_unless_exist
-    assert_equal true, @cache.write(1, "aaaaaaaaaa")
-    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
-    @cache.write(1, nil)
-    assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
-  end
-
-  def test_write_expired_value_with_unless_exist
-    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
-    travel 2.seconds
-    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix `ActiveSupport::Cache::MemoryStore#write` support for `unless_exist: true` when using the `namespace` option as well.

### Detail

This Pull Request fixes `MemoryStore#write_entry` so that it passes a nil namespace to `exist?`. This is necessary because `exist?` since the _key_ has already been normalized to include the namespace.

### Additional information

In addition to adding a test for `write` with `unless_exist: true` using a `namespace` as well, the existing tests for `write` with `unless_exist: true` were moved to `MemoryStoreTest` (from `MemoryStorePruningTest`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
