### PR TITLE
Use constant for RequestId regex

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -17,6 +17,8 @@ module ActionDispatch
   # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
   # from multiple pieces of the stack.
   class RequestId
+    RE = /[^\w\-@]/ # :nodoc:
+
     def initialize(app, header:)
       @app = app
       @header = header
@@ -31,7 +33,7 @@ module ActionDispatch
     private
       def make_request_id(request_id)
         if request_id.presence
-          request_id.gsub(/[^\w\-@]/, "").first(255)
+          request_id.gsub(RE, "").first(255)
         else
           internal_request_id
         end


### PR DESCRIPTION
### Motivation / Background

Reading through some profiles and code for other reasons, I saw this RequestId middleware and that it did this gsub regex thing, and that we created a new regex object for every request. Seemed unnecessary.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

Pull a regex into a class constant.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

I did not check the following. Covered by existing tests, and I don't think this PR warrants a changelog entry.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
