### PR TITLE
Ensure triggers are enabled when operation fails in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -457,8 +457,8 @@ module ActiveRecord
         statements = table_deletes + fixture_inserts
 
         with_multi_statements do
-          disable_referential_integrity do
-            transaction(requires_new: true) do
+          transaction(requires_new: true) do
+            disable_referential_integrity do
               execute_batch(statements, "Fixtures Load")
             end
           end


### PR DESCRIPTION
Fixes #50191.

Shortened repro script:
```
$ cd activerecord
$ ARCONN=postgresql bin/test test/cases/fixtures_test.rb test/cases/adapters/postgresql/deferred_constraints_test.rb -n "/^(?:FixturesTest#(?:test_bulk_insert_with_a_multi_statement_query_raises_an_exception_when_any_insert_fails)|PostgresqlDeferredConstraintsTest#(?:test_defer_constraints_with_specific_fk))$/" --seed 49401
```

When fixture test executes https://github.com/rails/rails/blob/139c5678aa5d9a4209ca06919abea7a9da449b36/activerecord/test/cases/fixtures_test.rb#L113-L129 `insert_fixtire_set` from line 126 uses `disable_referential_integrity`. An error is raised, but triggers are not enabled back in https://github.com/rails/rails/blob/139c5678aa5d9a4209ca06919abea7a9da449b36/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb#L7-L39 and so for all the other tests from `PostgresqlDeferredConstraintsTest` they are not enabled and any deferrable foreign keys are just disabled.

cc @yahonda 