### PR TITLE
Fix duplicate `DEFERRABLE` directive added for foreign keys in PostgreSQL and SQLite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -18,7 +18,6 @@ module ActiveRecord
 
           def visit_AddForeignKey(o)
             super.dup.tap do |sql|
-              sql << " DEFERRABLE INITIALLY #{o.options[:deferrable].to_s.upcase}" if o.deferrable
               sql << " NOT VALID" unless o.validate?
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb
@@ -5,12 +5,6 @@ module ActiveRecord
     module SQLite3
       class SchemaCreation < SchemaCreation # :nodoc:
         private
-          def visit_AddForeignKey(o)
-            super.dup.tap do |sql|
-              sql << " DEFERRABLE INITIALLY #{o.options[:deferrable].to_s.upcase}" if o.deferrable
-            end
-          end
-
           def visit_ForeignKeyDefinition(o)
             super.dup.tap do |sql|
               sql << " DEFERRABLE INITIALLY #{o.deferrable.to_s.upcase}" if o.deferrable

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -519,7 +519,9 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
 
         if ActiveRecord::Base.connection.supports_deferrable_constraints?
           def test_deferrable_foreign_key
-            @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", deferrable: :immediate
+            assert_queries_match(/\("id"\)\s+DEFERRABLE INITIALLY IMMEDIATE\W*\z/i) do
+              @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", deferrable: :immediate
+            end
 
             foreign_keys = @connection.foreign_keys("astronauts")
             assert_equal 1, foreign_keys.size


### PR DESCRIPTION
When adding a foreign key with a `:deferrable` option, a duplicate `"DEFERRABLE"` directive is generated. 
Something like:
```sql
ALTER TABLE "authors" ADD CONSTRAINT "fk_rails_94423a17a3"
FOREIGN KEY ("author_address_id")
  REFERENCES "author_addresses" ("id")
 DEFERRABLE INITIALLY IMMEDIATE DEFERRABLE INITIALLY IMMEDIATE
```

This PR fixes that.