### PR TITLE
Fix `read_multi` with local cache and namespace

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -826,7 +826,7 @@ module ActiveSupport
           end
         end
 
-        def deserialize_entry(payload)
+        def deserialize_entry(payload, **)
           payload.nil? ? nil : @coder.load(payload)
         rescue DeserializationError
           nil

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -139,7 +139,7 @@ module ActiveSupport
             local_entries = local_cache.read_multi_entries(keys_to_names.keys)
             local_entries.transform_keys! { |key| keys_to_names[key] }
             local_entries.transform_values! do |payload|
-              deserialize_entry(payload, raw: options[:raw])&.value
+              deserialize_entry(payload, **options)&.value
             end
             missed_names = names - local_entries.keys
 

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -62,6 +62,19 @@ class NullStoreTest < ActiveSupport::TestCase
     assert_nil @cache.read("name")
   end
 
+  def test_namespaced_local_store_strategy
+    namespaced_cache = ActiveSupport::Cache.lookup_store(:null_store, namespace: "foo")
+
+    namespaced_cache.with_local_cache do
+      namespaced_cache.write("name", "value")
+      assert_equal "value", namespaced_cache.read("name")
+      namespaced_cache.delete("name")
+      assert_nil namespaced_cache.read("name")
+      namespaced_cache.write("name", "value")
+    end
+    assert_nil namespaced_cache.read("name")
+  end
+
   def test_local_store_repeated_reads
     @cache.with_local_cache do
       @cache.read("foo")
@@ -69,6 +82,18 @@ class NullStoreTest < ActiveSupport::TestCase
 
       @cache.read_multi("foo", "bar")
       assert_equal({ "foo" => nil, "bar" => nil }, @cache.read_multi("foo", "bar"))
+    end
+  end
+
+  def test_namespaced_local_store_repeated_reads
+    namespaced_cache = ActiveSupport::Cache.lookup_store(:null_store, namespace: "foo")
+
+    namespaced_cache.with_local_cache do
+      namespaced_cache.read("foo")
+      assert_nil namespaced_cache.read("foo")
+
+      namespaced_cache.read_multi("foo", "bar")
+      assert_equal({ "foo" => nil, "bar" => nil }, namespaced_cache.read_multi("foo", "bar"))
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveSupport::Cache::Strategy::LocalCache` was not properly handling `read_multi` when a `namespace` was used. This was because `read_multi_entries` was using _key_ values, instead of _name_ values as per the implementations of that interface in the cache stores.

### Detail

This Pull Request changes `ActiveSupport::Cache::Strategy::LocalCache#read_multi` to correctly accept name values instead of key values.

### Additional information

Tests have been added for local_store usage with namespaces.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
