### PR TITLE
Translate Trilogy syscall errors as conn failed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ platforms :ruby, :windows do
   group :db do
     gem "pg", "~> 1.3"
     gem "mysql2", "~> 0.5"
-    gem "trilogy", ">= 2.5.0"
+    gem "trilogy", ">= 2.7.0"
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
     timeout (0.4.1)
     tomlrb (2.0.3)
     trailblazer-option (0.1.2)
-    trilogy (2.6.0)
+    trilogy (2.7.0)
     turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -654,7 +654,7 @@ DEPENDENCIES
   syntax_tree (= 6.1.1)
   tailwindcss-rails
   terser (>= 1.1.4)
-  trilogy (>= 2.5.0)
+  trilogy (>= 2.7.0)
   turbo-rails
   tzinfo-data
   useragent

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -2,7 +2,7 @@
 
 require "active_record/connection_adapters/abstract_mysql_adapter"
 
-gem "trilogy", "~> 2.4"
+gem "trilogy", "~> 2.7"
 require "trilogy"
 
 require "active_record/connection_adapters/trilogy/database_statements"
@@ -209,10 +209,11 @@ module ActiveRecord
           end
 
           case exception
-          when Errno::EPIPE, SocketError, IOError
+          when SocketError, IOError
             return ConnectionFailed.new(message, connection_pool: @pool)
           when ::Trilogy::Error
-            if /Connection reset by peer|TRILOGY_CLOSED_CONNECTION|TRILOGY_INVALID_SEQUENCE_ID|TRILOGY_UNEXPECTED_PACKET/.match?(exception.message)
+            if /TRILOGY_CLOSED_CONNECTION|TRILOGY_INVALID_SEQUENCE_ID|TRILOGY_UNEXPECTED_PACKET/.match?(exception.message) ||
+                exception.is_a?(SystemCallError)
               return ConnectionFailed.new(message, connection_pool: @pool)
             end
           end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -358,6 +358,38 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     assert_includes error.message, "/var/invalid.sock"
   end
 
+  test "EPIPE raises ActiveRecord::ConnectionFailed" do
+    assert_raises(ActiveRecord::ConnectionFailed) do
+      @conn.raw_connection.stub(:query, -> (*) { raise Trilogy::SyscallError::EPIPE }) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
+  test "ETIMEDOUT raises ActiveRecord::ConnectionFailed" do
+    assert_raises(ActiveRecord::ConnectionFailed) do
+      @conn.raw_connection.stub(:query, -> (*) { raise Trilogy::SyscallError::ETIMEDOUT }) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
+  test "ECONNREFUSED raises ActiveRecord::ConnectionFailed" do
+    assert_raises(ActiveRecord::ConnectionFailed) do
+      @conn.raw_connection.stub(:query, -> (*) { raise Trilogy::SyscallError::ECONNREFUSED }) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
+  test "ECONNRESET raises ActiveRecord::ConnectionFailed" do
+    assert_raises(ActiveRecord::ConnectionFailed) do
+      @conn.raw_connection.stub(:query, -> (*) { raise Trilogy::SyscallError::ECONNRESET }) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
   # Create a temporary subscription to verify notification is sent.
   # Optionally verify the notification payload includes expected types.
   def assert_notification(notification, expected_payload = {}, &block)

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -14,7 +14,7 @@ module Rails
       def gem_for_database(database = options[:database])
         case database
         when "mysql"          then ["mysql2", ["~> 0.5"]]
-        when "trilogy"        then ["trilogy", ["~> 2.4"]]
+        when "trilogy"        then ["trilogy", ["~> 2.7"]]
         when "postgresql"     then ["pg", ["~> 1.1"]]
         when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -100,7 +100,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use trilogy as the database for Active Record", content
-              assert_match 'gem "trilogy", "~> 2.4"', content
+              assert_match 'gem "trilogy", "~> 2.7"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
At GitHub we get a fair number of Trilogy `ETIMEDOUT` errors (for known reasons that we might be able to improve somewhat, but I doubt we'll make them go away entirely). These are very much retryable network errors, so it'd be handy if these `ETIMEDOUT` errors were translated to `ConnectionFailed` instead of `StatementInvalid`, making them `retryable_connection_error`s.

https://github.com/rails/rails/blob/ed2bc92b82ddc111150cdf48bb646fd97b3baacb/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1077-L1078

We're already translating `ECONNRESET` (via matching on the error message) and `EPIPE` to `ConnectionFailed`. Rather than adding another case, this commit treats all of the Trilogy `SystemCallError` subclasses as `ConnectionFailed`.

~Unfortunately `Trilogy::TimeoutError` is a subclass of `ETIMEDOUT`, so we have to move the `AdapterTimeout` check into the case statement so we can break out to the `super` call in the case of `Trilogy::TimeoutError` that does have an error code (1205, i.e. lock timeout). Cleaning up the various Trilogy timeout errors is a project for another day.~

~We should be able to simplify this exception translation further once we bump the required Trilogy version to 2.6, but I figured I'd start out with this minimal change that works on Trilogy 2.4 as well.~

Bumped Trilogy to 2.7, which includes https://github.com/trilogy-libraries/trilogy/pull/150 so we can do this more cleanly.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
