### PR TITLE
Add config for validating migration timestamps

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `active_record.config.validate_migration_timestamps` option for validating migration timestamps.
+
+    When set, validates that the timestamp prefix for a migration is in the form YYYYMMDDHHMMSS.
+    This is designed to prevent migration timestamps from being modified by hand.
+
+    *Adrianna Chang*
+
 *   When using a `DATABASE_URL`, allow for a configuration to map the protocol in the URL to a specific database
     adapter. This allows decoupling the adapter the application chooses to use from the database connection details
     set in the deployment environment.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -372,6 +372,14 @@ module ActiveRecord
 
   ##
   # :singleton-method:
+  # Specify whether or not to validate migration timestamps. When set, an error
+  # will be raised if a timestamp is not a valid timestamp in the form
+  # YYYYMMDDHHMMSS. +timestamped_migrations+ must be set to true.
+  singleton_class.attr_accessor :validate_migration_timestamps
+  self.validate_migration_timestamps = false
+
+  ##
+  # :singleton-method:
   # Specify strategy to use for executing migrations.
   singleton_class.attr_accessor :migration_strategy
   self.migration_strategy = Migration::DefaultStrategy

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1802,3 +1802,102 @@ class CopyMigrationsTest < ActiveRecord::TestCase
     assert_raise(ArgumentError) { ActiveRecord::Migration[1.0] }
   end
 end
+
+class MigrationValidationTest < ActiveRecord::TestCase
+  def setup
+    @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
+    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+    @active_record_validate_timestamps_was = ActiveRecord.validate_migration_timestamps
+    ActiveRecord.validate_migration_timestamps = true
+    ActiveRecord::Base.connection.schema_cache.clear!
+
+    @migrations_path = MIGRATIONS_ROOT + "/temp"
+    @migrator = ActiveRecord::MigrationContext.new(@migrations_path, @schema_migration, @internal_metadata)
+  end
+
+  def teardown
+    @schema_migration.create_table
+    @schema_migration.delete_all_versions
+    ActiveRecord.validate_migration_timestamps = @active_record_validate_timestamps_was
+    ActiveRecord::Migration.verbose = @verbose_was
+  end
+
+  def test_migration_raises_if_timestamp_not_14_digits
+    with_temp_migration_file(@migrations_path, "201801010101010000_test_migration.rb") do
+      error = assert_raises(ActiveRecord::InvalidMigrationTimestampError) do
+        @migrator.up(201801010101010000)
+      end
+      assert_match(/Invalid timestamp 201801010101010000 for migration file: test_migration/, error.message)
+    end
+
+    with_temp_migration_file(@migrations_path, "201801010_test_migration.rb") do
+      error = assert_raises(ActiveRecord::InvalidMigrationTimestampError) do
+        @migrator.up(201801010)
+      end
+      assert_match(/Invalid timestamp 201801010 for migration file: test_migration/, error.message)
+    end
+  end
+
+  def test_migration_raises_if_timestamp_is_invalid_date
+    # 2023-15-26 is an invalid date
+    with_temp_migration_file(@migrations_path, "20231526101010_test_migration.rb") do
+      error = assert_raises(ActiveRecord::InvalidMigrationTimestampError) do
+        @migrator.up(20231526101010)
+      end
+      assert_match(/Invalid timestamp 20231526101010 for migration file: test_migration/, error.message)
+    end
+  end
+
+  def test_migration_raises_if_timestamp_is_invalid_day_month_combo
+    # 2023-02-31 is an invalid date; 02 and 31 are valid month / days individually,
+    # but February 31 does not exist.
+    with_temp_migration_file(@migrations_path, "20230231101010_test_migration.rb") do
+      error = assert_raises(ActiveRecord::InvalidMigrationTimestampError) do
+        @migrator.up(20230231101010)
+      end
+      assert_match(/Invalid timestamp 20230231101010 for migration file: test_migration/, error.message)
+    end
+  end
+
+  def test_migration_succeeds_despite_invalid_timestamp_if_validate_timestamps_is_false
+    validate_migration_timestamps_was = ActiveRecord.validate_migration_timestamps
+    ActiveRecord.validate_migration_timestamps = false
+    with_temp_migration_file(@migrations_path, "201801010_test_migration.rb") do
+      @migrator.up(201801010)
+      assert_equal 201801010, @migrator.current_version
+    end
+  ensure
+    ActiveRecord.validate_migration_timestamps = validate_migration_timestamps_was
+  end
+
+  def test_migration_succeeds_despite_invalid_timestamp_if_timestamped_migrations_is_false
+    timestamped_migrations_was = ActiveRecord.timestamped_migrations
+    ActiveRecord.timestamped_migrations = false
+    with_temp_migration_file(@migrations_path, "201801010_test_migration.rb") do
+      @migrator.up(201801010)
+      assert_equal 201801010, @migrator.current_version
+    end
+  ensure
+    ActiveRecord.timestamped_migrations = timestamped_migrations_was
+  end
+
+  private
+    def with_temp_migration_file(migrations_dir, filename)
+      Dir.mkdir(migrations_dir) unless Dir.exist?(migrations_dir)
+      path = File.join(migrations_dir, filename)
+
+      File.open(path, "w+") do |file|
+        file << <<-MIGRATION
+      class TestMigration < ActiveRecord::Migration::Current
+        def change; end
+      end
+        MIGRATION
+      end
+
+      yield
+    ensure
+      File.delete(path) if File.exist?(path)
+      Dir.rmdir(migrations_dir) if Dir.exist?(migrations_dir)
+    end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -58,6 +58,10 @@ NOTE: If you need to apply configuration directly to a class, use a [lazy load h
 
 Below are the default values associated with each target version. In cases of conflicting values, newer versions take precedence over older versions.
 
+#### Default Values for Target Version 7.2
+
+- [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
+
 #### Default Values for Target Version 7.1
 
 - [`config.action_dispatch.debug_exception_log_level`](#config-action-dispatch-debug-exception-log-level): `:error`
@@ -1046,6 +1050,17 @@ Specifies if an error should be raised if the order of a query is ignored during
 #### `config.active_record.timestamped_migrations`
 
 Controls whether migrations are numbered with serial integers or with timestamps. The default is `true`, to use timestamps, which are preferred if there are multiple developers working on the same application.
+
+#### `config.active_record.validate_migration_timestamps`
+
+Controls whether to validate migration timestamps. When set, an error will be raised if a timestamp is not a valid timestamp in the form YYYYMMDDHHMMSS. `config.active_record.timestamped_migrations` must be set to `true`.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.2                   | `true`               |
 
 #### `config.active_record.db_warnings_action`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -323,6 +323,10 @@ module Rails
           end
         when "7.2"
           load_defaults "7.1"
+
+          if respond_to?(:active_record)
+            active_record.validate_migration_timestamps = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
@@ -8,3 +8,13 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Enable validation of migration timestamps. Migration timestamps must be
+# in the form YYYYMMDDHHMMSS, or an ActiveRecord::InvalidMigrationTimestampError
+# will be raised.
+#
+# Applications with existing timestamped migrations that do not adhere to the
+# expected format can disable validation by setting this config to `false`.
+#++
+# Rails.application.config.active_record.validate_migration_timestamps = true

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -319,6 +319,7 @@ class LoadingTest < ActiveSupport::TestCase
   test "columns migrations also trigger reloading" do
     add_to_config <<-RUBY
       config.enable_reloading = true
+      config.active_record.timestamped_migrations = false
     RUBY
 
     app_file "config/routes.rb", <<-RUBY

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -8,6 +8,7 @@ module ApplicationTests
       def setup
         build_app
         FileUtils.rm_rf("#{app_path}/config/environments")
+        add_to_config("config.active_record.timestamped_migrations = false")
       end
 
       def teardown
@@ -17,7 +18,7 @@ module ApplicationTests
       test "running migrations with given scope" do
         rails "generate", "model", "user", "username:string", "password:string"
 
-        app_file "db/migrate/01_a_migration.bukkits.rb", <<-MIGRATION
+        app_file "db/migrate/02_a_migration.bukkits.rb", <<-MIGRATION
           class AMigration < ActiveRecord::Migration::Current
           end
         MIGRATION
@@ -200,6 +201,8 @@ module ApplicationTests
       end
 
       test "migration status" do
+        remove_from_config("config.active_record.timestamped_migrations = false")
+
         rails "generate", "model", "user", "username:string", "password:string"
         rails "generate", "migration", "add_email_to_users", "email:string"
         rails "db:migrate"
@@ -217,7 +220,7 @@ module ApplicationTests
       end
 
       test "migration status without timestamps" do
-        add_to_config("config.active_record.timestamped_migrations = false")
+        remove_from_config("config.active_record.timestamped_migrations = false")
 
         rails "generate", "model", "user", "username:string", "password:string"
         rails "generate", "migration", "add_email_to_users", "email:string"
@@ -236,6 +239,8 @@ module ApplicationTests
       end
 
       test "migration status after rollback and redo" do
+        remove_from_config("config.active_record.timestamped_migrations = false")
+
         rails "generate", "model", "user", "username:string", "password:string"
         rails "generate", "migration", "add_email_to_users", "email:string"
         rails "db:migrate"
@@ -259,6 +264,8 @@ module ApplicationTests
       end
 
       test "migration status after rollback and forward" do
+        remove_from_config("config.active_record.timestamped_migrations = false")
+
         rails "generate", "model", "user", "username:string", "password:string"
         rails "generate", "migration", "add_email_to_users", "email:string"
         rails "db:migrate"
@@ -283,6 +290,8 @@ module ApplicationTests
 
       test "raise error on any move when current migration does not exist" do
         Dir.chdir(app_path) do
+          remove_from_config("config.active_record.timestamped_migrations = false")
+
           rails "generate", "model", "user", "username:string", "password:string"
           rails "generate", "migration", "add_email_to_users", "email:string"
           rails "db:migrate"
@@ -382,8 +391,6 @@ module ApplicationTests
       end
 
       test "migration status after rollback and redo without timestamps" do
-        add_to_config("config.active_record.timestamped_migrations = false")
-
         rails "generate", "model", "user", "username:string", "password:string"
         rails "generate", "migration", "add_email_to_users", "email:string"
         rails "db:migrate"
@@ -497,6 +504,8 @@ module ApplicationTests
 
       test "migration status migrated file is deleted" do
         Dir.chdir(app_path) do
+          remove_from_config("config.active_record.timestamped_migrations = false")
+
           rails "generate", "model", "user", "username:string", "password:string"
           rails "generate", "migration", "add_email_to_users", "email:string"
           rails "db:migrate"
@@ -523,7 +532,7 @@ module ApplicationTests
 
           rails("db:migrate")
 
-          app_file "db/migrate/01_a_migration.bukkits.rb", <<-MIGRATION
+          app_file "db/migrate/02_a_migration.bukkits.rb", <<-MIGRATION
             class AMigration < ActiveRecord::Migration::Current
               def change
                 User.first

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -10,6 +10,7 @@ module ApplicationTests
       def setup
         build_app(multi_db: true)
         FileUtils.rm_rf("#{app_path}/config/environments")
+        add_to_config("config.active_record.timestamped_migrations = false")
       end
 
       def teardown
@@ -779,11 +780,13 @@ module ApplicationTests
       end
 
       test "db:migrate:status works on all databases" do
+        remove_from_config("config.active_record.timestamped_migrations = false")
         require "#{app_path}/config/environment"
         db_migrate_and_migrate_status
       end
 
       test "db:migrate:status:namespace works" do
+        remove_from_config("config.active_record.timestamped_migrations = false")
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
           db_migrate_namespaced db_config.name

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -74,6 +74,8 @@ module RailtiesTest
     end
 
     test "copying migrations" do
+      add_to_config("config.active_record.timestamped_migrations = false")
+
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration::Current
         end
@@ -125,6 +127,8 @@ module RailtiesTest
     end
 
     test "copying migrations to specific database" do
+      add_to_config("config.active_record.timestamped_migrations = false")
+
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration::Current
         end
@@ -185,6 +189,8 @@ module RailtiesTest
         RUBY
       end
 
+      add_to_config("config.active_record.timestamped_migrations = false")
+
       @plugin.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration::Current
         end
@@ -224,6 +230,8 @@ module RailtiesTest
           end
         RUBY
       end
+
+      add_to_config("config.active_record.timestamped_migrations = false")
 
       @core.write "db/migrate/1_create_users.rb", <<-RUBY
         class CreateUsers < ActiveRecord::Migration::Current; end


### PR DESCRIPTION
### Motivation / Background

At Shopify, we've managed to get into a situation where several of our migration filenames have timestamps that are invalid: either an unexpected number of digits, a date that doesn't exist, etc. This hasn't been an issue historically, because we have a lot of custom code around migrations, but we're trying to move towards vanilla Rails migrations. I noticed `bin/rails db:rollback` is broken for us, because it uses [`.max`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration.rb#L1428-L1430) to determine the latest migration version to rollback: for us, this is a migration from several years ago that has already been rolled into our structured SQL file, but whose timestamp is 15 digits long (and thus is always considered the max).

Given that Rails makes assumptions about the format of the timestamp prefix on migration files, it would be beneficial to introduce a config option that enforces this. We'd make it opt-in, and only apply it if `active_record.config.timestamped_migrations` is set. This PR proposes such a config.

### Detail

This PR introduces a `config.active_record.validate_migration_timestamps` config. When set, it validates that the timestamp prefix for a migration is in the form YYYYMMDDHHMMSS, with the goal of preventing migration timestamps from being modified by hand. It is turned off by default. Migrations with invalid timestamps will see a `InvalidMigrationTimestampError` raised.

### Additional information

We'd discussed validating that the timestamp was not in the future, but there seem to be other tests that would contradict this, e.g.:
https://github.com/rails/rails/blob/4467b26a3e9b96756525ae7acc2b885b3ceb2194/activerecord/test/cases/migration_test.rb#L1688-L1704

For now, I've opted to check that 1) the length and format matches, and 2) the date is a real date.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
