### PR TITLE
Document delegated methods in `ActiveModel::Errors` [ci skip]

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -63,6 +63,7 @@ module ActiveModel
 
     extend Forwardable
 
+    ##
     # :method: each
     #
     # :call-seq: each(&block)
@@ -74,6 +75,31 @@ module ActiveModel
     #     # Will yield <#ActiveModel::Error attribute=name, type=too_short,
     #                                       options={:count=>3}>
     #   end
+
+    ##
+    # :method: clear
+    #
+    # :call-seq: clear
+    #
+    # Clears all errors. Clearing the errors does not, however, make the model
+    # valid. The next time the validations are run (for example, via
+    # ActiveRecord::Validations#valid?), the errors collection will be filled
+    # again if any validations fail.
+
+    ##
+    # :method: empty?
+    #
+    # :call-seq: empty?
+    #
+    # Returns true if there are no errors.
+
+    ##
+    # :method: size
+    #
+    # :call-seq: size
+    #
+    # Returns number of errors.
+
     def_delegators :@errors, :each, :clear, :empty?, :size, :uniq!
 
     # The actual array of +Error+ objects


### PR DESCRIPTION
### Motivation / Background

Fixes #50187

### Detail

Some delegated methods in `ActiveModel::Errors` weren't documented. And `each` seems to have been documented without the proper RDoc syntax which would explain why it's not showing up in the docs.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
