### PR TITLE
Optimize many delegated methods on ActiveSupport::Duration

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -14,7 +14,7 @@ module ActiveSupport
   class Duration
     class Scalar < Numeric # :nodoc:
       attr_reader :value
-      delegate :to_i, :to_f, :to_s, to: :value
+      delegate :to_i, :to_f, :to_s, to: :@value
 
       def initialize(value)
         @value = value
@@ -220,6 +220,8 @@ module ActiveSupport
           end
         end
     end
+
+    delegate :to_f, :positive?, :negative?, :zero?, :abs, to: :@value, as: Integer
 
     def initialize(value, parts, variable = nil) # :nodoc:
       @value, @parts = value, parts


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/50136

Using delegate saves on the `method_missing + public_send` combo.

I chose to delegate to all the methods I saw called in Rails own test suite, but there is likely a handful more candidates for explicit delegation.

But also this rely on a new (private) parameter in `Module#delegate` to provide the expected delegated type and use that to define delegators with the extact required signature. This saves on array and hash allocations caused by splatting.

In some ways it's a continuation of https://github.com/rails/rails/pull/46875

Note that I didn't make the new `as:` parameter public, as I fear it's a bit too brittle to be used. For the same reason I'm considering reverting the optimized path behavior on `to: :class` and requiring to explictly pass `as: self` for that optimized path. (FYI: @amatsuda)

Co-Authored-By: @Morriar