### PR TITLE
Ensure all GH Actions set to read-only contents

### DIFF
--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -2,6 +2,9 @@ name: rails-new-docker
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   APP_NAME: devrails
   APP_PATH: dev/devrails


### PR DESCRIPTION
Since a GH token is required for the action-discord notify action to fetch the commit message, otherwise it would make unauthenticated requests leading to rate limiting. This shouldn't impact the result of a workflow, but it's annoying.

The permissions for this token can vary based on the repository's settings. So to ensure we don't accidentally get a token with write access or something, we should use restrictive permissions per workflow, like the other workflows in this project.

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
