### PR TITLE
Allow custom Thor commands to load from `lib/commands` by ensuring `lib` is added to the $LOAD_PATH before looking up commands

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix custom Thor commands in `lib/commands` not being found, by ensuring
+    `lib` is added to the $LOAD_PATH before looking up commands.
+
+    *Ben Sheldon*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -13,6 +13,7 @@ module Rails
 
     autoload :Behavior
     autoload :Base
+    autoload :Actions
 
     class CorrectableNameError < StandardError # :nodoc:
       attr_reader :name
@@ -44,6 +45,8 @@ module Rails
     VERSION_MAPPINGS = %w(-v --version).to_set
 
     class << self
+      include Actions
+
       def hidden_commands # :nodoc:
         @hidden_commands ||= []
       end
@@ -61,6 +64,11 @@ module Rails
         command = find_by_namespace(namespace, command_name)
 
         with_argv(args) do
+          unless command && command.all_commands[command_name]
+            require_application!
+            command = find_by_namespace(namespace, command_name)
+          end
+
           if command && command.all_commands[command_name]
             command.perform(command_name, args, config)
           else
@@ -112,6 +120,7 @@ module Rails
       end
 
       def printing_commands # :nodoc:
+        require_application!
         lookup!
 
         (subclasses - hidden_commands).flat_map(&:printing_commands)

--- a/railties/test/command/help_integration_test.rb
+++ b/railties/test/command/help_integration_test.rb
@@ -30,6 +30,35 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
     assert_no_match "MY_TASK already defined? => true", output
   end
 
+  test "loads app command files only once on unrecognized command" do
+    app_file "lib/commands/my_command.rb", <<~RUBY
+      puts "MY_COMMAND already defined? => \#{!!defined?(MY_COMMAND)}"
+      MY_COMMAND = true
+    RUBY
+
+    output = rails "vershen", allow_failure: true
+
+    assert_match "MY_COMMAND already defined? => false", output
+    assert_no_match "MY_COMMAND already defined? => true", output
+  end
+
+  test "loads app command files from lib/commands" do
+    app_file "lib/commands/custom_command.rb", <<~RUBY
+      class Rails::Command::CustomCommand < Rails::Command::Base
+        desc "custom", "Custom command"
+        def perform
+          puts "Performed custom command"
+        end
+      end
+    RUBY
+
+    help_output = rails "help", allow_failure: true
+    assert_match "Custom command", help_output
+
+    command_output = rails "custom", allow_failure: true
+    assert_match "Performed custom command", command_output
+  end
+
   test "prints help via `X:help` command when running `X` and `X:X` command is not defined" do
     help = rails "dev:help"
     output = rails "dev", allow_failure: true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Closes #50193

This Pull Request makes Thor commands included in `lib/commands/*_command.rb` work. They previously did not work because available commands were generated before the Application was required, which meant that `lib` had not yet been added to the $LOAD_PATH (requiring the Application adds `lib` to the $LOAD_PATH, explained in #48596).

Because requiring the application could slightly slow down invoking commands, this change will first try to find the command _without_ requiring the Application, and if not found, will then require the Application and try the lookup again.

cc @matthewd 

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

I think Thor commands, especially the options syntax, is a big improvement over Rake, which is why I would like this to work, and it largely seems like it _should_ work with this very small tweak.

**I think it's allowable to defer documentation**: Guides can be updated to explain Thor commands alongside Rake tasks. Maybe a default `lib/commands/.keep` too.

There were previously some other changes in this; they've been extracted to #58376

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
