### PR TITLE
Add runner script option to disable Executor wrap

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use `bin/rails runner --skip-executor` option to not wrap the runner script
+    with an Executor.
+
+    *Ben Sheldon*
+
 *   Fix isolated engines to take `ActiveRecord::Base.table_name_prefix` into consideration.
     This will allow for engine defined models, such as inside Active Storage, to respect
     Active Record table name prefix configuration.

--- a/railties/test/commands/runner_test.rb
+++ b/railties/test/commands/runner_test.rb
@@ -44,6 +44,16 @@ class Rails::RunnerTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  def test_rails_runner_with_conditional_executor
+    assert_equal <<~OUTPUT, run_runner_command("puts Rails.application.executor.active?", allow_failure: true)
+      true
+    OUTPUT
+
+    assert_equal <<~OUTPUT, run_runner_command("--skip-executor", "puts Rails.application.executor.active?", allow_failure: true)
+      false
+    OUTPUT
+  end
+
   def test_rails_runner_with_syntax_error_in_ruby_code
     command_output = run_runner_command("This is not ruby code", allow_failure: true)
 
@@ -61,7 +71,7 @@ class Rails::RunnerTest < ActiveSupport::TestCase
   end
 
   private
-    def run_runner_command(argument, allow_failure: false)
-      rails "runner", argument, allow_failure: allow_failure
+    def run_runner_command(*arguments, allow_failure: false)
+      rails "runner", *arguments, allow_failure: allow_failure
     end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Rails runner scripts were wrapped with a Rails Executor in https://github.com/rails/rails/pull/44999

This is great! Except when using the Runner to execute long-running/looping/daemon-like scripts. In that case, it would be better to allow for intentionally adding Executor wraps around individual units of work in that script.

### Detail

This Pull Request allows passing `--skip-executor` to the Rails script runner to conditionally _not_ add an Executor wrap to the script.

~**Help wanted:** I don't particularly like the naming. I wanted to make it affirmative, but it's also true by default which means passing `false` option is necessary. The other option is to make it a negative boolean .e.g `--skip-executor`. What do you think?~

**Another option:** Instead of removing the Executor, maybe the runner should be wrapped with a reentrant Executor `#perform` that was introduced in #43550, instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
