### PR TITLE
Lock json gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "bcrypt", "~> 3.1.11", require: false
 gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
-gem "json", ">= 2.0.0"
+gem "json", ">= 2.0.0", "!=2.7.0"
 
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,7 +593,7 @@ DEPENDENCIES
   importmap-rails (>= 1.2.3)
   jbuilder
   jsbundling-rails
-  json (>= 2.0.0)
+  json (>= 2.0.0, != 2.7.0)
   libxml-ruby
   listen (~> 3.3)
   mdl


### PR DESCRIPTION
Locks the json gem to 2.6.3 until there is a new
release that includes https://github.com/flori/json/pull/554
