### PR TITLE
Fixed getting context for nuxt 3.7+ in conjunction with vite

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -3,10 +3,14 @@
   factory(global.ActionCable = {}));
 })(this, (function(exports) {
   "use strict";
-  var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
-  };
+  var adapters = {};
+  if (typeof global !== 'undefined') {
+    adapters.logger = global.console;
+    adapters.WebSocket = global.WebSocket;
+  } else {
+    adapters.logger = self.console;
+    adapters.WebSocket = self.WebSocket;
+  }
   var logger = {
     log(...messages) {
       if (this.enabled) {

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -3,14 +3,20 @@
   factory(global.ActionCable = {}));
 })(this, (function(exports) {
   "use strict";
-  var adapters = {};
-  if (typeof global !== 'undefined') {
-    adapters.logger = global.console;
-    adapters.WebSocket = global.WebSocket;
-  } else {
-    adapters.logger = self.console;
-    adapters.WebSocket = self.WebSocket;
+  var getAdapter = () => {
+    const adapter = {}
+    if (typeof self !== "undefined") {
+      adapter.logger = self.console;
+      adapter.WebSocket = self.WebSocket;
+    } else {
+      adapter.logger = global.console;
+      adapter.WebSocket = global.WebSocket;
+    }
+    return adapter;
   }
+
+  var adapters = getAdapter();
+
   var logger = {
     log(...messages) {
       if (this.enabled) {

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -8,6 +8,9 @@
     if (typeof self !== "undefined") {
       adapter.logger = self.console;
       adapter.WebSocket = self.WebSocket;
+    } else if(typeof window !== "undefined") {
+      adapter.logger = window.console;
+      adapter.WebSocket = window.WebSocket;
     } else {
       adapter.logger = global.console;
       adapter.WebSocket = global.WebSocket;

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -12,7 +12,9 @@
       adapter.logger = window.console;
       adapter.WebSocket = window.WebSocket;
     } else {
+      // eslint-disable-next-line no-undef
       adapter.logger = global.console;
+      // eslint-disable-next-line no-undef
       adapter.WebSocket = global.WebSocket;
     }
     return adapter;

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -1,12 +1,16 @@
-var adapters = {};
-
-if (typeof global !== 'undefined') {
-  adapters.logger = global.console;
-  adapters.WebSocket = global.WebSocket;
-} else {
-  adapters.logger = self.console;
-  adapters.WebSocket = self.WebSocket;
+var getAdapter = () => {
+  const adapter = {}
+  if (typeof self !== "undefined") {
+    adapter.logger = self.console;
+    adapter.WebSocket = self.WebSocket;
+  } else {
+    adapter.logger = global.console;
+    adapter.WebSocket = global.WebSocket;
+  }
+  return adapter;
 }
+
+var adapters = getAdapter();
 
 var logger = {
   log(...messages) {

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -1,7 +1,12 @@
-var adapters = {
-  logger: self.console,
-  WebSocket: self.WebSocket
-};
+var adapters = {};
+
+if (typeof global !== 'undefined') {
+  adapters.logger = global.console;
+  adapters.WebSocket = global.WebSocket;
+} else {
+  adapters.logger = self.console;
+  adapters.WebSocket = self.WebSocket;
+}
 
 var logger = {
   log(...messages) {

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -3,6 +3,9 @@ var getAdapter = () => {
   if (typeof self !== "undefined") {
     adapter.logger = self.console;
     adapter.WebSocket = self.WebSocket;
+  } else if(typeof window !== "undefined") {
+    adapter.logger = window.console;
+    adapter.WebSocket = window.WebSocket;
   } else {
     adapter.logger = global.console;
     adapter.WebSocket = global.WebSocket;

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -3,10 +3,14 @@
   factory(global.ActionCable = {}));
 })(this, (function(exports) {
   "use strict";
-  var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
-  };
+  var adapters = {};
+  if (typeof global !== 'undefined') {
+    adapters.logger = global.console;
+    adapters.WebSocket = global.WebSocket;
+  } else {
+    adapters.logger = self.console;
+    adapters.WebSocket = self.WebSocket;
+  }
   var logger = {
     log(...messages) {
       if (this.enabled) {

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -3,14 +3,20 @@
   factory(global.ActionCable = {}));
 })(this, (function(exports) {
   "use strict";
-  var adapters = {};
-  if (typeof global !== 'undefined') {
-    adapters.logger = global.console;
-    adapters.WebSocket = global.WebSocket;
-  } else {
-    adapters.logger = self.console;
-    adapters.WebSocket = self.WebSocket;
+  var getAdapter = () => {
+    const adapter = {}
+    if (typeof self !== "undefined") {
+      adapter.logger = self.console;
+      adapter.WebSocket = self.WebSocket;
+    } else {
+      adapter.logger = global.console;
+      adapter.WebSocket = global.WebSocket;
+    }
+    return adapter;
   }
+
+  var adapters = getAdapter();
+
   var logger = {
     log(...messages) {
       if (this.enabled) {

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -8,6 +8,9 @@
     if (typeof self !== "undefined") {
       adapter.logger = self.console;
       adapter.WebSocket = self.WebSocket;
+    } else if(typeof window !== "undefined") {
+      adapter.logger = window.console;
+      adapter.WebSocket = window.WebSocket;
     } else {
       adapter.logger = global.console;
       adapter.WebSocket = global.WebSocket;

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -12,7 +12,9 @@
       adapter.logger = window.console;
       adapter.WebSocket = window.WebSocket;
     } else {
+      // eslint-disable-next-line no-undef
       adapter.logger = global.console;
+      // eslint-disable-next-line no-undef
       adapter.WebSocket = global.WebSocket;
     }
     return adapter;

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,20 @@
+
+const getAdapter = () => {
+  const adapter = {};
+  if (typeof self !== "undefined") {
+    adapter.logger = self.console;
+    adapter.WebSocket = self.WebSocket;
+  } else if (typeof window !== "undefined") {
+    adapter.logger = window.console;
+    adapter.WebSocket = window.WebSocket;
+  } else {
+    adapter.logger = global.console;
+    adapter.WebSocket = global.WebSocket;
+  }
+  return adapter
+}
+var adapters = getAdapter();
+
 export default {
-  logger: typeof self !== "undefined" ? self.console : global.console,
-  WebSocket: typeof self !== "undefined" ? self.WebSocket : global.WebSocket
+  adapters
 }

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -8,7 +8,9 @@ const getAdapter = () => {
     adapter.logger = window.console;
     adapter.WebSocket = window.WebSocket;
   } else {
+    // eslint-disable-next-line no-undef
     adapter.logger = global.console;
+    // eslint-disable-next-line no-undef
     adapter.WebSocket = global.WebSocket;
   }
   return adapter

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,4 @@
 export default {
-  logger: self.console,
-  WebSocket: self.WebSocket
+  logger: typeof self !== "undefined" ? self.console : global.console,
+  WebSocket: typeof self !== "undefined" ? self.WebSocket : global.WebSocket
 }

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -16,6 +16,18 @@ module("ActionCable", () => {
         assert.equal(ActionCable.adapters.logger, self.console)
       })
     })
+
+    module("WebSocket", () => {
+      test("default is global.WebSocket", assert => {
+        assert.equal(ActionCable.adapters.WebSocket, global.WebSocket)
+      })
+    })
+
+    module("logger", () => {
+      test("default is global.console", assert => {
+        assert.equal(ActionCable.adapters.logger, global.console)
+      })
+    })
   })
 
   module("#createConsumer", () => {

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -16,6 +16,7 @@ module("ActionCable", () => {
         })
       }  else {
           test("default is global.WebSocket", assert => {
+            // eslint-disable-next-line no-undef
             assert.equal(ActionCable.adapters.WebSocket, global.WebSocket)
           })
       }
@@ -34,6 +35,7 @@ module("ActionCable", () => {
     }else {
       module("logger", () => {
         test("default is global.console", assert => {
+          // eslint-disable-next-line no-undef
           assert.equal(ActionCable.adapters.logger, global.console)
         })
       })

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -10,7 +10,11 @@ module("ActionCable", () => {
         test("default is self.WebSocket", assert => {
           assert.equal(ActionCable.adapters.WebSocket, self.WebSocket)
         })
-      }else {
+      } else if(typeof window !== "undefined") {
+        test("default is global.WebSocket", assert => {
+          assert.equal(ActionCable.adapters.WebSocket, window.WebSocket)
+        })
+      }  else {
           test("default is global.WebSocket", assert => {
             assert.equal(ActionCable.adapters.WebSocket, global.WebSocket)
           })
@@ -23,8 +27,11 @@ module("ActionCable", () => {
           assert.equal(ActionCable.adapters.logger, self.console)
         })
       })
-
-    } else {
+    }  else if(typeof window !== "undefined") {
+      test("default is global.WebSocket", assert => {
+        assert.equal(ActionCable.adapters.WebSocket, window.console)
+      })
+    }else {
       module("logger", () => {
         test("default is global.console", assert => {
           assert.equal(ActionCable.adapters.logger, global.console)

--- a/actioncable/test/javascript/src/unit/action_cable_test.js
+++ b/actioncable/test/javascript/src/unit/action_cable_test.js
@@ -6,28 +6,31 @@ const {module, test} = QUnit
 module("ActionCable", () => {
   module("Adapters", () => {
     module("WebSocket", () => {
-      test("default is self.WebSocket", assert => {
-        assert.equal(ActionCable.adapters.WebSocket, self.WebSocket)
-      })
+      if(typeof self !== "undefined") {
+        test("default is self.WebSocket", assert => {
+          assert.equal(ActionCable.adapters.WebSocket, self.WebSocket)
+        })
+      }else {
+          test("default is global.WebSocket", assert => {
+            assert.equal(ActionCable.adapters.WebSocket, global.WebSocket)
+          })
+      }
     })
 
-    module("logger", () => {
-      test("default is self.console", assert => {
-        assert.equal(ActionCable.adapters.logger, self.console)
+    if(typeof self !== "undefined") {
+      module("logger", () => {
+        test("default is self.console", assert => {
+          assert.equal(ActionCable.adapters.logger, self.console)
+        })
       })
-    })
 
-    module("WebSocket", () => {
-      test("default is global.WebSocket", assert => {
-        assert.equal(ActionCable.adapters.WebSocket, global.WebSocket)
+    } else {
+      module("logger", () => {
+        test("default is global.console", assert => {
+          assert.equal(ActionCable.adapters.logger, global.console)
+        })
       })
-    })
-
-    module("logger", () => {
-      test("default is global.console", assert => {
-        assert.equal(ActionCable.adapters.logger, global.console)
-      })
-    })
+    }
   })
 
   module("#createConsumer", () => {


### PR DESCRIPTION
1) This request needs to be combined, as it corrects the error when losing context for node when working with the next 3.7+ version in conjunction with vite. The context for self is undefined, in the code I change it to global, which exists in node
2) I added a section of code that determines whether there is a context for global, otherwise self

### Checklist


* [+] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs. 

- Yes 
###
* [ +] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- https://github.com/rails/rails/issues/50232
* [+ ] Tests are added or updated if you fix a bug or add a feature.
###
* [ +] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.