### PR TITLE
Fix `Time.now`/`DateTime.now`/`Date.today` to return results in a system timezone after `#travel_to`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `Time.now/DateTime.now/Date.today' to return results in a system timezone after `#travel_to'.
+
+    There is a bug in the current implementation of #travel_to:
+    it remembers a timezone of its argument, and all stubbed methods start
+    returning results in that remembered timezone. However, the expected
+    behaviour is to return results in a system timezone.
+
+    *Aleksei Chernenkov*
+
 *   Add `ErrorReported#unexpected` to report precondition violations.
 
     For example:

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -169,6 +169,10 @@ module ActiveSupport
           now = date_or_time.to_time.change(usec: 0)
         end
 
+        # +now+ must be in local system timezone, because +Time.at(now)+
+        # and +now.to_date+ (see stubs below) will use +now+'s timezone too!
+        now = now.getlocal
+
         stubs = simple_stubs
         stubbed_time = Time.now if stubs.stubbing(Time, :now)
         stubs.stub_object(Time, :now) { at(now) }

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -122,6 +122,44 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_to_with_different_system_and_application_time_zones
+    with_env_tz "US/Eastern" do # system time zone: -05
+      expected_time_in_2021 = Time.new(2021)
+
+      with_tz_default ActiveSupport::TimeZone["Ekaterinburg"] do # application time zone: +05
+        destination_time = Time.new(2023, 12, 1, 5, 6, 7, 5 * 3600)
+
+        # All stubbed methods are expected to return values in system (-05) time zone
+        expected_utc_offset = -5 * 3600
+        expected_time = Time.new(2023, 11, 30, 19, 6, 7, expected_utc_offset)
+        expected_datetime = DateTime.new(2023, 11, 30, 19, 6, 7, -Rational(5, 24))
+        expected_date = Date.new(2023, 11, 30)
+
+        travel_to destination_time do
+          assert_equal expected_time, Time.now
+          assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
+          assert_equal expected_utc_offset, Time.now.utc_offset
+
+          assert_equal expected_datetime, DateTime.now
+          assert_equal expected_datetime.to_fs(:db), DateTime.now.to_fs(:db)
+          assert_equal expected_utc_offset, DateTime.now.utc_offset
+
+          assert_equal expected_date, Date.today
+
+          # Time.new with no args equals to Time.now
+          assert_equal expected_time, Time.new
+          assert_equal expected_time.to_fs(:db), Time.new.to_fs(:db)
+          assert_equal expected_utc_offset, Time.new.utc_offset
+
+          # Time.new with any args falls back to original Ruby implementation
+          assert_equal expected_time_in_2021, Time.new(2021)
+          assert_equal expected_time_in_2021.to_fs(:db), Time.new(2021).to_fs(:db)
+          assert_equal expected_time_in_2021.utc_offset, Time.new(2021).utc_offset
+        end
+      end
+    end
+  end
+
   def test_time_helper_travel_to_with_string_for_time_zone
     with_env_tz "US/Eastern" do
       with_tz_default ActiveSupport::TimeZone["UTC"] do


### PR DESCRIPTION
### Motivation / Background

Fix incorrect `Date.today` result value that caused [a bug with the `Faker::Time.backward` method](https://github.com/faker-ruby/faker/issues/2861) in the Faker gem.

### Detail

There is a bug in the current implementation of `#travel_to`: it remembers a timezone of its argument, and all stubbed methods (`Time.now`, `DateTime.now`, `Date.today`) start returning results in that remembered timezone. However, the expected behaviour is to return results in a system timezone.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
