### PR TITLE
[Fix #50230] Preserve serialized timezone when deserializing with `ActiveJob::Serializers::TimeWithZoneSerializer`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Preserve the serialized timezone when deserializing `ActiveSupport::TimeWithZone` arguments.
+
+    *Joshua Young*
+
 *   Remove deprecated `:exponentially_longer` value for the `:wait` in `retry_on`.
 
     *Rafael Mendonça França*

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -2,9 +2,18 @@
 
 module ActiveJob
   module Serializers
-    class TimeWithZoneSerializer < TimeObjectSerializer # :nodoc:
+    class TimeWithZoneSerializer < ObjectSerializer # :nodoc:
+      NANO_PRECISION = 9
+
+      def serialize(time_with_zone)
+        super(
+          "value" => time_with_zone.iso8601(NANO_PRECISION),
+          "time_zone" => time_with_zone.time_zone.tzinfo.name
+        )
+      end
+
       def deserialize(hash)
-        Time.iso8601(hash["value"]).in_time_zone
+        Time.iso8601(hash["value"]).in_time_zone(hash["time_zone"] || Time.zone)
       end
 
       private

--- a/activejob/test/serializers/time_with_zone_serializer_test.rb
+++ b/activejob/test/serializers/time_with_zone_serializer_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TimeWithZoneSerializerTest < ActiveSupport::TestCase
+  test "#deserialize preserves serialized time zone" do
+    time_zone_before = Time.zone
+
+    Time.zone = "America/Los_Angeles"
+    time_with_zone = Time.parse("08:00").in_time_zone
+
+    assert_equal "America/Los_Angeles", time_with_zone.time_zone.tzinfo.name
+
+    serialized = ActiveJob::Serializers::TimeWithZoneSerializer.serialize(time_with_zone)
+    Time.zone = "Europe/London"
+    deserialized = ActiveJob::Serializers::TimeWithZoneSerializer.deserialize(serialized)
+
+    assert_equal "America/Los_Angeles", deserialized.time_zone.tzinfo.name
+    assert_equal time_with_zone, deserialized
+  ensure
+    Time.zone = time_zone_before
+  end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/50230

### Detail

This Pull Request changes `ActiveJob::Serializers::TimeWithZoneSerializer` to include the time zone of the provided time with zone object in the serialized hash which is then used during deserialization.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

A side effect of this change is that `ActiveJob::Serializers::TimeWithZoneSerializer` now inherits directly from `ActiveJob::Serializers::ObjectSerializer` instead of `ActiveJob::Serializers::TimeObjectSerializer` in order to define it's own `#serialize`. I don't see another way to implement this while preserving the current inheritance.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
