### PR TITLE
Alias `field_set_tag` helper to `fieldset_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Alias `field_set_tag` helper to `fieldset_tag` to match `<fieldset>` element
+
+    *Sean Doyle*
+
 *   Deprecate passing content to void elements when using `tag.br` type tag builders.
 
     *Hartley McGuire*

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -675,11 +675,13 @@ module ActionView
       #   <% end %>
       #   # => <fieldset class="format"><p><input id="name" name="name" type="text" /></p></fieldset>
       def field_set_tag(legend = nil, options = nil, &block)
-        output = tag(:fieldset, options, true)
-        output.safe_concat(content_tag("legend", legend)) unless legend.blank?
-        output.concat(capture(&block)) if block_given?
-        output.safe_concat("</fieldset>")
+        content = []
+        content << content_tag("legend", legend) unless legend.blank?
+        content << capture(&block) if block_given?
+
+        content_tag(:fieldset, safe_join(content), options)
       end
+      alias_method :fieldset_tag, :field_set_tag
 
       # Creates a text field of type "color".
       #

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -925,6 +925,11 @@ class FormTagHelperTest < ActionView::TestCase
     expected = %(<fieldset class="format">Hello world!</fieldset>)
     assert_dom_equal expected, output_buffer
 
+    output_buffer = render_erb("<%= fieldset_tag('', :class => 'format') do %>Hello world!<% end %>")
+
+    expected = %(<fieldset class="format">Hello world!</fieldset>)
+    assert_dom_equal expected, output_buffer
+
     output_buffer = render_erb("<%= field_set_tag %>")
 
     expected = %(<fieldset></fieldset>)


### PR DESCRIPTION
### Motivation / Background

The [field_set_tag][] renders a `<fieldset>` element. At times, the desire to render a `fieldset` results in calling `fieldset_tag`, only to be surprised by a `NoMethodError`.

Originally, the method's name was `fieldset_tag` helper (defined in [0e6c8e5][] in 2007), but was renamed in [73c7083][] (3 days later).

### Detail

This commit aliases `field_set_tag` to `fieldset_tag` so that both are available.

### Additional information

Additionally, defines the method so that it utilizes the [content_tag][] so that it isn't responsible for manually managing the closing (`</fieldset>`) of the opening `<fieldset>` tag.

[field_set_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-field_set_tag
[0e6c8e5]: https://github.com/rails/rails/commit/0e6c8e5f6c168b9d376122f730c604d3758f4b04
[73c7083]: https://github.com/rails/rails/commit/73c70836515879f69a152535f3ab411acc3317b8
[content_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
