### PR TITLE
Update security.md typo about HTTP Strict-Transport-Security [ci-skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1139,7 +1139,7 @@ config.action_dispatch.default_headers.clear
 
 ### `Strict-Transport-Security` Header
 
-The HTTP [`Strict-Transport-Security`][] (HTST) response header makes sure the
+The HTTP [`Strict-Transport-Security`][] (HSTS) response header makes sure the
 browser automatically upgrades to HTTPS for current and future connections.
 
 The header is added to the response when enabling the `force_ssl` option:


### PR DESCRIPTION
### Motivation / Background


This Pull Request has been created because of a security.md typo about HTTP Strict-Transport-Security.
The abbreviation for HTTP Strict-Transport-Security is written as "HTST" in that text, but the correct is "HSTS".

### Detail

This Pull Request changes changes the spelling of abbreviation in security.md

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
