### PR TITLE
Make isolated engines aware of ActiveRecord::Base table name prefix

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix isolated engines to take `ActiveRecord::Base.table_name_prefix` into consideration.
+    This will allow for engine defined models, such as inside Active Storage, to respect
+    Active Record table name prefix configuration.
+
+    *Chedli Bourguiba*
+
 *   Fix running `db:system:change` when app has no Dockerfile.
 
     *Hartley McGuire*

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -396,6 +396,12 @@ module Rails
 
             unless mod.respond_to?(:table_name_prefix)
               define_method(:table_name_prefix) { "#{name}_" }
+
+              ActiveSupport.on_load(:active_record) do
+                mod.singleton_class.redefine_method(:table_name_prefix) do
+                  "#{ActiveRecord::Base.table_name_prefix}#{name}_"
+                end
+              end
             end
 
             unless mod.respond_to?(:use_relative_model_naming?)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1290,6 +1290,32 @@ en:
       assert_equal "foo", Bukkits.table_name_prefix
     end
 
+    test "take ActiveRecord table_name_prefix into consideration when defining table_name_prefix" do
+      @plugin.write "lib/bukkits.rb", <<-RUBY
+        module Bukkits
+          class Engine < ::Rails::Engine
+            isolate_namespace(Bukkits)
+          end
+        end
+      RUBY
+
+      @plugin.write "app/models/bukkits/post.rb", <<-RUBY
+        module Bukkits
+          class Post < ActiveRecord::Base
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.active_record.table_name_prefix = "ar_prefix_"
+      RUBY
+
+      boot_rails
+
+      assert_equal "ar_prefix_bukkits_posts", Bukkits::Post.table_name
+      assert_equal "ar_prefix_bukkits_", Bukkits.table_name_prefix
+    end
+
     test "fetching engine by path" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/50246 cc @jonathanhefner 
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because to fix a long standing issue with isolated engines.
In effect, isolated engines define their own `table_name_prefix` method which does not take into consideration The ActiveRecord table name prefix.

### Detail

This Pull Request redefines `table_name_prefix` for engines only when ActiveRecord is loaded. this will allow to prepend `ActiveRecord::Base.table_name_prefix` for isolated engines that generate AR tables for their internal use.

### Additional information

This will fix engines such as `active_storage`, `action_text` and `action_mailbox` that generate tables.

- For ActiveStorage, this PR to be merged first because table names are hard coded https://github.com/rails/rails/pull/50167 
- For the two latter, they would need a separate PR should their AR model have hard coded table names.

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
